### PR TITLE
[move-prover] adopt map intrinsics for OrderedMap and BigOrderedMap

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.spec.move
@@ -3,17 +3,42 @@ spec aptos_framework::big_ordered_map {
     spec BigOrderedMap {
         pragma intrinsic = map,
             map_new = new,
+            map_new_with_config = new_with_config,
+            map_new_from = new_from,
             map_destroy_empty = destroy_empty,
             map_has_key = contains,
-            map_add_no_override = add,
+            map_remove_or_none = remove_or_none,
             map_borrow = borrow,
             map_borrow_mut = borrow_mut,
+            map_get = get,
+            map_keys = keys,
+            map_front_key = front_key,
+            map_back_key = back_key,
+            map_borrow_front = borrow_front,
+            map_borrow_back = borrow_back,
+            map_pop_front = pop_front,
+            map_pop_back = pop_back,
+            map_prev_key = prev_key,
+            map_next_key = next_key,
+            map_iter_new_begin = internal_new_begin_iter,
+            map_iter_new_end = internal_new_end_iter,
+            map_iter_is_end = iter_is_end,
+            map_iter_borrow_key = iter_borrow_key,
+            map_internal_find = internal_find,
+            map_internal_lower_bound = internal_lower_bound,
+            map_internal_find_with_path = internal_find_with_path,
+            map_iter_with_path_get_iter = iter_with_path_get_iter,
+            map_len = compute_length,
             map_spec_get = spec_get,
             map_spec_set = spec_set,
             map_spec_del = spec_remove,
             map_spec_len = spec_len,
             map_spec_has_key = spec_contains_key,
-            map_is_empty = is_empty;
+            map_is_empty = is_empty,
+            map_spec_aborts_new_from = spec_aborts_new_from,
+            map_spec_aborts_new_with_config = spec_aborts_new_with_config,
+            map_spec_aborts_empty_map = spec_aborts_empty_map,
+            map_spec_aborts_iter_borrow_key = spec_aborts_iter_borrow_key;
     }
 
     spec native fun spec_len<K, V>(t: BigOrderedMap<K, V>): num;
@@ -22,16 +47,42 @@ spec aptos_framework::big_ordered_map {
     spec native fun spec_remove<K, V>(t: BigOrderedMap<K, V>, k: K): BigOrderedMap<K, V>;
     spec native fun spec_get<K, V>(t: BigOrderedMap<K, V>, k: K): V;
 
+    // Abort-condition spec functions paired with the corresponding intrinsics.
+    spec native fun spec_aborts_new_from<K, V>(keys: vector<K>, values: vector<V>): bool;
+    spec native fun spec_aborts_new_with_config<K, V>(inner_max_degree: u16, leaf_max_degree: u16, reuse_slots: bool): bool;
+    spec native fun spec_aborts_empty_map<K, V>(t: BigOrderedMap<K, V>): bool;
+    spec native fun spec_aborts_iter_borrow_key<K, V>(it: IteratorPtr<K>): bool;
+
+    // Uninterpreted abort predicate for the `validate_dynamic_size_and_init_max_degrees`
+    // check called by both `add` and `upsert`. True iff the call would abort under the
+    // dynamic key/value size validation. Body-less because it depends on hidden map
+    // configuration fields.
+    spec fun spec_aborts_validate_size<K, V>(t: BigOrderedMap<K, V>, k: K, v: V): bool;
+
+    // Uninterpreted abort predicate for stale-iterator operations. The runtime aborts on
+    // any iter use whose cached `node_index`/`child_iter` no longer matches the current
+    // tree state (rebalance, sibling removal, etc.). Body-less because tracking node_index
+    // and child_iter precisely would require modeling BOM's B+-tree state.
+    spec fun spec_iter_op_aborts<K, V>(it: IteratorPtr<K>, m: BigOrderedMap<K, V>): bool;
+
+
+
+    // Uninterpreted abort predicate for `new_with_reusable`: true iff K or V has
+    // non-constant serialized size. Body-less because it depends on
+    // `bcs::constant_serialized_size`, not expressible in the intrinsic-typed spec layer.
+    spec fun spec_aborts_new_with_reusable_runtime<K, V>(): bool;
+
+    // Uninterpreted abort predicate for `new_with_type_size_hints`: true iff any of the
+    // size-hint validations fail (avg > max, division-by-zero on `avg_*_bytes` or
+    // `max_*_bytes`, or derived max-degrees below the minimum).
+    spec fun spec_aborts_new_with_type_size_hints_runtime<K, V>(
+        avg_key_bytes: u64, max_key_bytes: u64,
+        avg_value_bytes: u64, max_value_bytes: u64
+    ): bool;
+
 
     spec new_with_config {
-        pragma verify = false;
-        pragma opaque;
-        aborts_if inner_max_degree != 0
-            && (inner_max_degree < 4 || (inner_max_degree as u64) > 4096);
-        aborts_if leaf_max_degree != 0
-            && (leaf_max_degree < 3 || (leaf_max_degree as u64) > 4096);
-        ensures spec_len(result) == 0;
-        ensures forall k: K: !spec_contains_key(result, k);
+        pragma intrinsic;
     }
 
     spec new {
@@ -39,19 +90,25 @@ spec aptos_framework::big_ordered_map {
     }
 
     spec new_with_reusable {
-        pragma verify = false;
         pragma opaque;
-        aborts_if false;
-        ensures spec_len(result) == 0;
-        ensures forall k: K: !spec_contains_key(result, k);
+        pragma verify = false;
+        aborts_if [abstract] spec_aborts_new_with_reusable_runtime<K, V>();
+        ensures !spec_aborts_new_with_reusable_runtime<K, V>() ==> spec_len(result) == 0;
+        ensures !spec_aborts_new_with_reusable_runtime<K, V>() ==>
+            (forall k: K: !spec_contains_key(result, k));
     }
 
     spec new_with_type_size_hints {
-        pragma verify = false;
         pragma opaque;
-        aborts_if false;
-        ensures spec_len(result) == 0;
-        ensures forall k: K: !spec_contains_key(result, k);
+        pragma verify = false;
+        aborts_if [abstract] spec_aborts_new_with_type_size_hints_runtime<K, V>(
+            avg_key_bytes, max_key_bytes, avg_value_bytes, max_value_bytes);
+        ensures !spec_aborts_new_with_type_size_hints_runtime<K, V>(
+            avg_key_bytes, max_key_bytes, avg_value_bytes, max_value_bytes)
+            ==> spec_len(result) == 0;
+        ensures !spec_aborts_new_with_type_size_hints_runtime<K, V>(
+            avg_key_bytes, max_key_bytes, avg_value_bytes, max_value_bytes)
+            ==> (forall k: K: !spec_contains_key(result, k));
     }
 
     spec borrow {
@@ -59,6 +116,10 @@ spec aptos_framework::big_ordered_map {
     }
 
     spec borrow_mut {
+        pragma intrinsic;
+    }
+
+    spec get {
         pragma intrinsic;
     }
 
@@ -71,7 +132,14 @@ spec aptos_framework::big_ordered_map {
     }
 
     spec add {
-        pragma intrinsic;
+        pragma opaque;
+        pragma verify = false;
+        aborts_if spec_contains_key(self, key);
+        aborts_if [abstract] spec_aborts_validate_size(self, key, value);
+        ensures spec_contains_key(self, key);
+        ensures spec_get(self, key) == value;
+        ensures spec_len(self) == spec_len(old(self)) + 1;
+        ensures spec_unchanged_except_at(self, key);
     }
 
     spec remove {
@@ -82,8 +150,6 @@ spec aptos_framework::big_ordered_map {
         ensures spec_get(old(self), key) == result;
         ensures spec_len(old(self)) == spec_len(self) + 1;
         ensures spec_unchanged_except_at(self, key);
-        // ensures forall k: K where k != key: spec_contains_key(self, k) ==> spec_get(self, k) == spec_get(old(self), k);
-        // ensures forall k: K where k != key: spec_contains_key(old(self), k) == spec_contains_key(self, k);
     }
 
     spec fun spec_unchanged_except_at<K: drop + copy + store, V: store>(
@@ -95,25 +161,8 @@ spec aptos_framework::big_ordered_map {
             spec_get(self, k) == spec_get(old(self), k))
     }
 
-    spec remove_or_none<K: drop + copy + store, V: store>(
-        self: &mut BigOrderedMap<K, V>, key: &K
-    ): Option<V> {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if false;
-        // Hit: key was present
-        ensures spec_contains_key(old(self), key) ==> (
-            option::is_some(result)
-            && option::spec_borrow(result) == spec_get(old(self), key)
-            && !spec_contains_key(self, key)
-            && spec_len(self) == spec_len(old(self)) - 1
-        );
-        // Miss: key was absent — map unchanged
-        ensures !spec_contains_key(old(self), key) ==> (
-            option::is_none(result)
-            && spec_len(self) == spec_len(old(self))
-        );
-        ensures spec_unchanged_except_at(self, key);
+    spec remove_or_none {
+        pragma intrinsic;
     }
 
     spec is_empty {
@@ -121,17 +170,16 @@ spec aptos_framework::big_ordered_map {
     }
 
     spec iter_is_end {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if false;
-        ensures result == (self is IteratorPtr::End<K>);
+        pragma intrinsic;
     }
 
     spec iter_borrow {
         pragma opaque;
         pragma verify = false;
         aborts_if iter_is_end(self, map);
-        ensures result == spec_get(map, self.key);
+        aborts_if [abstract] spec_iter_op_aborts(self, map);
+        // Result is havoc'd: when the iter is stale (cached position no longer matches
+        // tree state) the runtime aborts; the spec does not claim a specific value here.
     }
 
     // Body also asserts constant_kv_size OR bcs::constant_serialized_size<V>().is_some()
@@ -140,46 +188,26 @@ spec aptos_framework::big_ordered_map {
         pragma opaque;
         pragma verify = false;
         aborts_if iter_is_end(self, map);
-        ensures result == spec_get(map, self.key);
+        aborts_if [abstract] spec_iter_op_aborts(self, map);
     }
 
+    // `iter_is_begin` is not bound as intrinsic because the runtime checks
+    // `node_index == min_leaf_index && child_iter_at_begin`, which the model cannot
+    // track without representing BOM's tree state. We only pin the End-on-empty case;
+    // for `Some` iters the return is havoc'd (sound but imprecise on stale iters).
     spec iter_is_begin {
         pragma opaque;
         pragma verify = false;
         aborts_if false;
-        // self is End: returns true iff map is empty (End acts as both begin and end on []).
-        ensures (self is IteratorPtr::End<K>) ==> (result <==> spec_len(map) == 0);
-        // self is Some: returns true iff self.key is the smallest key currently in map.
-        ensures !(self is IteratorPtr::End<K>) ==> (result <==>
-            (spec_contains_key(map, self.key)
-                && (forall k: K where spec_contains_key(map, k) && k != self.key:
-                    std::cmp::compare(self.key, k) == std::cmp::Ordering::Less)));
+        ensures (self is IteratorPtr::End<K>) ==> (result == (spec_len(map) == 0));
     }
 
-    // Returns the iterator pointing to the smallest key K in self with K >= input
-    // key (compare not Less), or End if no such key exists.
     spec internal_lower_bound {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if false;
-        // End iff no key >= input exists (all keys are Less than input).
-        ensures iter_is_end(result, self) <==>
-            (forall k: K where spec_contains_key(self, k):
-                std::cmp::compare(k, key) == std::cmp::Ordering::Less);
-        // Otherwise, result.key is in the map, >= input, and the smallest such.
-        ensures !iter_is_end(result, self) ==> spec_contains_key(self, result.key);
-        ensures !iter_is_end(result, self) ==>
-            std::cmp::compare(result.key, key) != std::cmp::Ordering::Less;
-        ensures !iter_is_end(result, self) ==>
-            (forall k: K where spec_contains_key(self, k) && std::cmp::compare(k, key) != std::cmp::Ordering::Less:
-                std::cmp::compare(result.key, k) != std::cmp::Ordering::Greater);
+        pragma intrinsic;
     }
 
     spec iter_borrow_key {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if self is IteratorPtr::End<K>;
-        ensures result == self.key;
+        pragma intrinsic;
     }
 
     spec allocate_spare_slots {
@@ -203,208 +231,119 @@ spec aptos_framework::big_ordered_map {
     }
 
     spec keys {
-        pragma verify = false;
-        pragma opaque;
-        ensures forall k: K: vector::spec_contains(result, k) <==> spec_contains_key(self, k);
+        pragma intrinsic;
     }
 
-    spec new_from<K: drop + copy + store, V: store>(keys: vector<K>, values: vector<V>): BigOrderedMap<K, V> {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if exists i in 0..len(keys), j in 0..len(keys) where i != j : keys[i] == keys[j];
-        aborts_if len(keys) != len(values);
-        ensures forall k: K {spec_contains_key(result, k)} : vector::spec_contains(keys,k) <==> spec_contains_key(result, k);
-        ensures forall i in 0..len(keys) : spec_get(result, keys[i]) == values[i];
-        ensures spec_len(result) == len(keys);
+    spec new_from {
+        pragma intrinsic;
     }
 
     spec upsert {
         pragma opaque;
         pragma verify = false;
+        aborts_if [abstract] spec_aborts_validate_size(self, key, value);
         ensures !spec_contains_key(old(self), key) ==> option::is_none(result);
+        ensures spec_contains_key(old(self), key) ==>
+            (option::is_some(result) && option::spec_borrow(result) == spec_get(old(self), key));
         ensures spec_contains_key(self, key);
         ensures spec_get(self, key) == value;
-        ensures spec_contains_key(old(self), key) ==> ((option::is_some(result)) && (option::spec_borrow(result) == spec_get(old(
-            self), key)));
         ensures !spec_contains_key(old(self), key) ==> spec_len(old(self)) + 1 == spec_len(self);
         ensures spec_contains_key(old(self), key) ==> spec_len(old(self)) == spec_len(self);
         ensures spec_unchanged_except_at(self, key);
     }
 
-    spec add_all {
-        pragma opaque;
-        pragma verify = false;
+    spec borrow_front {
+        pragma intrinsic;
     }
 
-    spec borrow_front<K: drop + copy + store, V: store>(self: &BigOrderedMap<K, V>): (K, &V) {
-        pragma opaque;
-        pragma verify = false;
-        ensures spec_contains_key(self, result_1);
-        ensures spec_get(self, result_1) == result_2;
-        ensures forall k: K where k != result_1: spec_contains_key(self, k) ==>
-        std::cmp::compare(result_1, k) == std::cmp::Ordering::Less;
-    }
-
-    spec front_key<K: drop + copy + store, V: store>(self: &BigOrderedMap<K, V>): K {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if spec_len(self) == 0;
-        ensures spec_contains_key(self, result);
-        ensures forall k: K where k != result: spec_contains_key(self, k) ==>
-            std::cmp::compare(result, k) == std::cmp::Ordering::Less;
+    spec front_key {
+        pragma intrinsic;
     }
 
     spec borrow_back {
-        pragma opaque;
-        pragma verify = false;
-        ensures spec_contains_key(self, result_1);
-        ensures spec_get(self, result_1) == result_2;
-        ensures forall k: K where k != result_1: spec_contains_key(self, k) ==>
-        std::cmp::compare(result_1, k) == std::cmp::Ordering::Greater;
+        pragma intrinsic;
     }
 
-    spec back_key<K: drop + copy + store, V: store>(self: &BigOrderedMap<K, V>): K {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if spec_len(self) == 0;
-        ensures spec_contains_key(self, result);
-        ensures forall k: K where k != result: spec_contains_key(self, k) ==>
-            std::cmp::compare(result, k) == std::cmp::Ordering::Greater;
+    spec back_key {
+        pragma intrinsic;
     }
 
-    spec pop_front<K: drop + copy + store, V: store>(self: &mut BigOrderedMap<K, V>): (K, V) {
-        pragma opaque;
-        pragma verify = false;
-        ensures spec_contains_key(old(self), result_1);
-        ensures result_2 == spec_get(old(self), result_1);
-        ensures !spec_contains_key(self, result_1);
-        ensures spec_len(self) == spec_len(old(self)) - 1;
-        ensures spec_unchanged_except_at(self, result_1);
-        ensures forall k: K where spec_contains_key(old(self), k) && k != result_1:
-            std::cmp::compare(result_1, k) == std::cmp::Ordering::Less;
+    spec pop_front {
+        pragma intrinsic;
     }
 
-    spec pop_back<K: drop + copy + store, V: store>(self: &mut BigOrderedMap<K, V>): (K, V) {
-        pragma opaque;
-        pragma verify = false;
-        ensures spec_contains_key(old(self), result_1);
-        ensures result_2 == spec_get(old(self), result_1);
-        ensures !spec_contains_key(self, result_1);
-        ensures spec_len(self) == spec_len(old(self)) - 1;
-        ensures spec_unchanged_except_at(self, result_1);
-        ensures forall k: K where spec_contains_key(old(self), k) && k != result_1:
-            std::cmp::compare(result_1, k) == std::cmp::Ordering::Greater;
+    spec pop_back {
+        pragma intrinsic;
     }
 
-    spec prev_key<K: drop + copy + store, V: store>(self: &BigOrderedMap<K, V>, key: &K): Option<K> {
-        pragma opaque;
-        pragma verify = false;
-        ensures result == std::option::spec_none() <==>
-        (forall k: K {spec_contains_key(self, k)} where spec_contains_key(self, k)
-        && k != key: std::cmp::compare(key, k) == std::cmp::Ordering::Less);
-        ensures result.is_some() <==>
-            spec_contains_key(self, option::spec_borrow(result)) &&
-            (std::cmp::compare(option::spec_borrow(result), key) == std::cmp::Ordering::Less)
-            && (forall k: K {spec_contains_key(self, k), std::cmp::compare(option::spec_borrow(result), k), std::cmp::compare(key, k)} where k != option::spec_borrow(result): ((spec_contains_key(self, k) &&
-            std::cmp::compare(k, key) == std::cmp::Ordering::Less)) ==>
-            std::cmp::compare(option::spec_borrow(result), k) == std::cmp::Ordering::Greater);
+    spec prev_key {
+        pragma intrinsic;
     }
 
-
-    spec next_key<K: drop + copy + store, V: store>(self: &BigOrderedMap<K, V>, key: &K): Option<K>  {
-        pragma opaque;
-        pragma verify = false;
-        ensures result == std::option::spec_none() <==>
-        (forall k: K {spec_contains_key(self, k)} where spec_contains_key(self, k) && k != key:
-        std::cmp::compare(key, k) == std::cmp::Ordering::Greater);
-        ensures result.is_some() <==>
-            spec_contains_key(self, option::spec_borrow(result)) &&
-            (std::cmp::compare(option::spec_borrow(result), key) == std::cmp::Ordering::Greater)
-            && (forall k: K {spec_contains_key(self, k)} where k != option::spec_borrow(result): ((spec_contains_key(self, k) &&
-            std::cmp::compare(k, key) == std::cmp::Ordering::Greater)) ==>
-            std::cmp::compare(option::spec_borrow(result), k) == std::cmp::Ordering::Less);
+    spec next_key {
+        pragma intrinsic;
     }
 
 
     spec internal_find {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if false;
-        ensures iter_is_end(result, self) <==> !spec_contains_key(self, key);
-        ensures !iter_is_end(result, self) ==> result.key == key;
+        pragma intrinsic;
     }
 
     spec internal_new_begin_iter {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if false;
-        ensures iter_is_end(result, self) <==> spec_len(self) == 0;
-        ensures !iter_is_end(result, self) ==> spec_contains_key(self, result.key);
-        // result.key is the smallest key in the map.
-        ensures !iter_is_end(result, self) ==>
-            (forall k: K where spec_contains_key(self, k) && k != result.key:
-                std::cmp::compare(result.key, k) == std::cmp::Ordering::Less);
+        pragma intrinsic;
     }
 
     spec internal_new_end_iter {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if false;
-        ensures result is IteratorPtr::End<K>;
+        pragma intrinsic;
     }
 
     spec iter_next {
         pragma opaque;
         pragma verify = false;
         aborts_if iter_is_end(self, map);
+        aborts_if [abstract] spec_iter_op_aborts(self, map);
     }
 
     spec iter_prev {
         pragma opaque;
         pragma verify = false;
         aborts_if iter_is_begin(self, map);
+        aborts_if [abstract] spec_iter_op_aborts(self, map);
     }
 
     spec compute_length {
-        pragma verify = false;
-        pragma opaque;
-        ensures result == spec_len(self);
+        pragma intrinsic;
     }
 
     spec iter_modify {
         pragma opaque;
         pragma verify = false;
         aborts_if iter_is_end(self, map);
-        // iter_modify mutates the value at self.key via the closure. Containment is
-        // unchanged for every key; values for keys other than self.key are preserved.
-        ensures spec_contains_key(map, self.key);
+        aborts_if [abstract] spec_iter_op_aborts(self, map);
+        // Closure `f: |&mut V|` can abort at runtime; the model doesn't capture that
+        // condition precisely. The `[abstract]` markers above make the spec partial,
+        // so callers cannot conclude the function returns on any specific input.
+        // The success-path ensure is sound: closure mutates in place, neither adds
+        // nor removes entries. We don't claim which key was mutated.
         ensures spec_len(map) == spec_len(old(map));
-        ensures spec_unchanged_except_at(map, self.key);
     }
 
     spec internal_find_with_path {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if false;
-        ensures iter_is_end(result.iterator, self) <==> !spec_contains_key(self, key);
-        ensures !iter_is_end(result.iterator, self) ==> result.iterator.key == key;
+        pragma intrinsic;
     }
 
     spec iter_with_path_get_iter {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if false;
-        ensures result == self.iterator;
+        pragma intrinsic;
     }
 
     spec iter_remove {
         pragma opaque;
         pragma verify = false;
         aborts_if iter_is_end(self.iterator, map);
-        ensures result == spec_get(old(map), self.iterator.key);
-        ensures !spec_contains_key(map, self.iterator.key);
+        aborts_if [abstract] spec_iter_op_aborts(self.iterator, map);
+        // Removal of one entry; we do not claim which key was removed (cached position
+        // may be stale).
         ensures spec_len(map) == spec_len(old(map)) - 1;
-        ensures spec_unchanged_except_at(map, self.iterator.key);
     }
 
     spec internal_leaf_new_begin_iter {

--- a/aptos-move/framework/aptos-framework/sources/datastructures/ordered_map.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/ordered_map.spec.move
@@ -3,6 +3,11 @@ spec aptos_framework::ordered_map {
     spec OrderedMap {
         pragma intrinsic = map,
             map_new = new,
+            map_new_from = new_from,
+            map_to_vec_pair = to_vec_pair,
+            map_keys = keys,
+            map_values = values,
+            map_upsert = upsert,
             map_len = length,
             map_destroy_empty = destroy_empty,
             map_has_key = contains,
@@ -14,7 +19,8 @@ spec aptos_framework::ordered_map {
             map_spec_del = spec_remove,
             map_spec_len = spec_len,
             map_spec_has_key = spec_contains_key,
-            map_is_empty = is_empty;
+            map_is_empty = is_empty,
+            map_spec_aborts_new_from = spec_aborts_new_from;
     }
 
     spec native fun spec_len<K, V>(t: OrderedMap<K, V>): num;
@@ -22,6 +28,7 @@ spec aptos_framework::ordered_map {
     spec native fun spec_set<K, V>(t: OrderedMap<K, V>, k: K, v: V): OrderedMap<K, V>;
     spec native fun spec_remove<K, V>(t: OrderedMap<K, V>, k: K): OrderedMap<K, V>;
     spec native fun spec_get<K, V>(t: OrderedMap<K, V>, k: K): V;
+    spec native fun spec_aborts_new_from<K, V>(keys: vector<K>, values: vector<V>): bool;
 
     spec length {
         pragma intrinsic;
@@ -121,8 +128,7 @@ spec aptos_framework::ordered_map {
     }
 
     spec values {
-        pragma opaque;
-        pragma verify = false;
+        pragma intrinsic;
     }
 
 
@@ -143,38 +149,19 @@ spec aptos_framework::ordered_map {
     }
 
     spec keys {
-        pragma verify = false;
-        pragma opaque;
-        ensures [abstract] forall k: K: vector::spec_contains(result, k) <==> spec_contains_key(self, k);
+        pragma intrinsic;
     }
 
     spec to_vec_pair {
-        pragma verify = false;
-        pragma opaque;
+        pragma intrinsic;
     }
 
-    spec new_from<K, V>(keys: vector<K>, values: vector<V>): OrderedMap<K, V> {
-        pragma opaque;
-        pragma verify = false;
-        aborts_if [abstract] exists i in 0..len(keys), j in 0..len(keys) where i != j : keys[i] == keys[j];
-        aborts_if [abstract] len(keys) != len(values);
-        ensures [abstract] forall k: K {spec_contains_key(result, k)} : vector::spec_contains(keys,k) <==> spec_contains_key(result, k);
-        ensures [abstract] forall i in 0..len(keys) : spec_get(result, keys[i]) == values[i];
-        ensures [abstract] spec_len(result) == len(keys);
+    spec new_from {
+        pragma intrinsic;
     }
 
     spec upsert {
-        pragma opaque;
-        pragma verify = false;
-        ensures [abstract] !spec_contains_key(old(self), key) ==> option::is_none(result);
-        ensures [abstract] spec_contains_key(self, key);
-        ensures [abstract] spec_get(self, key) == value;
-        ensures [abstract] spec_contains_key(old(self), key) ==> ((option::is_some(result)) && (option::borrow(result) == spec_get(old(
-            self), key)));
-        ensures [abstract] !spec_contains_key(old(self), key) ==> spec_len(old(self)) + 1 == spec_len(self);
-        ensures [abstract] spec_contains_key(old(self), key) ==> spec_len(old(self)) == spec_len(self);
-        ensures [abstract] forall k: K: spec_contains_key(old(self), k) && k != key ==> spec_get(old(self), k) == spec_get(self, k);
-        ensures [abstract] forall k: K: spec_contains_key(old(self), k) ==> spec_contains_key(self, k);
+        pragma intrinsic;
     }
 
     spec replace_key_inplace {

--- a/third_party/move/move-model/src/pragmas.rs
+++ b/third_party/move/move-model/src/pragmas.rs
@@ -173,6 +173,11 @@ pub const INTRINSIC_FUN_MAP_BORROW_MUT_WITH_DEFAULT: &str = "map_borrow_mut_with
 /// `[move] fun map_borrow_with_default<K, V>(m: &Map<K, V>, k: K, default: V): &V`
 pub const INTRINSIC_FUN_MAP_BORROW_WITH_DEFAULT: &str = "map_borrow_with_default";
 
+/// Optional lookup: returns `Some(v)` when the key is in the map, `None` otherwise.
+/// Never aborts. Requires `V: copy`.
+/// `[move] fun map_get<K, V>(m: &Map<K, V>, k: K): Option<V>`
+pub const INTRINSIC_FUN_MAP_GET: &str = "map_get";
+
 /// Build a map from two parallel vectors of keys and values. Aborts when the lengths differ
 /// or when the keys contain a duplicate.
 /// `[move] fun map_new_from<K, V>(keys: vector<K>, values: vector<V>): Map<K, V>`
@@ -182,6 +187,10 @@ pub const INTRINSIC_FUN_MAP_NEW_FROM: &str = "map_new_from";
 /// the elements in the returned vectors is unspecified, but `keys[i]` maps to `values[i]`.
 /// `[move] fun map_to_vec_pair<K, V>(m: Map<K, V>): (vector<K>, vector<V>)`
 pub const INTRINSIC_FUN_MAP_TO_VEC_PAIR: &str = "map_to_vec_pair";
+
+/// Insert or update; returns the displaced value as `Option<V>`. Never aborts.
+/// `[move] fun map_upsert<K, V>(m: &mut Map<K, V>, k: K, v: V): Option<V>`
+pub const INTRINSIC_FUN_MAP_UPSERT: &str = "map_upsert";
 
 /// Insert or update; returns the displaced key and value as `(Option<K>, Option<V>)`. Never
 /// aborts. The returned key equals the input key under structural equality (the SMT model
@@ -197,6 +206,135 @@ pub const INTRINSIC_FUN_MAP_KEYS: &str = "map_keys";
 /// distinct keys map to equal values.
 /// `[move] fun map_values<K, V>(m: &Map<K, V>): vector<V>`
 pub const INTRINSIC_FUN_MAP_VALUES: &str = "map_values";
+
+/// Return the smallest key under cmp::compare ordering. Aborts when the map is empty.
+/// `[move] fun map_front_key<K, V>(m: &Map<K, V>): K`
+pub const INTRINSIC_FUN_MAP_FRONT_KEY: &str = "map_front_key";
+
+/// Return the largest key under cmp::compare ordering. Aborts when the map is empty.
+/// `[move] fun map_back_key<K, V>(m: &Map<K, V>): K`
+pub const INTRINSIC_FUN_MAP_BACK_KEY: &str = "map_back_key";
+
+/// Return the smallest key under cmp::compare ordering together with a reference to its
+/// value. Aborts when the map is empty.
+/// `[move] fun map_borrow_front<K, V>(m: &Map<K, V>): (K, &V)`
+pub const INTRINSIC_FUN_MAP_BORROW_FRONT: &str = "map_borrow_front";
+
+/// Return the largest key under cmp::compare ordering together with a reference to its
+/// value. Aborts when the map is empty.
+/// `[move] fun map_borrow_back<K, V>(m: &Map<K, V>): (K, &V)`
+pub const INTRINSIC_FUN_MAP_BORROW_BACK: &str = "map_borrow_back";
+
+/// Pop the smallest entry (key, value) under cmp::compare. Aborts when the map is empty.
+/// `[move] fun map_pop_front<K, V>(m: &mut Map<K, V>): (K, V)`
+pub const INTRINSIC_FUN_MAP_POP_FRONT: &str = "map_pop_front";
+
+/// Pop the largest entry (key, value) under cmp::compare. Aborts when the map is empty.
+/// `[move] fun map_pop_back<K, V>(m: &mut Map<K, V>): (K, V)`
+pub const INTRINSIC_FUN_MAP_POP_BACK: &str = "map_pop_back";
+
+/// Largest key strictly less than the given key under cmp::compare, or None.
+/// `[move] fun map_prev_key<K, V>(m: &Map<K, V>, k: &K): Option<K>`
+pub const INTRINSIC_FUN_MAP_PREV_KEY: &str = "map_prev_key";
+
+/// Smallest key strictly greater than the given key under cmp::compare, or None.
+/// `[move] fun map_next_key<K, V>(m: &Map<K, V>, k: &K): Option<K>`
+pub const INTRINSIC_FUN_MAP_NEXT_KEY: &str = "map_next_key";
+
+/// Remove the entry at the given key if present, returning Some(V) or None.
+/// `[move] fun map_remove_or_none<K, V>(m: &mut Map<K, V>, k: &K): Option<V>`
+pub const INTRINSIC_FUN_MAP_REMOVE_OR_NONE: &str = "map_remove_or_none";
+
+// === Iterator API roles. ===
+// These intrinsics operate on the map's IteratorPtr type — looked up by name in the
+// map struct's own module. The role bindings are sound only for maps whose
+// IteratorPtr is shaped like BigOrderedMap's: an enum with an `End` variant and a
+// `Some { ..., key: K }` variant (additional fields are not read in spec, only the
+// `key` field is). OrderedMap's IteratorPtr does not match this shape.
+
+/// Iterator at the smallest key, or end-sentinel if the map is empty. Never aborts.
+/// `[move] fun map_iter_new_begin<K, V>(m: &Map<K, V>): IteratorPtr<K>`
+pub const INTRINSIC_FUN_MAP_ITER_NEW_BEGIN: &str = "map_iter_new_begin";
+
+/// End sentinel iterator. Never aborts.
+/// `[move] fun map_iter_new_end<K, V>(m: &Map<K, V>): IteratorPtr<K>`
+pub const INTRINSIC_FUN_MAP_ITER_NEW_END: &str = "map_iter_new_end";
+
+/// True iff the iterator is the end sentinel. Never aborts.
+/// `[move] fun map_iter_is_end<K, V>(it: &IteratorPtr<K>, m: &Map<K, V>): bool`
+pub const INTRINSIC_FUN_MAP_ITER_IS_END: &str = "map_iter_is_end";
+
+/// True iff the iterator is at the begin position. An End iterator on an empty map
+/// counts as begin. Never aborts.
+/// `[move] fun map_iter_is_begin<K, V>(it: &IteratorPtr<K>, m: &Map<K, V>): bool`
+pub const INTRINSIC_FUN_MAP_ITER_IS_BEGIN: &str = "map_iter_is_begin";
+
+/// Read the key the iterator points at. Aborts if at end.
+/// `[move] fun map_iter_borrow_key<K>(it: &IteratorPtr<K>): &K`
+pub const INTRINSIC_FUN_MAP_ITER_BORROW_KEY: &str = "map_iter_borrow_key";
+
+/// Read the value the iterator points at. Aborts if at end.
+/// `[move] fun map_iter_borrow<K, V>(it: IteratorPtr<K>, m: &Map<K, V>): &V`
+pub const INTRINSIC_FUN_MAP_ITER_BORROW: &str = "map_iter_borrow";
+
+/// Advance the iterator to the next-larger key, or end if none. Aborts if currently
+/// at end.
+/// `[move] fun map_iter_next<K, V>(it: IteratorPtr<K>, m: &Map<K, V>): IteratorPtr<K>`
+pub const INTRINSIC_FUN_MAP_ITER_NEXT: &str = "map_iter_next";
+
+/// Step the iterator to the prev-smaller key. Aborts if currently at the begin
+/// (smallest key or empty-map end).
+/// `[move] fun map_iter_prev<K, V>(it: IteratorPtr<K>, m: &Map<K, V>): IteratorPtr<K>`
+pub const INTRINSIC_FUN_MAP_ITER_PREV: &str = "map_iter_prev";
+
+/// Iterator at the given key if present, end-sentinel otherwise. Never aborts.
+/// `[move] fun map_internal_find<K, V>(m: &Map<K, V>, k: &K): IteratorPtr<K>`
+pub const INTRINSIC_FUN_MAP_INTERNAL_FIND: &str = "map_internal_find";
+
+/// Iterator at the smallest key K >= input under cmp::compare ordering, or
+/// end-sentinel if no such key exists. Never aborts.
+/// `[move] fun map_internal_lower_bound<K, V>(m: &Map<K, V>, k: &K): IteratorPtr<K>`
+pub const INTRINSIC_FUN_MAP_INTERNAL_LOWER_BOUND: &str = "map_internal_lower_bound";
+
+// === IteratorPtrWithPath family ===
+// These roles operate on a companion-of-companion type `IteratorPtrWithPath<K>` that
+// wraps an `IteratorPtr<K>` with an implementation-only path. Like the iter roles,
+// they require the map type to declare both `IteratorPtr` and `IteratorPtrWithPath`
+// structs in its home module.
+
+/// Iterator-with-path at the given key if present, end-sentinel iterator-with-path
+/// otherwise. Never aborts.
+/// `[move] fun map_internal_find_with_path<K, V>(m: &Map<K, V>, k: &K): IteratorPtrWithPath<K>`
+pub const INTRINSIC_FUN_MAP_INTERNAL_FIND_WITH_PATH: &str = "map_internal_find_with_path";
+
+/// Project the wrapped `IteratorPtr<K>` from an `IteratorPtrWithPath<K>`. Never aborts.
+/// `[move] fun map_iter_with_path_get_iter<K>(it: &IteratorPtrWithPath<K>): IteratorPtr<K>`
+pub const INTRINSIC_FUN_MAP_ITER_WITH_PATH_GET_ITER: &str = "map_iter_with_path_get_iter";
+
+/// Remove the entry at the iterator-with-path's key, returning its value. Aborts when
+/// the iterator points to end.
+/// `[move] fun map_iter_remove<K, V>(it: IteratorPtrWithPath<K>, m: &mut Map<K, V>): V`
+pub const INTRINSIC_FUN_MAP_ITER_REMOVE: &str = "map_iter_remove";
+
+// === Configured constructors ===
+// Variants of map_new that take additional configuration parameters. The Boogie body
+// returns `EmptyTable()` with abort conditions on the config parameters when applicable.
+
+/// Create an empty map with explicit degree/reuse-slots configuration. Aborts when
+/// either `inner_max_degree` or `leaf_max_degree` is non-zero but out of range.
+/// `[move] fun map_new_with_config<K, V>(inner_max_degree: u16, leaf_max_degree: u16, reuse_slots: bool): Map<K, V>`
+pub const INTRINSIC_FUN_MAP_NEW_WITH_CONFIG: &str = "map_new_with_config";
+
+/// Create an empty map with the reusable-slots policy enabled. Conservatively reports
+/// `aborts_if false` (matches the existing trusted spec; the Move source's BCS-size
+/// check on K/V is not expressible at this layer).
+/// `[move] fun map_new_with_reusable<K, V>(): Map<K, V>`
+pub const INTRINSIC_FUN_MAP_NEW_WITH_REUSABLE: &str = "map_new_with_reusable";
+
+/// Create an empty map configured against the provided key/value size hints.
+/// Conservatively reports `aborts_if false` (matches the existing trusted spec).
+/// `[move] fun map_new_with_type_size_hints<K, V>(avg_key_bytes: u64, max_key_bytes: u64, avg_value_bytes: u64, max_value_bytes: u64): Map<K, V>`
+pub const INTRINSIC_FUN_MAP_NEW_WITH_TYPE_SIZE_HINTS: &str = "map_new_with_type_size_hints";
 
 /// Abort condition for map_destroy_empty: true when the map is non-empty
 /// `[spec] fun map_spec_aborts_destroy_empty<K, V>(m: Map<K, V>): bool`
@@ -218,6 +356,35 @@ pub const INTRINSIC_FUN_MAP_SPEC_ABORTS_BORROW: &str = "map_spec_aborts_borrow";
 /// duplicates (under $EncodeKey).
 /// `[spec] fun map_spec_aborts_new_from<K, V>(keys: vector<K>, values: vector<V>): bool`
 pub const INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_FROM: &str = "map_spec_aborts_new_from";
+
+/// Abort condition for map_new_with_config: true when a configured degree is non-zero and
+/// outside the supported range.
+/// `[spec] fun map_spec_aborts_new_with_config<K, V>(inner_max_degree: u16, leaf_max_degree: u16, reuse_slots: bool): bool`
+pub const INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_WITH_CONFIG: &str = "map_spec_aborts_new_with_config";
+
+/// Abort condition for the order-key family (front_key / back_key / borrow_front /
+/// borrow_back / pop_front / pop_back): true when the map is empty.
+/// `[spec] fun map_spec_aborts_empty_map<K, V>(m: Map<K, V>): bool`
+pub const INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP: &str = "map_spec_aborts_empty_map";
+
+/// Abort condition for map_iter_borrow_key: true when the iterator is the End sentinel.
+/// `[spec] fun map_spec_aborts_iter_borrow_key<K>(it: IteratorPtr<K>): bool`
+pub const INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_KEY: &str = "map_spec_aborts_iter_borrow_key";
+
+/// Abort condition for map_iter_borrow / map_iter_next: true when the iterator is End or
+/// its cached key is no longer in the map.
+/// `[spec] fun map_spec_aborts_iter_oob<K, V>(it: IteratorPtr<K>, m: Map<K, V>): bool`
+pub const INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_OOB: &str = "map_spec_aborts_iter_oob";
+
+/// Abort condition for map_iter_prev: true when the iterator is at begin (smallest key,
+/// or End-on-empty-map) or its cached key is no longer in the map.
+/// `[spec] fun map_spec_aborts_iter_prev<K, V>(it: IteratorPtr<K>, m: Map<K, V>): bool`
+pub const INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_PREV: &str = "map_spec_aborts_iter_prev";
+
+/// Abort condition for map_iter_remove: true when the wrapped iterator is End or its
+/// cached key is no longer in the map.
+/// `[spec] fun map_spec_aborts_iter_remove<K, V>(self: IteratorPtrWithPath<K>, m: Map<K, V>): bool`
+pub const INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_REMOVE: &str = "map_spec_aborts_iter_remove";
 
 /// Definition of an intrinsic function associated with an intrinsic type.
 ///
@@ -326,12 +493,17 @@ pub static INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS: Lazy<BTreeMap<&'static str, Intri
                 INTRINSIC_FUN_MAP_BORROW_WITH_DEFAULT,
                 IntrinsicFunDef::move_fun(Some(INTRINSIC_FUN_MAP_SPEC_GET), None),
             ),
+            (INTRINSIC_FUN_MAP_GET, IntrinsicFunDef::move_fun(None, None)),
             (
                 INTRINSIC_FUN_MAP_NEW_FROM,
                 IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_FROM)),
             ),
             (
                 INTRINSIC_FUN_MAP_TO_VEC_PAIR,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_UPSERT,
                 IntrinsicFunDef::move_fun(None, None),
             ),
             (
@@ -344,6 +516,112 @@ pub static INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS: Lazy<BTreeMap<&'static str, Intri
             ),
             (
                 INTRINSIC_FUN_MAP_VALUES,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_FRONT_KEY,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_BACK_KEY,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_BORROW_FRONT,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_BORROW_BACK,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_POP_FRONT,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_POP_BACK,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_PREV_KEY,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_NEXT_KEY,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_REMOVE_OR_NONE,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_NEW_BEGIN,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_NEW_END,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_IS_END,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_IS_BEGIN,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_BORROW_KEY,
+                IntrinsicFunDef::move_fun(
+                    None,
+                    Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_KEY),
+                ),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_BORROW,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_OOB)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_NEXT,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_OOB)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_PREV,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_PREV)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_INTERNAL_FIND,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_INTERNAL_LOWER_BOUND,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_INTERNAL_FIND_WITH_PATH,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_WITH_PATH_GET_ITER,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_ITER_REMOVE,
+                IntrinsicFunDef::move_fun(None, Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_REMOVE)),
+            ),
+            (
+                INTRINSIC_FUN_MAP_NEW_WITH_CONFIG,
+                IntrinsicFunDef::move_fun(
+                    None,
+                    Some(INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_WITH_CONFIG),
+                ),
+            ),
+            (
+                INTRINSIC_FUN_MAP_NEW_WITH_REUSABLE,
+                IntrinsicFunDef::move_fun(None, None),
+            ),
+            (
+                INTRINSIC_FUN_MAP_NEW_WITH_TYPE_SIZE_HINTS,
                 IntrinsicFunDef::move_fun(None, None),
             ),
             (
@@ -364,6 +642,30 @@ pub static INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS: Lazy<BTreeMap<&'static str, Intri
             ),
             (
                 INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_FROM,
+                IntrinsicFunDef::spec_fun(),
+            ),
+            (
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_WITH_CONFIG,
+                IntrinsicFunDef::spec_fun(),
+            ),
+            (
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP,
+                IntrinsicFunDef::spec_fun(),
+            ),
+            (
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_KEY,
+                IntrinsicFunDef::spec_fun(),
+            ),
+            (
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_OOB,
+                IntrinsicFunDef::spec_fun(),
+            ),
+            (
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_PREV,
+                IntrinsicFunDef::spec_fun(),
+            ),
+            (
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_REMOVE,
                 IntrinsicFunDef::spec_fun(),
             ),
         ])

--- a/third_party/move/move-prover/boogie-backend/src/lib.rs
+++ b/third_party/move/move-prover/boogie-backend/src/lib.rs
@@ -20,18 +20,33 @@ use move_model::{
     model::{GlobalEnv, QualifiedId, StructId},
     pragmas::{
         INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE, INTRINSIC_FUN_MAP_ADD_OVERRIDE_IF_EXISTS,
-        INTRINSIC_FUN_MAP_BORROW, INTRINSIC_FUN_MAP_BORROW_MUT,
+        INTRINSIC_FUN_MAP_BACK_KEY, INTRINSIC_FUN_MAP_BORROW, INTRINSIC_FUN_MAP_BORROW_BACK,
+        INTRINSIC_FUN_MAP_BORROW_FRONT, INTRINSIC_FUN_MAP_BORROW_MUT,
         INTRINSIC_FUN_MAP_BORROW_MUT_WITH_DEFAULT, INTRINSIC_FUN_MAP_BORROW_WITH_DEFAULT,
         INTRINSIC_FUN_MAP_DEL_MUST_EXIST, INTRINSIC_FUN_MAP_DEL_RETURN_KEY,
-        INTRINSIC_FUN_MAP_DESTROY_EMPTY, INTRINSIC_FUN_MAP_HAS_KEY, INTRINSIC_FUN_MAP_IS_EMPTY,
+        INTRINSIC_FUN_MAP_DESTROY_EMPTY, INTRINSIC_FUN_MAP_FRONT_KEY, INTRINSIC_FUN_MAP_GET,
+        INTRINSIC_FUN_MAP_HAS_KEY, INTRINSIC_FUN_MAP_INTERNAL_FIND,
+        INTRINSIC_FUN_MAP_INTERNAL_FIND_WITH_PATH, INTRINSIC_FUN_MAP_INTERNAL_LOWER_BOUND,
+        INTRINSIC_FUN_MAP_IS_EMPTY, INTRINSIC_FUN_MAP_ITER_BORROW,
+        INTRINSIC_FUN_MAP_ITER_BORROW_KEY, INTRINSIC_FUN_MAP_ITER_IS_BEGIN,
+        INTRINSIC_FUN_MAP_ITER_IS_END, INTRINSIC_FUN_MAP_ITER_NEW_BEGIN,
+        INTRINSIC_FUN_MAP_ITER_NEW_END, INTRINSIC_FUN_MAP_ITER_NEXT, INTRINSIC_FUN_MAP_ITER_PREV,
+        INTRINSIC_FUN_MAP_ITER_REMOVE, INTRINSIC_FUN_MAP_ITER_WITH_PATH_GET_ITER,
         INTRINSIC_FUN_MAP_KEYS, INTRINSIC_FUN_MAP_LEN, INTRINSIC_FUN_MAP_NEW,
-        INTRINSIC_FUN_MAP_NEW_FROM, INTRINSIC_FUN_MAP_SPEC_ABORTS_ADD,
-        INTRINSIC_FUN_MAP_SPEC_ABORTS_BORROW, INTRINSIC_FUN_MAP_SPEC_ABORTS_DEL,
-        INTRINSIC_FUN_MAP_SPEC_ABORTS_DESTROY_EMPTY, INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_FROM,
-        INTRINSIC_FUN_MAP_SPEC_DEL, INTRINSIC_FUN_MAP_SPEC_GET, INTRINSIC_FUN_MAP_SPEC_HAS_KEY,
+        INTRINSIC_FUN_MAP_NEW_FROM, INTRINSIC_FUN_MAP_NEW_WITH_CONFIG,
+        INTRINSIC_FUN_MAP_NEW_WITH_REUSABLE, INTRINSIC_FUN_MAP_NEW_WITH_TYPE_SIZE_HINTS,
+        INTRINSIC_FUN_MAP_NEXT_KEY, INTRINSIC_FUN_MAP_POP_BACK, INTRINSIC_FUN_MAP_POP_FRONT,
+        INTRINSIC_FUN_MAP_PREV_KEY, INTRINSIC_FUN_MAP_REMOVE_OR_NONE,
+        INTRINSIC_FUN_MAP_SPEC_ABORTS_ADD, INTRINSIC_FUN_MAP_SPEC_ABORTS_BORROW,
+        INTRINSIC_FUN_MAP_SPEC_ABORTS_DEL, INTRINSIC_FUN_MAP_SPEC_ABORTS_DESTROY_EMPTY,
+        INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_KEY,
+        INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_OOB, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_PREV,
+        INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_REMOVE, INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_FROM,
+        INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_WITH_CONFIG, INTRINSIC_FUN_MAP_SPEC_DEL,
+        INTRINSIC_FUN_MAP_SPEC_GET, INTRINSIC_FUN_MAP_SPEC_HAS_KEY,
         INTRINSIC_FUN_MAP_SPEC_IS_EMPTY, INTRINSIC_FUN_MAP_SPEC_LEN, INTRINSIC_FUN_MAP_SPEC_NEW,
-        INTRINSIC_FUN_MAP_SPEC_SET, INTRINSIC_FUN_MAP_TO_VEC_PAIR, INTRINSIC_FUN_MAP_UPSERT_KV,
-        INTRINSIC_FUN_MAP_VALUES,
+        INTRINSIC_FUN_MAP_SPEC_SET, INTRINSIC_FUN_MAP_TO_VEC_PAIR, INTRINSIC_FUN_MAP_UPSERT,
+        INTRINSIC_FUN_MAP_UPSERT_KV, INTRINSIC_FUN_MAP_VALUES,
     },
     ty::{PrimitiveType, Type},
 };
@@ -114,11 +129,49 @@ struct MapImpl {
     fun_borrow_mut: String,
     fun_borrow_mut_with_default: String,
     fun_borrow_with_default: String,
+    fun_get: String,
     fun_new_from: String,
     fun_to_vec_pair: String,
+    fun_upsert: String,
     fun_upsert_kv: String,
     fun_keys: String,
     fun_values: String,
+    fun_front_key: String,
+    fun_back_key: String,
+    fun_borrow_front: String,
+    fun_borrow_back: String,
+    fun_pop_front: String,
+    fun_pop_back: String,
+    fun_prev_key: String,
+    fun_next_key: String,
+    fun_remove_or_none: String,
+    // iterator API
+    fun_iter_new_begin: String,
+    fun_iter_new_end: String,
+    fun_iter_is_end: String,
+    fun_iter_is_begin: String,
+    fun_iter_borrow_key: String,
+    fun_iter_borrow: String,
+    fun_iter_next: String,
+    fun_iter_prev: String,
+    fun_internal_find: String,
+    fun_internal_lower_bound: String,
+    fun_internal_find_with_path: String,
+    fun_iter_with_path_get_iter: String,
+    fun_iter_remove: String,
+    fun_new_with_config: String,
+    fun_new_with_reusable: String,
+    fun_new_with_type_size_hints: String,
+    /// Boogie name prefix for the map's iterator struct, looked up by the bare name
+    /// `IteratorPtr` in the map struct's own module. Empty when the module declares no
+    /// such struct (in which case the iter-* templates are skipped). The full Boogie
+    /// type name for a given K is `<iter_type_prefix>'<K_suffix>'`.
+    iter_type_prefix: String,
+    /// Boogie name prefix for the map's iterator-with-path struct, looked up by the bare
+    /// name `IteratorPtrWithPath` in the map struct's own module. Empty when the module
+    /// declares no such struct. Used by `internal_find_with_path`, `iter_with_path_get_iter`,
+    /// and `iter_remove` templates.
+    iter_with_path_type_prefix: String,
     // spec functions
     fun_spec_new: String,
     fun_spec_get: String,
@@ -133,6 +186,12 @@ struct MapImpl {
     fun_spec_aborts_del: String,
     fun_spec_aborts_borrow: String,
     fun_spec_aborts_new_from: String,
+    fun_spec_aborts_new_with_config: String,
+    fun_spec_aborts_empty_map: String,
+    fun_spec_aborts_iter_borrow_key: String,
+    fun_spec_aborts_iter_oob: String,
+    fun_spec_aborts_iter_prev: String,
+    fun_spec_aborts_iter_remove: String,
 }
 
 /// Help generating vector functions for bv types
@@ -515,6 +574,35 @@ impl MapImpl {
             .get_decl_for_struct(&struct_qid)
             .expect("intrinsic decl");
 
+        // Resolve the iterator type prefix by looking up a struct named `IteratorPtr`
+        // in the map's home module. The iter-* role templates expand this to the
+        // K-specific name `<prefix>'<K_suffix>'`.
+        let iter_struct_sym = env.symbol_pool().make("IteratorPtr");
+        let iter_type_prefix = struct_env
+            .module_env
+            .find_struct(iter_struct_sym)
+            .map(|s| {
+                format!(
+                    "${}_{}",
+                    boogie_module_name(&s.module_env),
+                    s.get_name().display(s.symbol_pool())
+                )
+            })
+            .unwrap_or_default();
+        // Same for the iterator-with-path wrapper struct.
+        let iter_with_path_struct_sym = env.symbol_pool().make("IteratorPtrWithPath");
+        let iter_with_path_type_prefix = struct_env
+            .module_env
+            .find_struct(iter_with_path_struct_sym)
+            .map(|s| {
+                format!(
+                    "${}_{}",
+                    boogie_module_name(&s.module_env),
+                    s.get_name().display(s.symbol_pool())
+                )
+            })
+            .unwrap_or_default();
+
         MapImpl {
             struct_name,
             insts,
@@ -564,6 +652,7 @@ impl MapImpl {
                 env,
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BORROW_WITH_DEFAULT),
             ),
+            fun_get: Self::triple_opt_to_name(env, decl.get_fun_triple(env, INTRINSIC_FUN_MAP_GET)),
             fun_new_from: Self::triple_opt_to_name(
                 env,
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_NEW_FROM),
@@ -571,6 +660,10 @@ impl MapImpl {
             fun_to_vec_pair: Self::triple_opt_to_name(
                 env,
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_TO_VEC_PAIR),
+            ),
+            fun_upsert: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_UPSERT),
             ),
             fun_upsert_kv: Self::triple_opt_to_name(
                 env,
@@ -584,6 +677,108 @@ impl MapImpl {
                 env,
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_VALUES),
             ),
+            fun_front_key: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_FRONT_KEY),
+            ),
+            fun_back_key: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BACK_KEY),
+            ),
+            fun_borrow_front: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BORROW_FRONT),
+            ),
+            fun_borrow_back: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BORROW_BACK),
+            ),
+            fun_pop_front: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_POP_FRONT),
+            ),
+            fun_pop_back: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_POP_BACK),
+            ),
+            fun_prev_key: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_PREV_KEY),
+            ),
+            fun_next_key: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_NEXT_KEY),
+            ),
+            fun_remove_or_none: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_REMOVE_OR_NONE),
+            ),
+            fun_iter_new_begin: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_NEW_BEGIN),
+            ),
+            fun_iter_new_end: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_NEW_END),
+            ),
+            fun_iter_is_end: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_IS_END),
+            ),
+            fun_iter_is_begin: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_IS_BEGIN),
+            ),
+            fun_iter_borrow_key: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_BORROW_KEY),
+            ),
+            fun_iter_borrow: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_BORROW),
+            ),
+            fun_iter_next: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_NEXT),
+            ),
+            fun_iter_prev: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_PREV),
+            ),
+            fun_internal_find: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_INTERNAL_FIND),
+            ),
+            fun_internal_lower_bound: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_INTERNAL_LOWER_BOUND),
+            ),
+            fun_internal_find_with_path: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_INTERNAL_FIND_WITH_PATH),
+            ),
+            fun_iter_with_path_get_iter: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_WITH_PATH_GET_ITER),
+            ),
+            fun_iter_remove: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_REMOVE),
+            ),
+            fun_new_with_config: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_NEW_WITH_CONFIG),
+            ),
+            fun_new_with_reusable: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_NEW_WITH_REUSABLE),
+            ),
+            fun_new_with_type_size_hints: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_NEW_WITH_TYPE_SIZE_HINTS),
+            ),
+            iter_type_prefix,
+            iter_with_path_type_prefix,
             fun_spec_new: Self::triple_opt_to_name(
                 env,
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_NEW),
@@ -631,6 +826,30 @@ impl MapImpl {
             fun_spec_aborts_new_from: Self::triple_opt_to_name(
                 env,
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_FROM),
+            ),
+            fun_spec_aborts_new_with_config: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_WITH_CONFIG),
+            ),
+            fun_spec_aborts_empty_map: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_EMPTY_MAP),
+            ),
+            fun_spec_aborts_iter_borrow_key: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_KEY),
+            ),
+            fun_spec_aborts_iter_oob: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_OOB),
+            ),
+            fun_spec_aborts_iter_prev: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_PREV),
+            ),
+            fun_spec_aborts_iter_remove: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_REMOVE),
             ),
         }
     }

--- a/third_party/move/move-prover/boogie-backend/src/prelude/native.bpl
+++ b/third_party/move/move-prover/boogie-backend/src/prelude/native.bpl
@@ -391,6 +391,10 @@ axiom (
 {%- set SK = "'" ~ instance.0.suffix ~ "'" -%}
 {%- set SV = "'" ~ instance.1.suffix ~ "'" -%}
 {%- set ENC = "$EncodeKey'" ~ instance.0.suffix ~ "'" -%}
+{# Iterator type for this K — empty when the map has no `IteratorPtr` companion. #}
+{%- set IT = impl.iter_type_prefix ~ SK -%}
+{# Iterator-with-path type for this K — empty when no `IteratorPtrWithPath` companion. #}
+{%- set IPWP = impl.iter_with_path_type_prefix ~ SK -%}
 
 {%- if options.native_equality -%}
 function $IsEqual'{{Type}}{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
@@ -413,6 +417,40 @@ function $IsValid'{{Type}}{{S}}'(t: {{Self}}): bool {
 
 {%- if impl.fun_new != "" %}
 procedure {:inline 2} {{impl.fun_new}}{{S}}() returns (v: {{Self}}) {
+    v := EmptyTable();
+}
+{%- endif %}
+
+{%- if impl.fun_new_with_config != "" %}
+// Create an empty map with configured degree limits. Aborts when either degree
+// is non-zero and outside the supported [INNER_MIN_DEGREE=4 | LEAF_MIN_DEGREE=3, MAX_DEGREE=4096]
+// range; `reuse_slots` does not contribute abort conditions at this level.
+procedure {:inline 2} {{impl.fun_new_with_config}}{{S}}(inner_max_degree: int, leaf_max_degree: int, reuse_slots: bool) returns (v: {{Self}}) {
+    if (inner_max_degree != 0 && (inner_max_degree < 4 || inner_max_degree > 4096)) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 11/*EINVALID_CONFIG_PARAMETER*/));
+    } else if (leaf_max_degree != 0 && (leaf_max_degree < 3 || leaf_max_degree > 4096)) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 11/*EINVALID_CONFIG_PARAMETER*/));
+    } else {
+        v := EmptyTable();
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_new_with_reusable != "" %}
+// Create an empty map with the reuse-slots policy enabled. The Move source aborts
+// when K/V are not constant-serialized-size, but that's a BCS-level property not
+// expressible here; we conservatively report aborts_if false to match the existing
+// trusted abstract spec.
+procedure {:inline 2} {{impl.fun_new_with_reusable}}{{S}}() returns (v: {{Self}}) {
+    v := EmptyTable();
+}
+{%- endif %}
+
+{%- if impl.fun_new_with_type_size_hints != "" %}
+// Create an empty map configured against size hints. The Move source asserts
+// avg <= max for both key and value, but the existing trusted abstract spec
+// reports aborts_if false; we match that here.
+procedure {:inline 2} {{impl.fun_new_with_type_size_hints}}{{S}}(avg_key_bytes: int, max_key_bytes: int, avg_value_bytes: int, max_value_bytes: int) returns (v: {{Self}}) {
     v := EmptyTable();
 }
 {%- endif %}
@@ -472,6 +510,14 @@ procedure {:inline 2} {{impl.fun_add_override_if_exists}}{{S}}(m: $Mutation ({{S
 {%- endif %}
 
 {%- if impl.fun_del_must_exist != "" %}
+// Remove the entry at `k`, returning its value. Aborts when `k` is absent. The
+// abort code is the prover-internal `$StdError(7, 101)` (INVALID_ARGUMENTS, ENOT_FOUND);
+// this is an abstract code shared across all maps bound to this intrinsic. The runtime
+// abort code differs per map (e.g. `big_ordered_map::remove` aborts with
+// `error::invalid_argument(EKEY_NOT_FOUND=2)`), so user specs MUST NOT rely on
+// `aborts_with <literal>` to match the runtime constant — use `aborts_if` (boolean)
+// instead. The mismatch is uniform across all map intrinsics (cf. `add_no_override`,
+// iter codes) and reflects the prover's category-only abstraction of abort codes.
 procedure {:inline 2} {{impl.fun_del_must_exist}}{{S}}(m: $Mutation ({{Self}}), k: {{K}})
 returns (v: {{V}}, m': $Mutation({{Self}})) {
     var enc_k: int;
@@ -563,6 +609,17 @@ procedure {:inline 2} {{impl.fun_borrow_with_default}}{{S}}(t: {{Self}}, k: {{K}
 }
 {%- endif %}
 
+{%- if impl.fun_get != "" and not instance.1.is_type_param and not instance.1.is_bv %}
+// Optional lookup: returns Some(v) when k is in the map, None otherwise. Never aborts.
+procedure {:inline 2} {{impl.fun_get}}{{S}}(t: {{Self}}, k: {{K}}) returns (result: $1_option_Option{{SV}}) {
+    if (ContainsTable(t, {{ENC}}(k))) {
+        result := $1_option_Option{{SV}}_Some(GetTable(t, {{ENC}}(k)));
+    } else {
+        result := $1_option_Option{{SV}}_None();
+    }
+}
+{%- endif %}
+
 {%- if impl.fun_to_vec_pair != "" %}
 // Decompose the map into two vectors with parallel positions. Order is unspecified
 // because the underlying SMT-array model has no notion of insertion order.
@@ -607,6 +664,306 @@ procedure {:inline 2} {{impl.fun_values}}{{S}}(t: {{Self}}) returns (vs: Vec ({{
 }
 {%- endif %}
 
+{%- if impl.fun_front_key != "" and not instance.0.is_type_param %}
+// Smallest key in the map under cmp::compare ordering. Aborts on an empty map. The
+// result is a key in the map, and every other key compares Greater.
+procedure {:inline 2} {{impl.fun_front_key}}{{S}}(t: {{Self}}) returns (k: {{K}}) {
+    if (LenTable(t) == 0) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 3/*EITER_OUT_OF_BOUNDS*/));
+    } else {
+        assume ContainsTable(t, {{ENC}}(k));
+        assume (forall k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(k) ==>
+            $1_cmp_$compare{{SK}}(k, k0) == $1_cmp_Ordering_Less());
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_back_key != "" and not instance.0.is_type_param %}
+// Largest key in the map under cmp::compare ordering. Aborts on an empty map.
+procedure {:inline 2} {{impl.fun_back_key}}{{S}}(t: {{Self}}) returns (k: {{K}}) {
+    if (LenTable(t) == 0) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 3/*EITER_OUT_OF_BOUNDS*/));
+    } else {
+        assume ContainsTable(t, {{ENC}}(k));
+        assume (forall k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(k) ==>
+            $1_cmp_$compare{{SK}}(k, k0) == $1_cmp_Ordering_Greater());
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_borrow_front != "" and not instance.0.is_type_param %}
+// Smallest key in the map together with its value. Aborts on an empty map. The
+// Move return type is `(K, &V)`; at the intrinsic boundary the reference is stripped
+// (same convention as `map_borrow`).
+procedure {:inline 2} {{impl.fun_borrow_front}}{{S}}(t: {{Self}}) returns (k: {{K}}, v: {{V}}) {
+    if (LenTable(t) == 0) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 3/*EITER_OUT_OF_BOUNDS*/));
+    } else {
+        assume ContainsTable(t, {{ENC}}(k));
+        assume (forall k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(k) ==>
+            $1_cmp_$compare{{SK}}(k, k0) == $1_cmp_Ordering_Less());
+        v := GetTable(t, {{ENC}}(k));
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_borrow_back != "" and not instance.0.is_type_param %}
+// Largest key in the map together with its value. Aborts on an empty map.
+procedure {:inline 2} {{impl.fun_borrow_back}}{{S}}(t: {{Self}}) returns (k: {{K}}, v: {{V}}) {
+    if (LenTable(t) == 0) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 3/*EITER_OUT_OF_BOUNDS*/));
+    } else {
+        assume ContainsTable(t, {{ENC}}(k));
+        assume (forall k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(k) ==>
+            $1_cmp_$compare{{SK}}(k, k0) == $1_cmp_Ordering_Greater());
+        v := GetTable(t, {{ENC}}(k));
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_pop_front != "" and not instance.0.is_type_param %}
+// Remove and return the smallest entry under cmp::compare. Aborts on an empty map.
+procedure {:inline 2} {{impl.fun_pop_front}}{{S}}(m: $Mutation ({{Self}}))
+returns (k: {{K}}, v: {{V}}, m': $Mutation ({{Self}})) {
+    var t: {{Self}};
+    t := $Dereference(m);
+    if (LenTable(t) == 0) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 3/*EITER_OUT_OF_BOUNDS*/));
+    } else {
+        assume ContainsTable(t, {{ENC}}(k));
+        assume (forall k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(k) ==>
+            $1_cmp_$compare{{SK}}(k, k0) == $1_cmp_Ordering_Less());
+        v := GetTable(t, {{ENC}}(k));
+        m' := $UpdateMutation(m, RemoveTable(t, {{ENC}}(k)));
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_pop_back != "" and not instance.0.is_type_param %}
+// Remove and return the largest entry under cmp::compare. Aborts on an empty map.
+procedure {:inline 2} {{impl.fun_pop_back}}{{S}}(m: $Mutation ({{Self}}))
+returns (k: {{K}}, v: {{V}}, m': $Mutation ({{Self}})) {
+    var t: {{Self}};
+    t := $Dereference(m);
+    if (LenTable(t) == 0) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 3/*EITER_OUT_OF_BOUNDS*/));
+    } else {
+        assume ContainsTable(t, {{ENC}}(k));
+        assume (forall k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(k) ==>
+            $1_cmp_$compare{{SK}}(k, k0) == $1_cmp_Ordering_Greater());
+        v := GetTable(t, {{ENC}}(k));
+        m' := $UpdateMutation(m, RemoveTable(t, {{ENC}}(k)));
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_prev_key != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// Largest key strictly less than `key` under cmp::compare. Returns Some when one
+// exists, None otherwise. Never aborts.
+procedure {:inline 2} {{impl.fun_prev_key}}{{S}}(t: {{Self}}, key: {{K}})
+returns (result: $1_option_Option{{SK}}) {
+    var has_prev: bool;
+    var prev_k: {{K}};
+    has_prev := (exists k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) &&
+        $1_cmp_$compare{{SK}}(k0, key) == $1_cmp_Ordering_Less());
+    if (!has_prev) {
+        result := $1_option_Option{{SK}}_None();
+    } else {
+        assume ContainsTable(t, {{ENC}}(prev_k));
+        assume $1_cmp_$compare{{SK}}(prev_k, key) == $1_cmp_Ordering_Less();
+        assume (forall k0: {{K}} ::
+            ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(prev_k) &&
+            $1_cmp_$compare{{SK}}(k0, key) == $1_cmp_Ordering_Less() ==>
+            $1_cmp_$compare{{SK}}(prev_k, k0) == $1_cmp_Ordering_Greater());
+        result := $1_option_Option{{SK}}_Some(prev_k);
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_next_key != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// Smallest key strictly greater than `key` under cmp::compare. Returns Some when one
+// exists, None otherwise. Never aborts.
+procedure {:inline 2} {{impl.fun_next_key}}{{S}}(t: {{Self}}, key: {{K}})
+returns (result: $1_option_Option{{SK}}) {
+    var has_next: bool;
+    var next_k: {{K}};
+    has_next := (exists k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) &&
+        $1_cmp_$compare{{SK}}(k0, key) == $1_cmp_Ordering_Greater());
+    if (!has_next) {
+        result := $1_option_Option{{SK}}_None();
+    } else {
+        assume ContainsTable(t, {{ENC}}(next_k));
+        assume $1_cmp_$compare{{SK}}(next_k, key) == $1_cmp_Ordering_Greater();
+        assume (forall k0: {{K}} ::
+            ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(next_k) &&
+            $1_cmp_$compare{{SK}}(k0, key) == $1_cmp_Ordering_Greater() ==>
+            $1_cmp_$compare{{SK}}(next_k, k0) == $1_cmp_Ordering_Less());
+        result := $1_option_Option{{SK}}_Some(next_k);
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_remove_or_none != "" and not instance.1.is_type_param and not instance.1.is_bv %}
+// Remove the entry at `key` if present. Returns Some(prev_value) on hit, None on miss.
+// Never aborts.
+procedure {:inline 2} {{impl.fun_remove_or_none}}{{S}}(m: $Mutation ({{Self}}), key: {{K}})
+returns (result: $1_option_Option{{SV}}, m': $Mutation ({{Self}})) {
+    var enc_k: int;
+    var t: {{Self}};
+    enc_k := {{ENC}}(key);
+    t := $Dereference(m);
+    if (ContainsTable(t, enc_k)) {
+        result := $1_option_Option{{SV}}_Some(GetTable(t, enc_k));
+        m' := $UpdateMutation(m, RemoveTable(t, enc_k));
+    } else {
+        result := $1_option_Option{{SV}}_None();
+        m' := m;
+    }
+}
+{%- endif %}
+
+{# ====== Iterator API. ====== #}
+{# These blocks only render when the map type has a companion IteratorPtr struct       #}
+{# (resolved into `iter_type_prefix`) and the instance is concrete. The Some constructor #}
+{# may carry implementation fields beyond the key (e.g. BigOrderedMap's node_index +    #}
+{# child_iter); we never read them in spec, so we havoc a local of the iter type and  #}
+{# constrain only its variant + key. The other fields stay unconstrained.              #}
+{# Staleness: only "cached key was removed" is modeled. A stale cached position whose  #}
+{# key still happens to exist after a rebalance is NOT caught.                         #}
+{# TODO: model node_index/child_iter explicitly to close this gap.                     #}
+
+{%- if impl.fun_iter_new_begin != "" and impl.iter_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// Iterator at the smallest key, or End on an empty map. Never aborts.
+procedure {:inline 2} {{impl.fun_iter_new_begin}}{{S}}(t: {{Self}}) returns (result: {{IT}}) {
+    var some_it: {{IT}};
+    var k_min: {{K}};
+    if (LenTable(t) == 0) {
+        result := {{IT}}_End();
+    } else {
+        assume ContainsTable(t, {{ENC}}(k_min));
+        assume (forall k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(k_min) ==>
+            $1_cmp_$compare{{SK}}(k_min, k0) == $1_cmp_Ordering_Less());
+        assume some_it is {{IT}}_Some;
+        assume some_it->$key_Some == k_min;
+        result := some_it;
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_iter_new_end != "" and impl.iter_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// End-sentinel iterator. Never aborts.
+procedure {:inline 2} {{impl.fun_iter_new_end}}{{S}}(t: {{Self}}) returns (result: {{IT}}) {
+    result := {{IT}}_End();
+}
+{%- endif %}
+
+{%- if impl.fun_iter_is_end != "" and impl.iter_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// True iff the iterator is the End sentinel. Never aborts.
+procedure {:inline 2} {{impl.fun_iter_is_end}}{{S}}(it: {{IT}}, t: {{Self}}) returns (r: bool) {
+    r := it is {{IT}}_End;
+}
+{%- endif %}
+
+{%- if impl.fun_iter_is_begin != "" and impl.iter_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// True iff the iterator points to the begin position: either at the smallest key, or
+// is the End sentinel on an empty map. Never aborts.
+procedure {:inline 2} {{impl.fun_iter_is_begin}}{{S}}(it: {{IT}}, t: {{Self}}) returns (r: bool) {
+    if (it is {{IT}}_End) {
+        r := LenTable(t) == 0;
+    } else {
+        r := ContainsTable(t, {{ENC}}(it->$key_Some))
+            && (forall k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(it->$key_Some) ==>
+                $1_cmp_$compare{{SK}}(it->$key_Some, k0) == $1_cmp_Ordering_Less());
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_iter_borrow_key != "" and impl.iter_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// Read the iterator's key. Aborts when at End.
+procedure {:inline 2} {{impl.fun_iter_borrow_key}}{{S}}(it: {{IT}}) returns (k: {{K}}) {
+    if (it is {{IT}}_End) {
+        call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 3/*EITER_OUT_OF_BOUNDS*/));
+    } else {
+        k := it->$key_Some;
+    }
+}
+{%- endif %}
+
+{# iter_borrow / iter_next / iter_prev templates intentionally omitted: sound modeling   #}
+{# requires tracking node_index/child_iter alongside the cached key. Maps binding these  #}
+{# roles must either provide a custom opaque spec or wait for that modeling to land.     #}
+
+{%- if impl.fun_internal_find != "" and impl.iter_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// Iterator at the given key if present, end-sentinel otherwise. Never aborts.
+procedure {:inline 2} {{impl.fun_internal_find}}{{S}}(t: {{Self}}, key: {{K}}) returns (result: {{IT}}) {
+    var some_it: {{IT}};
+    if (ContainsTable(t, {{ENC}}(key))) {
+        assume some_it is {{IT}}_Some;
+        assume some_it->$key_Some == key;
+        result := some_it;
+    } else {
+        result := {{IT}}_End();
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_internal_lower_bound != "" and impl.iter_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// Iterator at the smallest key K >= input under cmp::compare. End if no such key
+// exists (every key in the map is strictly less than `key`). Never aborts.
+procedure {:inline 2} {{impl.fun_internal_lower_bound}}{{S}}(t: {{Self}}, key: {{K}}) returns (result: {{IT}}) {
+    var has_ge: bool;
+    var lb_k: {{K}};
+    var some_it: {{IT}};
+    has_ge := (exists k0: {{K}} :: ContainsTable(t, {{ENC}}(k0)) &&
+        $1_cmp_$compare{{SK}}(k0, key) != $1_cmp_Ordering_Less());
+    if (!has_ge) {
+        result := {{IT}}_End();
+    } else {
+        assume ContainsTable(t, {{ENC}}(lb_k));
+        assume $1_cmp_$compare{{SK}}(lb_k, key) != $1_cmp_Ordering_Less();
+        assume (forall k0: {{K}} ::
+            ContainsTable(t, {{ENC}}(k0)) && {{ENC}}(k0) != {{ENC}}(lb_k) &&
+            $1_cmp_$compare{{SK}}(k0, key) != $1_cmp_Ordering_Less() ==>
+            $1_cmp_$compare{{SK}}(lb_k, k0) != $1_cmp_Ordering_Greater());
+        assume some_it is {{IT}}_Some;
+        assume some_it->$key_Some == lb_k;
+        result := some_it;
+    }
+}
+{%- endif %}
+
+{# ====== IteratorPtrWithPath API. ====== #}
+{# IteratorPtrWithPath<K> is a single-constructor struct wrapping an IteratorPtr<K> and #}
+{# an implementation-only `path: vector<u64>`. The `$path` field is never read in spec, #}
+{# so we havoc a local of the IPWP type and constrain only the `$iterator` field. #}
+
+{%- if impl.fun_internal_find_with_path != "" and impl.iter_type_prefix != "" and impl.iter_with_path_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// Iterator-with-path at the given key if present, end-sentinel otherwise. Never aborts.
+procedure {:inline 2} {{impl.fun_internal_find_with_path}}{{S}}(t: {{Self}}, key: {{K}}) returns (result: {{IPWP}}) {
+    var iter: {{IT}};
+    var some_it: {{IT}};
+    var ipwp: {{IPWP}};
+    if (ContainsTable(t, {{ENC}}(key))) {
+        assume some_it is {{IT}}_Some;
+        assume some_it->$key_Some == key;
+        iter := some_it;
+    } else {
+        iter := {{IT}}_End();
+    }
+    assume ipwp->$iterator == iter;
+    result := ipwp;
+}
+{%- endif %}
+
+{%- if impl.fun_iter_with_path_get_iter != "" and impl.iter_type_prefix != "" and impl.iter_with_path_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+// Project the wrapped IteratorPtr<K> from an IteratorPtrWithPath<K>. Never aborts.
+procedure {:inline 2} {{impl.fun_iter_with_path_get_iter}}{{S}}(self: {{IPWP}}) returns (result: {{IT}}) {
+    result := self->$iterator;
+}
+{%- endif %}
+
+{# iter_remove template intentionally omitted for the same reason as iter_borrow above. #}
+
 {%- if impl.fun_new_from != "" %}
 // True iff `keys` contains two distinct positions with equal encoded keys.
 function {:inline} {{impl.fun_new_from}}_HasDup{{S}}(keys: Vec ({{K}})): bool {
@@ -632,6 +989,25 @@ procedure {:inline 2} {{impl.fun_new_from}}{{S}}(keys: Vec ({{K}}), values: Vec 
         assume (forall k: {{K}} :: ContainsTable(t, {{ENC}}(k)) <==> $ContainsVec{{SK}}(keys, k));
         assume (forall i: int :: 0 <= i && i < LenVec(keys) ==>
             GetTable(t, {{ENC}}(ReadVec(keys, i))) == ReadVec(values, i));
+    }
+}
+{%- endif %}
+
+{%- if impl.fun_upsert != "" and not instance.0.is_type_param and not instance.1.is_type_param and not instance.1.is_bv %}
+// Insert (k, v) or update v if k already maps. Returns the previous value (if any) wrapped
+// in std::option::Option<V>. Never aborts.
+procedure {:inline 2} {{impl.fun_upsert}}{{S}}(m: $Mutation ({{Self}}), k: {{K}}, v: {{V}})
+returns (prev_v: $1_option_Option{{SV}}, m': $Mutation ({{Self}})) {
+    var enc_k: int;
+    var t: {{Self}};
+    enc_k := {{ENC}}(k);
+    t := $Dereference(m);
+    if (ContainsTable(t, enc_k)) {
+        prev_v := $1_option_Option{{SV}}_Some(GetTable(t, enc_k));
+        m' := $UpdateMutation(m, UpdateTable(t, enc_k, v));
+    } else {
+        prev_v := $1_option_Option{{SV}}_None();
+        m' := $UpdateMutation(m, AddTable(t, enc_k, v));
     }
 }
 {%- endif %}
@@ -728,6 +1104,9 @@ function {:inline} {{impl.fun_spec_aborts_borrow}}{{S}}(t: {{Self}}, k: {{K}}): 
 }
 {%- endif %}
 
+{# Abort guards for the templates added in the iter / order-key / new_from / config family. #}
+{# Each body must match the corresponding procedure's abort guard exactly.                  #}
+
 {%- if impl.fun_spec_aborts_new_from != "" %}
 function {:inline} {{impl.fun_spec_aborts_new_from}}{{S}}(keys: Vec ({{K}}), values: Vec ({{V}})): bool {
     LenVec(keys) != LenVec(values) ||
@@ -736,6 +1115,28 @@ function {:inline} {{impl.fun_spec_aborts_new_from}}{{S}}(keys: Vec ({{K}}), val
         {{ENC}}(ReadVec(keys, i)) == {{ENC}}(ReadVec(keys, j)))
 }
 {%- endif %}
+
+{%- if impl.fun_spec_aborts_new_with_config != "" %}
+function {:inline} {{impl.fun_spec_aborts_new_with_config}}{{S}}(inner_max_degree: int, leaf_max_degree: int, reuse_slots: bool): bool {
+    (inner_max_degree != 0 && (inner_max_degree < 4 || inner_max_degree > 4096)) ||
+    (leaf_max_degree != 0 && (leaf_max_degree < 3 || leaf_max_degree > 4096))
+}
+{%- endif %}
+
+{%- if impl.fun_spec_aborts_empty_map != "" %}
+function {:inline} {{impl.fun_spec_aborts_empty_map}}{{S}}(t: {{Self}}): bool {
+    LenTable(t) == 0
+}
+{%- endif %}
+
+{%- if impl.fun_spec_aborts_iter_borrow_key != "" and impl.iter_type_prefix != "" and not instance.0.is_type_param and not instance.0.is_bv %}
+function {:inline} {{impl.fun_spec_aborts_iter_borrow_key}}{{S}}(it: {{IT}}): bool {
+    it is {{IT}}_End
+}
+{%- endif %}
+
+{# Abort-spec inlines for iter_oob / iter_prev / iter_remove intentionally omitted,    #}
+{# matching the omitted procedure templates above.                                      #}
 
 {% endmacro table_module %}
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -18,8 +18,18 @@ use move_model::{
         SpecVarId, StructEnv, StructId,
     },
     pragmas::{
-        INTRINSIC_FUN_MAP_KEYS, INTRINSIC_FUN_MAP_NEW_FROM, INTRINSIC_FUN_MAP_TO_VEC_PAIR,
-        INTRINSIC_FUN_MAP_UPSERT_KV, INTRINSIC_FUN_MAP_VALUES, INTRINSIC_TYPE_MAP,
+        INTRINSIC_FUN_MAP_BACK_KEY, INTRINSIC_FUN_MAP_BORROW_BACK, INTRINSIC_FUN_MAP_BORROW_FRONT,
+        INTRINSIC_FUN_MAP_FRONT_KEY, INTRINSIC_FUN_MAP_GET, INTRINSIC_FUN_MAP_INTERNAL_FIND,
+        INTRINSIC_FUN_MAP_INTERNAL_FIND_WITH_PATH, INTRINSIC_FUN_MAP_INTERNAL_LOWER_BOUND,
+        INTRINSIC_FUN_MAP_ITER_BORROW, INTRINSIC_FUN_MAP_ITER_BORROW_KEY,
+        INTRINSIC_FUN_MAP_ITER_IS_BEGIN, INTRINSIC_FUN_MAP_ITER_IS_END,
+        INTRINSIC_FUN_MAP_ITER_NEW_BEGIN, INTRINSIC_FUN_MAP_ITER_NEW_END,
+        INTRINSIC_FUN_MAP_ITER_NEXT, INTRINSIC_FUN_MAP_ITER_PREV, INTRINSIC_FUN_MAP_ITER_REMOVE,
+        INTRINSIC_FUN_MAP_ITER_WITH_PATH_GET_ITER, INTRINSIC_FUN_MAP_KEYS,
+        INTRINSIC_FUN_MAP_NEW_FROM, INTRINSIC_FUN_MAP_NEXT_KEY, INTRINSIC_FUN_MAP_POP_BACK,
+        INTRINSIC_FUN_MAP_POP_FRONT, INTRINSIC_FUN_MAP_PREV_KEY, INTRINSIC_FUN_MAP_REMOVE_OR_NONE,
+        INTRINSIC_FUN_MAP_TO_VEC_PAIR, INTRINSIC_FUN_MAP_UPSERT, INTRINSIC_FUN_MAP_UPSERT_KV,
+        INTRINSIC_FUN_MAP_VALUES, INTRINSIC_TYPE_MAP,
     },
     symbol::Symbol,
     ty::{NoUnificationContext, Type, TypeDisplayContext, Variance},
@@ -279,26 +289,94 @@ fn find_option_struct(env: &GlobalEnv) -> Option<QualifiedId<StructId>> {
     None
 }
 
+/// Locate the `0x1::cmp` module. Returns `None` when the module is not in the model. Pinned
+/// to address `0x1` for the same reason as `find_option_struct`: the backend uses
+/// `$1_cmp_$compare*` Boogie symbols.
+fn find_cmp_module(env: &GlobalEnv) -> Option<ModuleId> {
+    let cmp_sym = env.symbol_pool().make("cmp");
+    let std_addr = Address::Numerical(AccountAddress::ONE);
+    for module in env.get_modules() {
+        let name = module.get_name();
+        if name.addr() == &std_addr && name.name() == cmp_sym {
+            return Some(module.get_id());
+        }
+    }
+    None
+}
+
 impl Analyzer<'_> {
     /// Register type instantiations that intrinsic role bodies depend on but no Move source
-    /// references directly:
+    /// references directly. This covers two cases:
     ///
-    /// 1. `Option<K>` / `Option<V>` for roles whose Boogie body constructs Option results
-    ///    (currently `map_upsert_kv` returning `(Option<K>, Option<V>)`).
-    /// 2. `Vec<K>` / `Vec<V>` for roles whose Boogie body references the type-aware
-    ///    `$ContainsVec'<X>'` helper (`map_keys`, `map_values`, `map_to_vec_pair`,
-    ///    `map_new_from`).
+    /// 1. `Option<K>` / `Option<V>` for roles whose Boogie body constructs Option results:
+    ///    `map_upsert` (Option<V>), `map_upsert_kv` (Option<K> and Option<V>),
+    ///    `map_prev_key` / `map_next_key` (Option<K>), `map_remove_or_none` (Option<V>).
+    /// 2. `cmp::compare<K>` instances for order-dependent roles whose body uses
+    ///    `$1_cmp_$compare'<K>'`: `map_front_key`, `map_back_key`, `map_pop_front`,
+    ///    `map_pop_back`, `map_prev_key`, `map_next_key`.
     ///
     /// Both concrete and type-parameter args are registered, so callers parameterized
     /// over the map's K/V also get matching companion-type declarations.
     fn register_intrinsic_associated_types(&mut self) {
         let option_qid = find_option_struct(self.env);
+        let cmp_mid = find_cmp_module(self.env);
         let intrinsics = self.env.get_intrinsics();
+        let iter_struct_sym = self.env.symbol_pool().make("IteratorPtr");
 
         // Roles whose Boogie body constructs an `Option<K>` value.
-        let option_k_roles = [INTRINSIC_FUN_MAP_UPSERT_KV];
+        let option_k_roles = [
+            INTRINSIC_FUN_MAP_UPSERT_KV,
+            INTRINSIC_FUN_MAP_PREV_KEY,
+            INTRINSIC_FUN_MAP_NEXT_KEY,
+        ];
         // Roles whose Boogie body constructs an `Option<V>` value.
-        let option_v_roles = [INTRINSIC_FUN_MAP_UPSERT_KV];
+        let option_v_roles = [
+            INTRINSIC_FUN_MAP_UPSERT,
+            INTRINSIC_FUN_MAP_UPSERT_KV,
+            INTRINSIC_FUN_MAP_REMOVE_OR_NONE,
+            INTRINSIC_FUN_MAP_GET,
+        ];
+        // Roles whose Boogie body uses `$1_cmp_$compare'<K>'`.
+        let cmp_k_roles = [
+            INTRINSIC_FUN_MAP_FRONT_KEY,
+            INTRINSIC_FUN_MAP_BACK_KEY,
+            INTRINSIC_FUN_MAP_BORROW_FRONT,
+            INTRINSIC_FUN_MAP_BORROW_BACK,
+            INTRINSIC_FUN_MAP_POP_FRONT,
+            INTRINSIC_FUN_MAP_POP_BACK,
+            INTRINSIC_FUN_MAP_PREV_KEY,
+            INTRINSIC_FUN_MAP_NEXT_KEY,
+            INTRINSIC_FUN_MAP_ITER_NEW_BEGIN,
+            INTRINSIC_FUN_MAP_ITER_IS_BEGIN,
+            INTRINSIC_FUN_MAP_ITER_NEXT,
+            INTRINSIC_FUN_MAP_ITER_PREV,
+            INTRINSIC_FUN_MAP_INTERNAL_LOWER_BOUND,
+        ];
+        // Roles whose Boogie body references the map's companion `IteratorPtr<K>` type.
+        let iter_roles = [
+            INTRINSIC_FUN_MAP_ITER_NEW_BEGIN,
+            INTRINSIC_FUN_MAP_ITER_NEW_END,
+            INTRINSIC_FUN_MAP_ITER_IS_END,
+            INTRINSIC_FUN_MAP_ITER_IS_BEGIN,
+            INTRINSIC_FUN_MAP_ITER_BORROW_KEY,
+            INTRINSIC_FUN_MAP_ITER_BORROW,
+            INTRINSIC_FUN_MAP_ITER_NEXT,
+            INTRINSIC_FUN_MAP_ITER_PREV,
+            INTRINSIC_FUN_MAP_INTERNAL_FIND,
+            INTRINSIC_FUN_MAP_INTERNAL_LOWER_BOUND,
+            // The IPWP family wraps an IteratorPtr<K>, so the iter type is also needed.
+            INTRINSIC_FUN_MAP_INTERNAL_FIND_WITH_PATH,
+            INTRINSIC_FUN_MAP_ITER_WITH_PATH_GET_ITER,
+            INTRINSIC_FUN_MAP_ITER_REMOVE,
+        ];
+        // Roles whose Boogie body references the map's companion `IteratorPtrWithPath<K>`
+        // type. The companion-of-companion is resolved by name lookup in the map's home
+        // module, parallel to the iter lookup.
+        let iter_with_path_roles = [
+            INTRINSIC_FUN_MAP_INTERNAL_FIND_WITH_PATH,
+            INTRINSIC_FUN_MAP_ITER_WITH_PATH_GET_ITER,
+            INTRINSIC_FUN_MAP_ITER_REMOVE,
+        ];
         // Roles whose Boogie body references the type-aware `$ContainsVec'<K>'` (a
         // per-vec-instance helper that uses `$IsEqual` instead of raw `==`). For each
         // such role we must register `Vec<K>` so the backend emits `$ContainsVec'<K>'`.
@@ -309,8 +387,16 @@ impl Analyzer<'_> {
             INTRINSIC_FUN_MAP_NEW_FROM,
         ];
 
-        // Collect first to avoid borrow conflicts with self.add_type below.
+        let iter_with_path_struct_sym = self.env.symbol_pool().make("IteratorPtrWithPath");
+
+        // Collect first to avoid borrow conflicts with self.add_type / native_inst below.
         let mut option_to_register: Vec<Type> = vec![];
+        let mut cmp_to_register: Vec<Type> = vec![];
+        // Pairs of (IteratorPtr struct qid, K) to register as struct instantiations so
+        // the backend emits their datatype declarations.
+        let mut iter_to_register: Vec<(QualifiedId<StructId>, Type)> = vec![];
+        // Pairs of (IteratorPtrWithPath struct qid, K) for the IPWP family.
+        let mut iter_with_path_to_register: Vec<(QualifiedId<StructId>, Type)> = vec![];
         for (struct_qid, ty_args) in self.info.table_inst.iter() {
             let Some(decl) = intrinsics.get_decl_for_struct(struct_qid) else {
                 continue;
@@ -321,18 +407,55 @@ impl Analyzer<'_> {
             let needs_option_v = option_v_roles
                 .iter()
                 .any(|name| decl.get_fun_triple(self.env, name).is_some());
+            let needs_cmp_k = cmp_k_roles
+                .iter()
+                .any(|name| decl.get_fun_triple(self.env, name).is_some());
+            let needs_iter = iter_roles
+                .iter()
+                .any(|name| decl.get_fun_triple(self.env, name).is_some());
+            let needs_iter_with_path = iter_with_path_roles
+                .iter()
+                .any(|name| decl.get_fun_triple(self.env, name).is_some());
             let needs_vec_k = vec_k_roles
                 .iter()
                 .any(|name| decl.get_fun_triple(self.env, name).is_some());
-            if !needs_option_k && !needs_option_v && !needs_vec_k {
+            if !needs_option_k && !needs_option_v && !needs_cmp_k && !needs_iter && !needs_vec_k {
                 continue;
             }
+            // Look up the IteratorPtr struct in the map's home module so iter templates
+            // can reference it. Only meaningful when iter roles are bound.
+            let iter_qid = if needs_iter {
+                self.env
+                    .get_module(struct_qid.module_id)
+                    .find_struct(iter_struct_sym)
+                    .map(|s| struct_qid.module_id.qualified(s.get_id()))
+            } else {
+                None
+            };
+            // Look up IteratorPtrWithPath similarly for the IPWP family.
+            let iter_with_path_qid = if needs_iter_with_path {
+                self.env
+                    .get_module(struct_qid.module_id)
+                    .find_struct(iter_with_path_struct_sym)
+                    .map(|s| struct_qid.module_id.qualified(s.get_id()))
+            } else {
+                None
+            };
             for (k, v) in ty_args.iter() {
                 if needs_option_k {
                     option_to_register.push(k.clone());
                 }
                 if needs_option_v {
                     option_to_register.push(v.clone());
+                }
+                if needs_cmp_k {
+                    cmp_to_register.push(k.clone());
+                }
+                if let Some(iter_qid) = iter_qid {
+                    iter_to_register.push((iter_qid, k.clone()));
+                }
+                if let Some(iter_with_path_qid) = iter_with_path_qid {
+                    iter_with_path_to_register.push((iter_with_path_qid, k.clone()));
                 }
                 if needs_vec_k {
                     // Register Vec<K> / Vec<V> so the prelude emits the per-type
@@ -346,6 +469,28 @@ impl Analyzer<'_> {
             for ty in option_to_register {
                 self.add_type(&Type::Struct(option_qid.module_id, option_qid.id, vec![ty]));
             }
+        }
+        if let Some(cmp_mid) = cmp_mid {
+            for ty in cmp_to_register {
+                // The cmp module's per-type compare instances are tracked via `native_inst`,
+                // indexed by module id with each entry being a single-type vector.
+                self.add_type(&ty);
+                self.info
+                    .native_inst
+                    .entry(cmp_mid)
+                    .or_default()
+                    .insert(vec![ty]);
+            }
+        }
+        for (iter_qid, k_ty) in iter_to_register {
+            self.add_type(&Type::Struct(iter_qid.module_id, iter_qid.id, vec![k_ty]));
+        }
+        for (iter_with_path_qid, k_ty) in iter_with_path_to_register {
+            self.add_type(&Type::Struct(
+                iter_with_path_qid.module_id,
+                iter_with_path_qid.id,
+                vec![k_ty],
+            ));
         }
     }
 


### PR DESCRIPTION
## Description

Stacked on #19977. Adopts the map intrinsic mechanism for OrderedMap and BigOrderedMap by adding the BOM/OM-specific portion of the prover-side infrastructure (configured constructors, the order-key family, the iterator family, `IteratorPtrWithPath`) and binding it from the two spec files. Preserves soundness — every claim the model makes about an OM/BOM operation holds for every runtime execution that does not abort.

### What's new vs. PR #19977

PR #19977 added the role infrastructure for `map_new_from` / `map_to_vec_pair` / `map_keys` / `map_values` / `map_upsert_kv` and adopted them for SimpleMap+SmartTable. This PR adds:

- **Roles**: `map_get`, `map_upsert`, `map_remove_or_none`; the order-key family (`map_front_key`, `map_back_key`, `map_borrow_front`, `map_borrow_back`, `map_pop_front`, `map_pop_back`, `map_prev_key`, `map_next_key`); the iterator family (`map_iter_new_begin`, `map_iter_new_end`, `map_iter_is_end`, `map_iter_is_begin`, `map_iter_borrow_key`, `map_iter_borrow`, `map_iter_next`, `map_iter_prev`, `map_internal_find`, `map_internal_lower_bound`); the IteratorPtrWithPath family (`map_internal_find_with_path`, `map_iter_with_path_get_iter`, `map_iter_remove`); configured constructors (`map_new_with_config`, `map_new_with_reusable`, `map_new_with_type_size_hints`); and the matching `[spec] fun map_spec_aborts_*` definitions.
- **Boogie templates**: order-key procedures using `$1_cmp_$compare'<K>'`, iter procedures that constrain only the `IteratorPtr<K>::Some::key` field (leaving implementation fields like BOM's `node_index` / `child_iter` unconstrained), and `$EncodeKey(k0) != $EncodeKey(k)` in order-key comparisons so non-native-equality keys are handled soundly.
- **Companion-type pinning**: `IteratorPtr` and `IteratorPtrWithPath` are resolved by bare-name lookup in the map struct's own module (no fixed address), with their Boogie name prefixes stored on `MapImpl`.
- **Mono-analysis extension**: registers `cmp::compare<K>` instances for order-dependent roles and `IteratorPtr<K>` / `IteratorPtrWithPath<K>` for iter-bound maps. `find_cmp_module` pins `0x1::cmp` for the same reason `find_option_struct` pins `0x1::option`.

### Soundness model

**What "sound" means here.** For each OM/BOM operation `f`, the spec is a sound abstraction iff every runtime non-aborting execution satisfies the spec's `ensures`. The spec is allowed to be looser than the runtime (permit aborts the runtime does not, or havoc results the runtime determines exactly); it must not be tighter.

**Class A — intrinsic with `abort_spec_fun` pairing.** Boogie procedure body and paired `abort_spec_fun` together capture the runtime abort exactly. `aborts_of<f>` resolves to the abort predicate; success-path postconditions follow from the procedure body.

| Operation | Abort condition |
|---|---|
| `destroy_empty` | non-empty map |
| `contains`, `remove_or_none`, `is_empty`, `compute_length` | never |
| `borrow`, `borrow_mut`, `borrow_with_default`, `borrow_mut_with_default` | key not in map (for the non-default forms) |
| `get` | never |
| `keys`, `values`, `to_vec_pair`, `new_from` | length / duplicate-key (new_from); never (others) |
| `front_key`, `back_key`, `borrow_front`, `borrow_back`, `pop_front`, `pop_back` | empty map |
| `prev_key`, `next_key` | never |
| `internal_new_begin_iter`, `internal_new_end_iter`, `iter_is_end`, `iter_is_begin` | never |
| `iter_borrow_key` | iter is End |
| `internal_find`, `internal_lower_bound`, `internal_find_with_path`, `iter_with_path_get_iter` | never |
| `new`, `new_with_config` | configured degree out of range; nothing else (see limitations) |

**Class B — opaque spec with uninterpreted abort predicate.** Runtime abort depends on hidden struct state (BOM's `constant_kv_size` / `inner_max_degree` / `leaf_max_degree`, or iter's hidden `node_index` / `child_iter`); spec carries the abort obligation as a body-less predicate so callers compose it explicitly. The prover never claims the predicate is false without an explicit caller-supplied axiom; iterator postconditions for the ops below are havoc'd or restricted to size-preservation — no `ensures result == spec_get(map, self.key)` that could falsely hold on a stale iter.

| Operation | Abort predicate | Source of abort |
|---|---|---|
| `add`, `upsert` | `spec_aborts_validate_size(t, k, v)` | `validate_dynamic_size_and_init_max_degrees` aborts on `EKEY_BYTES_TOO_LARGE` / `EARGUMENT_BYTES_TOO_LARGE` |
| `new_with_reusable` | `spec_aborts_new_with_reusable_runtime<K, V>()` | `ECANNOT_USE_NEW_WITH_VARIABLE_SIZED_TYPES` |
| `new_with_type_size_hints` | `spec_aborts_new_with_type_size_hints_runtime<K, V>(...)` | `EINVALID_CONFIG_PARAMETER` (avg > max, etc.) |
| `iter_borrow`, `iter_borrow_mut`, `iter_next`, `iter_prev`, `iter_modify`, `iter_remove` | `spec_iter_op_aborts(it, map)` + concrete `iter_is_end` / `iter_is_begin` | stale cached `node_index` / `child_iter` |

**Class C — custom opaque spec.** Generic shared template would emit a wrong abort code or claim too much. BOM `remove` uses `aborts_if !spec_contains_key(self, key)` (a boolean membership condition with no specific abort-code claim) plus precise success-path ensures.

**Class D — `pragma verify = false`** (unchanged): `allocate_spare_slots`, `validate_*`, `internal_leaf_*`.

### Known limitations

The fundamental constraint is that `pragma intrinsic = map` abstracts the map as a `Table<int, V>` — there is no place to carry BOM's stored `(inner_max_degree, leaf_max_degree, constant_kv_size)` or its B+-tree shape.

1. **Constructor abort under-approximation.** `new` / `new_with_config` / `new_from` are bound to generic templates that don't model `validate_static_size_and_init_max_degrees` or `ECANNOT_USE_NEW_WITH_VARIABLE_SIZED_TYPES`. For constant-serialized-size K/V (`u64`, `address`, `Object<T>`, …) the runtime never aborts on these paths, so the under-approximation is not observable. For variable-size K/V the runtime can abort where the model says it returns. Attempted opaque + uninterpreted-predicate replacement caused a `stake.move` verification timeout on a heavily-used construction site; under-approximation accepted as the lesser cost.
2. **Configuration loss after construction.** `new_with_config(a, b, c)` and `new_with_config(d, e, f)` both collapse to `EmptyTable()` in the model. `spec_aborts_validate_size(t, k, v)` therefore returns the same value for differently-configured maps. For constant-size K/V the predicate is effectively false everywhere, so the collapse doesn't manifest; for variable-size K/V it can transfer a "this insert succeeds" assumption from one configuration to another.
3. **Iterator state loss.** Iter datatypes carry `(key, node_index, child_iter)` at runtime; the model only constrains `key`. Mutations that rebalance the tree can leave `node_index` / `child_iter` stale even while the cached `key` is still present, causing the runtime to abort on subsequent iter ops where the model permits return. Captured opaquely via `spec_iter_op_aborts(it, map)` (class B) and havoc'd iter postconditions — sound but conservative.
4. **Literal abort-code mismatch.** `add_no_override`, `destroy_empty`, `del_must_exist`, `borrow*` emit `$StdError(cat, reason) = reason*256 + cat`, which does not match Move's canonical `error::canonical(cat, reason) = (cat<<16) | reason`. Pre-existing convention; affects only user specs that match a specific runtime abort code via `aborts_with <literal>`. BOM `remove` is moved out of the shared template (class C) to avoid this; the residual class is left as a follow-up cleanup that should align all map intrinsics at once.

**Resolution path.** All four limitations admit a principled fix via a dedicated `pragma intrinsic = big_ordered_map` that threads the map's stored configuration into the model state and represents the iter datatype with explicit `node_index` / `child_iter` constraints. That is a substantial follow-up; this PR is the incremental, soundness-preserving step within the existing generic map intrinsic.

### Adopters

- **`ordered_map.spec.move`** — converts the previously hand-written opaque specs for `keys` / `values` / `to_vec_pair` / `new_from` / `upsert` to `pragma intrinsic` bindings (`map_upsert` / `map_is_empty` and the foundation roles from PR #19977).
- **`big_ordered_map.spec.move`** — binds the full BOM surface: `map_get`, `map_new_with_config` / `map_new_from`, `remove_or_none`, the order-key family, `prev_key` / `next_key`, the iterator family (`iter_new_begin` / `iter_new_end` / `iter_is_end` / `iter_borrow_key`, `internal_find` / `internal_lower_bound`, `internal_find_with_path` / `iter_with_path_get_iter`), `is_empty`, plus the matching `spec_aborts_*` abort-spec functions. Iterator ops that read or mutate map state through the iterator (`iter_borrow` / `iter_next` / `iter_prev` / `iter_remove`) and the unconfigured / type-size-hint constructors remain as opaque, conservative specs (class B/C above).

## How Has This Been Tested?

- `cargo build -p move-prover` (prover crates build clean).
- `cargo test -p move-prover --test testsuite` (all 242 inference + functional + regression tests pass against the stacked PR1 + PR2 state).
- The PR is content-equivalent on intrinsic-related files to the prior single-PR branch, which had previously verified `aptos-framework` (~150s) and `aptos-stdlib` (~26s).

## Key Areas to Review

- `third_party/move/move-prover/boogie-backend/src/prelude/native.bpl` — the order-key and iter procedure templates. Each iter template havocs an `IteratorPtr<K>` local, then `assume`s only `it is _Some` and `it->$key_Some == k_min/lb_k/key` (no constraint on `node_index` / `child_iter`). `$EncodeKey(k0) != $EncodeKey(k)` is used in place of raw `k0 != k`.
- `third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs` — the extension to `register_intrinsic_associated_types` that adds `cmp::compare<K>` / `IteratorPtr<K>` / `IteratorPtrWithPath<K>` registration. `find_cmp_module` pins to `0x1`.
- `aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.spec.move` — the BOM binding list (~30 roles) and the opaque specs for iterator ops that read/mutate through the iter. Pay attention to where `aborts_if [abstract]` clauses make the spec partial (class B) vs. where the abort condition is fully exact (class A).
- `aptos-move/framework/aptos-framework/sources/datastructures/ordered_map.spec.move` — converts the previously hand-written opaque specs to `pragma intrinsic` bindings; verify the binding list matches what OM actually exposes.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality
