### PR TITLE
[storage] Open DBs concurrently via thread::scope

### DIFF
--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -115,59 +115,81 @@ impl AptosDB {
         max_num_nodes_per_lru_cache_shard: usize,
         hot_state_config: HotStateConfig,
     ) -> Result<(LedgerDb, StateMerkleDb, StateMerkleDb, StateKvDb, StateKvDb)> {
-        let ledger_db = LedgerDb::new(
-            db_paths.ledger_db_root_path(),
-            rocksdb_configs.ledger_db_config,
-            env,
-            block_cache,
-            readonly,
-        )?;
-        let hot_state_kv_db = StateKvDb::new(
-            db_paths,
-            rocksdb_configs.state_kv_db_config,
-            env,
-            block_cache,
-            readonly,
-            /* is_hot = */ true,
-            hot_state_config.delete_on_restart,
-        )?;
-        let state_kv_db = StateKvDb::new(
-            db_paths,
-            rocksdb_configs.state_kv_db_config,
-            env,
-            block_cache,
-            readonly,
-            /* is_hot = */ false,
-            /* delete_on_restart = */ false,
-        )?;
-        let hot_state_merkle_db = StateMerkleDb::new(
-            db_paths,
-            rocksdb_configs.state_merkle_db_config,
-            env,
-            block_cache,
-            readonly,
-            max_num_nodes_per_lru_cache_shard,
-            /* is_hot = */ true,
-            hot_state_config.delete_on_restart,
-        )?;
-        let state_merkle_db = StateMerkleDb::new(
-            db_paths,
-            rocksdb_configs.state_merkle_db_config,
-            env,
-            block_cache,
-            readonly,
-            max_num_nodes_per_lru_cache_shard,
-            /* is_hot = */ false,
-            /* delete_on_restart = */ false,
-        )?;
+        std::thread::scope(|s| {
+            let ledger_handle = s.spawn(|| {
+                LedgerDb::new(
+                    db_paths.ledger_db_root_path(),
+                    rocksdb_configs.ledger_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                )
+            });
+            let hot_state_kv_handle = s.spawn(|| {
+                StateKvDb::new(
+                    db_paths,
+                    rocksdb_configs.state_kv_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    /* is_hot = */ true,
+                    hot_state_config.delete_on_restart,
+                )
+            });
+            let state_kv_handle = s.spawn(|| {
+                StateKvDb::new(
+                    db_paths,
+                    rocksdb_configs.state_kv_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    /* is_hot = */ false,
+                    /* delete_on_restart = */ false,
+                )
+            });
+            let hot_state_merkle_handle = s.spawn(|| {
+                StateMerkleDb::new(
+                    db_paths,
+                    rocksdb_configs.state_merkle_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    max_num_nodes_per_lru_cache_shard,
+                    /* is_hot = */ true,
+                    hot_state_config.delete_on_restart,
+                )
+            });
+            let state_merkle_handle = s.spawn(|| {
+                StateMerkleDb::new(
+                    db_paths,
+                    rocksdb_configs.state_merkle_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    max_num_nodes_per_lru_cache_shard,
+                    /* is_hot = */ false,
+                    /* delete_on_restart = */ false,
+                )
+            });
 
-        Ok((
-            ledger_db,
-            hot_state_merkle_db,
-            state_merkle_db,
-            hot_state_kv_db,
-            state_kv_db,
-        ))
+            Ok((
+                ledger_handle
+                    .join()
+                    .expect("Ledger db open thread panicked")?,
+                hot_state_merkle_handle
+                    .join()
+                    .expect("Hot state merkle db open thread panicked")?,
+                state_merkle_handle
+                    .join()
+                    .expect("State merkle db open thread panicked")?,
+                hot_state_kv_handle
+                    .join()
+                    .expect("Hot state kv db open thread panicked")?,
+                state_kv_handle
+                    .join()
+                    .expect("State kv db open thread panicked")?,
+            ))
+        })
     }
 
     pub fn add_version_update_subscriber(

--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -19,7 +19,6 @@ use crate::{
     },
 };
 use aptos_config::config::RocksdbConfig;
-use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::prelude::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
 use aptos_schemadb::{batch::SchemaBatch, Cache, ColumnFamilyDescriptor, Env, DB};
@@ -140,8 +139,8 @@ impl LedgerDb {
         let mut transaction_db = None;
         let mut transaction_info_db = None;
         let mut write_set_db = None;
-        THREAD_MANAGER.get_non_exe_cpu_pool().scope(|s| {
-            s.spawn(|_| {
+        std::thread::scope(|s| {
+            s.spawn(|| {
                 let event_db_raw = Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(EVENT_DB_NAME),
@@ -158,7 +157,7 @@ impl LedgerDb {
                     EventStore::new(event_db_raw),
                 ));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 persisted_auxiliary_info_db = Some(PersistedAuxiliaryInfoDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(PERSISTED_AUXILIARY_INFO_DB_NAME),
@@ -171,7 +170,7 @@ impl LedgerDb {
                     .unwrap(),
                 )));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 transaction_accumulator_db = Some(TransactionAccumulatorDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(TRANSACTION_ACCUMULATOR_DB_NAME),
@@ -184,7 +183,7 @@ impl LedgerDb {
                     .unwrap(),
                 )));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 transaction_auxiliary_data_db = Some(TransactionAuxiliaryDataDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(TRANSACTION_AUXILIARY_DATA_DB_NAME),
@@ -197,7 +196,7 @@ impl LedgerDb {
                     .unwrap(),
                 )))
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 transaction_db = Some(TransactionDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(TRANSACTION_DB_NAME),
@@ -210,7 +209,7 @@ impl LedgerDb {
                     .unwrap(),
                 )));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 transaction_info_db = Some(TransactionInfoDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(TRANSACTION_INFO_DB_NAME),
@@ -223,7 +222,7 @@ impl LedgerDb {
                     .unwrap(),
                 )));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 write_set_db = Some(WriteSetDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(WRITE_SET_DB_NAME),

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -145,34 +145,11 @@ impl StateKvDb {
         };
         let state_kv_metadata_db_path = Self::metadata_db_path(metadata_db_root_path, is_hot);
 
-        let state_kv_metadata_db = Arc::new(Self::open_db(
-            state_kv_metadata_db_path.clone(),
-            metadata_db_name(is_hot),
-            &state_kv_db_config,
-            env,
-            block_cache,
-            readonly,
-            is_hot,
-            delete_on_restart,
-        )?);
-
-        info!(
-            state_kv_metadata_db_path = state_kv_metadata_db_path,
-            is_hot = is_hot,
-            "Opened state kv metadata db!"
-        );
-
-        let state_kv_db_shards = (0..NUM_STATE_SHARDS)
-            .into_par_iter()
-            .map(|shard_id| {
-                let shard_root_path = if is_hot {
-                    db_paths.hot_state_kv_db_shard_root_path(shard_id)
-                } else {
-                    db_paths.state_kv_db_shard_root_path(shard_id)
-                };
-                let db = Self::open_shard(
-                    shard_root_path,
-                    shard_id,
+        let (metadata_db, shards) = std::thread::scope(|s| {
+            let metadata_handle = s.spawn(|| {
+                let db = Self::open_db(
+                    state_kv_metadata_db_path.clone(),
+                    metadata_db_name(is_hot),
                     &state_kv_db_config,
                     env,
                     block_cache,
@@ -181,17 +158,55 @@ impl StateKvDb {
                     delete_on_restart,
                 )
                 .unwrap_or_else(|e| {
-                    let db_type = if is_hot { "hot state kv" } else { "state kv" };
-                    panic!("Failed to open {db_type} db shard {shard_id}: {e:?}.")
+                    panic!("Failed to open state kv metadata db (is_hot: {is_hot}): {e:?}.")
                 });
                 Arc::new(db)
-            })
-            .collect::<Vec<_>>()
+            });
+
+            let shard_handles: Vec<_> = (0..NUM_STATE_SHARDS)
+                .map(|shard_id| {
+                    s.spawn(move || {
+                        let shard_root_path = if is_hot {
+                            db_paths.hot_state_kv_db_shard_root_path(shard_id)
+                        } else {
+                            db_paths.state_kv_db_shard_root_path(shard_id)
+                        };
+                        let db = Self::open_shard(
+                            shard_root_path,
+                            shard_id,
+                            &state_kv_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                            is_hot,
+                            delete_on_restart,
+                        )
+                        .unwrap_or_else(|e| {
+                            let db_type = if is_hot { "hot state kv" } else { "state kv" };
+                            panic!("Failed to open {db_type} db shard {shard_id}: {e:?}.")
+                        });
+                        Arc::new(db)
+                    })
+                })
+                .collect();
+
+            // Joined in shard-id order so each array index matches its shard id.
+            let shards = shard_handles
+                .into_iter()
+                .map(|handle| handle.join().expect("State kv shard open thread panicked"))
+                .collect::<Vec<_>>();
+            let metadata_db = metadata_handle
+                .join()
+                .expect("State kv metadata open thread panicked");
+            (metadata_db, shards)
+        });
+
+        let state_kv_db_shards: [_; NUM_STATE_SHARDS] = shards
             .try_into()
-            .unwrap();
+            .expect("Collected exactly NUM_STATE_SHARDS shards");
 
         let state_kv_db = Self {
-            inner: ShardedKvDb::new(state_kv_metadata_db, state_kv_db_shards),
+            inner: ShardedKvDb::new(metadata_db, state_kv_db_shards),
             is_hot,
         };
 

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -32,7 +32,6 @@ use aptos_types::{
     state_store::{state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
-use rayon::prelude::*;
 use std::{
     ops::Deref,
     path::{Path, PathBuf},
@@ -158,51 +157,69 @@ impl StateMerkleDb {
             is_hot,
         );
 
-        let state_merkle_metadata_db = Arc::new(Self::open_db(
-            state_merkle_metadata_db_path.clone(),
-            metadata_db_name(is_hot),
-            &state_merkle_db_config,
-            env,
-            block_cache,
-            readonly,
-            delete_on_restart,
-        )?);
-
-        info!(
-            state_merkle_metadata_db_path = state_merkle_metadata_db_path,
-            "Opened state merkle metadata db!"
-        );
-
-        let state_merkle_db_shards: [Arc<DB>; NUM_STATE_SHARDS] = (0..NUM_STATE_SHARDS)
-            .into_par_iter()
-            .map(|shard_id| {
-                let shard_root_path = if is_hot {
-                    db_paths.hot_state_merkle_db_shard_root_path(shard_id)
-                } else {
-                    db_paths.state_merkle_db_shard_root_path(shard_id)
-                };
-                let db = Self::open_shard(
-                    shard_root_path,
-                    shard_id,
+        let (metadata_db, shards) = std::thread::scope(|s| {
+            let metadata_handle = s.spawn(|| {
+                let db = Self::open_db(
+                    state_merkle_metadata_db_path.clone(),
+                    metadata_db_name(is_hot),
                     &state_merkle_db_config,
                     env,
                     block_cache,
                     readonly,
-                    is_hot,
                     delete_on_restart,
                 )
-                .unwrap_or_else(|e| {
-                    panic!("Failed to open state merkle db shard {shard_id}: {e:?}.")
-                });
+                .unwrap_or_else(|e| panic!("Failed to open state merkle metadata db: {e:?}."));
                 Arc::new(db)
-            })
-            .collect::<Vec<_>>()
+            });
+
+            let shard_handles: Vec<_> = (0..NUM_STATE_SHARDS)
+                .map(|shard_id| {
+                    s.spawn(move || {
+                        let shard_root_path = if is_hot {
+                            db_paths.hot_state_merkle_db_shard_root_path(shard_id)
+                        } else {
+                            db_paths.state_merkle_db_shard_root_path(shard_id)
+                        };
+                        let db = Self::open_shard(
+                            shard_root_path,
+                            shard_id,
+                            &state_merkle_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                            is_hot,
+                            delete_on_restart,
+                        )
+                        .unwrap_or_else(|e| {
+                            panic!("Failed to open state merkle db shard {shard_id}: {e:?}.")
+                        });
+                        Arc::new(db)
+                    })
+                })
+                .collect();
+
+            // Joined in shard-id order so each array index matches its shard id.
+            let shards = shard_handles
+                .into_iter()
+                .map(|handle| {
+                    handle
+                        .join()
+                        .expect("State merkle shard open thread panicked")
+                })
+                .collect::<Vec<_>>();
+            let metadata_db = metadata_handle
+                .join()
+                .expect("State merkle metadata open thread panicked");
+            (metadata_db, shards)
+        });
+
+        let state_merkle_db_shards: [Arc<DB>; NUM_STATE_SHARDS] = shards
             .try_into()
-            .unwrap();
+            .expect("Collected exactly NUM_STATE_SHARDS shards");
 
         let db_tag: &'static str = if is_hot { "hot" } else { "cold" };
         let inner = ShardedJmtMerkleDb::new(
-            state_merkle_metadata_db,
+            metadata_db,
             state_merkle_db_shards,
             max_nodes_per_lru_cache_shard,
             db_tag,


### PR DESCRIPTION

A cold start opened the per-DB metadata and 16 shards (state kv and
merkle), the five top-level DBs in `open_dbs`, and the ledger sub-DBs
either serially or through a rayon pool sized to the core count. Open
each on a dedicated thread with `std::thread::scope` instead, so they
all open at once even on hosts with fewer than 16 cores. The opens are
mostly blocking I/O and this runs once at startup, so the extra threads
cost nothing meaningful.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches only one-time startup I/O paths but increases concurrent RocksDB opens and thread count; panics on worker failure remain the error path.
> 
> **Overview**
> **Parallelizes AptosDB cold-start RocksDB opens** using `std::thread::scope` so metadata, shards, top-level DBs, and ledger sub-DBs can all open at once instead of serially or via a core-sized rayon / `THREAD_MANAGER` pool.
> 
> `open_dbs` now spawns five threads for ledger, hot/cold state KV, and hot/cold state merkle. **Ledger** sub-DB opens switch from `THREAD_MANAGER.get_non_exe_cpu_pool()` to `std::thread::scope` (seven RocksDB instances). **State KV** and **state merkle** open metadata and all `NUM_STATE_SHARDS` shards concurrently in one scope, with handles joined in shard-id order for stable array indexing; rayon parallel shard open is removed from merkle open. Failures in scoped workers still surface via `join()` + `expect` / `unwrap_or_else` panics. A couple of metadata “opened” log lines on KV/merkle are dropped in the refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a3c5d5a3a498a99bb91120f9db915870307e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->