### PR TITLE
[smoke-test] Deflake latest events/txns test

### DIFF
--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -132,16 +132,37 @@ async fn test_latest_events_and_transactions() {
         .into_inner();
 
     create_and_fund_account(&mut swarm, 100).await;
-    let cur_events = client
-        .get_new_block_events_bcs(None, Some(2))
-        .await
-        .unwrap()
-        .into_inner();
-    let (cur_transations, cur_ledger) = client
-        .get_transactions(None, Some(2))
-        .await
-        .unwrap()
-        .into_parts();
+
+    // `enable_event` serves these "latest" queries from the internal indexer, which
+    // lags storage; `create_and_fund_account` only waits for the storage commit. Poll
+    // until the indexer reflects the funding blocks before checking the ordering
+    // invariants below.
+    let deadline = Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS);
+    let (cur_events, cur_transations, cur_ledger) = loop {
+        let cur_events = client
+            .get_new_block_events_bcs(None, Some(2))
+            .await
+            .unwrap()
+            .into_inner();
+        let (cur_transations, cur_ledger) = client
+            .get_transactions(None, Some(2))
+            .await
+            .unwrap()
+            .into_parts();
+
+        if start_events[0].event.round() < cur_events[0].event.round()
+            && start_transations[0].version() < cur_transations[0].version()
+        {
+            break (cur_events, cur_transations, cur_ledger);
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "Timed out waiting for the internal indexer to catch up to the latest \
+             events and transactions",
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
 
     assert!(start_events[0].event.round() < cur_events[0].event.round());
     assert!(cur_events[0].event.round() < cur_events[1].event.round());


### PR DESCRIPTION

`test_latest_events_and_transactions` snapshots the latest block events
and transactions, funds an account, then asserts the latest values moved
forward. It had become extremely flaky on:

    assertion failed: start_events[0].event.round() < cur_events[0].event.round()

## Why it races

The test enables `indexer_db_config.enable_event` (#16875), so these
"latest" queries are served by the internal indexer instead of from
storage. The indexer ingests asynchronously and lags storage, and
`get_latest_ledger_info()` reports the indexer's capped version.
`create_and_fund_account` only waits for the storage commit, so the
post-funding read can still observe the pre-funding indexer version, and
the strict-ordering assertions fail.

## What surfaced it

The race has existed since the test moved onto the internal indexer, but
stayed dormant while blocks committed slowly enough for the indexer to
catch up between the two reads. It turned severe on 2026-05-26, bisected
to #19878 ("[consensus] Reduce round initial timeout from 1000ms to
500ms"): its parent passes 15/15 locally while #19878 fails 14/15. Faster
rounds commit faster and shrink the window the async indexer has to catch
up, so the post-funding read almost always sees stale data. This lines up
with CI, where the test was green until #19878 merged and every failure
since is on the assertion above.

## Fix

After funding, poll until the internal indexer has caught up (the latest
events and transactions advance past the pre-funding snapshot) before
checking the ordering invariants, bounded by `MAX_HEALTHY_WAIT_SECS`. A
genuinely stuck indexer now fails with a clear timeout rather than a
confusing ordering assertion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths affected.
> 
> **Overview**
> **Deflakes `test_latest_events_and_transactions`** by waiting for the internal indexer to catch up after account funding instead of reading latest block events and transactions once.
> 
> With `enable_event`, those queries come from the async indexer, which can lag behind the storage commit that `create_and_fund_account` waits on. The test now polls every 200ms until both the latest event round and transaction version move past the pre-funding snapshot, bounded by `MAX_HEALTHY_WAIT_SECS`, then runs the same ordering assertions. A stuck indexer fails with an explicit timeout message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf6007f7e787450bbfbf17b50a255cad5b567ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->