### PR TITLE
[node] Add startup phase timing logs

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -692,6 +692,8 @@ pub fn setup_environment_and_start_node(
     api_port_tx: Option<oneshot::Sender<u16>>,
     indexer_grpc_port_tx: Option<oneshot::Sender<u16>>,
 ) -> anyhow::Result<AptosHandle> {
+    let node_boot_start = std::time::Instant::now();
+
     // Log the node config at node startup
     node_config.log_all_configs();
 
@@ -780,6 +782,7 @@ pub fn setup_environment_and_start_node(
     ) = state_sync::create_event_subscription_service(&node_config, &db_rw);
 
     // Set up the networks and gather the application network handles
+    let network_setup_start = std::time::Instant::now();
     let peers_and_metadata = network::create_peers_and_metadata(&node_config);
     let (
         network_runtimes,
@@ -796,6 +799,10 @@ pub fn setup_environment_and_start_node(
         peers_and_metadata.clone(),
         &mut event_subscription_service,
     );
+    info!(
+        time_ms = network_setup_start.elapsed().as_millis() as u64,
+        "Set up networks and gathered application interfaces."
+    );
 
     // Start the peer monitoring service
     let peer_monitoring_service_runtime = services::start_peer_monitoring_service(
@@ -805,6 +812,7 @@ pub fn setup_environment_and_start_node(
     );
 
     // Start state sync and get the notification endpoints for mempool and consensus
+    let state_sync_start = std::time::Instant::now();
     let (aptos_data_client, state_sync_runtime, mempool_listener, consensus_notifier) =
         state_sync::start_state_sync_and_get_notification_handles(
             &node_config,
@@ -813,6 +821,10 @@ pub fn setup_environment_and_start_node(
             event_subscription_service,
             db_rw.clone(),
         )?;
+    info!(
+        time_ms = state_sync_start.elapsed().as_millis() as u64,
+        "Started state sync (driver, data client, storage service)."
+    );
 
     // Inject the now-available components into the already-running inspection service.
     // This unblocks /peer_information (and any other endpoints that need these values).
@@ -864,9 +876,13 @@ pub fn setup_environment_and_start_node(
     );
 
     // Wait until state sync has been initialized
-    debug!("Waiting until state sync is initialized!");
+    info!("Waiting until state sync is initialized (bootstrapping)...");
+    let state_sync_bootstrap_start = std::time::Instant::now();
     state_sync_runtime.block_until_initialized();
-    debug!("State sync initialization complete.");
+    info!(
+        time_ms = state_sync_bootstrap_start.elapsed().as_millis() as u64,
+        "State sync initialization (bootstrapping) complete."
+    );
 
     // Create the consensus observer and publisher (if enabled)
     let (consensus_observer_runtime, consensus_publisher_runtime, consensus_publisher) =
@@ -890,6 +906,11 @@ pub fn setup_environment_and_start_node(
         vtxn_pool,
         consensus_publisher.clone(),
         &mut admin_service,
+    );
+
+    info!(
+        time_ms = node_boot_start.elapsed().as_millis() as u64,
+        "Node startup complete; all runtimes initialized."
     );
 
     Ok(AptosHandle {

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -18,7 +18,7 @@ use aptos_indexer_grpc_table_info::runtime::{
     bootstrap as bootstrap_indexer_table_info, bootstrap_internal_indexer_db,
 };
 use aptos_inspection_service::server::InspectionServiceComponents;
-use aptos_logger::{debug, telemetry_log_writer::TelemetryLog, LoggerFilterUpdater};
+use aptos_logger::{info, telemetry_log_writer::TelemetryLog, LoggerFilterUpdater};
 use aptos_mempool::{
     network::MempoolSyncMsg, MempoolClientRequest, MempoolClientSender, QuorumStoreRequest,
 };
@@ -160,7 +160,10 @@ pub fn start_consensus_runtime(
         consensus_publisher,
         num_worker_threads,
     );
-    debug!("Consensus started in {} ms", instant.elapsed().as_millis());
+    info!(
+        time_ms = instant.elapsed().as_millis() as u64,
+        "Consensus started (incl. ConsensusDB, QuorumStoreDB, RandDB open + recovery)."
+    );
 
     consensus
 }
@@ -192,7 +195,10 @@ pub fn start_mempool_runtime_and_get_consensus_sender(
         mempool_reconfig_subscription,
         peers_and_metadata,
     );
-    debug!("Mempool started in {} ms", instant.elapsed().as_millis());
+    info!(
+        time_ms = instant.elapsed().as_millis() as u64,
+        "Mempool started."
+    );
 
     (mempool, consensus_to_mempool_sender)
 }

--- a/aptos-node/src/storage.rs
+++ b/aptos-node/src/storage.rs
@@ -8,7 +8,7 @@ use aptos_db::{fast_sync_storage_wrapper::FastSyncStorageWrapper, AptosDB};
 use aptos_db_indexer::db_indexer::InternalIndexerDB;
 use aptos_executor::db_bootstrapper::maybe_bootstrap;
 use aptos_indexer_grpc_table_info::internal_indexer_db_service::InternalIndexerDBService;
-use aptos_logger::{debug, info};
+use aptos_logger::info;
 use aptos_storage_interface::{DbReader, DbReaderWriter};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures, transaction::Version, waypoint::Waypoint,
@@ -188,14 +188,15 @@ pub fn initialize_database_and_checkpoints(
     }
 
     // Open the database
+    info!("Opening storage (AptosDB + backup service)...");
     let instant = Instant::now();
     let (_aptos_db, db_rw, backup_service, indexer_db_opt, update_receiver) =
         bootstrap_db(node_config)?;
 
     // Log the duration to open storage
-    debug!(
-        "Storage service started in {} ms",
-        instant.elapsed().as_millis()
+    info!(
+        time_ms = instant.elapsed().as_millis() as u64,
+        "Opened storage (AptosDB + backup service)."
     );
 
     Ok((

--- a/consensus/src/quorum_store/batch_store.rs
+++ b/consensus/src/quorum_store/batch_store.rs
@@ -237,9 +237,15 @@ impl BatchStore {
         expiration_buffer_usecs: u64,
         batch_store: &BatchStore,
     ) {
+        let load_start = std::time::Instant::now();
         let db_content = db
             .get_all_batches()
             .expect("failed to read v1 data from db");
+        aptos_logger::info!(
+            num_batches = db_content.len(),
+            time_ms = load_start.elapsed().as_millis() as u64,
+            "Loaded quorum store batches (v1) from DB on recovery."
+        );
         let db_content = db_content.into_iter().map(|(k, v)| (k, v.into())).collect();
         Self::load_batches_from_db(
             current_epoch,
@@ -262,9 +268,15 @@ impl BatchStore {
         expiration_buffer_usecs: u64,
         batch_store: &BatchStore,
     ) {
+        let load_start = std::time::Instant::now();
         let db_content = db
             .get_all_batches_v2()
             .expect("failed to read v2 data from db");
+        aptos_logger::info!(
+            num_batches = db_content.len(),
+            time_ms = load_start.elapsed().as_millis() as u64,
+            "Loaded quorum store batches (v2) from DB on recovery."
+        );
         Self::load_batches_from_db(
             current_epoch,
             last_certified_time,

--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -167,6 +167,7 @@ impl AptosDB {
         let position_epoch_snapshot_pruner_config: StateMerklePrunerConfig =
             pruner_config.epoch_snapshot_pruner_config.into();
 
+        let state_store_start = Instant::now();
         let mut myself = Self::new_with_dbs(
             ledger_db,
             hot_state_merkle_db,
@@ -179,6 +180,10 @@ impl AptosDB {
             empty_buffered_state_for_restore,
             internal_indexer_db,
             hot_state_config,
+        );
+        info!(
+            time_ms = state_store_start.elapsed().as_millis() as u64,
+            "Built AptosDB StateStore and pruners (incl. hot-state load, truncation, replay)."
         );
 
         if ENABLE_TRADING_NATIVE {

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -115,81 +115,141 @@ impl AptosDB {
         max_num_nodes_per_lru_cache_shard: usize,
         hot_state_config: HotStateConfig,
     ) -> Result<(LedgerDb, StateMerkleDb, StateMerkleDb, StateKvDb, StateKvDb)> {
-        std::thread::scope(|s| {
-            let ledger_handle = s.spawn(|| {
-                LedgerDb::new(
-                    db_paths.ledger_db_root_path(),
-                    rocksdb_configs.ledger_db_config,
-                    env,
-                    block_cache,
-                    readonly,
-                )
-            });
-            let hot_state_kv_handle = s.spawn(|| {
-                StateKvDb::new(
-                    db_paths,
-                    rocksdb_configs.state_kv_db_config,
-                    env,
-                    block_cache,
-                    readonly,
-                    /* is_hot = */ true,
-                    hot_state_config.delete_on_restart,
-                )
-            });
-            let state_kv_handle = s.spawn(|| {
-                StateKvDb::new(
-                    db_paths,
-                    rocksdb_configs.state_kv_db_config,
-                    env,
-                    block_cache,
-                    readonly,
-                    /* is_hot = */ false,
-                    /* delete_on_restart = */ false,
-                )
-            });
-            let hot_state_merkle_handle = s.spawn(|| {
-                StateMerkleDb::new(
-                    db_paths,
-                    rocksdb_configs.state_merkle_db_config,
-                    env,
-                    block_cache,
-                    readonly,
-                    max_num_nodes_per_lru_cache_shard,
-                    /* is_hot = */ true,
-                    hot_state_config.delete_on_restart,
-                )
-            });
-            let state_merkle_handle = s.spawn(|| {
-                StateMerkleDb::new(
-                    db_paths,
-                    rocksdb_configs.state_merkle_db_config,
-                    env,
-                    block_cache,
-                    readonly,
-                    max_num_nodes_per_lru_cache_shard,
-                    /* is_hot = */ false,
-                    /* delete_on_restart = */ false,
-                )
-            });
+        let start = Instant::now();
+        let result = std::thread::scope(
+            |s| -> Result<(LedgerDb, StateMerkleDb, StateMerkleDb, StateKvDb, StateKvDb)> {
+                // Open each sub-DB group on its own named thread, each timing its own
+                // open so the slowest group is attributable in the logs.
+                let ledger_handle = std::thread::Builder::new()
+                    .name("open-ledger-db".to_string())
+                    .spawn_scoped(s, || {
+                        let t = Instant::now();
+                        let db = LedgerDb::new(
+                            db_paths.ledger_db_root_path(),
+                            rocksdb_configs.ledger_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                        );
+                        info!(
+                            db_group = "ledger",
+                            time_ms = t.elapsed().as_millis() as u64,
+                            "Opened AptosDB sub-DB group."
+                        );
+                        db
+                    })
+                    .expect("Failed to spawn open-ledger-db thread");
+                let hot_state_kv_handle = std::thread::Builder::new()
+                    .name("open-hot-kv-db".to_string())
+                    .spawn_scoped(s, || {
+                        let t = Instant::now();
+                        let db = StateKvDb::new(
+                            db_paths,
+                            rocksdb_configs.state_kv_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                            /* is_hot = */ true,
+                            hot_state_config.delete_on_restart,
+                        );
+                        info!(
+                            db_group = "hot_state_kv",
+                            time_ms = t.elapsed().as_millis() as u64,
+                            "Opened AptosDB sub-DB group."
+                        );
+                        db
+                    })
+                    .expect("Failed to spawn open-hot-kv-db thread");
+                let state_kv_handle = std::thread::Builder::new()
+                    .name("open-kv-db".to_string())
+                    .spawn_scoped(s, || {
+                        let t = Instant::now();
+                        let db = StateKvDb::new(
+                            db_paths,
+                            rocksdb_configs.state_kv_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                            /* is_hot = */ false,
+                            /* delete_on_restart = */ false,
+                        );
+                        info!(
+                            db_group = "state_kv",
+                            time_ms = t.elapsed().as_millis() as u64,
+                            "Opened AptosDB sub-DB group."
+                        );
+                        db
+                    })
+                    .expect("Failed to spawn open-kv-db thread");
+                let hot_state_merkle_handle = std::thread::Builder::new()
+                    .name("open-hot-mkl-db".to_string())
+                    .spawn_scoped(s, || {
+                        let t = Instant::now();
+                        let db = StateMerkleDb::new(
+                            db_paths,
+                            rocksdb_configs.state_merkle_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                            max_num_nodes_per_lru_cache_shard,
+                            /* is_hot = */ true,
+                            hot_state_config.delete_on_restart,
+                        );
+                        info!(
+                            db_group = "hot_state_merkle",
+                            time_ms = t.elapsed().as_millis() as u64,
+                            "Opened AptosDB sub-DB group."
+                        );
+                        db
+                    })
+                    .expect("Failed to spawn open-hot-mkl-db thread");
+                let state_merkle_handle = std::thread::Builder::new()
+                    .name("open-mkl-db".to_string())
+                    .spawn_scoped(s, || {
+                        let t = Instant::now();
+                        let db = StateMerkleDb::new(
+                            db_paths,
+                            rocksdb_configs.state_merkle_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                            max_num_nodes_per_lru_cache_shard,
+                            /* is_hot = */ false,
+                            /* delete_on_restart = */ false,
+                        );
+                        info!(
+                            db_group = "state_merkle",
+                            time_ms = t.elapsed().as_millis() as u64,
+                            "Opened AptosDB sub-DB group."
+                        );
+                        db
+                    })
+                    .expect("Failed to spawn open-mkl-db thread");
 
-            Ok((
-                ledger_handle
-                    .join()
-                    .expect("Ledger db open thread panicked")?,
-                hot_state_merkle_handle
-                    .join()
-                    .expect("Hot state merkle db open thread panicked")?,
-                state_merkle_handle
-                    .join()
-                    .expect("State merkle db open thread panicked")?,
-                hot_state_kv_handle
-                    .join()
-                    .expect("Hot state kv db open thread panicked")?,
-                state_kv_handle
-                    .join()
-                    .expect("State kv db open thread panicked")?,
-            ))
-        })
+                Ok((
+                    ledger_handle
+                        .join()
+                        .expect("Ledger db open thread panicked")?,
+                    hot_state_merkle_handle
+                        .join()
+                        .expect("Hot state merkle db open thread panicked")?,
+                    state_merkle_handle
+                        .join()
+                        .expect("State merkle db open thread panicked")?,
+                    hot_state_kv_handle
+                        .join()
+                        .expect("Hot state kv db open thread panicked")?,
+                    state_kv_handle
+                        .join()
+                        .expect("State kv db open thread panicked")?,
+                ))
+            },
+        );
+        info!(
+            time_ms = start.elapsed().as_millis() as u64,
+            "Opened all AptosDB sub-DBs concurrently."
+        );
+        result
     }
 
     pub fn add_version_update_subscriber(

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -115,59 +115,81 @@ impl AptosDB {
         max_num_nodes_per_lru_cache_shard: usize,
         hot_state_config: HotStateConfig,
     ) -> Result<(LedgerDb, StateMerkleDb, StateMerkleDb, StateKvDb, StateKvDb)> {
-        let ledger_db = LedgerDb::new(
-            db_paths.ledger_db_root_path(),
-            rocksdb_configs.ledger_db_config,
-            env,
-            block_cache,
-            readonly,
-        )?;
-        let hot_state_kv_db = StateKvDb::new(
-            db_paths,
-            rocksdb_configs.state_kv_db_config,
-            env,
-            block_cache,
-            readonly,
-            /* is_hot = */ true,
-            hot_state_config.delete_on_restart,
-        )?;
-        let state_kv_db = StateKvDb::new(
-            db_paths,
-            rocksdb_configs.state_kv_db_config,
-            env,
-            block_cache,
-            readonly,
-            /* is_hot = */ false,
-            /* delete_on_restart = */ false,
-        )?;
-        let hot_state_merkle_db = StateMerkleDb::new(
-            db_paths,
-            rocksdb_configs.state_merkle_db_config,
-            env,
-            block_cache,
-            readonly,
-            max_num_nodes_per_lru_cache_shard,
-            /* is_hot = */ true,
-            hot_state_config.delete_on_restart,
-        )?;
-        let state_merkle_db = StateMerkleDb::new(
-            db_paths,
-            rocksdb_configs.state_merkle_db_config,
-            env,
-            block_cache,
-            readonly,
-            max_num_nodes_per_lru_cache_shard,
-            /* is_hot = */ false,
-            /* delete_on_restart = */ false,
-        )?;
+        std::thread::scope(|s| {
+            let ledger_handle = s.spawn(|| {
+                LedgerDb::new(
+                    db_paths.ledger_db_root_path(),
+                    rocksdb_configs.ledger_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                )
+            });
+            let hot_state_kv_handle = s.spawn(|| {
+                StateKvDb::new(
+                    db_paths,
+                    rocksdb_configs.state_kv_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    /* is_hot = */ true,
+                    hot_state_config.delete_on_restart,
+                )
+            });
+            let state_kv_handle = s.spawn(|| {
+                StateKvDb::new(
+                    db_paths,
+                    rocksdb_configs.state_kv_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    /* is_hot = */ false,
+                    /* delete_on_restart = */ false,
+                )
+            });
+            let hot_state_merkle_handle = s.spawn(|| {
+                StateMerkleDb::new(
+                    db_paths,
+                    rocksdb_configs.state_merkle_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    max_num_nodes_per_lru_cache_shard,
+                    /* is_hot = */ true,
+                    hot_state_config.delete_on_restart,
+                )
+            });
+            let state_merkle_handle = s.spawn(|| {
+                StateMerkleDb::new(
+                    db_paths,
+                    rocksdb_configs.state_merkle_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    max_num_nodes_per_lru_cache_shard,
+                    /* is_hot = */ false,
+                    /* delete_on_restart = */ false,
+                )
+            });
 
-        Ok((
-            ledger_db,
-            hot_state_merkle_db,
-            state_merkle_db,
-            hot_state_kv_db,
-            state_kv_db,
-        ))
+            Ok((
+                ledger_handle
+                    .join()
+                    .expect("Ledger db open thread panicked")?,
+                hot_state_merkle_handle
+                    .join()
+                    .expect("Hot state merkle db open thread panicked")?,
+                state_merkle_handle
+                    .join()
+                    .expect("State merkle db open thread panicked")?,
+                hot_state_kv_handle
+                    .join()
+                    .expect("Hot state kv db open thread panicked")?,
+                state_kv_handle
+                    .join()
+                    .expect("State kv db open thread panicked")?,
+            ))
+        })
     }
 
     pub fn add_version_update_subscriber(

--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -19,7 +19,6 @@ use crate::{
     },
 };
 use aptos_config::config::RocksdbConfig;
-use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::prelude::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
 use aptos_schemadb::{batch::SchemaBatch, Cache, ColumnFamilyDescriptor, Env, DB};
@@ -140,8 +139,8 @@ impl LedgerDb {
         let mut transaction_db = None;
         let mut transaction_info_db = None;
         let mut write_set_db = None;
-        THREAD_MANAGER.get_non_exe_cpu_pool().scope(|s| {
-            s.spawn(|_| {
+        std::thread::scope(|s| {
+            s.spawn(|| {
                 let event_db_raw = Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(EVENT_DB_NAME),
@@ -158,7 +157,7 @@ impl LedgerDb {
                     EventStore::new(event_db_raw),
                 ));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 persisted_auxiliary_info_db = Some(PersistedAuxiliaryInfoDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(PERSISTED_AUXILIARY_INFO_DB_NAME),
@@ -171,7 +170,7 @@ impl LedgerDb {
                     .unwrap(),
                 )));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 transaction_accumulator_db = Some(TransactionAccumulatorDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(TRANSACTION_ACCUMULATOR_DB_NAME),
@@ -184,7 +183,7 @@ impl LedgerDb {
                     .unwrap(),
                 )));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 transaction_auxiliary_data_db = Some(TransactionAuxiliaryDataDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(TRANSACTION_AUXILIARY_DATA_DB_NAME),
@@ -197,7 +196,7 @@ impl LedgerDb {
                     .unwrap(),
                 )))
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 transaction_db = Some(TransactionDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(TRANSACTION_DB_NAME),
@@ -210,7 +209,7 @@ impl LedgerDb {
                     .unwrap(),
                 )));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 transaction_info_db = Some(TransactionInfoDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(TRANSACTION_INFO_DB_NAME),
@@ -223,7 +222,7 @@ impl LedgerDb {
                     .unwrap(),
                 )));
             });
-            s.spawn(|_| {
+            s.spawn(|| {
                 write_set_db = Some(WriteSetDb::new(Arc::new(
                     Self::open_rocksdb(
                         ledger_db_folder.join(WRITE_SET_DB_NAME),

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -145,34 +145,11 @@ impl StateKvDb {
         };
         let state_kv_metadata_db_path = Self::metadata_db_path(metadata_db_root_path, is_hot);
 
-        let state_kv_metadata_db = Arc::new(Self::open_db(
-            state_kv_metadata_db_path.clone(),
-            metadata_db_name(is_hot),
-            &state_kv_db_config,
-            env,
-            block_cache,
-            readonly,
-            is_hot,
-            delete_on_restart,
-        )?);
-
-        info!(
-            state_kv_metadata_db_path = state_kv_metadata_db_path,
-            is_hot = is_hot,
-            "Opened state kv metadata db!"
-        );
-
-        let state_kv_db_shards = (0..NUM_STATE_SHARDS)
-            .into_par_iter()
-            .map(|shard_id| {
-                let shard_root_path = if is_hot {
-                    db_paths.hot_state_kv_db_shard_root_path(shard_id)
-                } else {
-                    db_paths.state_kv_db_shard_root_path(shard_id)
-                };
-                let db = Self::open_shard(
-                    shard_root_path,
-                    shard_id,
+        let (metadata_db, shards) = std::thread::scope(|s| {
+            let metadata_handle = s.spawn(|| {
+                Self::open_db(
+                    state_kv_metadata_db_path.clone(),
+                    metadata_db_name(is_hot),
                     &state_kv_db_config,
                     env,
                     block_cache,
@@ -180,15 +157,57 @@ impl StateKvDb {
                     is_hot,
                     delete_on_restart,
                 )
-                .unwrap_or_else(|e| {
-                    let db_type = if is_hot { "hot state kv" } else { "state kv" };
-                    panic!("Failed to open {db_type} db shard {shard_id}: {e:?}.")
-                });
-                Arc::new(db)
-            })
-            .collect::<Vec<_>>()
+            });
+
+            let shard_handles: Vec<_> = (0..NUM_STATE_SHARDS)
+                .map(|shard_id| {
+                    s.spawn(move || {
+                        let shard_root_path = if is_hot {
+                            db_paths.hot_state_kv_db_shard_root_path(shard_id)
+                        } else {
+                            db_paths.state_kv_db_shard_root_path(shard_id)
+                        };
+                        let db = Self::open_shard(
+                            shard_root_path,
+                            shard_id,
+                            &state_kv_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                            is_hot,
+                            delete_on_restart,
+                        )
+                        .unwrap_or_else(|e| {
+                            let db_type = if is_hot { "hot state kv" } else { "state kv" };
+                            panic!("Failed to open {db_type} db shard {shard_id}: {e:?}.")
+                        });
+                        Arc::new(db)
+                    })
+                })
+                .collect();
+
+            // Joined in shard-id order so each array index matches its shard id.
+            let shards = shard_handles
+                .into_iter()
+                .map(|handle| handle.join().expect("State kv shard open thread panicked"))
+                .collect::<Vec<_>>();
+            let metadata_db = metadata_handle
+                .join()
+                .expect("State kv metadata open thread panicked");
+            (metadata_db, shards)
+        });
+
+        let state_kv_metadata_db = Arc::new(metadata_db?);
+
+        info!(
+            state_kv_metadata_db_path = state_kv_metadata_db_path,
+            is_hot = is_hot,
+            "Opened state kv metadata db!"
+        );
+
+        let state_kv_db_shards: [_; NUM_STATE_SHARDS] = shards
             .try_into()
-            .unwrap();
+            .expect("Collected exactly NUM_STATE_SHARDS shards");
 
         let state_kv_db = Self {
             inner: ShardedKvDb::new(state_kv_metadata_db, state_kv_db_shards),

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -32,7 +32,6 @@ use aptos_types::{
     state_store::{state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
-use rayon::prelude::*;
 use std::{
     ops::Deref,
     path::{Path, PathBuf},
@@ -158,47 +157,70 @@ impl StateMerkleDb {
             is_hot,
         );
 
-        let state_merkle_metadata_db = Arc::new(Self::open_db(
-            state_merkle_metadata_db_path.clone(),
-            metadata_db_name(is_hot),
-            &state_merkle_db_config,
-            env,
-            block_cache,
-            readonly,
-            delete_on_restart,
-        )?);
+        let (metadata_db, shards) = std::thread::scope(|s| {
+            let metadata_handle = s.spawn(|| {
+                Self::open_db(
+                    state_merkle_metadata_db_path.clone(),
+                    metadata_db_name(is_hot),
+                    &state_merkle_db_config,
+                    env,
+                    block_cache,
+                    readonly,
+                    delete_on_restart,
+                )
+            });
+
+            let shard_handles: Vec<_> = (0..NUM_STATE_SHARDS)
+                .map(|shard_id| {
+                    s.spawn(move || {
+                        let shard_root_path = if is_hot {
+                            db_paths.hot_state_merkle_db_shard_root_path(shard_id)
+                        } else {
+                            db_paths.state_merkle_db_shard_root_path(shard_id)
+                        };
+                        let db = Self::open_shard(
+                            shard_root_path,
+                            shard_id,
+                            &state_merkle_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                            is_hot,
+                            delete_on_restart,
+                        )
+                        .unwrap_or_else(|e| {
+                            panic!("Failed to open state merkle db shard {shard_id}: {e:?}.")
+                        });
+                        Arc::new(db)
+                    })
+                })
+                .collect();
+
+            // Joined in shard-id order so each array index matches its shard id.
+            let shards = shard_handles
+                .into_iter()
+                .map(|handle| {
+                    handle
+                        .join()
+                        .expect("State merkle shard open thread panicked")
+                })
+                .collect::<Vec<_>>();
+            let metadata_db = metadata_handle
+                .join()
+                .expect("State merkle metadata open thread panicked");
+            (metadata_db, shards)
+        });
+
+        let state_merkle_metadata_db = Arc::new(metadata_db?);
 
         info!(
             state_merkle_metadata_db_path = state_merkle_metadata_db_path,
             "Opened state merkle metadata db!"
         );
 
-        let state_merkle_db_shards: [Arc<DB>; NUM_STATE_SHARDS] = (0..NUM_STATE_SHARDS)
-            .into_par_iter()
-            .map(|shard_id| {
-                let shard_root_path = if is_hot {
-                    db_paths.hot_state_merkle_db_shard_root_path(shard_id)
-                } else {
-                    db_paths.state_merkle_db_shard_root_path(shard_id)
-                };
-                let db = Self::open_shard(
-                    shard_root_path,
-                    shard_id,
-                    &state_merkle_db_config,
-                    env,
-                    block_cache,
-                    readonly,
-                    is_hot,
-                    delete_on_restart,
-                )
-                .unwrap_or_else(|e| {
-                    panic!("Failed to open state merkle db shard {shard_id}: {e:?}.")
-                });
-                Arc::new(db)
-            })
-            .collect::<Vec<_>>()
+        let state_merkle_db_shards: [Arc<DB>; NUM_STATE_SHARDS] = shards
             .try_into()
-            .unwrap();
+            .expect("Collected exactly NUM_STATE_SHARDS shards");
 
         let db_tag: &'static str = if is_hot { "hot" } else { "cold" };
         let inner = ShardedJmtMerkleDb::new(

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -452,6 +452,7 @@ impl StateStore {
         hot_state_config: HotStateConfig,
     ) -> Self {
         if !hack_for_tests && !empty_buffered_state_for_restore {
+            let sync_progress_start = std::time::Instant::now();
             Self::sync_commit_progress(
                 Arc::clone(&ledger_db),
                 Arc::clone(&state_kv_db),
@@ -460,6 +461,10 @@ impl StateStore {
                 Arc::clone(&hot_state_merkle_db),
                 /*crash_if_difference_is_too_large=*/ true,
                 hot_state_config.delete_on_restart,
+            );
+            info!(
+                time_ms = sync_progress_start.elapsed().as_millis() as u64,
+                "Synced DB commit progress (truncation) on open."
             );
         }
         let state_db = Arc::new(StateDb {
@@ -748,6 +753,7 @@ impl StateStore {
         hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
         hot_state_config: HotStateConfig,
     ) -> Result<BufferedState> {
+        let init_start = std::time::Instant::now();
         let num_transactions = state_db
             .ledger_db
             .metadata_db()
@@ -884,6 +890,7 @@ impl StateStore {
                 .hot_root_hash()
                 .expect("main state always has a hot half"),
             latest_snapshot_root_hash = current_state.last_checkpoint().summary().root_hash(),
+            time_ms = init_start.elapsed().as_millis() as u64,
             "StateStore initialization finished.",
         );
         Ok(buffered_state)

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -39,7 +39,13 @@ pub use rocksdb::{
     DBCompressionType, Env, Options, ReadOptions, SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
 };
 use rocksdb::{ErrorKind, WriteOptions};
-use std::{collections::HashSet, fmt, iter::Iterator, path::Path};
+use std::{
+    collections::HashSet,
+    fmt,
+    iter::Iterator,
+    path::Path,
+    time::{Duration, Instant},
+};
 
 pub type ColumnFamilyName = &'static str;
 
@@ -151,6 +157,7 @@ impl DB {
         cfds: Vec<ColumnFamilyDescriptor>,
         open_mode: OpenMode,
     ) -> DbResult<DB> {
+        let start = Instant::now();
         // ignore error, since it'll fail to list cfs on the first open
         let existing_cfs: HashSet<String> = rocksdb::DB::list_cf(&db_opts, path.de_unc())
             .unwrap_or_default()
@@ -195,7 +202,14 @@ impl DB {
         }
         .into_db_res()?;
 
-        Ok(Self::log_construct(name, open_mode, inner, db_opts))
+        Ok(Self::log_construct(
+            name,
+            open_mode,
+            &requested_cfs,
+            inner,
+            db_opts,
+            start.elapsed(),
+        ))
     }
 
     fn cfd_for_unrecognized_cf(cf: &String) -> ColumnFamilyDescriptor {
@@ -206,17 +220,66 @@ impl DB {
         ColumnFamilyDescriptor::new(cf.to_string(), cf_opts)
     }
 
-    fn log_construct(name: &str, open_mode: OpenMode, inner: rocksdb::DB, opts: Options) -> DB {
-        info!(
-            rocksdb_name = name,
-            open_mode = ?open_mode,
-            "Opened RocksDB."
-        );
-        DB {
+    fn log_construct(
+        name: &str,
+        open_mode: OpenMode,
+        requested_cfs: &HashSet<String>,
+        inner: rocksdb::DB,
+        opts: Options,
+        open_duration: Duration,
+    ) -> DB {
+        let db = DB {
             name: name.to_string(),
             inner,
             opts,
+        };
+        // Best-effort size/health summary aggregated across the DB's column
+        // families, logged alongside the open latency to explain slow opens.
+        // The memtable / L0 / pending-compaction fields tell a WAL-replay-bound
+        // open (data recovered into memtables, large `memtable_bytes`) apart
+        // from a compaction-bloat-bound one (un-compacted, tombstone-heavy SSTs,
+        // large `l0_files` / `pending_compaction_bytes`). Property reads that
+        // fail fall back to 0 so this never blocks an open.
+        let mut total_sst_bytes: u64 = 0;
+        let mut live_sst_bytes: u64 = 0;
+        let mut estimate_num_keys: u64 = 0;
+        let mut memtable_bytes: u64 = 0;
+        let mut l0_files: u64 = 0;
+        let mut pending_compaction_bytes: u64 = 0;
+        for cf in requested_cfs {
+            total_sst_bytes += db
+                .get_property(cf.as_str(), "rocksdb.total-sst-files-size")
+                .unwrap_or(0);
+            live_sst_bytes += db
+                .get_property(cf.as_str(), "rocksdb.live-sst-files-size")
+                .unwrap_or(0);
+            estimate_num_keys += db
+                .get_property(cf.as_str(), "rocksdb.estimate-num-keys")
+                .unwrap_or(0);
+            memtable_bytes += db
+                .get_property(cf.as_str(), "rocksdb.size-all-mem-tables")
+                .unwrap_or(0);
+            l0_files += db
+                .get_property(cf.as_str(), "rocksdb.num-files-at-level0")
+                .unwrap_or(0);
+            pending_compaction_bytes += db
+                .get_property(cf.as_str(), "rocksdb.estimate-pending-compaction-bytes")
+                .unwrap_or(0);
         }
+        info!(
+            rocksdb_name = name,
+            open_mode = ?open_mode,
+            time_ms = open_duration.as_millis() as u64,
+            num_cfs = requested_cfs.len(),
+            total_sst_bytes = total_sst_bytes,
+            live_sst_bytes = live_sst_bytes,
+            estimate_num_keys = estimate_num_keys,
+            memtable_bytes = memtable_bytes,
+            l0_files = l0_files,
+            pending_compaction_bytes = pending_compaction_bytes,
+            "Opened RocksDB."
+        );
+        db
     }
 
     /// Reads single record by key.


### PR DESCRIPTION

Cold-restart startup spends minutes across several phases that were either
logged only at `debug!` (invisible at the prod `info` level) or not timed at
all, so it is hard to tell where the time goes (AptosDB open, hot-state load,
QuorumstoreDB open, and a large pre-open gap). Add `info!` timing across the
whole startup path so a single deploy gives a full breakdown.

- **schemadb**: every `DB::open` now logs `time_ms` plus an aggregate
  size/health summary over its column families (`total_sst_bytes`,
  `live_sst_bytes`, `estimate_num_keys`, `memtable_bytes`, `l0_files`,
  `pending_compaction_bytes`). One change instruments all ~64 AptosDB shards,
  the ledger sub-DBs, and the ConsensusDB / QuorumstoreDB / RandDB / state-sync
  DBs -- enough to explain a slow open and to tell a WAL-replay-bound open
  (large `memtable_bytes`) from a compaction-bloat-bound one (large `l0_files`
  / `pending_compaction_bytes`).
- **AptosDB::open_dbs**: time the overall concurrent open and each sub-DB
  group, and name the per-group threads (open-ledger-db, open-hot-kv-db, ...)
  so each groups opens are attributable in the logs.
- **AptosDB open_internal / StateStore**: split the post-open work into
  state-store build, commit-progress truncation, and write-set replay /
  buffered-state init (the hot-state KV load was already timed).
- **QuorumStore**: time the v1/v2 batch recovery scans, which deserialize
  every persisted batch on startup.
- **aptos-node**: time the orchestration phases (network setup, state-sync
  start, state-sync bootstrap wait, total boot) and promote the existing
  storage / mempool / consensus startup logs from `debug!` to `info!`.

All new logs are `info!` so they appear at the production log level.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/20038).
* __->__ #20038
* #20036