### PR TITLE
[consensus] Cap RocksDB WAL size

### DIFF
--- a/consensus/src/consensusdb/mod.rs
+++ b/consensus/src/consensusdb/mod.rs
@@ -26,6 +26,8 @@ use std::{iter::Iterator, path::Path, time::Instant};
 
 /// The name of the consensus db file
 pub const CONSENSUS_DB_NAME: &str = "consensus_db";
+/// Upperbound for total live WAL size.
+const MAX_TOTAL_WAL_SIZE_BYTES: u64 = 256 << 20;
 
 /// Creates new physical DB checkpoint in directory specified by `checkpoint_path`.
 pub fn create_checkpoint<P: AsRef<Path> + Clone>(db_path: P, checkpoint_path: P) -> Result<()> {
@@ -65,6 +67,7 @@ impl ConsensusDB {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+        opts.set_max_total_wal_size(MAX_TOTAL_WAL_SIZE_BYTES);
         let db = DB::open(path.clone(), "consensus", column_families, opts)
             .expect("ConsensusDB open failed; unable to continue");
 

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -52,6 +52,8 @@ pub trait QuorumStoreStorage: Sync + Send {
 
 /// The name of the quorum store db file
 pub const QUORUM_STORE_DB_NAME: &str = "quorumstoreDB";
+/// Upperbound for total live WAL size.
+const MAX_TOTAL_WAL_SIZE_BYTES: u64 = 256 << 20;
 
 pub struct QuorumStoreDB {
     db: DB,
@@ -67,6 +69,7 @@ impl QuorumStoreDB {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+        opts.set_max_total_wal_size(MAX_TOTAL_WAL_SIZE_BYTES);
         let db = DB::open(path.clone(), QUORUM_STORE_DB_NAME, column_families, opts)
             .expect("QuorumstoreDB open failed; unable to continue");
 

--- a/consensus/src/rand/rand_gen/storage/db.rs
+++ b/consensus/src/rand/rand_gen/storage/db.rs
@@ -24,6 +24,8 @@ pub struct RandDb {
 }
 
 pub const RAND_DB_NAME: &str = "rand_db";
+/// Upperbound for total live WAL size.
+const MAX_TOTAL_WAL_SIZE_BYTES: u64 = 256 << 20;
 
 impl RandDb {
     pub(crate) fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
@@ -38,6 +40,7 @@ impl RandDb {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+        opts.set_max_total_wal_size(MAX_TOTAL_WAL_SIZE_BYTES);
         let db = Arc::new(
             DB::open(path.clone(), RAND_DB_NAME, column_families, opts)
                 .expect("RandDB open failed; unable to continue"),

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -39,7 +39,13 @@ pub use rocksdb::{
     DBCompressionType, Env, Options, ReadOptions, SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
 };
 use rocksdb::{ErrorKind, WriteOptions};
-use std::{collections::HashSet, fmt, iter::Iterator, path::Path};
+use std::{
+    collections::HashSet,
+    fmt,
+    iter::Iterator,
+    path::Path,
+    time::{Duration, Instant},
+};
 
 pub type ColumnFamilyName = &'static str;
 
@@ -151,6 +157,7 @@ impl DB {
         cfds: Vec<ColumnFamilyDescriptor>,
         open_mode: OpenMode,
     ) -> DbResult<DB> {
+        let start = Instant::now();
         // ignore error, since it'll fail to list cfs on the first open
         let existing_cfs: HashSet<String> = rocksdb::DB::list_cf(&db_opts, path.de_unc())
             .unwrap_or_default()
@@ -195,7 +202,13 @@ impl DB {
         }
         .into_db_res()?;
 
-        Ok(Self::log_construct(name, open_mode, inner, db_opts))
+        Ok(Self::log_construct(
+            name,
+            open_mode,
+            inner,
+            db_opts,
+            start.elapsed(),
+        ))
     }
 
     fn cfd_for_unrecognized_cf(cf: &String) -> ColumnFamilyDescriptor {
@@ -206,10 +219,17 @@ impl DB {
         ColumnFamilyDescriptor::new(cf.to_string(), cf_opts)
     }
 
-    fn log_construct(name: &str, open_mode: OpenMode, inner: rocksdb::DB, opts: Options) -> DB {
+    fn log_construct(
+        name: &str,
+        open_mode: OpenMode,
+        inner: rocksdb::DB,
+        opts: Options,
+        open_duration: Duration,
+    ) -> DB {
         info!(
             rocksdb_name = name,
             open_mode = ?open_mode,
+            time_ms = open_duration.as_millis() as u64,
             "Opened RocksDB."
         );
         DB {


### PR DESCRIPTION

I was looking at node startup time on devnet, and noticed that a few of
these databases take quite long to open. Cap the total live WAL size of
all three consensus RocksDB instances (`consensus_db`, `quorumstoreDB`,
and `rand_db`) to 256 MiB, similar to commit 56c4fd1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> WAL caps can increase flush/compaction under heavy consensus writes and affect crash-recovery behavior slightly, but the limit mirrors an existing storage change and targets startup latency.
> 
> **Overview**
> Caps **total live WAL size** to **256 MiB** on the three consensus-side RocksDB opens (`consensus_db`, `quorumstoreDB`, `rand_db`) via `opts.set_max_total_wal_size`, matching the pattern used elsewhere to shorten DB open time when WALs have grown large.
> 
> **schemadb** now records how long RocksDB open takes and logs **`time_ms`** on the generic `"Opened RocksDB."` line (in addition to the existing per-DB open timing in consensus).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da956e51340f4f83610304571f86e5e0b32ca11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->