### PR TITLE
change executor bench to feedback output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,6 +4798,7 @@ dependencies = [
  "aptos-infallible",
  "aptos-logger",
  "aptos-sdk",
+ "aptos-types",
  "async-trait",
  "clap 4.5.60",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,6 @@ members = [
     "execution/executor-types",
     "experimental/bulk-txn-submit",
     "experimental/execution/ptx-executor",
-
     "experimental/runtimes",
     "experimental/storage/hexy",
     "experimental/storage/layered-map",
@@ -306,6 +305,7 @@ rust-version = "1.88"
 # Internal crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
 aptos = { path = "crates/aptos" }
+aptos-abstract-gas-usage = { path = "aptos-move/aptos-abstract-gas-usage" }
 aptos-accumulator = { path = "storage/accumulator" }
 aptos-admin-service = { path = "crates/aptos-admin-service" }
 aptos-aggregator = { path = "aptos-move/aptos-aggregator" }
@@ -316,19 +316,21 @@ aptos-backup-cli = { path = "storage/backup/backup-cli" }
 aptos-backup-service = { path = "storage/backup/backup-service" }
 aptos-batch-encryption = { path = "crates/aptos-batch-encryption" }
 aptos-bcs-utils = { path = "crates/aptos-bcs-utils" }
-aptos-bounded-executor = { path = "crates/bounded-executor" }
-aptos-block-executor = { path = "aptos-move/block-executor" }
 aptos-bitvec = { path = "crates/aptos-bitvec" }
+aptos-block-executor = { path = "aptos-move/block-executor" }
+aptos-block-partitioner = { path = "execution/block-partitioner" }
+aptos-bounded-executor = { path = "crates/bounded-executor" }
 aptos-build-info = { path = "crates/aptos-build-info" }
 aptos-cached-packages = { path = "aptos-move/framework/cached-packages" }
+aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
 aptos-channels = { path = "crates/channel" }
 aptos-cli-common = { path = "crates/aptos-cli-common" }
 aptos-collections = { path = "crates/aptos-collections" }
 aptos-compression = { path = "crates/aptos-compression" }
+aptos-config = { path = "config" }
 aptos-consensus = { path = "consensus" }
 aptos-consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
 aptos-consensus-types = { path = "consensus/consensus-types" }
-aptos-config = { path = "config" }
 aptos-crash-handler = { path = "crates/crash-handler" }
 aptos-crypto = { path = "crates/aptos-crypto" }
 aptos-crypto-derive = { path = "crates/aptos-crypto-derive" }
@@ -342,32 +344,28 @@ aptos-debugger = { path = "crates/aptos-debugger" }
 aptos-dkg = { path = "crates/aptos-dkg" }
 aptos-dkg-runtime = { path = "dkg" }
 aptos-drop-helper = { path = "crates/aptos-drop-helper" }
+aptos-enum-conversion-derive = { path = "crates/aptos-enum-conversion-derive" }
 aptos-event-notifications = { path = "state-sync/inter-component/event-notifications" }
 aptos-executor = { path = "execution/executor" }
-aptos-block-partitioner = { path = "execution/block-partitioner" }
-aptos-enum-conversion-derive = { path = "crates/aptos-enum-conversion-derive" }
 aptos-executor-service = { path = "execution/executor-service" }
 aptos-executor-test-helpers = { path = "execution/executor-test-helpers" }
 aptos-executor-types = { path = "execution/executor-types" }
-aptos-experimental-hexy = { path = "experimental/storage/hexy" }
 aptos-experimental-bulk-txn-submit = { path = "experimental/bulk-txn-submit" }
+aptos-experimental-hexy = { path = "experimental/storage/hexy" }
 aptos-experimental-layered-map = { path = "experimental/storage/layered-map" }
 aptos-experimental-ptx-executor = { path = "experimental/execution/ptx-executor" }
 aptos-experimental-runtimes = { path = "experimental/runtimes" }
+aptos-fallible = { path = "crates/fallible" }
 aptos-faucet-cli = { path = "crates/aptos-faucet/cli" }
 aptos-faucet-core = { path = "crates/aptos-faucet/core" }
-aptos-faucet-service = { path = "crates/aptos-faucet/service" }
 aptos-faucet-metrics-server = { path = "crates/aptos-faucet/metrics-server" }
-aptos-fallible = { path = "crates/fallible" }
+aptos-faucet-service = { path = "crates/aptos-faucet/service" }
 aptos-forge = { path = "testsuite/forge" }
 aptos-framework = { path = "aptos-move/framework" }
 aptos-framework-natives = { path = "aptos-move/framework/natives" }
-aptos-release-bundle = { path = "aptos-move/framework/release-bundle" }
-fuzzer = { path = "testsuite/fuzzer" }
-aptos-abstract-gas-usage = { path = "aptos-move/aptos-abstract-gas-usage" }
-aptos-gas-meter = { path = "aptos-move/aptos-gas-meter" }
 aptos-gas-algebra = { path = "aptos-move/aptos-gas-algebra" }
 aptos-gas-calibration = { path = "aptos-move/aptos-gas-calibration" }
+aptos-gas-meter = { path = "aptos-move/aptos-gas-meter" }
 aptos-gas-profiling = { path = "aptos-move/aptos-gas-profiling" }
 aptos-gas-schedule = { path = "aptos-move/aptos-gas-schedule" }
 aptos-gas-schedule-updator = { path = "aptos-move/aptos-gas-schedule-updator" }
@@ -379,18 +377,18 @@ aptos-in-memory-cache = { path = "crates/aptos-in-memory-cache" }
 aptos-indexer-grpc-cache-worker = { path = "ecosystem/indexer-grpc/indexer-grpc-cache-worker" }
 aptos-indexer-grpc-data-service = { path = "ecosystem/indexer-grpc/indexer-grpc-data-service" }
 aptos-indexer-grpc-data-service-v2 = { path = "ecosystem/indexer-grpc/indexer-grpc-data-service-v2" }
-aptos-indexer-grpc-file-store = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store" }
 aptos-indexer-grpc-file-checker = { path = "ecosystem/indexer-grpc/indexer-grpc-file-checker" }
+aptos-indexer-grpc-file-store = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store" }
 aptos-indexer-grpc-file-store-backfiller = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller" }
 aptos-indexer-grpc-fullnode = { path = "ecosystem/indexer-grpc/indexer-grpc-fullnode" }
 aptos-indexer-grpc-gateway = { path = "ecosystem/indexer-grpc/indexer-grpc-gateway" }
 aptos-indexer-grpc-in-memory-cache-benchmark = { path = "ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark" }
 aptos-indexer-grpc-manager = { path = "ecosystem/indexer-grpc/indexer-grpc-manager" }
+aptos-indexer-grpc-server-framework = { path = "ecosystem/indexer-grpc/indexer-grpc-server-framework" }
 aptos-indexer-grpc-table-info = { path = "ecosystem/indexer-grpc/indexer-grpc-table-info" }
-aptos-indexer-test-transactions = { path = "ecosystem/indexer-grpc/indexer-test-transactions" }
 aptos-indexer-grpc-utils = { path = "ecosystem/indexer-grpc/indexer-grpc-utils" }
 aptos-indexer-grpc-v2-file-store-backfiller = { path = "ecosystem/indexer-grpc/indexer-grpc-v2-file-store-backfiller" }
-aptos-indexer-grpc-server-framework = { path = "ecosystem/indexer-grpc/indexer-grpc-server-framework" }
+aptos-indexer-test-transactions = { path = "ecosystem/indexer-grpc/indexer-test-transactions" }
 aptos-indexer-transaction-generator = { path = "ecosystem/indexer-grpc/indexer-transaction-generator" }
 aptos-infallible = { path = "crates/aptos-infallible" }
 aptos-inspection-service = { path = "crates/aptos-inspection-service" }
@@ -399,6 +397,9 @@ aptos-jemalloc = { path = "crates/aptos-jemalloc" }
 aptos-jwk-consensus = { path = "crates/aptos-jwk-consensus" }
 aptos-jwk-utils = { path = "crates/jwk-utils" }
 aptos-keygen = { path = "crates/aptos-keygen" }
+aptos-keyless-common = { path = "keyless/common" }
+aptos-keyless-pepper-common = { path = "keyless/pepper/common" }
+aptos-keyless-pepper-service = { path = "keyless/pepper/service" }
 aptos-language-e2e-tests = { path = "aptos-move/e2e-tests" }
 aptos-ledger = { path = "crates/aptos-ledger" }
 aptos-localnet = { path = "crates/aptos-localnet" }
@@ -411,10 +412,10 @@ aptos-memsocket = { path = "network/memsocket" }
 aptos-metrics-core = { path = "crates/aptos-metrics-core" }
 aptos-move-cli = { path = "aptos-move/cli" }
 aptos-move-debugger = { path = "aptos-move/aptos-debugger" }
-aptos-move-examples = { path = "aptos-move/move-examples" }
-aptos-move-flow = { path = "aptos-move/flow" }
 aptos-move-e2e-benchmark = { path = "aptos-move/e2e-benchmark" }
 aptos-move-e2e-test-harness = { path = "aptos-move/e2e-move-test-harness" }
+aptos-move-examples = { path = "aptos-move/move-examples" }
+aptos-move-flow = { path = "aptos-move/flow" }
 aptos-mvhashmap = { path = "aptos-move/mvhashmap" }
 aptos-native-interface = { path = "aptos-move/aptos-native-interface" }
 aptos-netcore = { path = "network/netcore" }
@@ -432,15 +433,13 @@ aptos-package-builder = { path = "aptos-move/package-builder" }
 aptos-peer-monitoring-service-client = { path = "peer-monitoring-service/client" }
 aptos-peer-monitoring-service-server = { path = "peer-monitoring-service/server" }
 aptos-peer-monitoring-service-types = { path = "peer-monitoring-service/types" }
-aptos-keyless-common = { path = "keyless/common" }
-aptos-keyless-pepper-common = { path = "keyless/pepper/common" }
-aptos-keyless-pepper-service = { path = "keyless/pepper/service" }
 aptos-profiler = { path = "crates/aptos-profiler" }
 aptos-proptest-helpers = { path = "crates/aptos-proptest-helpers" }
 aptos-protos = { path = "protos/rust" }
 aptos-proxy = { path = "crates/proxy" }
 aptos-push-metrics = { path = "crates/aptos-push-metrics" }
 aptos-release-builder = { path = "aptos-move/aptos-release-builder" }
+aptos-release-bundle = { path = "aptos-move/framework/release-bundle" }
 aptos-reliable-broadcast = { path = "crates/reliable-broadcast" }
 aptos-replay-benchmark = { path = "aptos-move/replay-benchmark" }
 aptos-resource-viewer = { path = "aptos-move/aptos-resource-viewer" }
@@ -463,11 +462,9 @@ aptos-state-sync-driver = { path = "state-sync/state-sync-driver" }
 aptos-storage-interface = { path = "storage/storage-interface" }
 aptos-storage-service-client = { path = "state-sync/storage-service/client" }
 aptos-storage-service-notifications = { path = "state-sync/inter-component/storage-service-notifications" }
-aptos-storage-service-types = { path = "state-sync/storage-service/types" }
 aptos-storage-service-server = { path = "state-sync/storage-service/server" }
+aptos-storage-service-types = { path = "state-sync/storage-service/types" }
 aptos-system-utils = { path = "crates/aptos-system-utils" }
-aptos-transaction-filter = { path = "ecosystem/indexer-grpc/transaction-filter" }
-aptos-transaction-filters = { path = "crates/aptos-transaction-filters" }
 aptos-telemetry = { path = "crates/aptos-telemetry" }
 aptos-telemetry-service = { path = "crates/aptos-telemetry-service" }
 aptos-temppath = { path = "crates/aptos-temppath" }
@@ -477,11 +474,13 @@ aptos-time-service = { path = "crates/aptos-time-service", features = [
 ] }
 aptos-token-bucket = { path = "crates/aptos-token-bucket" }
 aptos-transaction-emitter-lib = { path = "crates/transaction-emitter-lib" }
+aptos-transaction-filter = { path = "ecosystem/indexer-grpc/transaction-filter" }
+aptos-transaction-filters = { path = "crates/aptos-transaction-filters" }
 aptos-transaction-generator-lib = { path = "crates/transaction-generator-lib" }
-aptos-transaction-workloads-lib = { path = "crates/transaction-workloads-lib" }
 aptos-transaction-simulation = { path = "aptos-move/aptos-transaction-simulation" }
-aptos-transaction-tracing = { path = "crates/aptos-transaction-tracing" }
 aptos-transaction-simulation-session = { path = "aptos-move/aptos-transaction-simulation-session" }
+aptos-transaction-tracing = { path = "crates/aptos-transaction-tracing" }
+aptos-transaction-workloads-lib = { path = "crates/transaction-workloads-lib" }
 aptos-transactional-test-harness = { path = "aptos-move/aptos-transactional-test-harness" }
 aptos-types = { path = "types" }
 aptos-validator-interface = { path = "aptos-move/aptos-validator-interface" }
@@ -489,29 +488,29 @@ aptos-validator-transaction-pool = { path = "crates/validator-transaction-pool" 
 aptos-vault-client = { path = "secure/storage/vault" }
 aptos-vm = { path = "aptos-move/aptos-vm" }
 aptos-vm-environment = { path = "aptos-move/aptos-vm-environment" }
-aptos-vm-logging = { path = "aptos-move/aptos-vm-logging" }
 aptos-vm-genesis = { path = "aptos-move/vm-genesis" }
+aptos-vm-logging = { path = "aptos-move/aptos-vm-logging" }
 aptos-vm-types = { path = "aptos-move/aptos-vm-types" }
 aptos-vm-validator = { path = "vm-validator" }
-aptos-workspace-server = { path = "aptos-move/aptos-workspace-server" }
 aptos-warp-webserver = { path = "crates/aptos-warp-webserver" }
-aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
+aptos-workspace-server = { path = "aptos-move/aptos-workspace-server" }
+fuzzer = { path = "testsuite/fuzzer" }
 
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
 aes-gcm = "0.10.3"
-ahash = { version = "0.8.11", features = ["serde"] }
-atty = "0.2.14"
-nalgebra = "0.32"
-float-cmp = "0.9.0"
 again = "0.1.2"
+ahash = { version = "0.8.11", features = ["serde"] }
 ambassador = "0.4.1"
 annotate-snippets = "0.11.5"
-anyhow = "1.0.98"
 anstyle = "1.0.1"
+anyhow = "1.0.98"
+aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", tag = "aptos-indexer-processor-sdk-v2.2.1", features = [
+    "postgres_partial",
+] }
+aptos-moving-average = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", tag = "aptos-indexer-processor-sdk-v2.2.1" }
 arbitrary = { version = "1.4.1", features = ["derive"] }
 arc-swap = "1.6.0"
-arr_macro = "0.2.1"
 ark-bls12-381 = { version = "0.5.0", features = ["curve"] }
 ark-bn254 = { version = "0.5.0", features = ["curve"] }
 ark-ec = { version = "0.5.0", features = ["parallel", "rayon"] }
@@ -524,34 +523,31 @@ ark-relations = "0.5.0"
 ark-serialize = { version = "0.5.0", features = ["derive"] }
 ark-snark = { version = "0.5.0" }
 ark-std = { version = "0.5.0", features = ["getrandom"] }
-aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", tag = "aptos-indexer-processor-sdk-v2.2.1", features = [
-    "postgres_partial",
-] }
-aptos-moving-average = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", tag = "aptos-indexer-processor-sdk-v2.2.1" }
+arr_macro = "0.2.1"
 assert_approx_eq = "1.1.0"
 async-channel = "1.7.1"
 async-mutex = "1.4.0"
 async-recursion = "1.0.5"
 async-trait = "0.1.53"
+atty = "0.2.14"
 axum = "0.7.5"
-base64 = "0.13.0"
 backoff = { version = "0.4.0", features = ["tokio"] }
 backtrace = "0.3.58"
+base64 = "0.13.0"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 better_any = "0.1.1"
 bigdecimal = { version = "0.4.0", features = ["serde"] }
-version-compare = "0.1.1"
 bitflags = "2.11.0"
 bitvec = "1.0.1"
-boxcar = "0.2.13"
 blake2 = "0.10.4"
-blake3 = { version = "1.5.4", features = ["mmap", "rayon"] }
 blake2-rfc = "0.2.18"
+blake3 = { version = "1.5.4", features = ["mmap", "rayon"] }
 bls12_381 = "0.8.0"
 blst = "0.3.15"
 # The __private_bench feature exposes the Fp12 type which we need to implement a multi-threaded multi-pairing.
 blstrs = { version = "0.7.1", features = ["serde", "__private_bench"] }
 bollard = "0.15"
+boxcar = "0.2.13"
 build_html = "2.5.0"
 bulletproofs = { version = "4.0.0" }
 bumpalo = { version = "3.14" }
@@ -559,9 +555,9 @@ byteorder = "1.4.3"
 bytes = { version = "1.4.0", features = ["serde"] }
 bytesize = { version = "1.3.0" }
 camino = { version = "1.1.6" }
+cfg-if = "1.0.0"
 chrono = { version = "0.4.19", features = ["clock", "serde"] }
 chrono-tz = "0.10.1"
-cfg-if = "1.0.0"
 ciborium = "0.2"
 claims = "0.7"
 clap = { version = "4.3.9", features = [
@@ -594,12 +590,13 @@ curve25519-dalek = "3"
 curve25519-dalek-ng = "4"
 dashmap = { version = "7.0.0-rc2", features = ["inline-more"] }
 datatest-stable = "0.1.1"
+dearbitrary = { version = "1.0.4", features = ["derive"] }
 debug-ignore = { version = "1.0.3", features = ["serde"] }
-derivative = "2.2.0"
 derivation-path = "0.2.0"
+derivative = "2.2.0"
 derive_builder = "0.20.0"
-determinator = "0.12.0"
 derive_more = "0.99.11"
+determinator = "0.12.0"
 diesel = { version = "~2.3", features = ["uuid"] }
 diesel-async = { version = "0.7.4", features = [
     "async-connection-wrapper",
@@ -622,9 +619,8 @@ enum_dispatch = "0.3.12"
 env_logger = "0.10.0"
 equivalent = "1.0"
 erased-serde = "0.3.13"
-ethnum = "1.5.2"
 ethers = { version = "2" }
-dearbitrary = { version = "1.0.4", features = ["derive"] }
+ethnum = "1.5.2"
 fail = "0.5.0"
 ff = { version = "0.13", features = ["derive"] }
 field_count = "0.1.1"
@@ -635,17 +631,18 @@ firestore = "0.43.0"
 fixed = "1.25.1"
 flate2 = "1.0.24"
 flexi_logger = "0.27.4"
+float-cmp = "0.9.0"
+fs2 = "0.4.3"
 futures = "0.3.29"
 futures-channel = "0.3.29"
 futures-core = "0.3.29"
 futures-util = "0.3.29"
 fxhash = "0.2.1"
-fs2 = "0.4.3"
-getrandom = "0.2.2"
 gcp-bigquery-client = "0.16.8"
 generic-array = { version = "0.14.7", features = ["serde"] }
-get_if_addrs = "0.5.3"
 get-size = { version = "0.1.4", features = ["derive"] }
+get_if_addrs = "0.5.3"
+getrandom = "0.2.2"
 git2 = "0.16.1"
 glob = "0.3.0"
 goldenfile = "1.5.2"
@@ -674,14 +671,14 @@ inferno = "0.11.14"
 internment = { version = "0.5.0", features = ["arc"] }
 ipnet = "2.5.0"
 itertools = "0.13"
+jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.1" }
+jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.6.1" }
+jemalloc_pprof = { version = "0.8", features = ["symbolize"] }
 jemallocator = { package = "tikv-jemallocator", version = "0.6.1", features = [
     "profiling",
     "stats",
     "unprefixed_malloc_on_supported_platforms",
 ] }
-jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.1" }
-jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.6.1" }
-jemalloc_pprof = { version = "0.8", features = ["symbolize"] }
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
 jwt = "0.16.0"
@@ -694,14 +691,15 @@ log = "0.4.17"
 lru = "0.16.1"
 lz4 = "1.28.0"
 maplit = "1.0.2"
-merlin = "3"
 memchr = "2.7.4"
 memory-stats = "1.0.0"
+merlin = "3"
 mime = "0.3.16"
 mini-moka = { version = "0.10.3", features = ["sync"] }
 mirai-annotations = "1.12.0"
 mockall = "0.11.4"
 more-asserts = "0.3.0"
+nalgebra = "0.32"
 named-lock = "0.2.0"
 native-tls = "0.2.10"
 neptune = { version = "13.0.0", default-features = false }
@@ -709,30 +707,26 @@ notify = "8.2.0"
 ntest = "0.9.3"
 num = "0.4.0"
 num-bigint = { version = "0.3.2", features = ["rand"] }
-num_cpus = "1.13.1"
 num-derive = "0.4.2"
 num-integer = "0.1.42"
 num-traits = "0.2.19"
+num_cpus = "1.13.1"
 once_cell = "1.10.0"
 open = "5.3.1"
 opentelemetry = { version = "0.27.0", features = ["trace"] }
-opentelemetry_sdk = { version = "0.27.0", features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = { version = "0.27.0", features = ["grpc-tonic", "trace"] }
+opentelemetry_sdk = { version = "0.27.0", features = ["trace", "rt-tokio"] }
 ordered-float = "3.9.1"
 ouroboros = "0.15.6"
 owo-colors = "3.5.0"
 p256 = { version = "0.13.2" }
-prettydiff = "0.6.2"
-primitive-types = { version = "0.12.2" }
-signature = "2.1.0"
-slh-dsa = "=0.2.0-rc.4"
 pairing = "0.23"
 parking_lot = "0.12.0"
-paste = "1.0.7"
-pathsearch = "0.2.0"
 passkey-authenticator = { version = "0.2.0", features = ["testable"] }
 passkey-client = { version = "0.2.0" }
 passkey-types = { version = "0.2.0" }
+paste = "1.0.7"
+pathsearch = "0.2.0"
 pbjson = "0.5.1"
 percent-encoding = "2.1.0"
 petgraph = "0.6.5"
@@ -745,11 +739,13 @@ poseidon-ark = { git = "https://github.com/arnaucube/poseidon-ark.git", rev = "6
 pprof = { version = "0.11", features = ["flamegraph", "protobuf-codec"] }
 pretty = "0.10.0"
 pretty_assertions = "1.2.1"
+prettydiff = "0.6.2"
+primitive-types = { version = "0.12.2" }
+proc-macro2 = "1.0.38"
 # We set default-features to false so we don't onboard the libpq dep. See more here:
 # https://github.com/aptos-labs/aptos-core/pull/12568
 processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors-v2.git", tag = "aptos-indexer-processors-v2.4.1", default-features = false }
 procfs = "0.14.1"
-proc-macro2 = "1.0.38"
 project-root = "0.2.2"
 prometheus = { version = "0.13.3", default-features = false }
 prometheus-http-query = "0.5.2"
@@ -758,8 +754,8 @@ proptest-derive = "0.5.1"
 prost = { version = "0.13.4", features = ["no-recursion-limit"] }
 prost-types = "0.13.3"
 quanta = "0.10.1"
-quick_cache = "0.5.1"
 quick-junit = "0.5.0"
+quick_cache = "0.5.1"
 quote = "1.0.18"
 rand = "0.7.3"
 rand_core = "0.5.1"
@@ -792,31 +788,33 @@ rsa = { version = "0.9.6" }
 rstack-self = { version = "0.3.0", features = ["dw"], default-features = false }
 rstest = "0.15.0"
 rustc-hash = "2"
-rusty-fork = "0.3.0"
 rustversion = "1.0.14"
+rusty-fork = "0.3.0"
 scopeguard = "1.2.0"
-sha2 = "0.9.3"
-sha256 = "1.4.0"
-sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
-sha3 = "0.9.1"
-shell-words = "1.0.0"
-siphasher = "0.3.10"
 serde = { version = "1.0.193", features = ["derive", "rc"] }
 serde-big-array = "0.5.1"
+serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "9d2374af843a4562a194529b3cadb8518d7fcd65" }
+serde-name = "0.2.1"
+serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "9d2374af843a4562a194529b3cadb8518d7fcd65" }
 serde_bytes = "0.11.6"
 serde_json = { version = "1.0.81", features = [
     "preserve_order",
     "arbitrary_precision",
 ] } # Note: arbitrary_precision is required to parse u256 in JSON
-serde_repr = "0.1"
 serde_merge = "0.1.3"
-serde-name = "0.2.1"
-serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "9d2374af843a4562a194529b3cadb8518d7fcd65" }
-serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "9d2374af843a4562a194529b3cadb8518d7fcd65" }
+serde_repr = "0.1"
 serde_with = "3.4.0"
 serde_yaml = "0.8.24"
 set_env = "1.3.4"
+sha2 = "0.9.3"
+sha256 = "1.4.0"
+sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
+sha3 = "0.9.1"
 shadow-rs = "0.16.2"
+shell-words = "1.0.0"
+signature = "2.1.0"
+siphasher = "0.3.10"
+slh-dsa = "=0.2.0-rc.4"
 smallbitvec = "2.5.1"
 smallvec = "1.8.0"
 specializer = { path = "third_party/move/mono-move/specializer" }
@@ -835,21 +833,10 @@ test-case = "3.1.0"
 textwrap = "0.15.0"
 thiserror = "1.0.37"
 thousands = "0.2.0"
-threadpool = "1.8.1"
 thread_local = "1.1.7"
+threadpool = "1.8.1"
 tiny-bip39 = "0.8.2"
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
-tracing = "0.1.37"
-tracing-log = "0.2.0"
-tracing-opentelemetry = "0.28.0"
-tracing-subscriber = { version = "0.3.17", features = [
-    "json",
-    "env-filter",
-    "registry",
-] }
-triomphe = "0.1.14"
-trybuild = "1.0.80"
-try_match = "0.4.2"
 tokio = { version = "1.35.1", features = ["full"] }
 tokio-io-timeout = "1.2.0"
 tokio-retry = "0.3.0"
@@ -868,6 +855,17 @@ tonic = { version = "0.12.3", features = [
 ] }
 tonic-reflection = "0.12.3"
 topological-sort = "0.2.2"
+tracing = "0.1.37"
+tracing-log = "0.2.0"
+tracing-opentelemetry = "0.28.0"
+tracing-subscriber = { version = "0.3.17", features = [
+    "json",
+    "env-filter",
+    "registry",
+] }
+triomphe = "0.1.14"
+try_match = "0.4.2"
+trybuild = "1.0.80"
 tui = "0.19.0"
 typed-arena = "2.0.2"
 typenum = "1.17.0"
@@ -880,6 +878,7 @@ url = { version = "2.4.0", features = ["serde"] }
 usdt = "0.6.0"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 variant_count = "1.1.0"
+version-compare = "0.1.1"
 walkdir = "2.3.3"
 warp = { version = "0.3.5", features = ["tls"] }
 warp-reverse-proxy = "1.0.0"
@@ -892,12 +891,15 @@ x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", rev = "b9cd
 z3tracer = "0.8.0"
 
 # MOVE DEPENDENCIES
+aptos-move-stdlib = { path = "aptos-move/framework/move-stdlib" }
+aptos-table-natives = { path = "aptos-move/framework/table-natives" }
+legacy-move-compiler = { path = "third_party/move/move-compiler-v2/legacy-move-compiler" }
 mono-move-alloc = { path = "third_party/move/mono-move/alloc" }
-mono-move-orchestrator = { path = "third_party/move/mono-move/orchestrator" }
 mono-move-core = { path = "third_party/move/mono-move/core" }
 mono-move-global-context = { path = "third_party/move/mono-move/global-context" }
 mono-move-loader = { path = "third_party/move/mono-move/loader" }
 mono-move-natives = { path = "third_party/move/mono-move/natives" }
+mono-move-orchestrator = { path = "third_party/move/mono-move/orchestrator" }
 mono-move-runtime = { path = "third_party/move/mono-move/runtime" }
 mono-move-testsuite = { path = "third_party/move/mono-move/testsuite" }
 move-abigen = { path = "third_party/move/tools/move-abigen" }
@@ -906,14 +908,13 @@ move-binary-format = { path = "third_party/move/move-binary-format" }
 move-borrow-graph = { path = "third_party/move/move-borrow-graph" }
 move-bytecode-source-map = { path = "third_party/move/move-ir-compiler/move-bytecode-source-map" }
 move-bytecode-spec = { path = "third_party/move/move-bytecode-spec" }
+move-bytecode-utils = { path = "third_party/move/tools/move-bytecode-utils" }
 move-bytecode-verifier = { path = "third_party/move/move-bytecode-verifier" }
 move-bytecode-verifier-invalid-mutations = { path = "third_party/move/move-bytecode-verifier/invalid-mutations" }
-move-bytecode-utils = { path = "third_party/move/tools/move-bytecode-utils" }
 move-command-line-common = { path = "third_party/move/move-command-line-common" }
-move-coverage = { path = "third_party/move/tools/move-coverage" }
-legacy-move-compiler = { path = "third_party/move/move-compiler-v2/legacy-move-compiler" }
 move-compiler-v2 = { path = "third_party/move/move-compiler-v2" }
 move-core-types = { path = "third_party/move/move-core/types" }
+move-coverage = { path = "third_party/move/tools/move-coverage" }
 move-decompiler = { path = "third_party/move/tools/move-decompiler" }
 move-docgen = { path = "third_party/move/tools/move-docgen" }
 move-ir-types = { path = "third_party/move/move-ir/types" }
@@ -925,10 +926,8 @@ move-package-manifest = { path = "third_party/move/tools/move-package-manifest" 
 move-prover = { path = "third_party/move/move-prover" }
 move-prover-boogie-backend = { path = "third_party/move/move-prover/boogie-backend" }
 move-prover-bytecode-pipeline = { path = "third_party/move/move-prover/bytecode-pipeline" }
-move-prover-test-utils = { path = "third_party/move/move-prover/test-utils" }
 move-prover-lab = { path = "third_party/move/move-prover/lab" }
-aptos-move-stdlib = { path = "aptos-move/framework/move-stdlib" }
-aptos-table-natives = { path = "aptos-move/framework/table-natives" }
+move-prover-test-utils = { path = "third_party/move/move-prover/test-utils" }
 move-resource-viewer = { path = "third_party/move/tools/move-resource-viewer" }
 move-stackless-bytecode = { path = "third_party/move/move-model/bytecode" }
 move-stackless-bytecode-test-utils = { path = "third_party/move/move-model/bytecode-test-utils" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,6 +12,12 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["mime"]
+
+[features]
+failpoints = ["fail/failpoints"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-api-types = { workspace = true }
@@ -69,9 +75,3 @@ rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 warp = { workspace = true }
-
-[features]
-failpoints = ["fail/failpoints"]
-
-[package.metadata.cargo-machete]
-ignored = ["mime"]

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["async-trait", "poem", "poem-openapi-derive"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
@@ -35,6 +38,3 @@ poem-openapi = { workspace = true }
 poem-openapi-derive = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = ["async-trait", "poem", "poem-openapi-derive"]

--- a/aptos-move/aptos-aggregator/Cargo.toml
+++ b/aptos-move/aptos-aggregator/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+testing = []
+
 [dependencies]
 aptos-types = { workspace = true }
 bcs = { workspace = true }
@@ -24,7 +28,3 @@ triomphe = { workspace = true }
 [dev-dependencies]
 once_cell = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-default = []
-testing = []

--- a/aptos-move/aptos-debugger/Cargo.toml
+++ b/aptos-move/aptos-debugger/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[[bin]]
+name = "remote-gas-profiler"
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-block-executor = { workspace = true }
@@ -35,6 +38,3 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
-
-[[bin]]
-name = "remote-gas-profiler"

--- a/aptos-move/aptos-gas-schedule/Cargo.toml
+++ b/aptos-move/aptos-gas-schedule/Cargo.toml
@@ -11,6 +11,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+testing = ["aptos-global-constants/testing"]
+
 [dependencies]
 aptos-gas-algebra = { workspace = true }
 aptos-global-constants = { workspace = true }
@@ -18,6 +21,3 @@ move-core-types = { workspace = true }
 move-vm-types = { workspace = true }
 paste = { workspace = true }
 rand = { workspace = true }
-
-[features]
-testing = ["aptos-global-constants/testing"]

--- a/aptos-move/aptos-release-builder/Cargo.toml
+++ b/aptos-move/aptos-release-builder/Cargo.toml
@@ -12,9 +12,13 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[[bin]]
+name = "aptos-release-builder"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { workspace = true }
-aptos = { workspace = true, features = [ "no-upload-proposal" ] }
+aptos = { workspace = true, features = ["no-upload-proposal"] }
 aptos-build-info = { workspace = true }
 aptos-cli-common = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -59,7 +63,3 @@ strum_macros = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 walkdir = { workspace = true }
-
-[[bin]]
-name = "aptos-release-builder"
-path = "src/main.rs"

--- a/aptos-move/aptos-sdk-builder/Cargo.toml
+++ b/aptos-move/aptos-sdk-builder/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-types = { workspace = true }
@@ -30,6 +33,3 @@ aptos-cached-packages = { workspace = true }
 aptos-framework = { workspace = true }
 tempfile = { workspace = true }
 which = { workspace = true }
-
-[features]
-default = []

--- a/aptos-move/aptos-transaction-benchmarks/Cargo.toml
+++ b/aptos-move/aptos-transaction-benchmarks/Cargo.toml
@@ -21,7 +21,7 @@ aptos-language-e2e-tests = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-node-resource-metrics = { workspace = true }
-aptos-push-metrics =  { workspace = true }
+aptos-push-metrics = { workspace = true }
 aptos-transaction-simulation = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }

--- a/aptos-move/aptos-transaction-simulation/Cargo.toml
+++ b/aptos-move/aptos-transaction-simulation/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true, features = ["cloneable-private-keys"] }
@@ -26,6 +29,3 @@ once_cell = { workspace = true }
 parking_lot = { workspace = true }
 proptest = { workspace = true }
 serde = { workspace = true }
-
-[features]
-default = []

--- a/aptos-move/aptos-vm-environment/Cargo.toml
+++ b/aptos-move/aptos-vm-environment/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+testing = ["aptos-move-stdlib/testing"]
+profiling = ["move-vm-runtime/profiling"]
+
 [dependencies]
 aptos-framework-natives = { workspace = true }
 aptos-gas-algebra = { workspace = true }
@@ -36,8 +41,3 @@ triomphe = { workspace = true }
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["testing", "fuzzing"] }
 serde = { workspace = true }
-
-[features]
-default = []
-testing = ["aptos-move-stdlib/testing"]
-profiling = ["move-vm-runtime/profiling"]

--- a/aptos-move/aptos-vm-profiling/Cargo.toml
+++ b/aptos-move/aptos-vm-profiling/Cargo.toml
@@ -9,6 +9,18 @@ publish = false
 edition = { workspace = true }
 default-run = "main"
 
+[[bin]]
+name = "main"
+path  = "src/main.rs"
+
+[[bin]]
+name = "run-move"
+path = "src/bins/run_move.rs"
+
+[[bin]]
+name = "run-aptos-p2p"
+path = "src/bins/run_aptos_p2p.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
@@ -33,15 +45,3 @@ move-core-types = { workspace = true }
 move-vm-runtime = { workspace = true }
 move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true }
-
-[[bin]]
-name = "main"
-path  = "src/main.rs"
-
-[[bin]]
-name = "run-move"
-path = "src/bins/run_move.rs"
-
-[[bin]]
-name = "run-aptos-p2p"
-path = "src/bins/run_aptos_p2p.rs"

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -12,6 +12,23 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = [
+    "move-core-types/fuzzing",
+    "move-binary-format/fuzzing",
+    "move-vm-types/fuzzing",
+    "aptos-framework-natives/fuzzing",
+    "aptos-types/fuzzing",
+]
+failpoints = ["fail/failpoints", "move-vm-runtime/failpoints"]
+profiling = ["move-vm-runtime/profiling"]
+testing = [
+    "move-unit-test",
+    "aptos-framework-natives/testing",
+    "aptos-vm-environment/testing",
+]
+
 [dependencies]
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -72,10 +89,3 @@ move-vm-types = { workspace = true, features = ["testing"] }
 proptest = { workspace = true }
 rand_core = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["move-core-types/fuzzing", "move-binary-format/fuzzing", "move-vm-types/fuzzing", "aptos-framework-natives/fuzzing", "aptos-types/fuzzing"]
-failpoints = ["fail/failpoints", "move-vm-runtime/failpoints"]
-profiling = ["move-vm-runtime/profiling"]
-testing = ["move-unit-test", "aptos-framework-natives/testing", "aptos-vm-environment/testing"]

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+testing = []
+fuzzing = ["criterion", "proptest", "proptest-derive"]
+
 [dependencies]
 ambassador = { workspace = true }
 anyhow = { workspace = true }
@@ -64,10 +68,6 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-testing = []
-fuzzing = ["criterion", "proptest", "proptest-derive"]
 
 [[bench]]
 name = "scheduler_benches"

--- a/aptos-move/cli/Cargo.toml
+++ b/aptos-move/cli/Cargo.toml
@@ -16,6 +16,11 @@ name = "move"
 path = "src/main.rs"
 required-features = ["binary"]
 
+[features]
+default = []
+binary = ["testing"]
+testing = ["aptos-vm/testing"]
+
 [dependencies]
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -79,8 +84,3 @@ mockall = { workspace = true }
 move-prover-test-utils = { workspace = true }
 regex = { workspace = true }
 termcolor = { workspace = true }
-
-[features]
-default = []
-binary = ["testing"]
-testing = ["aptos-vm/testing"]

--- a/aptos-move/e2e-benchmark/Cargo.toml
+++ b/aptos-move/e2e-benchmark/Cargo.toml
@@ -11,6 +11,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+profiling = ["aptos-vm-environment/profiling"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-cached-packages = { workspace = true }
@@ -30,7 +34,3 @@ clap = { workspace = true }
 rand = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-
-[features]
-default = []
-profiling = ["aptos-vm-environment/profiling"]

--- a/aptos-move/e2e-move-test-harness/Cargo.toml
+++ b/aptos-move/e2e-move-test-harness/Cargo.toml
@@ -12,6 +12,12 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[lib]
+doctest = false
+
+[features]
+testing = ["aptos-gas-schedule/testing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-cached-packages = { workspace = true }
@@ -31,9 +37,3 @@ once_cell = { workspace = true }
 project-root = { workspace = true }
 proptest = { workspace = true }
 serde = { workspace = true }
-
-[lib]
-doctest = false
-
-[features]
-testing = ["aptos-gas-schedule/testing"]

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -12,6 +12,14 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[lib]
+doctest = false
+
+[features]
+default = []
+profiling = ["aptos-vm/profiling"]
+move-harness-with-test-only = ["aptos-cached-packages/move-harness-with-test-only"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-cached-packages = { workspace = true }
@@ -59,11 +67,3 @@ test-case = { workspace = true }
 thousands = { workspace = true }
 tokio = { workspace = true }
 triomphe = { workspace = true }
-
-[lib]
-doctest = false
-
-[features]
-default = []
-profiling = ["aptos-vm/profiling"]
-move-harness-with-test-only = ["aptos-cached-packages/move-harness-with-test-only"]

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-abstract-gas-usage = { workspace = true }
@@ -55,10 +59,6 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
-
-[features]
-default = []
-fuzzing = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -12,6 +12,13 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = [
+    "aptos-cached-packages/fuzzing",
+    "move-core-types/fuzzing",
+    "aptos-types/fuzzing",
+]
+
 [dependencies]
 aptos-cached-packages = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -32,10 +39,3 @@ move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true }
 proptest = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-default = [
-    "aptos-cached-packages/fuzzing",
-    "move-core-types/fuzzing",
-    "aptos-types/fuzzing",
-]

--- a/aptos-move/flow/Cargo.toml
+++ b/aptos-move/flow/Cargo.toml
@@ -11,6 +11,14 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ bin }-v{ version }/{ bin }-v{ version }-{ target }.zip"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/{ bin }-v{ version }/{ bin }-v{ version }-{ target }.zip"
+
 [[bin]]
 name = "move-flow"
 path = "src/main.rs"
@@ -65,11 +73,3 @@ move-prover-test-utils = { workspace = true }
 regex = { workspace = true }
 rmcp = { workspace = true, features = ["client"] }
 tempfile = { workspace = true }
-
-[package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/{ bin }-v{ version }/{ bin }-v{ version }-{ target }.zip"
-bin-dir = "{ bin }{ binary-ext }"
-pkg-fmt = "zip"
-
-[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
-pkg-url = "{ repo }/releases/download/{ bin }-v{ version }/{ bin }-v{ version }-{ target }.zip"

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -12,6 +12,21 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["aptos-crypto", "aptos-move-stdlib"]
+
+[lib]
+doctest = false
+
+[features]
+default = []
+fuzzing = ["aptos-framework-natives/fuzzing", "aptos-types/fuzzing"]
+testing = [
+    "aptos-framework-natives/testing",
+    "aptos-move-stdlib/testing",
+    "aptos-crypto/fuzzing",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -58,14 +73,3 @@ move-prover-test-utils = { workspace = true }
 move-unit-test = { workspace = true }
 move-vm-types = { workspace = true, features = ["testing"] }
 regex = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["aptos-framework-natives/fuzzing", "aptos-types/fuzzing"]
-testing = ["aptos-framework-natives/testing", "aptos-move-stdlib/testing", "aptos-crypto/fuzzing"]
-
-[lib]
-doctest = false
-
-[package.metadata.cargo-machete]
-ignored = ["aptos-crypto", "aptos-move-stdlib"]

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -12,6 +12,17 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["proptest"]
+
+[features]
+default = []
+fuzzing = ["proptest", "proptest-derive"]
+testing = ["aptos-framework", "aptos-package-builder"]
+# Enable test mode genesis bundle which includes #[test_only] Move code.
+# This is used by MoveHarness in e2e tests that need to call #[test_only] functions.
+move-harness-with-test-only = []
+
 [dependencies]
 aptos-framework = { workspace = true, optional = true }
 aptos-package-builder = { workspace = true, optional = true }
@@ -22,14 +33,3 @@ move-core-types = { workspace = true }
 once_cell = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
-
-[features]
-default = []
-fuzzing = ["proptest", "proptest-derive"]
-testing = ["aptos-framework", "aptos-package-builder"]
-# Enable test mode genesis bundle which includes #[test_only] Move code.
-# This is used by MoveHarness in e2e tests that need to call #[test_only] functions.
-move-harness-with-test-only = []
-
-[package.metadata.cargo-machete]
-ignored = ["proptest"]

--- a/aptos-move/framework/natives/Cargo.toml
+++ b/aptos-move/framework/natives/Cargo.toml
@@ -12,6 +12,17 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes"]
+
+[lib]
+doctest = false
+
+[features]
+default = []
+fuzzing = ["aptos-types/fuzzing"]
+testing = ["aptos-crypto/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
@@ -60,14 +71,3 @@ triomphe = { workspace = true }
 
 [dev-dependencies]
 claims = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["aptos-types/fuzzing"]
-testing = ["aptos-crypto/fuzzing"]
-
-[lib]
-doctest = false
-
-[package.metadata.cargo-machete]
-ignored = ["serde_bytes"]

--- a/aptos-move/framework/release-bundle/Cargo.toml
+++ b/aptos-move/framework/release-bundle/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -22,6 +25,3 @@ move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-model = { workspace = true }
 serde = { workspace = true }
-
-[lib]
-doctest = false

--- a/aptos-move/move-examples/Cargo.toml
+++ b/aptos-move/move-examples/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-types = { workspace = true }
-aptos-vm ={ workspace = true, features = ["testing"] }
+aptos-vm = { workspace = true, features = ["testing"] }
 clap = { workspace = true }
 move-model = { workspace = true }
 move-package = { workspace = true }

--- a/aptos-move/script-composer/Cargo.toml
+++ b/aptos-move/script-composer/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes", "wasm-bindgen-futures", "getrandom"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
@@ -30,6 +33,3 @@ wasm-bindgen-futures = { workspace = true }
 [dev-dependencies]
 aptos-move-e2e-test-harness = { workspace = true }
 aptos-types = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = ["serde_bytes", "wasm-bindgen-futures", "getrandom"]

--- a/aptos-move/vm-genesis/Cargo.toml
+++ b/aptos-move/vm-genesis/Cargo.toml
@@ -12,8 +12,12 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["aptos-types/fuzzing", "move-core-types/fuzzing", "move-vm-types/fuzzing"]
+
 [dependencies]
-aptos-cached-packages =  { workspace = true }
+aptos-cached-packages = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-release-bundle = { workspace = true }
@@ -36,7 +40,3 @@ aptos-proptest-helpers = { workspace = true }
 move-core-types = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["aptos-types/fuzzing", "move-core-types/fuzzing", "move-vm-types/fuzzing"]

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -12,6 +12,30 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["aptos-crypto", "move-vm-types"]
+
+[features]
+assert-private-keys-not-cloneable = ["aptos-crypto/assert-private-keys-not-cloneable"]
+check-vm-features = []
+consensus-only-perf-test = [
+    "aptos-executor/consensus-only-perf-test",
+    "aptos-mempool/consensus-only-perf-test",
+    "aptos-db/consensus-only-perf-test",
+]
+default = []
+failpoints = [
+    "fail/failpoints",
+    "aptos-consensus/failpoints",
+    "aptos-executor/failpoints",
+    "aptos-mempool/failpoints",
+    "aptos-api/failpoints",
+    "aptos-config/failpoints",
+    "aptos-network/failpoints",
+]
+tokio-console = ["aptos-logger/tokio-console", "aptos-config/tokio-console"]
+smoke-test = ["aptos-jwk-consensus/smoke-test", "aptos-dkg-runtime/smoke-test"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-admin-service = { workspace = true }
@@ -79,20 +103,8 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true }
 ureq = { workspace = true }
 
-[target.'cfg(unix)'.dependencies]
-aptos-jemalloc = { workspace = true }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 rstack-self = { workspace = true }
 
-[features]
-assert-private-keys-not-cloneable = ["aptos-crypto/assert-private-keys-not-cloneable"]
-check-vm-features = []
-consensus-only-perf-test = ["aptos-executor/consensus-only-perf-test", "aptos-mempool/consensus-only-perf-test", "aptos-db/consensus-only-perf-test"]
-default = []
-failpoints = ["fail/failpoints", "aptos-consensus/failpoints", "aptos-executor/failpoints", "aptos-mempool/failpoints", "aptos-api/failpoints", "aptos-config/failpoints", "aptos-network/failpoints"]
-tokio-console = ["aptos-logger/tokio-console", "aptos-config/tokio-console"]
-smoke-test = ["aptos-jwk-consensus/smoke-test", "aptos-dkg-runtime/smoke-test"]
-
-[package.metadata.cargo-machete]
-ignored = ["aptos-crypto", "move-vm-types"]
+[target.'cfg(unix)'.dependencies]
+aptos-jemalloc = { workspace = true }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -12,6 +12,17 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["strum"]
+
+[features]
+default = []
+failpoints = []
+fuzzing = ["aptos-crypto/fuzzing", "aptos-types/fuzzing"]
+smoke-test = []
+testing = []
+tokio-console = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -44,14 +55,3 @@ url = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }
 tempfile = { workspace = true }
-
-[features]
-default = []
-failpoints = []
-fuzzing = ["aptos-crypto/fuzzing", "aptos-types/fuzzing"]
-smoke-test = []
-testing = []
-tokio-console = []
-
-[package.metadata.cargo-machete]
-ignored = ["strum"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -12,6 +12,21 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes", "ark-std"]
+
+[features]
+default = []
+fuzzing = [
+    "aptos-consensus-types/fuzzing",
+    "aptos-config/fuzzing",
+    "aptos-crypto/fuzzing",
+    "aptos-mempool/fuzzing",
+    "aptos-types/fuzzing",
+    "aptos-safety-rules/testing",
+]
+failpoints = ["fail/failpoints"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-batch-encryption = { workspace = true }
@@ -113,21 +128,6 @@ move-core-types = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 tempfile = { workspace = true }
-
-[features]
-default = []
-fuzzing = [
-    "aptos-consensus-types/fuzzing",
-    "aptos-config/fuzzing",
-    "aptos-crypto/fuzzing",
-    "aptos-mempool/fuzzing",
-    "aptos-types/fuzzing",
-    "aptos-safety-rules/testing",
-]
-failpoints = ["fail/failpoints"]
-
-[package.metadata.cargo-machete]
-ignored = ["serde_bytes", "ark-std"]
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+failpoints = ["fail/failpoints"]
+fuzzing = ["proptest", "aptos-types/fuzzing", "aptos-crypto/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
@@ -40,8 +45,3 @@ tokio = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }
 proptest = { workspace = true }
 serde_json = { workspace = true }
-
-[features]
-default = []
-failpoints = ["fail/failpoints"]
-fuzzing = ["proptest", "aptos-types/fuzzing", "aptos-crypto/fuzzing"]

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["aptos-consensus-types/fuzzing", "aptos-config/fuzzing", "proptest"]
+testing = ["aptos-secure-storage/testing"]
+
 [dependencies]
 aptos-config = { workspace = true }
 aptos-consensus-types = { workspace = true }
@@ -47,8 +52,3 @@ tempfile = { workspace = true }
 name = "safety_rules"
 harness = false
 required-features = ["testing"]
-
-[features]
-default = []
-fuzzing = ["aptos-consensus-types/fuzzing", "aptos-config/fuzzing", "proptest"]
-testing = ["aptos-secure-storage/testing"]

--- a/crates/aptos-admin-service/Cargo.toml
+++ b/crates/aptos-admin-service/Cargo.toml
@@ -32,9 +32,9 @@ sha256 = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+jemalloc_pprof = { workspace = true }
+
 [target.'cfg(unix)'.dependencies]
 jemalloc-ctl = { workspace = true }
 jemalloc-sys = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-jemalloc_pprof = { workspace = true }

--- a/crates/aptos-batch-encryption/Cargo.toml
+++ b/crates/aptos-batch-encryption/Cargo.toml
@@ -11,6 +11,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["ark-bn254", "ark-ff-asm", "ark-ff-macros", "serde_bytes"]
+
 [lib]
 name = "aptos_batch_encryption"
 doctest = false
@@ -48,9 +51,6 @@ thiserror = { workspace = true }
 criterion = { workspace = true }
 itertools = { workspace = true }
 tempfile = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = ["ark-bn254", "ark-ff-asm", "ark-ff-macros", "serde_bytes"]
 
 [[bench]]
 name = "fk_algorithm"

--- a/crates/aptos-bitvec/Cargo.toml
+++ b/crates/aptos-bitvec/Cargo.toml
@@ -12,6 +12,12 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes"]
+
+[features]
+fuzzing = ["proptest"]
+
 [dependencies]
 proptest = { workspace = true, optional = true }
 serde = { workspace = true }
@@ -22,9 +28,3 @@ bcs = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 serde_json = { workspace = true }
-
-[features]
-fuzzing = ["proptest"]
-
-[package.metadata.cargo-machete]
-ignored = ["serde_bytes"]

--- a/crates/aptos-crypto/Cargo.toml
+++ b/crates/aptos-crypto/Cargo.toml
@@ -12,6 +12,14 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+arkworks-upgrade-compat-test = []
+assert-private-keys-not-cloneable = []
+cloneable-private-keys = []
+fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys", "arbitrary"]
+testing = []
+
 [dependencies]
 aes-gcm = { workspace = true }
 anyhow = { workspace = true }
@@ -94,14 +102,6 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 serde_json = { workspace = true }
 trybuild = { workspace = true }
-
-[features]
-default = []
-arkworks-upgrade-compat-test = []
-assert-private-keys-not-cloneable = []
-cloneable-private-keys = []
-fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys", "arbitrary"]
-testing = []
 
 [[bench]]
 name = "ark_batch_mul"

--- a/crates/aptos-dkg/Cargo.toml
+++ b/crates/aptos-dkg/Cargo.toml
@@ -4,6 +4,18 @@ version = "0.2.0"
 edition = { workspace = true }
 license = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes"]
+
+[features]
+assert-private-keys-not-cloneable = []
+fuzzing = []
+parallel = []
+range_proof_timing = []
+range_proof_timing_multivariate = []
+range_proof_timing_univariate_v2 = [
+] # per-component timing for dekart_univariate_v2; use --test range_proof -- --nocapture to see output
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -45,14 +57,6 @@ static_assertions = { workspace = true }
 chrono = { workspace = true }
 num_cpus = { workspace = true }
 
-[features]
-assert-private-keys-not-cloneable = []
-fuzzing = []
-parallel = []
-range_proof_timing = []
-range_proof_timing_multivariate = []
-range_proof_timing_univariate_v2 = []  # per-component timing for dekart_univariate_v2; use --test range_proof -- --nocapture to see output
-
 [[bench]]
 name = "bsgs"
 harness = false
@@ -92,6 +96,3 @@ harness = false
 [[bench]]
 name = "weighted_vuf"
 harness = false
-
-[package.metadata.cargo-machete]
-ignored = ["serde_bytes"]

--- a/crates/aptos-faucet/core/Cargo.toml
+++ b/crates/aptos-faucet/core/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+integration-tests = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
@@ -40,6 +43,3 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
-
-[features]
-integration-tests = []

--- a/crates/aptos-genesis/Cargo.toml
+++ b/crates/aptos-genesis/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+testing = []
+fuzzing = ["aptos-config/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-cached-packages = { workspace = true }
@@ -34,7 +38,3 @@ serde_yaml = { workspace = true }
 
 [dev-dependencies]
 aptos-config = { workspace = true }
-
-[features]
-testing = []
-fuzzing = ["aptos-config/fuzzing"]

--- a/crates/aptos-jemalloc/Cargo.toml
+++ b/crates/aptos-jemalloc/Cargo.toml
@@ -13,8 +13,8 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { workspace = true }
-jemalloc-ctl = { workspace = true, features = ["stats"] }
-aptos-metrics-core = { workspace = true }
 aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
+jemalloc-ctl = { workspace = true, features = ["stats"] }
+jemallocator = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/aptos-jwk-consensus/Cargo.toml
+++ b/crates/aptos-jwk-consensus/Cargo.toml
@@ -11,6 +11,8 @@ license = { workspace = true }
 publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
+[features]
+smoke-test = []
 
 [dependencies]
 anyhow = { workspace = true }
@@ -47,5 +49,3 @@ tokio-retry = { workspace = true }
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing"] }
 aptos-validator-transaction-pool = { workspace = true, features = ["fuzzing"] }
-[features]
-smoke-test = []

--- a/crates/aptos-logger/Cargo.toml
+++ b/crates/aptos-logger/Cargo.toml
@@ -12,6 +12,14 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["strum"]
+
+[features]
+default = []
+tokio-console = ["console-subscriber"]
+node-identity = ["aptos-node-identity"]
+
 # Do NOT add any inter-project dependencies.
 # This is to avoid ever having a circular dependency with the aptos-logger crate.
 [dependencies]
@@ -36,11 +44,3 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-
-[features]
-default = []
-tokio-console = ["console-subscriber"]
-node-identity = ["aptos-node-identity"]
-
-[package.metadata.cargo-machete]
-ignored = ["strum"]

--- a/crates/aptos-time-service/Cargo.toml
+++ b/crates/aptos-time-service/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+async = ["futures", "pin-project", "tokio"]
+testing = ["async"]
+
 [dependencies]
 aptos-infallible = { workspace = true }
 enum_dispatch = { workspace = true }
@@ -25,8 +30,3 @@ futures = { workspace = true }
 pin-project = { workspace = true }
 tokio = { workspace = true }
 tokio-test = { workspace = true }
-
-[features]
-default = []
-async = ["futures", "pin-project", "tokio"]
-testing = ["async"]

--- a/crates/aptos-transaction-filters/Cargo.toml
+++ b/crates/aptos-transaction-filters/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+fuzzing = []
+
 [dependencies]
 aptos-crypto = { workspace = true }
 aptos-types = { workspace = true }
@@ -22,6 +25,3 @@ serde_yaml = { workspace = true }
 
 [dev-dependencies]
 aptos-crypto = { workspace = true, features = ["fuzzing", "testing"] }
-
-[features]
-fuzzing = []

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -12,6 +12,12 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = []
+no-upload-proposal = []
+cli-framework-test-move = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-api-types = { workspace = true }
@@ -91,12 +97,6 @@ url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = { workspace = true }
-
-[features]
-default = []
-fuzzing = []
-no-upload-proposal = []
-cli-framework-test-move = []
 
 [build-dependencies]
 shadow-rs = { workspace = true }

--- a/crates/reliable-broadcast/Cargo.toml
+++ b/crates/reliable-broadcast/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-bounded-executor = { workspace = true }
@@ -32,6 +35,3 @@ tokio-retry = { workspace = true }
 [dev-dependencies]
 aptos-consensus-types = { workspace = true, features = ["fuzzing"] }
 aptos-time-service = { workspace = true, features = ["testing"] }
-
-[features]
-default = []

--- a/crates/transaction-generator-lib/Cargo.toml
+++ b/crates/transaction-generator-lib/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-infallible = { workspace = true }
+aptos-types = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-sdk = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/transaction-generator-lib/Cargo.toml
+++ b/crates/transaction-generator-lib/Cargo.toml
@@ -16,9 +16,9 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-infallible = { workspace = true }
-aptos-types = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-sdk = { workspace = true }
+aptos-types = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }

--- a/crates/transaction-generator-lib/src/accounts_pool_wrapper.rs
+++ b/crates/transaction-generator-lib/src/accounts_pool_wrapper.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{ObjectPool, TransactionGenerator, TransactionGeneratorCreator};
+use crate::{ObjectPool, TransactionFeedback, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};
 use rand::{rngs::StdRng, SeedableRng};
 use std::sync::Arc;
@@ -85,5 +85,9 @@ impl TransactionGeneratorCreator for AccountsPoolWrapperCreator {
             self.source_accounts_pool.clone(),
             self.destination_accounts_pool.clone(),
         ))
+    }
+
+    fn transaction_feedback(&self) -> Option<Arc<dyn TransactionFeedback>> {
+        self.creator.transaction_feedback()
     }
 }

--- a/crates/transaction-generator-lib/src/lib.rs
+++ b/crates/transaction-generator-lib/src/lib.rs
@@ -11,6 +11,7 @@ use aptos_sdk::{
     transaction_builder::{aptos_stdlib, TransactionFactory},
     types::{transaction::SignedTransaction, LocalAccount},
 };
+use aptos_types::transaction::TransactionOutput;
 use async_trait::async_trait;
 use clap::{Parser, ValueEnum};
 use log::{info, warn};
@@ -146,9 +147,29 @@ pub trait TransactionGenerator: Sync + Send {
     ) -> Vec<SignedTransaction>;
 }
 
+/// Callback invoked after each block is ledger-updated, with all transaction outputs
+/// (including events). Implementors can inspect events to feed data back into subsequent
+/// transaction generation (e.g., reading UIDs emitted by a register step to use in a
+/// follow-up commit step).
+pub trait TransactionFeedback: Sync + Send {
+    fn on_block_committed(&self, outputs: &[TransactionOutput]);
+
+    /// Called by the block generator in the main thread (outside rayon) before
+    /// each block. Implementations should block here until there is work to
+    /// generate, preventing empty blocks while waiting for on-chain events.
+    /// Default: no-op.
+    fn wait_until_ready(&self) {}
+}
+
 #[async_trait]
 pub trait TransactionGeneratorCreator: Sync + Send {
     fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator>;
+
+    /// Return a feedback handler if this generator needs to observe transaction outputs.
+    /// Default implementation returns None (no feedback needed).
+    fn transaction_feedback(&self) -> Option<Arc<dyn TransactionFeedback>> {
+        None
+    }
 }
 
 pub struct CounterState {

--- a/crates/transaction-generator-lib/src/transaction_mix_generator.rs
+++ b/crates/transaction-generator-lib/src/transaction_mix_generator.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
-use crate::{TransactionGenerator, TransactionGeneratorCreator};
+use crate::{TransactionFeedback, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::sync::{
@@ -95,5 +95,12 @@ impl TransactionGeneratorCreator for PhasedTxnMixGeneratorCreator {
             txn_mix_per_phase,
             self.phase.clone(),
         ))
+    }
+
+    fn transaction_feedback(&self) -> Option<Arc<dyn TransactionFeedback>> {
+        self.txn_mix_per_phase_creators
+            .iter()
+            .flat_map(|phase| phase.iter())
+            .find_map(|(creator, _)| creator.transaction_feedback())
     }
 }

--- a/crates/transaction-generator-lib/src/transaction_mix_generator.rs
+++ b/crates/transaction-generator-lib/src/transaction_mix_generator.rs
@@ -2,11 +2,34 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{TransactionFeedback, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};
+use aptos_types::transaction::TransactionOutput;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
+
+/// Dispatches feedback events to the handler for the currently active phase.
+struct PhasedFeedback {
+    feedbacks: Vec<Option<Arc<dyn TransactionFeedback>>>,
+    phase: Arc<AtomicUsize>,
+}
+
+impl TransactionFeedback for PhasedFeedback {
+    fn on_block_committed(&self, outputs: &[TransactionOutput]) {
+        let phase = self.phase.load(Ordering::Relaxed);
+        if let Some(Some(fb)) = self.feedbacks.get(phase) {
+            fb.on_block_committed(outputs);
+        }
+    }
+
+    fn wait_until_ready(&self) {
+        let phase = self.phase.load(Ordering::Relaxed);
+        if let Some(Some(fb)) = self.feedbacks.get(phase) {
+            fb.wait_until_ready();
+        }
+    }
+}
 
 pub struct PhasedTxnMixGenerator {
     rng: StdRng,
@@ -98,9 +121,30 @@ impl TransactionGeneratorCreator for PhasedTxnMixGeneratorCreator {
     }
 
     fn transaction_feedback(&self) -> Option<Arc<dyn TransactionFeedback>> {
-        self.txn_mix_per_phase_creators
+        let feedbacks_per_phase: Vec<Option<Arc<dyn TransactionFeedback>>> = self
+            .txn_mix_per_phase_creators
             .iter()
-            .flat_map(|phase| phase.iter())
-            .find_map(|(creator, _)| creator.transaction_feedback())
+            .map(|phase| {
+                let feedbacks: Vec<_> = phase
+                    .iter()
+                    .filter_map(|(creator, _)| creator.transaction_feedback())
+                    .collect();
+                // TODO: support multiple feedbacks per phase via a broadcast wrapper
+                assert!(
+                    feedbacks.len() <= 1,
+                    "At most one creator per phase may provide TransactionFeedback"
+                );
+                feedbacks.into_iter().next()
+            })
+            .collect();
+
+        if feedbacks_per_phase.iter().any(|f| f.is_some()) {
+            Some(Arc::new(PhasedFeedback {
+                feedbacks: feedbacks_per_phase,
+                phase: self.phase.clone(),
+            }))
+        } else {
+            None
+        }
     }
 }

--- a/crates/transaction-generator-lib/src/workflow_delegator.rs
+++ b/crates/transaction-generator-lib/src/workflow_delegator.rs
@@ -8,8 +8,8 @@ use crate::{
         CustomModulesDelegationGeneratorCreator, UserModuleTransactionGenerator,
     },
     publishing::publish_util::Package,
-    ObjectPool, ReliableTransactionSubmitter, RootAccountHandle, TransactionGenerator,
-    TransactionGeneratorCreator, WorkflowProgress,
+    ObjectPool, ReliableTransactionSubmitter, RootAccountHandle, TransactionFeedback,
+    TransactionGenerator, TransactionGeneratorCreator, WorkflowProgress,
 };
 use aptos_logger::{sample, sample::SampleRate};
 use aptos_sdk::{
@@ -405,5 +405,9 @@ impl TransactionGeneratorCreator for WorkflowTxnGeneratorCreator {
                 .collect(),
             self.stage_switch_conditions.clone(),
         ))
+    }
+
+    fn transaction_feedback(&self) -> Option<Arc<dyn TransactionFeedback>> {
+        self.creators.iter().find_map(|c| c.transaction_feedback())
     }
 }

--- a/crates/transaction-generator-lib/src/workflow_delegator.rs
+++ b/crates/transaction-generator-lib/src/workflow_delegator.rs
@@ -408,6 +408,15 @@ impl TransactionGeneratorCreator for WorkflowTxnGeneratorCreator {
     }
 
     fn transaction_feedback(&self) -> Option<Arc<dyn TransactionFeedback>> {
-        self.creators.iter().find_map(|c| c.transaction_feedback())
+        let feedbacks: Vec<_> = self
+            .creators
+            .iter()
+            .filter_map(|c| c.transaction_feedback())
+            .collect();
+        assert!(
+            feedbacks.len() <= 1,
+            "At most one creator in a workflow may provide TransactionFeedback"
+        );
+        feedbacks.into_iter().next()
     }
 }

--- a/crates/validator-transaction-pool/Cargo.toml
+++ b/crates/validator-transaction-pool/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+fuzzing = []
+
 [dependencies]
 aptos-channels = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -22,6 +25,3 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing"] }
-
-[features]
-fuzzing = []

--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -12,6 +12,12 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["ark-std", "serde_bytes"]
+
+[features]
+smoke-test = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
@@ -54,9 +60,3 @@ tokio-retry = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["testing"] }
-
-[features]
-smoke-test = []
-
-[package.metadata.cargo-machete]
-ignored = ["ark-std", "serde_bytes"]

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+integration-tests = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-indexer-grpc-server-framework = { workspace = true }
@@ -39,6 +42,3 @@ jemallocator = { workspace = true }
 aptos-config = { workspace = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
-
-[features]
-integration-tests = []

--- a/ecosystem/indexer-grpc/indexer-grpc-manager/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-manager/Cargo.toml
@@ -34,9 +34,9 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 warp = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+jemallocator = { workspace = true }
+
 [dev-dependencies]
 aptos-config = { workspace = true }
 serde_json = { workspace = true }
-
-[target.'cfg(unix)'.dependencies]
-jemallocator = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/Cargo.toml
@@ -21,7 +21,7 @@ aptos-config = { workspace = true }
 aptos-faucet-core = { workspace = true }
 aptos-indexer-grpc-utils = { workspace = true }
 aptos-move-cli = { workspace = true, features = ["testing"] }
-aptos-protos ={ workspace = true }
+aptos-protos = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }

--- a/execution/block-partitioner/Cargo.toml
+++ b/execution/block-partitioner/Cargo.toml
@@ -13,6 +13,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+
 [dependencies]
 aptos-crypto = { workspace = true }
 aptos-logger = { workspace = true }
@@ -28,14 +31,11 @@ rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 
-[dev-dependencies]
-criterion = { workspace = true }
-
 [target.'cfg(unix)'.dependencies]
 jemallocator = { workspace = true }
 
-[features]
-default = []
+[dev-dependencies]
+criterion = { workspace = true }
 
 [[bench]]
 name = "v2"

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["aptos-config/fuzzing", "aptos-crypto/fuzzing", "aptos-types/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
@@ -37,7 +41,7 @@ aptos-metrics-core = { workspace = true }
 aptos-mvhashmap = { workspace = true }
 aptos-node-resource-metrics = { workspace = true }
 aptos-protos = { workspace = true }
-aptos-push-metrics =  { workspace = true }
+aptos-push-metrics = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-transaction-generator-lib = { workspace = true }
@@ -76,7 +80,3 @@ aptos-profiler = { workspace = true }
 
 [dev-dependencies]
 aptos-temppath = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["aptos-config/fuzzing", "aptos-crypto/fuzzing", "aptos-types/fuzzing"]

--- a/execution/executor-benchmark/src/ledger_update_stage.rs
+++ b/execution/executor-benchmark/src/ledger_update_stage.rs
@@ -5,6 +5,7 @@ use crate::pipeline::{CommitBlockMessage, LedgerUpdateMessage};
 use aptos_executor::block_executor::BlockExecutor;
 use aptos_executor_types::BlockExecutorTrait;
 use aptos_infallible::Mutex;
+use aptos_transaction_generator_lib::TransactionFeedback;
 use aptos_vm::VMBlockExecutor;
 use move_core_types::language_storage::StructTag;
 use std::{
@@ -26,6 +27,7 @@ pub struct LedgerUpdateStage<V> {
     allow_discards: bool,
     allow_retries: bool,
     event_summary: Arc<Mutex<BTreeMap<(usize, StructTag), usize>>>,
+    transaction_feedback: Option<Arc<dyn TransactionFeedback>>,
 }
 
 impl<V> LedgerUpdateStage<V>
@@ -39,6 +41,7 @@ where
         allow_discards: bool,
         allow_retries: bool,
         event_summary: Arc<Mutex<BTreeMap<(usize, StructTag), usize>>>,
+        transaction_feedback: Option<Arc<dyn TransactionFeedback>>,
     ) -> Self {
         Self {
             executor,
@@ -47,6 +50,7 @@ where
             allow_discards,
             allow_retries,
             event_summary,
+            transaction_feedback,
         }
     }
 
@@ -81,14 +85,21 @@ where
             }
         }
 
+        let transaction_outputs = &output.execution_output.to_commit.transaction_outputs;
+
         let mut event_summary = self.event_summary.lock();
-        for output in &output.execution_output.to_commit.transaction_outputs {
-            for event in output.events() {
+        for txn_output in transaction_outputs {
+            for event in txn_output.events() {
                 let count = event_summary
                     .entry((stage, event.type_tag().struct_tag().unwrap().clone()))
                     .or_insert(0);
                 *count += 1;
             }
+        }
+        drop(event_summary);
+
+        if let Some(feedback) = &self.transaction_feedback {
+            feedback.on_block_committed(transaction_outputs);
         }
 
         match &self.commit_processing {

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -46,7 +46,8 @@ use aptos_storage_interface::{
     state_store::state_view::db_state_view::LatestDbStateCheckpointView, DbReader, DbReaderWriter,
 };
 use aptos_transaction_generator_lib::{
-    create_txn_generator_creator, AlwaysApproveRootAccountHandle, TransactionGeneratorCreator,
+    create_txn_generator_creator, AlwaysApproveRootAccountHandle, TransactionFeedback,
+    TransactionGeneratorCreator,
     TransactionType::{self, CoinTransfer},
 };
 use aptos_types::on_chain_config::{FeatureFlag, Features};
@@ -264,6 +265,7 @@ enum InitializedBenchmarkWorkload {
         transaction_generators: Vec<Box<dyn aptos_transaction_generator_lib::TransactionGenerator>>,
         phase: Arc<AtomicUsize>,
         workload_name: String,
+        transaction_feedback: Option<Arc<dyn TransactionFeedback>>,
     },
     Transfer {
         connected_tx_grps: usize,
@@ -369,6 +371,7 @@ where
                 &PipelineConfig::default(),
                 Arc::clone(&ts),
             );
+            let transaction_feedback = transaction_generator_creator.transaction_feedback();
             // need to initialize all workers and finish with all transactions before we start the timer:
             InitializedBenchmarkWorkload::TransactionMix {
                 transaction_generators: (0..pipeline_config.num_generator_workers)
@@ -376,6 +379,7 @@ where
                     .collect::<Vec<_>>(),
                 phase,
                 workload_name,
+                transaction_feedback,
             }
         },
         BenchmarkWorkload::Transfer {
@@ -391,6 +395,27 @@ where
 
     let start_version = db.reader.expect_synced_version();
 
+    let transaction_feedback = match &initialized_workload {
+        InitializedBenchmarkWorkload::TransactionMix {
+            transaction_feedback,
+            ..
+        } => transaction_feedback.clone(),
+        _ => None,
+    };
+
+    // generate_then_execute is incompatible with TransactionFeedback: feedback requires
+    // execution to run concurrently with generation so that on-chain events can flow back
+    // to the generator before all blocks are pre-generated.
+    let pipeline_config = if transaction_feedback.is_some() && pipeline_config.generate_then_execute
+    {
+        PipelineConfig {
+            generate_then_execute: false,
+            ..pipeline_config
+        }
+    } else {
+        pipeline_config
+    };
+
     // Initialize table_info_service and grpc stream if indexer_grpc is enabled
     let indexer_wrapper = init_indexer_wrapper(&config, &db, &storage_test_config, start_version);
 
@@ -401,6 +426,7 @@ where
         &pipeline_config,
         Some(num_blocks),
         indexer_wrapper,
+        transaction_feedback,
     );
 
     let root_account = Arc::into_inner(root_account).unwrap();
@@ -422,6 +448,7 @@ where
             transaction_generators,
             phase,
             workload_name,
+            transaction_feedback,
         } => {
             let num_blocks_created = generator.run_workload(
                 block_size,
@@ -429,6 +456,7 @@ where
                 transaction_generators,
                 phase,
                 transactions_per_sender,
+                transaction_feedback,
             );
             (num_blocks_created, workload_name)
         },
@@ -507,6 +535,7 @@ where
         pipeline_config,
         None,
         None, // No indexer for init workload
+        None,
     );
 
     let runtime = Runtime::new().unwrap();
@@ -613,6 +642,7 @@ fn add_accounts_impl<V>(
         &pipeline_config,
         Some(1), // Only 1 block
         None,
+        None,
     );
 
     info!("Sending the first block metadata transaction to start a new epoch");
@@ -636,6 +666,7 @@ fn add_accounts_impl<V>(
         &pipeline_config,
         Some(num_new_accounts / block_size * 101 / 100),
         indexer_wrapper,
+        None,
     );
 
     let mut generator = TransactionGenerator::new_with_existing_db(

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -400,16 +400,16 @@ where
             transaction_feedback,
             ..
         } => transaction_feedback.clone(),
-        _ => None,
+        InitializedBenchmarkWorkload::Transfer { .. } => None,
     };
 
-    // generate_then_execute is incompatible with TransactionFeedback: feedback requires
-    // execution to run concurrently with generation so that on-chain events can flow back
-    // to the generator before all blocks are pre-generated.
-    let pipeline_config = if transaction_feedback.is_some() && pipeline_config.generate_then_execute
-    {
+    // generate_then_execute and split_stages are incompatible with TransactionFeedback:
+    // both delay execution until all blocks are pre-generated, preventing on-chain events
+    // from flowing back to the generator while wait_until_ready is blocking.
+    let pipeline_config = if transaction_feedback.is_some() {
         PipelineConfig {
             generate_then_execute: false,
+            split_stages: false,
             ..pipeline_config
         }
     } else {

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -17,6 +17,7 @@ use aptos_indexer_grpc_table_info::table_info_service::TableInfoService;
 use aptos_infallible::Mutex;
 use aptos_logger::info;
 use aptos_metrics_core::IntCounterVecHelper;
+use aptos_transaction_generator_lib::TransactionFeedback;
 use aptos_types::{
     block_executor::partitioner::ExecutableBlock,
     transaction::{Transaction, TransactionPayload, Version},
@@ -76,6 +77,7 @@ where
         // Need to specify num blocks, to size queues correctly, when delay_execution_start, split_stages or skip_commit are used
         num_blocks: Option<usize>,
         indexer_wrapper: Option<(Arc<TableInfoService>, Arc<AtomicU64>, Arc<AtomicBool>)>,
+        transaction_feedback: Option<Arc<dyn TransactionFeedback>>,
     ) -> (Self, SyncSender<Vec<Transaction>>) {
         let parent_block_id = executor.committed_block_id();
         let executor_1 = Arc::new(executor);
@@ -153,6 +155,7 @@ where
             config.allow_discards,
             config.allow_retries,
             staged_events_clone,
+            transaction_feedback,
         );
 
         let print_transactions = config.print_transactions;

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -15,6 +15,7 @@ use aptos_sdk::{
 use aptos_storage_interface::{
     state_store::state_view::db_state_view::LatestDbStateCheckpointView, DbReader, DbReaderWriter,
 };
+use aptos_transaction_generator_lib::TransactionFeedback;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{aptos_test_root_address, AccountResource, BlockResource, CORE_CODE_ADDRESS},
@@ -54,6 +55,16 @@ use thread_local::ThreadLocal;
 
 const META_FILENAME: &str = "metadata.toml";
 pub const MAX_ACCOUNTS_INVOLVED_IN_P2P: usize = 1_000_000;
+
+/// Optional lower bound on the timestamp used in `epoch_change_block`.
+/// When non-zero, the epoch-change block's timestamp is clamped to at least
+/// this value, causing `BenchmarkTimestamp::from_db` to reflect the same
+/// floor in every subsequent block.  Set before calling `epoch_change_block`.
+static MIN_BLOCK_TIMESTAMP_USECS: AtomicU64 = AtomicU64::new(0);
+
+pub fn set_min_block_timestamp_usecs(min: u64) {
+    MIN_BLOCK_TIMESTAMP_USECS.store(min, Ordering::SeqCst);
+}
 
 fn validator_address() -> AccountAddress {
     // Replicate the exact same logic as genesis creation in test_config_with_custom_onchain
@@ -234,7 +245,8 @@ impl BenchmarkTimestamp {
 
         let epoch_interval = block_resource.epoch_interval();
         let last_reconfig_time = config.last_reconfiguration_time_micros();
-        let epoch_change_timestamp = last_reconfig_time + epoch_interval + 1;
+        let epoch_change_timestamp = (last_reconfig_time + epoch_interval + 1)
+            .max(MIN_BLOCK_TIMESTAMP_USECS.load(Ordering::SeqCst));
 
         info!(
             "epoch_change_block: last_reconfig_time={}, epoch_interval={}, \
@@ -540,6 +552,7 @@ impl TransactionGenerator {
         transaction_generators: Vec<Box<dyn aptos_transaction_generator_lib::TransactionGenerator>>,
         phase: Arc<AtomicUsize>,
         transactions_per_sender: usize,
+        feedback: Option<Arc<dyn TransactionFeedback>>,
     ) -> usize {
         let last_non_empty_phase = Arc::new(AtomicUsize::new(0));
         let transaction_generators = Mutex::new(transaction_generators);
@@ -548,6 +561,13 @@ impl TransactionGenerator {
         let account_pool_size = self.main_signer_accounts.as_ref().unwrap().accounts.len();
         let transaction_generator = ThreadLocal::with_capacity(self.num_workers);
         for i in 0..num_blocks {
+            // Wait in the main thread (outside rayon) until there is work to
+            // generate. This prevents flooding the pipeline with empty blocks
+            // while accounts are waiting for on-chain events (e.g. UIDs).
+            if let Some(fb) = feedback.as_ref() {
+                fb.wait_until_ready();
+            }
+
             let sender_indices = rand::seq::index::sample(
                 &mut thread_rng(),
                 account_pool_size,
@@ -952,11 +972,12 @@ impl TransactionGenerator {
                     val, last_generated_at
                 );
                 return true;
+            } else {
+                info!(
+                    "Block generation: no transactions generated in phase {}, moving to next phase",
+                    val
+                );
             }
-            info!(
-                "Block generation: no transactions generated in phase {}, moving to next phase",
-                val
-            );
         } else {
             let val = phase.load(Ordering::Relaxed);
             last_non_empty_phase.fetch_max(val, Ordering::Relaxed);

--- a/execution/executor-service/Cargo.toml
+++ b/execution/executor-service/Cargo.toml
@@ -21,7 +21,7 @@ aptos-keygen = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-node-resource-metrics = { workspace = true }
-aptos-push-metrics =  { workspace = true }
+aptos-push-metrics = { workspace = true }
 aptos-secure-net = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["aptos-crypto/fuzzing", "aptos-types/fuzzing"]
+bench = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
@@ -35,11 +40,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing", "testing"] }
-
-[features]
-default = []
-fuzzing = ["aptos-crypto/fuzzing", "aptos-types/fuzzing"]
-bench = []
 
 [[bench]]
 name = "default"

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -12,6 +12,17 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = [
+    "aptos-consensus-types/fuzzing",
+    "aptos-crypto/fuzzing",
+    "aptos-types/fuzzing",
+    "aptos-storage-interface/fuzzing",
+]
+failpoints = ["fail/failpoints", "aptos-vm/failpoints"]
+consensus-only-perf-test = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-block-executor = { workspace = true }
@@ -55,12 +66,6 @@ arr_macro = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["aptos-consensus-types/fuzzing", "aptos-crypto/fuzzing", "aptos-types/fuzzing", "aptos-storage-interface/fuzzing"]
-failpoints = ["fail/failpoints", "aptos-vm/failpoints"]
-consensus-only-perf-test = []
 
 [[bench]]
 name = "data_collection"

--- a/experimental/storage/hexy/Cargo.toml
+++ b/experimental/storage/hexy/Cargo.toml
@@ -21,14 +21,14 @@ aptos-metrics-core = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+jemallocator = { workspace = true }
+
 [dev-dependencies]
 aptos-crypto = { workspace = true, features = ["fuzzing"] }
 criterion = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
-
-[target.'cfg(unix)'.dependencies]
-jemallocator = { workspace = true }
 
 [[bench]]
 name = "sort_dedup"

--- a/experimental/storage/layered-map/Cargo.toml
+++ b/experimental/storage/layered-map/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[lib]
+bench = false
+
 [dependencies]
 ahash = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -34,9 +37,6 @@ rocksdb = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 jemallocator = { workspace = true }
-
-[lib]
-bench = false
 
 [[bench]]
 name = "sorting"

--- a/keyless/pepper/common/Cargo.toml
+++ b/keyless/pepper/common/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["bcs"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -31,6 +34,3 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde-big-array = { workspace = true }
 sha2_0_10_6 = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = ["bcs"]

--- a/keyless/pepper/example-client-rust/Cargo.toml
+++ b/keyless/pepper/example-client-rust/Cargo.toml
@@ -18,7 +18,7 @@ aptos-infallible = { workspace = true }
 aptos-keyless-pepper-common = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
-blstrs =  { workspace = true }
+blstrs = { workspace = true }
 clap = { workspace = true }
 firestore = { workspace = true }
 hex = { workspace = true }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -12,6 +12,17 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+failpoints = ["fail/failpoints", "aptos-vm-validator/failpoints"]
+fuzzing = [
+    "proptest",
+    "aptos-types/fuzzing",
+    "aptos-storage-interface/fuzzing",
+    "aptos-config/fuzzing",
+]
+consensus-only-perf-test = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-bounded-executor = { workspace = true }
@@ -61,9 +72,3 @@ aptos-time-service = { workspace = true, features = ["testing"] }
 aptos-transaction-filters = { workspace = true, features = ["fuzzing"] }
 enum_dispatch = { workspace = true }
 proptest = { workspace = true }
-
-[features]
-default = []
-failpoints = ["fail/failpoints", "aptos-vm-validator/failpoints"]
-fuzzing = ["proptest", "aptos-types/fuzzing", "aptos-storage-interface/fuzzing", "aptos-config/fuzzing"]
-consensus-only-perf-test = []

--- a/network/framework/Cargo.toml
+++ b/network/framework/Cargo.toml
@@ -12,6 +12,32 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes"]
+
+[features]
+default = []
+failpoints = ["fail/failpoints"]
+fuzzing = [
+    "aptos-bitvec/fuzzing",
+    "aptos-config/fuzzing",
+    "aptos-crypto/fuzzing",
+    "aptos-types/fuzzing",
+    "aptos-proptest-helpers",
+    "aptos-time-service/testing",
+    "aptos-types/fuzzing",
+    "aptos-memsocket/testing",
+    "aptos-netcore/fuzzing",
+    "proptest",
+    "proptest-derive",
+]
+testing = [
+    "aptos-config/testing",
+    "aptos-time-service/testing",
+    "aptos-memsocket/testing",
+    "aptos-netcore/testing",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
@@ -76,12 +102,3 @@ rand_core = { workspace = true }
 [[bench]]
 name = "network_cloning"
 harness = false
-
-[features]
-default = []
-failpoints = ["fail/failpoints"]
-fuzzing = ["aptos-bitvec/fuzzing", "aptos-config/fuzzing", "aptos-crypto/fuzzing", "aptos-types/fuzzing", "aptos-proptest-helpers", "aptos-time-service/testing", "aptos-types/fuzzing", "aptos-memsocket/testing", "aptos-netcore/fuzzing", "proptest", "proptest-derive"]
-testing = ["aptos-config/testing", "aptos-time-service/testing", "aptos-memsocket/testing", "aptos-netcore/testing"]
-
-[package.metadata.cargo-machete]
-ignored = ["serde_bytes"]

--- a/network/memsocket/Cargo.toml
+++ b/network/memsocket/Cargo.toml
@@ -12,13 +12,13 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = []
+testing = []
+
 [dependencies]
 aptos-infallible = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
-
-[features]
-default = []
-fuzzing = []
-testing = []

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["aptos-memsocket/fuzzing", "aptos-types/fuzzing"]
+testing = ["aptos-memsocket/testing"]
+
 [dependencies]
 aptos-memsocket = { workspace = true }
 aptos-proxy = { workspace = true }
@@ -27,8 +32,3 @@ url = { workspace = true }
 [dev-dependencies]
 aptos-memsocket = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }
-
-[features]
-default = []
-fuzzing = ["aptos-memsocket/fuzzing", "aptos-types/fuzzing"]
-testing = ["aptos-memsocket/testing"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["tiny-bip39"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-batch-encryption = { workspace = true }
@@ -40,6 +43,3 @@ once_cell = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = ["tiny-bip39"]

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+fuzzing = ["aptos-crypto/fuzzing"]
+testing = []
+
 [dependencies]
 aptos-crypto = { workspace = true }
 aptos-infallible = { workspace = true }
@@ -32,7 +36,3 @@ thiserror = { workspace = true }
 aptos-crypto = { workspace = true, features = ["fuzzing"] }
 aptos-crypto-derive = { workspace = true }
 rand = { workspace = true }
-
-[features]
-fuzzing = ["aptos-crypto/fuzzing"]
-testing = []

--- a/secure/storage/vault/Cargo.toml
+++ b/secure/storage/vault/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+fuzzing = ["proptest", "aptos-types", "aptos-types/fuzzing"]
+
 [dependencies]
 aptos-crypto = { workspace = true }
 aptos-types = { workspace = true, optional = true }
@@ -29,6 +32,3 @@ ureq = { workspace = true }
 aptos-proptest-helpers = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }
 proptest = { workspace = true }
-
-[features]
-fuzzing = ["proptest", "aptos-types", "aptos-types/fuzzing"]

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["proptest", "aptos-crypto/fuzzing", "aptos-types/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -22,7 +26,3 @@ proptest = { workspace = true, optional = true }
 aptos-crypto = { workspace = true, features = ["fuzzing"] }
 proptest = { workspace = true }
 rand = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["proptest", "aptos-crypto/fuzzing", "aptos-types/fuzzing"]

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -12,6 +12,23 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = [
+    "proptest",
+    "proptest-derive",
+    "aptos-proptest-helpers",
+    "aptos-temppath",
+    "aptos-crypto/fuzzing",
+    "aptos-jellyfish-merkle/fuzzing",
+    "aptos-types/fuzzing",
+    "aptos-executor-types/fuzzing",
+    "aptos-schemadb/fuzzing",
+    "aptos-scratchpad/fuzzing",
+]
+consensus-only-perf-test = []
+db-debugger = ["aptos-temppath", "clap", "crossbeam-channel", "owo-colors", "indicatif"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-accumulator = { workspace = true }
@@ -71,9 +88,3 @@ ouroboros = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["proptest", "proptest-derive", "aptos-proptest-helpers", "aptos-temppath", "aptos-crypto/fuzzing", "aptos-jellyfish-merkle/fuzzing", "aptos-types/fuzzing", "aptos-executor-types/fuzzing", "aptos-schemadb/fuzzing", "aptos-scratchpad/fuzzing"]
-consensus-only-perf-test = []
-db-debugger = ["aptos-temppath", "clap", "crossbeam-channel", "owo-colors", "indicatif"]

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+testing = []
+fuzzing = ["aptos-db/fuzzing"]
+consensus-only-perf-test = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-backup-service = { workspace = true }
@@ -67,8 +72,3 @@ aptos-proptest-helpers = { workspace = true }
 aptos-storage-interface = { workspace = true }
 proptest = { workspace = true }
 warp = { workspace = true }
-
-[features]
-testing = []
-fuzzing = ["aptos-db/fuzzing"]
-consensus-only-perf-test = []

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+fuzzing = ["aptos-db/fuzzing"]
+
 [dependencies]
 aptos-crypto = { workspace = true }
 aptos-db = { workspace = true }
@@ -34,6 +37,3 @@ aptos-config = { workspace = true }
 aptos-db = { workspace = true, features = ["fuzzing"] }
 aptos-temppath = { workspace = true }
 reqwest = { workspace = true }
-
-[features]
-fuzzing = ["aptos-db/fuzzing"]

--- a/storage/indexer/Cargo.toml
+++ b/storage/indexer/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["aptos-types/fuzzing", "aptos-schemadb/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
@@ -34,7 +38,3 @@ aptos-proptest-helpers = { workspace = true }
 aptos-schemadb = { workspace = true, features = ["fuzzing"] }
 aptos-types = { workspace = true, features = ["fuzzing"] }
 rand = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["aptos-types/fuzzing", "aptos-schemadb/fuzzing"]

--- a/storage/indexer_schemas/Cargo.toml
+++ b/storage/indexer_schemas/Cargo.toml
@@ -12,6 +12,15 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = [
+    "proptest",
+    "proptest-derive",
+    "aptos-types/fuzzing",
+    "aptos-schemadb/fuzzing",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -31,7 +40,3 @@ aptos-types = { workspace = true, features = ["fuzzing"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["proptest", "proptest-derive", "aptos-types/fuzzing", "aptos-schemadb/fuzzing"]

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["proptest", "proptest-derive", "aptos-crypto/fuzzing", "aptos-types/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -42,7 +46,3 @@ aptos-types = { workspace = true, features = ["fuzzing"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["proptest", "proptest-derive", "aptos-crypto/fuzzing", "aptos-types/fuzzing"]

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+fuzzing = ["proptest"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-drop-helper = { workspace = true }
@@ -30,6 +33,3 @@ rocksdb = { workspace = true, features = ["jemalloc"] }
 aptos-temppath = { workspace = true }
 byteorder = { workspace = true }
 proptest = { workspace = true }
-
-[features]
-fuzzing = ["proptest"]

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -12,6 +12,15 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[lib]
+# Allow Criterion benchmarks to take command line arguments
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[features]
+fuzzing = ["aptos-types/fuzzing", "proptest"]
+bench = ["proptest", "criterion"]
+
 [dependencies]
 aptos-crypto = { workspace = true }
 aptos-drop-helper = { workspace = true }
@@ -38,16 +47,7 @@ rand = { workspace = true }
 [target.'cfg(unix)'.dev-dependencies]
 jemallocator = { workspace = true }
 
-[features]
-fuzzing = ["aptos-types/fuzzing", "proptest"]
-bench = ["proptest", "criterion"]
-
 [[bench]]
 name = "sparse_merkle"
 harness = false
 required-features = ["bench"]
-
-[lib]
-# Allow Criterion benchmarks to take command line arguments
-# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
-bench = false

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -12,6 +12,13 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["proptest"]
+
+[features]
+default = []
+fuzzing = ["aptos-types/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
@@ -40,10 +47,3 @@ thiserror = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }
 bytes = { workspace = true }
 lru = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["aptos-types/fuzzing"]
-
-[package.metadata.cargo-machete]
-ignored = ["proptest"]

--- a/testsuite/forge-cli/Cargo.toml
+++ b/testsuite/forge-cli/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[[bin]]
+name = "forge"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-cached-packages = { workspace = true }
@@ -39,7 +43,3 @@ url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = { workspace = true }
-
-[[bin]]
-name = "forge"
-path = "src/main.rs"

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -12,6 +12,10 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+testing = ["aptos-global-constants/testing"]
+
 [dependencies]
 again = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
@@ -70,7 +74,3 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 serde_merge = { workspace = true }
-
-[features]
-default = []
-testing = ["aptos-global-constants/testing"]

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -81,6 +81,12 @@ path = "fuzz_targets/move/aptosvm_publish_and_run_transactional.rs"
 test = false
 doc = false
 
+[[bin]]
+name = "u256_diff_fuzz"
+path = "fuzz_targets/u256_diff_fuzz.rs"
+test = false
+doc = false
+
 [features]
 consensus = ["dep:aptos-consensus"]
 
@@ -112,9 +118,3 @@ primitive-types = { workspace = true }
 ring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-
-[[bin]]
-name = "u256_diff_fuzz"
-path = "fuzz_targets/u256_diff_fuzz.rs"
-test = false
-doc = false

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[[bin]]
+name = "compute"
+path = "src/compute.rs"
+test = false
+
 [dependencies]
 aptos-api-types = { workspace = true }
 aptos-batch-encryption = { workspace = true }
@@ -29,8 +34,3 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde-reflection = { workspace = true }
 serde_yaml = { workspace = true }
-
-[[bin]]
-name = "compute"
-path = "src/compute.rs"
-test = false

--- a/third_party/move/documentation/framework-book/builder/Cargo.toml
+++ b/third_party/move/documentation/framework-book/builder/Cargo.toml
@@ -12,13 +12,13 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[[bin]]
+name = "aptos-framework-book-builder"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-framework = { workspace = true }
 move-docgen = { workspace = true }
 move-model = { workspace = true }
 tempfile = { workspace = true }
-
-[[bin]]
-name = "aptos-framework-book-builder"
-path = "src/main.rs"

--- a/third_party/move/mono-move/orchestrator/Cargo.toml
+++ b/third_party/move/mono-move/orchestrator/Cargo.toml
@@ -11,13 +11,13 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[[bin]]
+name = "mseir-compiler"
+path = "src/bin/mseir-compiler.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
 mono-move-global-context = { workspace = true }
 move-binary-format = { workspace = true }
 specializer = { workspace = true }
-
-[[bin]]
-name = "mseir-compiler"
-path = "src/bin/mseir-compiler.rs"

--- a/third_party/move/mono-move/specializer/Cargo.toml
+++ b/third_party/move/mono-move/specializer/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = { workspace = true }
 publish = false
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow = { workspace = true }
 mono-move-core = { workspace = true }
@@ -13,6 +16,3 @@ move-core-types = { workspace = true }
 shared-dsa = { workspace = true }
 smallbitvec = { workspace = true }
 smallvec = { workspace = true }
-
-[lib]
-doctest = false

--- a/third_party/move/move-binary-format/Cargo.toml
+++ b/third_party/move/move-binary-format/Cargo.toml
@@ -9,6 +9,17 @@ license = "Apache-2.0"
 publish = ["crates-io"]
 edition = { workspace = true }
 
+[features]
+default = []
+fuzzing = [
+    "proptest",
+    "proptest-derive",
+    "arbitrary",
+    "dearbitrary",
+    "move-core-types/fuzzing",
+]
+testing = []
+
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
@@ -29,8 +40,3 @@ move-core-types = { workspace = true, features = ["fuzzing"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 serde_json = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["proptest", "proptest-derive", "arbitrary", "dearbitrary", "move-core-types/fuzzing"]
-testing = []

--- a/third_party/move/move-binary-format/serializer-tests/Cargo.toml
+++ b/third_party/move/move-binary-format/serializer-tests/Cargo.toml
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[features]
+fuzzing = ["move-binary-format/fuzzing"]
+
 [dev-dependencies]
 move-binary-format = { workspace = true, features = ["fuzzing"] }
 move-core-types = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 similar-asserts = "1.7.0"
-
-[features]
-fuzzing = ["move-binary-format/fuzzing"]

--- a/third_party/move/move-bytecode-spec/Cargo.toml
+++ b/third_party/move/move-bytecode-spec/Cargo.toml
@@ -9,10 +9,10 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[lib]
+proc-macro = true
+
 [dependencies]
 once_cell = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
-
-[lib]
-proc-macro = true

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[features]
+fuzzing = ["move-binary-format/fuzzing"]
+
 [dev-dependencies]
 fail = { workspace = true, features = ['failpoints'] }
 hex = { workspace = true }
@@ -18,6 +21,3 @@ move-bytecode-verifier-invalid-mutations = { workspace = true }
 move-core-types = { workspace = true }
 petgraph = { workspace = true }
 proptest = { workspace = true }
-
-[features]
-fuzzing = ["move-binary-format/fuzzing"]

--- a/third_party/move/move-compiler-v2/Cargo.toml
+++ b/third_party/move/move-compiler-v2/Cargo.toml
@@ -9,6 +9,12 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["strum"]
+
+[lib]
+doctest = false
+
 [dependencies]
 abstract-domain-derive = { path = "../move-model/bytecode/abstract_domain_derive" }
 anyhow = { workspace = true }
@@ -48,13 +54,7 @@ move-prover-test-utils = { workspace = true }
 move-stdlib = { path = "../move-stdlib" }
 walkdir = { workspace = true }
 
-[lib]
-doctest = false
-
 [[test]]
 name = "testsuite"
 harness = false
 doctest = false
-
-[package.metadata.cargo-machete]
-ignored = ["strum"]

--- a/third_party/move/move-core/types/Cargo.toml
+++ b/third_party/move/move-core/types/Cargo.toml
@@ -9,6 +9,10 @@ license = "Apache-2.0"
 publish = ["crates-io"]
 edition = { workspace = true }
 
+[features]
+default = []
+fuzzing = ["proptest", "proptest-derive", "arbitrary", "dearbitrary"]
+
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true, features = ["derive_arbitrary"], optional = true }
@@ -38,7 +42,3 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 regex = { workspace = true }
 serde_json = { workspace = true }
-
-[features]
-default = []
-fuzzing = ["proptest", "proptest-derive", "arbitrary", "dearbitrary"]

--- a/third_party/move/move-examples/Cargo.toml
+++ b/third_party/move/move-examples/Cargo.toml
@@ -7,10 +7,10 @@ description = "Move examples"
 license = "Apache-2.0"
 publish = false
 
+[features]
+
 [dependencies]
 
 [dev-dependencies]
 move-prover = { workspace = true }
 move-stdlib = { path = "../move-stdlib" }
-
-[features]

--- a/third_party/move/move-model/bytecode/Cargo.toml
+++ b/third_party/move/move-model/bytecode/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[features]
+default = []
+
 [dependencies]
 abstract-domain-derive = { path = "./abstract_domain_derive" }
 anyhow = { workspace = true }
@@ -30,9 +33,6 @@ try_match = { workspace = true }
 anyhow = { workspace = true }
 datatest-stable = { workspace = true }
 move-stackless-bytecode-test-utils = { workspace = true }
-
-[features]
-default = []
 
 [[test]]
 name = "testsuite"

--- a/third_party/move/move-model/bytecode/ast-generator-tests/Cargo.toml
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = { workspace = true }
 license = "Apache-2.0"
 
+[lib]
+doctest = false
+
 [dev-dependencies]
 anyhow = { workspace = true }
 codespan-reporting = { workspace = true, features = ["serde", "serialization"] }
@@ -16,6 +19,3 @@ move-stackless-bytecode = { workspace = true }
 [[test]]
 name = "testsuite"
 harness = false
-
-[lib]
-doctest = false

--- a/third_party/move/move-prover/e2e-tests/Cargo.toml
+++ b/third_party/move/move-prover/e2e-tests/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow = { workspace = true }
 codespan-reporting = { workspace = true }
@@ -22,6 +25,3 @@ move-prover = { workspace = true }
 move-prover-test-utils = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
-
-[lib]
-doctest = false

--- a/third_party/move/move-symbol-pool/Cargo.toml
+++ b/third_party/move/move-symbol-pool/Cargo.toml
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[features]
+default = []
+
 [dependencies]
 once_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = { workspace = true }
-
-[features]
-default = []

--- a/third_party/move/move-vm/integration-tests/Cargo.toml
+++ b/third_party/move/move-vm/integration-tests/Cargo.toml
@@ -8,6 +8,10 @@ homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
+
+[features]
+default = []
+table-extension = ["move-vm-test-utils/table-extension"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -29,7 +33,3 @@ move-vm-types = { workspace = true, features = ["testing"] }
 smallvec = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-default = []
-table-extension = ["move-vm-test-utils/table-extension"]

--- a/third_party/move/move-vm/profiler/Cargo.toml
+++ b/third_party/move/move-vm/profiler/Cargo.toml
@@ -11,11 +11,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+probe-profiler = ["dep:usdt"]
+
 [dependencies]
 move-vm-types = { workspace = true }
 once_cell = { workspace = true }
 usdt = { workspace = true, optional = true }
-
-[features]
-default = []
-probe-profiler = ["dep:usdt"]

--- a/third_party/move/move-vm/runtime/Cargo.toml
+++ b/third_party/move/move-vm/runtime/Cargo.toml
@@ -8,6 +8,17 @@ homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
+
+[features]
+default = ["inline-callstack"]
+profiling = ["move-vm-profiler/probe-profiler"]
+testing = []
+fuzzing = ["move-vm-types/fuzzing"]
+failpoints = ["fail/failpoints"]
+# Enable this features for tests that check bytecode verification.
+disable_verifier_cache = []
+force-inline = []
+inline-callstack = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -43,19 +54,6 @@ move-binary-format = { workspace = true, features = ["fuzzing"] }
 move-vm-types = { workspace = true, features = ["testing"] }
 smallbitvec = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-default = [
-    "inline-callstack",
-]
-profiling = ["move-vm-profiler/probe-profiler"]
-testing = []
-fuzzing = ["move-vm-types/fuzzing"]
-failpoints = ["fail/failpoints"]
-# Enable this features for tests that check bytecode verification.
-disable_verifier_cache = []
-force-inline = []
-inline-callstack = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/third_party/move/move-vm/test-utils/Cargo.toml
+++ b/third_party/move/move-vm/test-utils/Cargo.toml
@@ -8,6 +8,10 @@ homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
+
+[features]
+default = []
+table-extension = ["move-table-extension"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,7 +25,3 @@ move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
-
-[features]
-default = []
-table-extension = ["move-table-extension"]

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -9,6 +9,14 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[features]
+default = ["inline-vm-casts", "inline-locals"]
+testing = []
+fuzzing = ["proptest", "move-binary-format/fuzzing"]
+force-inline = []
+inline-vm-casts = []
+inline-locals = []
+
 [dependencies]
 ambassador = { workspace = true }
 bcs = { workspace = true }
@@ -41,14 +49,3 @@ rand = { workspace = true }
 [[bench]]
 name = "drop_bench"
 harness = false
-
-[features]
-default = [
-    "inline-vm-casts",
-    "inline-locals"
-]
-testing = []
-fuzzing = ["proptest", "move-binary-format/fuzzing"]
-force-inline = []
-inline-vm-casts = []
-inline-locals = []

--- a/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
+++ b/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
@@ -9,6 +9,10 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[features]
+failpoints = ['move-vm-runtime/failpoints']
+fuzzing = ["arbitrary", "dearbitrary", "aptos-framework", "bcs"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-framework = { workspace = true, optional = true }
@@ -47,7 +51,3 @@ difference = { workspace = true }
 [[test]]
 name = "tests"
 harness = false
-
-[features]
-failpoints = ['move-vm-runtime/failpoints']
-fuzzing = ["arbitrary", "dearbitrary", "aptos-framework", "bcs"]

--- a/third_party/move/tools/move-asm/Cargo.toml
+++ b/third_party/move/tools/move-asm/Cargo.toml
@@ -9,6 +9,16 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[lib]
+doctest = false
+
+[[bin]]
+name = "move-bytecode-stats"
+path = "src/bytecode_stats.rs"
+
+[features]
+default = []
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
@@ -25,16 +35,6 @@ libtest-mimic = { workspace = true }
 move-transactional-test-runner = { workspace = true }
 walkdir = { workspace = true }
 
-[features]
-default = []
-
 [[test]]
 name = "testsuite"
 harness = false
-
-[[bin]]
-name = "move-bytecode-stats"
-path = "src/bytecode_stats.rs"
-
-[lib]
-doctest = false

--- a/third_party/move/tools/move-coverage/Cargo.toml
+++ b/third_party/move/tools/move-coverage/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[features]
+default = []
+
 [dependencies]
 anyhow = { workspace = true }
 bcs = { workspace = true }
@@ -22,6 +25,3 @@ move-core-types = { workspace = true }
 move-ir-types = { workspace = true }
 petgraph = { workspace = true }
 serde = { workspace = true }
-
-[features]
-default = []

--- a/third_party/move/tools/move-decompiler/Cargo.toml
+++ b/third_party/move/tools/move-decompiler/Cargo.toml
@@ -9,6 +9,12 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[lib]
+doctest = false
+
+[features]
+default = []
+
 [dependencies]
 anyhow = { workspace = true }
 bcs = { workspace = true }
@@ -31,12 +37,6 @@ once_cell = { workspace = true }
 tempfile = { workspace = true }
 walkdir = { workspace = true }
 
-[features]
-default = []
-
 [[test]]
 name = "testsuite"
 harness = false
-
-[lib]
-doctest = false

--- a/third_party/move/tools/move-unit-test/Cargo.toml
+++ b/third_party/move/tools/move-unit-test/Cargo.toml
@@ -9,6 +9,13 @@ license = "Apache-2.0"
 publish = false
 edition = { workspace = true }
 
+[[bin]]
+name = "move-unit-test"
+path = "src/main.rs"
+
+[features]
+table-extension = ["move-vm-test-utils/table-extension"]
+
 [dependencies]
 anyhow = { workspace = true }
 better_any = { workspace = true }
@@ -45,15 +52,6 @@ move-model = { path = "../../move-model" }
 move-package = { path = "../move-package" }
 tempfile = { workspace = true }
 
-[[bin]]
-name = "move-unit-test"
-path = "src/main.rs"
-
 [[test]]
 name = "move_unit_test_testsuite"
 harness = false
-
-[features]
-table-extension = [
-    "move-vm-test-utils/table-extension"
-]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -12,6 +12,20 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ['poem-openapi']
+
+[features]
+default = []
+testing = ["aptos-crypto/fuzzing"]
+fuzzing = [
+    "proptest",
+    "proptest-derive",
+    "aptos-crypto/fuzzing",
+    "move-core-types/fuzzing",
+    "arbitrary",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-batch-encryption = { workspace = true }
@@ -95,17 +109,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 
-[features]
-default = []
-testing = ["aptos-crypto/fuzzing"]
-fuzzing = [
-    "proptest",
-    "proptest-derive",
-    "aptos-crypto/fuzzing",
-    "move-core-types/fuzzing",
-    "arbitrary",
-]
-
 [[bench]]
 name = "keyless"
 harness = false
@@ -113,6 +116,3 @@ harness = false
 [[bench]]
 name = "state_key"
 harness = false
-
-[package.metadata.cargo-machete]
-ignored = ['poem-openapi']

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+failpoints = ["fail/failpoints"]
+fuzzing = ["aptos-types/fuzzing", "aptos-crypto/fuzzing", "aptos-db/fuzzing"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-logger = { workspace = true }
@@ -35,8 +40,3 @@ aptos-types = { workspace = true, features = ["testing"] }
 aptos-vm-genesis = { workspace = true }
 move-vm-types = { workspace = true, features = ["testing"] }
 rand = { workspace = true }
-
-[features]
-default = []
-failpoints = ["fail/failpoints"]
-fuzzing = ["aptos-types/fuzzing", "aptos-crypto/fuzzing", "aptos-db/fuzzing"]


### PR DESCRIPTION
## Description
Add a way to allow feedback data after commitment.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes executor-benchmark pipeline timing and pipeline config when feedback is enabled; core node execution paths are untouched but benchmark workloads relying on generate-then-execute may behave differently.
> 
> **Overview**
> Adds a **post-commit feedback loop** so executor benchmarks can drive multi-step workloads from on-chain events (e.g. register then commit using emitted UIDs).
> 
> **`TransactionFeedback`** in `transaction-generator-lib` exposes `on_block_committed` (per-block `TransactionOutput`s) and optional `wait_until_ready` (block before generating the next block). `TransactionGeneratorCreator::transaction_feedback()` is implemented on account-pool wrappers, phased mix generators (`PhasedFeedback`), and workflow delegators (at most one feedback source per workflow/phase).
> 
> The executor benchmark **pipes feedback through the pipeline**: `LedgerUpdateStage` invokes `on_block_committed` after ledger update; `run_workload` calls `wait_until_ready` on the main thread before each block. When feedback is present, **`generate_then_execute` and `split_stages` are forced off** so execution stays in sync with generation.
> 
> Also adds **`set_min_block_timestamp_usecs`** to floor epoch-change block timestamps, declares **`aptos-types`** on `transaction-generator-lib`, and includes widespread **Cargo.toml section reordering** (features/bins/metadata) with no intended behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5684e2350022154f9a11ee6cc127f8f78942f31b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->