### PR TITLE
[move-flow] Add facts query in move_package_query

### DIFF
--- a/aptos-move/flow/src/mcp/tools/package_query.rs
+++ b/aptos-move/flow/src/mcp/tools/package_query.rs
@@ -7,7 +7,17 @@ use super::super::{
     common::{mcp_err, resolve_function, tool_error, try_call},
     session::{into_call_tool_result, FlowSession},
 };
-use move_model::model::{FunId, GlobalEnv, QualifiedId};
+use move_model::{
+    ast::{
+        AccessSpecifier, AccessSpecifierKind, AddressSpecifier, Attribute, ExpData, Operation,
+        ResourceSpecifier,
+    },
+    model::{
+        FunId, FunctionEnv, GlobalEnv, Loc, ModuleEnv, NamedConstantEnv, QualifiedId, StructEnv,
+        TypeParameter, Visibility,
+    },
+    ty::ReferenceKind,
+};
 use rmcp::{
     handler::server::wrapper::Parameters, model::CallToolResult, schemars, tool, tool_router,
 };
@@ -37,6 +47,10 @@ enum QueryType {
     /// Returns direct and transitive calls/uses by a given function.
     /// "called" = direct calls; "used" = direct calls + closure captures.
     FunctionUsage,
+    /// Returns full-fidelity, compiler-sourced per-module facts (functions,
+    /// types, constants, friends, attributes, locations) consumed by the
+    /// GitNexus Move ingestion pipeline. See `build_facts` for the shape.
+    Facts,
 }
 
 // ========== MCP Tool ==========
@@ -95,6 +109,11 @@ impl FlowSession {
                 })?;
                 let result = build_function_usage(data.env(), &function)?;
                 log::info!("move_package_query function_usage({})", function);
+                Ok(into_call_tool_result(&result))
+            },
+            QueryType::Facts => {
+                let result = build_facts(data.env());
+                log::info!("move_package_query facts: {} module(s)", result.len());
                 Ok(into_call_tool_result(&result))
             },
         }
@@ -275,4 +294,513 @@ fn qids_to_names(env: &GlobalEnv, qids: &BTreeSet<QualifiedId<FunId>>) -> BTreeS
     qids.iter()
         .map(|qid| env.get_function(*qid).get_full_name_with_address())
         .collect()
+}
+
+// ========== Query: facts ==========
+//
+// Full-fidelity, compiler-sourced per-module facts. Every field is sourced from
+// the `GlobalEnv` — no string re-parsing of Move source. Wire keys use
+// `camelCase` to match the GitNexus `MoveFactsMap` consumer in
+// `gitnexus/src/core/move/compiler-facts.ts` exactly. Optional empty arrays may
+// be omitted; the consumer treats absent arrays as empty.
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ModuleFacts {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    span: Option<[u32; 2]>,
+    friends: Vec<FriendFacts>,
+    attributes: Vec<AttributeFacts>,
+    functions: Vec<FunctionFacts>,
+    types: Vec<TypeFacts>,
+    constants: Vec<ConstantSummary>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FriendFacts {
+    module: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AttributeFacts {
+    name: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TypeParamFacts {
+    name: String,
+    abilities: Vec<String>,
+    is_phantom: bool,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ParamFacts {
+    name: String,
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FieldFacts {
+    name: String,
+    #[serde(rename = "type")]
+    type_: String,
+    positional: bool,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VariantFacts {
+    name: String,
+    /// One of `"unit"`, `"positional"`, `"named"`.
+    kind: String,
+    fields: Vec<FieldFacts>,
+    attributes: Vec<AttributeFacts>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeclaredAccessFacts {
+    /// One of `"reads"`, `"writes"`, `"legacy_acquires"`.
+    kind: String,
+    resource: DeclaredAccessResource,
+    address: DeclaredAccessAddress,
+    negated: bool,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeclaredAccessResource {
+    /// One of `"any"`, `"at_address"`, `"in_module"`, `"resource"`.
+    form: String,
+    value: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeclaredAccessAddress {
+    /// One of `"any"`, `"address"`, `"parameter"`, `"call"`.
+    form: String,
+    value: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ResourceAccessFacts {
+    reads: Vec<String>,
+    writes: Vec<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FunctionFacts {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    span: Option<[u32; 2]>,
+    /// One of `"public"`, `"friend"`, `"package"`, `"internal"`.
+    visibility: String,
+    is_entry: bool,
+    is_inline: bool,
+    is_native: bool,
+    is_view: bool,
+    attributes: Vec<AttributeFacts>,
+    type_params: Vec<TypeParamFacts>,
+    params: Vec<ParamFacts>,
+    return_type: Option<String>,
+    declared_access: Vec<DeclaredAccessFacts>,
+    acquires_inferred: Vec<String>,
+    resource_access: ResourceAccessFacts,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TypeFacts {
+    /// `"struct"` or `"enum"`.
+    kind: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    span: Option<[u32; 2]>,
+    abilities: Vec<String>,
+    type_params: Vec<TypeParamFacts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fields: Option<Vec<FieldFacts>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    variants: Option<Vec<VariantFacts>>,
+    attributes: Vec<AttributeFacts>,
+}
+
+/// Build per-module facts for every primary target module in `env`.
+fn build_facts(env: &GlobalEnv) -> BTreeMap<String, ModuleFacts> {
+    env.get_primary_target_modules()
+        .iter()
+        .map(|module| {
+            let name = module.get_full_name_str();
+            let facts = build_module_facts(env, module);
+            (name, facts)
+        })
+        .collect()
+}
+
+fn build_module_facts(env: &GlobalEnv, module: &ModuleEnv<'_>) -> ModuleFacts {
+    let (file, span) = loc_to_file_span(env, &module.get_loc());
+
+    let friends: Vec<FriendFacts> = module
+        .get_friend_modules()
+        .iter()
+        .map(|id| FriendFacts {
+            module: env.get_module(*id).get_full_name_str(),
+        })
+        .collect();
+
+    let attributes = attrs_to_facts(env, module.get_attributes());
+
+    let functions: Vec<FunctionFacts> = module
+        .get_functions()
+        .map(|f| build_function_facts(env, &f))
+        .collect();
+
+    let types: Vec<TypeFacts> = module
+        .get_structs()
+        .map(|s| build_type_facts(env, &s))
+        .collect();
+
+    let constants: Vec<ConstantSummary> = module
+        .get_named_constants()
+        .map(|c| build_constant_summary(env, &c))
+        .collect();
+
+    ModuleFacts {
+        file,
+        span,
+        friends,
+        attributes,
+        functions,
+        types,
+        constants,
+    }
+}
+
+fn build_constant_summary(env: &GlobalEnv, c: &NamedConstantEnv<'_>) -> ConstantSummary {
+    let ctx = c.get_type_display_ctx();
+    ConstantSummary {
+        name: c.get_name().display(env.symbol_pool()).to_string(),
+        type_: c.get_type().display(&ctx).to_string(),
+        value: env.display(&c.get_value()).to_string(),
+    }
+}
+
+fn build_function_facts(env: &GlobalEnv, func: &FunctionEnv<'_>) -> FunctionFacts {
+    let (file, span) = loc_to_file_span(env, &func.get_loc());
+    let type_ctx = func.get_type_display_ctx();
+
+    let symbol_pool = env.symbol_pool();
+    let params: Vec<ParamFacts> = func
+        .get_parameters_ref()
+        .iter()
+        .map(|p| ParamFacts {
+            name: p.0.display(symbol_pool).to_string(),
+            type_: p.1.display(&type_ctx).to_string(),
+        })
+        .collect();
+
+    let return_type = format_return_type(func, &type_ctx);
+
+    let acquires_inferred: Vec<String> = func
+        .get_acquired_structs()
+        .map(|set| {
+            set.iter()
+                .map(|sid| {
+                    func.module_env
+                        .get_struct(*sid)
+                        .get_full_name_with_address()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let declared_access: Vec<DeclaredAccessFacts> = func
+        .get_access_specifiers()
+        .map(|specs| specs.iter().map(|s| access_spec_to_facts(env, s)).collect())
+        .unwrap_or_default();
+
+    let resource_access = build_resource_access(env, func, &type_ctx);
+
+    let attributes = attrs_to_facts(env, func.get_attributes());
+    let is_view = func
+        .get_attributes()
+        .iter()
+        .any(|a| symbol_pool.string(a.name()).as_str() == "view");
+
+    FunctionFacts {
+        name: func.get_name_str(),
+        file,
+        span,
+        visibility: visibility_str(func),
+        is_entry: func.is_entry(),
+        is_inline: func.is_inline(),
+        is_native: func.is_native(),
+        is_view,
+        attributes,
+        type_params: type_params_to_facts(env, &func.get_type_parameters()),
+        params,
+        return_type,
+        declared_access,
+        acquires_inferred,
+        resource_access,
+    }
+}
+
+fn build_type_facts(env: &GlobalEnv, s: &StructEnv<'_>) -> TypeFacts {
+    let (file, span) = loc_to_file_span(env, &s.get_loc());
+    let type_ctx = s.get_type_display_ctx();
+    let symbol_pool = env.symbol_pool();
+
+    let abilities: Vec<String> = s
+        .get_abilities()
+        .into_iter()
+        .map(|a| a.to_string())
+        .collect();
+
+    let type_params = type_params_to_facts(env, s.get_type_parameters());
+
+    let (kind, fields, variants) = if s.has_variants() {
+        let variants: Vec<VariantFacts> = s
+            .get_variants()
+            .map(|v| {
+                let v_fields: Vec<FieldFacts> = s
+                    .get_fields_of_variant(v)
+                    .map(|f| FieldFacts {
+                        name: f.get_name().display(symbol_pool).to_string(),
+                        type_: f.get_type().display(&type_ctx).to_string(),
+                        positional: f.is_positional(),
+                    })
+                    .collect();
+                let v_attrs = attrs_to_facts(env, s.get_variant_attributes(v));
+                let kind = if v_fields.is_empty() {
+                    "unit"
+                } else if v_fields.iter().all(|f| f.positional) {
+                    "positional"
+                } else {
+                    "named"
+                };
+                VariantFacts {
+                    name: v.display(symbol_pool).to_string(),
+                    kind: kind.to_string(),
+                    fields: v_fields,
+                    attributes: v_attrs,
+                }
+            })
+            .collect();
+        ("enum", None, Some(variants))
+    } else {
+        let fields: Vec<FieldFacts> = s
+            .get_fields()
+            .map(|f| FieldFacts {
+                name: f.get_name().display(symbol_pool).to_string(),
+                type_: f.get_type().display(&type_ctx).to_string(),
+                positional: f.is_positional(),
+            })
+            .collect();
+        ("struct", Some(fields), None)
+    };
+
+    let attributes = attrs_to_facts(env, s.get_attributes());
+
+    TypeFacts {
+        kind: kind.to_string(),
+        name: s.get_name().display(symbol_pool).to_string(),
+        file,
+        span,
+        abilities,
+        type_params,
+        fields,
+        variants,
+        attributes,
+    }
+}
+
+fn type_params_to_facts(env: &GlobalEnv, params: &[TypeParameter]) -> Vec<TypeParamFacts> {
+    let symbol_pool = env.symbol_pool();
+    params
+        .iter()
+        .map(|tp| TypeParamFacts {
+            name: tp.0.display(symbol_pool).to_string(),
+            abilities: tp.1.abilities.into_iter().map(|a| a.to_string()).collect(),
+            is_phantom: tp.1.is_phantom,
+        })
+        .collect()
+}
+
+fn attrs_to_facts(env: &GlobalEnv, attrs: &[Attribute]) -> Vec<AttributeFacts> {
+    let symbol_pool = env.symbol_pool();
+    attrs
+        .iter()
+        .map(|a| AttributeFacts {
+            name: symbol_pool.string(a.name()).to_string(),
+        })
+        .collect()
+}
+
+fn visibility_str(func: &FunctionEnv<'_>) -> String {
+    if func.has_package_visibility() {
+        return "package".to_string();
+    }
+    match func.visibility() {
+        Visibility::Public => "public",
+        Visibility::Friend => "friend",
+        Visibility::Private => "internal",
+    }
+    .to_string()
+}
+
+fn format_return_type(
+    func: &FunctionEnv<'_>,
+    type_ctx: &move_model::ty::TypeDisplayContext<'_>,
+) -> Option<String> {
+    use move_model::ty::Type;
+    let result = func.get_result_type();
+    if let Type::Tuple(ts) = &result
+        && ts.is_empty()
+    {
+        return None;
+    }
+    Some(result.display(type_ctx).to_string())
+}
+
+fn access_spec_to_facts(env: &GlobalEnv, spec: &AccessSpecifier) -> DeclaredAccessFacts {
+    let kind = match spec.kind {
+        AccessSpecifierKind::Reads => "reads",
+        AccessSpecifierKind::Writes => "writes",
+        AccessSpecifierKind::LegacyAcquires => "legacy_acquires",
+    };
+    let (form, value) = match &spec.resource.1 {
+        ResourceSpecifier::Any => ("any", "*".to_string()),
+        ResourceSpecifier::DeclaredAtAddress(addr) => ("at_address", env.display(addr).to_string()),
+        ResourceSpecifier::DeclaredInModule(mid) => {
+            ("in_module", env.get_module(*mid).get_full_name_str())
+        },
+        ResourceSpecifier::Resource(qid) => {
+            let struct_env = env.get_struct(qid.to_qualified_id());
+            let mut s = struct_env.get_full_name_with_address();
+            if !qid.inst.is_empty() {
+                let ctx = struct_env.get_type_display_ctx();
+                let args: Vec<String> = qid
+                    .inst
+                    .iter()
+                    .map(|t| t.display(&ctx).to_string())
+                    .collect();
+                s.push('<');
+                s.push_str(&args.join(", "));
+                s.push('>');
+            }
+            ("resource", s)
+        },
+    };
+    let address = address_spec_to_facts(env, &spec.address.1);
+    DeclaredAccessFacts {
+        kind: kind.to_string(),
+        resource: DeclaredAccessResource {
+            form: form.to_string(),
+            value,
+        },
+        address,
+        negated: spec.negated,
+    }
+}
+
+fn address_spec_to_facts(env: &GlobalEnv, addr: &AddressSpecifier) -> DeclaredAccessAddress {
+    let symbol_pool = env.symbol_pool();
+    let (form, value) = match addr {
+        AddressSpecifier::Any => ("any", "*".to_string()),
+        AddressSpecifier::Address(a) => ("address", env.display(a).to_string()),
+        AddressSpecifier::Parameter(sym) => ("parameter", sym.display(symbol_pool).to_string()),
+        AddressSpecifier::Call(qid, sym) => {
+            let fun = env.get_function(qid.to_qualified_id());
+            let mut s = fun.get_full_name_with_address();
+            if !qid.inst.is_empty() {
+                let ctx = fun.get_type_display_ctx();
+                let args: Vec<String> = qid
+                    .inst
+                    .iter()
+                    .map(|t| t.display(&ctx).to_string())
+                    .collect();
+                s.push('<');
+                s.push_str(&args.join(", "));
+                s.push('>');
+            }
+            s.push('(');
+            s.push_str(&sym.display(symbol_pool).to_string());
+            s.push(')');
+            ("call", s)
+        },
+    };
+    DeclaredAccessAddress {
+        form: form.to_string(),
+        value,
+    }
+}
+
+/// Derive read/write resource access for `func` by walking the function body AST
+/// for `borrow_global` / `move_from` / `move_to` operations. Empty when the
+/// function has no AST body (e.g. native). The values are type expressions in
+/// the function's display context (`CoinStore<CoinType>`), not necessarily
+/// fully qualified — matches the consumer contract.
+fn build_resource_access(
+    env: &GlobalEnv,
+    func: &FunctionEnv<'_>,
+    type_ctx: &move_model::ty::TypeDisplayContext<'_>,
+) -> ResourceAccessFacts {
+    let Some(body) = func.get_def() else {
+        return ResourceAccessFacts {
+            reads: vec![],
+            writes: vec![],
+        };
+    };
+    let mut reads = BTreeSet::new();
+    let mut writes = BTreeSet::new();
+    body.visit_pre_order(&mut |e| {
+        if let ExpData::Call(node_id, op, _) = e {
+            let bucket = match op {
+                Operation::BorrowGlobal(ReferenceKind::Immutable) => Some(&mut reads),
+                Operation::BorrowGlobal(ReferenceKind::Mutable)
+                | Operation::MoveFrom
+                | Operation::MoveTo => Some(&mut writes),
+                _ => None,
+            };
+            if let Some(bucket) = bucket {
+                let insts = env.get_node_instantiation(*node_id);
+                if let Some(ty) = insts.first() {
+                    bucket.insert(ty.display(type_ctx).to_string());
+                }
+            }
+        }
+        true
+    });
+    ResourceAccessFacts {
+        reads: reads.into_iter().collect(),
+        writes: writes.into_iter().collect(),
+    }
+}
+
+/// Convert a `Loc` to `(source_file, [start_line, end_line])`, where lines are
+/// 1-indexed. The file name comes directly from the loc's file id (always
+/// available), independent of line-column resolution. `span` is `None` when
+/// either endpoint cannot be resolved (e.g. generated or out-of-range locs).
+fn loc_to_file_span(env: &GlobalEnv, loc: &Loc) -> (Option<String>, Option<[u32; 2]>) {
+    let file = Some(env.get_file(loc.file_id()).to_string_lossy().into_owned());
+    let start = env.get_location(loc).map(|l| l.line.0 + 1);
+    let end = env.get_location(&loc.at_end()).map(|l| l.line.0 + 1);
+    let span = start.zip(end).map(|(s, e)| [s, e]);
+    (file, span)
 }

--- a/aptos-move/flow/src/tests/list_tools/success.exp
+++ b/aptos-move/flow/src/tests/list_tools/success.exp
@@ -97,6 +97,11 @@
               "description": "Returns direct and transitive calls/uses by a given function.\n\"called\" = direct calls; \"used\" = direct calls + closure captures.",
               "type": "string",
               "const": "function_usage"
+            },
+            {
+              "description": "Returns full-fidelity, compiler-sourced per-module facts (functions,\ntypes, constants, friends, attributes, locations) consumed by the\nGitNexus Move ingestion pipeline. See `build_facts` for the shape.",
+              "type": "string",
+              "const": "facts"
             }
           ]
         }

--- a/aptos-move/flow/src/tests/move_package_query/facts.exp
+++ b/aptos-move/flow/src/tests/move_package_query/facts.exp
@@ -1,0 +1,263 @@
+{
+  "0xcafe::coin": {
+    "file": "<TEMPDIR>/coin.move",
+    "span": [
+      1,
+      29
+    ],
+    "friends": [
+      {
+        "module": "0xcafe::coin_admin"
+      }
+    ],
+    "attributes": [],
+    "functions": [
+      {
+        "name": "balance_of",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          26,
+          28
+        ],
+        "visibility": "public",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": true,
+        "attributes": [
+          {
+            "name": "view"
+          }
+        ],
+        "typeParams": [
+          {
+            "name": "CoinType",
+            "abilities": [],
+            "isPhantom": false
+          }
+        ],
+        "params": [
+          {
+            "name": "addr",
+            "type": "address"
+          }
+        ],
+        "returnType": "u64",
+        "declaredAccess": [
+          {
+            "kind": "legacy_acquires",
+            "resource": {
+              "form": "resource",
+              "value": "0xcafe::coin::CoinStore"
+            },
+            "address": {
+              "form": "any",
+              "value": "*"
+            },
+            "negated": false
+          }
+        ],
+        "acquiresInferred": [
+          "0xcafe::coin::CoinStore"
+        ],
+        "resourceAccess": {
+          "reads": [
+            "CoinStore<CoinType>"
+          ],
+          "writes": []
+        }
+      },
+      {
+        "name": "register",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          21,
+          23
+        ],
+        "visibility": "public",
+        "isEntry": true,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [
+          {
+            "name": "CoinType",
+            "abilities": [],
+            "isPhantom": false
+          }
+        ],
+        "params": [
+          {
+            "name": "account",
+            "type": "&signer"
+          }
+        ],
+        "returnType": null,
+        "declaredAccess": [],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": [
+            "CoinStore<CoinType>"
+          ]
+        }
+      }
+    ],
+    "types": [
+      {
+        "kind": "struct",
+        "name": "CoinStore",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          6,
+          8
+        ],
+        "abilities": [
+          "key"
+        ],
+        "typeParams": [
+          {
+            "name": "CoinType",
+            "abilities": [],
+            "isPhantom": true
+          }
+        ],
+        "fields": [
+          {
+            "name": "balance",
+            "type": "u64",
+            "positional": false
+          }
+        ],
+        "attributes": []
+      },
+      {
+        "kind": "enum",
+        "name": "Status",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          15,
+          19
+        ],
+        "abilities": [
+          "drop",
+          "store"
+        ],
+        "typeParams": [],
+        "variants": [
+          {
+            "name": "Active",
+            "kind": "unit",
+            "fields": [],
+            "attributes": []
+          },
+          {
+            "name": "Frozen",
+            "kind": "named",
+            "fields": [
+              {
+                "name": "reason",
+                "type": "u64",
+                "positional": false
+              }
+            ],
+            "attributes": []
+          },
+          {
+            "name": "Pending",
+            "kind": "positional",
+            "fields": [
+              {
+                "name": "0",
+                "type": "u64",
+                "positional": true
+              },
+              {
+                "name": "1",
+                "type": "u64",
+                "positional": true
+              }
+            ],
+            "attributes": []
+          }
+        ],
+        "attributes": []
+      },
+      {
+        "kind": "struct",
+        "name": "TransferEvent",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          11,
+          13
+        ],
+        "abilities": [
+          "drop",
+          "store"
+        ],
+        "typeParams": [],
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64",
+            "positional": false
+          }
+        ],
+        "attributes": [
+          {
+            "name": "event"
+          }
+        ]
+      }
+    ],
+    "constants": [
+      {
+        "name": "E_NOT_REGISTERED",
+        "type": "u64",
+        "value": "1"
+      }
+    ]
+  },
+  "0xcafe::coin_admin": {
+    "file": "<TEMPDIR>/coin.move",
+    "span": [
+      31,
+      33
+    ],
+    "friends": [],
+    "attributes": [],
+    "functions": [
+      {
+        "name": "freeze_account",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          32,
+          32
+        ],
+        "visibility": "friend",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "_addr",
+            "type": "address"
+          }
+        ],
+        "returnType": null,
+        "declaredAccess": [],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        }
+      }
+    ],
+    "types": [],
+    "constants": []
+  }
+}

--- a/aptos-move/flow/src/tests/move_package_query/facts.rs
+++ b/aptos-move/flow/src/tests/move_package_query/facts.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::tests::common;
+
+#[tokio::test]
+async fn move_package_query_facts() {
+    let pkg = common::make_package("facts", &[(
+        "coin",
+        "module 0xCAFE::coin {
+    friend 0xCAFE::coin_admin;
+
+    const E_NOT_REGISTERED: u64 = 1;
+
+    struct CoinStore<phantom CoinType> has key {
+        balance: u64,
+    }
+
+    #[event]
+    struct TransferEvent has drop, store {
+        amount: u64,
+    }
+
+    enum Status has drop, store {
+        Active,
+        Frozen { reason: u64 },
+        Pending(u64, u64),
+    }
+
+    public entry fun register<CoinType>(account: &signer) {
+        move_to(account, CoinStore<CoinType> { balance: 0 });
+    }
+
+    #[view]
+    public fun balance_of<CoinType>(addr: address): u64 acquires CoinStore {
+        borrow_global<CoinStore<CoinType>>(addr).balance
+    }
+}
+
+module 0xCAFE::coin_admin {
+    public(friend) fun freeze_account(_addr: address) {}
+}",
+    )]);
+    let dir = pkg.path().to_str().unwrap();
+    let client = common::make_client().await;
+    let result = common::call_tool(
+        &client,
+        "move_package_query",
+        serde_json::json!({ "package_path": dir, "query": "facts" }),
+    )
+    .await;
+    let formatted = common::format_tool_result(&result);
+    common::check_baseline(file!(), &formatted);
+}

--- a/aptos-move/flow/src/tests/move_package_query/invalid_query.exp
+++ b/aptos-move/flow/src/tests/move_package_query/invalid_query.exp
@@ -1,1 +1,1 @@
-rpc_error: Mcp error: -32602: failed to deserialize parameters: unknown variant `nonsense`, expected one of `dep_graph`, `module_summary`, `call_graph`, `function_usage`
+rpc_error: Mcp error: -32602: failed to deserialize parameters: unknown variant `nonsense`, expected one of `dep_graph`, `module_summary`, `call_graph`, `function_usage`, `facts`

--- a/aptos-move/flow/src/tests/move_package_query/mod.rs
+++ b/aptos-move/flow/src/tests/move_package_query/mod.rs
@@ -6,6 +6,7 @@ mod call_graph_closure;
 mod call_graph_leaf;
 mod dep_graph;
 mod dep_graph_no_deps;
+mod facts;
 mod function_usage;
 mod function_usage_bad_format;
 mod function_usage_bad_function;


### PR DESCRIPTION
## Summary

Adds a `facts` variant on `move_package_query` that returns the full compiler-sourced layout of a Move package (modules, functions, types, constants, friends, attributes, declared access, resource reads/writes, locations).

Used by the GitNexus Move integration to ingest Move code straight from the compiler, avoiding tree-sitter and regex fallbacks.

## Test plan
- [x] `cargo test -p aptos-move-flow -- move_package_query`
- [x] `cargo clippy -p aptos-move-flow --all-targets`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only MCP query extension in aptos-move-flow with tests; no runtime, auth, or on-chain behavior changes.
> 
> **Overview**
> Adds a **`facts`** query variant to the `move_package_query` MCP tool so callers can request compiler-sourced, per-module JSON instead of lighter summaries like `module_summary` or `call_graph`.
> 
> The new path runs **`build_facts`** over `GlobalEnv` and emits **camelCase** payloads aligned with GitNexus `MoveFactsMap`: module file/line spans, friends and attributes, functions (visibility, entry/view/native flags, params, declared access, inferred acquires, AST-derived resource reads/writes), structs/enums with variants, and constants. **`move_package_query`** wires `QueryType::Facts` to that builder; tool listing and invalid-query errors include the new variant.
> 
> Coverage is a baseline test (`facts.rs` / `facts.exp`) on a small coin package (friends, `#[view]`, acquires, enums, `move_to`/`borrow_global`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f844a08ef3941ebf489f0313644158c0050e4719. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->