### PR TITLE
[mono-move] Implement vector::move_range native

### DIFF
--- a/third_party/move/mono-move/core/src/native/context.rs
+++ b/third_party/move/mono-move/core/src/native/context.rs
@@ -5,7 +5,7 @@
 
 use super::{
     result::VMInternalError,
-    value::{VMValue, Vector},
+    value::{Opaque, Ref, VMValue, Vector},
 };
 use crate::types::InternedType;
 
@@ -72,4 +72,23 @@ pub trait NativeContext {
     /// returns a handle to it. The vector stays live for the rest of the
     /// native call.
     fn new_byte_vector<'a>(&'a self, bytes: &[u8]) -> Result<Vector<'a, u8>, VMInternalError>;
+
+    /// Grows the vector behind `target` so it can hold at least `required_cap`
+    /// elements of `elem_size` bytes, allocating it if it is empty. When
+    /// `target` is empty, the fresh allocation copies its GC descriptor from
+    /// `donor`, a non-empty `vector<T>` of the same element type. May trigger
+    /// GC; the new heap pointer is written back through `target`'s reference.
+    ///
+    /// # Safety
+    ///
+    /// `target` and `donor` must reference `vector<T>` values of the same `T`,
+    /// `elem_size` must equal the byte size of `T`, and if `target` is empty
+    /// then `donor` must be non-empty.
+    unsafe fn grow_vector<'a>(
+        &self,
+        target: &Ref<'a, Vector<'a, Opaque>>,
+        donor: &Ref<'a, Vector<'a, Opaque>>,
+        elem_size: usize,
+        required_cap: usize,
+    ) -> Result<(), VMInternalError>;
 }

--- a/third_party/move/mono-move/core/src/native/value.rs
+++ b/third_party/move/mono-move/core/src/native/value.rs
@@ -3,9 +3,10 @@
 
 //! Read / write of native arg and return values through a frame slot.
 
+use super::{context::NativeContext, result::VMInternalError};
 use crate::{
     align::MAX_ALIGN,
-    memory::{read_fat_ptr, read_ptr, read_u64, write_fat_ptr, write_ptr},
+    memory::{read_fat_ptr, read_ptr, read_u64, write_fat_ptr, write_ptr, write_u64},
     root_pool::{ObjectHandle, ReferenceHandle, RootPool},
     VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
 };
@@ -186,6 +187,82 @@ impl<'a, V> Ref<'a, Vector<'a, V>> {
     }
 }
 
+impl<'a> Ref<'a, Vector<'a, Opaque>> {
+    /// Moves `length` elements out of `from` (starting at `removal`) and
+    /// inserts them into `self` (the destination) at `insert`, growing `self`
+    /// as needed. When `self` is empty, the fresh allocation borrows its GC
+    /// descriptor from `from`.
+    ///
+    /// Positions are assumed to be in bounds and `length` non-zero; the caller
+    /// is responsible for checking and aborting otherwise.
+    ///
+    /// # Safety
+    ///
+    /// `self` and `from` must reference `vector<T>` values of the same `T`,
+    /// `elem_size` must equal the byte size of `T`, the positions must be in
+    /// range, and `length` must be non-zero.
+    pub unsafe fn move_range<C: NativeContext>(
+        &self,
+        from: &Ref<'a, Vector<'a, Opaque>>,
+        removal: usize,
+        length: usize,
+        insert: usize,
+        elem_size: usize,
+        ctx: &C,
+    ) -> Result<(), VMInternalError> {
+        let to_len = self.borrow().len() as usize;
+
+        // Grow the destination to hold the inserted elements. This is the only
+        // allocation, and the only point at which a GC can run.
+        unsafe { ctx.grow_vector(self, from, elem_size, to_len + length)? };
+
+        // The grow may have relocated either vector, so re-borrow for fresh
+        // pointers. No allocation happens past this point.
+        let to_vec = self.borrow();
+        let from_vec = from.borrow();
+        // SAFETY: used transiently, with no allocation before the writes below.
+        let to_data = unsafe { to_vec.data_ptr() };
+        let from_data = unsafe { from_vec.data_ptr() };
+        let from_len = from_vec.len() as usize;
+
+        // SAFETY: every range lies within the now-sized vectors.
+        unsafe {
+            // Open a gap in `self` at `insert` by shifting its tail right.
+            if to_len > insert {
+                std::ptr::copy(
+                    to_data.add(insert * elem_size),
+                    to_data.add((insert + length) * elem_size),
+                    (to_len - insert) * elem_size,
+                );
+            }
+            // Copy the moved range from `from` into the gap. Move's borrow
+            // rules make `from` and `to` distinct, but we use an overlapping
+            // copy so this stays sound even if speculative execution ever
+            // produces transiently aliasing references.
+            // TODO(security): switch back to `copy_nonoverlapping` once we've
+            // confirmed Block-STM speculation cannot alias the two vectors.
+            std::ptr::copy(
+                from_data.add(removal * elem_size),
+                to_data.add(insert * elem_size),
+                length * elem_size,
+            );
+            // Close the gap left in `from` by shifting its tail left.
+            if from_len > removal + length {
+                std::ptr::copy(
+                    from_data.add((removal + length) * elem_size),
+                    from_data.add(removal * elem_size),
+                    (from_len - removal - length) * elem_size,
+                );
+            }
+
+            // Both objects now hold their adjusted element counts.
+            to_vec.set_len((to_len + length) as u64);
+            from_vec.set_len((from_len - length) as u64);
+        }
+        Ok(())
+    }
+}
+
 impl<'a, T> VMValue<'a> for Ref<'a, T> {
     const FRAME_SLOT_SIZE: usize = 16;
 
@@ -257,6 +334,36 @@ impl<'a, V> Vector<'a, V> {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Pointer to element 0 of the data region, or null if the vector is
+    /// empty/unallocated.
+    ///
+    /// # Safety
+    ///
+    /// The pointer is invalidated by any GC; the caller must use it only
+    /// transiently, before any allocation that could trigger collection.
+    #[inline]
+    pub unsafe fn data_ptr(&self) -> *mut u8 {
+        let p = self.ptr();
+        if p.is_null() {
+            std::ptr::null_mut()
+        } else {
+            // SAFETY: a non-null vector object stores its data at `VEC_DATA_OFFSET`.
+            unsafe { p.add(VEC_DATA_OFFSET) }
+        }
+    }
+
+    /// Overwrites the vector's element count.
+    ///
+    /// # Safety
+    ///
+    /// The backing heap object must be non-null and have capacity for `len`
+    /// elements.
+    #[inline]
+    pub unsafe fn set_len(&self, len: u64) {
+        // SAFETY: caller guarantees a non-null object with room for `len` elements.
+        unsafe { write_u64(self.ptr(), VEC_LENGTH_OFFSET, len) };
     }
 
     // TODO: Other vector APIs, added on-demand.

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -18,6 +18,7 @@ pub mod mem;
 pub mod signer;
 pub mod test_natives;
 pub mod type_info;
+pub mod vector;
 
 pub use aggregator_v2::make_all_aggregator_v2_natives;
 pub use function_info::make_all_function_info_natives;
@@ -25,6 +26,7 @@ pub use mem::make_all_mem_natives;
 pub use signer::make_all_signer_natives;
 pub use test_natives::{make_all_test_natives, native_u64_add, native_u64_identity};
 pub use type_info::make_all_type_info_natives;
+pub use vector::make_all_vector_natives;
 
 /// How a native is dispatched against a call's type arguments. A native that
 /// works for any instantiation registers as [`Dispatch::Polymorphic`]; a native
@@ -59,6 +61,7 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
     natives.extend(make_all_type_info_natives::<F>());
     natives.extend(make_all_function_info_natives::<F>());
     natives.extend(make_all_aggregator_v2_natives::<F>());
+    natives.extend(make_all_vector_natives::<F>());
     natives
 }
 

--- a/third_party/move/mono-move/natives/src/test_natives.rs
+++ b/third_party/move/mono-move/natives/src/test_natives.rs
@@ -4,7 +4,7 @@
 //! Synthetic natives used by the differential harness. Expected to go
 //! away once real natives are wired up.
 
-use crate::{monomorphic_natives, NativeEntry};
+use crate::{monomorphic_natives, polymorphic_natives, vector::native_move_range, NativeEntry};
 use mono_move_core::native::{NativeContext, NativeContextFamily, NativeStatus, VMInternalError};
 
 pub fn native_u64_add<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
@@ -32,8 +32,15 @@ pub fn native_u64_identity<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VM
 }
 
 pub fn make_all_test_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
-    monomorphic_natives![
+    let mut natives = monomorphic_natives![
         ("0x1::test_natives::u64_add", native_u64_add),
         ("0x1::test_natives::u64_identity", native_u64_identity),
-    ]
+    ];
+    // `vector::move_range` is not declared in the test stdlib, so expose the
+    // real native under a test-only module name to exercise it differentially.
+    natives.extend(polymorphic_natives![(
+        "0x1::vector_natives::move_range",
+        native_move_range
+    )]);
+    natives
 }

--- a/third_party/move/mono-move/natives/src/vector.rs
+++ b/third_party/move/mono-move/natives/src/vector.rs
@@ -1,0 +1,71 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `vector` module.
+
+use crate::{polymorphic_natives, NativeEntry};
+use mono_move_core::{
+    native::{
+        NativeContext, NativeContextFamily, NativeStatus, Opaque, Ref, VMInternalError, Vector,
+    },
+    types::view_type,
+};
+
+/// Given positions/lengths fall outside the vector boundaries.
+const EINDEX_OUT_OF_BOUNDS: u64 = 1;
+
+/// `0x1::vector::move_range<T>(from: &mut vector<T>, removal_position: u64, length: u64, to: &mut vector<T>, insert_position: u64)`
+///
+/// Removes `length` elements from `from` starting at `removal_position` and
+/// inserts them into `to` at `insert_position`.
+pub fn native_move_range<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // TODO: charge gas.
+    let (size, _) = view_type(ctx.ty_arg(0)?).size_and_align().ok_or_else(|| {
+        VMInternalError::InvariantViolation("vector::move_range: element type has no size".into())
+    })?;
+    let elem_size = size as usize;
+
+    // SAFETY: args 0/3 are `&mut vector<T>`, args 1/2/4 are `u64`, and
+    // `elem_size` is the byte size of `T`.
+    unsafe {
+        let from: Ref<Vector<Opaque>> = ctx.arg(0)?;
+        let removal_position = ctx.arg::<u64>(1)? as usize;
+        let length = ctx.arg::<u64>(2)? as usize;
+        let to: Ref<Vector<Opaque>> = ctx.arg(3)?;
+        let insert_position = ctx.arg::<u64>(4)? as usize;
+
+        // Bounds are checked here so the abort code matches the legacy native.
+        let from_len = from.borrow().len() as usize;
+        let to_len = to.borrow().len() as usize;
+        if removal_position
+            .checked_add(length)
+            .is_none_or(|end| end > from_len)
+            || insert_position > to_len
+        {
+            return Ok(NativeStatus::Abort {
+                code: EINDEX_OUT_OF_BOUNDS,
+                message: None,
+            });
+        }
+
+        // Moving nothing is a no-op (and avoids allocating an empty `to`).
+        if length == 0 {
+            return Ok(NativeStatus::Success);
+        }
+
+        to.move_range(
+            &from,
+            removal_position,
+            length,
+            insert_position,
+            elem_size,
+            ctx,
+        )?;
+    }
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `vector` module.
+pub fn make_all_vector_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    polymorphic_natives![("0x1::vector::move_range", native_move_range)]
+}

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -10,16 +10,16 @@ use crate::{
     error::RuntimeError,
     global_storage::ResourceReadWriteSet,
     heap::{alloc_vec, is_heap_ptr, Heap, TopFrame},
-    memory::write_u64,
+    memory::{read_descriptor, read_obj_size, read_ptr, read_u64, write_ptr, write_u64},
     types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
 };
 use mono_move_core::{
     native::{
-        NativeABI, NativeContext, NativeContextFamily, NativeFunction, NativeRegistry, RootPool,
-        VMInternalError, VMValue, Vector,
+        NativeABI, NativeContext, NativeContextFamily, NativeFunction, NativeRegistry, Opaque, Ref,
+        RootPool, VMInternalError, VMValue, Vector,
     },
     types::InternedType,
-    DescriptorProvider, GasMeter, TRIVIAL_DESCRIPTOR_ID,
+    DescriptorId, DescriptorProvider, GasMeter, OBJECT_HEADER_SIZE, TRIVIAL_DESCRIPTOR_ID,
 };
 use std::cell::{Cell, UnsafeCell};
 
@@ -206,18 +206,7 @@ impl NativeContext for ProductionNativeContext<'_> {
             len,
         )
         // Allocation failures are resource-limit conditions, not VM bugs.
-        .map_err(|e| match e {
-            RuntimeError::OutOfHeapMemory { requested } => {
-                VMInternalError::OutOfHeapMemory { requested }
-            },
-            RuntimeError::AllocationTooLarge { requested } => {
-                VMInternalError::AllocationTooLarge { requested }
-            },
-            RuntimeError::VecAllocSizeOverflow => VMInternalError::VecAllocSizeOverflow,
-            other => VMInternalError::InvariantViolation(format!(
-                "byte-vector allocation failed: {other}"
-            )),
-        })?;
+        .map_err(map_alloc_err)?;
         // SAFETY: `ptr` is a fresh vector with room for `len` bytes; no GC runs
         // between here and these writes, so the raw pointer is valid.
         unsafe {
@@ -227,6 +216,114 @@ impl NativeContext for ProductionNativeContext<'_> {
         // Root it so it survives later allocations and is GC-relocated.
         // SAFETY: `ptr` is the data pointer of the freshly allocated vector.
         Ok(Vector::from_handle(unsafe { self.pool.root_object(ptr) }))
+    }
+
+    unsafe fn grow_vector<'a>(
+        &self,
+        target: &Ref<'a, Vector<'a, Opaque>>,
+        donor: &Ref<'a, Vector<'a, Opaque>>,
+        elem_size: usize,
+        required_cap: usize,
+    ) -> Result<(), VMInternalError> {
+        // A zero-sized element type would divide-by-zero in the capacity math
+        // below; the caller is contracted to pass the byte size of a real `T`.
+        debug_assert!(elem_size != 0, "grow_vector: elem_size must be non-zero");
+
+        // SAFETY: `heap` and `rws` are distinct fields, so reborrowing both
+        // through `&self` at once is sound (see the type-level aliasing rule).
+        let heap = unsafe { &mut **self.heap.get() };
+        let rws = unsafe { &mut **self.rws.get() };
+
+        // The reference handles are rooted, so `target.ptr()` / `donor.ptr()`
+        // stay current across the GC `alloc_vec` may trigger.
+        // SAFETY: `target` references a live `vector<T>`; its slot holds the
+        // current heap pointer (null for an empty vector).
+        let old_ptr = unsafe { read_ptr(target.ptr(), 0usize) };
+
+        if old_ptr.is_null() {
+            // `target` is empty: allocate a fresh vector, copying the GC
+            // descriptor from the (non-empty) donor of the same element type.
+            // SAFETY: `donor` is a non-empty `vector<T>` (caller's contract).
+            let src_ptr = unsafe { read_ptr(donor.ptr(), 0usize) };
+            let descriptor_id = DescriptorId(unsafe { read_descriptor(src_ptr) });
+            let new_ptr = alloc_vec(
+                heap,
+                self.desc_provider,
+                rws,
+                &self.pool,
+                self.frame_ptr,
+                TopFrame::Native(self.abi),
+                descriptor_id,
+                elem_size as u32,
+                (required_cap as u64).max(4),
+            )
+            .map_err(map_alloc_err)?;
+            // `alloc_vec` zero-inits the length; just publish the new pointer
+            // through the (post-GC) reference.
+            // SAFETY: `target.ptr()` is re-read after the allocation's GC.
+            unsafe { write_ptr(target.ptr(), 0usize, new_ptr) };
+            return Ok(());
+        }
+
+        // `target` is non-empty: grow only if it can't already hold `required_cap`.
+        // SAFETY: `old_ptr` is a live vector object.
+        let old_len = unsafe { read_u64(old_ptr, VEC_LENGTH_OFFSET) };
+        let old_total = unsafe { read_obj_size(old_ptr) } as usize;
+        let old_cap = (old_total - OBJECT_HEADER_SIZE - VEC_DATA_OFFSET) / elem_size;
+        if required_cap <= old_cap {
+            return Ok(());
+        }
+
+        let descriptor_id = DescriptorId(unsafe { read_descriptor(old_ptr) });
+        let doubled = if old_cap == 0 { 4 } else { old_cap * 2 };
+        let new_cap = doubled.max(required_cap);
+        let new_ptr = alloc_vec(
+            heap,
+            self.desc_provider,
+            rws,
+            &self.pool,
+            self.frame_ptr,
+            TopFrame::Native(self.abi),
+            descriptor_id,
+            elem_size as u32,
+            new_cap as u64,
+        )
+        .map_err(map_alloc_err)?;
+
+        // `alloc_vec` may have run a GC; re-read the old pointer through the
+        // rooted reference, copy the live elements over, then publish the new
+        // pointer through the reference.
+        // SAFETY: `target.ptr()` is re-read after the GC; both objects own at
+        // least `byte_count` data bytes and are distinct allocations.
+        unsafe {
+            let old_ptr = read_ptr(target.ptr(), 0usize);
+            let byte_count = old_len as usize * elem_size;
+            if byte_count > 0 {
+                std::ptr::copy_nonoverlapping(
+                    old_ptr.add(VEC_DATA_OFFSET),
+                    new_ptr.add(VEC_DATA_OFFSET),
+                    byte_count,
+                );
+            }
+            write_u64(new_ptr, VEC_LENGTH_OFFSET, old_len);
+            write_ptr(target.ptr(), 0usize, new_ptr);
+        }
+        Ok(())
+    }
+}
+
+/// Maps an allocation failure to the native-facing error. Resource-limit
+/// conditions surface as such; anything else is a VM invariant violation.
+fn map_alloc_err(e: RuntimeError) -> VMInternalError {
+    match e {
+        RuntimeError::OutOfHeapMemory { requested } => {
+            VMInternalError::OutOfHeapMemory { requested }
+        },
+        RuntimeError::AllocationTooLarge { requested } => {
+            VMInternalError::AllocationTooLarge { requested }
+        },
+        RuntimeError::VecAllocSizeOverflow => VMInternalError::VecAllocSizeOverflow,
+        other => VMInternalError::InvariantViolation(format!("vector allocation failed: {other}")),
     }
 }
 

--- a/third_party/move/mono-move/testsuite/src/v1_test_natives.rs
+++ b/third_party/move/mono-move/testsuite/src/v1_test_natives.rs
@@ -5,7 +5,10 @@ use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas, ident_str};
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction, NativeFunctionTable};
 use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Value, VectorRef},
 };
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
@@ -36,6 +39,41 @@ fn v1_native_u64_identity(
     ]))
 }
 
+/// Mirrors the legacy `0x1::vector::move_range` native, registered under a
+/// test-only module name. The real `vector` module in the test stdlib does not
+/// declare `move_range`, so the differential test calls it through this alias.
+fn v1_native_move_range(
+    _ctx: &mut NativeContext,
+    ty_args: &[Type],
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let insert_position = pop_arg!(args, u64) as usize;
+    let to = pop_arg!(args, VectorRef);
+    let length = pop_arg!(args, u64) as usize;
+    let removal_position = pop_arg!(args, u64) as usize;
+    let from = pop_arg!(args, VectorRef);
+
+    let to_len = to.length_as_usize()?;
+    let from_len = from.length_as_usize()?;
+    if removal_position
+        .checked_add(length)
+        .is_none_or(|end| end > from_len)
+        || insert_position > to_len
+    {
+        // EINDEX_OUT_OF_BOUNDS, matching the v2 native and the real one.
+        return Ok(NativeResult::err(InternalGas::zero(), 1));
+    }
+    VectorRef::move_range(
+        &from,
+        removal_position,
+        length,
+        &to,
+        insert_position,
+        &ty_args[0],
+    )?;
+    Ok(NativeResult::ok(InternalGas::zero(), smallvec![]))
+}
+
 /// Build a list of test natives for the v1 VM, matching the ones we have for v2
 /// (in the `mono-move-natives` crate).
 ///
@@ -55,6 +93,12 @@ pub fn make_all_v1_test_natives() -> NativeFunctionTable {
             module,
             ident_str!("u64_identity").to_owned(),
             Arc::new(v1_native_u64_identity) as NativeFunction,
+        ),
+        (
+            AccountAddress::ONE,
+            ident_str!("vector_natives").to_owned(),
+            ident_str!("move_range").to_owned(),
+            Arc::new(v1_native_move_range) as NativeFunction,
         ),
     ]
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/vector_move_range.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/vector_move_range.move
@@ -1,0 +1,124 @@
+// Differential test for `vector::move_range`.
+//
+// The test stdlib's `vector` module doesn't declare `move_range`, so it is
+// declared here under a test-only module name and registered on both VMs (see
+// `v1_test_natives.rs` and `make_all_test_natives`). Each case builds
+// `from`/`to`, splices a range across them, and returns the resulting vectors
+// so both VMs can be compared. `vector<u8>` cases use byte literals (loaded
+// from the constant pool); the `u64` case builds via `push_back` and reads
+// elements back to confirm the per-element byte math.
+
+// RUN: publish
+module 0x1::vector_natives {
+    public native fun move_range<T>(
+        from: &mut vector<T>,
+        removal_position: u64,
+        length: u64,
+        to: &mut vector<T>,
+        insert_position: u64,
+    );
+}
+module 0x42::vec_move_range {
+    use std::vector;
+    use 0x1::vector_natives::move_range;
+
+    // length == 1 fast path.
+    public fun single_element(): (vector<u8>, vector<u8>) {
+        let from = b"\x01\x02\x03\x04\x05";
+        let to = b"\x0a\x14\x1e";
+        move_range(&mut from, 1, 1, &mut to, 1);
+        (from, to)
+    }
+
+    // Full drain of `from` appended to the end of `to`.
+    public fun full_drain_append(): (vector<u8>, vector<u8>) {
+        let from = b"\x01\x02\x03";
+        let to = b"\x09";
+        move_range(&mut from, 0, 3, &mut to, 1);
+        (from, to)
+    }
+
+    // Tail of `from` appended to the end of `to`.
+    public fun tail_split_append(): (vector<u8>, vector<u8>) {
+        let from = b"\x01\x02\x03\x04";
+        let to = b"\x09";
+        move_range(&mut from, 2, 2, &mut to, 1);
+        (from, to)
+    }
+
+    // General splice: insert in the middle of `to`, forcing `to` to grow.
+    public fun general_splice(): (vector<u8>, vector<u8>) {
+        let from = b"\x01\x02\x03\x04\x05";
+        let to = b"\x0a\x14\x1e";
+        move_range(&mut from, 1, 2, &mut to, 1);
+        (from, to)
+    }
+
+    // Destination starts empty (null), exercising the allocate-from-donor path.
+    public fun empty_destination(): (vector<u8>, vector<u8>) {
+        let from = b"\x07\x08";
+        let to = vector::empty<u8>();
+        move_range(&mut from, 0, 2, &mut to, 0);
+        (from, to)
+    }
+
+    // 8-byte elements: build, splice, then read elements back.
+    public fun u64_elements(): (u64, u64, u64, u64) {
+        let from = vector::empty<u64>();
+        vector::push_back(&mut from, 100);
+        vector::push_back(&mut from, 200);
+        vector::push_back(&mut from, 300);
+        vector::push_back(&mut from, 400);
+        let to = vector::empty<u64>();
+        vector::push_back(&mut to, 10);
+        vector::push_back(&mut to, 20);
+        move_range(&mut from, 1, 2, &mut to, 1);
+        // to = [10, 200, 300, 20], from = [100, 400]
+        (
+            vector::length(&to),
+            *vector::borrow(&to, 1),
+            *vector::borrow(&to, 2),
+            *vector::borrow(&from, 1),
+        )
+    }
+
+    // removal_position + length exceeds from's length.
+    public fun removal_out_of_bounds(): vector<u8> {
+        let from = b"\x01\x02";
+        let to = b"\x09";
+        move_range(&mut from, 1, 5, &mut to, 0);
+        to
+    }
+
+    // insert_position exceeds to's length.
+    public fun insert_out_of_bounds(): vector<u8> {
+        let from = b"\x01\x02\x03";
+        let to = b"\x09";
+        move_range(&mut from, 0, 1, &mut to, 5);
+        to
+    }
+}
+
+// RUN: execute 0x42::vec_move_range::single_element
+// CHECK: results: 0x01030405, 0x0a02141e
+
+// RUN: execute 0x42::vec_move_range::full_drain_append
+// CHECK: results: 0x, 0x09010203
+
+// RUN: execute 0x42::vec_move_range::tail_split_append
+// CHECK: results: 0x0102, 0x090304
+
+// RUN: execute 0x42::vec_move_range::general_splice
+// CHECK: results: 0x010405, 0x0a0203141e
+
+// RUN: execute 0x42::vec_move_range::empty_destination
+// CHECK: results: 0x, 0x0708
+
+// RUN: execute 0x42::vec_move_range::u64_elements
+// CHECK: results: 4, 200, 300, 400
+
+// RUN: execute 0x42::vec_move_range::removal_out_of_bounds
+// CHECK: aborted: code 1
+
+// RUN: execute 0x42::vec_move_range::insert_out_of_bounds
+// CHECK: aborted: code 1


### PR DESCRIPTION
Implements the `vector::move_range` native for the mono-move VM.

`move_range` is the only true native in move-stdlib's `vector` module — the other vector operations are bytecode instructions, already handled by the interpreter. It splices a range of elements out of one vector and inserts them into another.

It is exposed as `to.move_range(&from, .., ctx)` on a vector reference, mirroring the legacy `VectorRef::move_range`. Growing the destination allocates a new heap object and writes the pointer back through the reference, so the method lives on the reference rather than the bare vector handle. It calls a new `NativeContext::grow_vector` primitive that owns the GC-safe grow/allocate, then does the splice with raw memory moves. Reads use the safe `Ref`/`Vector` API; only the single allocation and the element moves drop to raw pointers.

Testing: the test stdlib's `vector` module doesn't declare `move_range`, so the differential test declares it under a test-only module and registers matching natives on both VMs, rather than modifying the shared stdlib. Cases cover all four legacy fast-paths, the empty-destination path, an 8-byte element type, and both out-of-bounds aborts. All differential tests pass.
