### PR TITLE
[forge] etna: switch to realistic_500tps, 20m duration

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -138,7 +138,7 @@ jobs:
               { TEST_NAME: 'realistic-env-max-load-encrypted', FORGE_RUNNER_DURATION_SECS: 480, FORGE_TEST_SUITE: 'realistic_env_max_load_encrypted' },
               // Pin to the aptos-core SHA that the etna-rust image is built from, so the forge
               // test runner matches the etna binary under test.
-              { TEST_NAME: 'etna', FORGE_RUNNER_DURATION_SECS: 3600, FORGE_TEST_SUITE: 'land_blocking', FORGE_IMAGE_NAME: 'etna-rust', GIT_SHA: 'c66dbf952b692bc017b459e3e6e44cc2a43d6958' }
+              { TEST_NAME: 'etna', FORGE_RUNNER_DURATION_SECS: 1200, FORGE_TEST_SUITE: 'realistic_500tps', FORGE_IMAGE_NAME: 'etna-rust', GIT_SHA: 'c66dbf952b692bc017b459e3e6e44cc2a43d6958' }
             ];
 
             const matrix = testName != "all" ? tests.filter(test => test.TEST_NAME === testName) : tests;


### PR DESCRIPTION
## Summary
- Switch the etna entry in forge-stable from `land_blocking` to `realistic_500tps` (suite pattern defined in the etna forge runner at `rust/etna-forge/src/main.rs`).
- Reduce `FORGE_RUNNER_DURATION_SECS` from 3600 to 1200 (20 minutes).

## Test plan
- [ ] Trigger the forge-stable workflow with `TEST_NAME=etna` and confirm the etna runner accepts the `realistic_500tps` suite and completes in ~20 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)