### PR TITLE
[move] validate Identifier during deserialization

### DIFF
--- a/third_party/move/move-core/types/src/identifier.rs
+++ b/third_party/move/move-core/types/src/identifier.rs
@@ -107,7 +107,7 @@ pub(crate) static ALLOWED_NO_SELF_IDENTIFIERS: &str =
 /// An owned identifier.
 ///
 /// For more details, see the module level documentation.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[cfg_attr(
     any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
@@ -167,6 +167,26 @@ impl Identifier {
     /// Converts this `Identifier` into a UTF-8-encoded byte sequence.
     pub fn into_bytes(self) -> Vec<u8> {
         self.into_string().into_bytes()
+    }
+}
+
+// A custom `Deserialize` impl which, unlike the derived one, enforces the
+// validity invariant on the deserialized identifier. Without this check, BCS
+// deserialization of untrusted bytes can produce an `Identifier` for which
+// `is_valid` does not hold (e.g., one containing whitespace), breaking
+// invariants downstream consumers rely on, such as the Display/parse roundtrip
+// for type tags.
+//
+// Note: deserializing the inner `Box<str>` directly keeps the wire format of
+// the derived impl, since serde data formats treat newtype structs as
+// transparent wrappers around their inner value.
+impl<'de> Deserialize<'de> for Identifier {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <Box<str>>::deserialize(deserializer)?;
+        Self::new(s).map_err(serde::de::Error::custom)
     }
 }
 

--- a/third_party/move/move-core/types/src/unit_tests/identifier_test.rs
+++ b/third_party/move/move-core/types/src/unit_tests/identifier_test.rs
@@ -130,3 +130,46 @@ fn serde_serialize_no_wrapper() {
     let s = serde_json::to_string(&foobar).expect("Identifier should serialize correctly");
     assert_eq!(s, "\"foobar\"");
 }
+
+#[test]
+fn bcs_deserialize_valid_identifier_roundtrips() {
+    // An `Identifier` is BCS-encoded exactly like its inner string.
+    for valid in ["foo", "FOO", "_foo", "$foo", "x_y$z123", "<SELF>", "<SELF>_0"] {
+        let bytes = bcs::to_bytes(valid).unwrap();
+        let id: Identifier = bcs::from_bytes(&bytes).unwrap();
+        assert_eq!(id.as_str(), valid);
+    }
+}
+
+#[test]
+fn bcs_deserialize_invalid_identifier_rejected() {
+    for invalid in [
+        "", "_", "0", "0foo", "foo bar", "fo\no", "\n\n\ng\n", "foo-bar", "<SELF>_",
+    ] {
+        let bytes = bcs::to_bytes(invalid).unwrap();
+        bcs::from_bytes::<Identifier>(&bytes).expect_err(&format!(
+            "deserializing invalid identifier {:?} should fail",
+            invalid
+        ));
+    }
+}
+
+#[test]
+fn bcs_deserialize_unchecked_identifier_rejected() {
+    // `new_unchecked` can construct invalid in-memory identifiers (e.g., for
+    // move-asm); those must not survive a serialization roundtrip.
+    let id = Identifier::new_unchecked("not valid");
+    let bytes = bcs::to_bytes(&id).unwrap();
+    bcs::from_bytes::<Identifier>(&bytes)
+        .expect_err("deserializing an unchecked invalid identifier should fail");
+}
+
+#[test]
+fn serde_json_deserialize_invalid_identifier_rejected() {
+    for invalid in ["\"\"", "\"_\"", "\"123foo\"", "\"foo bar\"", "\"fo\\no\""] {
+        serde_json::from_str::<Identifier>(invalid).expect_err(&format!(
+            "deserializing invalid identifier {} should fail",
+            invalid
+        ));
+    }
+}

--- a/third_party/move/move-core/types/src/unit_tests/language_storage_test.rs
+++ b/third_party/move/move-core/types/src/unit_tests/language_storage_test.rs
@@ -20,6 +20,61 @@ proptest! {
 }
 
 #[test]
+fn test_type_tag_deserialize_rejects_invalid_identifiers() {
+    // BCS mirror of `StructTag`, but with unvalidated strings in place of
+    // `Identifier` fields.
+    #[derive(serde::Serialize)]
+    struct RawStructTag {
+        address: AccountAddress,
+        module: String,
+        name: String,
+        type_args: Vec<TypeTag>,
+    }
+
+    let raw_struct_tag_bytes = |module: &str, name: &str| {
+        // `TypeTag::Struct` is enum variant 7 on the wire.
+        let mut bytes = vec![7u8];
+        bytes.extend(
+            bcs::to_bytes(&RawStructTag {
+                address: AccountAddress::ONE,
+                module: module.to_string(),
+                name: name.to_string(),
+                type_args: vec![],
+            })
+            .unwrap(),
+        );
+        bytes
+    };
+
+    // Sanity-check the layout: valid identifiers deserialize successfully.
+    let tag: TypeTag = bcs::from_bytes(&raw_struct_tag_bytes("m", "S")).unwrap();
+    assert_eq!(
+        tag,
+        TypeTag::Struct(Box::new(StructTag {
+            address: AccountAddress::ONE,
+            module: Identifier::from(ident_str!("m")),
+            name: Identifier::from(ident_str!("S")),
+            type_args: vec![],
+        }))
+    );
+
+    // Invalid identifiers must be rejected instead of producing a `TypeTag`
+    // whose Display output cannot be parsed back.
+    for (module, name) in [
+        ("\n\n\ng\n", "S"),
+        ("m", "\n\n\ng\n"),
+        ("has space", "S"),
+        ("m", ""),
+        ("0starts_with_digit", "S"),
+    ] {
+        bcs::from_bytes::<TypeTag>(&raw_struct_tag_bytes(module, name)).expect_err(&format!(
+            "deserializing struct tag with invalid identifier ({:?}, {:?}) should fail",
+            module, name
+        ));
+    }
+}
+
+#[test]
 fn test_type_tag_deserialize_case_insensitive() {
     let org_struct_tag = StructTag {
         address: AccountAddress::ONE,


### PR DESCRIPTION
## Description

Fixes #19765

`Identifier` used `#[derive(Deserialize)]`, which builds the value straight from raw bytes without calling `is_valid`. BCS deserialization of untrusted input could therefore produce `Identifier`s containing newlines, NULs, spaces, etc. — violating the type invariant and breaking the Display→parse roundtrip for `TypeTag`s built from them (the parser strips whitespace, so `parse(display(tag)) != tag`).

This PR replaces the derived impl with a custom `Deserialize` that validates via `Identifier::new`, matching the strict validation the binary-format deserializer already performs in `load_identifier`. The wire format is unchanged: serde formats treat newtype structs as transparent, so deserializing the inner `Box<str>` consumes exactly the same bytes as the derived impl.

## How Has This Been Tested?

New unit tests in `move-core-types`:
- `bcs_deserialize_valid_identifier_roundtrips` — valid identifiers (incl. `_`/`$`-prefixed, `<SELF>`) still roundtrip
- `bcs_deserialize_invalid_identifier_rejected` — invalid strings (empty, `_`, leading digit, whitespace, control chars) now fail to deserialize
- `bcs_deserialize_unchecked_identifier_rejected` — `new_unchecked` values don't survive a serde roundtrip
- `serde_json_deserialize_invalid_identifier_rejected` — same enforcement on the JSON path
- `test_type_tag_deserialize_rejects_invalid_identifiers` — `TypeTag`-level regression test reproducing the issue's attack shape, with a layout sanity check

Existing coverage that exercises the new impl: `identifier_canonical_serialization` and `serde_json_roundtrip` proptests. `cargo test -p move-core-types` passes (57 tests).

## Key Areas to Review

- Wire-format compatibility: the custom impl deserializes the inner `Box<str>` instead of going through `deserialize_newtype_struct`. For BCS and serde_json these are byte-identical paths.
- Behavior shift: payloads carrying invalid identifiers (e.g., a bogus entry-function name) previously deserialized fine and only failed later at function resolution; they are now rejected at the deserialization boundary. Committed on-chain data is unaffected because module publishing already validates identifiers strictly in the binary-format deserializer.
- `Identifier::new_unchecked` (used by move-asm for intentionally-invalid in-memory identifiers) is untouched; such values just can no longer cross a serde boundary.

## Type of Change
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens deserialization for types used in `TypeTag` and VM-facing paths; valid on-chain data should be unaffected, but off-chain or malformed payloads with invalid identifier strings will now error earlier at the boundary.
> 
> **Overview**
> Replaces derived `Deserialize` on **`Identifier`** with a custom implementation that runs **`Identifier::new`** so BCS/JSON cannot materialize invalid strings (whitespace, control chars, etc.) from untrusted bytes. Wire format is unchanged by deserializing the inner **`Box<str>`** directly.
> 
> Invalid identifiers now fail at deserialization instead of slipping through into **`TypeTag`** and breaking Display/parse roundtrips. Tests cover BCS/JSON rejection, **`new_unchecked`** roundtrips, and struct-tag-level BCS payloads with bad module/name fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c755c1aeabada6a956c50e9662fb1bb3abd202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->