### PR TITLE
[consensus] Prefetch randomness trusted setup

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -735,6 +735,15 @@ pub fn setup_environment_and_start_node(
         }
     }
 
+    // Kick off the randomness trusted-setup deserialize (DigestKey / PublicParameters)
+    // on background threads now, so the tens-of-seconds load overlaps the database open
+    // below instead of blocking consensus startup afterward. The blob paths come from
+    // config (no DB needed); the values are read later during epoch setup.
+    aptos_dkg_runtime::prefetch_trusted_setup(
+        node_config.consensus.digest_key_blob_path.as_ref(),
+        node_config.consensus.public_parameters_blob_path.as_ref(),
+    );
+
     // Set up the storage database and any RocksDB checkpoints
     let (db_rw, backup_service, genesis_waypoint, indexer_db_opt, update_receiver) =
         storage::initialize_database_and_checkpoints(&mut node_config)?;
@@ -750,16 +759,14 @@ pub fn setup_environment_and_start_node(
     // Set the chain_id in global AptosNodeIdentity
     aptos_node_identity::set_chain_id(chain_id)?;
 
-    // Initialize the DigestKey and PublicParameters for chunky DKG
+    // Record DigestKey/PublicParameters source metrics. The file deserialize itself was
+    // kicked off before the database open by `prefetch_trusted_setup` (above), so it runs
+    // concurrently with RocksDB open rather than blocking consensus startup here.
     aptos_dkg_runtime::initialize_digest_key_with_counters(
-        node_config.consensus.digest_key_blob_path.as_ref(),
         chain_id,
         node_config.base.role.is_validator(),
     );
-    aptos_dkg_runtime::initialize_public_parameters_with_counters(
-        node_config.consensus.public_parameters_blob_path.as_ref(),
-        chain_id,
-    );
+    aptos_dkg_runtime::initialize_public_parameters_with_counters(chain_id);
 
     // Start the telemetry service (as early as possible and before any blocking calls)
     let telemetry_runtime = services::start_telemetry_service(

--- a/dkg/src/lib.rs
+++ b/dkg/src/lib.rs
@@ -73,30 +73,61 @@ pub fn start_dkg_runtime(
     runtime
 }
 
-/// Initialize the DigestKey and emit Prometheus counters for the source.
-/// Spawns a background thread to eagerly load the key from file and record load duration.
-pub fn initialize_digest_key_with_counters(
-    blob_path: Option<&PathBuf>,
-    chain_id: ChainId,
-    is_validator: bool,
+/// Begin deserializing the randomness trusted setup (`DigestKey` / `PublicParameters`)
+/// from disk on background threads.
+///
+/// These are otherwise loaded lazily on first use during consensus epoch setup, where
+/// the (tens-of-seconds) BCS deserialize blocks the node from rejoining. Kicking the
+/// load off here -- before the database is opened -- lets it run concurrently with the
+/// RocksDB open instead of serially after it. The lazy globals are thread-safe, so the
+/// later first access simply returns the value these threads have already populated.
+///
+/// Only the file-backed load is started here (it needs no `chain_id`); test-chain
+/// fallbacks with no blob file are resolved later by the `*_with_counters` functions.
+/// Must be called before those functions (it owns the one-time path setup).
+pub fn prefetch_trusted_setup(
+    digest_key_blob_path: Option<&PathBuf>,
+    public_parameters_blob_path: Option<&PathBuf>,
 ) {
-    if let Some(path) = blob_path {
-        set_digest_key_path(path.clone());
+    // PublicParameters are needed by every role (fullnodes use them during state sync).
+    if let Some(path) = public_parameters_blob_path {
+        set_public_parameters_path(path.clone());
+        let path = path.clone();
+        std::thread::Builder::new()
+            .name("pub-params-load".into())
+            .spawn(move || {
+                let start = Instant::now();
+                let _ = &*PUBLIC_PARAMETERS;
+                counters::PUBLIC_PARAMS_LOAD_DURATION_SECONDS
+                    .observe(start.elapsed().as_secs_f64());
+                publish_blake3(&path, &counters::PUBLIC_PARAMS_BLAKE3, "PublicParameters");
+            })
+            .expect("Failed to spawn pub-params-load thread");
     }
-    let source = initialize_digest_key(chain_id, is_validator);
-    match source {
-        DigestKeySource::WillLoadFromFile { path, file_size } => {
-            counters::DIGEST_KEY_FILE_SIZE_BYTES.set(file_size as i64);
-            counters::DIGEST_KEY_SOURCE
-                .with_label_values(&["file"])
-                .set(1);
-            // Eagerly load the key in a background thread so the metric is available on all nodes.
-            std::thread::spawn(move || {
+    if let Some(path) = digest_key_blob_path {
+        set_digest_key_path(path.clone());
+        let path = path.clone();
+        std::thread::Builder::new()
+            .name("digest-key-load".into())
+            .spawn(move || {
                 let start = Instant::now();
                 let _ = &*DIGEST_KEY;
                 counters::DIGEST_KEY_LOAD_DURATION_SECONDS.observe(start.elapsed().as_secs_f64());
                 publish_blake3(&path, &counters::DIGEST_KEY_BLAKE3, "DigestKey");
-            });
+            })
+            .expect("Failed to spawn digest-key-load thread");
+    }
+}
+
+/// Emit Prometheus counters describing the resolved `DigestKey` source. The file load
+/// itself is kicked off earlier by [`prefetch_trusted_setup`].
+pub fn initialize_digest_key_with_counters(chain_id: ChainId, is_validator: bool) {
+    match initialize_digest_key(chain_id, is_validator) {
+        DigestKeySource::WillLoadFromFile { file_size, .. } => {
+            counters::DIGEST_KEY_FILE_SIZE_BYTES.set(file_size as i64);
+            counters::DIGEST_KEY_SOURCE
+                .with_label_values(&["file"])
+                .set(1);
         },
         DigestKeySource::TestKeyFallback => {
             counters::DIGEST_KEY_SOURCE
@@ -111,26 +142,15 @@ pub fn initialize_digest_key_with_counters(
     }
 }
 
-/// Initialize the PublicParameters and emit Prometheus counters for the source.
-/// Spawns a background thread to eagerly load from file and record load duration.
-pub fn initialize_public_parameters_with_counters(blob_path: Option<&PathBuf>, chain_id: ChainId) {
-    if let Some(path) = blob_path {
-        set_public_parameters_path(path.clone());
-    }
-    let source = initialize_public_parameters(chain_id);
-    match source {
-        PublicParametersSource::WillLoadFromFile { path, file_size } => {
+/// Emit Prometheus counters describing the resolved `PublicParameters` source. The file
+/// load itself is kicked off earlier by [`prefetch_trusted_setup`].
+pub fn initialize_public_parameters_with_counters(chain_id: ChainId) {
+    match initialize_public_parameters(chain_id) {
+        PublicParametersSource::WillLoadFromFile { file_size, .. } => {
             counters::PUBLIC_PARAMS_FILE_SIZE_BYTES.set(file_size as i64);
             counters::PUBLIC_PARAMS_SOURCE
                 .with_label_values(&["file"])
                 .set(1);
-            std::thread::spawn(move || {
-                let start = Instant::now();
-                let _ = &*PUBLIC_PARAMETERS;
-                counters::PUBLIC_PARAMS_LOAD_DURATION_SECONDS
-                    .observe(start.elapsed().as_secs_f64());
-                publish_blake3(&path, &counters::PUBLIC_PARAMS_BLAKE3, "PublicParameters");
-            });
         },
         PublicParametersSource::TestKeyFallback => {
             counters::PUBLIC_PARAMS_SOURCE


### PR DESCRIPTION

The randomness trusted setup -- the `DigestKey` and `PublicParameters`
for the weighted VUF -- is deserialized lazily on first use during
consensus epoch setup. On a cold restart that deserialize sits on the
critical path and blocks the validator from rejoining: it takes ~14s on
fast devnet hosts but 57-62s on slower ones (CPU-bound BLS point
deserialization).

The load depends only on the configured blob paths, not on the database,
so there is no reason to defer it until storage is up. Kick it off on
background threads (`prefetch_trusted_setup`) before opening the database
so it overlaps the RocksDB open instead of running serially after it. The
`Lazy` globals it populates are thread-safe, so consensus's later first
access simply returns the value the background threads have already
loaded.

This splits the one-time path setup and eager load out of the
`initialize_*_with_counters` helpers, which now only record the source
metrics. The test-fallback and no-blob cases are unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
