### PR TITLE
[forge] etna: bump pinned aptos-core SHA to match etna main

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -138,7 +138,7 @@ jobs:
               { TEST_NAME: 'realistic-env-max-load-encrypted', FORGE_RUNNER_DURATION_SECS: 480, FORGE_TEST_SUITE: 'realistic_env_max_load_encrypted' },
               // Pin to the aptos-core SHA that the etna-rust image is built from, so the forge
               // test runner matches the etna binary under test.
-              { TEST_NAME: 'etna', FORGE_RUNNER_DURATION_SECS: 1200, FORGE_TEST_SUITE: 'realistic_500tps', FORGE_IMAGE_NAME: 'etna-rust', GIT_SHA: 'c66dbf952b692bc017b459e3e6e44cc2a43d6958' }
+              { TEST_NAME: 'etna', FORGE_RUNNER_DURATION_SECS: 1200, FORGE_TEST_SUITE: 'realistic_500tps', FORGE_IMAGE_NAME: 'etna-rust', GIT_SHA: '355f89b539bba771357ca2fa5aab11c0779cfd06' }
             ];
 
             const matrix = testName != "all" ? tests.filter(test => test.TEST_NAME === testName) : tests;


### PR DESCRIPTION
## Summary
- Bump the `GIT_SHA` pin for the etna forge-stable entry from `c66dbf95` to `355f89b5` to match what etna's `origin/main` `rust/Cargo.toml` currently pins aptos-core to.
- The previous pin was 42 etna commits behind; under the old SHA, the realistic_500tps run had a ~40-minute chain-vs-wallclock timestamp gap that caused `TRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE` submission rejections and the realistic workload only reaching ~70 user TPS instead of 500.

## Test plan
- [ ] Trigger the forge-stable workflow with `TEST_NAME=etna` and verify the etna run no longer shows `TRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE` rejections and reaches the expected throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)