### PR TITLE
[batch-enc][chunky-dkg] streaming DigestKey setup with bounded residency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]

--- a/aptos-move/aptos-vm/src/validator_txns/chunky_dkg.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/chunky_dkg.rs
@@ -158,7 +158,7 @@ impl AptosVM {
         // and trust consensus.
         if let Some(digest_key) = DIGEST_KEY.as_ref() {
             let derived_key_bytes = trx
-                .derive_encryption_key_bytes(digest_key.tau_g2)
+                .derive_encryption_key_bytes(digest_key.tau_g2())
                 .map_err(|_| ExecutionFailure::Expected(ExpectedFailure::EncryptionKeyMismatch))?;
             if derived_key_bytes != encryption_key {
                 return Err(ExecutionFailure::Expected(

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -753,6 +753,12 @@ pub fn setup_environment_and_start_node(
     // Initialize the DigestKey and PublicParameters for chunky DKG
     aptos_dkg_runtime::initialize_digest_key_with_counters(
         node_config.consensus.digest_key_blob_path.as_ref(),
+        aptos_types::dkg::chunky_dkg::DigestKeyStoreConfigOverride {
+            pinned_prefix_rounds: node_config.consensus.digest_key_pinned_prefix_rounds,
+            sliding_lookback_rounds: node_config.consensus.digest_key_sliding_lookback_rounds,
+            sliding_lookahead_rounds: node_config.consensus.digest_key_sliding_lookahead_rounds,
+            read_batch_rounds: node_config.consensus.digest_key_read_batch_rounds,
+        },
         chain_id,
         node_config.base.role.is_validator(),
     );

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -107,6 +107,15 @@ pub struct ConsensusConfig {
     /// Path to the digest key blob file (BCS-serialized DigestKey).
     /// Required for validators on non-test chains. For test chains, falls back to TEST_DIGEST_KEY.
     pub digest_key_blob_path: Option<PathBuf>,
+    /// Streaming DigestKey store: rounds pinned in memory at startup. Never evicted, so epoch
+    /// wrap to round 0 stays instant.
+    pub digest_key_pinned_prefix_rounds: usize,
+    /// Streaming DigestKey store: rounds kept resident behind `cursor` past the pinned prefix.
+    pub digest_key_sliding_lookback_rounds: usize,
+    /// Streaming DigestKey store: rounds prefetched ahead of `cursor` past the pinned prefix.
+    pub digest_key_sliding_lookahead_rounds: usize,
+    /// Streaming DigestKey store: number of rounds the loader reads per syscall.
+    pub digest_key_read_batch_rounds: usize,
     /// Path to the public parameters blob file (BCS-serialized PublicParameters).
     /// Required for validators on non-test chains. For test chains, falls back to TEST_PUBLIC_PARAMETERS.
     pub public_parameters_blob_path: Option<PathBuf>,
@@ -408,6 +417,10 @@ impl Default for ConsensusConfig {
             },
             secret_share_request_delay_ms: 300,
             digest_key_blob_path: None,
+            digest_key_pinned_prefix_rounds: 10_000,
+            digest_key_sliding_lookback_rounds: 100,
+            digest_key_sliding_lookahead_rounds: 100,
+            digest_key_read_batch_rounds: 64,
             public_parameters_blob_path: None,
             num_bounded_executor_tasks: 16,
             enable_pre_commit: true,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1202,7 +1202,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             bcs::from_bytes::<AggregatedSubtranscript>(dkg_session_state.transcript.as_slice())
                 .map_err(NoSecretSharingReason::TranscriptDeserializationError)?;
 
-        let digest_key = DIGEST_KEY
+        let digest_key_handle = DIGEST_KEY
             .as_ref()
             .ok_or(NoSecretSharingReason::NoTrustedSetupAvailable)?
             .clone();
@@ -1210,7 +1210,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         let current_player = Player { id: my_index };
 
         let (encryption_key, verification_keys, msk_share) = FPTXWeighted::setup(
-            &digest_key,
+            &*digest_key_handle,
             &dkg_session.public_parameters,
             &subtranscript.subtranscript,
             &dkg_session.threshold_config,
@@ -1221,7 +1221,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         Ok(SecretShareConfig::new(
             new_epoch_state.verifier.clone(),
-            digest_key,
+            digest_key_handle,
             msk_share,
             verification_keys,
             dkg_session.threshold_config.clone(),

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -374,7 +374,7 @@ async fn decrypt_validator_path(
         monitor!(
             "decryption_digest",
             DIGEST_POOL.install(|| {
-                FPTXWeighted::digest(&digest_key, &txn_ciphertexts, encryption_round)
+                FPTXWeighted::digest(&*digest_key, &txn_ciphertexts, encryption_round)
                     .map(|(digest, proofs_promise)| (txn_ciphertexts, digest, proofs_promise))
             })
         )
@@ -415,7 +415,7 @@ async fn decrypt_validator_path(
         "decryption_eval_proofs",
         tokio::task::spawn_blocking(move || {
             EVAL_PROOFS_POOL
-                .install(|| FPTXWeighted::eval_proofs_compute_all(&proofs_promise, &digest_key))
+                .install(|| FPTXWeighted::eval_proofs_compute_all(&proofs_promise, &*digest_key))
         })
         .await
         .map_err(|e| anyhow!("proof computation panicked: {e}"))?

--- a/crates/aptos-batch-encryption/Cargo.toml
+++ b/crates/aptos-batch-encryption/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = { workspace = true }
 # TODO: Fix compiler errors so we can use `workspace = true` here
 sha2 = { version = "0.10.6" }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/aptos-batch-encryption/benches/fk_algorithm.rs
+++ b/crates/aptos-batch-encryption/benches/fk_algorithm.rs
@@ -17,10 +17,11 @@ pub fn eval_proofs_at_roots_of_unity(c: &mut Criterion) {
         let poly: DensePolynomial<Fr> =
             DensePolynomial::from_coefficients_vec(vec![Fr::rand(&mut rng); poly_degree + 1]);
         let tau_powers_projective: Vec<Vec<G1Projective>> = setup
-            .tau_powers_g1
+            .rounds
             .iter()
-            .map(|gs| {
-                gs.iter()
+            .map(|r| {
+                r.tau_powers_g1
+                    .iter()
                     .map(|g| G1Projective::from(*g))
                     .collect::<Vec<G1Projective>>()
             })
@@ -48,10 +49,11 @@ pub fn eval_proofs_at_x_coords(c: &mut Criterion) {
         let x_coords = vec![Fr::rand(&mut rng); poly_degree];
 
         let tau_powers_projective: Vec<Vec<G1Projective>> = setup
-            .tau_powers_g1
+            .rounds
             .iter()
-            .map(|gs| {
-                gs.iter()
+            .map(|r| {
+                r.tau_powers_g1
+                    .iter()
                     .map(|g| G1Projective::from(*g))
                     .collect::<Vec<G1Projective>>()
             })

--- a/crates/aptos-batch-encryption/src/schemes/fptx.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx.rs
@@ -5,7 +5,7 @@ use crate::{
     group::*,
     shared::{
         ciphertext::{CTDecrypt, CTEncrypt, PreparedCiphertext, StandardCiphertext},
-        digest::{Digest, DigestKey, EvalProof, EvalProofs, EvalProofsPromise},
+        digest::{Digest, DigestKey, DigestKeyView, EvalProof, EvalProofs, EvalProofsPromise},
         encryption_key::EncryptionKey,
         ids::{Id, IdSet, UncomputedCoeffs},
         key_derivation::{
@@ -30,7 +30,6 @@ impl BatchThresholdEncryption for FPTX {
     type DecryptionKey = BIBEDecryptionKey;
     type DecryptionKeyShare = BIBEDecryptionKeyShare;
     type Digest = Digest;
-    type DigestKey = DigestKey;
     type EncryptionKey = EncryptionKey;
     type EvalProof = EvalProof;
     type EvalProofs = EvalProofs;
@@ -45,7 +44,7 @@ impl BatchThresholdEncryption for FPTX {
     type VerificationKey = BIBEVerificationKey;
 
     fn setup(
-        _digest_key: &Self::DigestKey,
+        _digest_key: &dyn DigestKeyView,
         _pvss_public_params: &<Self::SubTranscript as TranscriptCore>::PublicParameters,
         _subtranscript: &Self::SubTranscript,
         _threshold_config: &Self::ThresholdConfig,
@@ -61,7 +60,7 @@ impl BatchThresholdEncryption for FPTX {
     }
 
     fn extract_encryption_key(
-        _digest_key: &Self::DigestKey,
+        _digest_key: &dyn DigestKeyView,
         _subtranscript: &Self::SubTranscript,
     ) -> Result<Self::EncryptionKey> {
         // B/c unweighted chunky is being removed
@@ -75,7 +74,7 @@ impl BatchThresholdEncryption for FPTX {
         threshold_config: &Self::ThresholdConfig,
     ) -> Result<(
         Self::EncryptionKey,
-        Self::DigestKey,
+        DigestKey,
         Vec<Self::VerificationKey>,
         Vec<Self::MasterSecretKeyShare>,
     )> {
@@ -91,11 +90,11 @@ impl BatchThresholdEncryption for FPTX {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
-    fn max_batch_size(dk: &Self::DigestKey) -> usize {
+    fn max_batch_size(dk: &dyn DigestKeyView) -> usize {
         dk.max_batch_size()
     }
 
-    fn num_rounds(dk: &Self::DigestKey) -> usize {
+    fn num_rounds(dk: &dyn DigestKeyView) -> usize {
         dk.num_rounds()
     }
 
@@ -109,7 +108,7 @@ impl BatchThresholdEncryption for FPTX {
     }
 
     fn digest(
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
         cts: &[Self::Ciphertext],
         round: u64,
     ) -> anyhow::Result<(Self::Digest, Self::EvalProofsPromise)> {
@@ -132,14 +131,14 @@ impl BatchThresholdEncryption for FPTX {
 
     fn eval_proofs_compute_all(
         proofs: &Self::EvalProofsPromise,
-        digest_key: &DigestKey,
+        digest_key: &dyn DigestKeyView,
     ) -> Self::EvalProofs {
         proofs.compute_all(digest_key)
     }
 
     fn eval_proofs_compute_all_vzgg_multi_point_eval(
         proofs: &Self::EvalProofsPromise,
-        digest_key: &DigestKey,
+        digest_key: &dyn DigestKeyView,
     ) -> Self::EvalProofs {
         proofs.compute_all_vzgg_multi_point_eval(digest_key)
     }

--- a/crates/aptos-batch-encryption/src/schemes/fptx.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx.rs
@@ -86,7 +86,7 @@ impl BatchThresholdEncryption for FPTX {
         let (mpk, vks, msk_shares) =
             key_derivation::gen_msk_shares(msk, &mut rng, threshold_config);
 
-        let ek = EncryptionKey::new(mpk, digest_key.tau_g2);
+        let ek = EncryptionKey::new(mpk, digest_key.tau_g2());
 
         Ok((ek, digest_key, vks, msk_shares))
     }

--- a/crates/aptos-batch-encryption/src/schemes/fptx_succinct.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_succinct.rs
@@ -88,8 +88,8 @@ impl BatchThresholdEncryption for FPTXSuccinct {
 
         let ek = AugmentedEncryptionKey {
             sig_mpk_g2: mpk,
-            tau_g2: digest_key.tau_g2,
-            tau_mpk_g2: (digest_key.tau_g2 * msk).into(),
+            tau_g2: digest_key.tau_g2(),
+            tau_mpk_g2: (digest_key.tau_g2() * msk).into(),
         };
 
         Ok((ek, digest_key, vks, msk_shares))

--- a/crates/aptos-batch-encryption/src/schemes/fptx_succinct.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_succinct.rs
@@ -6,7 +6,7 @@ use crate::{
     schemes::fptx::FPTX,
     shared::{
         ciphertext::{CTDecrypt, CTEncrypt, PreparedCiphertext, SuccinctCiphertext},
-        digest::{Digest, DigestKey, EvalProof, EvalProofs, EvalProofsPromise},
+        digest::{Digest, DigestKey, DigestKeyView, EvalProof, EvalProofs, EvalProofsPromise},
         encryption_key::AugmentedEncryptionKey,
         ids::{Id, IdSet, UncomputedCoeffs},
         key_derivation::{
@@ -33,7 +33,6 @@ impl BatchThresholdEncryption for FPTXSuccinct {
     type DecryptionKey = BIBEDecryptionKey;
     type DecryptionKeyShare = BIBEDecryptionKeyShare;
     type Digest = Digest;
-    type DigestKey = DigestKey;
     type EncryptionKey = AugmentedEncryptionKey;
     type EvalProof = EvalProof;
     type EvalProofs = EvalProofs;
@@ -46,7 +45,7 @@ impl BatchThresholdEncryption for FPTXSuccinct {
     type VerificationKey = BIBEVerificationKey;
 
     fn setup(
-        _digest_key: &Self::DigestKey,
+        _digest_key: &dyn DigestKeyView,
         _pvss_public_params: &<Self::SubTranscript as TranscriptCore>::PublicParameters,
         _subtranscript: &Self::SubTranscript,
         _tc: &Self::ThresholdConfig,
@@ -62,7 +61,7 @@ impl BatchThresholdEncryption for FPTXSuccinct {
     }
 
     fn extract_encryption_key(
-        _digest_key: &Self::DigestKey,
+        _digest_key: &dyn DigestKeyView,
         _subtranscript: &Self::SubTranscript,
     ) -> Result<Self::EncryptionKey> {
         // B/c unweighted chunky is being removed
@@ -76,7 +75,7 @@ impl BatchThresholdEncryption for FPTXSuccinct {
         tc: &Self::ThresholdConfig,
     ) -> Result<(
         Self::EncryptionKey,
-        Self::DigestKey,
+        DigestKey,
         Vec<Self::VerificationKey>,
         Vec<Self::MasterSecretKeyShare>,
     )> {
@@ -95,11 +94,11 @@ impl BatchThresholdEncryption for FPTXSuccinct {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
-    fn max_batch_size(dk: &Self::DigestKey) -> usize {
+    fn max_batch_size(dk: &dyn DigestKeyView) -> usize {
         dk.max_batch_size()
     }
 
-    fn num_rounds(dk: &Self::DigestKey) -> usize {
+    fn num_rounds(dk: &dyn DigestKeyView) -> usize {
         dk.num_rounds()
     }
 
@@ -113,7 +112,7 @@ impl BatchThresholdEncryption for FPTXSuccinct {
     }
 
     fn digest(
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
         cts: &[Self::Ciphertext],
         round: u64,
     ) -> anyhow::Result<(Self::Digest, Self::EvalProofsPromise)> {
@@ -136,14 +135,14 @@ impl BatchThresholdEncryption for FPTXSuccinct {
 
     fn eval_proofs_compute_all(
         proofs: &Self::EvalProofsPromise,
-        digest_key: &DigestKey,
+        digest_key: &dyn DigestKeyView,
     ) -> Self::EvalProofs {
         FPTX::eval_proofs_compute_all(proofs, digest_key)
     }
 
     fn eval_proofs_compute_all_vzgg_multi_point_eval(
         proofs: &Self::EvalProofsPromise,
-        digest_key: &DigestKey,
+        digest_key: &dyn DigestKeyView,
     ) -> Self::EvalProofs {
         FPTX::eval_proofs_compute_all_vzgg_multi_point_eval(proofs, digest_key)
     }

--- a/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
@@ -6,7 +6,7 @@ use crate::{
     schemes::fptx::FPTX,
     shared::{
         ciphertext::{PreparedCiphertext, StandardCiphertext},
-        digest::{Digest, DigestKey, EvalProof, EvalProofs, EvalProofsPromise},
+        digest::{Digest, DigestKey, DigestKeyView, EvalProof, EvalProofs, EvalProofsPromise},
         encryption_key::EncryptionKey,
         ids::Id,
         key_derivation::{
@@ -224,7 +224,6 @@ impl BatchThresholdEncryption for FPTXWeighted {
     type DecryptionKey = BIBEDecryptionKey;
     type DecryptionKeyShare = WeightedBIBEDecryptionKeyShare;
     type Digest = Digest;
-    type DigestKey = DigestKey;
     type EncryptionKey = EncryptionKey;
     type EvalProof = EvalProof;
     type EvalProofs = EvalProofs;
@@ -237,7 +236,7 @@ impl BatchThresholdEncryption for FPTXWeighted {
     type VerificationKey = WeightedBIBEVerificationKey;
 
     fn setup(
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
         pvss_public_params: &<Self::SubTranscript as TranscriptCore>::PublicParameters,
         subtranscript: &Self::SubTranscript,
         threshold_config: &Self::ThresholdConfig,
@@ -296,7 +295,7 @@ impl BatchThresholdEncryption for FPTXWeighted {
     }
 
     fn extract_encryption_key(
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
         subtranscript: &Self::SubTranscript,
     ) -> Result<Self::EncryptionKey> {
         let mpk_g2: G2Affine = subtranscript.get_dealt_public_key().as_g2();
@@ -310,7 +309,7 @@ impl BatchThresholdEncryption for FPTXWeighted {
         threshold_config: &Self::ThresholdConfig,
     ) -> Result<(
         Self::EncryptionKey,
-        Self::DigestKey,
+        DigestKey,
         Vec<Self::VerificationKey>,
         Vec<Self::MasterSecretKeyShare>,
     )> {
@@ -325,11 +324,11 @@ impl BatchThresholdEncryption for FPTXWeighted {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
-    fn max_batch_size(dk: &Self::DigestKey) -> usize {
+    fn max_batch_size(dk: &dyn DigestKeyView) -> usize {
         dk.max_batch_size()
     }
 
-    fn num_rounds(dk: &Self::DigestKey) -> usize {
+    fn num_rounds(dk: &dyn DigestKeyView) -> usize {
         dk.num_rounds()
     }
 
@@ -343,7 +342,7 @@ impl BatchThresholdEncryption for FPTXWeighted {
     }
 
     fn digest(
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
         cts: &[Self::Ciphertext],
         round: u64,
     ) -> anyhow::Result<(Self::Digest, Self::EvalProofsPromise)> {
@@ -363,14 +362,14 @@ impl BatchThresholdEncryption for FPTXWeighted {
 
     fn eval_proofs_compute_all(
         proofs: &Self::EvalProofsPromise,
-        digest_key: &DigestKey,
+        digest_key: &dyn DigestKeyView,
     ) -> Self::EvalProofs {
         FPTX::eval_proofs_compute_all(proofs, digest_key)
     }
 
     fn eval_proofs_compute_all_vzgg_multi_point_eval(
         proofs: &Self::EvalProofsPromise,
-        digest_key: &DigestKey,
+        digest_key: &dyn DigestKeyView,
     ) -> Self::EvalProofs {
         FPTX::eval_proofs_compute_all_vzgg_multi_point_eval(proofs, digest_key)
     }

--- a/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
@@ -250,7 +250,7 @@ impl BatchThresholdEncryption for FPTXWeighted {
     )> {
         let mpk_g2: G2Affine = subtranscript.get_dealt_public_key().as_g2();
 
-        let ek = EncryptionKey::new(mpk_g2, digest_key.tau_g2);
+        let ek = EncryptionKey::new(mpk_g2, digest_key.tau_g2());
 
         let vks: Vec<Self::VerificationKey> = threshold_config
             .get_players()
@@ -300,7 +300,7 @@ impl BatchThresholdEncryption for FPTXWeighted {
         subtranscript: &Self::SubTranscript,
     ) -> Result<Self::EncryptionKey> {
         let mpk_g2: G2Affine = subtranscript.get_dealt_public_key().as_g2();
-        Ok(EncryptionKey::new(mpk_g2, digest_key.tau_g2))
+        Ok(EncryptionKey::new(mpk_g2, digest_key.tau_g2()))
     }
 
     fn setup_for_testing(
@@ -320,7 +320,7 @@ impl BatchThresholdEncryption for FPTXWeighted {
         let msk = Fr::rand(&mut rng);
         let (mpk, vks, msk_shares) = gen_weighted_msk_shares(msk, &mut rng, threshold_config);
 
-        let ek = EncryptionKey::new(mpk, digest_key.tau_g2);
+        let ek = EncryptionKey::new(mpk, digest_key.tau_g2());
 
         Ok((ek, digest_key, vks, msk_shares))
     }

--- a/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
+++ b/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
@@ -413,7 +413,7 @@ impl<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize>
     pub fn params(&self) -> FKDomainParams<F> {
         FKDomainParams {
             toeplitz_domain: self.toeplitz_domain.clone(),
-            fft_domain: self.fft_domain.clone(),
+            fft_domain: self.fft_domain,
         }
     }
 }

--- a/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
+++ b/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
@@ -273,6 +273,131 @@ impl<F: FftField + Sized> ToeplitzDomain<F> {
     }
 }
 
+/// The round-independent parameters of the FK algorithm: the Toeplitz domain and the FFT evaluation
+/// domain. Splitting these out of [`FKDomain`] lets callers run the algorithm against a single
+/// round's prepared input without materializing the full `Vec<PreparedInput>` from the trusted
+/// setup file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FKDomainParams<F: FftField> {
+    pub toeplitz_domain: ToeplitzDomain<F>,
+    pub fft_domain: Radix2EvaluationDomain<F>,
+}
+
+impl<F: FftField> FKDomainParams<F> {
+    pub fn new(max_poly_degree: usize, eval_domain_size: usize) -> Option<Self> {
+        Some(Self {
+            toeplitz_domain: ToeplitzDomain::new(max_poly_degree)?,
+            fft_domain: Radix2EvaluationDomain::new(eval_domain_size)?,
+        })
+    }
+
+    pub fn toeplitz_for_poly(&self, f: &[F]) -> Vec<F> {
+        let toeplitz: Vec<F> = Vec::from(&f[1..])
+            .into_iter()
+            .chain(vec![F::zero(); f.len() - 2])
+            .collect();
+
+        debug_assert_eq!(toeplitz.len(), self.toeplitz_domain.dimension() * 2 - 1);
+
+        toeplitz
+    }
+}
+
+impl<F: FftField> FKDomainParams<F> {
+    /// Prepare a per-round Toeplitz input from the round's `tau_powers`. Mirrors the per-round
+    /// step in `FKDomain::new`, exposed so we can build prepared inputs incrementally as rounds
+    /// stream off disk.
+    pub fn prepare_round_input<T>(&self, tau_powers_for_round: &[T]) -> PreparedInput<F, T>
+    where
+        T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize,
+    {
+        let mut tau_powers_reversed: Vec<T> = tau_powers_for_round.to_vec();
+        tau_powers_reversed.reverse();
+        self.toeplitz_domain
+            .prepare_input(&tau_powers_reversed[1..])
+    }
+
+    fn compute_h_term_commitments_with<T>(
+        &self,
+        f: &[F],
+        prepared_toeplitz_input: &PreparedInput<F, T>,
+    ) -> Vec<T>
+    where
+        T: DomainCoeff<F>
+            + Mul<F, Output = T>
+            + VariableBaseMSM<ScalarField = F>
+            + CanonicalSerialize
+            + CanonicalDeserialize,
+    {
+        let mut f = Vec::from(f);
+        f.extend(std::iter::repeat_n(
+            F::zero(),
+            self.toeplitz_domain.dimension() + 1 - f.len(),
+        ));
+        debug_assert_eq!(self.toeplitz_domain.dimension(), f.len() - 1);
+
+        self.toeplitz_domain
+            .eval_prepared(&self.toeplitz_for_poly(&f), prepared_toeplitz_input)
+    }
+
+    pub fn eval_proofs_at_roots_of_unity_with<T>(
+        &self,
+        f: &[F],
+        prepared_toeplitz_input: &PreparedInput<F, T>,
+    ) -> Vec<T>
+    where
+        T: DomainCoeff<F>
+            + Mul<F, Output = T>
+            + VariableBaseMSM<ScalarField = F>
+            + CanonicalSerialize
+            + CanonicalDeserialize,
+    {
+        let h_term_commitments = self.compute_h_term_commitments_with(f, prepared_toeplitz_input);
+        self.fft_domain.fft(&h_term_commitments)
+    }
+
+    pub fn eval_proofs_at_x_coords_with<T>(
+        &self,
+        f: &[F],
+        x_coords: &[F],
+        prepared_toeplitz_input: &PreparedInput<F, T>,
+    ) -> Vec<T>
+    where
+        T: DomainCoeff<F>
+            + Mul<F, Output = T>
+            + VariableBaseMSM<ScalarField = F>
+            + CanonicalSerialize
+            + CanonicalDeserialize,
+    {
+        let h_term_commitments = self.compute_h_term_commitments_with(f, prepared_toeplitz_input);
+        multi_point_eval(&h_term_commitments, x_coords)
+    }
+
+    pub fn eval_proofs_at_x_coords_naive_multi_point_eval_with<T>(
+        &self,
+        f: &[F],
+        x_coords: &[F],
+        prepared_toeplitz_input: &PreparedInput<F, T>,
+    ) -> Vec<T>
+    where
+        T: DomainCoeff<F>
+            + Mul<F, Output = T>
+            + VariableBaseMSM<ScalarField = F>
+            + CanonicalSerialize
+            + CanonicalDeserialize,
+    {
+        let h_term_commitments = self.compute_h_term_commitments_with(f, prepared_toeplitz_input);
+
+        multi_point_eval_naive(
+            &h_term_commitments
+                .into_iter()
+                .map(T::MulBase::from)
+                .collect::<Vec<T::MulBase>>(),
+            x_coords,
+        )
+    }
+}
+
 /// Encapsulates the [`ToeplitzDomain`] and a FFT evaluation domain required for running the FK
 /// algorithm.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -280,6 +405,17 @@ pub struct FKDomain<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + Canoni
     pub toeplitz_domain: ToeplitzDomain<F>,
     pub fft_domain: Radix2EvaluationDomain<F>,
     pub prepared_toeplitz_inputs: Vec<PreparedInput<F, T>>,
+}
+
+impl<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize> FKDomain<F, T> {
+    /// Borrow the round-independent params for callers that want to drive the FK algorithm against
+    /// a single round's prepared input.
+    pub fn params(&self) -> FKDomainParams<F> {
+        FKDomainParams {
+            toeplitz_domain: self.toeplitz_domain.clone(),
+            fft_domain: self.fft_domain.clone(),
+        }
+    }
 }
 
 impl<

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
@@ -184,6 +184,7 @@ pub mod tests {
         schemes::fptx::FPTX,
         shared::{
             ciphertext::bibe::InnerCiphertext as _,
+            digest::DigestKeyView as _,
             ids::{Id, IdSet},
             key_derivation::BIBEDecryptionKey,
         },

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
@@ -126,7 +126,7 @@ pub mod tests {
         group::*,
         shared::{
             ciphertext::bibe::{BIBECTDecrypt as _, BIBECTEncrypt as _, InnerCiphertext as _},
-            digest::DigestKey,
+            digest::{DigestKey, DigestKeyView as _},
             encryption_key::AugmentedEncryptionKey,
             ids::{Id, IdSet},
             key_derivation::{self, BIBEDecryptionKey},

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
@@ -146,7 +146,7 @@ pub mod tests {
         let msk = Fr::rand(&mut rng);
         let (mpk, _, msk_shares) = key_derivation::gen_msk_shares(msk, &mut rng, &tc);
 
-        let ek = AugmentedEncryptionKey::new(mpk, dk.tau_g2, (dk.tau_g2 * msk).into());
+        let ek = AugmentedEncryptionKey::new(mpk, dk.tau_g2(), (dk.tau_g2() * msk).into());
 
         let mut ids = IdSet::with_capacity(dk.max_batch_size());
         let mut counter = Fr::zero();

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/mod.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/mod.rs
@@ -230,7 +230,7 @@ pub mod tests {
         let msk = Fr::rand(&mut rng);
         let (mpk, _, msk_shares) = key_derivation::gen_msk_shares(msk, &mut rng, &tc);
 
-        let ek = AugmentedEncryptionKey::new(mpk, dk.tau_g2, (dk.tau_g2 * msk).into());
+        let ek = AugmentedEncryptionKey::new(mpk, dk.tau_g2(), (dk.tau_g2() * msk).into());
 
         let plaintext = String::from("hi");
         let associated_data = String::from("");

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/mod.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/mod.rs
@@ -182,7 +182,7 @@ pub mod tests {
         schemes::fptx::FPTX,
         shared::{
             ciphertext::{CTDecrypt, CTEncrypt, StandardCiphertext, SuccinctCiphertext},
-            digest::DigestKey,
+            digest::{DigestKey, DigestKeyView as _},
             encryption_key::AugmentedEncryptionKey,
             ids::{Id, IdSet},
             key_derivation::{self, BIBEDecryptionKey},

--- a/crates/aptos-batch-encryption/src/shared/digest.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest.rs
@@ -6,7 +6,10 @@ use super::ids::{ComputedCoeffs, Id, IdSet};
 use crate::{
     errors::{BatchEncryptionError, DigestKeyInitError},
     group::{Fr, G1Affine, G1Projective, G2Affine, G2Projective, PairingSetting},
-    shared::{algebra::fk_algorithm::FKDomain, ids::UncomputedCoeffs},
+    shared::{
+        algebra::fk_algorithm::{FKDomain, FKDomainParams, PreparedInput},
+        ids::UncomputedCoeffs,
+    },
 };
 use anyhow::{anyhow, Result};
 use aptos_crypto::arkworks::serialization::{ark_de, ark_se};
@@ -20,14 +23,90 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     ops::{Deref, DerefMut},
+    sync::Arc,
 };
 
+/// Round-independent setup data: tau_g2 plus the FK algorithm domain params (`toeplitz_domain`,
+/// `fft_domain`). This is what every consumer that only needs to derive an encryption key reads.
+///
+/// Carries `batch_size` and `num_rounds` so consumers don't need to touch a `RoundData` to learn
+/// the shape of the setup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DigestKeyHeader {
+    pub tau_g2: G2Affine,
+    pub batch_size: usize,
+    pub num_rounds: usize,
+    pub fk_params: FKDomainParams<Fr>,
+}
+
+/// Per-round setup data. One of these per round in the trusted setup file; the streaming
+/// `DigestKeyStore` only keeps a bounded window of these in memory at once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoundData {
+    pub tau_powers_g1: Vec<G1Affine>,
+    pub prepared_toeplitz_input: PreparedInput<Fr, G1Projective>,
+}
+
+/// Read-only view over the trusted setup. Both the eagerly-loaded [`DigestKey`] and the
+/// streaming `DigestKeyStore` implement this so consumers can be written once against either.
+pub trait DigestKeyView: Send + Sync {
+    fn header(&self) -> &DigestKeyHeader;
+    fn round(&self, r: usize) -> Arc<RoundData>;
+
+    fn max_batch_size(&self) -> usize {
+        self.header().batch_size
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.header().num_rounds
+    }
+
+    fn tau_g2(&self) -> G2Affine {
+        self.header().tau_g2
+    }
+}
+
 /// The digest public parameters.
+///
+/// Internally split into a round-independent [`DigestKeyHeader`] and a vector of per-round
+/// [`RoundData`] blobs (each wrapped in `Arc` so they can be shared with — or migrated into —
+/// the streaming `DigestKeyStore` without copying). Callers that only need `tau_g2` go through
+/// [`DigestKey::tau_g2`]; callers that need per-round data go through [`DigestKey::round`].
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DigestKey {
-    pub tau_g2: G2Affine,
-    pub tau_powers_g1: Vec<Vec<G1Affine>>,
-    pub fk_domain: FKDomain<Fr, G1Projective>,
+    pub header: Arc<DigestKeyHeader>,
+    pub rounds: Vec<Arc<RoundData>>,
+}
+
+impl DigestKey {
+    /// Construct a `DigestKey` directly from its split-out pieces. Used by the file reader and
+    /// tests to assemble a key without going through the round-generating `new` path.
+    pub fn from_parts(header: Arc<DigestKeyHeader>, rounds: Vec<Arc<RoundData>>) -> Self {
+        Self { header, rounds }
+    }
+
+    pub fn tau_g2(&self) -> G2Affine {
+        self.header.tau_g2
+    }
+
+    pub fn tau_powers_g1_for_round(&self, round: usize) -> &[G1Affine] {
+        &self.rounds[round].tau_powers_g1
+    }
+
+    /// Borrow the round-data slot. Cheap clone (Arc).
+    pub fn round_data(&self, round: usize) -> Arc<RoundData> {
+        Arc::clone(&self.rounds[round])
+    }
+}
+
+impl DigestKeyView for DigestKey {
+    fn header(&self) -> &DigestKeyHeader {
+        &self.header
+    }
+
+    fn round(&self, r: usize) -> Arc<RoundData> {
+        Arc::clone(&self.rounds[r])
+    }
 }
 
 /// A succinct commitment to a set of IDs. Internally, a KZG commitment over a shifted
@@ -105,11 +184,36 @@ impl DigestKey {
             BatchEncryptionError::DigestInitError(DigestKeyInitError::FKDomainInitFailure),
         )?;
 
-        Ok(DigestKey {
+        Ok(Self::from_fk_domain(tau_g2, tau_powers_g1, fk_domain))
+    }
+
+    /// Internal helper: assemble a `DigestKey` from the legacy split (tau_g2, per-round powers,
+    /// fully-materialized `FKDomain`). Splits the FKDomain into params + per-round prepared
+    /// inputs and packages each round.
+    fn from_fk_domain(
+        tau_g2: G2Affine,
+        tau_powers_g1: Vec<Vec<G1Affine>>,
+        fk_domain: FKDomain<Fr, G1Projective>,
+    ) -> Self {
+        let batch_size = tau_powers_g1[0].len() - 1;
+        let num_rounds = tau_powers_g1.len();
+        let header = Arc::new(DigestKeyHeader {
             tau_g2,
-            tau_powers_g1,
-            fk_domain,
-        })
+            batch_size,
+            num_rounds,
+            fk_params: fk_domain.params(),
+        });
+        let rounds: Vec<Arc<RoundData>> = tau_powers_g1
+            .into_iter()
+            .zip(fk_domain.prepared_toeplitz_inputs)
+            .map(|(tau_powers_g1, prepared_toeplitz_input)| {
+                Arc::new(RoundData {
+                    tau_powers_g1,
+                    prepared_toeplitz_input,
+                })
+            })
+            .collect();
+        Self { header, rounds }
     }
 
     pub fn with_randomized_powers_of_tau(
@@ -152,19 +256,19 @@ impl DigestKey {
                 DigestKeyInitError::FKDomainInitFailure,
             ))?;
 
-        Ok(Self {
+        Ok(Self::from_fk_domain(
             tau_g2,
-            tau_powers_g1: randomized_tau_powers_g1,
+            randomized_tau_powers_g1,
             fk_domain,
-        })
+        ))
     }
 
     pub fn max_batch_size(&self) -> usize {
-        self.tau_powers_g1[0].len() - 1
+        self.header.batch_size
     }
 
     pub fn num_rounds(&self) -> usize {
-        self.tau_powers_g1.len()
+        self.header.num_rounds
     }
 
     pub fn digest(
@@ -173,23 +277,26 @@ impl DigestKey {
         round: u64,
     ) -> Result<(Digest, EvalProofsPromise)> {
         let round: usize = round as usize;
-        if round >= self.tau_powers_g1.len() {
+        if round >= self.header.num_rounds {
             Err(anyhow!(
                 "Tried to compute digest with round greater than setup length."
             ))
-        } else if ids.capacity() > self.tau_powers_g1[round].len() - 1 {
-            Err(anyhow!(
-                "Tried to compute a batch digest with size {}, where setup supports up to size {}",
-                ids.capacity(),
-                self.tau_powers_g1[round].len() - 1
-            ))?
         } else {
+            let round_data = self.round_data(round);
+            let tau_powers = &round_data.tau_powers_g1;
+            if ids.capacity() > tau_powers.len() - 1 {
+                Err(anyhow!(
+                    "Tried to compute a batch digest with size {}, where setup supports up to size {}",
+                    ids.capacity(),
+                    tau_powers.len() - 1
+                ))?;
+            }
             let ids = ids.compute_poly_coeffs();
             let mut coeffs = ids.poly_coeffs();
-            coeffs.resize(self.tau_powers_g1[round].len(), Fr::zero());
+            coeffs.resize(tau_powers.len(), Fr::zero());
 
             let digest = Digest {
-                digest_g1: G1Projective::msm(&self.tau_powers_g1[round], &coeffs)
+                digest_g1: G1Projective::msm(tau_powers, &coeffs)
                     .expect("Sizes should always match up b/c of check above")
                     .into(),
                 round,
@@ -201,7 +308,7 @@ impl DigestKey {
 
     fn verify_pf(&self, digest: &Digest, id: Id, pf: G1Affine) -> Result<()> {
         Ok(PairingSetting::multi_pairing([pf, -digest.as_g1()], [
-            G2Affine::from(self.tau_g2 - G2Projective::from(G2Affine::generator() * id.x())),
+            G2Affine::from(self.header.tau_g2 - G2Projective::from(G2Affine::generator() * id.x())),
             G2Affine::generator(),
         ])
         .is_zero()
@@ -351,8 +458,13 @@ pub(crate) mod tests {
     fn test_with_randomized_powers_of_tau() {
         let mut rng = thread_rng();
         let dk = DigestKey::new(&mut rng, 8, 2).unwrap();
+        let tau_powers_g1: Vec<Vec<G1Affine>> = dk
+            .rounds
+            .iter()
+            .map(|r| r.tau_powers_g1.clone())
+            .collect();
         let dk2 =
-            DigestKey::with_randomized_powers_of_tau(dk.tau_powers_g1.clone(), dk.tau_g2).unwrap();
+            DigestKey::with_randomized_powers_of_tau(tau_powers_g1, dk.header.tau_g2).unwrap();
         assert_eq!(dk, dk2);
     }
 }

--- a/crates/aptos-batch-encryption/src/shared/digest.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest.rs
@@ -64,6 +64,63 @@ pub trait DigestKeyView: Send + Sync {
     fn tau_g2(&self) -> G2Affine {
         self.header().tau_g2
     }
+
+    fn digest(
+        &self,
+        ids: &mut IdSet<UncomputedCoeffs>,
+        round: u64,
+    ) -> Result<(Digest, EvalProofsPromise)> {
+        let round_usize: usize = round as usize;
+        if round_usize >= self.num_rounds() {
+            return Err(anyhow!(
+                "Tried to compute digest with round greater than setup length."
+            ));
+        }
+        let round_data = self.round(round_usize);
+        let tau_powers = &round_data.tau_powers_g1;
+        if ids.capacity() > tau_powers.len() - 1 {
+            return Err(anyhow!(
+                "Tried to compute a batch digest with size {}, where setup supports up to size {}",
+                ids.capacity(),
+                tau_powers.len() - 1
+            ));
+        }
+        let ids = ids.compute_poly_coeffs();
+        let mut coeffs = ids.poly_coeffs();
+        coeffs.resize(tau_powers.len(), Fr::zero());
+
+        let digest = Digest {
+            digest_g1: G1Projective::msm(tau_powers, &coeffs)
+                .expect("Sizes should always match up b/c of check above")
+                .into(),
+            round: round_usize,
+        };
+
+        Ok((digest.clone(), EvalProofsPromise::new(digest, ids)))
+    }
+
+    fn verify_pf(&self, digest: &Digest, id: Id, pf: G1Affine) -> Result<()> {
+        Ok(PairingSetting::multi_pairing([pf, -digest.as_g1()], [
+            G2Affine::from(
+                self.header().tau_g2 - G2Projective::from(G2Affine::generator() * id.x()),
+            ),
+            G2Affine::generator(),
+        ])
+        .is_zero()
+        .then_some(())
+        .ok_or(BatchEncryptionError::EvalProofVerifyError)?)
+    }
+
+    fn verify(&self, digest: &Digest, pfs: &EvalProofs, id: Id) -> Result<()> {
+        let pf = pfs.computed_proofs[&id];
+        self.verify_pf(digest, id, pf)
+    }
+
+    fn verify_all(&self, digest: &Digest, pfs: &EvalProofs) -> Result<()> {
+        pfs.computed_proofs
+            .iter()
+            .try_for_each(|(id, pf)| self.verify_pf(digest, *id, *pf))
+    }
 }
 
 /// The digest public parameters.
@@ -270,62 +327,6 @@ impl DigestKey {
     pub fn num_rounds(&self) -> usize {
         self.header.num_rounds
     }
-
-    pub fn digest(
-        &self,
-        ids: &mut IdSet<UncomputedCoeffs>,
-        round: u64,
-    ) -> Result<(Digest, EvalProofsPromise)> {
-        let round: usize = round as usize;
-        if round >= self.header.num_rounds {
-            Err(anyhow!(
-                "Tried to compute digest with round greater than setup length."
-            ))
-        } else {
-            let round_data = self.round_data(round);
-            let tau_powers = &round_data.tau_powers_g1;
-            if ids.capacity() > tau_powers.len() - 1 {
-                Err(anyhow!(
-                    "Tried to compute a batch digest with size {}, where setup supports up to size {}",
-                    ids.capacity(),
-                    tau_powers.len() - 1
-                ))?;
-            }
-            let ids = ids.compute_poly_coeffs();
-            let mut coeffs = ids.poly_coeffs();
-            coeffs.resize(tau_powers.len(), Fr::zero());
-
-            let digest = Digest {
-                digest_g1: G1Projective::msm(tau_powers, &coeffs)
-                    .expect("Sizes should always match up b/c of check above")
-                    .into(),
-                round,
-            };
-
-            Ok((digest.clone(), EvalProofsPromise::new(digest, ids)))
-        }
-    }
-
-    fn verify_pf(&self, digest: &Digest, id: Id, pf: G1Affine) -> Result<()> {
-        Ok(PairingSetting::multi_pairing([pf, -digest.as_g1()], [
-            G2Affine::from(self.header.tau_g2 - G2Projective::from(G2Affine::generator() * id.x())),
-            G2Affine::generator(),
-        ])
-        .is_zero()
-        .then_some(())
-        .ok_or(BatchEncryptionError::EvalProofVerifyError)?)
-    }
-
-    pub fn verify(&self, digest: &Digest, pfs: &EvalProofs, id: Id) -> Result<()> {
-        let pf = pfs.computed_proofs[&id];
-        self.verify_pf(digest, id, pf)
-    }
-
-    pub fn verify_all(&self, digest: &Digest, pfs: &EvalProofs) -> Result<()> {
-        pfs.computed_proofs
-            .iter()
-            .try_for_each(|(id, pf)| self.verify_pf(digest, *id, *pf))
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -339,7 +340,7 @@ impl EvalProofsPromise {
         Self { digest, ids }
     }
 
-    pub fn compute_all(&self, digest_key: &DigestKey) -> EvalProofs {
+    pub fn compute_all(&self, digest_key: &dyn DigestKeyView) -> EvalProofs {
         EvalProofs {
             computed_proofs: self
                 .ids
@@ -347,7 +348,7 @@ impl EvalProofsPromise {
         }
     }
 
-    pub fn compute_all_vzgg_multi_point_eval(&self, digest_key: &DigestKey) -> EvalProofs {
+    pub fn compute_all_vzgg_multi_point_eval(&self, digest_key: &dyn DigestKeyView) -> EvalProofs {
         EvalProofs {
             computed_proofs: self
                 .ids
@@ -458,11 +459,8 @@ pub(crate) mod tests {
     fn test_with_randomized_powers_of_tau() {
         let mut rng = thread_rng();
         let dk = DigestKey::new(&mut rng, 8, 2).unwrap();
-        let tau_powers_g1: Vec<Vec<G1Affine>> = dk
-            .rounds
-            .iter()
-            .map(|r| r.tau_powers_g1.clone())
-            .collect();
+        let tau_powers_g1: Vec<Vec<G1Affine>> =
+            dk.rounds.iter().map(|r| r.tau_powers_g1.clone()).collect();
         let dk2 =
             DigestKey::with_randomized_powers_of_tau(tau_powers_g1, dk.header.tau_g2).unwrap();
         assert_eq!(dk, dk2);

--- a/crates/aptos-batch-encryption/src/shared/digest_key_file.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest_key_file.rs
@@ -4,8 +4,8 @@
 use crate::{
     group::{Fr, G1Affine, G1Projective, G2Affine},
     shared::{
-        algebra::fk_algorithm::{FKDomain, PreparedInput, ToeplitzDomain},
-        digest::DigestKey,
+        algebra::fk_algorithm::{FKDomainParams, PreparedInput, ToeplitzDomain},
+        digest::{DigestKey, DigestKeyHeader, RoundData},
     },
 };
 use anyhow::{bail, Result};
@@ -18,8 +18,9 @@ use ark_serialize::{
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
-    io::{Read, Seek, Write},
+    io::{Cursor, Read, Seek, Write},
     path::Path,
+    sync::Arc,
 };
 
 // Structs
@@ -89,21 +90,25 @@ impl From<(Vec<G1Affine>, PreparedInput<Fr, G1Projective>)> for Round {
 
 impl From<DigestKey> for (HeaderV1, Vec<Round>) {
     fn from(value: DigestKey) -> Self {
-        (
-            HeaderV1 {
-                batch_size: value.max_batch_size(),
-                num_rounds: value.tau_powers_g1.len(),
-                tau_g2: value.tau_g2,
-                toeplitz_domain: value.fk_domain.toeplitz_domain,
-                fft_domain: value.fk_domain.fft_domain,
-            },
-            value
-                .tau_powers_g1
-                .into_iter()
-                .zip(value.fk_domain.prepared_toeplitz_inputs)
-                .map(Round::from)
-                .collect(),
-        )
+        let header_v1 = HeaderV1 {
+            batch_size: value.header.batch_size,
+            num_rounds: value.header.num_rounds,
+            tau_g2: value.header.tau_g2,
+            toeplitz_domain: value.header.fk_params.toeplitz_domain.clone(),
+            fft_domain: value.header.fk_params.fft_domain,
+        };
+        let rounds: Vec<Round> = value
+            .rounds
+            .into_iter()
+            .map(|round_arc| {
+                let round = Arc::try_unwrap(round_arc).unwrap_or_else(|arc| (*arc).clone());
+                Round {
+                    tau_powers_g1: round.tau_powers_g1,
+                    prepared_toeplitz_input: round.prepared_toeplitz_input,
+                }
+            })
+            .collect();
+        (header_v1, rounds)
     }
 }
 
@@ -152,24 +157,29 @@ pub fn write_round(file: &File, round: &Round, header: &HeaderV1) -> Result<()> 
 impl From<(HeaderV1, Vec<Round>)> for DigestKey {
     // Assumes correct shape
     fn from(value: (HeaderV1, Vec<Round>)) -> Self {
-        let (tau_powers_g1, prepared_toeplitz_inputs): (
-            Vec<Vec<G1Affine>>,
-            Vec<PreparedInput<Fr, G1Projective>>,
-        ) = value
-            .1
+        let (header_v1, file_rounds) = value;
+        let rounds: Vec<Arc<RoundData>> = file_rounds
             .into_iter()
-            .map(|round| (round.tau_powers_g1, round.prepared_toeplitz_input))
+            .map(|round| {
+                Arc::new(RoundData {
+                    tau_powers_g1: round.tau_powers_g1,
+                    prepared_toeplitz_input: round.prepared_toeplitz_input,
+                })
+            })
             .collect();
-
-        Self {
-            tau_g2: value.0.tau_g2,
-            tau_powers_g1,
-            fk_domain: FKDomain {
-                toeplitz_domain: value.0.toeplitz_domain,
-                fft_domain: value.0.fft_domain,
-                prepared_toeplitz_inputs,
+        // `num_rounds` reflects the rounds actually carried by this `DigestKey`, which may be
+        // a subrange of the file (see `read_digest_key_range`). HeaderV1.num_rounds is the
+        // on-disk count.
+        let header = Arc::new(DigestKeyHeader {
+            tau_g2: header_v1.tau_g2,
+            batch_size: header_v1.batch_size,
+            num_rounds: rounds.len(),
+            fk_params: FKDomainParams {
+                toeplitz_domain: header_v1.toeplitz_domain,
+                fft_domain: header_v1.fft_domain,
             },
-        }
+        });
+        DigestKey::from_parts(header, rounds)
     }
 }
 
@@ -272,6 +282,36 @@ pub fn read_round(file: &File, header: &HeaderV1) -> Result<Round> {
     })
 }
 
+/// Decode a single round from an in-memory byte slice of length `header.round_size_bytes()`.
+///
+/// Pure CPU work. The streaming `DigestKeyStore` uses this to amortize I/O: read a batch of N
+/// round-sized chunks in one `read_exact`, then decode each chunk with this function.
+pub fn decode_round_from_slice(buf: &[u8], header: &HeaderV1) -> Result<Round> {
+    if buf.len() != header.round_size_bytes() {
+        bail!(
+            "decode_round_from_slice: buffer size {} does not match round size {}",
+            buf.len(),
+            header.round_size_bytes()
+        );
+    }
+    let mut cursor = Cursor::new(buf);
+
+    let mut tau_powers_g1: Vec<G1Affine> = (0..header.num_powers_per_round())
+        .map(|_| G1Affine::deserialize_with_mode(&mut cursor, Compress::No, Validate::No))
+        .collect::<std::result::Result<Vec<G1Affine>, SerializationError>>()?;
+    tau_powers_g1.shrink_to_fit();
+
+    let mut prepared_input_y: Vec<G1Projective> = (0..header.prepared_input_size())
+        .map(|_| G1Projective::deserialize_with_mode(&mut cursor, Compress::No, Validate::No))
+        .collect::<std::result::Result<Vec<G1Projective>, SerializationError>>()?;
+    prepared_input_y.shrink_to_fit();
+
+    Ok(Round {
+        tau_powers_g1,
+        prepared_toeplitz_input: PreparedInput::new(prepared_input_y),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use crate::shared::{digest::DigestKey, digest_key_file::*};
@@ -339,10 +379,10 @@ mod tests {
 
         let dk_from_file = read_digest_key_range(file.path(), 2, 3).unwrap();
 
-        dk.tau_powers_g1.remove(0);
-        dk.tau_powers_g1.remove(0);
-        dk.fk_domain.prepared_toeplitz_inputs.remove(0);
-        dk.fk_domain.prepared_toeplitz_inputs.remove(0);
+        dk.rounds.remove(0);
+        dk.rounds.remove(0);
+        let header = std::sync::Arc::make_mut(&mut dk.header);
+        header.num_rounds = 3;
 
         assert_eq!(dk, dk_from_file);
     }

--- a/crates/aptos-batch-encryption/src/shared/digest_key_store.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest_key_store.rs
@@ -1,0 +1,478 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+//! Streaming, bounded-residency reader for the on-disk `DigestKey` trusted setup.
+//!
+//! The trusted setup file is large (hundreds of MB to several GB). Loading it all into RAM was
+//! the previous design (`Lazy<Option<Arc<DigestKey>>>`); this module replaces that with a
+//! windowed loader:
+//!
+//! - **Pinned prefix**: rounds `[0, pinned_prefix_rounds)` are loaded at startup and never
+//!   evicted. This makes epoch wrap (consumer going back to round 0) instant — no cold-start I/O.
+//! - **Sliding window**: rounds `>= pinned_prefix_rounds` are tracked in a window
+//!   `[cursor - sliding_lookback_rounds, cursor + sliding_lookahead_rounds]`. As the consumer
+//!   advances `cursor`, the background loader prefetches ahead and evicts behind.
+//!
+//! Every round read is decoded via [`decode_round_from_slice`] from a batched read buffer
+//! (`read_batch_rounds × round_size` bytes per I/O), amortizing syscall cost across rounds.
+//!
+//! The store implements [`DigestKeyView`] so it is a drop-in replacement for `&DigestKey` in
+//! per-round consumers (`IdSet::compute_*_eval_proofs_with_setup`, FPTX scheme `digest`/`setup`).
+
+use crate::shared::{
+    algebra::fk_algorithm::FKDomainParams,
+    digest::{DigestKeyHeader, DigestKeyView, RoundData},
+    digest_key_file::{decode_round_from_slice, Header, HeaderV1},
+};
+use anyhow::{anyhow, bail, Result};
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Condvar, Mutex, RwLock,
+    },
+    thread,
+    time::Duration,
+};
+
+/// Tuning knobs for [`DigestKeyStore`]. All fields are in rounds (not bytes) so the operator
+/// chooses memory consumption directly.
+#[derive(Debug, Clone)]
+pub struct DigestKeyStoreConfig {
+    /// Rounds `[0, pinned_prefix_rounds)` are loaded at startup and pinned in memory. Sized
+    /// to cover the steady-state hot prefix; epoch wrap to round 0 stays instant because
+    /// these slots never get evicted.
+    pub pinned_prefix_rounds: usize,
+    /// When the consumer is past the pinned prefix, the loader keeps this many rounds behind
+    /// `cursor` resident in the sliding tier so a small backward step doesn't refault.
+    pub sliding_lookback_rounds: usize,
+    /// Loader pulls this many rounds ahead of `cursor` in the sliding tier. Tune so the
+    /// loader stays ahead of the consumer's round-consumption rate.
+    pub sliding_lookahead_rounds: usize,
+    /// Per-syscall batch size. The loader reads `read_batch_rounds * round_size_bytes` bytes
+    /// at a time into a scratch buffer, then decodes each round and publishes it.
+    pub read_batch_rounds: usize,
+}
+
+impl Default for DigestKeyStoreConfig {
+    fn default() -> Self {
+        Self {
+            pinned_prefix_rounds: 10_000,
+            sliding_lookback_rounds: 100,
+            sliding_lookahead_rounds: 100,
+            read_batch_rounds: 64,
+        }
+    }
+}
+
+/// Streaming, bounded-residency view over a `DigestKey` blob file.
+pub struct DigestKeyStore {
+    inner: Arc<Inner>,
+    _loader_join: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+struct Inner {
+    header: Arc<DigestKeyHeader>,
+    /// On-disk header. Used by the loader to compute round size and seek positions.
+    file_header_v1: HeaderV1,
+    /// Resolved round count on disk = `min(file_header.num_rounds, ...)`. Equal to
+    /// `file_header_v1.num_rounds` today; carried separately so it's clear that `header.num_rounds`
+    /// (the view trait surface) is the *resident* round count, not the on-disk count.
+    num_rounds_on_disk: usize,
+    /// Effective pinned prefix length = `min(cfg.pinned_prefix_rounds, num_rounds_on_disk)`.
+    pinned_prefix_len: usize,
+    /// Round-indexed slots for the pinned prefix. `None` until the loader publishes a slot;
+    /// a fast consumer can block on `loader_wake` waiting for one to be filled.
+    pinned: Vec<RwLock<Option<Arc<RoundData>>>>,
+    /// Sliding tier — only used for rounds `>= pinned_prefix_len`.
+    sliding: RwLock<BTreeMap<usize, Arc<RoundData>>>,
+    /// Highest round the consumer has touched. The loader uses this to compute the sliding
+    /// window target.
+    cursor: AtomicUsize,
+    /// `pinned_prefix_len` once the pinned prefix is fully loaded. Used as a fast path so
+    /// pinned readers don't grab the condvar.
+    pinned_loaded_through: AtomicUsize,
+    cfg: DigestKeyStoreConfig,
+    path: PathBuf,
+    shutdown: AtomicBool,
+    /// Notified on every publish (pinned or sliding) and on every `advance` / `shutdown`.
+    loader_wake: Condvar,
+    /// Guards the condvar wait condition only. Coarse but correct: anyone waiting on `round(r)`
+    /// holds this for the duration of the wait.
+    wait_lock: Mutex<()>,
+}
+
+impl DigestKeyStore {
+    pub fn open(path: &Path, cfg: DigestKeyStoreConfig) -> Result<Arc<Self>> {
+        let mut file = File::open(path)
+            .map_err(|e| anyhow!("DigestKeyStore: failed to open {}: {}", path.display(), e))?;
+
+        let mut header_buf = vec![0u8; Header::representation_size_bytes()];
+        file.read_exact(&mut header_buf)
+            .map_err(|e| anyhow!("DigestKeyStore: failed to read header: {}", e))?;
+        let header_v1 = match bcs::from_bytes::<Header>(&header_buf)? {
+            Header::V1(h) => h,
+        };
+
+        let expected_size_bytes = Header::representation_size_bytes()
+            + header_v1.round_size_bytes() * header_v1.num_rounds;
+        let actual = file.metadata()?.len() as usize;
+        if actual != expected_size_bytes {
+            bail!(
+                "DigestKeyStore: file size mismatch — expected {} bytes ({} rounds), got {} bytes",
+                expected_size_bytes,
+                header_v1.num_rounds,
+                actual
+            );
+        }
+
+        let num_rounds_on_disk = header_v1.num_rounds;
+        let pinned_prefix_len = cfg.pinned_prefix_rounds.min(num_rounds_on_disk);
+
+        let view_header = Arc::new(DigestKeyHeader {
+            tau_g2: header_v1.tau_g2,
+            batch_size: header_v1.batch_size,
+            num_rounds: num_rounds_on_disk,
+            fk_params: FKDomainParams {
+                toeplitz_domain: header_v1.toeplitz_domain.clone(),
+                fft_domain: header_v1.fft_domain,
+            },
+        });
+
+        let mut pinned = Vec::with_capacity(pinned_prefix_len);
+        for _ in 0..pinned_prefix_len {
+            pinned.push(RwLock::new(None));
+        }
+
+        let inner = Arc::new(Inner {
+            header: view_header,
+            file_header_v1: header_v1,
+            num_rounds_on_disk,
+            pinned_prefix_len,
+            pinned,
+            sliding: RwLock::new(BTreeMap::new()),
+            cursor: AtomicUsize::new(0),
+            pinned_loaded_through: AtomicUsize::new(0),
+            cfg,
+            path: path.to_path_buf(),
+            shutdown: AtomicBool::new(false),
+            loader_wake: Condvar::new(),
+            wait_lock: Mutex::new(()),
+        });
+
+        let inner_for_loader = Arc::clone(&inner);
+        let join = thread::Builder::new()
+            .name("digest-key-loader".into())
+            .spawn(move || loader_main(inner_for_loader))?;
+
+        Ok(Arc::new(Self {
+            inner,
+            _loader_join: Mutex::new(Some(join)),
+        }))
+    }
+
+    /// Hint to the loader that the consumer has advanced to round `r`. Auto-called by
+    /// [`DigestKeyStore::round`] too, so explicit calls are only needed when the consumer
+    /// wants to drive prefetch without actually fetching.
+    pub fn advance(&self, r: usize) {
+        let prev = self.inner.cursor.load(Ordering::Relaxed);
+        if r > prev {
+            self.inner.cursor.store(r, Ordering::Relaxed);
+            self.inner.loader_wake.notify_all();
+        }
+    }
+
+    /// Number of rounds available on disk.
+    pub fn num_rounds_on_disk(&self) -> usize {
+        self.inner.num_rounds_on_disk
+    }
+
+    /// Block until the pinned prefix is fully loaded. Used at startup so consumers don't race
+    /// the loader for the first few rounds.
+    pub fn wait_pinned_ready(&self) {
+        let target = self.inner.pinned_prefix_len;
+        if self.inner.pinned_loaded_through.load(Ordering::Acquire) >= target {
+            return;
+        }
+        let mut guard = self.inner.wait_lock.lock().unwrap();
+        while self.inner.pinned_loaded_through.load(Ordering::Acquire) < target {
+            guard = self.inner.loader_wake.wait(guard).unwrap();
+        }
+    }
+}
+
+impl Drop for DigestKeyStore {
+    fn drop(&mut self) {
+        self.inner.shutdown.store(true, Ordering::Release);
+        self.inner.loader_wake.notify_all();
+        if let Some(handle) = self._loader_join.lock().unwrap().take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl DigestKeyView for DigestKeyStore {
+    fn header(&self) -> &DigestKeyHeader {
+        &self.inner.header
+    }
+
+    fn round(&self, r: usize) -> Arc<RoundData> {
+        // Auto-advance cursor. Consumers don't have to remember to call `advance`.
+        let prev = self.inner.cursor.load(Ordering::Relaxed);
+        if r > prev {
+            self.inner.cursor.store(r, Ordering::Relaxed);
+            self.inner.loader_wake.notify_all();
+        }
+
+        if r < self.inner.pinned_prefix_len {
+            if let Some(arc) = self
+                .inner
+                .pinned
+                .get(r)
+                .and_then(|slot| slot.read().unwrap().clone())
+            {
+                return arc;
+            }
+            // Slow path: pinned slot not yet loaded.
+            let mut guard = self.inner.wait_lock.lock().unwrap();
+            loop {
+                if let Some(arc) = self.inner.pinned[r].read().unwrap().clone() {
+                    return arc;
+                }
+                guard = self.inner.loader_wake.wait(guard).unwrap();
+            }
+        }
+
+        // Sliding tier.
+        if let Some(arc) = self.inner.sliding.read().unwrap().get(&r).cloned() {
+            return arc;
+        }
+        let mut guard = self.inner.wait_lock.lock().unwrap();
+        loop {
+            if let Some(arc) = self.inner.sliding.read().unwrap().get(&r).cloned() {
+                return arc;
+            }
+            guard = self.inner.loader_wake.wait(guard).unwrap();
+        }
+    }
+}
+
+fn loader_main(inner: Arc<Inner>) {
+    let result = loader_main_inner(&inner);
+    if let Err(e) = result {
+        // We have no good way to surface this to the consumer (they're parked on
+        // `loader_wake`). Wake them so they exit their wait loops and observe missing rounds.
+        tracing::error!("DigestKeyStore loader thread failed: {}", e);
+        inner.shutdown.store(true, Ordering::Release);
+        inner.loader_wake.notify_all();
+    }
+}
+
+fn loader_main_inner(inner: &Inner) -> Result<()> {
+    let header_v1 = inner.file_header_v1.clone();
+    let round_size = header_v1.round_size_bytes();
+    let header_offset = Header::representation_size_bytes();
+    let batch_rounds = inner.cfg.read_batch_rounds.max(1);
+
+    let mut file = File::open(&inner.path)?;
+    file.seek(SeekFrom::Start(header_offset as u64))?;
+
+    let mut scratch = vec![0u8; batch_rounds * round_size];
+    let mut file_cursor_round: usize = 0;
+
+    // Phase 1: pinned prefix, strictly forward.
+    while file_cursor_round < inner.pinned_prefix_len {
+        if inner.shutdown.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let remaining_in_pinned = inner.pinned_prefix_len - file_cursor_round;
+        let this_batch = batch_rounds.min(remaining_in_pinned);
+        let bytes = this_batch * round_size;
+        file.read_exact(&mut scratch[..bytes])?;
+
+        for i in 0..this_batch {
+            let r = file_cursor_round + i;
+            let round_bytes = &scratch[i * round_size..(i + 1) * round_size];
+            let round_file = decode_round_from_slice(round_bytes, &header_v1)?;
+            let arc = Arc::new(RoundData {
+                tau_powers_g1: round_file.tau_powers_g1,
+                prepared_toeplitz_input: round_file.prepared_toeplitz_input,
+            });
+            *inner.pinned[r].write().unwrap() = Some(arc);
+            inner
+                .pinned_loaded_through
+                .store(r + 1, Ordering::Release);
+            inner.loader_wake.notify_all();
+        }
+        file_cursor_round += this_batch;
+    }
+
+    // Phase 2: sliding tier maintenance.
+    // `file_cursor_round` is the next round the file's read pointer will deliver. When the
+    // consumer's window asks for a round we haven't seen, we may need to seek backward (rare)
+    // or jump forward.
+    let lookback = inner.cfg.sliding_lookback_rounds;
+    let lookahead = inner.cfg.sliding_lookahead_rounds;
+    let num_rounds = inner.num_rounds_on_disk;
+    let pinned_len = inner.pinned_prefix_len;
+
+    loop {
+        if inner.shutdown.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let cursor = inner.cursor.load(Ordering::Acquire);
+        // Sliding tier only covers rounds >= pinned_len.
+        let window_lo = cursor.saturating_sub(lookback).max(pinned_len);
+        let window_hi_excl = (cursor + lookahead + 1).min(num_rounds);
+
+        // Evict everything outside the window.
+        {
+            let mut sliding = inner.sliding.write().unwrap();
+            // BTreeMap retain isn't stable; collect keys to drop.
+            let drop_keys: Vec<usize> = sliding
+                .range(..window_lo)
+                .chain(sliding.range(window_hi_excl..))
+                .map(|(k, _)| *k)
+                .collect();
+            for k in drop_keys {
+                sliding.remove(&k);
+            }
+        }
+
+        if window_lo >= window_hi_excl {
+            // No sliding work — consumer is still in the pinned region, or past EOF.
+            let guard = inner.wait_lock.lock().unwrap();
+            // Park, but wake periodically as a safety net in case a notify was missed.
+            let _ = inner
+                .loader_wake
+                .wait_timeout(guard, Duration::from_millis(50))
+                .unwrap();
+            continue;
+        }
+
+        // Find the next round in [window_lo, window_hi_excl) that isn't resident.
+        let next_missing = {
+            let sliding = inner.sliding.read().unwrap();
+            (window_lo..window_hi_excl).find(|r| !sliding.contains_key(r))
+        };
+
+        let Some(r) = next_missing else {
+            // Window is fully resident; park.
+            let guard = inner.wait_lock.lock().unwrap();
+            let _ = inner
+                .loader_wake
+                .wait_timeout(guard, Duration::from_millis(50))
+                .unwrap();
+            continue;
+        };
+
+        // Seek the file cursor to `r` if needed.
+        if file_cursor_round != r {
+            let offset = header_offset as u64 + (r as u64) * (round_size as u64);
+            file.seek(SeekFrom::Start(offset))?;
+            file_cursor_round = r;
+        }
+
+        // Decide how many contiguous missing rounds we can batch-read starting at `r`.
+        let max_batch_end = (r + batch_rounds).min(window_hi_excl);
+        let batch_end = {
+            let sliding = inner.sliding.read().unwrap();
+            (r..max_batch_end)
+                .take_while(|i| !sliding.contains_key(i))
+                .last()
+                .map(|last| last + 1)
+                .unwrap_or(r + 1)
+        };
+        let this_batch = batch_end - r;
+        let bytes = this_batch * round_size;
+        file.read_exact(&mut scratch[..bytes])?;
+
+        for i in 0..this_batch {
+            let round = r + i;
+            let round_bytes = &scratch[i * round_size..(i + 1) * round_size];
+            let round_file = decode_round_from_slice(round_bytes, &header_v1)?;
+            let arc = Arc::new(RoundData {
+                tau_powers_g1: round_file.tau_powers_g1,
+                prepared_toeplitz_input: round_file.prepared_toeplitz_input,
+            });
+            inner.sliding.write().unwrap().insert(round, arc);
+            inner.loader_wake.notify_all();
+        }
+        file_cursor_round += this_batch;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::{digest::DigestKey, digest_key_file::write_digest_key};
+    use ark_std::rand::thread_rng;
+    use tempfile::NamedTempFile;
+
+    fn make_setup(batch_size: usize, num_rounds: usize) -> (NamedTempFile, DigestKey) {
+        let mut rng = thread_rng();
+        let dk = DigestKey::new(&mut rng, batch_size, num_rounds).unwrap();
+        let file = NamedTempFile::new().unwrap();
+        write_digest_key(file.path(), dk.clone()).unwrap();
+        (file, dk)
+    }
+
+    #[test]
+    fn sequential_walk_matches_eager_load() {
+        let (file, dk) = make_setup(8, 12);
+        let cfg = DigestKeyStoreConfig {
+            pinned_prefix_rounds: 4,
+            sliding_lookback_rounds: 2,
+            sliding_lookahead_rounds: 2,
+            read_batch_rounds: 3,
+        };
+        let store = DigestKeyStore::open(file.path(), cfg).unwrap();
+        store.wait_pinned_ready();
+
+        assert_eq!(store.num_rounds(), dk.num_rounds());
+        assert_eq!(store.tau_g2(), dk.tau_g2());
+        for r in 0..dk.num_rounds() {
+            let from_store = store.round(r);
+            let from_dk = dk.round_data(r);
+            assert_eq!(*from_store, *from_dk, "round {} mismatch", r);
+        }
+    }
+
+    #[test]
+    fn epoch_wrap_round_zero_stays_pinned() {
+        let (file, dk) = make_setup(8, 8);
+        let cfg = DigestKeyStoreConfig {
+            pinned_prefix_rounds: 4,
+            sliding_lookback_rounds: 1,
+            sliding_lookahead_rounds: 1,
+            read_batch_rounds: 2,
+        };
+        let store = DigestKeyStore::open(file.path(), cfg).unwrap();
+        store.wait_pinned_ready();
+        // Walk into the sliding tier.
+        for r in 0..8 {
+            let _ = store.round(r);
+        }
+        // Wrap. Round 0 must still be pinned and instantly available.
+        let from_store_zero = store.round(0);
+        assert_eq!(*from_store_zero, *dk.round_data(0));
+    }
+
+    #[test]
+    fn full_file_pinned_no_sliding_work() {
+        let (file, dk) = make_setup(8, 5);
+        let cfg = DigestKeyStoreConfig {
+            pinned_prefix_rounds: 100,
+            sliding_lookback_rounds: 5,
+            sliding_lookahead_rounds: 5,
+            read_batch_rounds: 2,
+        };
+        let store = DigestKeyStore::open(file.path(), cfg).unwrap();
+        store.wait_pinned_ready();
+        for r in 0..dk.num_rounds() {
+            assert_eq!(*store.round(r), *dk.round_data(r));
+        }
+    }
+}

--- a/crates/aptos-batch-encryption/src/shared/digest_key_store.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest_key_store.rs
@@ -301,9 +301,7 @@ fn loader_main_inner(inner: &Inner) -> Result<()> {
                 prepared_toeplitz_input: round_file.prepared_toeplitz_input,
             });
             *inner.pinned[r].write().unwrap() = Some(arc);
-            inner
-                .pinned_loaded_through
-                .store(r + 1, Ordering::Release);
+            inner.pinned_loaded_through.store(r + 1, Ordering::Release);
             inner.loader_wake.notify_all();
         }
         file_cursor_round += this_batch;

--- a/crates/aptos-batch-encryption/src/shared/ids.rs
+++ b/crates/aptos-batch-encryption/src/shared/ids.rs
@@ -140,15 +140,17 @@ impl IdSet<ComputedCoeffs> {
 
     pub fn compute_all_eval_proofs_with_setup(
         &self,
-        setup: &crate::shared::digest::DigestKey,
+        setup: &dyn crate::shared::digest::DigestKeyView,
         round: usize,
     ) -> HashMap<Id, G1Affine> {
+        let round_data = setup.round(round);
         let pfs: Vec<G1Affine> = setup
-            .fk_domain
-            .eval_proofs_at_x_coords_naive_multi_point_eval(
+            .header()
+            .fk_params
+            .eval_proofs_at_x_coords_naive_multi_point_eval_with(
                 &self.poly_coeffs(),
                 &self.poly_roots,
-                round,
+                &round_data.prepared_toeplitz_input,
             )
             .iter()
             .map(|g| G1Affine::from(*g))
@@ -164,12 +166,18 @@ impl IdSet<ComputedCoeffs> {
 
     pub fn compute_all_eval_proofs_with_setup_vzgg_multi_point_eval(
         &self,
-        setup: &crate::shared::digest::DigestKey,
+        setup: &dyn crate::shared::digest::DigestKeyView,
         round: usize,
     ) -> HashMap<Id, G1Affine> {
+        let round_data = setup.round(round);
         let pfs: Vec<G1Affine> = setup
-            .fk_domain
-            .eval_proofs_at_x_coords(&self.poly_coeffs(), &self.poly_roots, round)
+            .header()
+            .fk_params
+            .eval_proofs_at_x_coords_with(
+                &self.poly_coeffs(),
+                &self.poly_roots,
+                &round_data.prepared_toeplitz_input,
+            )
             .iter()
             .map(|g| G1Affine::from(*g))
             .collect();
@@ -184,16 +192,18 @@ impl IdSet<ComputedCoeffs> {
 
     pub fn compute_eval_proofs_with_setup(
         &self,
-        setup: &crate::shared::digest::DigestKey,
+        setup: &dyn crate::shared::digest::DigestKeyView,
         ids: &[Id],
         round: usize,
     ) -> HashMap<Id, G1Affine> {
+        let round_data = setup.round(round);
         let pfs: Vec<G1Affine> = setup
-            .fk_domain
-            .eval_proofs_at_x_coords_naive_multi_point_eval(
+            .header()
+            .fk_params
+            .eval_proofs_at_x_coords_naive_multi_point_eval_with(
                 &self.poly_coeffs(),
                 &ids.iter().map(|id| id.x()).collect::<Vec<Fr>>(),
-                round,
+                &round_data.prepared_toeplitz_input,
             )
             .iter()
             .map(|g| G1Affine::from(*g))
@@ -209,7 +219,7 @@ impl IdSet<ComputedCoeffs> {
 
     pub fn compute_eval_proof_with_setup(
         &self,
-        setup: &crate::shared::digest::DigestKey,
+        setup: &dyn crate::shared::digest::DigestKeyView,
         id: Id,
         round: usize,
     ) -> G1Affine {
@@ -218,7 +228,8 @@ impl IdSet<ComputedCoeffs> {
         let mut q_coeffs = quotient(&self.poly_coeffs.mult_tree, index_of_id).coeffs;
         q_coeffs.push(Fr::zero());
 
-        G1Projective::msm(&setup.tau_powers_g1[round], &q_coeffs)
+        let round_data = setup.round(round);
+        G1Projective::msm(&round_data.tau_powers_g1, &q_coeffs)
             .unwrap()
             .into()
     }

--- a/crates/aptos-batch-encryption/src/shared/mod.rs
+++ b/crates/aptos-batch-encryption/src/shared/mod.rs
@@ -4,6 +4,7 @@ pub mod algebra;
 pub mod ciphertext;
 pub mod digest;
 pub mod digest_key_file;
+pub mod digest_key_store;
 pub mod encryption_key;
 pub mod ids;
 pub mod key_derivation;

--- a/crates/aptos-batch-encryption/src/tests/smoke/mod.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     errors::MissingEvalProofError,
+    shared::digest::DigestKey,
     traits::{BatchThresholdEncryption, DecryptionKeyShare},
 };
 use anyhow::Result;
@@ -30,7 +31,7 @@ fn associated_data() -> String {
 pub struct SmokeTest<Scheme: BatchThresholdEncryption> {
     tc: <Scheme as BatchThresholdEncryption>::ThresholdConfig,
     ek: <Scheme as BatchThresholdEncryption>::EncryptionKey,
-    dk: <Scheme as BatchThresholdEncryption>::DigestKey,
+    dk: DigestKey,
     vks: Vec<<Scheme as BatchThresholdEncryption>::VerificationKey>,
     msk_shares: Vec<<Scheme as BatchThresholdEncryption>::MasterSecretKeyShare>,
 }
@@ -58,7 +59,7 @@ impl<Scheme: BatchThresholdEncryption> SmokeTest<Scheme> {
     pub fn new(
         tc: <Scheme as BatchThresholdEncryption>::ThresholdConfig,
         ek: <Scheme as BatchThresholdEncryption>::EncryptionKey,
-        dk: <Scheme as BatchThresholdEncryption>::DigestKey,
+        dk: DigestKey,
         vks: Vec<<Scheme as BatchThresholdEncryption>::VerificationKey>,
         msk_shares: Vec<<Scheme as BatchThresholdEncryption>::MasterSecretKeyShare>,
     ) -> Self {

--- a/crates/aptos-batch-encryption/src/traits.rs
+++ b/crates/aptos-batch-encryption/src/traits.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
-use crate::errors::MissingEvalProofError;
+use crate::{errors::MissingEvalProofError, shared::digest::DigestKeyView};
 use anyhow::Result;
 use aptos_crypto::player::Player;
 use aptos_dkg::pvss::traits::TranscriptCore;
@@ -14,10 +14,6 @@ pub trait BatchThresholdEncryption {
 
     /// An encryption key for the scheme. Allows for generating ciphertexts.
     type EncryptionKey: Send + Sync;
-
-    /// A digest key for the scheme. Allows for generating digests given a list of ciphertexts.
-    /// Internally, this is a modified KZG setup.
-    type DigestKey: Send + Sync;
 
     /// A ciphertext for the scheme.
     type Ciphertext: Serialize
@@ -73,7 +69,7 @@ pub trait BatchThresholdEncryption {
     /// of ciphertexts, along with a vector of shares of type [`MasterSecretKeyShare`], which share
     /// the secret key according to the [`ThresholdConfig`] given as input. In production,
     fn setup(
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
         pvss_public_params: &<Self::SubTranscript as TranscriptCore>::PublicParameters,
         subtranscript: &Self::SubTranscript,
         threshold_config: &Self::ThresholdConfig,
@@ -86,12 +82,12 @@ pub trait BatchThresholdEncryption {
     )>;
 
     fn extract_encryption_key(
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
         subtranscript: &Self::SubTranscript,
     ) -> Result<Self::EncryptionKey>;
 
     /// Generates an (insecure) setup for the batch threshold encryption scheme. In production,
-    /// a DKG will be used to produce all parts of this setup except for [`DigestKey`], which will
+    /// a DKG will be used to produce all parts of this setup except for the digest key, which will
     /// be produced using a single-time trusted setup ceremony.
     fn setup_for_testing(
         seed: u64,
@@ -100,16 +96,16 @@ pub trait BatchThresholdEncryption {
         threshold_config: &Self::ThresholdConfig,
     ) -> Result<(
         Self::EncryptionKey,
-        Self::DigestKey,
+        crate::shared::digest::DigestKey,
         Vec<Self::VerificationKey>,
         Vec<Self::MasterSecretKeyShare>,
     )>;
 
     /// Gets the max batch size that the given digest key supports.
-    fn max_batch_size(dk: &Self::DigestKey) -> usize;
+    fn max_batch_size(dk: &dyn DigestKeyView) -> usize;
 
     /// Gets the number of rounds that the given digest key supports.
-    fn num_rounds(dk: &Self::DigestKey) -> usize;
+    fn num_rounds(dk: &dyn DigestKeyView) -> usize;
 
     /// Encrypt a plaintext with respect to any arbitrary associated data. This associated data is
     /// "bound" to the resulting CT, such that it will only verify with respect to the same
@@ -121,9 +117,9 @@ pub trait BatchThresholdEncryption {
         associated_data: &impl AssociatedData,
     ) -> Result<Self::Ciphertext>;
 
-    /// Derive a digest from a [`DigestKey`] and a slice of ciphertexts.
+    /// Derive a digest from a digest key and a slice of ciphertexts.
     fn digest(
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
         cts: &[Self::Ciphertext],
         round: u64,
     ) -> Result<(Self::Digest, Self::EvalProofsPromise)>;
@@ -140,7 +136,7 @@ pub trait BatchThresholdEncryption {
     /// Compute KZG eval proofs. This will be the most expensive operation in the scheme.
     fn eval_proofs_compute_all(
         proofs: &Self::EvalProofsPromise,
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
     ) -> Self::EvalProofs;
 
     /// Compute KZG eval proofs. This will be the most expensive operation in the scheme. This
@@ -148,7 +144,7 @@ pub trait BatchThresholdEncryption {
     /// from von zur Gathen and Gerhardt. Currently for benchmarking only, not for production use.
     fn eval_proofs_compute_all_vzgg_multi_point_eval(
         proofs: &Self::EvalProofsPromise,
-        digest_key: &Self::DigestKey,
+        digest_key: &dyn DigestKeyView,
     ) -> Self::EvalProofs;
 
     fn eval_proof_for_ct(

--- a/dkg/src/chunky/dkg_manager/mod.rs
+++ b/dkg/src/chunky/dkg_manager/mod.rs
@@ -575,7 +575,7 @@ impl ChunkyDKGManager {
             let digest_key = DIGEST_KEY
                 .as_ref()
                 .ok_or_else(|| anyhow!("DigestKey not available; cannot derive encryption key"))?;
-            let key = agg_subtrx_for_blocking.derive_encryption_key_bytes(digest_key.tau_g2)?;
+            let key = agg_subtrx_for_blocking.derive_encryption_key_bytes(digest_key.tau_g2())?;
             let bytes = bcs::to_bytes(agg_subtrx_for_blocking.as_ref())
                 .map_err(|e| anyhow!("transcript serialization error: {e}"))?;
             counters::CHUNKY_DKG_OBJECT_SIZE_BYTES

--- a/dkg/src/lib.rs
+++ b/dkg/src/lib.rs
@@ -25,8 +25,8 @@ use aptos_types::{
     chain_id::ChainId,
     dkg::chunky_dkg::{
         initialize_digest_key, initialize_public_parameters, set_digest_key_path,
-        set_public_parameters_path, DigestKeySource, PublicParametersSource, DIGEST_KEY,
-        PUBLIC_PARAMETERS,
+        set_digest_key_store_config, set_public_parameters_path, DigestKeySource,
+        DigestKeyStoreConfigOverride, PublicParametersSource, DIGEST_KEY, PUBLIC_PARAMETERS,
     },
 };
 use aptos_validator_transaction_pool::VTxnPoolState;
@@ -77,11 +77,13 @@ pub fn start_dkg_runtime(
 /// Spawns a background thread to eagerly load the key from file and record load duration.
 pub fn initialize_digest_key_with_counters(
     blob_path: Option<&PathBuf>,
+    store_config: DigestKeyStoreConfigOverride,
     chain_id: ChainId,
     is_validator: bool,
 ) {
     if let Some(path) = blob_path {
         set_digest_key_path(path.clone());
+        set_digest_key_store_config(store_config.into());
     }
     let source = initialize_digest_key(chain_id, is_validator);
     match source {

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -16,7 +16,11 @@ use crate::{
 use anyhow::Result;
 use aptos_batch_encryption::{
     group::{Fr, G2Affine, Pairing},
-    shared::{digest::DigestKey, digest_key_file, encryption_key::EncryptionKey},
+    shared::{
+        digest::{DigestKey, DigestKeyHeader, DigestKeyView, RoundData},
+        digest_key_store::{DigestKeyStore, DigestKeyStoreConfig},
+        encryption_key::EncryptionKey,
+    },
 };
 use aptos_bitvec::BitVec;
 use aptos_crypto::{bls12381, weighted_config::WeightedConfigArkworks};
@@ -187,47 +191,101 @@ pub fn initialize_public_parameters(chain_id: ChainId) -> PublicParametersSource
 /// Path to the BCS-serialized DigestKey blob file.
 static DIGEST_KEY_PATH: OnceLock<PathBuf> = OnceLock::new();
 
-/// Deferred DigestKey source — no expensive work at init time.
-#[derive(Debug)]
-enum DigestKeyOverride {
-    /// Resolve to TEST_DIGEST_KEY on first access (deferred).
+/// Streaming-store config. Set before `initialize_digest_key` if non-default values are needed.
+static DIGEST_KEY_STORE_CONFIG: OnceLock<DigestKeyStoreConfig> = OnceLock::new();
+
+/// Backing storage for the production `DigestKey`.
+///
+/// Either a streaming, bounded-residency `DigestKeyStore` (production, file-backed) or an
+/// in-memory `DigestKey` (test chains and explicit-set tests). Both implement `DigestKeyView`,
+/// so consumers see one uniform surface.
+pub enum DigestKeyHandle {
+    Store(Arc<DigestKeyStore>),
+    InMemory(Arc<DigestKey>),
+}
+
+impl DigestKeyHandle {
+    pub fn header(&self) -> &DigestKeyHeader {
+        match self {
+            DigestKeyHandle::Store(s) => DigestKeyView::header(s.as_ref()),
+            DigestKeyHandle::InMemory(k) => DigestKeyView::header(k.as_ref()),
+        }
+    }
+
+    pub fn round(&self, r: usize) -> Arc<RoundData> {
+        match self {
+            DigestKeyHandle::Store(s) => DigestKeyView::round(s.as_ref(), r),
+            DigestKeyHandle::InMemory(k) => DigestKeyView::round(k.as_ref(), r),
+        }
+    }
+
+    pub fn tau_g2(&self) -> G2Affine {
+        self.header().tau_g2
+    }
+
+    pub fn num_rounds(&self) -> usize {
+        self.header().num_rounds
+    }
+}
+
+impl DigestKeyView for DigestKeyHandle {
+    fn header(&self) -> &DigestKeyHeader {
+        DigestKeyHandle::header(self)
+    }
+
+    fn round(&self, r: usize) -> Arc<RoundData> {
+        DigestKeyHandle::round(self, r)
+    }
+}
+
+/// Deferred resolution of which backing source to use. Set by `initialize_digest_key`.
+enum DigestKeyResolution {
+    /// File-backed; lazy `DigestKeyStore::open` on first access.
+    FromFile {
+        path: PathBuf,
+        cfg: DigestKeyStoreConfig,
+    },
+    /// Test-chain validator fallback — `TEST_DIGEST_KEY` evaluated on first access.
     TestFallback,
-    /// An explicit Arc (e.g. set directly in tests).
+    /// Explicit `set_digest_key` from tests.
     Explicit(Arc<DigestKey>),
 }
 
-/// Deferred DigestKey override (for test chains).
-static DIGEST_KEY_OVERRIDE: OnceLock<DigestKeyOverride> = OnceLock::new();
+static DIGEST_KEY_RESOLUTION: OnceLock<DigestKeyResolution> = OnceLock::new();
 
-/// Production DigestKey: checks override first, then reads from file path.
-/// Returns `None` if neither was configured or if reading/deserializing fails.
-/// TEST_DIGEST_KEY is only evaluated here (on first access), not at boot.
-pub static DIGEST_KEY: Lazy<Option<Arc<DigestKey>>> = Lazy::new(|| {
-    match DIGEST_KEY_OVERRIDE.get() {
-        Some(DigestKeyOverride::TestFallback) => {
-            return Some(Arc::clone(&TEST_DIGEST_KEY));
+/// Production `DigestKey` handle. Lazily resolves on first access, opening the streaming store
+/// or installing the in-memory test key as needed.
+pub static DIGEST_KEY: Lazy<Option<Arc<DigestKeyHandle>>> = Lazy::new(|| {
+    let resolution = DIGEST_KEY_RESOLUTION.get()?;
+    match resolution {
+        DigestKeyResolution::TestFallback => Some(Arc::new(DigestKeyHandle::InMemory(Arc::clone(
+            &TEST_DIGEST_KEY,
+        )))),
+        DigestKeyResolution::Explicit(key) => {
+            Some(Arc::new(DigestKeyHandle::InMemory(Arc::clone(key))))
         },
-        Some(DigestKeyOverride::Explicit(key)) => {
-            return Some(Arc::clone(key));
+        DigestKeyResolution::FromFile { path, cfg } => {
+            let start = Instant::now();
+            match DigestKeyStore::open(path, cfg.clone()) {
+                Ok(store) => {
+                    tracing::info!(
+                        "[DigestKey] streaming store opened for {} in {:?}",
+                        path.display(),
+                        start.elapsed(),
+                    );
+                    Some(Arc::new(DigestKeyHandle::Store(store)))
+                },
+                Err(e) => {
+                    tracing::error!(
+                        "[DigestKey] failed to open streaming store for {}: {}",
+                        path.display(),
+                        e
+                    );
+                    None
+                },
+            }
         },
-        None => {},
     }
-    let path = DIGEST_KEY_PATH.get()?;
-    let start = Instant::now();
-    let key: DigestKey = match digest_key_file::read_digest_key(path) {
-        Ok(k) => k,
-        Err(e) => {
-            tracing::error!("[DigestKey] failed to read file: {}", e);
-            return None;
-        },
-    };
-    let elapsed = start.elapsed();
-    tracing::info!(
-        "[DigestKey] loaded from {} in {:?}",
-        path.display(),
-        elapsed,
-    );
-    Some(Arc::new(key))
 });
 
 /// Store the path to the DigestKey blob file. No I/O is performed.
@@ -237,10 +295,40 @@ pub fn set_digest_key_path(path: PathBuf) {
         .expect("DigestKey path already set");
 }
 
-/// Directly set the DigestKey.
+/// Override the default streaming-store tuning. Must be called before `initialize_digest_key`.
+pub fn set_digest_key_store_config(cfg: DigestKeyStoreConfig) {
+    DIGEST_KEY_STORE_CONFIG
+        .set(cfg)
+        .expect("DigestKeyStore config already set");
+}
+
+/// Mirror of [`DigestKeyStoreConfig`] suitable for `aptos-node` to pass in without a direct
+/// dependency on `aptos-batch-encryption`. The fields match `DigestKeyStoreConfig`.
+#[derive(Clone, Debug)]
+pub struct DigestKeyStoreConfigOverride {
+    pub pinned_prefix_rounds: usize,
+    pub sliding_lookback_rounds: usize,
+    pub sliding_lookahead_rounds: usize,
+    pub read_batch_rounds: usize,
+}
+
+impl From<DigestKeyStoreConfigOverride> for DigestKeyStoreConfig {
+    fn from(o: DigestKeyStoreConfigOverride) -> Self {
+        DigestKeyStoreConfig {
+            pinned_prefix_rounds: o.pinned_prefix_rounds,
+            sliding_lookback_rounds: o.sliding_lookback_rounds,
+            sliding_lookahead_rounds: o.sliding_lookahead_rounds,
+            read_batch_rounds: o.read_batch_rounds,
+        }
+    }
+}
+
+/// Directly set an in-memory DigestKey. Used by tests that need a specific test setup
+/// without going through the file path.
 pub fn set_digest_key(key: Arc<DigestKey>) {
-    DIGEST_KEY_OVERRIDE
-        .set(DigestKeyOverride::Explicit(key))
+    DIGEST_KEY_RESOLUTION
+        .set(DigestKeyResolution::Explicit(key))
+        .map_err(|_| ())
         .expect("DigestKey already set");
 }
 
@@ -262,14 +350,21 @@ pub enum DigestKeySource {
 pub fn initialize_digest_key(chain_id: ChainId, is_validator: bool) -> DigestKeySource {
     if let Some(path) = DIGEST_KEY_PATH.get() {
         match std::fs::metadata(path) {
-            Ok(meta) => DigestKeySource::WillLoadFromFile {
-                path: path.clone(),
-                file_size: meta.len(),
+            Ok(meta) => {
+                let cfg = DIGEST_KEY_STORE_CONFIG.get().cloned().unwrap_or_default();
+                let _ = DIGEST_KEY_RESOLUTION.set(DigestKeyResolution::FromFile {
+                    path: path.clone(),
+                    cfg,
+                });
+                DigestKeySource::WillLoadFromFile {
+                    path: path.clone(),
+                    file_size: meta.len(),
+                }
             },
             Err(_) => DigestKeySource::NotAvailable,
         }
     } else if chain_id == ChainId::test() && is_validator {
-        let _ = DIGEST_KEY_OVERRIDE.set(DigestKeyOverride::TestFallback);
+        let _ = DIGEST_KEY_RESOLUTION.set(DigestKeyResolution::TestFallback);
         DigestKeySource::TestKeyFallback
     } else {
         DigestKeySource::NotAvailable

--- a/types/src/secret_sharing.rs
+++ b/types/src/secret_sharing.rs
@@ -7,14 +7,15 @@
 
 use crate::{account_address::AccountAddress, validator_verifier::ValidatorVerifier};
 use aptos_batch_encryption::{
-    schemes::fptx_weighted::FPTXWeighted, traits::BatchThresholdEncryption,
+    schemes::fptx_weighted::FPTXWeighted, shared::digest::DigestKeyView,
+    traits::BatchThresholdEncryption,
 };
 use aptos_crypto::{hash::HashValue, player::Player};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
 
 pub type EncryptionKey = <FPTXWeighted as BatchThresholdEncryption>::EncryptionKey;
-pub type DigestKey = <FPTXWeighted as BatchThresholdEncryption>::DigestKey;
+pub type DigestKey = aptos_batch_encryption::shared::digest::DigestKey;
 pub type Ciphertext = <FPTXWeighted as BatchThresholdEncryption>::Ciphertext;
 pub type Id = <FPTXWeighted as BatchThresholdEncryption>::Id;
 pub type Round = u64;
@@ -143,7 +144,9 @@ impl SecretSharedKey {
 #[derive(Clone)]
 pub struct SecretShareConfig {
     validator: Arc<ValidatorVerifier>,
-    digest_key: Arc<DigestKey>,
+    /// Trait-object so this works with both the in-memory [`DigestKey`] (tests) and the
+    /// streaming `DigestKeyStore` (production).
+    digest_key: Arc<dyn DigestKeyView>,
     msk_share: MasterSecretKeyShare,
     verification_keys: Vec<VerificationKey>,
     config: <FPTXWeighted as BatchThresholdEncryption>::ThresholdConfig,
@@ -154,7 +157,7 @@ pub struct SecretShareConfig {
 impl SecretShareConfig {
     pub fn new(
         validator: Arc<ValidatorVerifier>,
-        digest_key: Arc<DigestKey>,
+        digest_key: Arc<dyn DigestKeyView>,
         msk_share: MasterSecretKeyShare,
         verification_keys: Vec<VerificationKey>,
         config: <FPTXWeighted as BatchThresholdEncryption>::ThresholdConfig,
@@ -189,11 +192,11 @@ impl SecretShareConfig {
             .ok_or_else(|| anyhow::anyhow!("Peer {} not found in validator index", peer))
     }
 
-    pub fn digest_key(&self) -> &DigestKey {
-        &self.digest_key
+    pub fn digest_key(&self) -> &dyn DigestKeyView {
+        &*self.digest_key
     }
 
-    pub fn digest_key_arc(&self) -> Arc<DigestKey> {
+    pub fn digest_key_arc(&self) -> Arc<dyn DigestKeyView> {
         Arc::clone(&self.digest_key)
     }
 


### PR DESCRIPTION
## Summary
Replace the all-in-RAM `DigestKey` trusted setup with a streaming `DigestKeyStore`:
- **Pinned prefix** of `pinned_prefix_rounds` (default 10_000) loaded at startup, never evicted — epoch wrap to round 0 stays instant.
- **Sliding window** beyond the pinned prefix maintained by a background loader thread; resident range `[cursor - lookback, cursor + lookahead]` (defaults 100/100).
- **Batched I/O**: loader reads `read_batch_rounds × round_size_bytes` per syscall (default 64 rounds), publishes each round as decoded so consumers waiting on round N unblock without the rest of the batch.
- `DigestKeyView` trait lets per-round consumers (FPTX `digest`/`eval_proofs_compute_all`, `IdSet::compute_*_eval_proofs_with_setup`) be agnostic to the backing storage.
- New consensus_config knobs: `digest_key_pinned_prefix_rounds`, `digest_key_sliding_lookback_rounds`, `digest_key_sliding_lookahead_rounds`, `digest_key_read_batch_rounds`.

## Commit layout
1. Split `DigestKey` into `DigestKeyHeader` + `RoundData`, add `DigestKeyView` trait (no behavior change).
2. New `DigestKeyStore` module with batched background loader + tests.
3. Wire the store through `chunky_dkg::DIGEST_KEY` via a `DigestKeyHandle` enum, refactor `BatchThresholdEncryption` to take `&dyn DigestKeyView`, migrate VM/consensus/DKG consumers.

## Test plan
- [x] `cargo test -p aptos-batch-encryption --lib` (45 passed, +3 new store tests)
- [x] `cargo test -p aptos-types --lib` (233 passed)
- [x] `cargo test -p aptos-consensus --lib` (416 passed)
- [x] `cargo check --workspace --tests` green
- [ ] ad-hoc forge `realistic_env_max_load_encrypted` on the failpoints image (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)