### PR TITLE
[emitter] Stop miscounting orderless txns as expired

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/metrics.rs
+++ b/crates/transaction-emitter-lib/src/emitter/metrics.rs
@@ -39,6 +39,16 @@ pub static TXN_EMITTER_EXPIRED: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter for total transactions whose final state we couldn't determine
+/// (e.g., over the per-cycle per-hash lookup budget).
+pub static TXN_EMITTER_UNRESOLVED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_txn_emitter_unresolved_total",
+        "Total number of transactions whose final state could not be determined"
+    )
+    .unwrap()
+});
+
 /// Counter for total failed transaction submissions.
 pub static TXN_EMITTER_FAILED_SUBMISSION: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
@@ -85,9 +95,10 @@ pub fn record_submission_stats(submitted: u64, failed: u64) {
 }
 
 /// Records transaction commit stats.
-pub fn record_commit_stats(committed: u64, expired: u64) {
+pub fn record_commit_stats(committed: u64, expired: u64, unresolved: u64) {
     TXN_EMITTER_COMMITTED.inc_by(committed);
     TXN_EMITTER_EXPIRED.inc_by(expired);
+    TXN_EMITTER_UNRESOLVED.inc_by(unresolved);
 }
 
 /// Records transaction latency in milliseconds for a batch of transactions.
@@ -120,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_record_commit_stats() {
-        record_commit_stats(95, 5);
+        record_commit_stats(95, 5, 0);
     }
 
     #[test]

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -1106,6 +1106,10 @@ pub struct OrderlessWaitOutcome {
     /// or the per-hash lookup itself errored. Reported separately from expired so the
     /// stat doesn't silently absorb undetected commits.
     pub unresolved: HashMap<AccountAddress, HashSet<HashValue>>,
+    /// Number of txns the per-hash fallback sweep confirmed on-chain. These are counted
+    /// as committed for TPS, but excluded from latency: the sweep runs past the
+    /// expiration deadline, so we don't have a meaningful completion time for them.
+    pub recovered: u64,
     pub sum_of_completion_timestamps_millis: u128,
 }
 
@@ -1121,6 +1125,7 @@ async fn wait_for_orderless_txns(
         return OrderlessWaitOutcome {
             expired: HashMap::new(),
             unresolved: HashMap::new(),
+            recovered: 0,
             sum_of_completion_timestamps_millis: 0,
         };
     }
@@ -1222,7 +1227,6 @@ async fn wait_for_orderless_txns(
     }
 
     classify_pending_orderless_txns(
-        start_time,
         client,
         pending_account_txns,
         fallback_lookup_cap,
@@ -1237,11 +1241,10 @@ async fn wait_for_orderless_txns(
 /// fan out unbounded API calls. Hashes beyond the cap are returned in `unresolved`
 /// rather than being silently bucketed as expired.
 async fn classify_pending_orderless_txns(
-    start_time: Instant,
     client: &RestClient,
     pending_account_txns: HashMap<AccountAddress, HashSet<HashValue>>,
     fallback_lookup_cap: usize,
-    mut sum_of_completion_timestamps_millis: u128,
+    sum_of_completion_timestamps_millis: u128,
 ) -> OrderlessWaitOutcome {
     let mut expired: HashMap<AccountAddress, HashSet<HashValue>> = HashMap::new();
     let mut unresolved: HashMap<AccountAddress, HashSet<HashValue>> = HashMap::new();
@@ -1250,6 +1253,7 @@ async fn classify_pending_orderless_txns(
         return OrderlessWaitOutcome {
             expired,
             unresolved,
+            recovered: 0,
             sum_of_completion_timestamps_millis,
         };
     }
@@ -1283,6 +1287,7 @@ async fn classify_pending_orderless_txns(
         return OrderlessWaitOutcome {
             expired,
             unresolved,
+            recovered: 0,
             sum_of_completion_timestamps_millis,
         };
     }
@@ -1292,7 +1297,6 @@ async fn classify_pending_orderless_txns(
     }))
     .await;
 
-    let millis_elapsed = start_time.elapsed().as_millis();
     let mut recovered = 0u64;
     let attempted = results.len() as u64;
     for (account, hash, result) in results {
@@ -1304,8 +1308,11 @@ async fn classify_pending_orderless_txns(
                     expired.entry(account).or_default().insert(hash);
                 } else {
                     // On-chain (success or VM failure both count as observed/committed).
+                    // Counted as committed for TPS, but deliberately not added to
+                    // sum_of_completion_timestamps_millis: this sweep runs past the
+                    // expiration deadline, so the elapsed time here is not a meaningful
+                    // commit latency. The caller excludes `recovered` from latency stats.
                     recovered += 1;
-                    sum_of_completion_timestamps_millis += millis_elapsed;
                 }
             },
             Err(RestError::Api(resp)) if resp.status_code == reqwest::StatusCode::NOT_FOUND => {
@@ -1334,6 +1341,7 @@ async fn classify_pending_orderless_txns(
     OrderlessWaitOutcome {
         expired,
         unresolved,
+        recovered,
         sum_of_completion_timestamps_millis,
     }
 }

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -1098,15 +1098,31 @@ fn pick_client(clients: &[RestClient]) -> &RestClient {
     clients.choose(&mut rand::thread_rng()).unwrap()
 }
 
+pub struct OrderlessWaitOutcome {
+    /// Hashes the summaries pass + fallback both failed to confirm as committed.
+    /// Treated as definitively not-committed (pending past deadline or server-side 404).
+    pub expired: HashMap<AccountAddress, HashSet<HashValue>>,
+    /// Hashes whose final state we couldn't determine: ran out of the fallback budget,
+    /// or the per-hash lookup itself errored. Reported separately from expired so the
+    /// stat doesn't silently absorb undetected commits.
+    pub unresolved: HashMap<AccountAddress, HashSet<HashValue>>,
+    pub sum_of_completion_timestamps_millis: u128,
+}
+
 async fn wait_for_orderless_txns(
     start_time: Instant,
     client: &RestClient,
     account_orderless_txns: &HashMap<AccountAddress, HashSet<HashValue>>,
     txn_expiration_ts_secs: u64,
     sleep_between_cycles: Duration,
-) -> (HashMap<AccountAddress, HashSet<HashValue>>, u128) {
+    fallback_lookup_cap: usize,
+) -> OrderlessWaitOutcome {
     if account_orderless_txns.is_empty() {
-        return (HashMap::new(), 0);
+        return OrderlessWaitOutcome {
+            expired: HashMap::new(),
+            unresolved: HashMap::new(),
+            sum_of_completion_timestamps_millis: 0,
+        };
     }
     let mut sum_of_completion_timestamps_millis = 0u128;
 
@@ -1204,7 +1220,122 @@ async fn wait_for_orderless_txns(
 
         time::sleep(sleep_between_cycles).await;
     }
-    (pending_account_txns, sum_of_completion_timestamps_millis)
+
+    classify_pending_orderless_txns(
+        start_time,
+        client,
+        pending_account_txns,
+        fallback_lookup_cap,
+        sum_of_completion_timestamps_millis,
+    )
+    .await
+}
+
+/// Per-hash sweep over hashes the summaries-based wait loop couldn't confirm.
+///
+/// Bounded by `fallback_lookup_cap` per worker cycle so a runaway worker cannot
+/// fan out unbounded API calls. Hashes beyond the cap are returned in `unresolved`
+/// rather than being silently bucketed as expired.
+async fn classify_pending_orderless_txns(
+    start_time: Instant,
+    client: &RestClient,
+    pending_account_txns: HashMap<AccountAddress, HashSet<HashValue>>,
+    fallback_lookup_cap: usize,
+    mut sum_of_completion_timestamps_millis: u128,
+) -> OrderlessWaitOutcome {
+    let mut expired: HashMap<AccountAddress, HashSet<HashValue>> = HashMap::new();
+    let mut unresolved: HashMap<AccountAddress, HashSet<HashValue>> = HashMap::new();
+
+    if pending_account_txns.is_empty() {
+        return OrderlessWaitOutcome {
+            expired,
+            unresolved,
+            sum_of_completion_timestamps_millis,
+        };
+    }
+
+    let total_pending: usize = pending_account_txns.values().map(|s| s.len()).sum();
+    let to_check_count = min(total_pending, fallback_lookup_cap);
+    let over_cap = total_pending.saturating_sub(fallback_lookup_cap);
+
+    // Flatten and split: first `to_check_count` go to per-hash lookup, the rest become unresolved.
+    let mut flattened: Vec<(AccountAddress, HashValue)> = pending_account_txns
+        .into_iter()
+        .flat_map(|(account, hashes)| hashes.into_iter().map(move |h| (account, h)))
+        .collect();
+    let to_classify: Vec<(AccountAddress, HashValue)> = flattened.drain(..to_check_count).collect();
+    for (account, hash) in flattened {
+        unresolved.entry(account).or_default().insert(hash);
+    }
+
+    if to_classify.is_empty() {
+        if over_cap > 0 {
+            sample!(
+                SampleRate::Duration(Duration::from_secs(15)),
+                warn!(
+                    "[{}] orderless fallback skipped: {} hashes over cap {} (unresolved)",
+                    client.path_prefix_string(),
+                    over_cap,
+                    fallback_lookup_cap,
+                )
+            );
+        }
+        return OrderlessWaitOutcome {
+            expired,
+            unresolved,
+            sum_of_completion_timestamps_millis,
+        };
+    }
+
+    let results = join_all(to_classify.into_iter().map(|(account, hash)| async move {
+        (account, hash, client.get_transaction_by_hash(hash).await)
+    }))
+    .await;
+
+    let millis_elapsed = start_time.elapsed().as_millis();
+    let mut recovered = 0u64;
+    let attempted = results.len() as u64;
+    for (account, hash, result) in results {
+        match result {
+            Ok(response) => {
+                let txn = response.into_inner();
+                if txn.is_pending() {
+                    // Still in mempool past our deadline — won't commit.
+                    expired.entry(account).or_default().insert(hash);
+                } else {
+                    // On-chain (success or VM failure both count as observed/committed).
+                    recovered += 1;
+                    sum_of_completion_timestamps_millis += millis_elapsed;
+                }
+            },
+            Err(RestError::Api(resp)) if resp.status_code == reqwest::StatusCode::NOT_FOUND => {
+                expired.entry(account).or_default().insert(hash);
+            },
+            Err(_) => {
+                unresolved.entry(account).or_default().insert(hash);
+            },
+        }
+    }
+
+    sample!(
+        SampleRate::Duration(Duration::from_secs(15)),
+        warn!(
+            "[{}] orderless fallback: attempted {}, recovered {}, expired_confirmed {}, unresolved {} (of which {} over cap {})",
+            client.path_prefix_string(),
+            attempted,
+            recovered,
+            expired.values().map(|s| s.len()).sum::<usize>(),
+            unresolved.values().map(|s| s.len()).sum::<usize>(),
+            over_cap,
+            fallback_lookup_cap,
+        )
+    );
+
+    OrderlessWaitOutcome {
+        expired,
+        unresolved,
+        sum_of_completion_timestamps_millis,
+    }
 }
 
 /// This function waits for the submitted transactions to be committed, up to

--- a/crates/transaction-emitter-lib/src/emitter/stats.rs
+++ b/crates/transaction-emitter-lib/src/emitter/stats.rs
@@ -16,6 +16,7 @@ pub struct TxnStats {
     pub submitted: u64,
     pub committed: u64,
     pub expired: u64,
+    pub unresolved: u64,
     pub failed_submission: u64,
     pub latency: u64,         // total milliseconds across all latency measurements
     pub latency_samples: u64, // number of events with latency measured
@@ -28,6 +29,7 @@ pub struct TxnStatsRate {
     pub submitted: f64,         // per second
     pub committed: f64,         // per second
     pub expired: f64,           // per second
+    pub unresolved: f64,        // per second
     pub failed_submission: f64, // per second
     pub latency: f64,           // mean latency (milliseconds)
     pub latency_samples: u64,   // number latency-measured events
@@ -41,11 +43,12 @@ impl fmt::Display for TxnStatsRate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "committed: {:.2} txn/s{}{}{}, latency: {:.2} ms, (p50: {} ms, p70: {}, p90: {} ms, p99: {} ms), latency samples: {}",
+            "committed: {:.2} txn/s{}{}{}{}, latency: {:.2} ms, (p50: {} ms, p70: {}, p90: {} ms, p99: {} ms), latency samples: {}",
             self.committed,
             if self.submitted != self.committed { format!(", submitted: {:.2} txn/s", self.submitted) } else { "".to_string()},
             if self.failed_submission != 0.0 { format!(", failed submission: {:.2} txn/s", self.failed_submission) } else { "".to_string()},
             if self.expired != 0.0 { format!(", expired: {:.2} txn/s", self.expired) } else { "".to_string()},
+            if self.unresolved != 0.0 { format!(", unresolved: {:.2} txn/s", self.unresolved) } else { "".to_string()},
             self.latency, self.p50_latency, self.p70_latency, self.p90_latency, self.p99_latency, self.latency_samples,
         )
     }
@@ -58,6 +61,7 @@ impl TxnStats {
             submitted: (self.submitted as f64) / window_secs,
             committed: (self.committed as f64) / window_secs,
             expired: (self.expired as f64) / window_secs,
+            unresolved: (self.unresolved as f64) / window_secs,
             failed_submission: (self.failed_submission as f64) / window_secs,
             latency: if self.latency_samples == 0 {
                 0.0
@@ -77,8 +81,8 @@ impl fmt::Display for TxnStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "submitted: {}, committed: {}, expired: {}, failed submission: {}",
-            self.submitted, self.committed, self.expired, self.failed_submission,
+            "submitted: {}, committed: {}, expired: {}, unresolved: {}, failed submission: {}",
+            self.submitted, self.committed, self.expired, self.unresolved, self.failed_submission,
         )
     }
 }
@@ -91,6 +95,7 @@ impl Sub for &TxnStats {
             submitted: self.submitted - other.submitted,
             committed: self.committed - other.committed,
             expired: self.expired - other.expired,
+            unresolved: self.unresolved - other.unresolved,
             failed_submission: self.failed_submission - other.failed_submission,
             latency: self.latency - other.latency,
             latency_samples: self.latency_samples - other.latency_samples,
@@ -108,6 +113,7 @@ impl Add for &TxnStats {
             submitted: self.submitted + other.submitted,
             committed: self.committed + other.committed,
             expired: self.expired + other.expired,
+            unresolved: self.unresolved + other.unresolved,
             failed_submission: self.failed_submission + other.failed_submission,
             latency: self.latency + other.latency,
             latency_samples: self.latency_samples + other.latency_samples,
@@ -122,6 +128,7 @@ pub struct StatsAccumulator {
     pub submitted: AtomicU64,
     pub committed: AtomicU64,
     pub expired: AtomicU64,
+    pub unresolved: AtomicU64,
     pub failed_submission: AtomicU64,
     pub latency: AtomicU64, // total milliseconds across all latency measurements
     pub latency_samples: AtomicU64, // number of events with latency measured
@@ -134,6 +141,7 @@ impl StatsAccumulator {
             submitted: self.submitted.load(Ordering::Relaxed),
             committed: self.committed.load(Ordering::Relaxed),
             expired: self.expired.load(Ordering::Relaxed),
+            unresolved: self.unresolved.load(Ordering::Relaxed),
             failed_submission: self.failed_submission.load(Ordering::Relaxed),
             latency: self.latency.load(Ordering::Relaxed),
             latency_samples: self.latency_samples.load(Ordering::Relaxed),
@@ -400,6 +408,7 @@ mod test {
             submitted: 0,
             committed: 10,
             expired: 0,
+            unresolved: 0,
             failed_submission: 0,
             latency: 0,
             latency_samples: 0,

--- a/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
+++ b/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
@@ -389,22 +389,31 @@ impl SubmissionWorker {
                 .fetch_add(num_committed as u64, Ordering::Relaxed);
 
             if !skip_latency_stats {
-                let sum_latency = sum_of_completion_timestamps_millis_seq_nums
-                    .saturating_add(orderless_outcome.sum_of_completion_timestamps_millis)
-                    .saturating_sub(avg_txn_offset_time as u128 * num_committed as u128);
-                let avg_latency = (sum_latency / num_committed as u128) as u64;
-                loop_stats
-                    .latency
-                    .fetch_add(sum_latency as u64, Ordering::Relaxed);
-                loop_stats
-                    .latency_samples
-                    .fetch_add(num_committed as u64, Ordering::Relaxed);
-                loop_stats
-                    .latencies
-                    .record_data_point(avg_latency, num_committed as u64);
+                // Fallback-recovered orderless txns are counted as committed for TPS, but
+                // we have no meaningful commit time for them (the per-hash sweep runs past
+                // the expiration deadline). Exclude them from latency so they don't corrupt
+                // the cycle average / percentiles. `latency_count` therefore matches exactly
+                // the txns that contributed a completion timestamp to the sums above.
+                let latency_count =
+                    num_committed.saturating_sub(orderless_outcome.recovered as usize);
+                if latency_count > 0 {
+                    let sum_latency = sum_of_completion_timestamps_millis_seq_nums
+                        .saturating_add(orderless_outcome.sum_of_completion_timestamps_millis)
+                        .saturating_sub(avg_txn_offset_time as u128 * latency_count as u128);
+                    let avg_latency = (sum_latency / latency_count as u128) as u64;
+                    loop_stats
+                        .latency
+                        .fetch_add(sum_latency as u64, Ordering::Relaxed);
+                    loop_stats
+                        .latency_samples
+                        .fetch_add(latency_count as u64, Ordering::Relaxed);
+                    loop_stats
+                        .latencies
+                        .record_data_point(avg_latency, latency_count as u64);
 
-                // Record Prometheus latency metric (once per committed txn for accurate percentiles)
-                record_latency_ms(avg_latency, num_committed as u64);
+                    // Record Prometheus latency metric (once per committed txn for accurate percentiles)
+                    record_latency_ms(avg_latency, latency_count as u64);
+                }
             }
         }
     }

--- a/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
+++ b/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
@@ -301,9 +301,15 @@ impl SubmissionWorker {
         check_account_sleep_duration: Duration,
         loop_stats: &StatsAccumulator,
     ) {
+        // Per worker-cycle cap for the orderless per-hash fallback sweep. Sized so a
+        // normal cycle's pending tail can fully recover, but a runaway cycle cannot
+        // fan out unbounded API calls. Hashes beyond the cap become `unresolved`.
+        let orderless_fallback_cap =
+            max(self.params.transactions_per_account.saturating_mul(4), 64);
+
         let (
             (latest_fetched_counts, sum_of_completion_timestamps_millis_seq_nums),
-            (failed_orderless_txns, sum_of_completion_timestamps_millis_orderless),
+            orderless_outcome,
         ) = join!(
             wait_for_accounts_sequence(
                 start_time,
@@ -318,6 +324,7 @@ impl SubmissionWorker {
                 &account_to_orderless_txns,
                 txn_expiration_ts_secs,
                 check_account_sleep_duration,
+                orderless_fallback_cap,
             )
         );
 
@@ -328,15 +335,20 @@ impl SubmissionWorker {
                 &latest_fetched_counts,
             );
         }
-        let (num_committed, num_expired) = count_committed_expired_stats(
+        let (num_committed, num_expired, num_unresolved) = count_stats(
             account_to_start_and_end_seq_num,
             latest_fetched_counts,
             account_to_orderless_txns,
-            failed_orderless_txns,
+            &orderless_outcome.expired,
+            &orderless_outcome.unresolved,
         );
 
         // Record Prometheus metrics for commit stats
-        record_commit_stats(num_committed as u64, num_expired as u64);
+        record_commit_stats(
+            num_committed as u64,
+            num_expired as u64,
+            num_unresolved as u64,
+        );
 
         if num_expired > 0 {
             loop_stats
@@ -356,6 +368,21 @@ impl SubmissionWorker {
             );
         }
 
+        if num_unresolved > 0 {
+            loop_stats
+                .unresolved
+                .fetch_add(num_unresolved as u64, Ordering::Relaxed);
+            sample!(
+                SampleRate::Duration(Duration::from_secs(60)),
+                warn!(
+                    "[{:?}] {} orderless transactions left unresolved (fallback budget {} per cycle)",
+                    self.client().path_prefix_string(),
+                    num_unresolved,
+                    orderless_fallback_cap,
+                )
+            );
+        }
+
         if num_committed > 0 {
             loop_stats
                 .committed
@@ -363,7 +390,7 @@ impl SubmissionWorker {
 
             if !skip_latency_stats {
                 let sum_latency = sum_of_completion_timestamps_millis_seq_nums
-                    .saturating_add(sum_of_completion_timestamps_millis_orderless)
+                    .saturating_add(orderless_outcome.sum_of_completion_timestamps_millis)
                     .saturating_sub(avg_txn_offset_time as u128 * num_committed as u128);
                 let avg_latency = (sum_latency / num_committed as u128) as u64;
                 loop_stats
@@ -443,13 +470,21 @@ fn update_account_seq_num(
     }
 }
 
-fn count_committed_expired_stats(
+/// Returns (committed, expired, unresolved).
+///
+/// Sequence-number txns only produce committed/expired — the on-chain sequence number
+/// is authoritative, so any txn not committed by the wait-loop's expiration is
+/// definitively expired. Orderless txns can additionally land in `unresolved` when
+/// the per-hash fallback sweep couldn't determine their state (over cap, or lookup
+/// errored).
+fn count_stats(
     account_to_start_and_end_seq_num: HashMap<AccountAddress, (u64, u64)>,
     latest_fetched_counts: HashMap<AccountAddress, u64>,
     account_to_orderless_txns: HashMap<AccountAddress, HashSet<HashValue>>,
-    failed_orderless_txns: HashMap<AccountAddress, HashSet<HashValue>>,
-) -> (usize, usize) {
-    let (seq_num_committed, seq_num_failed) = account_to_start_and_end_seq_num
+    expired_orderless_txns: &HashMap<AccountAddress, HashSet<HashValue>>,
+    unresolved_orderless_txns: &HashMap<AccountAddress, HashSet<HashValue>>,
+) -> (usize, usize, usize) {
+    let (seq_num_committed, seq_num_expired) = account_to_start_and_end_seq_num
         .iter()
         .map(
             |(address, (start_seq_num, end_seq_num))| match latest_fetched_counts.get(address) {
@@ -480,16 +515,23 @@ fn count_committed_expired_stats(
                 (committed + cur_committed, expired + cur_expired)
             },
         );
-    let total_orderless_txns: usize = account_to_orderless_txns
+
+    let total_orderless: usize = account_to_orderless_txns
         .values()
         .map(|txns| txns.len())
         .sum();
-    let failed_orderless_txns: usize = failed_orderless_txns.values().map(|txns| txns.len()).sum();
-    let committed_orderless_txns = total_orderless_txns - failed_orderless_txns;
+    let expired_orderless: usize = expired_orderless_txns.values().map(|txns| txns.len()).sum();
+    let unresolved_orderless: usize = unresolved_orderless_txns
+        .values()
+        .map(|txns| txns.len())
+        .sum();
+    let committed_orderless =
+        total_orderless.saturating_sub(expired_orderless + unresolved_orderless);
 
     (
-        seq_num_committed + committed_orderless_txns,
-        seq_num_failed + failed_orderless_txns,
+        seq_num_committed + committed_orderless,
+        seq_num_expired + expired_orderless,
+        unresolved_orderless,
     )
 }
 


### PR DESCRIPTION
## Summary

The orderless wait loop polls `get_account_transaction_summaries`, which returns the latest 100 txns for an account in newest-first order. Under healthy load, recent commits get paginated past that window before our next poll lands, so we never match the hash and bucket the txn as expired — even though it committed in ~700ms. Result: low real latency but reported expiry rates approaching the submission rate.

Observed in the wild:

```
[10s stat] phase 0: committed: 102.58 txn/s, submitted: 799.87 txn/s,
expired: 697.28 txn/s, latency: 771.07 ms,
(p50: 700 ms, p70: 700, p90: 700 ms, p99: 700 ms), latency samples: 99
```

`submitted ≈ committed + expired` exactly, with every committed-txn latency percentile at 700ms — the system isn't actually expiring 87% of submissions in 700ms (default txn expiration is 60s); the stat is wrong.

## Fix

After the summaries-based wait loop gives up, sweep the remaining hashes with `get_transaction_by_hash`. The sweep is bounded per worker cycle (`max(txns_per_account * 4, 64)`) so a stuck cycle cannot fan out unbounded API calls. Classification:

- `Ok(non-pending)` → recovered as **committed**
- `Ok(pending)` (past deadline) → **expired**
- `Err(404)` → **expired**
- `Err(_)` (network/other) → **unresolved**
- Over-cap hashes (never queried) → **unresolved**

New `unresolved` bucket added to `TxnStats` / `TxnStatsRate` / `StatsAccumulator` and threaded through `Add`/`Sub`/`Display`. Mirrors `committed`/`expired`/`failed_submission`; only prints when nonzero. New Prometheus counter `aptos_txn_emitter_unresolved_total`. Sampled warn log fires per worker cycle that uses the fallback so you can see attempted/recovered/expired_confirmed/over_cap in the worker output.

After this PR, `submitted = committed + expired + unresolved + failed_submission` is an invariant — undetected commits no longer silently inflate `expired`.

## Test plan

- [ ] `cargo test -p aptos-transaction-emitter-lib --lib` passes locally
- [ ] `cargo +nightly fmt --check` clean (lint script ran clean apart from the trailing \`git diff\` check before committing)
- [ ] Forge: run a realistic_500tps job with orderless workload and confirm \`expired\` rate drops to near zero, \`committed\` matches the submission rate, and \`unresolved\` is the visible signal if pagination keeps biting