### PR TITLE
reject negative deposit amount in rosetta extract_transfer

### DIFF
--- a/crates/aptos-rosetta/src/test/mod.rs
+++ b/crates/aptos-rosetta/src/test/mod.rs
@@ -4,9 +4,9 @@
 use crate::{
     common::native_coin,
     types::{
-        AccountIdentifier, Currency, CurrencyMetadata, OperationType, Transaction,
-        FUNGIBLE_ASSET_MODULE, FUNGIBLE_STORE_RESOURCE, OBJECT_CORE_RESOURCE, OBJECT_MODULE,
-        OBJECT_RESOURCE_GROUP,
+        AccountIdentifier, Amount, Currency, CurrencyMetadata, Operation, OperationType,
+        Transaction, Transfer, FUNGIBLE_ASSET_MODULE, FUNGIBLE_STORE_RESOURCE,
+        OBJECT_CORE_RESOURCE, OBJECT_MODULE, OBJECT_RESOURCE_GROUP,
     },
     RosettaContext,
 };
@@ -52,6 +52,61 @@ async fn test_rosetta_context() -> RosettaContext {
     currencies.insert(OTHER_CURRENCY.clone());
 
     RosettaContext::new(None, ChainId::test(), None, currencies).await
+}
+
+#[tokio::test]
+async fn test_extract_transfer_rejects_sign_confused_amounts() {
+    let context = test_rosetta_context().await;
+    let sender = AccountAddress::random();
+    let receiver = AccountAddress::random();
+
+    let mut ops = vec![
+        Operation::withdraw(
+            0,
+            None,
+            AccountIdentifier::base_account(sender),
+            native_coin(),
+            1,
+        ),
+        Operation::deposit(
+            1,
+            None,
+            AccountIdentifier::base_account(receiver),
+            native_coin(),
+            1,
+        ),
+    ];
+
+    // A well-formed transfer of 1 unit is accepted with the right amount.
+    let transfer = Transfer::extract_transfer(&context, &ops).expect("valid transfer");
+    assert_eq!(transfer.amount.0, 1);
+
+    // Flip the signs: withdraw "1", deposit "-1". -(1) == -1 satisfies the
+    // negation check and -1 <= u64::MAX, but casting -1 to u64 wraps to
+    // u64::MAX. This must be rejected, not silently turned into a huge amount.
+    ops[0].amount = Some(Amount {
+        value: "1".to_string(),
+        currency: native_coin(),
+    });
+    ops[1].amount = Some(Amount {
+        value: "-1".to_string(),
+        currency: native_coin(),
+    });
+    assert!(
+        Transfer::extract_transfer(&context, &ops).is_err(),
+        "transfer with a negative deposit amount must be rejected"
+    );
+
+    // An i128::MIN withdraw must not panic or wrap while negating.
+    ops[0].amount = Some(Amount {
+        value: i128::MIN.to_string(),
+        currency: native_coin(),
+    });
+    ops[1].amount = Some(Amount {
+        value: "1".to_string(),
+        currency: native_coin(),
+    });
+    assert!(Transfer::extract_transfer(&context, &ops).is_err());
 }
 
 fn primary_store_address(owner: AccountAddress, metadata: AccountAddress) -> AccountAddress {

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -2934,16 +2934,18 @@ impl Transfer {
         let deposit_value = i128::from_str(&deposit_amount.value)
             .map_err(|_| ApiError::InvalidTransferOperations(Some("Deposit amount is invalid")))?;
 
-        // We can't create or destroy coins, they must be negatives of each other
-        if -withdraw_value != deposit_value {
+        // We can't create or destroy coins, they must be negatives of each other.
+        // checked_neg guards against i128::MIN, whose negation does not fit in i128.
+        if withdraw_value.checked_neg() != Some(deposit_value) {
             return Err(ApiError::InvalidTransferOperations(Some(
                 "Withdraw amount must be equal to negative of deposit amount",
             )));
         }
 
-        // We converted to u128 to ensure no loss of precision in comparison,
-        // but now we actually have to check it's a u64
-        if deposit_value > u64::MAX as i128 {
+        // The deposit is the transfer amount. It must be a non-negative value that
+        // fits in a u64 before narrowing, otherwise the cast below would wrap (e.g.
+        // a deposit of -1 would become u64::MAX).
+        if deposit_value < 0 || deposit_value > u64::MAX as i128 {
             return Err(ApiError::InvalidTransferOperations(Some(
                 "Transfer amount must not be greater than u64 max",
             )));


### PR DESCRIPTION
## Description

`Transfer::extract_transfer` (the `/construction` parser that turns a withdraw+deposit operation pair into a coin transfer) reads both amounts from the request as `i128`, requires them to be negatives of each other, and rejects a deposit greater than `u64::MAX` before casting the deposit to `u64`. It never rejects a negative deposit. A request with withdraw `"1"` and deposit `"-1"` passes `-withdraw_value == deposit_value` and `-1 <= u64::MAX`, so `deposit_value as u64` wraps `-1` to `u64::MAX` and a transfer of `u64::MAX` is constructed instead of the request being rejected. The `-withdraw_value` negation also overflows for an `i128::MIN` withdraw value.

The fix rejects a negative deposit before the narrowing cast and uses `checked_neg` for the negation.

## How Has This Been Tested?

Added `test_extract_transfer_rejects_sign_confused_amounts` in `crates/aptos-rosetta/src/test/mod.rs`. It checks a well-formed 1-unit transfer still parses to amount 1, that withdraw `"1"` / deposit `"-1"` is now rejected (the old code returned `Ok` with amount `u64::MAX`), and that an `i128::MIN` withdraw is rejected without panicking. The test fails on the current code and passes with this change.

## Key Areas to Review

The sign convention: the deposit is the positive side and is what becomes the `u64` amount, so the non-negative bound belongs on `deposit_value`. Staking operation amounts arrive via the `U64` wrapper and already reject negatives, so they are unaffected.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Full Node (API, Indexer, etc.)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Rosetta `/construction` transfer parsing and blocks previously accepted malicious amounts that could have built enormous on-chain transfers.
> 
> **Overview**
> Fixes a **Rosetta construction** bug in `Transfer::extract_transfer` where malformed withdraw/deposit pairs could be accepted and turned into a **max `u64` transfer**.
> 
> Withdraw/deposit amounts must still be exact negatives, but the check now uses **`checked_neg`** so an `i128::MIN` withdraw cannot overflow when negated. Before casting the deposit to `u64`, the parser now **requires a non-negative deposit** that fits in `u64`, so pairs like withdraw `"1"` / deposit `"-1"` are rejected instead of wrapping to `u64::MAX`.
> 
> Adds **`test_extract_transfer_rejects_sign_confused_amounts`** to lock in valid 1-unit parsing and both rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e05c4c12d3c5e4bdca9fae94581d7e4707cbfb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->