### PR TITLE
[API] Small tweaks and improvements.

### DIFF
--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -119,6 +119,9 @@ impl EventsApi {
         /// If unspecified, defaults to default page size
         limit: Query<Option<u16>>,
     ) -> BasicResultWith404<Vec<VersionedEvent>> {
+        fail_point_poem("endpoint_get_events_by_event_handle")?;
+        self.context
+            .check_api_output_enabled("Get events by event handle", &accept_type)?;
         event_handle
             .0
             .verify(0)
@@ -131,9 +134,6 @@ impl EventsApi {
             .map_err(|err| {
                 BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
             })?;
-        fail_point_poem("endpoint_get_events_by_event_handle")?;
-        self.context
-            .check_api_output_enabled("Get events by event handle", &accept_type)?;
         let page = Page::new(
             start.0.map(|v| v.0),
             limit.0,

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -60,6 +60,9 @@ impl StateApi {
         /// If not provided, it will be the latest version
         ledger_version: Query<Option<U64>>,
     ) -> BasicResultWith404<MoveResource> {
+        fail_point_poem("endpoint_get_account_resource")?;
+        self.context
+            .check_api_output_enabled("Get account resource", &accept_type)?;
         resource_type
             .0
             .verify(0)
@@ -67,9 +70,6 @@ impl StateApi {
             .map_err(|err| {
                 BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
             })?;
-        fail_point_poem("endpoint_get_account_resource")?;
-        self.context
-            .check_api_output_enabled("Get account resource", &accept_type)?;
 
         let api = self.clone();
         api_spawn_blocking(move || {
@@ -153,6 +153,9 @@ impl StateApi {
         /// If not provided, it will be the latest version
         ledger_version: Query<Option<U64>>,
     ) -> BasicResultWith404<MoveValue> {
+        fail_point_poem("endpoint_get_table_item")?;
+        self.context
+            .check_api_output_enabled("Get table item", &accept_type)?;
         table_item_request
             .0
             .verify()
@@ -160,9 +163,6 @@ impl StateApi {
             .map_err(|err| {
                 BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
             })?;
-        fail_point_poem("endpoint_get_table_item")?;
-        self.context
-            .check_api_output_enabled("Get table item", &accept_type)?;
         let api = self.clone();
         api_spawn_blocking(move || {
             api.table_item(

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -647,6 +647,66 @@ async fn test_post_batch_entry_function_api_validation(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_post_json_batch_transactions_too_many() {
+    // Create a node config with max batch size of 1
+    let mut node_config = NodeConfig::default();
+    node_config.api.max_submit_transaction_batch_size = 1;
+
+    // Create a test context with test transactions
+    let mut context =
+        new_test_context_with_config(current_function_name!(), node_config, false, false);
+    let account_1 = context.gen_account();
+    let account_2 = context.gen_account();
+    let transaction_1 = context.create_user_account(&account_1).await;
+    let transaction_2 = context.create_user_account(&account_2).await;
+
+    // Submit the batch request with 2 transactions and expect a 400 response
+    let transaction_request_1 =
+        serde_json::to_value(build_submit_transaction_request(&context, &transaction_1)).unwrap();
+    let transaction_request_2 =
+        serde_json::to_value(build_submit_transaction_request(&context, &transaction_2)).unwrap();
+    let response = context
+        .expect_status_code(400)
+        .post(
+            "/transactions/batch",
+            json!([transaction_request_1, transaction_request_2]),
+        )
+        .await;
+
+    // Verify the error message
+    let response_message = response["message"].as_str().unwrap();
+    assert!(response_message.contains("Submitted too many transactions: 2, while limit is 1"),);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_post_bcs_batch_transactions_too_many() {
+    // Create a node config with max batch size of 2
+    let mut node_config = NodeConfig::default();
+    node_config.api.max_submit_transaction_batch_size = 2;
+
+    // Create a test context with test transactions
+    let mut context =
+        new_test_context_with_config(current_function_name!(), node_config, false, false);
+    let account_1 = context.gen_account();
+    let account_2 = context.gen_account();
+    let account_3 = context.gen_account();
+    let transaction_1 = context.create_user_account(&account_1).await;
+    let transaction_2 = context.create_user_account(&account_2).await;
+    let transaction_3 = context.create_user_account(&account_3).await;
+
+    // Submit the batch request with 3 transactions and expect a 400 response
+    let body = bcs::to_bytes(&vec![transaction_1, transaction_2, transaction_3]).unwrap();
+    let response = context
+        .expect_status_code(400)
+        .post_bcs_txn("/transactions/batch", body)
+        .await;
+
+    // Verify the error message
+    let response_message = response["message"].as_str().unwrap();
+    assert!(response_message.contains("Submitted too many transactions: 3, while limit is 2"),);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[rstest(
     use_txn_payload_v2_format,
     use_orderless_transactions,

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -478,6 +478,12 @@ impl TransactionsApi {
         accept_type: AcceptType,
         data: SubmitTransactionPost,
     ) -> SubmitTransactionResult<PendingTransaction> {
+        fail_point_poem("endpoint_submit_transaction")?;
+        if !self.context.node_config.api.transaction_submission_enabled {
+            return Err(api_disabled("Submit transaction"));
+        }
+        self.context
+            .check_api_output_enabled("Submit transaction", &accept_type)?;
         data.verify()
             .context("Submitted transaction invalid'")
             .map_err(|err| {
@@ -486,12 +492,6 @@ impl TransactionsApi {
                     AptosErrorCode::InvalidInput,
                 )
             })?;
-        fail_point_poem("endpoint_submit_transaction")?;
-        if !self.context.node_config.api.transaction_submission_enabled {
-            return Err(api_disabled("Submit transaction"));
-        }
-        self.context
-            .check_api_output_enabled("Submit transaction", &accept_type)?;
         let ledger_info = self.context.get_latest_ledger_info()?;
         let signed_transaction = self.get_signed_transaction(&ledger_info, data)?;
         self.create(&accept_type, &ledger_info, signed_transaction)
@@ -531,6 +531,13 @@ impl TransactionsApi {
         accept_type: AcceptType,
         data: SubmitTransactionsBatchPost,
     ) -> SubmitTransactionsBatchResult<TransactionsBatchSubmissionResult> {
+        fail_point_poem("endpoint_submit_batch_transactions")?;
+        if !self.context.node_config.api.transaction_submission_enabled {
+            return Err(api_disabled("Submit batch transaction"));
+        }
+        self.context
+            .check_api_output_enabled("Submit batch transactions", &accept_type)?;
+
         // Verify that the batch is not too large (for JSON requests)
         let max_transaction_batch_size = self.context.max_submit_transaction_batch_size();
         if let SubmitTransactionsBatchPost::Json(batch_submission_request) = &data {
@@ -555,12 +562,6 @@ impl TransactionsApi {
                     AptosErrorCode::InvalidInput,
                 )
             })?;
-        fail_point_poem("endpoint_submit_batch_transactions")?;
-        if !self.context.node_config.api.transaction_submission_enabled {
-            return Err(api_disabled("Submit batch transaction"));
-        }
-        self.context
-            .check_api_output_enabled("Submit batch transactions", &accept_type)?;
 
         // Verify that the batch is not too large (for BCS requests). We have to do this after
         // parsing, since we don't know how many transactions there are until we parse it.
@@ -615,6 +616,12 @@ impl TransactionsApi {
         estimate_prioritized_gas_unit_price: Query<Option<bool>>,
         data: SubmitTransactionPost,
     ) -> SimulateTransactionResult<Vec<UserTransaction>> {
+        fail_point_poem("endpoint_simulate_transaction")?;
+        if !self.context.node_config.api.transaction_simulation_enabled {
+            return Err(api_disabled("Simulate transaction"));
+        }
+        self.context
+            .check_api_output_enabled("Simulate transaction", &accept_type)?;
         data.verify()
             .context("Simulated transaction invalid")
             .map_err(|err| {
@@ -623,12 +630,6 @@ impl TransactionsApi {
                     AptosErrorCode::InvalidInput,
                 )
             })?;
-        fail_point_poem("endpoint_simulate_transaction")?;
-        if !self.context.node_config.api.transaction_simulation_enabled {
-            return Err(api_disabled("Simulate transaction"));
-        }
-        self.context
-            .check_api_output_enabled("Simulate transaction", &accept_type)?;
 
         let api = self.clone();
         let context = self.context.clone();
@@ -780,12 +781,6 @@ impl TransactionsApi {
         data: Json<EncodeSubmissionRequest>,
         // TODO: Use a new request type that can't return 507 but still returns all the other necessary errors.
     ) -> BasicResult<HexEncodedBytes> {
-        data.0
-            .verify()
-            .context("'UserTransactionRequest' invalid")
-            .map_err(|err| {
-                BasicError::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
-            })?;
         fail_point_poem("endpoint_encode_submission")?;
         if !self.context.node_config.api.encode_submission_enabled {
             return Err(api_forbidden(
@@ -795,6 +790,12 @@ impl TransactionsApi {
         }
         self.context
             .check_api_output_enabled("Encode submission", &accept_type)?;
+        data.0
+            .verify()
+            .context("'UserTransactionRequest' invalid")
+            .map_err(|err| {
+                BasicError::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
+            })?;
         let api = self.clone();
         api_spawn_blocking(move || api.get_signing_message(&accept_type, data.0)).await
     }

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -531,6 +531,22 @@ impl TransactionsApi {
         accept_type: AcceptType,
         data: SubmitTransactionsBatchPost,
     ) -> SubmitTransactionsBatchResult<TransactionsBatchSubmissionResult> {
+        // Verify that the batch is not too large (for JSON requests)
+        let max_transaction_batch_size = self.context.max_submit_transaction_batch_size();
+        if let SubmitTransactionsBatchPost::Json(batch_submission_request) = &data {
+            let num_submitted_transactions = batch_submission_request.0.len();
+            if num_submitted_transactions > max_transaction_batch_size {
+                return Err(SubmitTransactionError::bad_request_with_code_no_info(
+                    anyhow::anyhow!(
+                        "Submitted too many transactions: {}, while limit is {}",
+                        num_submitted_transactions,
+                        max_transaction_batch_size,
+                    ),
+                    AptosErrorCode::InvalidInput,
+                ));
+            }
+        }
+
         data.verify()
             .context("Submitted transactions invalid")
             .map_err(|err| {
@@ -545,9 +561,12 @@ impl TransactionsApi {
         }
         self.context
             .check_api_output_enabled("Submit batch transactions", &accept_type)?;
+
+        // Verify that the batch is not too large (for BCS requests). We have to do this after
+        // parsing, since we don't know how many transactions there are until we parse it.
         let ledger_info = self.context.get_latest_ledger_info()?;
         let signed_transactions_batch = self.get_signed_transactions_batch(&ledger_info, data)?;
-        if self.context.max_submit_transaction_batch_size() < signed_transactions_batch.len() {
+        if max_transaction_batch_size < signed_transactions_batch.len() {
             return Err(SubmitTransactionError::bad_request_with_code(
                 format!(
                     "Submitted too many transactions: {}, while limit is {}",
@@ -558,6 +577,7 @@ impl TransactionsApi {
                 &ledger_info,
             ));
         }
+
         self.create_batch(&accept_type, &ledger_info, signed_transactions_batch)
             .await
     }


### PR DESCRIPTION
## Description
This PR offers two small tweaks/improvements to the REST API:
1. Check JSON batch submission lengths before verifying contents (and add tests for JSON and BCS).
2. Ensure all API endpoints check API accessibility before doing any work.

## Testing Plan
New and existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral reordering and earlier batch-size rejection; no new submission paths, mainly fail-fast when the API is disabled or batches are oversized.
> 
> **Overview**
> REST handlers now run **fail points**, **feature/disabled checks**, and **`check_api_output_enabled`** before parsing or validating request bodies on several routes (events, state, submit/simulate/encode transaction).
> 
> **Batch submit** rejects JSON batches that exceed `max_submit_transaction_batch_size` by array length **before** per-transaction `verify()`; BCS still enforces the limit after decode. New tests cover JSON and BCS “too many transactions” **400** responses with the expected message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f790a035b0b8683329e41885e4a159d655d93b26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->