### PR TITLE
[Consensus Observer] Add ignored message metrics.

### DIFF
--- a/consensus/src/consensus_observer/common/metrics.rs
+++ b/consensus/src/consensus_observer/common/metrics.rs
@@ -46,6 +46,16 @@ pub static OBSERVER_CLEARED_BLOCK_STATE: Lazy<IntCounter> = Lazy::new(|| {
     ).unwrap()
 });
 
+/// Counter for tracking ignored (direct send) messages by the consensus observer
+pub static OBSERVER_IGNORED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_observer_ignored_messages",
+        "Counters related to ignored (direct send) messages by the consensus observer",
+        &["message_type", "network_id"]
+    )
+    .unwrap()
+});
+
 /// Counter for tracking dropped (direct send) messages by the consensus observer
 pub static OBSERVER_DROPPED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -529,6 +529,7 @@ impl ConsensusObserver {
                         commit_decision.proof_block_info()
                     ))
                 );
+                increment_ignored_message_counter(&peer_network_id, metrics::COMMIT_DECISION_LABEL);
                 return;
             }
 
@@ -779,6 +780,7 @@ impl ConsensusObserver {
                     ordered_block.proof_block_info()
                 ))
             );
+            increment_ignored_message_counter(&peer_network_id, metrics::ORDERED_BLOCK_LABEL);
             return;
         };
 
@@ -828,6 +830,7 @@ impl ConsensusObserver {
                     ordered_block.proof_block_info()
                 ))
             );
+            increment_ignored_message_counter(&peer_network_id, metrics::ORDERED_BLOCK_LABEL);
         }
     }
 
@@ -1380,6 +1383,15 @@ fn update_metrics_for_ordered_block_with_window_message(
         &metrics::OBSERVER_RECEIVED_MESSAGE_ROUNDS,
         metrics::ORDERED_BLOCK_WITH_WINDOW_LABEL,
         ordered_block.proof_block_info().round(),
+    );
+}
+
+/// Increments the ignored message counter for the given peer and message
+fn increment_ignored_message_counter(peer_network_id: &PeerNetworkId, message_label: &str) {
+    metrics::increment_counter(
+        &metrics::OBSERVER_IGNORED_MESSAGES,
+        message_label,
+        peer_network_id,
     );
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metrics-only changes with no alteration to message handling logic.
> 
> **Overview**
> Adds **`consensus_observer_ignored_messages`** (`message_type`, `network_id`) to count direct-send messages the observer accepts but deliberately does not act on—separate from existing **dropped**, **invalid**, and **rejected** counters.
> 
> Instrumentation is wired via **`increment_ignored_message_counter`** when a **commit decision** is skipped because state sync is already waiting on an epoch transition, and when **ordered blocks** are skipped for wrong epoch or a missing parent block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe4e1e98033a5c9544ae9ed60f01e533de1cf7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->