### PR TITLE
[mono-move] Support remaining vector operations: pack, unpack, swap

### DIFF
--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -272,6 +272,31 @@ pub struct CallClosureOp {
     pub provided_args: Vec<SizedSlot>,
 }
 
+/// Operand data for [`MicroOp::VecPack`].
+#[derive(Clone, Debug)]
+pub struct VecPackOp {
+    /// Frame slot that receives the vector's heap pointer.
+    pub dst: FrameOffset,
+    /// GC trace descriptor for the allocated vector object.
+    pub descriptor_id: DescriptorId,
+    /// Byte width of one element.
+    pub elem_size: u32,
+    /// Element sources (in the current frame), in element order.
+    pub srcs: Vec<FrameOffset>,
+}
+
+/// Operand data for [`MicroOp::VecUnpack`].
+#[derive(Clone, Debug)]
+pub struct VecUnpackOp {
+    /// Frame slot holding the vector's heap pointer (by value, not a
+    /// reference).
+    pub src: FrameOffset,
+    /// Byte width of one element.
+    pub elem_size: u32,
+    /// Element destinations (in the current frame), in element order.
+    pub dsts: Vec<FrameOffset>,
+}
+
 #[derive(Clone)]
 pub enum MicroOp {
     //======================================================================
@@ -759,7 +784,6 @@ pub enum MicroOp {
     // `elem_size` is baked into each instruction (statically known).
     //
     // May want:
-    // - VecSwap (native in Move's vector module),
     // - VecMoveRange (bulk move between vectors) — tricky: this is
     //   really a memcpy between two heap-allocated regions, but we
     //   currently have no vector-to-vector addressing mode,
@@ -820,6 +844,32 @@ pub enum MicroOp {
         vec_ref: FrameOffset,
         idx: FrameOffset,
         src: FrameOffset,
+        elem_size: u32,
+    },
+
+    /// Create a vector of exactly [`VecPackOp::srcs`]`.len()` elements: one
+    /// allocation at exact capacity (this part MAY TRIGGER GC), then one
+    /// element copy per source slot, then the heap pointer is written to
+    /// [`VecPackOp::dst`].
+    ///
+    /// Use `VecNew` fast path instead (null pointer, no allocation), when
+    /// [`VecPackOp::srcs`] are empty.
+    VecPack(Box<VecPackOp>),
+
+    /// Destructure a vector into [`VecUnpackOp::dsts`]`.len()` element slots.
+    /// [`VecUnpackOp::src`] holds the vector's heap pointer by value. Errors
+    /// unless the vector's length equals [`VecUnpackOp::dsts`]`.len()` exactly
+    /// (in either direction); a null pointer is the empty vector, so unpack
+    /// with zero [`VecUnpackOp::dsts`] succeeds on it.
+    VecUnpack(Box<VecUnpackOp>),
+
+    /// Swap vector[idx_a] and vector[idx_b]. `vec_ref` is a 16-byte fat pointer
+    /// whose target holds the vector's heap pointer; `idx_a`/`idx_b` are u64
+    /// slots. Errors if either index is out of bounds. Equal indices are valid.
+    VecSwap {
+        vec_ref: FrameOffset,
+        idx_a: FrameOffset,
+        idx_b: FrameOffset,
         elem_size: u32,
     },
 
@@ -1218,6 +1268,17 @@ pub enum MicroOp {
         base: FrameOffset,
         offsets: Box<[u32]>,
     },
+}
+
+/// Write a comma-separated list of frame offsets as `[o0], [o1], ...`.
+fn write_offset_list(f: &mut fmt::Formatter<'_>, offsets: &[FrameOffset]) -> fmt::Result {
+    for (pos, offset) in offsets.iter().enumerate() {
+        if pos > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "[{}]", offset.0)?;
+    }
+    Ok(())
 }
 
 // TODO: make gas costs optional in this output. Most tests don't care about
@@ -1619,6 +1680,28 @@ impl fmt::Display for MicroOp {
                     f,
                     "VecStoreElem [{}][[{}]] <- [{}] (size={})",
                     vec_ref.0, idx.0, src.0, elem_size
+                )
+            },
+            MicroOp::VecPack(op) => {
+                write!(f, "VecPack [{}] <- [", op.dst.0)?;
+                write_offset_list(f, &op.srcs)?;
+                write!(f, "] (size={}, desc={})", op.elem_size, op.descriptor_id)
+            },
+            MicroOp::VecUnpack(op) => {
+                write!(f, "VecUnpack [")?;
+                write_offset_list(f, &op.dsts)?;
+                write!(f, "] <- [{}] (size={})", op.src.0, op.elem_size)
+            },
+            MicroOp::VecSwap {
+                vec_ref,
+                idx_a,
+                idx_b,
+                elem_size,
+            } => {
+                write!(
+                    f,
+                    "VecSwap [{}][[{}]] <-> [{}][[{}]] (size={})",
+                    vec_ref.0, idx_a.0, vec_ref.0, idx_b.0, elem_size
                 )
             },
             MicroOp::StoreImmVec { dst, idx } => {
@@ -2085,6 +2168,7 @@ impl MicroOp {
             MicroOp::HeapNew { .. }
             | MicroOp::EnumNew { .. }
             | MicroOp::VecPushBack { .. }
+            | MicroOp::VecPack(_)
             | MicroOp::StoreImmVec { .. }
             | MicroOp::PackClosure(_)
             | MicroOp::BorrowGlobalMut { .. }
@@ -2144,6 +2228,8 @@ impl MicroOp {
             | MicroOp::VecPopBack { .. }
             | MicroOp::VecLoadElem { .. }
             | MicroOp::VecStoreElem { .. }
+            | MicroOp::VecUnpack(_)
+            | MicroOp::VecSwap { .. }
             | MicroOp::SlotBorrow { .. }
             | MicroOp::VecBorrow { .. }
             | MicroOp::HeapBorrow { .. }

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -29,7 +29,7 @@ pub use instruction::{
     captured_values_size, next_captured_value_offset, CallClosureOp, ClosureFuncRef, CmpKind,
     CodeOffset, DescriptorId, FrameOffset, IntBinaryOp, IntCastOp, IntCmpOp, IntNegateOp,
     IntOperand, IntShiftOp, IntTy, JumpIntCmpOp, JumpValueCmpOp, JumpValueRefCmpOp, MicroOp,
-    PackClosureOp, ShiftOperand, SizedSlot, ValueCmpOp, ValueRefCmpOp,
+    PackClosureOp, ShiftOperand, SizedSlot, ValueCmpOp, ValueRefCmpOp, VecPackOp, VecUnpackOp,
     CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET,
     CAPTURED_DATA_VALUES_SIZE_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DATA_SIZE,
     CLOSURE_FUNC_REF_OFFSET, CLOSURE_FUNC_REF_SIZE, CLOSURE_MASK_OFFSET, ENUM_DATA_OFFSET,

--- a/third_party/move/mono-move/docs/event_store.md
+++ b/third_party/move/mono-move/docs/event_store.md
@@ -66,7 +66,7 @@ Descriptor summary:
 
 `emit` and the growth path can each perform multiple allocations in sequence. Any of those allocations can trigger GC, and an in-flight pointer that isn't yet wired into a heap-reachable slot would otherwise be lost.
 
-This is exactly where `PinnedRoots` can be helpful. Alternatively we could reserve enough space upfront for all allocations the operation will make. Tradeoff: pinning costs per-allocation bookkeeping but handles variable-size or branching allocation paths; pre-reserving is simpler at the call site but needs a worst-case footprint estimate.
+This is exactly where `RootPool` can be helpful. Alternatively we could reserve enough space upfront for all allocations the operation will make. Tradeoff: pinning costs per-allocation bookkeeping but handles variable-size or branching allocation paths; pre-reserving is simpler at the call site but needs a worst-case footprint estimate.
 
 ## Key Operations
 

--- a/third_party/move/mono-move/docs/heap_and_gc.md
+++ b/third_party/move/mono-move/docs/heap_and_gc.md
@@ -140,14 +140,14 @@ All pointers must be updated after memory moves during GC. Missing a pointer lea
 2. **Pointer-slot accuracy** — `Function::frame_layout` (and, at safe points, the matching `safe_point_layouts` entry) together exactly match slots that hold live heap pointers.
 3. **Object header integrity** — `descriptor_id` and `size` live at fixed negative offsets (`obj_ptr - 8` and `obj_ptr - 4`) and are set by the allocator; user-emitted micro-ops only access offsets within the data region (≥ 0) so they cannot reach the header.
 
-### Auxiliary GC Roots: `PinnedRoots`
+### Auxiliary GC Roots: `RootPool`
 
 Stack frames are the primary root set, but some situations need to keep a heap pointer live before it's been stored anywhere a frame layout describes. Two examples:
 
 - **Fused multi-allocation micro-ops** (e.g. `PackClosure`) that allocate one object, then a second that may trigger GC while the first isn't yet linked into the frame.
 - **Native functions** (future) whose Rust code holds a heap pointer in a local variable across a call that may trigger GC.
 
-`PinnedRoots` is a handle-table root set — callers `pin(ptr)` to obtain a `PinGuard`, and the GC scans the table in addition to the call stack. Guards are RAII and support arbitrary drop order. This is conceptually the same mechanism as JNI local refs or V8 `Local<T>`.
+`RootPool` is a handle-table root set — callers `root_object(ptr)` to obtain an RAII handle, and the GC scans the pool in addition to the call stack, rewriting rooted pointers in place when objects relocate. Handles support arbitrary drop order. This is conceptually the same mechanism as JNI local refs or V8 `Local<T>`.
 
 ### Type Safety
 

--- a/third_party/move/mono-move/docs/memory_alignment.md
+++ b/third_party/move/mono-move/docs/memory_alignment.md
@@ -339,6 +339,6 @@ Vector micro-ops compute the address of element `i` as `vec_ptr + VEC_DATA_OFFSE
 
 If a future change introduces a vector element with alignment > 8 — most plausibly via [§8.2](#82-stronger-alignment-for-u128--u256--address--signer)'s stronger-alignment proposal for `address` / `u256` — the correct data offset becomes `align_up(8, elem_align)`, which varies per vector. Unlike struct or enum field offsets — which are baked into each access op at specialization time — vector access uses an indexed pattern (`base + data_offset + i * elem_size`), so the data offset must be expressible as a single value the runtime can use across every elem load, store, push, pop, and growth on a given vector.
 
-The current micro-op design has no channel for this: `VecLoadElem`, `VecStoreElem`, `VecPushBack`, `VecPopBack`, `AllocVec`, and `GrowVec` all rely on a hardcoded `VEC_DATA_OFFSET`. Bridging the gap would require adding per-vector or per-instruction data-offset metadata, or globally raising `VEC_DATA_OFFSET`, each with its own cost profile.
+The current micro-op design has no channel for this: every vector access, allocation, and growth path relies on a hardcoded `VEC_DATA_OFFSET`. Bridging the gap would require adding per-vector or per-instruction data-offset metadata, or globally raising `VEC_DATA_OFFSET`, each with its own cost profile.
 
 This is an open design question. It does not block MonoMove at `MAX_ALIGN = 8`, but it does need to be answered before any change that admits vector elements with alignment > 16.

--- a/third_party/move/mono-move/docs/native_functions_interface.md
+++ b/third_party/move/mono-move/docs/native_functions_interface.md
@@ -101,7 +101,7 @@ ctx.alloc(size: usize, descriptor_id: DescriptorId) -> *mut u8     // lower-leve
 
 These don't make memory access fully safe — natives still work with raw memory underneath — but they replace ad-hoc pointer arithmetic with methods that know what they're accessing.
 
-**GC safety.** Allocations during a native call can trigger GC, which relocates heap objects. Any wrapper (or raw pointer) the native is actively holding needs to be pinned through `PinnedRoots` so it survives — and gets updated by — collection. How that threads through the wrapper types may shift the final API: a wrapper might carry a `PinGuard<'_>` whose lifetime constrains how it composes with `&mut ctx` borrows. Details TBD.
+**GC safety.** Allocations during a native call can trigger GC, which relocates heap objects. Any wrapper (or raw pointer) the native is actively holding needs to be pinned through `RootPool` so it survives — and gets updated by — collection. How that threads through the wrapper types may shift the final API: a wrapper might carry a root handle whose lifetime constrains how it composes with `&mut ctx` borrows. Details TBD.
 
 - **Descriptor registration.** Custom heap shapes introduced by natives register their `ObjectDescriptor`s with the program-wide `ObjectDescriptorTable` at VM startup; the returned `DescriptorId`s are what `ctx.alloc_*` takes. Extensions (§6) are the natural owner — they hold the lifetime and naming of the heap shapes their natives operate on — but standalone natives can register too.
 - **No shadow arenas.** Today's `AlgebraContext.objs` / `NativeRistrettoPointContext.points` aren't carried forward — uncounted growth, beyond the gas budget. The crypto natives must be **rewritten**: the handle-into-arena indirection (`RistrettoPoint { handle: u64 }` + Rust-side `Vec`) becomes a real heap struct holding the bytes directly, with a proper `ObjectDescriptor`. Off the Decibel path; separate milestone.
@@ -162,7 +162,7 @@ impl MyExtension {
 
 - `init` (per extension, not on the trait) **constructs** a fresh extension at session start. Only the heap is available at this point — there's no calling frame, so the full native context doesn't exist yet. The extension allocates its heap data structures via `heap.alloc_*` and stores the resulting pointers in fields of `Self`. Returning `Self` (rather than mutating `&mut self`) avoids a half-initialized "before init" state with placeholder pointer fields.
 - `finalize` runs at session end — wrap up (BCS-serialize accumulated state, extract a change set for the host, etc.).
-- `gc_roots` yields a mutable reference to each heap root pointer the extension owns. The GC iterates during collection and writes the (possibly relocated) pointer back through each reference — alongside the call-stack walk and `PinnedRoots`.
+- `gc_roots` yields a mutable reference to each heap root pointer the extension owns. The GC iterates during collection and writes the (possibly relocated) pointer back through each reference — alongside the call-stack walk and `RootPool`.
 
 **Access from natives:**
 

--- a/third_party/move/mono-move/docs/stack_and_calling_convention.md
+++ b/third_party/move/mono-move/docs/stack_and_calling_convention.md
@@ -79,7 +79,7 @@ At any given safe point, the full set of GC roots on the frame is the union of `
 
 **Safe points** are the only instructions where GC can trigger:
 
-- **Allocating instructions** (`HeapNew`, `VecPushBack`, `ForceGC`): GC runs during the instruction, so the safe point is at that instruction's own PC.
+- **Allocating instructions** (see `MicroOp::is_allocating`): GC runs during the instruction, so the safe point is at that instruction's own PC.
 - **Call return sites**: when a callee triggers GC, the caller's saved PC is `call_pc + 1`. The safe point for a caller frame is the instruction *after* the call — at that point, the shared arg/return region holds return values, not arguments.
 
 When `zero_frame` is true, pointer slots are zeroed on entry so the GC always sees either a valid heap pointer or null — never stale data. `FrameLayoutInfo` is designed to be extended with additional per-slot type or layout information in the future (e.g., slot type tags for debugging or stronger runtime verification).

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -54,6 +54,9 @@ pub enum RuntimeError {
     #[error("VecPopBack on empty vector")]
     PopFromEmptyVector,
 
+    #[error("VecUnpack: expected {expected} elements, vector has {actual}")]
+    VecUnpackLengthMismatch { expected: u64, actual: u64 },
+
     #[error("{op} index out of bounds: idx={idx} len={len}")]
     VectorIndexOutOfBounds { op: VecOp, idx: u64, len: u64 },
 
@@ -127,6 +130,7 @@ impl IntoExecutionError for RuntimeError {
             | NegateMinOverflow { .. }
             | CastOutOfRange { .. }
             | PopFromEmptyVector
+            | VecUnpackLengthMismatch { .. }
             | VectorIndexOutOfBounds { .. }
             | InvalidAbortMessage
             | ResourceDoesNotExist { .. }
@@ -203,6 +207,7 @@ pub enum VecOp {
     LoadElem,
     StoreElem,
     Borrow,
+    Swap,
 }
 
 impl fmt::Display for VecOp {
@@ -211,6 +216,7 @@ impl fmt::Display for VecOp {
             VecOp::LoadElem => write!(f, "VecLoadElem"),
             VecOp::StoreElem => write!(f, "VecStoreElem"),
             VecOp::Borrow => write!(f, "VecBorrow"),
+            VecOp::Swap => write!(f, "VecSwap"),
         }
     }
 }

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -37,12 +37,12 @@ use mono_move_core::{
     types::{view_type_list, InternedTypeList},
     CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, ConstantPoolIndex, DescriptorId,
     DescriptorProvider, FrameOffset, Function, FunctionRef, IntBinaryOp, IntCastOp, IntNegateOp,
-    IntOperand, IntShiftOp, IntTy, LayoutProvider, MicroOp, PackClosureOp, ShiftOperand,
-    CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET,
-    CAPTURED_DATA_VALUES_SIZE_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID,
-    CLOSURE_FUNC_REF_OFFSET, CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET,
-    FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN,
-    OBJECT_HEADER_SIZE,
+    IntOperand, IntShiftOp, IntTy, LayoutProvider, MicroOp, PackClosureOp, ShiftOperand, VecPackOp,
+    VecUnpackOp, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
+    CAPTURED_DATA_VALUES_OFFSET, CAPTURED_DATA_VALUES_SIZE_OFFSET,
+    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID, CLOSURE_FUNC_REF_OFFSET,
+    CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
+    FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
 };
 use move_core_types::int256::{I256, U256};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -1406,6 +1406,46 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     );
                 },
 
+                MicroOp::VecPack(ref op) => {
+                    self.exec_vec_pack(fp, op)?;
+                },
+
+                MicroOp::VecUnpack(ref op) => {
+                    self.exec_vec_unpack(fp, op)?;
+                },
+
+                MicroOp::VecSwap {
+                    vec_ref,
+                    idx_a,
+                    idx_b,
+                    elem_size,
+                } => {
+                    let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                    let vec_ptr = read_ptr(ref_base, ref_off as usize);
+                    let idx_a = read_u64(fp, idx_a);
+                    let idx_b = read_u64(fp, idx_b);
+                    let len = read_vec_len(vec_ptr);
+                    // Indices are checked before the equal-indices no-op.
+                    for idx in [idx_a, idx_b] {
+                        if idx >= len {
+                            return Err(RuntimeError::VectorIndexOutOfBounds {
+                                op: VecOp::Swap,
+                                idx,
+                                len,
+                            });
+                        }
+                    }
+                    // Equal pointers are UB for `swap_nonoverlapping`; distinct
+                    // in-bounds indices guarantee disjoint element ranges.
+                    if idx_a != idx_b {
+                        std::ptr::swap_nonoverlapping(
+                            vec_elem_ptr(vec_ptr, idx_a, elem_size) as *mut u8,
+                            vec_elem_ptr(vec_ptr, idx_b, elem_size) as *mut u8,
+                            elem_size as usize,
+                        );
+                    }
+                },
+
                 // ----- Reference (fat pointer) instructions -----
                 MicroOp::VecBorrow {
                     dst,
@@ -1869,6 +1909,69 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
             }
             Ok(())
         }
+    }
+
+    /// Allocates the vector at exact capacity in a single allocation, writes
+    /// the length, copies each source element from the frame, and writes the
+    /// heap pointer to `op.dst`. Any GC runs inside the allocation, before the
+    /// fp-relative element reads, so those reads see post-GC pointers.
+    ///
+    /// # Safety
+    ///
+    /// - `fp` is the current frame pointer.
+    /// - `op.dst` and each `op.srcs` slot are in-bounds for the current frame.
+    unsafe fn exec_vec_pack(&mut self, fp: *mut u8, op: &VecPackOp) -> RuntimeResult<()> {
+        let count = op.srcs.len() as u64;
+        // TODO(perf): `alloc_vec!` zero-fills the whole allocation, but every
+        // payload byte is overwritten below before the op returns and no GC can
+        // intervene afterwards. A fully-initialized-payload alloc variant would
+        // avoid the dead memset. Padding needs to be carefully considered for
+        // the optimization.
+        let vec_ptr = alloc_vec!(self, fp, op.descriptor_id, op.elem_size, count)?;
+        unsafe {
+            write_u64(vec_ptr, VEC_LENGTH_OFFSET, count);
+            for (elem_idx, src) in op.srcs.iter().enumerate() {
+                // Non-overlapping: the source is a frame slot, the destination
+                // is in the freshly-allocated heap vector — disjoint regions.
+                std::ptr::copy_nonoverlapping(
+                    fp.add((*src).into()),
+                    vec_elem_ptr(vec_ptr, elem_idx as u64, op.elem_size) as *mut u8,
+                    op.elem_size as usize,
+                );
+            }
+            write_ptr(fp, op.dst, vec_ptr);
+        }
+        Ok(())
+    }
+
+    /// Checks that the vector's length equals `op.dsts.len()` — erroring on a
+    /// mismatch; then copies each element into its destination slot. A null
+    /// `src` is the empty vector: it unpacks cleanly when `dsts` is empty and
+    /// fails the length check otherwise.
+    ///
+    /// # Safety
+    ///
+    /// - `fp` is the current frame pointer.
+    /// - `op.src` and each `op.dsts` slot are in-bounds for the current frame.
+    unsafe fn exec_vec_unpack(&mut self, fp: *mut u8, op: &VecUnpackOp) -> RuntimeResult<()> {
+        unsafe {
+            let vec_ptr = read_ptr(fp, op.src);
+            let expected = op.dsts.len() as u64;
+            let actual = read_vec_len(vec_ptr);
+            if actual != expected {
+                return Err(RuntimeError::VecUnpackLengthMismatch { expected, actual });
+            }
+            for (elem_idx, dst) in op.dsts.iter().enumerate() {
+                // Non-overlapping: the source is a heap vector element, the
+                // destination is a frame slot — disjoint regions.
+                std::ptr::copy_nonoverlapping(
+                    vec_elem_ptr(vec_ptr, elem_idx as u64, op.elem_size),
+                    fp.add((*dst).into()),
+                    op.elem_size as usize,
+                );
+            }
+        }
+        Ok(())
     }
 
     /// Deep-copy the value tree rooted at the specified source into the

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -10,11 +10,12 @@
 //! enforced by [`mono_move_core::ObjectDescriptor`]'s constructors at
 //! publish time.
 //!
-//! TODO(maintainability):
+//! TODO:
 //! 1. Call this something other than verifier (well-formedness checker) to
 //!    avoid ambiguity with bytecode verifier.
 //! 2. Replace various hard-coded constants with named constants.
 //! 3. Precisely list out what is checked and what is out of scope.
+//! 4. For instructions with more than 1 destination, they must be disjoint.
 
 use mono_move_core::{
     captured_values_size,
@@ -618,23 +619,7 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
                 self.check_frame_access(Some(pc), vec_ref, 16);
                 self.check_nonzero_size(pc, elem_size);
                 self.check_frame_access(Some(pc), elem, elem_size);
-                self.check_descriptor_variant(
-                    pc,
-                    "VecPushBack",
-                    descriptor_id,
-                    |inner| match inner {
-                        ObjectDescriptorInner::Vector {
-                            elem_pointer_offsets,
-                            ..
-                        } => !elem_pointer_offsets.is_empty(),
-                        ObjectDescriptorInner::Trivial => true,
-                        ObjectDescriptorInner::Closure
-                        | ObjectDescriptorInner::Struct { .. }
-                        | ObjectDescriptorInner::Enum { .. }
-                        | ObjectDescriptorInner::CapturedData { .. } => false,
-                    },
-                    "a non-empty Vector or Trivial",
-                );
+                self.check_vector_descriptor(pc, "VecPushBack", descriptor_id, elem_size);
             },
 
             MicroOp::VecPopBack {
@@ -670,6 +655,35 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
                 self.check_frame_access_8(pc, idx);
                 self.check_nonzero_size(pc, elem_size);
                 self.check_frame_access(Some(pc), src, elem_size);
+            },
+
+            MicroOp::VecPack(ref op) => {
+                self.check_frame_access_8(pc, op.dst);
+                self.check_nonzero_size(pc, op.elem_size);
+                for &src in &op.srcs {
+                    self.check_frame_access(Some(pc), src, op.elem_size);
+                }
+                self.check_vector_descriptor(pc, "VecPack", op.descriptor_id, op.elem_size);
+            },
+
+            MicroOp::VecUnpack(ref op) => {
+                self.check_frame_access_8(pc, op.src);
+                self.check_nonzero_size(pc, op.elem_size);
+                for &dst in &op.dsts {
+                    self.check_frame_access(Some(pc), dst, op.elem_size);
+                }
+            },
+
+            MicroOp::VecSwap {
+                vec_ref,
+                idx_a,
+                idx_b,
+                elem_size,
+            } => {
+                self.check_frame_access(Some(pc), vec_ref, 16);
+                self.check_frame_access_8(pc, idx_a);
+                self.check_frame_access_8(pc, idx_b);
+                self.check_nonzero_size(pc, elem_size);
             },
 
             // ----- Borrow producing fat pointer (16B dst) -----
@@ -1112,6 +1126,65 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
         self.check_frame_access(Some(pc), op.dst, size);
         if let Some(rhs_off) = op.rhs.slot_offset() {
             self.check_frame_access(Some(pc), rhs_off, size);
+        }
+    }
+
+    /// Checks `descriptor_id` for a vector allocation of element stride
+    /// `elem_size`: it must be `Trivial`, or a `Vector` with a non-empty
+    /// pointer-offset list and a matching `elem_size`. The sizes must agree
+    /// because the GC strides the data region by the descriptor's `elem_size`,
+    /// so a mismatch would trace past the allocation.
+    fn check_vector_descriptor(
+        &mut self,
+        pc: usize,
+        op: &str,
+        descriptor_id: DescriptorId,
+        elem_size: u32,
+    ) {
+        match self
+            .provider
+            .descriptor(descriptor_id)
+            .map(|desc| desc.inner())
+        {
+            None => self.err(
+                Some(pc),
+                format!("{}: unknown descriptor_id {}", op, descriptor_id),
+            ),
+            Some(ObjectDescriptorInner::Vector {
+                elem_size: descriptor_elem_size,
+                elem_pointer_offsets,
+            }) => {
+                if elem_pointer_offsets.is_empty() {
+                    self.err(
+                        Some(pc),
+                        format!(
+                            "{}: descriptor_id {} is not a non-empty Vector or Trivial",
+                            op, descriptor_id
+                        ),
+                    );
+                } else if *descriptor_elem_size != elem_size {
+                    self.err(
+                        Some(pc),
+                        format!(
+                            "{}: elem_size {} does not match Vector descriptor_id {} elem_size {}",
+                            op, elem_size, descriptor_id, descriptor_elem_size
+                        ),
+                    );
+                }
+            },
+            Some(ObjectDescriptorInner::Trivial) => {},
+            Some(
+                ObjectDescriptorInner::Closure
+                | ObjectDescriptorInner::Struct { .. }
+                | ObjectDescriptorInner::Enum { .. }
+                | ObjectDescriptorInner::CapturedData { .. },
+            ) => self.err(
+                Some(pc),
+                format!(
+                    "{}: descriptor_id {} is not a non-empty Vector or Trivial",
+                    op, descriptor_id
+                ),
+            ),
         }
     }
 

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -908,13 +908,14 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
             // --- Vector ops ---
             B::VecPack(sig_idx, count) => {
+                // The bytecode verifier bounds the count to u16::MAX, so this cast is lossless.
                 let count = *count as u16;
                 let elems = self.pop_n_reverse(count as usize)?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let ty = self.interner.vector_of(elem_ty);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs
-                    .push(Instr::VecPack(dst, elem_ty, count, elems));
+                    .push(Instr::VecPack(dst, elem_ty, elems));
                 self.push_slot(dst);
             },
             B::VecLen(sig_idx) => {
@@ -961,6 +962,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 self.push_slot(dst);
             },
             B::VecUnpack(sig_idx, count) => {
+                // The bytecode verifier bounds the count to u16::MAX, so this cast is lossless.
                 let count = *count as u16;
                 let src = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
@@ -969,7 +971,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     dsts.push(self.alloc_vid(elem_ty)?);
                 }
                 self.current_block_instrs
-                    .push(Instr::VecUnpack(dsts.clone(), elem_ty, count, src));
+                    .push(Instr::VecUnpack(dsts.clone(), elem_ty, src));
                 for dst in dsts {
                     self.push_slot(dst);
                 }

--- a/third_party/move/mono-move/specializer/src/gas.rs
+++ b/third_party/move/mono-move/specializer/src/gas.rs
@@ -197,14 +197,19 @@ pub(crate) fn instr_cost(instr: &Instr, cx: &impl CostContext) -> Result<u64> {
         Instr::CallClosure(rets, _, args) => call_cost(cx, args, rets)?,
 
         // --- Vector ---
-        Instr::VecPack(_, _, _, elems) => VEC_NEW + sum_move(cx, elems)?,
+        Instr::VecPack(_, _, elems) => VEC_NEW + sum_move(cx, elems)?,
         Instr::VecLen(..) => VEC_LEN,
         Instr::VecImmBorrow(..) | Instr::VecMutBorrow(..) => VEC_BORROW,
         Instr::VecPushBack(elem_ty, _, _) | Instr::VecPopBack(_, elem_ty, _) => {
             vec_elem(concrete_type_size(*elem_ty, "vector elem type")?)
         },
-        Instr::VecUnpack(..) => VEC_NEW,
-        Instr::VecSwap(..) => VEC_BORROW,
+        Instr::VecUnpack(dsts, elem_ty, _) => {
+            VEC_NEW
+                + dsts.len() as u64 * move_bytes(concrete_type_size(*elem_ty, "vector elem type")?)
+        },
+        Instr::VecSwap(elem_ty, _, _, _) => {
+            2 * vec_elem(concrete_type_size(*elem_ty, "vector elem type")?)
+        },
 
         // --- Control flow ---
         Instr::Branch(..) => JUMP,

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -23,10 +23,10 @@ use anyhow::{anyhow, bail, Context, Result};
 use mono_move_core::{
     native::{FrameSlot, NativeABI},
     types::{strip_ref, view_type, InternedType, Type},
-    CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, FrameLayoutInfo, FrameOffset, IntBinaryOp,
-    IntCastOp, IntCmpOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, JumpIntCmpOp, JumpValueCmpOp,
-    JumpValueRefCmpOp, MicroOp, PackClosureOp, SafePointEntry, ShiftOperand, SizedSlot, ValueCmpOp,
-    ValueRefCmpOp, FRAME_METADATA_SIZE,
+    CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, DescriptorId, FrameLayoutInfo, FrameOffset,
+    IntBinaryOp, IntCastOp, IntCmpOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, JumpIntCmpOp,
+    JumpValueCmpOp, JumpValueRefCmpOp, MicroOp, PackClosureOp, SafePointEntry, ShiftOperand,
+    SizedSlot, ValueCmpOp, ValueRefCmpOp, VecPackOp, VecUnpackOp, FRAME_METADATA_SIZE,
 };
 use move_binary_format::file_format::{
     ConstantPoolIndex, FieldHandleIndex, VariantFieldHandleIndex,
@@ -399,6 +399,18 @@ impl<'a> LoweringState<'a> {
             })?;
         }
         Ok(())
+    }
+
+    /// `DescriptorId` published for `vec_ty`, with the shared diagnostic of
+    /// the allocating vector ops. `op_name` prefixes the error message.
+    fn vector_descriptor_id(&self, op_name: &str, vec_ty: InternedType) -> Result<DescriptorId> {
+        self.ctx.descriptor_id(vec_ty).ok_or_else(|| {
+            anyhow!(
+                "{}: no descriptor published for this vector type \
+                 (its element type may be generic or have unresolved layout)",
+                op_name
+            )
+        })
     }
 
     /// Interned-type corresponding to `slot`.
@@ -1317,24 +1329,61 @@ impl<'a> LoweringState<'a> {
                     elem_size,
                 })?;
             },
-            Instr::VecPack(dst, _elem_ty, _count, elems) => {
-                if !elems.is_empty() {
-                    bail!("VecPack with elements not yet lowered");
+            Instr::VecPack(dst, elem_ty, elems) => {
+                let dst_typed = self.def_typed_slot(*dst)?;
+                // Empty literal keeps the fast path: null pointer is the empty
+                // vector — no allocation, no descriptor needed.
+                if elems.is_empty() {
+                    self.emit(MicroOp::VecNew {
+                        dst: dst_typed.slot.offset,
+                    })?;
+                } else {
+                    let elem_size = concrete_type_size(*elem_ty, "vector elem type")?;
+                    let descriptor_id = self.vector_descriptor_id("VecPack", dst_typed.ty)?;
+                    let srcs = elems
+                        .iter()
+                        .map(|elem| Ok(self.slot(*elem)?.offset))
+                        .collect::<Result<Vec<_>>>()?;
+                    self.emit(MicroOp::VecPack(Box::new(VecPackOp {
+                        dst: dst_typed.slot.offset,
+                        descriptor_id,
+                        elem_size,
+                        srcs,
+                    })))?;
                 }
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::VecNew {
-                    dst: dst_info.offset,
+            },
+            Instr::VecUnpack(dsts, elem_ty, src) => {
+                // TODO: the Move compiler only emits `VecUnpack` with count 0,
+                // but handwritten bytecode may use it with any count. If we
+                // restrict to count 0, we can apply simplifications.
+                let elem_size = concrete_type_size(*elem_ty, "vector elem type")?;
+                let src_info = self.slot(*src)?;
+                let dst_offsets = dsts
+                    .iter()
+                    .map(|dst| Ok(self.def_slot(*dst)?.offset))
+                    .collect::<Result<Vec<_>>>()?;
+                self.emit(MicroOp::VecUnpack(Box::new(VecUnpackOp {
+                    src: src_info.offset,
+                    elem_size,
+                    dsts: dst_offsets,
+                })))?;
+            },
+            Instr::VecSwap(elem_ty, vec_ref, idx_a, idx_b) => {
+                let elem_size = concrete_type_size(*elem_ty, "vector elem type")?;
+                let vec_ref_info = self.slot(*vec_ref)?;
+                let idx_a_info = self.slot(*idx_a)?;
+                let idx_b_info = self.slot(*idx_b)?;
+                self.emit(MicroOp::VecSwap {
+                    vec_ref: vec_ref_info.offset,
+                    idx_a: idx_a_info.offset,
+                    idx_b: idx_b_info.offset,
+                    elem_size,
                 })?;
             },
             Instr::VecPushBack(elem_ty, vec_ref, val) => {
                 let elem_size = concrete_type_size(*elem_ty, "vector elem type")?;
                 let vec_ty = strip_ref(self.slot_interned_type(*vec_ref)?)?;
-                let descriptor_id = self.ctx.descriptor_id(vec_ty).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "VecPushBack: no descriptor published for this vector type \
-                         (its element type may be generic or have unresolved layout)"
-                    )
-                })?;
+                let descriptor_id = self.vector_descriptor_id("VecPushBack", vec_ty)?;
                 let vec_ref_info = self.slot(*vec_ref)?;
                 let val_info = self.slot(*val)?;
                 self.emit(MicroOp::VecPushBack {

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -658,11 +658,11 @@ fn display_instr(
         },
 
         // --- Vector ---
-        Instr::VecPack(d, elem_ty, count, elems) => {
+        Instr::VecPack(d, elem_ty, elems) => {
             write_dst(f, *d)?;
             write!(f, "vec_pack ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", count, slot_names(elems))
+            write!(f, ", {}, {}", elems.len(), slot_names(elems))
         },
         Instr::VecLen(d, elem_ty, s) => {
             write_dst(f, *d)?;
@@ -694,11 +694,11 @@ fn display_instr(
             display_type(f, *elem_ty)?;
             write!(f, ", {}", slot_name(*s))
         },
-        Instr::VecUnpack(ds, elem_ty, count, s) => {
+        Instr::VecUnpack(ds, elem_ty, s) => {
             write_dsts(f, ds)?;
             write!(f, "vec_unpack ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", count, slot_name(*s))
+            write!(f, ", {}, {}", ds.len(), slot_name(*s))
         },
         // VecSwap has no destination
         Instr::VecSwap(elem_ty, v, i, j) => {

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
@@ -530,13 +530,13 @@ pub(crate) fn extract_imm_value(instr: &Instr) -> Option<(Slot, ImmValue)> {
         | Instr::PackClosure(_, _, _, _)
         | Instr::PackClosureGeneric(_, _, _, _)
         | Instr::CallClosure(_, _, _)
-        | Instr::VecPack(_, _, _, _)
+        | Instr::VecPack(_, _, _)
         | Instr::VecLen(_, _, _)
         | Instr::VecImmBorrow(_, _, _, _)
         | Instr::VecMutBorrow(_, _, _, _)
         | Instr::VecPushBack(_, _, _)
         | Instr::VecPopBack(_, _, _)
-        | Instr::VecUnpack(_, _, _, _)
+        | Instr::VecUnpack(_, _, _)
         | Instr::VecSwap(_, _, _, _)
         | Instr::Branch(_)
         | Instr::BrTrue(_, _)
@@ -779,7 +779,7 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
             uses::<USES>(captured, &mut f);
         },
 
-        Instr::VecPack(dst, _, _, elems) => {
+        Instr::VecPack(dst, _, elems) => {
             def::<DEFS>(*dst, &mut f);
             uses::<USES>(elems, &mut f);
         },
@@ -796,7 +796,7 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
             used::<USES>(*vec_ref, &mut f);
             used::<USES>(*val, &mut f);
         },
-        Instr::VecUnpack(dsts, _, _, src) => {
+        Instr::VecUnpack(dsts, _, src) => {
             defs::<DEFS>(dsts, &mut f);
             used::<USES>(*src, &mut f);
         },
@@ -1107,7 +1107,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        Instr::VecPack(dst, _, _, elems) => {
+        Instr::VecPack(dst, _, elems) => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -1138,7 +1138,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slot(val, &mut f);
             }
         },
-        Instr::VecUnpack(dsts, _, _, src) => {
+        Instr::VecUnpack(dsts, _, src) => {
             if DEFS {
                 rewrite_slots(dsts, &mut f);
             }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -271,13 +271,13 @@ pub enum Instr {
     CallClosure(Vec<Slot>, InternedTypeList, Vec<Slot>),
 
     // --- Vector (second field is the vector's element type) ---
-    VecPack(Slot, InternedType, u16, Vec<Slot>),
+    VecPack(Slot, InternedType, Vec<Slot>),
     VecLen(Slot, InternedType, Slot),
     VecImmBorrow(Slot, InternedType, Slot, Slot),
     VecMutBorrow(Slot, InternedType, Slot, Slot),
     VecPushBack(InternedType, Slot, Slot),
     VecPopBack(Slot, InternedType, Slot),
-    VecUnpack(Vec<Slot>, InternedType, u16, Slot),
+    VecUnpack(Vec<Slot>, InternedType, Slot),
     VecSwap(InternedType, Slot, Slot, Slot),
 
     // --- Control flow ---

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_destroy_empty.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_destroy_empty.move
@@ -1,0 +1,36 @@
+// RUN: publish
+module 0x66::vec_destroy_empty {
+    use std::vector;
+
+    // `empty()` allocates nothing: null heap pointer.
+    public fun destroy_null(): u64 {
+        let items = vector::empty<u64>();
+        vector::destroy_empty(items);
+        7
+    }
+
+    // Push-then-pop leaves a non-null pointer to a zero-length vector.
+    public fun destroy_after_pop(value: u64): u64 {
+        let items = vector::empty<u64>();
+        vector::push_back(&mut items, value);
+        let popped = vector::pop_back(&mut items);
+        vector::destroy_empty(items);
+        popped
+    }
+
+    public fun destroy_nonempty(value: u64): u64 {
+        let items = vector[value, value];
+        vector::destroy_empty(items);
+        0
+    }
+}
+
+// RUN: execute 0x66::vec_destroy_empty::destroy_null
+// CHECK: results: 7
+
+// RUN: execute 0x66::vec_destroy_empty::destroy_after_pop --args 42
+// CHECK: results: 42
+
+// RUN: execute 0x66::vec_destroy_empty::destroy_nonempty --args 9
+// CHECK-V1-SUBSTR: VECTOR_OPERATION_ERROR
+// CHECK-V2-SUBSTR: VecUnpack: expected 0 elements

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_literals.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_literals.move
@@ -1,0 +1,96 @@
+// RUN: publish
+module 0x66::vec_literals {
+    use std::vector;
+
+    public fun sum_u8(a: u8, b: u8, c: u8): u64 {
+        let v = vector[a, b, c];
+        let s = 0u64;
+        let i = 0;
+        while (i < vector::length(&v)) {
+            s = s + (*vector::borrow(&v, i) as u64);
+            i = i + 1;
+        };
+        s
+    }
+
+    public fun sum_u64(a: u64, b: u64): u64 {
+        let v = vector[a, b];
+        *vector::borrow(&v, 0) + *vector::borrow(&v, 1)
+    }
+
+    public fun last_u256(a: u256, b: u256, c: u256, d: u256): u256 {
+        let v = vector[a, b, c, d];
+        *vector::borrow(&v, 3)
+    }
+
+    public fun nested(a: u8, b: u8): u64 {
+        let v = vector[vector[a], vector[b, b], vector[]];
+        (vector::length(vector::borrow(&v, 0))
+            + vector::length(vector::borrow(&v, 1))
+            + vector::length(vector::borrow(&v, 2))) * 100
+            + (*vector::borrow(vector::borrow(&v, 1), 1) as u64)
+    }
+
+    struct Pair has copy, drop {
+        first: u64,
+        second: u64,
+    }
+
+    public fun structs(x: u64, y: u64): u64 {
+        let v = vector[Pair { first: x, second: y }, Pair { first: y, second: x }];
+        let p = vector::borrow(&v, 1);
+        p.first * 1000 + p.second
+    }
+
+    public fun single(x: u64): u64 {
+        let v = vector[x];
+        vector::pop_back(&mut v)
+    }
+
+    fun take(v: vector<u64>): u64 {
+        *vector::borrow(&v, 0) * 10 + vector::length(&v)
+    }
+
+    public fun literal_as_arg(a: u64, b: u64): u64 {
+        take(vector[a, b])
+    }
+
+    fun bump(x: u64): u64 {
+        x + 1
+    }
+
+    public fun elements_from_calls(a: u64, b: u64): u64 {
+        let v = vector[bump(a), bump(b)];
+        *vector::borrow(&v, 0) * 100 + *vector::borrow(&v, 1)
+    }
+}
+
+// RUN: execute 0x66::vec_literals::sum_u8 --args 1, 2, 3
+// CHECK: results: 6
+
+// RUN: execute 0x66::vec_literals::sum_u8 --args 255, 255, 255
+// CHECK: results: 765
+
+// RUN: execute 0x66::vec_literals::sum_u64 --args 40, 2
+// CHECK: results: 42
+
+// RUN: execute 0x66::vec_literals::sum_u64 --args 18446744073709551615, 0
+// CHECK: results: 18446744073709551615
+
+// RUN: execute 0x66::vec_literals::last_u256 --args 1, 2, 3, 115792089237316195423570985008687907853269984665640564039457584007913129639935
+// CHECK: results: 115792089237316195423570985008687907853269984665640564039457584007913129639935
+
+// RUN: execute 0x66::vec_literals::nested --args 7, 9
+// CHECK: results: 309
+
+// RUN: execute 0x66::vec_literals::structs --args 5, 6
+// CHECK: results: 6005
+
+// RUN: execute 0x66::vec_literals::single --args 99
+// CHECK: results: 99
+
+// RUN: execute 0x66::vec_literals::literal_as_arg --args 7, 3
+// CHECK: results: 72
+
+// RUN: execute 0x66::vec_literals::elements_from_calls --args 4, 8
+// CHECK: results: 509

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_pack_gc_loop.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_pack_gc_loop.move
@@ -1,0 +1,29 @@
+// RUN: publish
+module 0x66::vec_pack_gc_loop {
+    use std::vector;
+
+    fun take_two(bytes: vector<u8>, nums: vector<u64>): u64 {
+        vector::length(&bytes) + vector::length(&nums)
+    }
+
+    public fun pack_loop(rounds: u64): u64 {
+        let total = 0;
+        let counter = 0;
+        while (counter < rounds) {
+            let nested = vector[vector[counter], vector[counter, counter]];
+            total = total + vector::length(&nested);
+            total = total + take_two(vector[1u8, 2u8], vector[counter, counter, counter]);
+            counter = counter + 1;
+        };
+        total
+    }
+}
+
+// 7 per round: nested len 2 + take_two (2 + 3).
+// RUN: execute 0x66::vec_pack_gc_loop::pack_loop --args 50 --heap-size 512
+// CHECK: results: 350
+// CHECK-GC-COUNT: 19
+
+// RUN: execute 0x66::vec_pack_gc_loop::pack_loop --args 0 --heap-size 512
+// CHECK: results: 0
+// CHECK-GC-COUNT: 0

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_pack_micro_ops.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_pack_micro_ops.exp
@@ -1,0 +1,109 @@
+=== micro-ops ===
+// module 0x66::vec_pack_micro_ops
+
+fun consume_empty() {
+  frame_data_size: 16
+  entry_gas: 74
+  code:
+    0: VecNew [8]
+    1: VecUnpack [] <- [8] (size=8)
+    2: Return
+}
+
+fun literal_args() {
+  frame_data_size: 16
+  entry_gas: 193
+  code:
+    0: VecPack [40] <- [[0]] (size=1, desc=0)
+    1: VecPack [48] <- [[8], [8]] (size=8, desc=0)
+    2: CallIndirect 0x66::vec_pack_micro_ops::take_two
+    3: Move8 [0] <- [40]
+    4: Return
+  safe_point_layouts:
+    0: []
+    1: [40]
+}
+
+fun pack_nested() {
+  frame_data_size: 96
+  entry_gas: 148
+  code:
+    0: VecPack [16] <- [[0], [0]] (size=1, desc=0)
+    1: VecPack [24] <- [[1]] (size=1, desc=0)
+    2: VecPack [8] <- [[16], [24]] (size=8, desc=2)
+    3: SlotBorrow [32] <- &[8]
+    4: StoreImm8 [48] <- #0
+    5: VecBorrow [56] <- &[32][[48]] (elem_size=8)
+    6: StoreImm8 [48] <- #1
+    7: VecBorrow [72] <- &[56][[48]] (elem_size=1)
+    8: ReadRef [88] <- *[72] (size=1)
+    9: SlotBorrow [32] <- &[8]
+    10: StoreImm8 [48] <- #1
+    11: VecBorrow [56] <- &[32][[48]] (elem_size=8)
+    12: StoreImm8 [48] <- #0
+    13: VecBorrow [72] <- &[56][[48]] (elem_size=1)
+    14: ReadRef [89] <- *[72] (size=1)
+    15: IntAdd [89] <- [88] + u8 [89]
+    16: Move(1) [0] <- [89]
+    17: Return
+  safe_point_layouts:
+    0: []
+    1: []
+    2: []
+}
+
+fun pack_u64() {
+  frame_data_size: 72
+  entry_gas: 175
+  code:
+    0: VecPack [24] <- [[0], [8], [16]] (size=8, desc=0)
+    1: SlotBorrow [32] <- &[24]
+    2: StoreImm8 [48] <- #1
+    3: VecBorrow [56] <- &[32][[48]] (elem_size=8)
+    4: ReadRef [48] <- *[56] (size=8)
+    5: Move8 [0] <- [48]
+    6: Return
+  safe_point_layouts:
+    0: []
+}
+
+fun swap_pair() {
+  frame_data_size: 88
+  entry_gas: 211
+  code:
+    0: VecPack [16] <- [[0], [8]] (size=8, desc=0)
+    1: SlotBorrow [24] <- &[16]
+    2: StoreImm8 [40] <- #0
+    3: StoreImm8 [48] <- #1
+    4: VecSwap [24][[40]] <-> [24][[48]] (size=8)
+    5: SlotBorrow [56] <- &[16]
+    6: StoreImm8 [48] <- #0
+    7: VecBorrow [72] <- &[56][[48]] (elem_size=8)
+    8: ReadRef [48] <- *[72] (size=8)
+    9: Move8 [0] <- [48]
+    10: Return
+  safe_point_layouts:
+    0: []
+}
+
+fun take_two() {
+  frame_data_size: 64
+  entry_gas: 72
+  code:
+    0: SlotBorrow [16] <- &[0]
+    1: VecLen [32] <- vec_len([16])
+    2: MulU64Imm [32] <- [32] * #10
+    3: SlotBorrow [40] <- &[8]
+    4: VecLen [56] <- vec_len([40])
+    5: AddU64 [56] <- [32] + [56]
+    6: Move8 [0] <- [56]
+    7: Return
+}
+=== frame-layout ===
+// module 0x66::vec_pack_micro_ops
+fun consume_empty: heap_ptr_offsets=[8] zero_frame=true
+fun literal_args: heap_ptr_offsets=[] zero_frame=false
+fun pack_nested: heap_ptr_offsets=[8, 16, 24, 32, 56, 72] zero_frame=true
+fun pack_u64: heap_ptr_offsets=[24, 32, 56] zero_frame=true
+fun swap_pair: heap_ptr_offsets=[16, 24, 56, 72] zero_frame=true
+fun take_two: heap_ptr_offsets=[0, 8, 16, 40] zero_frame=true

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_pack_micro_ops.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_pack_micro_ops.move
@@ -1,0 +1,52 @@
+// RUN: publish --print(micro-ops,frame-layout)
+module 0x66::vec_pack_micro_ops {
+    use std::vector;
+
+    public fun pack_u64(first: u64, second: u64, third: u64): u64 {
+        let items = vector[first, second, third];
+        *vector::borrow(&items, 1)
+    }
+
+    public fun pack_nested(low: u8, high: u8): u8 {
+        let front = vector[low, low];
+        let back = vector[high];
+        let outer = vector[front, back];
+        *vector::borrow(vector::borrow(&outer, 0), 1)
+            + *vector::borrow(vector::borrow(&outer, 1), 0)
+    }
+
+    public fun swap_pair(first: u64, second: u64): u64 {
+        let items = vector[first, second];
+        vector::swap(&mut items, 0, 1);
+        *vector::borrow(&items, 0)
+    }
+
+    public fun consume_empty(value: u64): u64 {
+        let items = vector::empty<u64>();
+        vector::destroy_empty(items);
+        value
+    }
+
+    fun take_two(bytes: vector<u8>, nums: vector<u64>): u64 {
+        vector::length(&bytes) * 10 + vector::length(&nums)
+    }
+
+    public fun literal_args(byte_val: u8, num_val: u64): u64 {
+        take_two(vector[byte_val], vector[num_val, num_val])
+    }
+}
+
+// RUN: execute 0x66::vec_pack_micro_ops::pack_u64 --args 5, 6, 7
+// CHECK: results: 6
+
+// RUN: execute 0x66::vec_pack_micro_ops::pack_nested --args 3, 4
+// CHECK: results: 7
+
+// RUN: execute 0x66::vec_pack_micro_ops::swap_pair --args 10, 20
+// CHECK: results: 20
+
+// RUN: execute 0x66::vec_pack_micro_ops::consume_empty --args 99
+// CHECK: results: 99
+
+// RUN: execute 0x66::vec_pack_micro_ops::literal_args --args 8, 250
+// CHECK: results: 12

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_swap.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_swap.move
@@ -1,0 +1,113 @@
+// RUN: publish
+module 0x66::vec_swap {
+    use std::vector;
+
+    // Digit-pair-encodes the elements (each < 100) for readback.
+    fun encode(items: &vector<u64>): u64 {
+        let total = 0;
+        let pos = 0;
+        while (pos < vector::length(items)) {
+            total = total * 100 + *vector::borrow(items, pos);
+            pos = pos + 1;
+        };
+        total
+    }
+
+    public fun swap_encode(idx_a: u64, idx_b: u64): u64 {
+        let items = vector[11, 22, 33, 44];
+        vector::swap(&mut items, idx_a, idx_b);
+        encode(&items)
+    }
+
+    public fun swap_empty(idx_a: u64, idx_b: u64): u64 {
+        let items = vector::empty<u64>();
+        vector::swap(&mut items, idx_a, idx_b);
+        vector::length(&items)
+    }
+
+    public fun swap_remove_encode(idx: u64): u64 {
+        let items = vector[11, 22, 33, 44];
+        let last_idx = vector::length(&items) - 1;
+        vector::swap(&mut items, idx, last_idx);
+        let removed = vector::pop_back(&mut items);
+        removed * 1000000 + encode(&items)
+    }
+
+    public fun swap_bytes_encode(idx_a: u64, idx_b: u64): u64 {
+        let bytes = vector[1u8, 2u8, 3u8, 4u8];
+        vector::swap(&mut bytes, idx_a, idx_b);
+        let total = 0u64;
+        let pos = 0;
+        while (pos < vector::length(&bytes)) {
+            total = total * 100 + (*vector::borrow(&bytes, pos) as u64);
+            pos = pos + 1;
+        };
+        total
+    }
+
+    public fun swap_wide(first: u256, second: u256): u256 {
+        let items = vector[first, second];
+        vector::swap(&mut items, 0, 1);
+        *vector::borrow(&items, 0) * 1000000 + *vector::borrow(&items, 1)
+    }
+}
+
+// First/last swap.
+// RUN: execute 0x66::vec_swap::swap_encode --args 0, 3
+// CHECK: results: 44223311
+
+// Adjacent elements.
+// RUN: execute 0x66::vec_swap::swap_encode --args 1, 2
+// CHECK: results: 11332244
+
+// Operand order is irrelevant.
+// RUN: execute 0x66::vec_swap::swap_encode --args 3, 0
+// CHECK: results: 44223311
+
+// In-bounds swap(i, i) is a no-op.
+// RUN: execute 0x66::vec_swap::swap_encode --args 2, 2
+// CHECK: results: 11223344
+
+// Out-of-bounds swap(i, i) must still error.
+// RUN: execute 0x66::vec_swap::swap_encode --args 5, 5
+// CHECK-V1-SUBSTR: VECTOR_OPERATION_ERROR
+// CHECK-V2-SUBSTR: VecSwap index out of bounds
+
+// First index out of bounds, second in bounds.
+// RUN: execute 0x66::vec_swap::swap_encode --args 4, 1
+// CHECK-V1-SUBSTR: VECTOR_OPERATION_ERROR
+// CHECK-V2-SUBSTR: VecSwap index out of bounds
+
+// Second index out of bounds, first in bounds.
+// RUN: execute 0x66::vec_swap::swap_encode --args 1, 4
+// CHECK-V1-SUBSTR: VECTOR_OPERATION_ERROR
+// CHECK-V2-SUBSTR: VecSwap index out of bounds
+
+// Swap on an empty (null-pointer) vector.
+// RUN: execute 0x66::vec_swap::swap_empty --args 0, 0
+// CHECK-V1-SUBSTR: VECTOR_OPERATION_ERROR
+// CHECK-V2-SUBSTR: VecSwap index out of bounds
+
+// swap_remove middle: last element moves into the hole.
+// RUN: execute 0x66::vec_swap::swap_remove_encode --args 1
+// CHECK: results: 22114433
+
+// swap_remove first.
+// RUN: execute 0x66::vec_swap::swap_remove_encode --args 0
+// CHECK: results: 11442233
+
+// swap_remove last: degenerate self-swap, order preserved.
+// RUN: execute 0x66::vec_swap::swap_remove_encode --args 3
+// CHECK: results: 44112233
+
+// 1-byte elements: [1, 2, 3, 4] -> [4, 2, 3, 1].
+// RUN: execute 0x66::vec_swap::swap_bytes_encode --args 0, 3
+// CHECK: results: 4020301
+
+// 1-byte elements, adjacent: [1, 2, 3, 4] -> [1, 3, 2, 4].
+// RUN: execute 0x66::vec_swap::swap_bytes_encode --args 1, 2
+// CHECK: results: 1030204
+
+// 32-byte elements: [5, 9] -> [9, 5].
+// RUN: execute 0x66::vec_swap::swap_wide --args 5, 9
+// CHECK: results: 9000005

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_unpack.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_unpack.masm
@@ -1,0 +1,93 @@
+// RUN: publish
+module 0x66::vec_unpack
+
+// Combine as a + 10*b + 100*c so result parity proves element order.
+fun pack3_unpack3(): u64
+    local elem_a: u64
+    local elem_b: u64
+    local elem_c: u64
+    ld_u64 1
+    ld_u64 2
+    ld_u64 3
+    vec_pack <u64>, 3
+    vec_unpack <u64>, 3
+    st_loc elem_c
+    st_loc elem_b
+    st_loc elem_a
+    move_loc elem_a
+    ld_u64 10
+    move_loc elem_b
+    mul
+    add
+    ld_u64 100
+    move_loc elem_c
+    mul
+    add
+    ret
+
+fun unpack_too_many(): u64
+    ld_u64 1
+    ld_u64 2
+    vec_pack <u64>, 2
+    vec_unpack <u64>, 3
+    add
+    add
+    ret
+
+fun unpack_too_few(): u64
+    ld_u64 1
+    ld_u64 2
+    ld_u64 3
+    vec_pack <u64>, 3
+    vec_unpack <u64>, 2
+    add
+    ret
+
+fun unpack_empty_nonzero(): u64
+    vec_pack <u64>, 0
+    vec_unpack <u64>, 1
+    ret
+
+fun unpack_zero_on_empty(): u64
+    vec_pack <u64>, 0
+    vec_unpack <u64>, 0
+    ld_u64 77
+    ret
+
+fun pack2_unpack2_u8(): u8
+    local byte_a: u8
+    local byte_b: u8
+    ld_u8 7
+    ld_u8 9
+    vec_pack <u8>, 2
+    vec_unpack <u8>, 2
+    st_loc byte_b
+    st_loc byte_a
+    move_loc byte_a
+    ld_u8 10
+    move_loc byte_b
+    mul
+    add
+    ret
+
+// RUN: execute 0x66::vec_unpack::pack3_unpack3
+// CHECK: results: 321
+
+// RUN: execute 0x66::vec_unpack::unpack_too_many
+// CHECK-V1-SUBSTR: VECTOR_OPERATION_ERROR
+// CHECK-V2-SUBSTR: VecUnpack: expected 3 elements, vector has 2
+
+// RUN: execute 0x66::vec_unpack::unpack_too_few
+// CHECK-V1-SUBSTR: VECTOR_OPERATION_ERROR
+// CHECK-V2-SUBSTR: VecUnpack: expected 2 elements, vector has 3
+
+// RUN: execute 0x66::vec_unpack::unpack_empty_nonzero
+// CHECK-V1-SUBSTR: VECTOR_OPERATION_ERROR
+// CHECK-V2-SUBSTR: VecUnpack: expected 1 elements, vector has 0
+
+// RUN: execute 0x66::vec_unpack::unpack_zero_on_empty
+// CHECK: results: 77
+
+// 7 + 10*9 = 97 proves both u8 elements landed intact.
+// RUN: execute 0x66::vec_unpack::pack2_unpack2_u8
+// CHECK: results: 97


### PR DESCRIPTION
## Description

In this PR, we support lowering of a few remaining vector operations: pack, unpack, swap. Corresponding micro-ops are added. Differential tests show end-to-end execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches heap allocation, GC safe points, and raw vector memory in the interpreter; behavior is heavily covered by differential tests but mistakes in length checks or GC ordering could cause aborts or memory bugs.
> 
> **Overview**
> Adds **`VecPack`**, **`VecUnpack`**, and **`VecSwap`** micro-ops so Move vector literals, `vector::destroy_empty`, and `vector::swap` can run on MonoMove instead of stopping at the specializer.
> 
> **`VecPack`** allocates a vector at exact capacity (may GC), copies frame elements in, and writes the heap pointer; empty packs lower to **`VecNew`** (null pointer). **`VecUnpack`** requires length to match destination count exactly (including zero destinations on an empty/null vector). **`VecSwap`** swaps two in-bounds elements via `swap_nonoverlapping`, with equal indices as a no-op.
> 
> The pipeline is wired through: stackless IR drops redundant `u16` counts (length comes from slot lists), lowering emits the new ops with vector descriptor lookup, the interpreter implements pack/unpack helpers, gas models unpack/swap, and the static verifier gains **`check_vector_descriptor`** shared with push-back. Docs rename **`PinnedRoots`** → **`RootPool`** in a few places (orthogonal to behavior).
> 
> Differential tests cover literals, nested vectors, unpack length errors, swap/remove patterns, destroy-empty vs nonempty, GC under tight heap during pack loops, and expected micro-op dumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b93c2174f3ac9e691e6966d75103e2957e3af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->