### PR TITLE
[consensus] Demote leader-reputation short-window log during catch-up

### DIFF
--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -134,16 +134,40 @@ impl AptosDBBackend {
         }
 
         if result.len() < self.window_size && !hit_end {
-            error!(
-                "We are not fetching far enough in history, we filtered from {} to {}, but asked for {}. Target ({}, {}), received from {:?} to {:?}.",
-                events.len(),
-                result.len(),
-                self.window_size,
-                target_epoch,
-                target_round,
-                events.last().map_or((0, 0), |e| (e.event.epoch(), e.event.round())),
-                events.first().map_or((0, 0), |e| (e.event.epoch(), e.event.round())),
-            );
+            // We asked for `window_size` events at or below `target_round` but got fewer,
+            // even though older events exist in the DB (`!hit_end`). Two reasons:
+            // - The events DB only goes back so far (pruned / never backfilled). The real
+            //   problem -> error.
+            // - We are electing for a round well behind the storage tip, so most of the
+            //   fetched events are newer than `target_round` and get filtered out, leaving
+            //   too few. Happens while catching up (state sync / block retrieval advanced
+            //   storage past the round driver); expected and transient -> warn.
+            // `events.len() - result.len()` is how far the tip is ahead of `target_round`;
+            // beyond `seek_len` (the buffer this fetch is sized for) we are in the second case.
+            let behind_tip = events.len() - result.len();
+            if behind_tip > self.seek_len {
+                warn!(
+                    "Electing for a round behind the storage tip (likely catching up), so the history window is short: filtered from {} to {}, but asked for {}. Target ({}, {}), received from {:?} to {:?}.",
+                    events.len(),
+                    result.len(),
+                    self.window_size,
+                    target_epoch,
+                    target_round,
+                    events.last().map_or((0, 0), |e| (e.event.epoch(), e.event.round())),
+                    events.first().map_or((0, 0), |e| (e.event.epoch(), e.event.round())),
+                );
+            } else {
+                error!(
+                    "We are not fetching far enough in history, we filtered from {} to {}, but asked for {}. Target ({}, {}), received from {:?} to {:?}.",
+                    events.len(),
+                    result.len(),
+                    self.window_size,
+                    target_epoch,
+                    target_round,
+                    events.last().map_or((0, 0), |e| (e.event.epoch(), e.event.round())),
+                    events.first().map_or((0, 0), |e| (e.event.epoch(), e.event.round())),
+                );
+            }
         }
 
         if result.is_empty() {


### PR DESCRIPTION
## Problem

`AptosDBBackend::get_from_db_result` logs an `error!` whenever the fetched `NewBlockEvent` window comes up shorter than `window_size`:

> We are not fetching far enough in history, we filtered from 1130 to 968, but asked for 990. Target (16137, 147392), received from (16137, 146424) to (16137, 147554).

The message implies missing/pruned history, but it also fires in a completely benign situation: when the node is electing a leader for a round **well behind the storage tip**. `get_latest_block_events()` anchors the fetch at the storage tip, so when the tip is far ahead of `target_round`, most fetched events are *newer* than `target_round` and get filtered out, leaving fewer than `window_size`.

This happens during **catch-up** — state sync or block retrieval writes committed blocks to storage, advancing the tip hundreds of rounds past the local round driver. The seek buffer (`seek_len`) is sized only for routine lookups just behind the tip, so it can't cover the gap.

### Observed on mainnet

`mainnet-validator-euwe4-3` emitted a ~100s burst of these errors (2026-06-05 22:02:37–22:04:15) right after an epoch change. Metrics for that exact window showed `sync_info_received_with_newer_cert` spiking ~6x (2/s → 13/s) alongside `block_retrieval` and `commit_decision`, while proposals/votes/timeouts stayed flat — i.e. the node was catching up, not losing history. It self-resolved when catch-up finished.

## Fix

Distinguish the two causes by how far the storage tip is ahead of `target_round`, which is exactly `events.len() - result.len()` (events newer than target that got filtered out):

- `behind_tip > seek_len` → node is behind the tip / catching up → **`warn`** (expected, transient)
- `behind_tip <= seek_len` → fetched within the sized buffer and still short → **`error`** (genuinely missing history — pruned / never backfilled)

No change to election behavior; only the log severity/message is gated. `seek_len` is the principled threshold since it's the buffer this fetch is sized to tolerate — no arbitrary constant.

Sanity check against the incident: `behind_tip = 1130 − 968 = 162 > seek_len(≈140)` → correctly demoted to `warn`.

## Test plan

- `cargo check -p aptos-consensus` — passes
- `cargo clippy -p aptos-consensus` — no new warnings from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)