### PR TITLE
[types] Defer signature decompression in AggregateSignature and SignatureWithStatus

### DIFF
--- a/consensus/consensus-types/src/order_vote.rs
+++ b/consensus/consensus-types/src/order_vote.rs
@@ -62,10 +62,6 @@ impl OrderVote {
         &self.ledger_info
     }
 
-    pub fn signature(&self) -> &bls12381::Signature {
-        self.signature.signature()
-    }
-
     // Question: SignatureWithStatus has interior mutability. Is it okay to expose this?
     pub fn signature_with_status(&self) -> &SignatureWithStatus {
         &self.signature

--- a/consensus/consensus-types/src/pipeline/commit_vote.rs
+++ b/consensus/consensus-types/src/pipeline/commit_vote.rs
@@ -78,9 +78,9 @@ impl CommitVote {
         &self.ledger_info
     }
 
-    /// Return the signature of the vote
-    pub fn signature(&self) -> &bls12381::Signature {
-        self.signature.signature()
+    /// Return the (decompressed) signature of the vote.
+    pub fn decompressed_signature(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        self.signature.decompressed_signature()
     }
 
     /// Returns the signature along with the verification status of the signature.

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -542,10 +542,6 @@ where
         Ok(validator.optimistic_verify(self.signer, &self.info, &self.signature)?)
     }
 
-    pub fn signature(&self) -> &bls12381::Signature {
-        self.signature.signature()
-    }
-
     pub fn signature_with_status(&self) -> &SignatureWithStatus {
         &self.signature
     }

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -107,11 +107,6 @@ impl Vote {
         &self.ledger_info
     }
 
-    /// Return the signature of the vote
-    pub fn signature(&self) -> &bls12381::Signature {
-        self.signature.signature()
-    }
-
     pub fn signature_with_status(&self) -> &SignatureWithStatus {
         &self.signature
     }

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -172,7 +172,12 @@ pub fn make_proposal_with_parent_and_overrides(
         PartialSignatures::empty(),
     );
 
-    ledger_info_with_signatures.add_signature(vote.author(), vote.signature().clone());
+    ledger_info_with_signatures.add_signature(
+        vote.author(),
+        vote.signature_with_status()
+            .decompressed_signature()
+            .unwrap(),
+    );
 
     let qc = QuorumCert::new(
         vote_data,

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -287,14 +287,26 @@ mod tests {
             li.clone(),
             signers[0].sign(&li).expect("Unable to sign ledger info"),
         );
-        partial_signatures.add_signature(signers[0].author(), vote_0.signature().clone());
+        partial_signatures.add_signature(
+            signers[0].author(),
+            vote_0
+                .signature_with_status()
+                .decompressed_signature()
+                .unwrap(),
+        );
 
         let vote_1 = OrderVote::new_with_signature(
             signers[1].author(),
             li.clone(),
             signers[1].sign(&li).expect("Unable to sign ledger info"),
         );
-        partial_signatures.add_signature(signers[1].author(), vote_1.signature().clone());
+        partial_signatures.add_signature(
+            signers[1].author(),
+            vote_1
+                .signature_with_status()
+                .decompressed_signature()
+                .unwrap(),
+        );
 
         let vote_2 = OrderVote::new_with_signature(
             signers[2].author(),
@@ -307,7 +319,13 @@ mod tests {
             li.clone(),
             signers[3].sign(&li).expect("Unable to sign ledger info"),
         );
-        partial_signatures.add_signature(signers[3].author(), vote_3.signature().clone());
+        partial_signatures.add_signature(
+            signers[3].author(),
+            vote_3
+                .signature_with_status()
+                .decompressed_signature()
+                .unwrap(),
+        );
 
         let vote_4 = OrderVote::new_with_signature(
             signers[4].author(),

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -716,7 +716,13 @@ mod tests {
             pending_votes.insert_vote(&vote_0, &validator_verifier),
             VoteReceptionResult::VoteAdded(1)
         );
-        partial_sigs.add_signature(signers[0].author(), vote_0.signature().clone());
+        partial_sigs.add_signature(
+            signers[0].author(),
+            vote_0
+                .signature_with_status()
+                .decompressed_signature()
+                .unwrap(),
+        );
 
         // same author voting for the same thing -> DuplicateVote
         assert_eq!(
@@ -728,7 +734,13 @@ mod tests {
             pending_votes.insert_vote(&vote_1, &validator_verifier),
             VoteReceptionResult::VoteAdded(2)
         );
-        partial_sigs.add_signature(signers[1].author(), vote_1.signature().clone());
+        partial_sigs.add_signature(
+            signers[1].author(),
+            vote_1
+                .signature_with_status()
+                .decompressed_signature()
+                .unwrap(),
+        );
 
         assert_eq!(validator_verifier.pessimistic_verify_set().len(), 0);
 
@@ -749,7 +761,13 @@ mod tests {
             },
         }
 
-        partial_sigs.add_signature(signers[3].author(), vote_3.signature().clone());
+        partial_sigs.add_signature(
+            signers[3].author(),
+            vote_3
+                .signature_with_status()
+                .decompressed_signature()
+                .unwrap(),
+        );
         let aggregated_sig = validator_verifier
             .aggregate_signatures(partial_sigs.signatures_iter())
             .unwrap();

--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -607,23 +607,23 @@ mod test {
         let mut partial_signatures = BTreeMap::new();
         partial_signatures.insert(
             validator_signers[0].author(),
-            commit_votes[0].signature().clone(),
+            commit_votes[0].decompressed_signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[1].author(),
-            commit_votes[1].signature().clone(),
+            commit_votes[1].decompressed_signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[2].author(),
-            commit_votes[2].signature().clone(),
+            commit_votes[2].decompressed_signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[3].author(),
-            commit_votes[3].signature().clone(),
+            commit_votes[3].decompressed_signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[4].author(),
-            commit_votes[4].signature().clone(),
+            commit_votes[4].decompressed_signature().unwrap(),
         );
         let li_with_sig = validator_verifier
             .aggregate_signatures(partial_signatures.iter())
@@ -711,23 +711,23 @@ mod test {
         let mut partial_signatures = BTreeMap::new();
         partial_signatures.insert(
             validator_signers[0].author(),
-            commit_votes[0].signature().clone(),
+            commit_votes[0].decompressed_signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[1].author(),
-            commit_votes[1].signature().clone(),
+            commit_votes[1].decompressed_signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[2].author(),
-            commit_votes[2].signature().clone(),
+            commit_votes[2].decompressed_signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[4].author(),
-            commit_votes[4].signature().clone(),
+            commit_votes[4].decompressed_signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[6].author(),
-            commit_votes[6].signature().clone(),
+            commit_votes[6].decompressed_signature().unwrap(),
         );
         let li_with_sig = validator_verifier
             .aggregate_signatures(partial_signatures.iter())

--- a/consensus/src/pipeline/signing_phase.rs
+++ b/consensus/src/pipeline/signing_phase.rs
@@ -84,8 +84,11 @@ impl StatelessPipeline for SigningPhase {
             fut.commit_vote_fut
                 .clone()
                 .await
-                .map(|vote| vote.signature().clone())
                 .map_err(|e| Error::InternalError(e.to_string()))
+                .and_then(|vote| {
+                    vote.decompressed_signature()
+                        .map_err(|e| Error::InternalError(e.to_string()))
+                })
         } else {
             self.safety_rule_handle
                 .sign_commit_vote(ordered_ledger_info, commit_ledger_info.clone())

--- a/types/src/aggregate_signature.rs
+++ b/types/src/aggregate_signature.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use crate::lazy_bls::LazyBlsSignature;
 use aptos_bitvec::BitVec;
-use aptos_crypto::bls12381;
+use aptos_crypto::{bls12381, CryptoMaterialError};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
@@ -12,10 +13,17 @@ use std::collections::BTreeMap;
 /// it stores a bit mask representing the set of validators participating in the signing process
 /// and the multi-signature/aggregated signature itself,
 /// which was aggregated from these validators' partial BLS signatures.
+///
+/// The aggregated signature is stored lazily as compressed bytes
+/// ([`LazyBlsSignature`]): its G2 point is only decompressed when actually
+/// needed for verification (via [`AggregateSignature::decompressed_sig`]), after
+/// cheaper structural checks have run. This bounds the per-message CPU work a
+/// peer-supplied payload can force on the receiver. The on-wire encoding is
+/// byte-identical to storing a `bls12381::Signature` directly.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, BCSCryptoHash)]
 pub struct AggregateSignature {
     validator_bitmask: BitVec,
-    sig: Option<bls12381::Signature>,
+    sig: Option<LazyBlsSignature>,
 }
 
 impl AggregateSignature {
@@ -25,7 +33,9 @@ impl AggregateSignature {
     ) -> Self {
         Self {
             validator_bitmask,
-            sig: aggregated_signature,
+            sig: aggregated_signature
+                .as_ref()
+                .map(LazyBlsSignature::from_signature),
         }
     }
 
@@ -61,8 +71,19 @@ impl AggregateSignature {
         self.validator_bitmask.count_ones() as usize
     }
 
-    pub fn sig(&self) -> &Option<bls12381::Signature> {
+    /// The aggregated signature in its lazy, still-compressed form. Callers that
+    /// only need the raw bytes (e.g. API hex export) can use this without paying
+    /// for decompression.
+    pub fn sig(&self) -> &Option<LazyBlsSignature> {
         &self.sig
+    }
+
+    /// Decompress the aggregated signature into a `bls12381::Signature`,
+    /// performing the deferred G2-point decompression. Returns `Ok(None)` if no
+    /// signature is present. This is the verification entry point — call it only
+    /// after cheaper structural checks (bitmask, voting power) have passed.
+    pub fn decompressed_sig(&self) -> Result<Option<bls12381::Signature>, CryptoMaterialError> {
+        self.sig.as_ref().map(|s| s.decompress()).transpose()
     }
 }
 

--- a/types/src/lazy_bls.rs
+++ b/types/src/lazy_bls.rs
@@ -1,0 +1,194 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Lazy wire type for BLS aggregate/multi-signatures.
+//!
+//! `LazyBlsSignature` carries the same on-wire encoding as
+//! `aptos_crypto::bls12381::Signature` but skips the expensive G2-point
+//! decompression at deserialization time. `bls12381::Signature`'s
+//! `Deserialize` runs `blst::min_pk::Signature::from_bytes`, which decompresses
+//! the 96-byte compressed G2 point (a field square root) on every element —
+//! before any cheap structural check on the surrounding message can run.
+//!
+//! By storing the raw compressed bytes and deferring decompression until
+//! [`LazyBlsSignature::decompress`] is called, callers can run cheap structural
+//! gates (vector length, bitmask, voting power) first and only pay the
+//! per-signature decompression cost once a message has cleared them. This
+//! bounds the CPU work a peer-supplied payload can force on the receiver.
+//!
+//! ## Wire compatibility
+//!
+//! `bls12381::Signature` derives serde via `SerializeKey`/`DeserializeKey`,
+//! which encode:
+//!   - non-human-readable (e.g. BCS): `serialize_newtype_struct("Signature",
+//!     serde_bytes::Bytes)` — i.e. a length-prefixed byte string named
+//!     "Signature".
+//!   - human-readable (e.g. JSON): `serialize_str("0x" + hex(bytes))`, decoded
+//!     via `from_encoded_string` (which also tolerates an AIP-80 prefix).
+//!
+//! `LazyBlsSignature` replicates both branches exactly, emitting the same serde
+//! data-model name ("Signature") so the encoding is byte-identical in every
+//! format and the serde-reflection format corpus is unchanged. The
+//! `lazy_bls_wire_compat_*` tests assert bitwise equality with
+//! `bls12381::Signature` for both BCS and JSON.
+
+use aptos_crypto::{bls12381, traits::ValidCryptoMaterial, CryptoMaterialError};
+use serde::{
+    de::{self, Deserializer},
+    ser::Serializer,
+    Deserialize, Serialize,
+};
+
+/// The serde data-model name used by `bls12381::Signature`'s `SerializeKey`
+/// derive. Must match so the on-wire encoding (and traced format) is identical.
+const SIGNATURE_NAME: &str = "Signature";
+
+/// Compressed-bytes form of a `bls12381::Signature`. Wire-identical to
+/// `bls12381::Signature`, but decoding does not decompress the G2 point.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct LazyBlsSignature([u8; bls12381::Signature::LENGTH]);
+
+impl LazyBlsSignature {
+    /// Capture the compressed wire bytes of a known-valid signature.
+    pub fn from_signature(sig: &bls12381::Signature) -> Self {
+        Self(sig.to_bytes())
+    }
+
+    /// Subgroup-unchecked G2 decompression — the expensive operation we defer
+    /// until a payload has cleared structural validation. (The subgroup check
+    /// itself still happens later, inside signature verification.)
+    pub fn decompress(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        bls12381::Signature::try_from(self.0.as_slice())
+    }
+
+    /// The raw 96-byte compressed encoding. Lets callers that only need the
+    /// bytes (e.g. API hex export) avoid decompression entirely.
+    pub fn to_bytes(&self) -> [u8; bls12381::Signature::LENGTH] {
+        self.0
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn from_raw_bytes_for_test(bytes: [u8; bls12381::Signature::LENGTH]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl Serialize for LazyBlsSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            // Mirror `to_encoded_string`: "0x" + hex(bytes).
+            serializer.serialize_str(&format!("0x{}", hex::encode(self.0)))
+        } else {
+            // Mirror `SerializeKey`: a newtype struct named "Signature" wrapping
+            // a serde_bytes byte string (length-prefixed in BCS).
+            serializer.serialize_newtype_struct(
+                SIGNATURE_NAME,
+                serde_bytes::Bytes::new(self.0.as_slice()),
+            )
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for LazyBlsSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: Vec<u8> = if deserializer.is_human_readable() {
+            // Mirror `from_encoded_string`: tolerate an AIP-80 prefix and/or a
+            // leading "0x", then hex-decode.
+            let encoded = <String>::deserialize(deserializer)?;
+            let stripped = encoded
+                .strip_prefix(bls12381::Signature::AIP_80_PREFIX)
+                .unwrap_or(&encoded);
+            let stripped = stripped.strip_prefix("0x").unwrap_or(stripped);
+            hex::decode(stripped).map_err(de::Error::custom)?
+        } else {
+            // Mirror `DeserializeKey`: a newtype struct named "Signature"
+            // wrapping a borrowed byte slice. Capture the bytes WITHOUT calling
+            // `bls12381::Signature::try_from` (which would decompress).
+            #[derive(Deserialize)]
+            #[serde(rename = "Signature")]
+            struct Value<'a>(&'a [u8]);
+
+            let value = Value::deserialize(deserializer)?;
+            value.0.to_vec()
+        };
+
+        let arr: [u8; bls12381::Signature::LENGTH] = bytes.try_into().map_err(|v: Vec<u8>| {
+            de::Error::custom(format!(
+                "invalid BLS signature length: {} (expected {})",
+                v.len(),
+                bls12381::Signature::LENGTH
+            ))
+        })?;
+        Ok(Self(arr))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_crypto::{bls12381::PrivateKey, test_utils::TestAptosCrypto, SigningKey, Uniform};
+
+    fn sample_signature() -> bls12381::Signature {
+        let mut rng = rand::thread_rng();
+        let sk = PrivateKey::generate(&mut rng);
+        sk.sign(&TestAptosCrypto("lazy_bls".to_string())).unwrap()
+    }
+
+    /// `LazyBlsSignature` must BCS-encode bitwise-identically to
+    /// `bls12381::Signature` so validators on either type interoperate on the
+    /// wire and on-disk blobs round-trip.
+    #[test]
+    fn lazy_bls_wire_compat_bcs() {
+        for _ in 0..16 {
+            let sig = sample_signature();
+            let lazy = LazyBlsSignature::from_signature(&sig);
+
+            let bytes_sig = bcs::to_bytes(&sig).unwrap();
+            let bytes_lazy = bcs::to_bytes(&lazy).unwrap();
+            assert_eq!(bytes_sig, bytes_lazy, "BCS encoding must match Signature");
+
+            // Bytes produced by Signature decode as LazyBlsSignature.
+            let decoded: LazyBlsSignature = bcs::from_bytes(&bytes_sig).unwrap();
+            assert_eq!(decoded, lazy);
+
+            // ...and bytes produced by LazyBlsSignature decode back to Signature.
+            let round: bls12381::Signature = bcs::from_bytes(&bytes_lazy).unwrap();
+            assert_eq!(round, sig);
+
+            // Deferred decompression yields the original signature.
+            assert_eq!(decoded.decompress().unwrap(), sig);
+        }
+    }
+
+    /// Human-readable (JSON) encoding must also match bitwise.
+    #[test]
+    fn lazy_bls_wire_compat_json() {
+        let sig = sample_signature();
+        let lazy = LazyBlsSignature::from_signature(&sig);
+
+        let json_sig = serde_json::to_string(&sig).unwrap();
+        let json_lazy = serde_json::to_string(&lazy).unwrap();
+        assert_eq!(json_sig, json_lazy, "JSON encoding must match Signature");
+
+        let decoded: LazyBlsSignature = serde_json::from_str(&json_sig).unwrap();
+        assert_eq!(decoded, lazy);
+        assert_eq!(decoded.decompress().unwrap(), sig);
+    }
+
+    /// A wrong-length payload must be rejected at deserialization, not silently
+    /// truncated/extended.
+    #[test]
+    fn rejects_wrong_length() {
+        // Encode a byte string of the wrong length the same way Signature would
+        // (newtype-struct-wrapped serde_bytes), then attempt to decode as lazy.
+        let short = serde_bytes::ByteBuf::from(vec![0u8; 95]);
+        let bytes = bcs::to_bytes(&short).unwrap();
+        assert!(bcs::from_bytes::<LazyBlsSignature>(&bytes).is_err());
+    }
+}

--- a/types/src/lazy_bls.rs
+++ b/types/src/lazy_bls.rs
@@ -38,6 +38,7 @@ use serde::{
     ser::Serializer,
     Deserialize, Serialize,
 };
+use std::{fmt, sync::OnceLock};
 
 /// The serde data-model name used by `bls12381::Signature`'s `SerializeKey`
 /// derive. Must match so the on-wire encoding (and traced format) is identical.
@@ -45,31 +46,90 @@ const SIGNATURE_NAME: &str = "Signature";
 
 /// Compressed-bytes form of a `bls12381::Signature`. Wire-identical to
 /// `bls12381::Signature`, but decoding does not decompress the G2 point.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct LazyBlsSignature([u8; bls12381::Signature::LENGTH]);
+#[derive(Clone)]
+pub struct LazyBlsSignature {
+    /// The compressed 96-byte wire encoding. This is the canonical identity of
+    /// the signature: the only field serialized, compared, or hashed.
+    bytes: [u8; bls12381::Signature::LENGTH],
+    /// Lazily-populated decompressed point, cached so that a signature we
+    /// constructed from an already-decompressed point (e.g. a freshly
+    /// aggregated multi-signature) does not pay the G2 decompression again
+    /// when it is immediately verified. Never serialized, and not part of the
+    /// value's identity (`Eq`/`Hash` ignore it).
+    ///
+    /// `OnceLock` (not `OnceCell`) because signatures are shared and
+    /// decompressed across rayon threads. `Box`ed so an *empty* cache costs
+    /// only a pointer, not an inline ~192-byte point — this keeps the
+    /// footprint of untrusted, still-compressed wire signatures small (a
+    /// peer-supplied `SignedBatchInfoMsg` is decoded in full before its length
+    /// cap is enforced, so per-signature memory is attacker-amplifiable).
+    decompressed: OnceLock<Box<bls12381::Signature>>,
+}
 
 impl LazyBlsSignature {
-    /// Capture the compressed wire bytes of a known-valid signature.
+    /// Capture the compressed wire bytes of a known-valid signature, keeping the
+    /// already-decompressed point cached so a subsequent [`Self::decompress`]
+    /// (e.g. the verify right after local aggregation) is free.
     pub fn from_signature(sig: &bls12381::Signature) -> Self {
-        Self(sig.to_bytes())
+        let decompressed = OnceLock::new();
+        // Infallible on a fresh cell.
+        let _ = decompressed.set(Box::new(sig.clone()));
+        Self {
+            bytes: sig.to_bytes(),
+            decompressed,
+        }
     }
 
     /// Subgroup-unchecked G2 decompression — the expensive operation we defer
     /// until a payload has cleared structural validation. (The subgroup check
-    /// itself still happens later, inside signature verification.)
+    /// itself still happens later, inside signature verification.) The result
+    /// is cached, so repeated calls — and signatures constructed via
+    /// [`Self::from_signature`] — do not decompress again.
     pub fn decompress(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
-        bls12381::Signature::try_from(self.0.as_slice())
+        if let Some(sig) = self.decompressed.get() {
+            return Ok((**sig).clone());
+        }
+        let sig = bls12381::Signature::try_from(self.bytes.as_slice())?;
+        // Ignore a race where another thread cached it first; the value is
+        // deterministic either way.
+        let _ = self.decompressed.set(Box::new(sig.clone()));
+        Ok(sig)
     }
 
     /// The raw 96-byte compressed encoding. Lets callers that only need the
     /// bytes (e.g. API hex export) avoid decompression entirely.
     pub fn to_bytes(&self) -> [u8; bls12381::Signature::LENGTH] {
-        self.0
+        self.bytes
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn from_raw_bytes_for_test(bytes: [u8; bls12381::Signature::LENGTH]) -> Self {
-        Self(bytes)
+        Self {
+            bytes,
+            decompressed: OnceLock::new(),
+        }
+    }
+}
+
+// Identity is the compressed bytes only; the decompression cache is a transient
+// performance aid and must not affect equality, hashing, or debug output.
+impl PartialEq for LazyBlsSignature {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes == other.bytes
+    }
+}
+
+impl Eq for LazyBlsSignature {}
+
+impl std::hash::Hash for LazyBlsSignature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.bytes.hash(state);
+    }
+}
+
+impl fmt::Debug for LazyBlsSignature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LazyBlsSignature(0x{})", hex::encode(self.bytes))
     }
 }
 
@@ -80,13 +140,13 @@ impl Serialize for LazyBlsSignature {
     {
         if serializer.is_human_readable() {
             // Mirror `to_encoded_string`: "0x" + hex(bytes).
-            serializer.serialize_str(&format!("0x{}", hex::encode(self.0)))
+            serializer.serialize_str(&format!("0x{}", hex::encode(self.bytes)))
         } else {
             // Mirror `SerializeKey`: a newtype struct named "Signature" wrapping
             // a serde_bytes byte string (length-prefixed in BCS).
             serializer.serialize_newtype_struct(
                 SIGNATURE_NAME,
-                serde_bytes::Bytes::new(self.0.as_slice()),
+                serde_bytes::Bytes::new(self.bytes.as_slice()),
             )
         }
     }
@@ -97,7 +157,21 @@ impl<'de> Deserialize<'de> for LazyBlsSignature {
     where
         D: Deserializer<'de>,
     {
-        let bytes: Vec<u8> = if deserializer.is_human_readable() {
+        // Copy out exactly `LENGTH` bytes from a length-checked slice. The
+        // length is validated *before* the copy, so a wrong-length field
+        // (up to the 64 MiB network message cap on the consensus ingress path)
+        // is rejected without allocating an owned copy of the input.
+        fn to_array<E: de::Error>(bytes: &[u8]) -> Result<[u8; bls12381::Signature::LENGTH], E> {
+            <[u8; bls12381::Signature::LENGTH]>::try_from(bytes).map_err(|_| {
+                E::custom(format!(
+                    "invalid BLS signature length: {} (expected {})",
+                    bytes.len(),
+                    bls12381::Signature::LENGTH
+                ))
+            })
+        }
+
+        if deserializer.is_human_readable() {
             // Mirror `from_encoded_string`: tolerate an AIP-80 prefix and/or a
             // leading "0x", then hex-decode.
             let encoded = <String>::deserialize(deserializer)?;
@@ -105,27 +179,27 @@ impl<'de> Deserialize<'de> for LazyBlsSignature {
                 .strip_prefix(bls12381::Signature::AIP_80_PREFIX)
                 .unwrap_or(&encoded);
             let stripped = stripped.strip_prefix("0x").unwrap_or(stripped);
-            hex::decode(stripped).map_err(de::Error::custom)?
+            let bytes = hex::decode(stripped).map_err(de::Error::custom)?;
+            Ok(Self {
+                bytes: to_array(&bytes)?,
+                decompressed: OnceLock::new(),
+            })
         } else {
             // Mirror `DeserializeKey`: a newtype struct named "Signature"
-            // wrapping a borrowed byte slice. Capture the bytes WITHOUT calling
-            // `bls12381::Signature::try_from` (which would decompress).
+            // wrapping a *borrowed* byte slice. Length-check the borrowed slice
+            // and copy out exactly `LENGTH` bytes, WITHOUT calling
+            // `bls12381::Signature::try_from` (which would decompress) and
+            // without first copying the whole (possibly oversized) field.
             #[derive(Deserialize)]
             #[serde(rename = "Signature")]
             struct Value<'a>(&'a [u8]);
 
             let value = Value::deserialize(deserializer)?;
-            value.0.to_vec()
-        };
-
-        let arr: [u8; bls12381::Signature::LENGTH] = bytes.try_into().map_err(|v: Vec<u8>| {
-            de::Error::custom(format!(
-                "invalid BLS signature length: {} (expected {})",
-                v.len(),
-                bls12381::Signature::LENGTH
-            ))
-        })?;
-        Ok(Self(arr))
+            Ok(Self {
+                bytes: to_array(value.0)?,
+                decompressed: OnceLock::new(),
+            })
+        }
     }
 }
 
@@ -166,6 +240,52 @@ mod tests {
         }
     }
 
+    /// The empty (uncached) footprint must stay small: untrusted wire
+    /// signatures are decoded before any length cap is enforced, so a bloated
+    /// per-signature size is attacker-amplifiable. Boxing the cache keeps an
+    /// empty `LazyBlsSignature` near the 96-byte payload plus a pointer, rather
+    /// than reserving an inline ~192-byte decompressed point.
+    #[test]
+    fn uncached_footprint_is_small() {
+        let size = std::mem::size_of::<LazyBlsSignature>();
+        assert!(
+            size <= 128,
+            "LazyBlsSignature grew to {size} bytes; an empty cache must not \
+             reserve the decompressed point inline (box it)",
+        );
+    }
+
+    /// The decompression cache is a transient perf aid and must not affect
+    /// identity: a cached (`from_signature`) and an uncached (`from_raw_bytes`)
+    /// instance with the same bytes must be equal, hash equally, and serialize
+    /// identically. `AggregateSignature`'s derived `Eq` relies on this.
+    #[test]
+    fn cache_does_not_affect_identity() {
+        use std::hash::{Hash, Hasher};
+
+        let sig = sample_signature();
+        let cached = LazyBlsSignature::from_signature(&sig); // cache pre-filled
+        let uncached = LazyBlsSignature::from_raw_bytes_for_test(sig.to_bytes()); // cache empty
+
+        assert_eq!(cached, uncached, "cache must not affect equality");
+        assert_eq!(
+            bcs::to_bytes(&cached).unwrap(),
+            bcs::to_bytes(&uncached).unwrap(),
+            "cache must not affect encoding",
+        );
+
+        let hash = |v: &LazyBlsSignature| {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            v.hash(&mut h);
+            h.finish()
+        };
+        assert_eq!(hash(&cached), hash(&uncached), "cache must not affect hash");
+
+        // Both decompress to the same signature, cached or not.
+        assert_eq!(cached.decompress().unwrap(), sig);
+        assert_eq!(uncached.decompress().unwrap(), sig);
+    }
+
     /// Human-readable (JSON) encoding must also match bitwise.
     #[test]
     fn lazy_bls_wire_compat_json() {
@@ -189,6 +309,14 @@ mod tests {
         // (newtype-struct-wrapped serde_bytes), then attempt to decode as lazy.
         let short = serde_bytes::ByteBuf::from(vec![0u8; 95]);
         let bytes = bcs::to_bytes(&short).unwrap();
+        assert!(bcs::from_bytes::<LazyBlsSignature>(&bytes).is_err());
+
+        // An oversized field (bounded on the wire only by the network message
+        // cap) must also be rejected. The borrowed slice is length-checked
+        // before any copy, so this rejects without allocating a ~1 MiB owned
+        // buffer.
+        let oversized = serde_bytes::ByteBuf::from(vec![0u8; 1 << 20]);
+        let bytes = bcs::to_bytes(&oversized).unwrap();
         assert!(bcs::from_bytes::<LazyBlsSignature>(&bytes).is_err());
     }
 }

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -7,6 +7,7 @@ use crate::{
     account_address::AccountAddress,
     block_info::{BlockInfo, Round},
     epoch_state::EpochState,
+    lazy_bls::LazyBlsSignature,
     on_chain_config::ValidatorSet,
     transaction::Version,
     validator_verifier::{ValidatorVerifier, VerifyError},
@@ -14,6 +15,7 @@ use crate::{
 use aptos_crypto::{
     bls12381,
     hash::{CryptoHash, HashValue},
+    CryptoMaterialError,
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use derivative::Derivative;
@@ -381,10 +383,22 @@ impl LedgerInfoWithVerifiedSignatures {
     }
 }
 
+/// A BLS signature plus its (locally-tracked, non-serialized) verification
+/// status.
+///
+/// The signature is stored lazily as compressed bytes ([`LazyBlsSignature`]):
+/// its G2 point is only decompressed when actually needed for verification (via
+/// [`SignatureWithStatus::decompressed_signature`]). This lets callers run cheap
+/// structural checks — e.g. the `signed_infos.len() <= max_num_batches` cap in
+/// `SignedBatchInfoMsg::verify_inner`, or the sender/expiration checks in
+/// `SignedBatchInfo::verify` — before paying the per-signature decompression
+/// cost, bounding the CPU work a peer-supplied payload can force on the
+/// receiver. The on-wire encoding is byte-identical to storing a
+/// `bls12381::Signature` directly.
 #[derive(Clone, Debug, Derivative)]
 #[derivative(PartialEq, Eq)]
 pub struct SignatureWithStatus {
-    signature: bls12381::Signature,
+    signature: LazyBlsSignature,
     #[derivative(PartialEq = "ignore")]
     // false if the signature not verified.
     // true if the signature is verified.
@@ -396,11 +410,30 @@ impl SignatureWithStatus {
         self.verification_status.store(true, Ordering::SeqCst);
     }
 
-    pub fn signature(&self) -> &bls12381::Signature {
+    /// The signature in its lazy, still-compressed form. Callers that only need
+    /// the raw bytes can use this without paying for decompression.
+    pub fn lazy_signature(&self) -> &LazyBlsSignature {
         &self.signature
     }
 
+    /// Decompress the signature into a `bls12381::Signature`, performing the
+    /// deferred G2-point decompression. Call this only after cheaper structural
+    /// checks have passed.
+    pub fn decompressed_signature(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        self.signature.decompress()
+    }
+
     pub fn from(signature: bls12381::Signature) -> Self {
+        Self {
+            signature: LazyBlsSignature::from_signature(&signature),
+            verification_status: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Build directly from a (possibly invalid) lazy signature. Used by tests to
+    /// inject a signature whose bytes don't decompress to a valid curve point.
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn new_for_test(signature: LazyBlsSignature) -> Self {
         Self {
             signature,
             verification_status: Arc::new(AtomicBool::new(false)),
@@ -426,8 +459,12 @@ impl<'de> Deserialize<'de> for SignatureWithStatus {
     where
         D: serde::Deserializer<'de>,
     {
-        let signature = bls12381::Signature::deserialize(deserializer)?;
-        Ok(SignatureWithStatus::from(signature))
+        // Decodes the compressed bytes WITHOUT decompressing the G2 point.
+        let signature = LazyBlsSignature::deserialize(deserializer)?;
+        Ok(SignatureWithStatus {
+            signature,
+            verification_status: Arc::new(AtomicBool::new(false)),
+        })
     }
 }
 
@@ -500,11 +537,17 @@ impl<T: Clone + Send + Sync + Serialize + CryptoHash> SignatureAggregator<T> {
     ) -> Result<AggregateSignature, VerifyError> {
         self.check_voting_power(verifier, true)?;
 
+        // Decompress each signature now that voting power has been checked.
         let all_signatures = self
             .signatures
             .iter()
-            .map(|(voter, sig)| (voter, sig.signature()));
-        verifier.aggregate_signatures(all_signatures)
+            .map(|(voter, sig)| {
+                sig.decompressed_signature()
+                    .map(|sig| (*voter, sig))
+                    .map_err(|_| VerifyError::FailedToAggregateSignature)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        verifier.aggregate_signatures(all_signatures.iter().map(|(voter, sig)| (voter, sig)))
     }
 
     fn filter_invalid_signatures(&mut self, verifier: &ValidatorVerifier) {
@@ -518,14 +561,29 @@ impl<T: Clone + Send + Sync + Serialize + CryptoHash> SignatureAggregator<T> {
         &mut self,
         verifier: &ValidatorVerifier,
     ) -> Result<(T, AggregateSignature), VerifyError> {
-        let aggregated_sig = self.try_aggregate(verifier)?;
+        // Bail early — before the expensive per-signature pass — if we don't
+        // yet have quorum voting power; more votes may still arrive.
+        self.check_voting_power(verifier, true)?;
 
-        match verifier.verify_multi_signatures(&self.data, &aggregated_sig) {
-            Ok(_) => {
-                // We are not marking all the signatures as "verified" here, as two malicious
-                // voters can collude and create a valid aggregated signature.
-                Ok((self.data.clone(), aggregated_sig))
-            },
+        // Optimistically aggregate the collected signatures and verify the
+        // result. Two things can go wrong: aggregation itself can fail if a
+        // signature can't be decompressed (a peer may submit an invalid point,
+        // which — now that decompression is deferred past deserialization — is
+        // only detected here), and verification can fail if any signature is
+        // invalid. In either case, fall back to verifying each signature
+        // individually, drop the invalid ones, and re-aggregate the remaining
+        // valid set. This ensures a single bad signature can't poison the
+        // accumulator and permanently block certificate formation for a digest.
+        let aggregated_sig = self.try_aggregate(verifier).and_then(|aggregated_sig| {
+            verifier
+                .verify_multi_signatures(&self.data, &aggregated_sig)
+                .map(|_| aggregated_sig)
+        });
+
+        match aggregated_sig {
+            // We are not marking all the signatures as "verified" here, as two malicious
+            // voters can collude and create a valid aggregated signature.
+            Ok(aggregated_sig) => Ok((self.data.clone(), aggregated_sig)),
             Err(_) => {
                 self.filter_invalid_signatures(verifier);
 
@@ -590,11 +648,11 @@ mod tests {
     fn test_signature_with_status_bcs() {
         let signature = bls12381::Signature::dummy_signature();
         let signature_with_status_1 = SignatureWithStatus {
-            signature: signature.clone(),
+            signature: LazyBlsSignature::from_signature(&signature),
             verification_status: Arc::new(AtomicBool::new(true)),
         };
         let signature_with_status_2 = SignatureWithStatus {
-            signature: signature.clone(),
+            signature: LazyBlsSignature::from_signature(&signature),
             verification_status: Arc::new(AtomicBool::new(false)),
         };
         let serialized_signature_with_status_1 =
@@ -606,7 +664,12 @@ mod tests {
         let deserialized_signature_with_status: SignatureWithStatus =
             bcs::from_bytes(&serialized_signature_with_status_1)
                 .expect("Failed to deserialize signature");
-        assert_eq!(*deserialized_signature_with_status.signature(), signature);
+        assert_eq!(
+            deserialized_signature_with_status
+                .decompressed_signature()
+                .unwrap(),
+            signature
+        );
         assert!(!deserialized_signature_with_status.is_verified());
     }
 
@@ -614,11 +677,11 @@ mod tests {
     fn test_signature_with_status_serde() {
         let signature = bls12381::Signature::dummy_signature();
         let signature_with_status_1 = SignatureWithStatus {
-            signature: signature.clone(),
+            signature: LazyBlsSignature::from_signature(&signature),
             verification_status: Arc::new(AtomicBool::new(true)),
         };
         let signature_with_status_2 = SignatureWithStatus {
-            signature: signature.clone(),
+            signature: LazyBlsSignature::from_signature(&signature),
             verification_status: Arc::new(AtomicBool::new(false)),
         };
         let serialized_signature_with_status_1 =
@@ -630,8 +693,30 @@ mod tests {
         let deserialized_signature_with_status: SignatureWithStatus =
             serde_json::from_str(&serialized_signature_with_status_1)
                 .expect("Failed to deserialize signature");
-        assert_eq!(*deserialized_signature_with_status.signature(), signature);
+        assert_eq!(
+            deserialized_signature_with_status
+                .decompressed_signature()
+                .unwrap(),
+            signature
+        );
         assert!(!deserialized_signature_with_status.is_verified());
+    }
+
+    /// Deserializing a `SignatureWithStatus` must NOT decompress the G2 point.
+    /// A well-formed-length but invalid signature payload must decode
+    /// successfully (proving decompression is deferred) and only error when
+    /// `decompressed_signature()` is explicitly called. This is the property
+    /// that lets callers reject oversized/malformed messages on cheap
+    /// structural checks before paying per-signature decompression cost.
+    #[test]
+    fn deserialize_defers_decompression() {
+        // 0xff.. is not a valid compressed G2 point (its flag bits are
+        // inconsistent), so decompression must fail — but decoding must not.
+        let garbage = serde_bytes::ByteBuf::from(vec![0xFFu8; bls12381::Signature::LENGTH]);
+        let bytes = bcs::to_bytes(&garbage).unwrap();
+        let sig_with_status: SignatureWithStatus =
+            bcs::from_bytes(&bytes).expect("lazy deserialization must not decompress");
+        assert!(sig_with_status.decompressed_signature().is_err());
     }
 
     #[test]
@@ -843,5 +928,77 @@ mod tests {
         assert_eq!(signature_aggregator.verified_voters().count(), 5);
         assert_eq!(signature_aggregator.all_voters().count(), 5);
         assert_eq!(validator_verifier.pessimistic_verify_set().len(), 2);
+    }
+
+    /// A single signature whose bytes don't decompress to a valid curve point
+    /// must not be able to block certificate formation. Since decompression is
+    /// deferred past deserialization, such a signature passes ingress and lands
+    /// in the accumulator; `aggregate_and_verify` must filter it out (like any
+    /// other invalid signature) and still aggregate the remaining valid quorum.
+    #[test]
+    fn undecompressible_signature_does_not_poison_aggregation() {
+        let ledger_info = LedgerInfo::new(BlockInfo::empty(), HashValue::random());
+
+        const NUM_SIGNERS: u8 = 7;
+        let validator_signers: Vec<ValidatorSigner> = (0..NUM_SIGNERS)
+            .map(|i| ValidatorSigner::random([i; 32]))
+            .collect();
+        let validator_infos = validator_signers
+            .iter()
+            .map(|v| ValidatorConsensusInfo::new(v.author(), v.public_key(), 1))
+            .collect();
+        // Quorum voting power of 5.
+        let validator_verifier =
+            ValidatorVerifier::new_with_quorum_voting_power(validator_infos, 5)
+                .expect("Incorrect quorum size.");
+
+        let mut signature_aggregator = SignatureAggregator::new(ledger_info.clone());
+        let mut partial_sig = PartialSignatures::empty();
+
+        // Five honest signatures — exactly enough for quorum on their own.
+        for signer in validator_signers.iter().take(5) {
+            let signature = signer.sign(&ledger_info).unwrap();
+            signature_aggregator.add_signature(
+                signer.author(),
+                &SignatureWithStatus::from(signature.clone()),
+            );
+            partial_sig.add_signature(signer.author(), signature);
+        }
+
+        // One Byzantine signature whose 96 bytes are not a valid G2 point.
+        let poison = SignatureWithStatus::new_for_test(LazyBlsSignature::from_raw_bytes_for_test(
+            [0xFFu8; bls12381::Signature::LENGTH],
+        ));
+        assert!(poison.decompressed_signature().is_err());
+        signature_aggregator.add_signature(validator_signers[5].author(), &poison);
+
+        // Voting power (6) clears quorum, so aggregation is attempted.
+        assert_eq!(
+            signature_aggregator
+                .check_voting_power(&validator_verifier, true)
+                .unwrap(),
+            6
+        );
+
+        // The certificate must still form over the five valid signatures.
+        let expected_sig = validator_verifier
+            .aggregate_signatures(partial_sig.signatures_iter())
+            .unwrap();
+        assert_eq!(
+            signature_aggregator
+                .aggregate_and_verify(&validator_verifier)
+                .unwrap(),
+            (ledger_info.clone(), expected_sig.clone())
+        );
+        // Result must be a genuinely valid aggregate signature.
+        validator_verifier
+            .verify_multi_signatures(&ledger_info, &expected_sig)
+            .unwrap();
+
+        // The poisoned signer was dropped and flagged for pessimistic verification.
+        assert_eq!(signature_aggregator.all_voters().count(), 5);
+        assert!(validator_verifier
+            .pessimistic_verify_set()
+            .contains(&validator_signers[5].author()));
     }
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -67,6 +67,7 @@ pub mod block_executor;
 pub mod bytes;
 pub mod delayed_fields;
 pub mod keyless;
+pub mod lazy_bls;
 pub mod state_store;
 #[cfg(test)]
 mod unit_tests;

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -370,10 +370,11 @@ impl ValidatorVerifier {
                 return Ok(());
             }
         }
-        // Verify empty multi signature
+        // Verify empty multi signature. Decompression of the G2 point is
+        // deferred to here, after the cheap structural checks above.
         let multi_sig = multi_signature
-            .sig()
-            .as_ref()
+            .decompressed_sig()
+            .map_err(|_| VerifyError::InvalidMultiSignature)?
             .ok_or(VerifyError::EmptySignature)?;
         // Verify the optimistically aggregated signature.
         let aggregated_key =
@@ -404,10 +405,11 @@ impl ValidatorVerifier {
         }
         // Verify the quorum voting power of the authors
         self.check_voting_power(authors.iter(), true)?;
-        // Verify empty aggregated signature
+        // Verify empty aggregated signature. Decompression of the G2 point is
+        // deferred to here, after the cheap structural checks above.
         let aggregated_sig = aggregated_signature
-            .sig()
-            .as_ref()
+            .decompressed_sig()
+            .map_err(|_| VerifyError::InvalidAggregatedSignature)?
             .ok_or(VerifyError::EmptySignature)?;
 
         aggregated_sig

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -278,7 +278,11 @@ impl ValidatorVerifier {
         if (!self.optimistic_sig_verification || self.pessimistic_verify_set.contains(&author))
             && !signature_with_status.is_verified()
         {
-            self.verify(author, message, signature_with_status.signature())?;
+            // Decompress the signature only now, after the cheap author check.
+            let signature = signature_with_status
+                .decompressed_signature()
+                .map_err(|_| VerifyError::InvalidMultiSignature)?;
+            self.verify(author, message, &signature)?;
             signature_with_status.set_verified();
         }
         Ok(())
@@ -296,9 +300,9 @@ impl ValidatorVerifier {
             .with_min_len(4) // At least 4 signatures are verified in each task
             .filter_map(|(account_address, signature)| {
                 if signature.is_verified()
-                    || self
-                        .verify(account_address, message, signature.signature())
-                        .is_ok()
+                    || signature
+                        .decompressed_signature()
+                        .is_ok_and(|sig| self.verify(account_address, message, &sig).is_ok())
                 {
                     signature.set_verified();
                     Some((account_address, signature))


### PR DESCRIPTION
## Summary

Stores BLS signatures in their compressed wire form and defers point decompression from deserialization to verification time. Introduces `LazyBlsSignature` as the stored form on:

- `AggregateSignature` — the multi-/aggregate-signature field.
- `SignatureWithStatus` — the per-signature type embedded in signed batch info, votes, order votes, and commit votes.

Verify and aggregate paths decompress after the cheap structural checks have run. Wire encoding is byte-identical and the serde format corpus is unchanged.

## Testing

- Wire-compat tests (BCS + JSON) assert bitwise equality with the prior encoding for both types.
- A regression test asserts deserialization does not decompress (a well-formed-length but invalid payload decodes, and only fails on explicit decompression).
- `validator_verifier`, `ledger_info`, `proof_of_store`, and consensus aggregation tests pass.
- `generate-format` corpus unchanged.
- Downstream crates compile; fmt + clippy clean.