### PR TITLE
[mono-move] Enum value traversal support

### DIFF
--- a/third_party/move/mono-move/core/src/value_layout.rs
+++ b/third_party/move/mono-move/core/src/value_layout.rs
@@ -18,7 +18,7 @@
 //! TODO: We will need descriptor IDs for non-inline structs and enums later.
 
 use crate::{
-    types::{view_type, InternedType, InternedTypeList, Type},
+    types::{view_type, InternedType, Type},
     DescriptorId, MAX_ALIGN,
 };
 use bitflags::bitflags;
@@ -103,12 +103,14 @@ pub enum LayoutKind {
         elem_id: LayoutId,
         descriptor_id: DescriptorId,
     },
-    /// An enum whose variants are resolved lazily on every walk (upgradable).
-    /// TODO: not yet implemented; the walks error on this kind.
-    /// TODO: add closed enum (for framework, frozen ones)
-    OpenEnum {
-        ty: InternedType,
-        ty_args: InternedTypeList,
+    /// A closed (non-upgradable) enum: an 8-byte heap-pointer slot pointing at
+    /// an enum object. Every variant's body is a published (pseudo) struct
+    /// layout.
+    ClosedEnum {
+        descriptor_id: DescriptorId,
+        /// One struct layout per variant, indexed by variant tag.
+        variants: Box<[LayoutId]>,
+        max_variant_size: u32,
     },
     /// A reference (16-byte fat pointer). All references share this layout.
     Ref,
@@ -293,14 +295,22 @@ impl ValueLayout {
         }
     }
 
-    /// Layout for an open enum.
-    pub fn open_enum(ty: InternedType, ty_args: InternedTypeList) -> ValueLayout {
+    /// Layout for a closed enum.
+    pub fn closed_enum(
+        descriptor_id: DescriptorId,
+        variants: Box<[LayoutId]>,
+        max_variant_size: u32,
+    ) -> ValueLayout {
         Self {
             size: 8,
             align: MAX_ALIGN as u32,
             fixed_bcs_size: None,
             flags: LayoutFlags::empty(),
-            kind: LayoutKind::OpenEnum { ty, ty_args },
+            kind: LayoutKind::ClosedEnum {
+                descriptor_id,
+                variants,
+                max_variant_size,
+            },
         }
     }
 

--- a/third_party/move/mono-move/core/src/value_layout.rs
+++ b/third_party/move/mono-move/core/src/value_layout.rs
@@ -103,14 +103,20 @@ pub enum LayoutKind {
         elem_id: LayoutId,
         descriptor_id: DescriptorId,
     },
-    /// A closed (non-upgradable) enum: an 8-byte heap-pointer slot pointing at
-    /// an enum object. Every variant's body is a published (pseudo) struct
-    /// layout.
-    ClosedEnum {
+    /// An enum whose variant layouts are fixed: an 8-byte heap-pointer slot
+    /// pointing at an enum object. Each variant body has its own published
+    /// layout, which may itself contain enums, vectors, or structs.
+    ///
+    /// TODO: today only frozen (non-upgradable) enums get this layout. Use it
+    /// for all enums once the upgrade story is finalized.
+    FrozenEnum {
         descriptor_id: DescriptorId,
-        /// One struct layout per variant, indexed by variant tag.
+        /// One layout per variant body, indexed by variant tag.
         variants: Box<[LayoutId]>,
-        max_variant_size: u32,
+        /// Size of the enum object's data region: the 8-byte tag plus the
+        /// widest variant body, rounded up to 8-byte alignment. Sized to the
+        /// largest variant so any variant fits.
+        max_size_across_variants: u32,
     },
     /// A reference (16-byte fat pointer). All references share this layout.
     Ref,
@@ -295,21 +301,21 @@ impl ValueLayout {
         }
     }
 
-    /// Layout for a closed enum.
-    pub fn closed_enum(
+    /// Layout for a frozen enum.
+    pub fn frozen_enum(
         descriptor_id: DescriptorId,
         variants: Box<[LayoutId]>,
-        max_variant_size: u32,
+        max_size_across_variants: u32,
     ) -> ValueLayout {
         Self {
             size: 8,
             align: MAX_ALIGN as u32,
             fixed_bcs_size: None,
             flags: LayoutFlags::empty(),
-            kind: LayoutKind::ClosedEnum {
+            kind: LayoutKind::FrozenEnum {
                 descriptor_id,
                 variants,
-                max_variant_size,
+                max_size_across_variants,
             },
         }
     }

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -230,7 +230,7 @@ struct Layouts {
     /// Type to layout ID mapping. Types are concrete.
     by_ty: DashMap<InternedType, LayoutId, ahash::RandomState>,
     /// Enum type to the layout IDs of its per-variant bodies. Variant bodies
-    /// have no Move type of their own, so they are keyed in this map.
+    /// may not have a Move type of their own, so they are keyed in this map.
     enum_variants_by_type: DashMap<InternedType, Box<[LayoutId]>, ahash::RandomState>,
     /// All existing layouts in ID order. `boxcar::Vec` is an append-only
     /// concurrent vector: entries are pushed through a shared `&` reference and

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -229,6 +229,9 @@ fn initial_descriptors() -> boxcar::Vec<ObjectDescriptor> {
 struct Layouts {
     /// Type to layout ID mapping. Types are concrete.
     by_ty: DashMap<InternedType, LayoutId, ahash::RandomState>,
+    /// Enum type to the layout IDs of its per-variant bodies. Variant bodies
+    /// have no Move type of their own, so they are keyed in this map.
+    enum_variants_by_type: DashMap<InternedType, Box<[LayoutId]>, ahash::RandomState>,
     /// All existing layouts in ID order. `boxcar::Vec` is an append-only
     /// concurrent vector: entries are pushed through a shared `&` reference and
     /// are never moved, so [`LayoutId`] indices stay stable and concurrent
@@ -248,6 +251,7 @@ impl Layouts {
     fn new() -> Self {
         Self {
             by_ty: DashMap::default(),
+            enum_variants_by_type: DashMap::default(),
             table: initial_layouts(),
         }
     }
@@ -255,8 +259,13 @@ impl Layouts {
     /// Resets layout table and type to layout ID mappings. Reserved layouts
     /// are added back to the layout table.
     fn reset(&mut self) {
-        let Self { by_ty, table } = self;
+        let Self {
+            by_ty,
+            enum_variants_by_type,
+            table,
+        } = self;
         by_ty.clear();
+        enum_variants_by_type.clear();
         *table = initial_layouts();
     }
 }
@@ -778,6 +787,30 @@ impl<'ctx> ExecutionGuard<'ctx> {
             let idx = self.ctx.layouts.table.push(layout);
             LayoutId::from_usize(idx)
         })
+    }
+
+    /// Publishes the variant-body layouts of enum and returns their [`LayoutId`]s.
+    pub fn publish_variant_layouts(
+        &self,
+        enum_ty: InternedType,
+        variants: Vec<ValueLayout>,
+    ) -> Box<[LayoutId]> {
+        // Fast path: existing entry returns without touching the shard
+        // write-lock.
+        if let Some(ids) = self.ctx.layouts.enum_variants_by_type.get(&enum_ty) {
+            return ids.clone();
+        }
+        self.ctx
+            .layouts
+            .enum_variants_by_type
+            .entry(enum_ty)
+            .or_insert_with(|| {
+                variants
+                    .into_iter()
+                    .map(|layout| LayoutId::from_usize(self.ctx.layouts.table.push(layout)))
+                    .collect()
+            })
+            .clone()
     }
 
     /// Looks up a type previously interned from a signature token of `module`.

--- a/third_party/move/mono-move/loader/src/loader.rs
+++ b/third_party/move/mono-move/loader/src/loader.rs
@@ -825,6 +825,14 @@ impl SpecializerContext for LoweringContext<'_, '_, '_> {
         self.loader.guard.publish_layout(ty, layout)
     }
 
+    fn publish_variant_layouts(
+        &self,
+        enum_ty: InternedType,
+        variants: Vec<ValueLayout>,
+    ) -> Box<[LayoutId]> {
+        self.loader.guard.publish_variant_layouts(enum_ty, variants)
+    }
+
     fn publish_struct_descriptor(
         &self,
         struct_ty: InternedType,

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -25,11 +25,12 @@
 use crate::{
     error::{RuntimeError, RuntimeInvariantViolation, RuntimeResult},
     heap::{heap_alloc, AllocationResult, Heap},
-    memory::{read_ptr, read_vec_len, write_ptr, write_u64},
+    memory::{read_enum_tag, read_ptr, read_vec_len, write_enum_tag, write_ptr, write_u64},
     types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
 };
 use mono_move_core::{
-    types::InternedType, LayoutId, LayoutKind, LayoutProvider, ValueLayout, OBJECT_HEADER_SIZE,
+    types::InternedType, LayoutId, LayoutKind, LayoutProvider, ValueLayout, ENUM_DATA_OFFSET,
+    OBJECT_HEADER_SIZE,
 };
 use move_core_types::int256::{I256, U256};
 use std::cmp::Ordering;
@@ -173,8 +174,24 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
             }
             Ok(())
         },
-        LayoutKind::OpenEnum { .. } | LayoutKind::Function => {
-            todo!("enums and function values is not yet supported");
+        LayoutKind::ClosedEnum { variants, .. } => {
+            // SAFETY: an enum value holds a non-null heap pointer and data
+            // follows the offset.
+            let obj_ptr = unsafe { read_ptr(base, 0usize) };
+            let tag = unsafe { read_enum_tag(obj_ptr) };
+            let variant_id = variants
+                .get(tag as usize)
+                .ok_or_else(|| enum_tag_out_of_range(tag, variants.len()))?;
+            write_uleb128_len(out, tag);
+
+            let variant_layout = layouts.layout(*variant_id).ok_or_else(layout_not_found)?;
+            // SAFETY: the variant body lives at the specified offset within
+            // the object.
+            unsafe { serialize_impl(layouts, obj_ptr.add(ENUM_DATA_OFFSET), variant_layout, out)? };
+            Ok(())
+        },
+        LayoutKind::Function => {
+            todo!("function values are not yet supported");
         },
         LayoutKind::Ref => Err(unreachable("References cannot be serialized")),
     }
@@ -298,15 +315,33 @@ unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
             }
             Ok(true)
         },
-        LayoutKind::OpenEnum { .. } | LayoutKind::Function => {
-            // TODO(enums): implement enum equality. Resolve the open enum's
-            // variants lazily (read the u64 tag at `ENUM_TAG_OFFSET` from each
-            // operand's heap object; if the tags differ return `false`, else
-            // recurse over the active variant's field layouts). `gc_layout`
-            // now lets functions that compare enums lower, so until this lands
-            // enum `==` (and equality of any value containing an enum) panics
-            // here. Same for function values.
-            todo!("enums or function values are not yet supported");
+        LayoutKind::ClosedEnum { variants, .. } => {
+            // SAFETY: well-typed enum values hold non-null heap pointers and
+            // every enum object stores its data following the offset.
+            let obj_a = unsafe { read_ptr(a, 0usize) };
+            let obj_b = unsafe { read_ptr(b, 0usize) };
+            let tag_a = unsafe { read_enum_tag(obj_a) };
+            let tag_b = unsafe { read_enum_tag(obj_b) };
+
+            if tag_a != tag_b {
+                return Ok(false);
+            }
+            let variant_id = *variants
+                .get(tag_a as usize)
+                .ok_or_else(|| enum_tag_out_of_range(tag_a, variants.len()))?;
+
+            // SAFETY: both variant bodies live at the specified offset.
+            unsafe {
+                equals_impl(
+                    layouts,
+                    obj_a.add(ENUM_DATA_OFFSET),
+                    obj_b.add(ENUM_DATA_OFFSET),
+                    variant_id,
+                )
+            }
+        },
+        LayoutKind::Function => {
+            todo!("function values are not yet supported");
         },
         LayoutKind::Ref => Err(unreachable("Equality runs on pointee types only")),
     }
@@ -460,8 +495,34 @@ unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
             }
             Ok(len_a.cmp(&len_b))
         },
-        LayoutKind::OpenEnum { .. } | LayoutKind::Function => {
-            todo!("enums and function values are not yet supported");
+        LayoutKind::ClosedEnum { variants, .. } => {
+            // SAFETY: well-typed enum values hold non-null heap pointers and
+            // every enum object stores its tag followed by data payload.
+            let obj_a = unsafe { read_ptr(a, 0usize) };
+            let obj_b = unsafe { read_ptr(b, 0usize) };
+            let tag_a = unsafe { read_enum_tag(obj_a) };
+            let tag_b = unsafe { read_enum_tag(obj_b) };
+
+            let ord = tag_a.cmp(&tag_b);
+            if ord.is_ne() {
+                return Ok(ord);
+            }
+            let variant_id = *variants
+                .get(tag_a as usize)
+                .ok_or_else(|| enum_tag_out_of_range(tag_a, variants.len()))?;
+
+            // SAFETY: both variant bodies live at the specified offset.
+            unsafe {
+                compare_impl(
+                    layouts,
+                    obj_a.add(ENUM_DATA_OFFSET),
+                    obj_b.add(ENUM_DATA_OFFSET),
+                    variant_id,
+                )
+            }
+        },
+        LayoutKind::Function => {
+            todo!("function values are not yet supported");
         },
         LayoutKind::Ref => Err(unreachable("Comparison runs on pointee types only")),
     }
@@ -632,8 +693,47 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
             unsafe { write_ptr(dst, 0usize, vec_ptr) };
             Ok(())
         },
-        LayoutKind::OpenEnum { .. } | LayoutKind::Function => {
-            todo!("enums and function values are not yet supported");
+        LayoutKind::ClosedEnum {
+            descriptor_id,
+            variants,
+            max_variant_size,
+        } => {
+            // BCS encodes the variant index as a ULEB128 before the fields.
+            let tag = read_uleb128_len(bytes, cursor)?;
+            if tag >= variants.len() as u64 {
+                return Err(RuntimeError::EnumVariantMismatch { tag }.into());
+            }
+
+            let variant_layout = layouts
+                .layout(variants[tag as usize])
+                .ok_or_else(layout_not_found)?;
+
+            let total_size = OBJECT_HEADER_SIZE + *max_variant_size as usize;
+            let obj_ptr = heap_alloc(heap, total_size, *descriptor_id)?;
+
+            // SAFETY: the allocation has enough size to write the tag.
+            unsafe { write_enum_tag(obj_ptr, tag) };
+
+            // SAFETY: variant body live at the specified offset. The maximum
+            // size was allocated so there is enough space to deserialize into.
+            unsafe {
+                deserialize_impl(
+                    layouts,
+                    heap,
+                    variant_layout,
+                    bytes,
+                    cursor,
+                    obj_ptr.add(ENUM_DATA_OFFSET),
+                )?
+            };
+
+            // SAFETY: `dst` has space to write the 8-byte enum pointer as
+            // guaranteed by the caller.
+            unsafe { write_ptr(dst, 0usize, obj_ptr) };
+            Ok(())
+        },
+        LayoutKind::Function => {
+            todo!("function values are not yet supported");
         },
         LayoutKind::Ref => Err(unreachable("References cannot be deserialized").into()),
     }
@@ -740,11 +840,23 @@ fn unreachable(message: &str) -> RuntimeError {
     RuntimeError::InvariantViolation(RuntimeInvariantViolation::Unreachable(message.to_string()))
 }
 
+/// Invariant violation when an in-memory enum tag does not name a variant. A
+/// well-formed enum's tag is always in range, so this signals heap corruption,
+/// not bad input (a bad BCS variant index is rejected as a user error during
+/// deserialization).
+fn enum_tag_out_of_range(tag: u64, variant_count: usize) -> RuntimeError {
+    RuntimeError::InvariantViolation(RuntimeInvariantViolation::EnumTagOutOfRange {
+        tag,
+        variant_count,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::heap::AllocationError;
     use mono_move_core::{
+        align_up_u32,
         types::U64_TY,
         value_layout::{U16_LAYOUT_ID, U64_LAYOUT_ID, U8_LAYOUT_ID},
         DescriptorId, FieldValueLayout, LayoutFlags, LayoutId, ValueLayoutTable,
@@ -1336,6 +1448,114 @@ mod tests {
             },
         ];
         unsafe { check_roundtrip(&table, id, 16, &values) };
+    }
+
+    /// Builds and pushes a closed-enum layout into `table`: one struct layout
+    /// per variant (via [`build_struct_layout`]), then the enum layout itself.
+    /// Each variant is `(in_memory_size, fields)`, with `fields` as
+    /// `(data_region_relative_offset, layout_id)` pairs. The heap payload size
+    /// is the 8-byte tag plus the widest variant region, rounded up to 8.
+    fn build_closed_enum_layout(
+        table: &mut ValueLayoutTable,
+        variants: Vec<(u32, Vec<(u32, LayoutId)>)>,
+    ) -> LayoutId {
+        let mut variant_ids = Vec::with_capacity(variants.len());
+        let mut max_data = 0u32;
+        for (size, fields) in variants {
+            max_data = max_data.max(size);
+            let layout = build_struct_layout(table, size, fields);
+            variant_ids.push(table.push(U64_TY, layout));
+        }
+        let max_variant_size = align_up_u32(8 + max_data, 8);
+        let layout = ValueLayout::closed_enum(
+            DescriptorId(3),
+            variant_ids.into_boxed_slice(),
+            max_variant_size,
+        );
+        table.push(U64_TY, layout)
+    }
+
+    #[test]
+    fn test_enum_unit_and_tuple_variants() {
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        enum E {
+            A,
+            B(u64),
+            C(u8, u64),
+        }
+
+        let mut table = ValueLayoutTable::new();
+        let eid = build_closed_enum_layout(&mut table, vec![
+            (0, vec![]),
+            (8, vec![(0, U64_LAYOUT_ID)]),
+            (16, vec![(0, U8_LAYOUT_ID), (8, U64_LAYOUT_ID)]),
+        ]);
+        let values = [
+            E::A,
+            E::B(0),
+            E::B(7),
+            E::C(1, 2),
+            E::C(1, 3),
+            E::C(2, 0),
+            E::A,
+        ];
+        unsafe { check_roundtrip(&table, eid, 8, &values) };
+    }
+
+    #[test]
+    fn test_enum_with_vector_variant() {
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        enum E {
+            Empty,
+            Items(Vec<u64>),
+        }
+
+        let mut table = ValueLayoutTable::new();
+        let vec_id = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
+        let eid = build_closed_enum_layout(&mut table, vec![(0, vec![]), (8, vec![(0, vec_id)])]);
+        let values = [
+            E::Empty,
+            E::Items(vec![]),
+            E::Items(vec![1]),
+            E::Items(vec![1, 2]),
+            E::Items(vec![2]),
+            E::Items(vec![1]),
+        ];
+        unsafe { check_roundtrip(&table, eid, 8, &values) };
+    }
+
+    #[test]
+    fn test_enum_as_struct_field() {
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        enum Inner {
+            X,
+            Y(u64),
+        }
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        struct Outer {
+            id: u64,
+            e: Inner,
+        }
+
+        let mut table = ValueLayoutTable::new();
+        let inner_eid =
+            build_closed_enum_layout(&mut table, vec![(0, vec![]), (8, vec![(0, U64_LAYOUT_ID)])]);
+        let outer = build_struct_layout(&table, 16, vec![(0, U64_LAYOUT_ID), (8, inner_eid)]);
+        let oid = table.push(U64_TY, outer);
+        let values = [
+            Outer { id: 1, e: Inner::X },
+            Outer {
+                id: 1,
+                e: Inner::Y(0),
+            },
+            Outer {
+                id: 1,
+                e: Inner::Y(5),
+            },
+            Outer { id: 2, e: Inner::X },
+            Outer { id: 1, e: Inner::X },
+        ];
+        unsafe { check_roundtrip(&table, oid, 16, &values) };
     }
 }
 

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -174,7 +174,7 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
             }
             Ok(())
         },
-        LayoutKind::ClosedEnum { variants, .. } => {
+        LayoutKind::FrozenEnum { variants, .. } => {
             // SAFETY: an enum value holds a non-null heap pointer and data
             // follows the offset.
             let obj_ptr = unsafe { read_ptr(base, 0usize) };
@@ -315,7 +315,7 @@ unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
             }
             Ok(true)
         },
-        LayoutKind::ClosedEnum { variants, .. } => {
+        LayoutKind::FrozenEnum { variants, .. } => {
             // SAFETY: well-typed enum values hold non-null heap pointers and
             // every enum object stores its data following the offset.
             let obj_a = unsafe { read_ptr(a, 0usize) };
@@ -323,12 +323,18 @@ unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
             let tag_a = unsafe { read_enum_tag(obj_a) };
             let tag_b = unsafe { read_enum_tag(obj_b) };
 
-            if tag_a != tag_b {
-                return Ok(false);
-            }
+            // Validate both tags before the equality check. An out-of-range tag
+            // is heap corruption and must fail closed even when the tags differ.
             let variant_id = *variants
                 .get(tag_a as usize)
                 .ok_or_else(|| enum_tag_out_of_range(tag_a, variants.len()))?;
+            if tag_b as usize >= variants.len() {
+                return Err(enum_tag_out_of_range(tag_b, variants.len()));
+            }
+
+            if tag_a != tag_b {
+                return Ok(false);
+            }
 
             // SAFETY: both variant bodies live at the specified offset.
             unsafe {
@@ -356,6 +362,8 @@ unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
 ///    lexicographically over their bytes.
 /// 3. Vectors compare lexicographically (over smaller prefix)
 /// 4. Structs compare field-by-field.
+/// 5. Enums compare by variant tag first, then field-by-field over the
+///    matching variant's body.
 ///
 /// # Safety
 ///
@@ -495,7 +503,7 @@ unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
             }
             Ok(len_a.cmp(&len_b))
         },
-        LayoutKind::ClosedEnum { variants, .. } => {
+        LayoutKind::FrozenEnum { variants, .. } => {
             // SAFETY: well-typed enum values hold non-null heap pointers and
             // every enum object stores its tag followed by data payload.
             let obj_a = unsafe { read_ptr(a, 0usize) };
@@ -503,13 +511,19 @@ unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
             let tag_a = unsafe { read_enum_tag(obj_a) };
             let tag_b = unsafe { read_enum_tag(obj_b) };
 
+            // Validate both tags before ordering them. An out-of-range tag is
+            // heap corruption and must fail closed even when the tags differ.
+            let variant_id = *variants
+                .get(tag_a as usize)
+                .ok_or_else(|| enum_tag_out_of_range(tag_a, variants.len()))?;
+            if tag_b as usize >= variants.len() {
+                return Err(enum_tag_out_of_range(tag_b, variants.len()));
+            }
+
             let ord = tag_a.cmp(&tag_b);
             if ord.is_ne() {
                 return Ok(ord);
             }
-            let variant_id = *variants
-                .get(tag_a as usize)
-                .ok_or_else(|| enum_tag_out_of_range(tag_a, variants.len()))?;
 
             // SAFETY: both variant bodies live at the specified offset.
             unsafe {
@@ -693,28 +707,28 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
             unsafe { write_ptr(dst, 0usize, vec_ptr) };
             Ok(())
         },
-        LayoutKind::ClosedEnum {
+        LayoutKind::FrozenEnum {
             descriptor_id,
             variants,
-            max_variant_size,
+            max_size_across_variants,
         } => {
             // BCS encodes the variant index as a ULEB128 before the fields.
             let tag = read_uleb128_len(bytes, cursor)?;
             if tag >= variants.len() as u64 {
-                return Err(RuntimeError::EnumVariantMismatch { tag }.into());
+                return Err(enum_tag_out_of_range(tag, variants.len()).into());
             }
 
             let variant_layout = layouts
                 .layout(variants[tag as usize])
                 .ok_or_else(layout_not_found)?;
 
-            let total_size = OBJECT_HEADER_SIZE + *max_variant_size as usize;
+            let total_size = OBJECT_HEADER_SIZE + *max_size_across_variants as usize;
             let obj_ptr = heap_alloc(heap, total_size, *descriptor_id)?;
 
             // SAFETY: the allocation has enough size to write the tag.
             unsafe { write_enum_tag(obj_ptr, tag) };
 
-            // SAFETY: variant body live at the specified offset. The maximum
+            // SAFETY: variant body lives at the specified offset. The maximum
             // size was allocated so there is enough space to deserialize into.
             unsafe {
                 deserialize_impl(
@@ -840,10 +854,10 @@ fn unreachable(message: &str) -> RuntimeError {
     RuntimeError::InvariantViolation(RuntimeInvariantViolation::Unreachable(message.to_string()))
 }
 
-/// Invariant violation when an in-memory enum tag does not name a variant. A
-/// well-formed enum's tag is always in range, so this signals heap corruption,
-/// not bad input (a bad BCS variant index is rejected as a user error during
-/// deserialization).
+/// Invariant violation when an enum tag does not name a variant, whether read
+/// from an in-memory value or decoded from BCS. A well-formed enum's tag is
+/// always in range, so an out-of-range tag signals corruption, not a legitimate
+/// runtime condition.
 fn enum_tag_out_of_range(tag: u64, variant_count: usize) -> RuntimeError {
     RuntimeError::InvariantViolation(RuntimeInvariantViolation::EnumTagOutOfRange {
         tag,
@@ -1450,12 +1464,12 @@ mod tests {
         unsafe { check_roundtrip(&table, id, 16, &values) };
     }
 
-    /// Builds and pushes a closed-enum layout into `table`: one struct layout
-    /// per variant (via [`build_struct_layout`]), then the enum layout itself.
+    /// Builds and pushes an enum layout into `table`: one struct layout per
+    /// variant (via [`build_struct_layout`]), then the enum layout itself.
     /// Each variant is `(in_memory_size, fields)`, with `fields` as
     /// `(data_region_relative_offset, layout_id)` pairs. The heap payload size
     /// is the 8-byte tag plus the widest variant region, rounded up to 8.
-    fn build_closed_enum_layout(
+    fn build_enum_layout(
         table: &mut ValueLayoutTable,
         variants: Vec<(u32, Vec<(u32, LayoutId)>)>,
     ) -> LayoutId {
@@ -1466,11 +1480,11 @@ mod tests {
             let layout = build_struct_layout(table, size, fields);
             variant_ids.push(table.push(U64_TY, layout));
         }
-        let max_variant_size = align_up_u32(8 + max_data, 8);
-        let layout = ValueLayout::closed_enum(
+        let max_size_across_variants = align_up_u32(8 + max_data, 8);
+        let layout = ValueLayout::frozen_enum(
             DescriptorId(3),
             variant_ids.into_boxed_slice(),
-            max_variant_size,
+            max_size_across_variants,
         );
         table.push(U64_TY, layout)
     }
@@ -1485,7 +1499,7 @@ mod tests {
         }
 
         let mut table = ValueLayoutTable::new();
-        let eid = build_closed_enum_layout(&mut table, vec![
+        let eid = build_enum_layout(&mut table, vec![
             (0, vec![]),
             (8, vec![(0, U64_LAYOUT_ID)]),
             (16, vec![(0, U8_LAYOUT_ID), (8, U64_LAYOUT_ID)]),
@@ -1512,7 +1526,7 @@ mod tests {
 
         let mut table = ValueLayoutTable::new();
         let vec_id = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
-        let eid = build_closed_enum_layout(&mut table, vec![(0, vec![]), (8, vec![(0, vec_id)])]);
+        let eid = build_enum_layout(&mut table, vec![(0, vec![]), (8, vec![(0, vec_id)])]);
         let values = [
             E::Empty,
             E::Items(vec![]),
@@ -1539,7 +1553,7 @@ mod tests {
 
         let mut table = ValueLayoutTable::new();
         let inner_eid =
-            build_closed_enum_layout(&mut table, vec![(0, vec![]), (8, vec![(0, U64_LAYOUT_ID)])]);
+            build_enum_layout(&mut table, vec![(0, vec![]), (8, vec![(0, U64_LAYOUT_ID)])]);
         let outer = build_struct_layout(&table, 16, vec![(0, U64_LAYOUT_ID), (8, inner_eid)]);
         let oid = table.push(U64_TY, outer);
         let values = [

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -1427,8 +1427,8 @@ fn discover_type_metadata(
                     let mut variant_layouts: Vec<Vec<VariantFieldLayout>> =
                         Vec::with_capacity(variants.len());
                     let mut variant_ptr_offsets: Vec<Vec<u32>> = Vec::with_capacity(variants.len());
-                    // One struct layout per variant body, for the closed-enum
-                    // value layout. Collected (not yet published) while every
+                    // One struct layout per variant body, for the enum value
+                    // layout. Collected (not yet published) while every
                     // variant's fields have a published layout; abandoned on the
                     // first miss. Published as one keyed set after the loop.
                     let mut variant_value_layouts: Vec<ValueLayout> =
@@ -1478,7 +1478,7 @@ fn discover_type_metadata(
 
                         // Build + publish this variant's value layout (a struct
                         // over its fields). Once any variant defers, stop — the
-                        // enum cannot be closed.
+                        // enum value layout cannot be built.
                         if all_value_layouts {
                             match try_build_inline_value_layout(
                                 &*ctx,
@@ -1514,7 +1514,7 @@ fn discover_type_metadata(
                             variants: variant_layouts,
                         });
 
-                        // Publish the closed-enum value layout when every variant
+                        // Publish the enum value layout when every variant
                         // body resolved. `size` is the heap payload (tag + widest
                         // variant region, 8-aligned) the allocator needs. The
                         // variant bodies are published as one set keyed by the
@@ -1525,7 +1525,7 @@ fn discover_type_metadata(
                             let variant_ids =
                                 ctx.publish_variant_layouts(ty, variant_value_layouts);
                             let value_layout =
-                                ValueLayout::closed_enum(descriptor_id, variant_ids, size);
+                                ValueLayout::frozen_enum(descriptor_id, variant_ids, size);
                             return Ok(Some(ctx.publish_layout(ty, value_layout)));
                         }
                     }

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -853,6 +853,17 @@ pub trait SpecializerContext {
     /// Publishes `layout` for `ty` and returns its assigned id. Idempotent.
     fn publish_layout(&self, ty: InternedType, layout: ValueLayout) -> LayoutId;
 
+    /// Publishes the variant-body layouts of `enum_ty` (one per variant, in tag
+    /// order), returning their ids. Idempotent on `enum_ty`: re-publishing the
+    /// same enum reuses the cached ids rather than appending a fresh set.
+    /// Variant bodies have no Move type of their own, so they are keyed by the
+    /// owning enum.
+    fn publish_variant_layouts(
+        &self,
+        enum_ty: InternedType,
+        variants: Vec<ValueLayout>,
+    ) -> Box<[LayoutId]>;
+
     /// Publishes a struct descriptor for `struct_ty` (with payload size `size`
     /// and intra-struct heap-pointer offsets `ptr_offsets`), returning the
     /// assigned [`DescriptorId`]. Used for resources spilled to the heap by
@@ -1195,6 +1206,63 @@ fn layout_inline_fields(
     Some((fields, total, max_align))
 }
 
+/// Builds the [`ValueLayout`] for an inline aggregate — a struct, or one enum
+/// variant body — from its field layouts and the published layout id of each
+/// field. `total`/`align` are the aggregate's in-memory size and alignment.
+///
+/// Returns `Ok(None)` when any field's layout is not yet published (the
+/// aggregate is deferred, mirroring a deferred struct). Errors only on an
+/// internal inconsistency (a published id that does not resolve to a layout).
+fn try_build_inline_value_layout(
+    ctx: &impl SpecializerContext,
+    field_layouts: &[VariantFieldLayout],
+    field_ids: &[Option<LayoutId>],
+    total: u32,
+    align: u32,
+) -> Result<Option<ValueLayout>> {
+    let mut layout_fields = Vec::with_capacity(field_layouts.len());
+    let mut fixed_bcs_total: u64 = 0;
+    let mut data_dependent = false;
+    for (field, &fid) in field_layouts.iter().zip(field_ids) {
+        // A field can be sized yet still lack a published layout (e.g. a
+        // `vector<T>` whose element layout is deferred). Defer the aggregate.
+        let Some(id) = fid else {
+            return Ok(None);
+        };
+        let Some(child) = ctx.layout(id) else {
+            bail!("published layout id does not resolve to a layout");
+        };
+        layout_fields.push(FieldValueLayout {
+            offset: field.offset,
+            id,
+        });
+        match child.fixed_bcs_size {
+            Some(bcs_sz) => fixed_bcs_total = fixed_bcs_total.saturating_add(bcs_sz as u64),
+            None => data_dependent = true,
+        }
+    }
+
+    let fixed_bcs_size = if data_dependent || fixed_bcs_total > u32::MAX as u64 {
+        None
+    } else {
+        Some(fixed_bcs_total as u32)
+    };
+    // No pointers and no padding exactly when the packed BCS size equals the
+    // in-memory size: a pointer field makes the BCS size data-dependent
+    // (`None`), and alignment padding makes it strictly smaller than `total`.
+    let mut flags = LayoutFlags::empty();
+    if fixed_bcs_size == Some(total) {
+        flags |= LayoutFlags::NO_POINTERS_NO_PADDING;
+    }
+    Ok(Some(ValueLayout::struct_layout(
+        total,
+        align,
+        fixed_bcs_size,
+        flags,
+        layout_fields.into_boxed_slice(),
+    )))
+}
+
 /// Recursive post-order DFS that visits every nominal reachable from the given
 /// type and, as a side effect, publishes its GC vector descriptors,
 /// `NominalLayout`s, and `ValueLayout`s. Returns the type's [`LayoutId`] when one
@@ -1325,58 +1393,25 @@ fn discover_type_metadata(
                     else {
                         return Ok(None);
                     };
-                    // TODO: remove legacy size/layout.
-                    let mut nominal_fields = Vec::with_capacity(fields.len());
-                    let mut layout_fields = Vec::with_capacity(fields.len());
-                    let mut fixed_bcs_total: u64 = 0;
-                    let mut data_dependent = false;
-
-                    for (field, &fid) in field_layouts.iter().zip(&field_ids) {
-                        // A field can be sized yet still lack a published layout:
-                        // `vector<T>` always reports an 8-byte pointer, but its
-                        // layout is deferred until the element layout and vector
-                        // descriptor exist. Defer the nominal too, rather than
-                        // treating this as an invariant violation.
-                        let Some(id) = fid else {
-                            return Ok(None);
-                        };
-                        let Some(child) = ctx.layout(id) else {
-                            bail!("published layout id does not resolve to a layout");
-                        };
-                        nominal_fields.push(FieldLayout::new(field.offset, field.ty));
-                        layout_fields.push(FieldValueLayout {
-                            offset: field.offset,
-                            id,
-                        });
-                        match child.fixed_bcs_size {
-                            Some(bcs_sz) => {
-                                fixed_bcs_total = fixed_bcs_total.saturating_add(bcs_sz as u64)
-                            },
-                            None => data_dependent = true,
-                        }
-                    }
-                    ctx.set_nominal_layout(ty, total, max_align, Some(&nominal_fields))?;
-
-                    let fixed_bcs_size = if data_dependent || fixed_bcs_total > u32::MAX as u64 {
-                        None
-                    } else {
-                        Some(fixed_bcs_total as u32)
-                    };
-                    // The struct has no pointers and no padding exactly when
-                    // its packed BCS size equals its in-memory size: a pointer
-                    // field makes the BCS size data-dependent (`None`), and any
-                    // alignment padding makes it strictly smaller than `total`.
-                    let mut flags = LayoutFlags::empty();
-                    if fixed_bcs_size == Some(total) {
-                        flags |= LayoutFlags::NO_POINTERS_NO_PADDING;
-                    }
-                    let value_layout = ValueLayout::struct_layout(
+                    // Defer the whole struct if any field's layout is not yet
+                    // published (e.g. a `vector<T>` whose element layout is
+                    // deferred), before recording any nominal layout.
+                    let Some(value_layout) = try_build_inline_value_layout(
+                        &*ctx,
+                        &field_layouts,
+                        &field_ids,
                         total,
                         max_align,
-                        fixed_bcs_size,
-                        flags,
-                        layout_fields.into_boxed_slice(),
-                    );
+                    )?
+                    else {
+                        return Ok(None);
+                    };
+                    // TODO: remove legacy size/layout.
+                    let nominal_fields = field_layouts
+                        .iter()
+                        .map(|field| FieldLayout::new(field.offset, field.ty))
+                        .collect::<Vec<_>>();
+                    ctx.set_nominal_layout(ty, total, max_align, Some(&nominal_fields))?;
                     Ok(Some(ctx.publish_layout(ty, value_layout)))
                 },
                 Some(FieldTypes::Enum(variants)) => {
@@ -1392,32 +1427,43 @@ fn discover_type_metadata(
                     let mut variant_layouts: Vec<Vec<VariantFieldLayout>> =
                         Vec::with_capacity(variants.len());
                     let mut variant_ptr_offsets: Vec<Vec<u32>> = Vec::with_capacity(variants.len());
+                    // One struct layout per variant body, for the closed-enum
+                    // value layout. Collected (not yet published) while every
+                    // variant's fields have a published layout; abandoned on the
+                    // first miss. Published as one keyed set after the loop.
+                    let mut variant_value_layouts: Vec<ValueLayout> =
+                        Vec::with_capacity(variants.len());
                     let mut max_data_size = 0u32;
                     let mut all_sized = true;
+                    let mut all_value_layouts = true;
 
                     'variants: for variant_fields in &variants {
                         // Substitute each field type by the enum's own type
                         // args (mirrors the Struct arm), then recurse so nested
-                        // vec/struct/enum descriptors get published.
+                        // vec/struct/enum descriptors and layouts get published,
+                        // capturing each field's layout id.
                         let fields = variant_fields
                             .iter()
                             .map(|field_ty| ctx.subst_type(*field_ty, *nominal_ty_args))
                             .collect::<Result<Vec<_>>>()?;
+                        let mut field_ids = Vec::with_capacity(fields.len());
                         for &field_ty in &fields {
-                            discover_type_metadata(
+                            field_ids.push(discover_type_metadata(
                                 ctx,
                                 field_ty,
                                 EMPTY_TYPE_LIST,
                                 visited,
                                 descriptors,
-                            )?;
+                            )?);
                         }
 
                         // Per-variant layout: offsets are data-region-relative
                         // (0-based after the tag).
-                        let Some((variant_layout, variant_size, _)) = layout_inline_fields(&fields)
+                        let Some((variant_layout, variant_size, variant_align)) =
+                            layout_inline_fields(&fields)
                         else {
                             all_sized = false;
+                            all_value_layouts = false;
                             break 'variants;
                         };
                         // GC pointer offsets: each field's inner pointer offsets
@@ -1426,8 +1472,26 @@ fn discover_type_metadata(
                             variant_layout.iter().map(|field| (field.offset, field.ty)),
                         ) else {
                             all_sized = false;
+                            all_value_layouts = false;
                             break 'variants;
                         };
+
+                        // Build + publish this variant's value layout (a struct
+                        // over its fields). Once any variant defers, stop — the
+                        // enum cannot be closed.
+                        if all_value_layouts {
+                            match try_build_inline_value_layout(
+                                &*ctx,
+                                &variant_layout,
+                                &field_ids,
+                                variant_size,
+                                variant_align,
+                            )? {
+                                Some(layout) => variant_value_layouts.push(layout),
+                                None => all_value_layouts = false,
+                            }
+                        }
+
                         max_data_size = max_data_size.max(variant_size);
                         variant_layouts.push(variant_layout);
                         variant_ptr_offsets.push(ptr_offsets);
@@ -1449,14 +1513,28 @@ fn discover_type_metadata(
                             descriptor_id,
                             variants: variant_layouts,
                         });
+
+                        // Publish the closed-enum value layout when every variant
+                        // body resolved. `size` is the heap payload (tag + widest
+                        // variant region, 8-aligned) the allocator needs. The
+                        // variant bodies are published as one set keyed by the
+                        // enum type (idempotent), so re-discovering the enum
+                        // reuses them rather than orphaning a fresh set.
+                        if all_value_layouts {
+                            debug_assert_eq!(variant_value_layouts.len(), variants.len());
+                            let variant_ids =
+                                ctx.publish_variant_layouts(ty, variant_value_layouts);
+                            let value_layout =
+                                ValueLayout::closed_enum(descriptor_id, variant_ids, size);
+                            return Ok(Some(ctx.publish_layout(ty, value_layout)));
+                        }
                     }
 
-                    // TODO: consider reconciling `EnumLayout`, `ValueLayout::open_enum`, and the enum descriptor.
-                    // The enum's `ValueLayout` is the open-enum shape regardless
-                    // of whether the variant field layout was derivable; the
-                    // value-traversal walk resolves variants lazily.
-                    let value_layout = ValueLayout::open_enum(ty, *nominal_ty_args);
-                    Ok(Some(ctx.publish_layout(ty, value_layout)))
+                    // The enum's variant bodies are not all resolvable yet, so
+                    // defer its value layout (mirrors a deferred struct). Only
+                    // reachable in the partial-load module pre-pass, never in
+                    // per-function lowering.
+                    Ok(None)
                 },
             }
         },

--- a/third_party/move/mono-move/testsuite/src/print_sections.rs
+++ b/third_party/move/mono-move/testsuite/src/print_sections.rs
@@ -275,6 +275,14 @@ impl SpecializerContext for SnapshotLoaderContext<'_, '_, '_> {
         self.guard.publish_layout(ty, layout)
     }
 
+    fn publish_variant_layouts(
+        &self,
+        enum_ty: InternedType,
+        variants: Vec<ValueLayout>,
+    ) -> Box<[LayoutId]> {
+        self.guard.publish_variant_layouts(enum_ty, variants)
+    }
+
     fn publish_struct_descriptor(
         &self,
         struct_ty: InternedType,


### PR DESCRIPTION
## What

Adds layout-driven value traversal for enums in the mono-move VM.

`core` gains a `ClosedEnum` value layout (replacing the unimplemented `OpenEnum`). It lists every variant body as its own published struct layout, plus the enum's GC descriptor and heap payload size. These enums are currently closed and non-upgradable, so every variant is known up front.

The four value walks in `runtime/value_utils.rs` now handle enums:
- **serialize** — read the heap pointer, read the `u64` tag, write it as the BCS variant index (ULEB128), then serialize the active variant's body.
- **deserialize** — read the variant index, allocate the `[tag][widest variant]` object (zero-filled), write the tag, deserialize the active variant's fields.
- **equals** — tags must match, then compare the active variant's fields.
- **compare** — order by tag first, then by fields (matching the legacy VM).

Each variant body is a struct layout, so the walks reuse the existing struct paths, including the blittable single-`memcpy` fast path.

`specializer` discovery builds and publishes the per-variant struct layouts and the `closed_enum` layout. Variant bodies have no Move type of their own, so they are published as one set keyed by the enum type — idempotent, like the descriptor caches, and reset alongside the other layout caches. Re-discovering an enum reuses them instead of leaking layout-table entries.

`OpenEnum` and its walks (which panicked) are removed. Function values remain `todo!()`, unchanged.

## Tests

New round-trip tests in `value_utils` cover unit/tuple variants, a padded variant, a blittable variant, a vector inside a variant, and an enum as a struct field — checked against `bcs` and derived `Ord`/`Eq` oracles. Existing runtime (incl. `int_ops`, `verifier_test`), specializer, loader, global-context, and snapshot suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core value representation, BCS round-trips, and ordering semantics for enums; bounded by new tests and unchanged function-value paths, but errors in tag/layout handling could affect correctness of equality and serialization.
> 
> **Overview**
> **Frozen enum layouts** replace the stub `OpenEnum` shape: an 8-byte heap pointer, GC descriptor, per-variant struct `LayoutId`s, and a max heap payload size. **`publish_variant_layouts`** caches variant-body layouts keyed by enum type (idempotent, cleared on layout reset) and is wired through `SpecializerContext`, loader, and testsuite.
> 
> **Runtime value walks** in `value_utils.rs` now handle `FrozenEnum`: BCS variant index (ULEB128) plus active variant body on serialize/deserialize; tag match then field-wise `equals`/`compare` (tag order first for ordering). Out-of-range tags fail as invariant violations. Function values stay `todo!()`.
> 
> **Specializer** discovery builds each variant body as an inline struct layout (shared `try_build_inline_value_layout` with structs), publishes the variant set, then `ValueLayout::frozen_enum` when every variant resolves; otherwise defers the enum layout like a struct. **`OpenEnum` / always-publish stub layout is removed.**
> 
> New **round-trip tests** cover unit/tuple variants, vectors in variants, and enums nested in structs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6e89e8720bf631abf7ead3a780cb01f535b7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->