### PR TITLE
[storage] Guard hot state reads with the hot pruners

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -410,6 +410,60 @@ impl AptosDB {
         Ok(())
     }
 
+    pub(super) fn error_if_hot_state_merkle_pruned(
+        &self,
+        data_type: &str,
+        version: Version,
+    ) -> Result<()> {
+        let min_readable_version = self
+            .state_store
+            .state_db
+            .state_pruner
+            .hot_state_merkle_pruner
+            .get_min_readable_version();
+        if version >= min_readable_version {
+            return Ok(());
+        }
+
+        let min_readable_epoch_snapshot_version = self
+            .state_store
+            .state_db
+            .state_pruner
+            .hot_epoch_snapshot_pruner
+            .get_min_readable_version();
+        if version >= min_readable_epoch_snapshot_version {
+            self.ledger_db.metadata_db().ensure_epoch_ending(version)
+        } else {
+            bail!(
+                "{} at version {} is pruned. snapshots are available at >= {}, epoch snapshots are available at >= {}",
+                data_type,
+                version,
+                min_readable_version,
+                min_readable_epoch_snapshot_version,
+            )
+        }
+    }
+
+    pub(super) fn error_if_hot_state_kv_pruned(
+        &self,
+        data_type: &str,
+        version: Version,
+    ) -> Result<()> {
+        let min_readable_version = self
+            .state_store
+            .state_pruner
+            .hot_state_kv_pruner
+            .get_min_readable_version();
+        ensure!(
+            version >= min_readable_version,
+            "{} at version {} is pruned, min available version is {}.",
+            data_type,
+            version,
+            min_readable_version
+        );
+        Ok(())
+    }
+
     pub(super) fn get_raw_block_info_by_height(&self, block_height: u64) -> Result<BlockInfo> {
         self.ledger_db
             .metadata_db()

--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -557,7 +557,11 @@ impl DbReader for AptosDB {
         use_hot_state: bool,
     ) -> Result<SparseMerkleProofExt> {
         gauged_api("get_state_proof_by_version_ext", || {
-            self.error_if_state_merkle_pruned("State merkle", version)?;
+            if use_hot_state {
+                self.error_if_hot_state_merkle_pruned("Hot state merkle", version)?;
+            } else {
+                self.error_if_state_merkle_pruned("State merkle", version)?;
+            }
 
             self.state_store.get_state_proof_by_version_ext(
                 key_hash,
@@ -589,9 +593,8 @@ impl DbReader for AptosDB {
         root_depth: usize,
     ) -> Result<(Option<HotStateValue>, SparseMerkleProofExt)> {
         gauged_api("get_hot_state_value_with_proof_by_version_ext", || {
-            // TODO(HotState): check `hot_state_kv_pruner` / `hot_state_merkle_pruner` instead.
-            self.error_if_state_kv_pruned("HotStateValue", version)?;
-            self.error_if_state_merkle_pruned("State merkle", version)?;
+            self.error_if_hot_state_kv_pruned("HotStateValue", version)?;
+            self.error_if_hot_state_merkle_pruned("Hot state merkle", version)?;
 
             self.state_store
                 .get_hot_state_value_with_proof_by_version_ext(key_hash, version, root_depth)

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -157,6 +157,56 @@ fn test_error_if_version_pruned() {
         "AptosDB Other Error: Transaction at version 9 is pruned, min available version is 10."
     );
     assert!(db.error_if_ledger_pruned("Transaction", 10).is_ok());
+
+    // Hot state guards consult the hot pruners, independent of the cold ones set above.
+    db.state_store
+        .state_db
+        .state_pruner
+        .hot_state_merkle_pruner
+        .save_min_readable_version(5)
+        .unwrap();
+    db.state_store
+        .state_db
+        .state_pruner
+        .hot_state_kv_pruner
+        .save_min_readable_version(10)
+        .unwrap();
+    assert_eq!(
+        db.error_if_hot_state_merkle_pruned("Hot state", 4)
+            .unwrap_err()
+            .to_string(),
+        "AptosDB Other Error: Version 4 is not epoch ending."
+    );
+    assert!(db.error_if_hot_state_merkle_pruned("Hot state", 5).is_ok());
+    assert_eq!(
+        db.error_if_hot_state_kv_pruned("HotStateValue", 9)
+            .unwrap_err()
+            .to_string(),
+        "AptosDB Other Error: HotStateValue at version 9 is pruned, min available version is 10."
+    );
+    assert!(db.error_if_hot_state_kv_pruned("HotStateValue", 10).is_ok());
+}
+
+#[test]
+fn test_state_proof_ext_guards_with_hot_pruner() {
+    let tmp_dir = TempPath::new();
+    let db = AptosDB::new_for_test(&tmp_dir);
+    // Prune the hot merkle above the queried version; leave the cold merkle unpruned.
+    db.state_store
+        .state_db
+        .state_pruner
+        .hot_state_merkle_pruner
+        .save_min_readable_version(10)
+        .unwrap();
+    let key_hash = StateKey::raw(b"key").hash();
+    // With use_hot_state the hot pruner must be consulted: version 5 < hot min 10 is rejected at
+    // the guard. Were the cold pruner (min 0) used instead, the guard would let version 5 through.
+    assert_eq!(
+        db.get_state_proof_by_version_ext(&key_hash, 5, 0, true)
+            .unwrap_err()
+            .to_string(),
+        "AptosDB Other Error: Version 5 is not epoch ending."
+    );
 }
 
 #[test]


### PR DESCRIPTION

The hot state reads checked whether a version was pruned using the cold
guards (`error_if_state_kv_pruned` / `error_if_state_merkle_pruned`):
`get_hot_state_value_with_proof_by_version_ext` (with a TODO to use the
hot pruners) and `get_state_proof_by_version_ext` when `use_hot_state` is
set. The hot state KV and Merkle DBs are pruned independently of the cold
ones, so the cold guards can wrongly admit a version whose hot data is
already gone, surfacing a confusing low-level error instead of a clean
"pruned" one.

Add `error_if_hot_state_kv_pruned` and `error_if_hot_state_merkle_pruned`
(mirroring the cold guards but consulting `hot_state_kv_pruner`,
`hot_state_merkle_pruner`, and `hot_epoch_snapshot_pruner`) and use them
for both hot read paths, dropping the TODO. Extends the pruner guard test
to cover the hot variants and adds a test that the proof reader consults
the hot pruner under `use_hot_state`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes read-path validation for hot state proofs and values; incorrect guards could wrongly reject valid reads or admit pruned versions, but scope is limited to AptosDB reader guards with added tests.
> 
> **Overview**
> Hot state read APIs were checking **cold** pruner min-readable versions, so a version could pass the guard while hot KV/Merkle data was already pruned, leading to confusing errors instead of a clear “pruned” response.
> 
> This adds **`error_if_hot_state_kv_pruned`** and **`error_if_hot_state_merkle_pruned`** (mirroring the cold helpers but using `hot_state_kv_pruner`, `hot_state_merkle_pruner`, and `hot_epoch_snapshot_pruner`). **`get_hot_state_value_with_proof_by_version_ext`** now uses both hot guards (replacing the old TODO). **`get_state_proof_by_version_ext`** picks the hot or cold merkle guard based on **`use_hot_state`**.
> 
> Tests cover the new guards and assert that **`use_hot_state: true`** consults the hot merkle pruner even when cold data is still readable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6a16320dd74a32d82b90cece86ad5d0d87d794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->