### PR TITLE
[mono-move] Basic hash natives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12862,9 +12862,14 @@ dependencies = [
 name = "mono-move-natives"
 version = "0.1.0"
 dependencies = [
+ "blake2-rfc",
  "mono-move-core",
  "move-core-types",
+ "ripemd",
+ "sha2 0.9.9",
  "sha3 0.9.1",
+ "siphasher 0.3.11",
+ "tiny-keccak",
 ]
 
 [[package]]

--- a/third_party/move/mono-move/natives/Cargo.toml
+++ b/third_party/move/mono-move/natives/Cargo.toml
@@ -14,4 +14,10 @@ rust-version = { workspace = true }
 [dependencies]
 mono-move-core = { workspace = true }
 move-core-types = { workspace = true }
+
+blake2-rfc = { workspace = true }
+ripemd = { workspace = true }
+sha2 = { workspace = true }
 sha3 = { workspace = true }
+siphasher = { workspace = true }
+tiny-keccak = { workspace = true }

--- a/third_party/move/mono-move/natives/src/aptos_hash.rs
+++ b/third_party/move/mono-move/natives/src/aptos_hash.rs
@@ -16,25 +16,38 @@ use sha2::Digest;
 use std::hash::Hasher;
 use tiny_keccak::{Hasher as KeccakHasher, Keccak};
 
-/// `0x1::aptos_hash::keccak256(bytes: vector<u8>): vector<u8>`
+/// Reads arg 0 as `vector<u8>`, hashes it with `hash`, and writes the digest
+/// back as a `vector<u8>` in return slot 0. Shared by every hash whose result
+/// is a byte vector.
 //
 // TODO: charge gas.
-pub fn native_keccak256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+fn native_hash<C: NativeContext>(
+    ctx: &C,
+    hash: impl FnOnce(&[u8]) -> Vec<u8>,
+) -> Result<NativeStatus, VMInternalError> {
     // SAFETY: arg 0 is `vector<u8>`.
     let data: Vector<u8> = unsafe { ctx.arg(0)? };
-    let mut output = [0u8; 32];
-    {
+    let digest = {
         // SAFETY: the bytes are consumed before any allocation, so GC cannot
         // relocate them while the slice is held.
         let bytes = unsafe { data.as_bytes() };
-        let mut hasher = Keccak::v256();
-        hasher.update(bytes);
-        hasher.finalize(&mut output);
-    }
-    let out = ctx.new_byte_vector(&output)?;
+        hash(bytes)
+    };
+    let out = ctx.new_byte_vector(&digest)?;
     // SAFETY: return 0 is `vector<u8>`.
     unsafe { ctx.set_return(0, out)? };
     Ok(NativeStatus::Success)
+}
+
+/// `0x1::aptos_hash::keccak256(bytes: vector<u8>): vector<u8>`
+pub fn native_keccak256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    native_hash(ctx, |bytes| {
+        let mut output = [0u8; 32];
+        let mut hasher = Keccak::v256();
+        hasher.update(bytes);
+        hasher.finalize(&mut output);
+        output.to_vec()
+    })
 }
 
 /// `0x1::aptos_hash::sip_hash(bytes: vector<u8>): u64`
@@ -57,79 +70,39 @@ pub fn native_sip_hash<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInte
 }
 
 /// `0x1::aptos_hash::sha2_512_internal(bytes: vector<u8>): vector<u8>`
-//
-// TODO: charge gas.
 pub fn native_sha2_512<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
-    // SAFETY: arg 0 is `vector<u8>`.
-    let data: Vector<u8> = unsafe { ctx.arg(0)? };
-    let digest = {
-        // SAFETY: the bytes are consumed before any allocation.
-        let bytes = unsafe { data.as_bytes() };
+    native_hash(ctx, |bytes| {
         let mut hasher = sha2::Sha512::new();
         hasher.update(bytes);
         hasher.finalize().to_vec()
-    };
-    let out = ctx.new_byte_vector(&digest)?;
-    // SAFETY: return 0 is `vector<u8>`.
-    unsafe { ctx.set_return(0, out)? };
-    Ok(NativeStatus::Success)
+    })
 }
 
 /// `0x1::aptos_hash::sha3_512_internal(bytes: vector<u8>): vector<u8>`
-//
-// TODO: charge gas.
 pub fn native_sha3_512<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
-    // SAFETY: arg 0 is `vector<u8>`.
-    let data: Vector<u8> = unsafe { ctx.arg(0)? };
-    let digest = {
-        // SAFETY: the bytes are consumed before any allocation.
-        let bytes = unsafe { data.as_bytes() };
+    native_hash(ctx, |bytes| {
         let mut hasher = sha3::Sha3_512::new();
         hasher.update(bytes);
         hasher.finalize().to_vec()
-    };
-    let out = ctx.new_byte_vector(&digest)?;
-    // SAFETY: return 0 is `vector<u8>`.
-    unsafe { ctx.set_return(0, out)? };
-    Ok(NativeStatus::Success)
+    })
 }
 
 /// `0x1::aptos_hash::ripemd160_internal(bytes: vector<u8>): vector<u8>`
-//
-// TODO: charge gas.
 pub fn native_ripemd160<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
-    // SAFETY: arg 0 is `vector<u8>`.
-    let data: Vector<u8> = unsafe { ctx.arg(0)? };
-    let digest = {
-        // SAFETY: the bytes are consumed before any allocation.
-        let bytes = unsafe { data.as_bytes() };
+    native_hash(ctx, |bytes| {
         let mut hasher = ripemd::Ripemd160::new();
         hasher.update(bytes);
         hasher.finalize().to_vec()
-    };
-    let out = ctx.new_byte_vector(&digest)?;
-    // SAFETY: return 0 is `vector<u8>`.
-    unsafe { ctx.set_return(0, out)? };
-    Ok(NativeStatus::Success)
+    })
 }
 
 /// `0x1::aptos_hash::blake2b_256_internal(bytes: vector<u8>): vector<u8>`
-//
-// TODO: charge gas.
 pub fn native_blake2b_256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
-    // SAFETY: arg 0 is `vector<u8>`.
-    let data: Vector<u8> = unsafe { ctx.arg(0)? };
-    let digest = {
-        // SAFETY: the bytes are consumed before any allocation.
-        let bytes = unsafe { data.as_bytes() };
+    native_hash(ctx, |bytes| {
         blake2_rfc::blake2b::blake2b(32, &[], bytes)
             .as_bytes()
             .to_vec()
-    };
-    let out = ctx.new_byte_vector(&digest)?;
-    // SAFETY: return 0 is `vector<u8>`.
-    unsafe { ctx.set_return(0, out)? };
-    Ok(NativeStatus::Success)
+    })
 }
 
 /// Natives for the `aptos_hash` module.

--- a/third_party/move/mono-move/natives/src/aptos_hash.rs
+++ b/third_party/move/mono-move/natives/src/aptos_hash.rs
@@ -1,0 +1,145 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `aptos_hash` module (`aptos_std::aptos_hash`).
+//!
+//! The `sha2_512`, `sha3_512`, `ripemd160`, and `blake2b_256` natives are the
+//! `*_internal` entry points; their public counterparts are feature-gated Move
+//! wrappers in the framework.
+
+use crate::{monomorphic_natives, NativeEntry};
+use mono_move_core::native::{
+    NativeContext, NativeContextFamily, NativeStatus, VMInternalError, Vector,
+};
+use ripemd::Digest as OtherDigest;
+use sha2::Digest;
+use std::hash::Hasher;
+use tiny_keccak::{Hasher as KeccakHasher, Keccak};
+
+/// `0x1::aptos_hash::keccak256(bytes: vector<u8>): vector<u8>`
+//
+// TODO: charge gas.
+pub fn native_keccak256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let data: Vector<u8> = unsafe { ctx.arg(0)? };
+    let mut output = [0u8; 32];
+    {
+        // SAFETY: the bytes are consumed before any allocation, so GC cannot
+        // relocate them while the slice is held.
+        let bytes = unsafe { data.as_bytes() };
+        let mut hasher = Keccak::v256();
+        hasher.update(bytes);
+        hasher.finalize(&mut output);
+    }
+    let out = ctx.new_byte_vector(&output)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::aptos_hash::sip_hash(bytes: vector<u8>): u64`
+//
+// TODO: charge gas.
+pub fn native_sip_hash<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let data: Vector<u8> = unsafe { ctx.arg(0)? };
+    let hash = {
+        // SAFETY: the bytes are consumed before any allocation, so GC cannot
+        // relocate them while the slice is held.
+        let bytes = unsafe { data.as_bytes() };
+        let mut hasher = siphasher::sip::SipHasher::new();
+        hasher.write(bytes);
+        hasher.finish()
+    };
+    // SAFETY: return 0 is `u64`.
+    unsafe { ctx.set_return(0, hash)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::aptos_hash::sha2_512_internal(bytes: vector<u8>): vector<u8>`
+//
+// TODO: charge gas.
+pub fn native_sha2_512<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let data: Vector<u8> = unsafe { ctx.arg(0)? };
+    let digest = {
+        // SAFETY: the bytes are consumed before any allocation.
+        let bytes = unsafe { data.as_bytes() };
+        let mut hasher = sha2::Sha512::new();
+        hasher.update(bytes);
+        hasher.finalize().to_vec()
+    };
+    let out = ctx.new_byte_vector(&digest)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::aptos_hash::sha3_512_internal(bytes: vector<u8>): vector<u8>`
+//
+// TODO: charge gas.
+pub fn native_sha3_512<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let data: Vector<u8> = unsafe { ctx.arg(0)? };
+    let digest = {
+        // SAFETY: the bytes are consumed before any allocation.
+        let bytes = unsafe { data.as_bytes() };
+        let mut hasher = sha3::Sha3_512::new();
+        hasher.update(bytes);
+        hasher.finalize().to_vec()
+    };
+    let out = ctx.new_byte_vector(&digest)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::aptos_hash::ripemd160_internal(bytes: vector<u8>): vector<u8>`
+//
+// TODO: charge gas.
+pub fn native_ripemd160<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let data: Vector<u8> = unsafe { ctx.arg(0)? };
+    let digest = {
+        // SAFETY: the bytes are consumed before any allocation.
+        let bytes = unsafe { data.as_bytes() };
+        let mut hasher = ripemd::Ripemd160::new();
+        hasher.update(bytes);
+        hasher.finalize().to_vec()
+    };
+    let out = ctx.new_byte_vector(&digest)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::aptos_hash::blake2b_256_internal(bytes: vector<u8>): vector<u8>`
+//
+// TODO: charge gas.
+pub fn native_blake2b_256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let data: Vector<u8> = unsafe { ctx.arg(0)? };
+    let digest = {
+        // SAFETY: the bytes are consumed before any allocation.
+        let bytes = unsafe { data.as_bytes() };
+        blake2_rfc::blake2b::blake2b(32, &[], bytes)
+            .as_bytes()
+            .to_vec()
+    };
+    let out = ctx.new_byte_vector(&digest)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `aptos_hash` module.
+pub fn make_all_aptos_hash_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![
+        ("0x1::aptos_hash::keccak256", native_keccak256),
+        ("0x1::aptos_hash::sip_hash", native_sip_hash),
+        ("0x1::aptos_hash::sha2_512_internal", native_sha2_512),
+        ("0x1::aptos_hash::sha3_512_internal", native_sha3_512),
+        ("0x1::aptos_hash::ripemd160_internal", native_ripemd160),
+        ("0x1::aptos_hash::blake2b_256_internal", native_blake2b_256),
+    ]
+}

--- a/third_party/move/mono-move/natives/src/hash.rs
+++ b/third_party/move/mono-move/natives/src/hash.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `hash` module (`std::hash`).
+
+use crate::{monomorphic_natives, NativeEntry};
+use mono_move_core::native::{
+    NativeContext, NativeContextFamily, NativeStatus, VMInternalError, Vector,
+};
+use sha2::{Digest, Sha256};
+use sha3::Sha3_256;
+
+/// `0x1::hash::sha2_256(data: vector<u8>): vector<u8>`
+//
+// TODO: charge gas.
+pub fn native_sha2_256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let data: Vector<u8> = unsafe { ctx.arg(0)? };
+    // SAFETY: the bytes are consumed before any allocation, so GC cannot
+    // relocate them while the slice is held.
+    let digest = {
+        let bytes = unsafe { data.as_bytes() };
+        Sha256::digest(bytes).to_vec()
+    };
+    let out = ctx.new_byte_vector(&digest)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::hash::sha3_256(data: vector<u8>): vector<u8>`
+//
+// TODO: charge gas.
+pub fn native_sha3_256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let data: Vector<u8> = unsafe { ctx.arg(0)? };
+    // SAFETY: the bytes are consumed before any allocation, so GC cannot
+    // relocate them while the slice is held.
+    let digest = {
+        let bytes = unsafe { data.as_bytes() };
+        Sha3_256::digest(bytes).to_vec()
+    };
+    let out = ctx.new_byte_vector(&digest)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `hash` module.
+pub fn make_all_hash_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![
+        ("0x1::hash::sha2_256", native_sha2_256),
+        ("0x1::hash::sha3_256", native_sha3_256),
+    ]
+}

--- a/third_party/move/mono-move/natives/src/hash.rs
+++ b/third_party/move/mono-move/natives/src/hash.rs
@@ -16,9 +16,9 @@ use sha3::Sha3_256;
 pub fn native_sha2_256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
     // SAFETY: arg 0 is `vector<u8>`.
     let data: Vector<u8> = unsafe { ctx.arg(0)? };
-    // SAFETY: the bytes are consumed before any allocation, so GC cannot
-    // relocate them while the slice is held.
     let digest = {
+        // SAFETY: the bytes are consumed before any allocation, so GC cannot
+        // relocate them while the slice is held.
         let bytes = unsafe { data.as_bytes() };
         Sha256::digest(bytes).to_vec()
     };
@@ -34,9 +34,9 @@ pub fn native_sha2_256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInte
 pub fn native_sha3_256<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
     // SAFETY: arg 0 is `vector<u8>`.
     let data: Vector<u8> = unsafe { ctx.arg(0)? };
-    // SAFETY: the bytes are consumed before any allocation, so GC cannot
-    // relocate them while the slice is held.
     let digest = {
+        // SAFETY: the bytes are consumed before any allocation, so GC cannot
+        // relocate them while the slice is held.
         let bytes = unsafe { data.as_bytes() };
         Sha3_256::digest(bytes).to_vec()
     };

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -14,8 +14,10 @@ use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
 mod address_derivation;
 pub mod aggregator_v2;
+pub mod aptos_hash;
 pub mod event;
 pub mod function_info;
+pub mod hash;
 pub mod mem;
 pub mod object;
 pub mod signer;
@@ -25,8 +27,10 @@ pub mod transaction_context;
 pub mod type_info;
 
 pub use aggregator_v2::make_all_aggregator_v2_natives;
+pub use aptos_hash::make_all_aptos_hash_natives;
 pub use event::{make_all_event_natives, EventEntry, EventKind, EventStore};
 pub use function_info::make_all_function_info_natives;
+pub use hash::make_all_hash_natives;
 pub use mem::make_all_mem_natives;
 pub use object::{make_all_object_natives, ObjectContextExtension};
 pub use signer::make_all_signer_natives;
@@ -72,6 +76,8 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
     natives.extend(make_all_object_natives::<F>());
     natives.extend(make_all_state_storage_natives::<F>());
     natives.extend(make_all_event_natives::<F>());
+    natives.extend(make_all_hash_natives::<F>());
+    natives.extend(make_all_aptos_hash_natives::<F>());
     natives
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/aptos_hash.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/aptos_hash.move
@@ -1,9 +1,12 @@
 // Differential test for the `aptos_hash` natives.
 //
-// The aptos-framework is not pre-published into the test environment, so the
-// natives are re-declared inline (same pattern as signer.move). The feature-
-// gated hashes use their true `*_internal` native entry points. Inputs are
-// byte-string literals; `// CHECK` asserts both VMs agree.
+// The aptos-framework is not pre-published here, so the natives are re-declared
+// inline (same pattern as signer.move).
+//
+// TODO: re-declaring the natives inline can drift from their real framework
+// signatures, a known source of hidden bugs (e.g. renaming a parameter can
+// silently enable receiver-style calls). Replace this by publishing the real
+// framework, gated behind a natives-only include directive.
 
 // RUN: publish
 module 0x1::aptos_hash {
@@ -16,10 +19,15 @@ module 0x1::aptos_hash {
 
     public fun keccak_empty(): vector<u8> { keccak256(b"") }
     public fun keccak_abc(): vector<u8> { keccak256(b"abc") }
-    public fun sip(): u64 { sip_hash(b"abc") }
+    public fun sip_empty(): u64 { sip_hash(b"") }
+    public fun sip_abc(): u64 { sip_hash(b"abc") }
+    public fun sha2_512_empty(): vector<u8> { sha2_512_internal(b"") }
     public fun sha2_512_abc(): vector<u8> { sha2_512_internal(b"abc") }
+    public fun sha3_512_empty(): vector<u8> { sha3_512_internal(b"") }
     public fun sha3_512_abc(): vector<u8> { sha3_512_internal(b"abc") }
+    public fun ripemd160_empty(): vector<u8> { ripemd160_internal(b"") }
     public fun ripemd160_abc(): vector<u8> { ripemd160_internal(b"abc") }
+    public fun blake2b_256_empty(): vector<u8> { blake2b_256_internal(b"") }
     public fun blake2b_256_abc(): vector<u8> { blake2b_256_internal(b"abc") }
 }
 
@@ -29,17 +37,32 @@ module 0x1::aptos_hash {
 // RUN: execute 0x1::aptos_hash::keccak_abc
 // CHECK: results: 0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45
 
-// RUN: execute 0x1::aptos_hash::sip
+// RUN: execute 0x1::aptos_hash::sip_empty
+// CHECK: results: 2202906307356721367
+
+// RUN: execute 0x1::aptos_hash::sip_abc
 // CHECK: results: 4596069200710135518
+
+// RUN: execute 0x1::aptos_hash::sha2_512_empty
+// CHECK: results: 0xcf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
 
 // RUN: execute 0x1::aptos_hash::sha2_512_abc
 // CHECK: results: 0xddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f
 
+// RUN: execute 0x1::aptos_hash::sha3_512_empty
+// CHECK: results: 0xa69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26
+
 // RUN: execute 0x1::aptos_hash::sha3_512_abc
 // CHECK: results: 0xb751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0
 
+// RUN: execute 0x1::aptos_hash::ripemd160_empty
+// CHECK: results: 0x9c1185a5c5e9fc54612808977ee8f548b2258d31
+
 // RUN: execute 0x1::aptos_hash::ripemd160_abc
 // CHECK: results: 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
+
+// RUN: execute 0x1::aptos_hash::blake2b_256_empty
+// CHECK: results: 0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
 
 // RUN: execute 0x1::aptos_hash::blake2b_256_abc
 // CHECK: results: 0xbddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/aptos_hash.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/aptos_hash.move
@@ -1,0 +1,45 @@
+// Differential test for the `aptos_hash` natives.
+//
+// The aptos-framework is not pre-published into the test environment, so the
+// natives are re-declared inline (same pattern as signer.move). The feature-
+// gated hashes use their true `*_internal` native entry points. Inputs are
+// byte-string literals; `// CHECK` asserts both VMs agree.
+
+// RUN: publish
+module 0x1::aptos_hash {
+    public native fun keccak256(bytes: vector<u8>): vector<u8>;
+    public native fun sip_hash(bytes: vector<u8>): u64;
+    native fun sha2_512_internal(bytes: vector<u8>): vector<u8>;
+    native fun sha3_512_internal(bytes: vector<u8>): vector<u8>;
+    native fun ripemd160_internal(bytes: vector<u8>): vector<u8>;
+    native fun blake2b_256_internal(bytes: vector<u8>): vector<u8>;
+
+    public fun keccak_empty(): vector<u8> { keccak256(b"") }
+    public fun keccak_abc(): vector<u8> { keccak256(b"abc") }
+    public fun sip(): u64 { sip_hash(b"abc") }
+    public fun sha2_512_abc(): vector<u8> { sha2_512_internal(b"abc") }
+    public fun sha3_512_abc(): vector<u8> { sha3_512_internal(b"abc") }
+    public fun ripemd160_abc(): vector<u8> { ripemd160_internal(b"abc") }
+    public fun blake2b_256_abc(): vector<u8> { blake2b_256_internal(b"abc") }
+}
+
+// RUN: execute 0x1::aptos_hash::keccak_empty
+// CHECK: results: 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+
+// RUN: execute 0x1::aptos_hash::keccak_abc
+// CHECK: results: 0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45
+
+// RUN: execute 0x1::aptos_hash::sip
+// CHECK: results: 4596069200710135518
+
+// RUN: execute 0x1::aptos_hash::sha2_512_abc
+// CHECK: results: 0xddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f
+
+// RUN: execute 0x1::aptos_hash::sha3_512_abc
+// CHECK: results: 0xb751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0
+
+// RUN: execute 0x1::aptos_hash::ripemd160_abc
+// CHECK: results: 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
+
+// RUN: execute 0x1::aptos_hash::blake2b_256_abc
+// CHECK: results: 0xbddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/hash.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/hash.move
@@ -1,9 +1,11 @@
 // Differential test for the `std::hash` natives (sha2_256, sha3_256).
 //
-// `std::hash` is part of the Move stdlib, which is pre-published into both VMs,
-// so it can be called directly. Inputs are built as byte-string literals since
-// the test harness only passes integer/bool/address arguments. Expected values
-// are the standard NIST test vectors; `// CHECK` asserts both VMs agree.
+// `std::hash` is in the Move stdlib, pre-published into both VMs, so it is
+// called directly. Inputs are byte-string literals.
+//
+// TODO: extend the test harness to pass richer argument types (beyond
+// integer/bool/address) and to support public structs and enums, so these
+// natives can be exercised with non-literal inputs.
 
 // RUN: publish
 module 0x1::main {

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/hash.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/hash.move
@@ -1,0 +1,28 @@
+// Differential test for the `std::hash` natives (sha2_256, sha3_256).
+//
+// `std::hash` is part of the Move stdlib, which is pre-published into both VMs,
+// so it can be called directly. Inputs are built as byte-string literals since
+// the test harness only passes integer/bool/address arguments. Expected values
+// are the standard NIST test vectors; `// CHECK` asserts both VMs agree.
+
+// RUN: publish
+module 0x1::main {
+    use std::hash;
+
+    public fun sha2_empty(): vector<u8> { hash::sha2_256(b"") }
+    public fun sha2_abc(): vector<u8> { hash::sha2_256(b"abc") }
+    public fun sha3_empty(): vector<u8> { hash::sha3_256(b"") }
+    public fun sha3_abc(): vector<u8> { hash::sha3_256(b"abc") }
+}
+
+// RUN: execute 0x1::main::sha2_empty
+// CHECK: results: 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+// RUN: execute 0x1::main::sha2_abc
+// CHECK: results: 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+// RUN: execute 0x1::main::sha3_empty
+// CHECK: results: 0xa7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
+
+// RUN: execute 0x1::main::sha3_abc
+// CHECK: results: 0x3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532


### PR DESCRIPTION
## Description

Adds the hash natives to MonoMove so Move code that hashes can run under the new VM with output identical to the legacy MoveVM.

Natives added:
- `std::hash`: `sha2_256`, `sha3_256`
- `aptos_std::aptos_hash`: `keccak256`, `sip_hash`, `sha2_512`, `sha3_512`, `ripemd160`, `blake2b_256`

Each native replicates the legacy MoveVM implementation byte-for-byte (same crates: `sha2`, `sha3`, `tiny-keccak`, `siphasher`, `ripemd`, `blake2-rfc`). The four feature-gated hashes register under their true `*_internal` native entry points — the public `sha2_512`/`sha3_512`/`ripemd160`/`blake2b_256` are non-native Move wrappers in the framework, so the actual natives are `sha2_512_internal`, etc.

Gas is not charged yet — `NativeContext` has no gas API, matching every other native in the crate (`// TODO: charge gas.`).

## How Has This Been Tested?

Two differential tests under `third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/`:
- `hash.move` — `sha2_256`/`sha3_256` over empty and `"abc"` inputs.
- `aptos_hash.move` — all six `aptos_hash` natives over empty/`"abc"` inputs.

The differential harness runs each case on both the legacy VM (V1) and MonoMove (V2) and asserts they produce the same result. The `// CHECK` literals are pinned to known published test vectors (NIST SHA-2/SHA-3, Keccak-256, RIPEMD-160, BLAKE2b-256), so the tests also lock correctness, not just V1/V2 agreement.

```
cargo test -p mono-move-testsuite --test differential -- natives/
```

All 17 natives differential tests pass.

## Type of Change

- [x] New feature

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hash natives underpin many on-chain identifiers and crypto flows; incorrect digests would break compatibility, though risk is mitigated by matching legacy crates and differential tests against pinned vectors.
> 
> **Overview**
> Adds **MonoMove** native implementations for `std::hash` (`sha2_256`, `sha3_256`) and `aptos_std::aptos_hash` (`keccak256`, `sip_hash`, plus `sha2_512_internal`, `sha3_512_internal`, `ripemd160_internal`, `blake2b_256_internal`), wired into `make_all_production_natives` with the same Rust crypto crates as the legacy VM.
> 
> Byte-vector digests share a small `native_hash` helper in `aptos_hash.rs`; `sip_hash` returns `u64`. **Gas is not charged yet** (`TODO: charge gas`), consistent with other natives in this crate.
> 
> Differential Move tests (`hash.move`, `aptos_hash.move`) run empty and `"abc"` inputs on V1 vs V2 with pinned known test vectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce7beb7792d22e29dae20228133c10ea3096f37e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->