### PR TITLE
[storage] Add hot state snapshot chunk-with-proof

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -32,7 +32,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
-        hot_state::HotStateValue,
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueChunkWithProof},
@@ -847,6 +847,19 @@ impl DbReader for AptosDB {
                 as Box<
                     dyn Iterator<Item = Result<(StateKey, HotStateValue)>> + '_,
                 >)
+        })
+    }
+
+    fn get_hot_state_value_chunk_proof(
+        &self,
+        version: Version,
+        first_index: usize,
+        raw_values: Vec<(StateKey, HotStateValue)>,
+    ) -> Result<HotStateValueChunkWithProof> {
+        gauged_api("get_hot_state_value_chunk_proof", || {
+            self.error_if_hot_state_merkle_pruned("Hot state merkle", version)?;
+            self.state_store
+                .get_hot_state_value_chunk_proof(version, first_index, raw_values)
         })
     }
 

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -21,7 +21,10 @@ use crate::{
     state_merkle_db::StateMerkleDb,
     state_restore::{StateSnapshotRestore, StateSnapshotRestoreMode, StateValueWriter},
     state_store::{buffered_state::BufferedState, persisted_state::PersistedState},
-    state_value_chunk::{build_value_chunk_proof, jmt_leaves_with_values, value_chunk_with_proof},
+    state_value_chunk::{
+        build_hot_value_chunk_proof, build_value_chunk_proof, jmt_leaves_with_values,
+        value_chunk_with_proof,
+    },
     utils::{
         truncation_helper::{
             find_tree_root_at_or_before, get_max_version_in_state_merkle_db, truncate_ledger_db,
@@ -69,7 +72,7 @@ use aptos_storage_interface::{
 use aptos_types::{
     proof::{definition::LeafCount, SparseMerkleProofExt, SparseMerkleRangeProof},
     state_store::{
-        hot_state::HotStateValue,
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_slot::{StateSlot, StateSlotKind},
         state_storage_usage::StateStorageUsage,
@@ -1525,6 +1528,22 @@ impl StateStore {
             Ok((key, value))
         })
         .take(chunk_size))
+    }
+
+    /// Assembles a [`HotStateValueChunkWithProof`] for the given hot state leaves, with a range
+    /// proof against the hot state Merkle root at `version`.
+    pub fn get_hot_state_value_chunk_proof(
+        &self,
+        version: Version,
+        first_index: usize,
+        raw_values: Vec<(StateKey, HotStateValue)>,
+    ) -> Result<HotStateValueChunkWithProof> {
+        build_hot_value_chunk_proof(
+            self.hot_state_merkle_db.as_ref(),
+            version,
+            first_index,
+            raw_values,
+        )
     }
 
     // state sync doesn't query for the progress, but keeps its record by itself.

--- a/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
@@ -5,11 +5,18 @@
 
 use crate::{db::test_helper::arb_blocks_to_commit_with_params, AptosDB};
 use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_jellyfish_merkle::{
+    mock_tree_store::MockTreeStore, restore::JellyfishMerkleRestore, JellyfishMerkleTree,
+};
 use aptos_storage_interface::{DbReader, Result as DbResult};
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::{hot_state::HotStateValue, state_key::StateKey, state_value::StateValue},
+    state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
+        state_key::StateKey,
+        state_value::StateValue,
+    },
     transaction::{
         BlockEndInfo, ExecutionStatus, Transaction, TransactionAuxiliaryData, TransactionInfo,
         TransactionToCommit, Version,
@@ -17,7 +24,7 @@ use aptos_types::{
     write_set::WriteSet,
 };
 use proptest::prelude::*;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 fn key(seed: &str) -> StateKey {
     StateKey::raw(seed.as_bytes())
@@ -93,6 +100,95 @@ fn collect_paged(
         out.extend(chunk);
     }
     out
+}
+
+/// Walks the whole hot state at `version`: read up to `chunk_size` leaves with the iterator, then
+/// wrap each batch in a range proof. Returns the proof-carrying chunks in order.
+fn collect_chunks_with_proof(
+    db: &AptosDB,
+    version: Version,
+    chunk_size: usize,
+) -> Vec<HotStateValueChunkWithProof> {
+    let mut chunks = vec![];
+    let mut first_index = 0;
+    loop {
+        let raw_values = collect_chunk(db, version, first_index, chunk_size);
+        if raw_values.is_empty() {
+            break;
+        }
+        let num_values = raw_values.len();
+        chunks.push(
+            db.get_hot_state_value_chunk_proof(version, first_index, raw_values)
+                .unwrap(),
+        );
+        first_index += num_values;
+    }
+    chunks
+}
+
+fn assert_chunks_reconstruct_root(version: Version, chunks: &[HotStateValueChunkWithProof]) {
+    assert!(!chunks.is_empty(), "no chunks to verify");
+    // Every chunk of the same snapshot carries the same root, and only the final chunk is last.
+    let root_hash = chunks[0].root_hash;
+    let last = chunks.len() - 1;
+    for (i, chunk) in chunks.iter().enumerate() {
+        assert_eq!(chunk.root_hash, root_hash);
+        assert_eq!(chunk.is_last_chunk(), i == last);
+    }
+
+    let store = Arc::new(MockTreeStore::<StateKey>::new(
+        false, /* allow_overwrite */
+    ));
+    let mut restore = JellyfishMerkleRestore::new(
+        Arc::clone(&store),
+        version,
+        root_hash,
+        false, /* async */
+    )
+    .unwrap();
+    for chunk in chunks {
+        let leaves: Vec<_> = chunk
+            .raw_values
+            .iter()
+            .map(|(k, hsv)| (k, hsv.hash()))
+            .collect();
+        restore.add_chunk_impl(leaves, chunk.proof.clone()).unwrap();
+    }
+    restore.finish_impl().unwrap();
+
+    let restored_root = JellyfishMerkleTree::new(store.as_ref())
+        .get_root_hash(version)
+        .unwrap();
+    assert_eq!(restored_root, root_hash);
+}
+
+fn assert_chunks_match_full(
+    chunks: &[HotStateValueChunkWithProof],
+    full: &[(StateKey, HotStateValue)],
+) {
+    let mut next_index = 0;
+    for chunk in chunks {
+        assert!(
+            !chunk.raw_values.is_empty(),
+            "chunk at index {next_index} is empty"
+        );
+
+        let first_index = next_index;
+        let last_index = first_index + chunk.raw_values.len() - 1;
+        assert!(
+            last_index < full.len(),
+            "chunk range {first_index}..={last_index} exceeds full length {}",
+            full.len()
+        );
+        assert_eq!(chunk.first_index as usize, first_index);
+        assert_eq!(chunk.last_index as usize, last_index);
+        assert_eq!(chunk.first_key, chunk.raw_values.first().unwrap().0.hash());
+        assert_eq!(chunk.last_key, chunk.raw_values.last().unwrap().0.hash());
+        assert_eq!(chunk.raw_values, full[first_index..=last_index]);
+
+        next_index += chunk.raw_values.len();
+    }
+    assert_eq!(next_index, full.len());
 }
 
 #[test]
@@ -185,11 +281,16 @@ fn test_hot_state_chunk_iter_at_older_checkpoint() {
 
     // Reading the older snapshot sees the state as of v0 only.
     assert_eq!(db.get_hot_state_item_count(0).unwrap(), 2);
-    let at_v0: BTreeMap<_, _> = collect_chunk(&db, 0, 0, usize::MAX).into_iter().collect();
+    let v0_full = collect_chunk(&db, 0, 0, usize::MAX);
+    let at_v0: BTreeMap<_, _> = v0_full.iter().cloned().collect();
     assert_eq!(at_v0[&key("a")].value_opt(), Some(&val(b"a0")));
     assert_eq!(at_v0[&key("a")].hot_since_version(), 0);
     assert_eq!(at_v0[&key("b")].value_opt(), Some(&val(b"b0")));
     assert!(!at_v0.contains_key(&key("c")));
+
+    let v0_chunks = collect_chunks_with_proof(&db, 0, 1);
+    assert_chunks_match_full(&v0_chunks, &v0_full);
+    assert_chunks_reconstruct_root(0, &v0_chunks);
 
     // At v1, `b` is untouched — its value and `hot_since_version` are still those from v0, even
     // though its JMT leaf now sits under a newer (v1) snapshot.
@@ -201,6 +302,67 @@ fn test_hot_state_chunk_iter_at_older_checkpoint() {
     assert_eq!(at_v1[&key("b")].hot_since_version(), 0);
     assert_eq!(at_v1[&key("c")].value_opt(), Some(&val(b"c1")));
     assert_eq!(at_v1[&key("c")].hot_since_version(), 1);
+}
+
+#[test]
+fn test_hot_state_chunk_with_proof() {
+    let tmp = TempPath::new();
+    let db = AptosDB::new_for_test(&tmp);
+
+    // A mix of occupied and vacant (deleted) hot entries across two checkpoints.
+    let last = commit_blocks(&db, vec![
+        vec![
+            (key("a"), Some(val(b"a0"))),
+            (key("b"), Some(val(b"b0"))),
+            (key("c"), Some(val(b"c0"))),
+        ],
+        vec![
+            (key("a"), None), // vacant
+            (key("d"), Some(val(b"d1"))),
+            (key("e"), Some(val(b"e1"))),
+        ],
+    ]);
+    let count = db.get_hot_state_item_count(last).unwrap();
+    assert_eq!(count, 5); // a (vacant), b, c, d, e
+
+    let iter_items = collect_chunk(&db, last, 0, usize::MAX);
+
+    // A single full chunk: its index/key range and values line up with the iterator output, and it
+    // is the last chunk.
+    let full = db
+        .get_hot_state_value_chunk_proof(last, 0, iter_items.clone())
+        .unwrap();
+    assert_eq!(full.first_index, 0);
+    assert_eq!(full.last_index as usize, count - 1);
+    assert_eq!(full.first_key, iter_items.first().unwrap().0.hash());
+    assert_eq!(full.last_key, iter_items.last().unwrap().0.hash());
+    assert_eq!(full.raw_values, iter_items);
+    assert!(full.is_last_chunk());
+    assert_chunks_reconstruct_root(last, &[full]);
+
+    // Paginated at various sizes: chunk metadata lines up with the single-pass read and every
+    // chunk verifies against the hot state root.
+    for chunk_size in [1, 2, 3, 5] {
+        let chunks = collect_chunks_with_proof(&db, last, chunk_size);
+        assert_chunks_match_full(&chunks, &iter_items);
+        assert_chunks_reconstruct_root(last, &chunks);
+    }
+}
+
+#[test]
+fn test_hot_state_chunk_proof_empty_errors() {
+    let tmp = TempPath::new();
+    let db = AptosDB::new_for_test(&tmp);
+    let version = commit_blocks(&db, vec![vec![(key("a"), Some(val(b"a0")))]]);
+
+    // An empty chunk has no rightmost key to anchor a range proof on.
+    let err = db
+        .get_hot_state_value_chunk_proof(version, 0, vec![])
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("empty"),
+        "expected an empty-chunk error, got: {err}"
+    );
 }
 
 /// The hot state expected at the latest checkpoint: every key ever written, keyed by key hash,
@@ -268,6 +430,14 @@ proptest! {
             prop_assert_eq!(k, key);
             prop_assert_eq!(hsv.value_opt(), value.as_ref());
             prop_assert_eq!(hsv.hot_since_version(), *ver);
+        }
+
+        // The proof path produces chunks whose metadata lines up with the single-pass read and
+        // reconstructs the hot state Merkle root (what the receiving node verifies).
+        let chunks = collect_chunks_with_proof(&db, ckpt, chunk_size);
+        assert_chunks_match_full(&chunks, &full);
+        if !full.is_empty() {
+            assert_chunks_reconstruct_root(ckpt, &chunks);
         }
 
         // Paging in `chunk_size`-sized steps reconstructs the same sequence.

--- a/storage/aptosdb/src/state_value_chunk.rs
+++ b/storage/aptosdb/src/state_value_chunk.rs
@@ -3,15 +3,17 @@
 
 //! Shared state-value snapshot chunk helpers, generic over the backing
 //! Jellyfish Merkle store. The JMT walk and range-proof assembly are identical
-//! across snapshot kinds; only the value lookup differs.
+//! across snapshot kinds; only the value lookup and the assembled chunk type differ.
 
 #![forbid(unsafe_code)]
 
-use aptos_crypto::hash::CryptoHash;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_jellyfish_merkle::{iterator::JellyfishMerkleIterator, JellyfishMerkleTree, TreeReader};
 use aptos_storage_interface::{AptosDbError, Result};
 use aptos_types::{
+    proof::SparseMerkleRangeProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -62,15 +64,26 @@ where
     build_value_chunk_proof(merkle_db.as_ref(), version, first_index, raw_values)
 }
 
-/// Assembles a [`StateValueChunkWithProof`] for `raw_values`: a range proof for
-/// the rightmost key against the store's root at `version`. The caller is
-/// responsible for any byte/time bounding of `raw_values`.
-pub(crate) fn build_value_chunk_proof<R>(
+/// The value-type-independent parts of a state value chunk proof: the chunk's index/key range and
+/// a range proof for its rightmost key against the store's root at `version`.
+struct ChunkRangeProof {
+    first_index: u64,
+    last_index: u64,
+    first_key: HashValue,
+    last_key: HashValue,
+    proof: SparseMerkleRangeProof,
+    root_hash: HashValue,
+}
+
+/// Builds the [`ChunkRangeProof`] for the chunk of `raw_values` (the chunk's leaves in JMT order)
+/// starting at `first_index`. Errors if `raw_values` is empty, since a non-empty chunk is needed
+/// to anchor the proof on a rightmost key.
+fn build_chunk_range_proof<R, V>(
     merkle_db: &R,
     version: Version,
     first_index: usize,
-    raw_values: Vec<(StateKey, StateValue)>,
-) -> Result<StateValueChunkWithProof>
+    raw_values: &[(StateKey, V)],
+) -> Result<ChunkRangeProof>
 where
     R: TreeReader<StateKey> + Sync,
 {
@@ -85,8 +98,67 @@ where
     let tree = JellyfishMerkleTree::<R, StateKey>::new(merkle_db);
     let proof = tree.get_range_proof(last_key, version)?;
     let root_hash = tree.get_root_hash(version)?;
-    Ok(StateValueChunkWithProof {
+    Ok(ChunkRangeProof {
         first_index: first_index as u64,
+        last_index,
+        first_key,
+        last_key,
+        proof,
+        root_hash,
+    })
+}
+
+/// Assembles a [`StateValueChunkWithProof`] for `raw_values`: a range proof for
+/// the rightmost key against the store's root at `version`.
+pub(crate) fn build_value_chunk_proof<R>(
+    merkle_db: &R,
+    version: Version,
+    first_index: usize,
+    raw_values: Vec<(StateKey, StateValue)>,
+) -> Result<StateValueChunkWithProof>
+where
+    R: TreeReader<StateKey> + Sync,
+{
+    let ChunkRangeProof {
+        first_index,
+        last_index,
+        first_key,
+        last_key,
+        proof,
+        root_hash,
+    } = build_chunk_range_proof(merkle_db, version, first_index, &raw_values)?;
+    Ok(StateValueChunkWithProof {
+        first_index,
+        last_index,
+        first_key,
+        last_key,
+        raw_values,
+        proof,
+        root_hash,
+    })
+}
+
+/// Assembles a [`HotStateValueChunkWithProof`] for `raw_values`: a range proof for the rightmost
+/// key against the hot state Merkle root at `version`.
+pub(crate) fn build_hot_value_chunk_proof<R>(
+    merkle_db: &R,
+    version: Version,
+    first_index: usize,
+    raw_values: Vec<(StateKey, HotStateValue)>,
+) -> Result<HotStateValueChunkWithProof>
+where
+    R: TreeReader<StateKey> + Sync,
+{
+    let ChunkRangeProof {
+        first_index,
+        last_index,
+        first_key,
+        last_key,
+        proof,
+        root_hash,
+    } = build_chunk_range_proof(merkle_db, version, first_index, &raw_values)?;
+    Ok(HotStateValueChunkWithProof {
+        first_index,
         last_index,
         first_key,
         last_key,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -17,7 +17,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
-        hot_state::HotStateValue,
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueChunkWithProof},
@@ -470,6 +470,15 @@ pub trait DbReader: Send + Sync {
             first_index: usize,
             chunk_size: usize,
         ) -> Result<Box<dyn Iterator<Item = Result<(StateKey, HotStateValue)>> + '_>>;
+
+        /// Assembles a hot state value chunk with a range proof against the hot state Merkle root
+        /// at `version`.
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> Result<HotStateValueChunkWithProof>;
 
         /// Returns if the state store pruner is enabled.
         fn is_state_merkle_pruner_enabled(&self) -> Result<bool>;

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -2,14 +2,16 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
+    proof::SparseMerkleRangeProof,
     state_store::{
+        state_key::StateKey,
         state_slot::{StateSlot, StateSlotKind},
         state_value::StateValue,
     },
     transaction::Version,
 };
 use aptos_crypto::{
-    hash::{CryptoHash, CryptoHasher},
+    hash::{CryptoHash, CryptoHasher, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
@@ -122,6 +124,36 @@ impl CryptoHash for HotStateValueRef<'_> {
         bcs::serialize_into(&mut state, &self)
             .expect("BCS serialization of HotStateValueRef should not fail");
         state.finish()
+    }
+}
+
+/// A single chunk of the hot state at a specific version, with a range proof against the hot state
+/// Merkle root.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HotStateValueChunkWithProof {
+    /// The first hot state index in chunk
+    pub first_index: u64,
+    /// The last hot state index in chunk
+    pub last_index: u64,
+    /// The first hot state key hash in chunk
+    pub first_key: HashValue,
+    /// The last hot state key hash in chunk
+    pub last_key: HashValue,
+    /// The state key and its hot state value.
+    pub raw_values: Vec<(StateKey, HotStateValue)>,
+    /// The proof to ensure the chunk is in the hot state tree
+    pub proof: SparseMerkleRangeProof,
+    /// The root hash of the hot state Merkle tree for this chunk
+    pub root_hash: HashValue,
+}
+
+impl HotStateValueChunkWithProof {
+    /// Returns true iff this is the last chunk (i.e. no more hot state values follow it).
+    pub fn is_last_chunk(&self) -> bool {
+        self.proof
+            .right_siblings()
+            .iter()
+            .all(|sibling| *sibling == *SPARSE_MERKLE_PLACEHOLDER_HASH)
     }
 }
 


### PR DESCRIPTION

Continuing hot state fast-sync support: a syncing node must be able to
verify each hot state snapshot chunk against the hot state Merkle root.
Building on the hot read APIs, add the proof builder and its `DbReader`
surface, mirroring the cold `get_state_value_chunk_proof`.

- Add `HotStateValueChunkWithProof`, the hot analog of
  `StateValueChunkWithProof`, carrying a `HotStateValue` per entry.
- The range-proof assembly depends only on the keys and the tree, not on
  the value payload, so factor it out of `state_value_chunk.rs` into a
  shared `build_chunk_range_proof`; the cold and hot proof builders are
  thin wrappers over it.
- Add `get_hot_state_value_chunk_proof` to `StateStore` and `DbReader`.
  Only the size-and-time-aware path (chunk iter + proof) is supported.

The test feeds the server-built chunks into the real
`JellyfishMerkleRestore` and asserts they reconstruct the hot state root,
exercising the same verification the receiving node performs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches state-sync proof surfaces and Merkle verification for hot state, but behavior mirrors the existing cold chunk-proof path and is covered by restore-level tests.
> 
> **Overview**
> Adds **verifiable hot state snapshot chunks** for fast sync: syncing nodes can fetch paginated `(StateKey, HotStateValue)` batches with a **sparse Merkle range proof** against the hot state root at a checkpoint version, parallel to cold `get_state_value_chunk_proof`.
> 
> Introduces **`HotStateValueChunkWithProof`** (indices, key hashes, `raw_values`, proof, `root_hash`, plus `is_last_chunk()`). **`build_chunk_range_proof`** in `state_value_chunk.rs` centralizes proof assembly from keys only; cold and hot chunk builders wrap it. **`get_hot_state_value_chunk_proof`** is wired through **`DbReader`**, **`StateStore`**, and **`AptosDB`** (with hot merkle prune checks).
> 
> Tests build chunks via the new API, assert metadata matches the chunk iterator, reject empty chunks, and **replay chunks through `JellyfishMerkleRestore`** to match the advertised root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a52e5a9071ab78caa8c0d2e0847e89817cfd1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->