### PR TITLE
[state-sync] Serve hot state chunks over storage service

### DIFF
--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -409,6 +409,9 @@ impl<T: StorageReaderInterface> Handler<T> {
             DataRequest::GetStateValuesWithProof(request) => {
                 self.get_state_value_chunk_with_proof(request)
             },
+            DataRequest::GetHotStateValuesWithProof(request) => {
+                self.get_hot_state_value_chunk_with_proof(request)
+            },
             DataRequest::GetEpochEndingLedgerInfos(request) => {
                 self.get_epoch_ending_ledger_infos(request)
             },
@@ -473,6 +476,21 @@ impl<T: StorageReaderInterface> Handler<T> {
 
         Ok(DataResponse::StateValueChunkWithProof(
             state_value_chunk_with_proof,
+        ))
+    }
+
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        request: &StateValuesWithProofRequest,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let hot_state_value_chunk_with_proof = self.storage.get_hot_state_value_chunk_with_proof(
+            request.version,
+            request.start_index,
+            request.end_index,
+        )?;
+
+        Ok(DataResponse::HotStateValueChunkWithProof(
+            hot_state_value_chunk_with_proof,
         ))
     }
 

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -21,6 +21,7 @@ use aptos_types::{
         AccumulatorRangeProof, TransactionAccumulatorRangeProof, TransactionInfoListWithProof,
     },
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -113,6 +114,17 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
         start_index: u64,
         end_index: u64,
     ) -> aptos_storage_service_types::Result<StateValueChunkWithProof, Error>;
+
+    /// Returns a chunk holding a list of hot state values starting at the
+    /// specified `start_index` and ending at `end_index` (inclusive). In
+    /// some cases, less hot state values may be returned (e.g., due to network
+    /// or chunk limits).
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> aptos_storage_service_types::Result<HotStateValueChunkWithProof, Error>;
 }
 
 /// The underlying implementation of the StorageReaderInterface, used by the
@@ -173,6 +185,30 @@ impl StorageReader {
 
         // No pruning has occurred. Return the transactions range.
         Ok(*transactions_range)
+    }
+
+    /// Raises the lower end of the cold state `range` to the earliest hot state root, so the
+    /// shared `states` range never advertises hot versions whose root has been pruned. Returns
+    /// `range` unchanged when the node does not serve hot state.
+    fn clamp_state_range_to_hot_state(
+        &self,
+        range: Option<CompleteDataRange<Version>>,
+    ) -> aptos_storage_service_types::Result<Option<CompleteDataRange<Version>>, Error> {
+        let Some(cold_range) = range else {
+            return Ok(None);
+        };
+        let Some(hot_min) = self.storage.get_hot_state_snapshot_min_servable_version()? else {
+            return Ok(Some(cold_range));
+        };
+
+        // Hot state never reaches further back than cold state, so only the lower end
+        // can move; if the clamp would pass the upper end, keep the cold range.
+        if hot_min <= cold_range.lowest() || hot_min > cold_range.highest() {
+            return Ok(Some(cold_range));
+        }
+        let clamped = CompleteDataRange::new(hot_min, cold_range.highest())
+            .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?;
+        Ok(Some(clamped))
     }
 
     /// Returns the transaction range held in the database (lowest to highest).
@@ -1030,6 +1066,87 @@ impl StorageReader {
             version, start_index, end_index
         )))
     }
+
+    /// Returns a hot state value chunk with proof response (bound by the max response size in
+    /// bytes). Hot state only supports size and time-aware chunking; there is no count-based
+    /// (legacy) fallback.
+    fn get_hot_state_value_chunk_with_proof_by_size(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        max_response_size: u64,
+    ) -> Result<HotStateValueChunkWithProof, Error> {
+        // Calculate the number of hot state values to fetch
+        let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
+        let max_num_state_values = self.config.max_state_chunk_size;
+        let num_state_values_to_fetch = min(expected_num_state_values, max_num_state_values);
+
+        // Get the hot state value chunk iterator
+        let mut state_value_iterator = self.storage.get_hot_state_value_chunk_iter(
+            version,
+            start_index as usize,
+            num_state_values_to_fetch as usize,
+        )?;
+
+        // Initialize the fetched hot state values
+        let mut state_values = vec![];
+
+        // Create a response progress tracker
+        let mut response_progress_tracker = ResponseDataProgressTracker::new(
+            num_state_values_to_fetch,
+            max_response_size,
+            self.config.max_storage_read_wait_time_ms,
+            self.time_service.clone(),
+        );
+
+        // Fetch as many hot state values as possible
+        while !response_progress_tracker.is_response_complete() {
+            match state_value_iterator.next() {
+                Some(Ok(state_value)) => {
+                    // Calculate the number of serialized bytes for the hot state value
+                    let num_serialized_bytes = get_num_serialized_bytes(&state_value)
+                        .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?;
+
+                    // Add the hot state value to the list
+                    if response_progress_tracker
+                        .data_items_fits_in_response(true, num_serialized_bytes)
+                    {
+                        state_values.push(state_value);
+                        response_progress_tracker.add_data_item(num_serialized_bytes);
+                    } else {
+                        break; // Cannot add any more data items
+                    }
+                },
+                Some(Err(error)) => {
+                    return Err(Error::StorageErrorEncountered(error.to_string()));
+                },
+                None => {
+                    // Log a warning that the iterator did not contain all the expected data
+                    warn!(
+                        "The hot state value iterator is missing data! Version: {:?}, \
+                        start index: {:?}, end index: {:?}, num state values to fetch: {:?}",
+                        version, start_index, end_index, num_state_values_to_fetch
+                    );
+                    break;
+                },
+            }
+        }
+
+        // Create the hot state value chunk with proof
+        let hot_state_value_chunk_with_proof = self.storage.get_hot_state_value_chunk_proof(
+            version,
+            start_index as usize,
+            state_values,
+        )?;
+
+        // Update the data truncation metrics
+        response_progress_tracker.update_data_truncation_metrics(
+            DataResponse::get_hot_state_value_chunk_with_proof_label(),
+        );
+
+        Ok(hot_state_value_chunk_with_proof)
+    }
 }
 
 impl StorageReaderInterface for StorageReader {
@@ -1057,8 +1174,10 @@ impl StorageReaderInterface for StorageReader {
         let transactions = self.fetch_transaction_range(latest_version)?;
         let transaction_outputs = self.fetch_transaction_output_range(latest_version)?;
 
-        // Fetch the state values range
+        // Fetch the state values range, then clamp its lower end so it also bounds
+        // hot state value chunk serviceability.
         let states = self.fetch_state_values_range(latest_version, &transactions)?;
+        let states = self.clamp_state_range_to_hot_state(states)?;
 
         // Return the relevant data summary
         let data_summary = DataSummary {
@@ -1213,6 +1332,20 @@ impl StorageReaderInterface for StorageReader {
             self.config.enable_size_and_time_aware_chunking,
         )
     }
+
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> aptos_storage_service_types::Result<HotStateValueChunkWithProof, Error> {
+        self.get_hot_state_value_chunk_with_proof_by_size(
+            version,
+            start_index,
+            end_index,
+            self.config.max_network_chunk_bytes,
+        )
+    }
 }
 
 // A simple macro that wraps each storage read call with a timer
@@ -1257,6 +1390,8 @@ impl DbReader for TimedStorageReader {
         fn is_state_merkle_pruner_enabled(&self) -> StorageResult<bool>;
 
         fn get_epoch_snapshot_prune_window(&self) -> StorageResult<usize>;
+
+        fn get_hot_state_snapshot_min_servable_version(&self) -> StorageResult<Option<Version>>;
 
         fn get_first_txn_version(&self) -> StorageResult<Option<Version>>;
 
@@ -1344,6 +1479,20 @@ impl DbReader for TimedStorageReader {
             first_index: usize,
             state_key_values: Vec<(StateKey, StateValue)>,
         ) -> StorageResult<StateValueChunkWithProof>;
+
+        fn get_hot_state_value_chunk_iter(
+            &self,
+            version: Version,
+            first_index: usize,
+            chunk_size: usize,
+        ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(StateKey, HotStateValue)>> + '_>>;
+
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> StorageResult<HotStateValueChunkWithProof>;
 
         fn get_persisted_auxiliary_info_iterator(
             &self,

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -40,6 +40,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -333,6 +334,8 @@ mock! {
 
         fn is_state_merkle_pruner_enabled(&self) -> aptos_storage_interface::Result<bool>;
 
+        fn get_hot_state_snapshot_min_servable_version(&self) -> aptos_storage_interface::Result<Option<Version>>;
+
         fn get_persisted_auxiliary_info_iterator(
             &self,
             start_version: Version,
@@ -389,6 +392,20 @@ mock! {
             first_index: usize,
             state_key_values: Vec<(StateKey, StateValue)>,
         ) -> aptos_storage_interface::Result<StateValueChunkWithProof>;
+
+        fn get_hot_state_value_chunk_iter(
+            &self,
+            version: Version,
+            first_index: usize,
+            chunk_size: usize,
+        ) -> aptos_storage_interface::Result<Box<dyn Iterator<Item = aptos_storage_interface::Result<(StateKey, HotStateValue)>>>>;
+
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> aptos_storage_interface::Result<HotStateValueChunkWithProof>;
     }
 }
 
@@ -417,6 +434,9 @@ pub fn create_mock_db_with_summary_updates(
     db_reader
         .expect_is_state_merkle_pruner_enabled()
         .returning(move || Ok(true));
+    db_reader
+        .expect_get_hot_state_snapshot_min_servable_version()
+        .returning(move || Ok(Some(lowest_version)));
 
     db_reader
 }

--- a/state-sync/storage-service/server/src/tests/state_values.rs
+++ b/state-sync/storage-service/server/src/tests/state_values.rs
@@ -16,6 +16,7 @@ use aptos_storage_service_types::{
 use aptos_types::{
     proof::definition::SparseMerkleRangeProof,
     state_store::{
+        hot_state::HotStateValueChunkWithProof,
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -89,6 +90,57 @@ async fn test_get_states_with_proof() {
                 DataResponse::StateValueChunkWithProof(state_value_chunk_with_proof)
             );
         }
+    }
+}
+
+#[tokio::test]
+async fn test_get_hot_states_with_proof() {
+    // Test small and large chunk requests (hot state only uses size and time-aware chunking)
+    let max_state_chunk_size = StorageServiceConfig::default().max_state_chunk_size;
+    for chunk_size in [1, 100, max_state_chunk_size] {
+        // Create test data
+        let version = 101;
+        let start_index = 100;
+        let end_index = start_index + chunk_size - 1;
+        let hot_state_value_chunk_with_proof = HotStateValueChunkWithProof {
+            first_index: start_index,
+            last_index: end_index,
+            first_key: HashValue::random(),
+            last_key: HashValue::random(),
+            raw_values: vec![],
+            proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::random(),
+        };
+
+        // Create the mock db reader
+        let mut db_reader = mock::create_mock_db_reader();
+        expect_get_hot_state_values_with_proof(
+            &mut db_reader,
+            version,
+            start_index,
+            chunk_size,
+            hot_state_value_chunk_with_proof.clone(),
+        );
+
+        // Create the storage client and server
+        let storage_config = utils::create_storage_config(false, true);
+        let (mut mock_client, mut service, _, _, _) =
+            MockClient::new(Some(db_reader), Some(storage_config));
+        utils::update_storage_server_summary(&mut service, version, 10);
+        tokio::spawn(service.start());
+
+        // Process a request to fetch a hot states chunk with a proof
+        let response =
+            get_hot_state_values_with_proof(&mut mock_client, version, start_index, end_index)
+                .await
+                .unwrap();
+
+        // Verify the response is correct
+        assert_matches!(response, StorageServiceResponse::RawResponse(_));
+        assert_eq!(
+            response.get_data_response().unwrap(),
+            DataResponse::HotStateValueChunkWithProof(hot_state_value_chunk_with_proof)
+        );
     }
 }
 
@@ -307,6 +359,60 @@ async fn get_state_values_with_proof(
         end_index,
     });
     utils::send_storage_request(mock_client, use_compression, data_request).await
+}
+
+/// Sets an expectation on the given mock db for a call to fetch hot state values with proof. Hot
+/// state is only served via the size and time-aware chunking path (iterator + proof).
+fn expect_get_hot_state_values_with_proof(
+    mock_db: &mut MockDatabaseReader,
+    version: u64,
+    start_index: u64,
+    chunk_size: u64,
+    mut hot_state_value_chunk_with_proof: HotStateValueChunkWithProof,
+) {
+    // Expect a call to get a hot state value iterator
+    let mut expectation_sequence = Sequence::new();
+    let state_value_iterator = hot_state_value_chunk_with_proof
+        .clone()
+        .raw_values
+        .into_iter()
+        .map(Ok);
+    mock_db
+        .expect_get_hot_state_value_chunk_iter()
+        .times(1)
+        .with(
+            eq(version),
+            eq(start_index as usize),
+            eq(chunk_size as usize),
+        )
+        .returning(move |_, _, _| Ok(Box::new(state_value_iterator.clone())))
+        .in_sequence(&mut expectation_sequence);
+
+    // Expect a call to get the hot state value chunk proof
+    mock_db
+        .expect_get_hot_state_value_chunk_proof()
+        .times(1)
+        .with(eq(version), eq(start_index as usize), always())
+        .return_once(move |_, _, given_state_values| {
+            hot_state_value_chunk_with_proof.raw_values = given_state_values;
+            Ok(hot_state_value_chunk_with_proof)
+        })
+        .in_sequence(&mut expectation_sequence);
+}
+
+/// Sends a hot state values with proof request and processes the response
+async fn get_hot_state_values_with_proof(
+    mock_client: &mut MockClient,
+    version: u64,
+    start_index: u64,
+    end_index: u64,
+) -> Result<StorageServiceResponse, StorageServiceError> {
+    let data_request = DataRequest::GetHotStateValuesWithProof(StateValuesWithProofRequest {
+        version,
+        start_index,
+        end_index,
+    });
+    utils::send_storage_request(mock_client, false, data_request).await
 }
 
 /// A helper method to request a states with proof chunk using the

--- a/state-sync/storage-service/server/src/tests/storage_summary.rs
+++ b/state-sync/storage-service/server/src/tests/storage_summary.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     refresh_cached_storage_summary,
-    storage::StorageReader,
+    storage::{StorageReader, StorageReaderInterface},
     tests::{
         mock,
         mock::{MockClient, MockDatabaseReader},
@@ -46,6 +46,7 @@ async fn test_refresh_cached_storage_summary() {
     let db_reader = create_db_reader_with_expectations(
         lowest_version,
         state_prune_window,
+        lowest_version,
         highest_ledger_info.clone(),
     );
     let storage_reader = StorageReader::new(
@@ -164,6 +165,7 @@ async fn test_get_storage_server_summary_advance_time() {
     let db_reader = create_db_reader_with_expectations(
         lowest_version,
         state_prune_window,
+        lowest_version,
         highest_ledger_info.clone(),
     );
 
@@ -222,6 +224,7 @@ async fn test_get_storage_server_summary_notification() {
     let db_reader = create_db_reader_with_expectations(
         lowest_version,
         state_prune_window,
+        lowest_version,
         highest_ledger_info.clone(),
     );
 
@@ -267,11 +270,46 @@ async fn test_get_storage_server_summary_notification() {
     }
 }
 
+#[tokio::test]
+async fn test_get_storage_server_summary_clamps_states_to_hot_state() {
+    // Create test data where the earliest hot state root sits inside the cold
+    // state range (i.e. above its lower end).
+    let highest_version = 1000;
+    let highest_epoch = 430;
+    let lowest_version = 11;
+    let state_prune_window = 200;
+    let hot_state_min_version = 900;
+    let highest_ledger_info =
+        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+
+    // Create the storage reader over a mock db
+    let db_reader = create_db_reader_with_expectations(
+        lowest_version,
+        state_prune_window,
+        hot_state_min_version,
+        highest_ledger_info,
+    );
+    let storage_reader = StorageReader::new(
+        StorageServiceConfig::default(),
+        Arc::new(db_reader),
+        TimeService::mock(),
+    );
+
+    // The cold state range is [801, 1000]; reusing it for hot state clamps the
+    // advertised range up to the earliest hot state root (900).
+    let data_summary = storage_reader.get_data_summary().unwrap();
+    assert_eq!(
+        data_summary.states,
+        Some(CompleteDataRange::new(hot_state_min_version, highest_version).unwrap()),
+    );
+}
+
 /// Creates a mock database reader with the necessary
 /// expectations to satisfy the storage server summary request.
 fn create_db_reader_with_expectations(
     lowest_version: Version,
     state_prune_window: usize,
+    hot_state_min_version: Version,
     highest_ledger_info: LedgerInfoWithSignatures,
 ) -> MockDatabaseReader {
     // Create the mock reader
@@ -293,6 +331,9 @@ fn create_db_reader_with_expectations(
     db_reader
         .expect_is_state_merkle_pruner_enabled()
         .returning(move || Ok(true));
+    db_reader
+        .expect_get_hot_state_snapshot_min_servable_version()
+        .returning(move || Ok(Some(hot_state_min_version)));
     db_reader
 }
 

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -53,6 +53,8 @@ pub enum DataRequest {
     GetTransactionDataWithProof(GetTransactionDataWithProofRequest), // Fetches transaction data with a proof
     GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest), // Optimistically fetches new transaction data with a proof
     SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest), // Subscribes to transaction data with a proof
+
+    GetHotStateValuesWithProof(StateValuesWithProofRequest), // Fetches a list of hot states with a proof
 }
 
 impl DataRequest {
@@ -65,6 +67,7 @@ impl DataRequest {
             Self::GetNumberOfStatesAtVersion(_) => "get_number_of_states_at_version",
             Self::GetServerProtocolVersion => "get_server_protocol_version",
             Self::GetStateValuesWithProof(_) => "get_state_values_with_proof",
+            Self::GetHotStateValuesWithProof(_) => "get_hot_state_values_with_proof",
             Self::GetStorageServerSummary => "get_storage_server_summary",
             Self::GetTransactionOutputsWithProof(_) => "get_transaction_outputs_with_proof",
             Self::GetTransactionsWithProof(_) => "get_transactions_with_proof",

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -4,7 +4,7 @@
 use crate::{
     requests::{
         DataRequest::{
-            GetEpochEndingLedgerInfos, GetNewTransactionDataWithProof,
+            GetEpochEndingLedgerInfos, GetHotStateValuesWithProof, GetNewTransactionDataWithProof,
             GetNewTransactionOutputsWithProof, GetNewTransactionsOrOutputsWithProof,
             GetNewTransactionsWithProof, GetNumberOfStatesAtVersion, GetServerProtocolVersion,
             GetStateValuesWithProof, GetStorageServerSummary, GetTransactionDataWithProof,
@@ -26,7 +26,7 @@ use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{
         TransactionListWithProof, TransactionListWithProofV2, TransactionOutputListWithProof,
         TransactionOutputListWithProofV2, Version,
@@ -158,6 +158,8 @@ pub enum DataResponse {
     // TODO: eventually we should deprecate all the old response types.
     TransactionDataWithProof(TransactionDataWithProofResponse),
     NewTransactionDataWithProof(NewTransactionDataWithProofResponse),
+
+    HotStateValueChunkWithProof(HotStateValueChunkWithProof),
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -193,6 +195,9 @@ impl DataResponse {
             Self::NumberOfStatesAtVersion(_) => Self::get_number_of_states_at_version_label(),
             Self::ServerProtocolVersion(_) => Self::get_server_protocol_version_label(),
             Self::StateValueChunkWithProof(_) => Self::get_state_value_chunk_with_proof_label(),
+            Self::HotStateValueChunkWithProof(_) => {
+                Self::get_hot_state_value_chunk_with_proof_label()
+            },
             Self::StorageServerSummary(_) => Self::get_storage_server_summary_label(),
             Self::TransactionOutputsWithProof(_) => {
                 Self::get_transaction_outputs_with_proof_label()
@@ -257,6 +262,11 @@ impl DataResponse {
     /// Returns a label for the state value chunk with proof response
     pub fn get_state_value_chunk_with_proof_label() -> &'static str {
         "state_value_chunk_with_proof"
+    }
+
+    /// Returns a label for the hot state value chunk with proof response
+    pub fn get_hot_state_value_chunk_with_proof_label() -> &'static str {
+        "hot_state_value_chunk_with_proof"
     }
 
     /// Returns a label for the storage server summary response
@@ -332,6 +342,21 @@ impl TryFrom<StorageServiceResponse> for StateValueChunkWithProof {
             DataResponse::StateValueChunkWithProof(inner) => Ok(inner),
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected state_value_chunk_with_proof, found {}",
+                data_response.get_label()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for HotStateValueChunkWithProof {
+    type Error = crate::responses::Error;
+
+    fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
+        let data_response = response.get_data_response()?;
+        match data_response {
+            DataResponse::HotStateValueChunkWithProof(inner) => Ok(inner),
+            _ => Err(Error::UnexpectedResponseError(format!(
+                "expected hot_state_value_chunk_with_proof, found {}",
                 data_response.get_label()
             ))),
         }
@@ -725,20 +750,10 @@ impl DataSummary {
                 .map(|range| range.contains(*version))
                 .unwrap_or(false),
             GetStateValuesWithProof(request) => {
-                let proof_version = request.version;
-
-                let can_serve_states = self
-                    .states
-                    .map(|range| range.contains(request.version))
-                    .unwrap_or(false);
-
-                let can_create_proof = self
-                    .synced_ledger_info
-                    .as_ref()
-                    .map(|li| li.ledger_info().version() >= proof_version)
-                    .unwrap_or(false);
-
-                can_serve_states && can_create_proof
+                self.can_service_state_values_with_proof(request.version)
+            },
+            GetHotStateValuesWithProof(request) => {
+                self.can_service_hot_state_values_with_proof(request.version)
             },
             GetTransactionOutputsWithProof(request) => self
                 .can_service_transaction_outputs_with_proof(
@@ -813,6 +828,21 @@ impl DataSummary {
             .as_ref()
             .map(|li| li.ledger_info().version() >= proof_version)
             .unwrap_or(false)
+    }
+
+    /// Returns true iff the peer can serve the state values at `version` and prove them
+    fn can_service_state_values_with_proof(&self, version: u64) -> bool {
+        let can_serve_states = self
+            .states
+            .map(|range| range.contains(version))
+            .unwrap_or(false);
+        can_serve_states && self.can_create_proof(version)
+    }
+
+    /// Returns true iff the peer can serve the hot state values at `version` and prove them.
+    /// Hot state reuses the cold `states` range (clamped to the earliest hot state root).
+    fn can_service_hot_state_values_with_proof(&self, version: u64) -> bool {
+        self.can_service_state_values_with_proof(version)
     }
 
     /// Returns true iff the peer can service the transaction outputs in the given range

--- a/state-sync/storage-service/types/src/tests.rs
+++ b/state-sync/storage-service/types/src/tests.rs
@@ -499,6 +499,41 @@ fn test_data_summary_service_state_chunk_request() {
 }
 
 #[test]
+fn test_data_summary_service_hot_state_chunk_request() {
+    // Hot state reuses the cold `states` range for serviceability.
+    let data_client_config = AptosDataClientConfig::default();
+    let data_summary = DataSummary {
+        synced_ledger_info: Some(create_ledger_info_at_version(250)),
+        states: Some(create_data_range(100, 300)),
+        ..Default::default()
+    };
+
+    for compression in [true, false] {
+        // Valid request versions (within the states range and at or below the synced version)
+        for version in [100, 200, 250] {
+            verify_serviceability(
+                &data_client_config,
+                &data_summary,
+                None,
+                create_hot_state_values_request_at_version(version, compression),
+                true,
+            );
+        }
+
+        // Invalid request versions (outside the states range or beyond the synced version)
+        for version in [50, 99, 251, 300] {
+            verify_serviceability(
+                &data_client_config,
+                &data_summary,
+                None,
+                create_hot_state_values_request_at_version(version, compression),
+                false,
+            );
+        }
+    }
+}
+
+#[test]
 fn test_protocol_metadata_service() {
     // Create the protocol metadata
     let metadata = ProtocolMetadata {
@@ -877,6 +912,19 @@ fn create_state_values_request_at_version(
     use_compression: bool,
 ) -> StorageServiceRequest {
     create_state_values_request(version, 0, 1000, use_compression)
+}
+
+/// Creates a request for hot state values at a given version
+fn create_hot_state_values_request_at_version(
+    version: Version,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    let data_request = DataRequest::GetHotStateValuesWithProof(StateValuesWithProofRequest {
+        version,
+        start_index: 0,
+        end_index: 1000,
+    });
+    StorageServiceRequest::new(data_request, use_compression)
 }
 
 /// Generates a random u64

--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -32,7 +32,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
-        hot_state::HotStateValue,
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueChunkWithProof},
@@ -847,6 +847,19 @@ impl DbReader for AptosDB {
                 as Box<
                     dyn Iterator<Item = Result<(StateKey, HotStateValue)>> + '_,
                 >)
+        })
+    }
+
+    fn get_hot_state_value_chunk_proof(
+        &self,
+        version: Version,
+        first_index: usize,
+        raw_values: Vec<(StateKey, HotStateValue)>,
+    ) -> Result<HotStateValueChunkWithProof> {
+        gauged_api("get_hot_state_value_chunk_proof", || {
+            self.error_if_hot_state_merkle_pruned("Hot state merkle", version)?;
+            self.state_store
+                .get_hot_state_value_chunk_proof(version, first_index, raw_values)
         })
     }
 

--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -863,6 +863,12 @@ impl DbReader for AptosDB {
         })
     }
 
+    fn get_hot_state_snapshot_min_servable_version(&self) -> Result<Option<Version>> {
+        gauged_api("get_hot_state_snapshot_min_servable_version", || {
+            self.state_store.hot_state_min_servable_version()
+        })
+    }
+
     fn is_state_merkle_pruner_enabled(&self) -> Result<bool> {
         gauged_api("is_state_merkle_pruner_enabled", || {
             Ok(self

--- a/storage/aptosdb/src/sharded_jmt_merkle_db.rs
+++ b/storage/aptosdb/src/sharded_jmt_merkle_db.rs
@@ -274,6 +274,18 @@ impl ShardedJmtMerkleDb {
         Ok(None)
     }
 
+    /// Returns the earliest version holding a state snapshot (JMT root), or `None`
+    /// if the tree is empty.
+    pub fn get_earliest_state_snapshot_version(&self) -> Result<Option<Version>> {
+        let mut iter = self.metadata_db().iter::<JellyfishMerkleNodeSchema>()?;
+        iter.seek_to_first();
+        match iter.next().transpose()? {
+            // The root (empty nibble path) sorts first within a version.
+            Some((key, _node)) => Ok(Some(key.version())),
+            None => Ok(None),
+        }
+    }
+
     pub(crate) fn create_jmt_commit_batch_for_shard(
         &self,
         version: Version,

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -1507,6 +1507,19 @@ impl StateStore {
         self.hot_state_merkle_db.get_leaf_count(version)
     }
 
+    /// Returns the lowest servable version for hot state value chunks (the earliest
+    /// persisted hot state Merkle snapshot), or `None` if this node does not serve
+    /// hot state. Hot state does not start from version 0.
+    pub fn hot_state_min_servable_version(&self) -> Result<Option<Version>> {
+        if self.hot_state_config.delete_on_restart {
+            return Ok(None);
+        }
+
+        self.state_db
+            .hot_state_merkle_db
+            .get_earliest_state_snapshot_version()
+    }
+
     /// Walks the hot state Merkle tree at `version` from `first_index` and yields up to
     /// `chunk_size` hot state leaves, each pairing the full key with its [`HotStateValue`] (the
     /// value or vacancy plus `hot_since_version`).

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -21,7 +21,10 @@ use crate::{
     state_merkle_db::StateMerkleDb,
     state_restore::{StateSnapshotRestore, StateSnapshotRestoreMode, StateValueWriter},
     state_store::{buffered_state::BufferedState, persisted_state::PersistedState},
-    state_value_chunk::{build_value_chunk_proof, jmt_leaves_with_values, value_chunk_with_proof},
+    state_value_chunk::{
+        build_hot_value_chunk_proof, build_value_chunk_proof, jmt_leaves_with_values,
+        value_chunk_with_proof,
+    },
     utils::{
         truncation_helper::{
             find_tree_root_at_or_before, get_max_version_in_state_merkle_db, truncate_ledger_db,
@@ -69,7 +72,7 @@ use aptos_storage_interface::{
 use aptos_types::{
     proof::{definition::LeafCount, SparseMerkleProofExt, SparseMerkleRangeProof},
     state_store::{
-        hot_state::HotStateValue,
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_slot::{StateSlot, StateSlotKind},
         state_storage_usage::StateStorageUsage,
@@ -1525,6 +1528,22 @@ impl StateStore {
             Ok((key, value))
         })
         .take(chunk_size))
+    }
+
+    /// Assembles a [`HotStateValueChunkWithProof`] for the given hot state leaves, with a range
+    /// proof against the hot state Merkle root at `version`.
+    pub fn get_hot_state_value_chunk_proof(
+        &self,
+        version: Version,
+        first_index: usize,
+        raw_values: Vec<(StateKey, HotStateValue)>,
+    ) -> Result<HotStateValueChunkWithProof> {
+        build_hot_value_chunk_proof(
+            self.hot_state_merkle_db.as_ref(),
+            version,
+            first_index,
+            raw_values,
+        )
     }
 
     // state sync doesn't query for the progress, but keeps its record by itself.

--- a/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
@@ -5,11 +5,18 @@
 
 use crate::{db::test_helper::arb_blocks_to_commit_with_params, AptosDB};
 use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_jellyfish_merkle::{
+    mock_tree_store::MockTreeStore, restore::JellyfishMerkleRestore, JellyfishMerkleTree,
+};
 use aptos_storage_interface::{DbReader, Result as DbResult};
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::{hot_state::HotStateValue, state_key::StateKey, state_value::StateValue},
+    state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
+        state_key::StateKey,
+        state_value::StateValue,
+    },
     transaction::{
         BlockEndInfo, ExecutionStatus, Transaction, TransactionAuxiliaryData, TransactionInfo,
         TransactionToCommit, Version,
@@ -17,7 +24,7 @@ use aptos_types::{
     write_set::WriteSet,
 };
 use proptest::prelude::*;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 fn key(seed: &str) -> StateKey {
     StateKey::raw(seed.as_bytes())
@@ -93,6 +100,69 @@ fn collect_paged(
         out.extend(chunk);
     }
     out
+}
+
+/// Walks the whole hot state at `version` as the storage service does: read up to `chunk_size`
+/// leaves with the iterator, then wrap each batch in a range proof. Returns the proof-carrying
+/// chunks in order.
+fn collect_chunks_with_proof(
+    db: &AptosDB,
+    version: Version,
+    chunk_size: usize,
+) -> Vec<HotStateValueChunkWithProof> {
+    let mut chunks = vec![];
+    let mut first_index = 0;
+    loop {
+        let raw_values = collect_chunk(db, version, first_index, chunk_size);
+        if raw_values.is_empty() {
+            break;
+        }
+        first_index += raw_values.len();
+        chunks.push(
+            db.get_hot_state_value_chunk_proof(version, first_index - raw_values.len(), raw_values)
+                .unwrap(),
+        );
+    }
+    chunks
+}
+
+/// Mirrors the receiving end of fast sync: feed the proof-carrying chunks into the JMT restore and
+/// assert they reconstruct the hot state Merkle root. Each `HotStateValue` is hashed exactly as it
+/// is into the hot state tree, so a wrong value or a bad proof would fail verification here.
+fn assert_chunks_reconstruct_root(version: Version, chunks: &[HotStateValueChunkWithProof]) {
+    assert!(!chunks.is_empty(), "no chunks to verify");
+    // Every chunk of the same snapshot carries the same root, and only the final chunk is last.
+    let root_hash = chunks[0].root_hash;
+    let last = chunks.len() - 1;
+    for (i, chunk) in chunks.iter().enumerate() {
+        assert_eq!(chunk.root_hash, root_hash);
+        assert_eq!(chunk.is_last_chunk(), i == last);
+    }
+
+    let store = Arc::new(MockTreeStore::<StateKey>::new(
+        true, /* allow_overwrite */
+    ));
+    let mut restore = JellyfishMerkleRestore::new(
+        Arc::clone(&store),
+        version,
+        root_hash,
+        false, /* async */
+    )
+    .unwrap();
+    for chunk in chunks {
+        let leaves: Vec<_> = chunk
+            .raw_values
+            .iter()
+            .map(|(k, hsv)| (k, hsv.hash()))
+            .collect();
+        restore.add_chunk_impl(leaves, chunk.proof.clone()).unwrap();
+    }
+    restore.finish_impl().unwrap();
+
+    let restored_root = JellyfishMerkleTree::new(store.as_ref())
+        .get_root_hash(version)
+        .unwrap();
+    assert_eq!(restored_root, root_hash);
 }
 
 #[test]
@@ -203,6 +273,64 @@ fn test_hot_state_chunk_iter_at_older_checkpoint() {
     assert_eq!(at_v1[&key("c")].hot_since_version(), 1);
 }
 
+#[test]
+fn test_hot_state_chunk_with_proof() {
+    let tmp = TempPath::new();
+    let db = AptosDB::new_for_test(&tmp);
+
+    // A mix of occupied and vacant (deleted) hot entries across two checkpoints.
+    let last = commit_blocks(&db, vec![
+        vec![
+            (key("a"), Some(val(b"a0"))),
+            (key("b"), Some(val(b"b0"))),
+            (key("c"), Some(val(b"c0"))),
+        ],
+        vec![
+            (key("a"), None), // vacant
+            (key("d"), Some(val(b"d1"))),
+            (key("e"), Some(val(b"e1"))),
+        ],
+    ]);
+    let count = db.get_hot_state_item_count(last).unwrap();
+    assert_eq!(count, 5); // a (vacant), b, c, d, e
+
+    let iter_items = collect_chunk(&db, last, 0, usize::MAX);
+
+    // A single full chunk: its index/key range and values line up with the iterator output, and it
+    // is the last chunk.
+    let full = db
+        .get_hot_state_value_chunk_proof(last, 0, iter_items.clone())
+        .unwrap();
+    assert_eq!(full.first_index, 0);
+    assert_eq!(full.last_index as usize, count - 1);
+    assert_eq!(full.first_key, iter_items.first().unwrap().0.hash());
+    assert_eq!(full.last_key, iter_items.last().unwrap().0.hash());
+    assert_eq!(full.raw_values, iter_items);
+    assert!(full.is_last_chunk());
+    assert_chunks_reconstruct_root(last, &[full]);
+
+    // Paginated at various sizes: the chunks concatenate back to the single-pass read and every
+    // chunk verifies against the hot state root.
+    for chunk_size in [1, 2, 3, 5] {
+        let chunks = collect_chunks_with_proof(&db, last, chunk_size);
+        let concatenated: Vec<_> = chunks.iter().flat_map(|c| c.raw_values.clone()).collect();
+        assert_eq!(concatenated, iter_items);
+        assert_chunks_reconstruct_root(last, &chunks);
+    }
+}
+
+#[test]
+fn test_hot_state_chunk_proof_empty_errors() {
+    let tmp = TempPath::new();
+    let db = AptosDB::new_for_test(&tmp);
+    let version = commit_blocks(&db, vec![vec![(key("a"), Some(val(b"a0")))]]);
+
+    // An empty chunk has no rightmost key to anchor a range proof on.
+    assert!(db
+        .get_hot_state_value_chunk_proof(version, 0, vec![])
+        .is_err());
+}
+
 /// The hot state expected at the latest checkpoint: every key ever written, keyed by key hash,
 /// carrying its latest value (vacant if last written as a deletion) and the version it was last
 /// written at (its `hot_since_version`). Mirrors that any write makes a key hot.
@@ -268,6 +396,15 @@ proptest! {
             prop_assert_eq!(k, key);
             prop_assert_eq!(hsv.value_opt(), value.as_ref());
             prop_assert_eq!(hsv.hot_since_version(), *ver);
+        }
+
+        // The proof path produces chunks that concatenate back to the single-pass read and
+        // reconstruct the hot state Merkle root (what the receiving node verifies).
+        let chunks = collect_chunks_with_proof(&db, ckpt, chunk_size);
+        let concatenated: Vec<_> = chunks.iter().flat_map(|c| c.raw_values.clone()).collect();
+        prop_assert_eq!(&concatenated, &full);
+        if !full.is_empty() {
+            assert_chunks_reconstruct_root(ckpt, &chunks);
         }
 
         // Paging in `chunk_size`-sized steps reconstructs the same sequence.

--- a/storage/aptosdb/src/state_value_chunk.rs
+++ b/storage/aptosdb/src/state_value_chunk.rs
@@ -3,15 +3,17 @@
 
 //! Shared state-value snapshot chunk helpers, generic over the backing
 //! Jellyfish Merkle store. The JMT walk and range-proof assembly are identical
-//! across snapshot kinds; only the value lookup differs.
+//! across snapshot kinds; only the value lookup and the assembled chunk type differ.
 
 #![forbid(unsafe_code)]
 
-use aptos_crypto::hash::CryptoHash;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_jellyfish_merkle::{iterator::JellyfishMerkleIterator, JellyfishMerkleTree, TreeReader};
 use aptos_storage_interface::{AptosDbError, Result};
 use aptos_types::{
+    proof::SparseMerkleRangeProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -62,15 +64,26 @@ where
     build_value_chunk_proof(merkle_db.as_ref(), version, first_index, raw_values)
 }
 
-/// Assembles a [`StateValueChunkWithProof`] for `raw_values`: a range proof for
-/// the rightmost key against the store's root at `version`. The caller is
-/// responsible for any byte/time bounding of `raw_values`.
-pub(crate) fn build_value_chunk_proof<R>(
+/// The value-type-independent parts of a state value chunk proof: the chunk's index/key range and
+/// a range proof for its rightmost key against the store's root at `version`.
+struct ChunkRangeProof {
+    first_index: u64,
+    last_index: u64,
+    first_key: HashValue,
+    last_key: HashValue,
+    proof: SparseMerkleRangeProof,
+    root_hash: HashValue,
+}
+
+/// Builds the [`ChunkRangeProof`] for the chunk of `raw_values` (the chunk's leaves in JMT order)
+/// starting at `first_index`. Errors if `raw_values` is empty, since a non-empty chunk is needed
+/// to anchor the proof on a rightmost key.
+fn build_chunk_range_proof<R, V>(
     merkle_db: &R,
     version: Version,
     first_index: usize,
-    raw_values: Vec<(StateKey, StateValue)>,
-) -> Result<StateValueChunkWithProof>
+    raw_values: &[(StateKey, V)],
+) -> Result<ChunkRangeProof>
 where
     R: TreeReader<StateKey> + Sync,
 {
@@ -85,8 +98,67 @@ where
     let tree = JellyfishMerkleTree::<R, StateKey>::new(merkle_db);
     let proof = tree.get_range_proof(last_key, version)?;
     let root_hash = tree.get_root_hash(version)?;
-    Ok(StateValueChunkWithProof {
+    Ok(ChunkRangeProof {
         first_index: first_index as u64,
+        last_index,
+        first_key,
+        last_key,
+        proof,
+        root_hash,
+    })
+}
+
+/// Assembles a [`StateValueChunkWithProof`] for `raw_values`: a range proof for
+/// the rightmost key against the store's root at `version`.
+pub(crate) fn build_value_chunk_proof<R>(
+    merkle_db: &R,
+    version: Version,
+    first_index: usize,
+    raw_values: Vec<(StateKey, StateValue)>,
+) -> Result<StateValueChunkWithProof>
+where
+    R: TreeReader<StateKey> + Sync,
+{
+    let ChunkRangeProof {
+        first_index,
+        last_index,
+        first_key,
+        last_key,
+        proof,
+        root_hash,
+    } = build_chunk_range_proof(merkle_db, version, first_index, &raw_values)?;
+    Ok(StateValueChunkWithProof {
+        first_index,
+        last_index,
+        first_key,
+        last_key,
+        raw_values,
+        proof,
+        root_hash,
+    })
+}
+
+/// Assembles a [`HotStateValueChunkWithProof`] for `raw_values`: a range proof for the rightmost
+/// key against the hot state Merkle root at `version`.
+pub(crate) fn build_hot_value_chunk_proof<R>(
+    merkle_db: &R,
+    version: Version,
+    first_index: usize,
+    raw_values: Vec<(StateKey, HotStateValue)>,
+) -> Result<HotStateValueChunkWithProof>
+where
+    R: TreeReader<StateKey> + Sync,
+{
+    let ChunkRangeProof {
+        first_index,
+        last_index,
+        first_key,
+        last_key,
+        proof,
+        root_hash,
+    } = build_chunk_range_proof(merkle_db, version, first_index, &raw_values)?;
+    Ok(HotStateValueChunkWithProof {
+        first_index,
         last_index,
         first_key,
         last_key,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -480,6 +480,11 @@ pub trait DbReader: Send + Sync {
             raw_values: Vec<(StateKey, HotStateValue)>,
         ) -> Result<HotStateValueChunkWithProof>;
 
+        /// Returns the lowest servable version for hot state value chunks (the earliest
+        /// persisted hot state Merkle snapshot), or `None` if this node does not serve
+        /// hot state.
+        fn get_hot_state_snapshot_min_servable_version(&self) -> Result<Option<Version>>;
+
         /// Returns if the state store pruner is enabled.
         fn is_state_merkle_pruner_enabled(&self) -> Result<bool>;
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -17,7 +17,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
-        hot_state::HotStateValue,
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueChunkWithProof},
@@ -470,6 +470,15 @@ pub trait DbReader: Send + Sync {
             first_index: usize,
             chunk_size: usize,
         ) -> Result<Box<dyn Iterator<Item = Result<(StateKey, HotStateValue)>> + '_>>;
+
+        /// Assembles a hot state value chunk with a range proof against the hot state Merkle root
+        /// at `version`.
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> Result<HotStateValueChunkWithProof>;
 
         /// Returns if the state store pruner is enabled.
         fn is_state_merkle_pruner_enabled(&self) -> Result<bool>;

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -2,14 +2,16 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
+    proof::SparseMerkleRangeProof,
     state_store::{
+        state_key::StateKey,
         state_slot::{StateSlot, StateSlotKind},
         state_value::StateValue,
     },
     transaction::Version,
 };
 use aptos_crypto::{
-    hash::{CryptoHash, CryptoHasher},
+    hash::{CryptoHash, CryptoHasher, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
@@ -122,6 +124,36 @@ impl CryptoHash for HotStateValueRef<'_> {
         bcs::serialize_into(&mut state, &self)
             .expect("BCS serialization of HotStateValueRef should not fail");
         state.finish()
+    }
+}
+
+/// A single chunk of the hot state at a specific version, with a range proof against the hot state
+/// Merkle root.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HotStateValueChunkWithProof {
+    /// The first hot state index in chunk
+    pub first_index: u64,
+    /// The last hot state index in chunk
+    pub last_index: u64,
+    /// The first hot state key hash in chunk
+    pub first_key: HashValue,
+    /// The last hot state key hash in chunk
+    pub last_key: HashValue,
+    /// The state key and its hot state value.
+    pub raw_values: Vec<(StateKey, HotStateValue)>,
+    /// The proof to ensure the chunk is in the hot state tree
+    pub proof: SparseMerkleRangeProof,
+    /// The root hash of the hot state Merkle tree for this chunk
+    pub root_hash: HashValue,
+}
+
+impl HotStateValueChunkWithProof {
+    /// Returns true iff this is the last chunk (i.e. no more hot state values follow it).
+    pub fn is_last_chunk(&self) -> bool {
+        self.proof
+            .right_siblings()
+            .iter()
+            .all(|sibling| *sibling == *SPARSE_MERKLE_PLACEHOLDER_HASH)
     }
 }
 


### PR DESCRIPTION

Add the storage-service protocol for serving hot state snapshot chunks,
the network-facing half of the server side of hot state fast-sync. With
the `DbReader` read APIs and proof builder already in place, this lets a
server answer a client's hot state requests.

- New `DataRequest::GetHotStateValuesWithProof` (reusing the existing
  state-values request shape) and a `DataResponse::HotStateValueChunkWithProof`
  response, with labels and a `TryFrom` conversion.
- Serviceability: hot state snapshots are persisted at the same
  checkpoints as cold state, so the advertised `states` range governs
  both. The shared check is factored into a helper used by the cold and
  hot arms.
- Handler dispatch and storage serving mirror the cold path, but hot
  state is served only via the size and time-aware chunking path
  (iterator + proof); there is no count-based fallback.

Tested with a mocked-DB server round-trip and serviceability checks.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/20102).
* __->__ #20102
* #20101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes state-sync serving and advertised data ranges for hot state; incorrect clamping or proof assembly could cause failed or unsafe fast sync, but behavior mirrors the existing cold state path with new tests.
> 
> **Overview**
> Adds **hot state fast-sync** support on the storage service: peers can request proof-carrying hot state snapshot chunks and see an accurate servable version range in the server summary.
> 
> The wire protocol gains `GetHotStateValuesWithProof` / `HotStateValueChunkWithProof` (reusing the cold state chunk request shape). The handler and `StorageReader` serve hot chunks via **iterator + size/time-aware chunking only**—no legacy count-halving path. `DataSummary` serviceability for hot requests reuses the shared `states` range via a refactored helper.
> 
> **Storage server summary** now **clamps** the lower bound of the advertised `states` range to `get_hot_state_snapshot_min_servable_version()` so clients are not offered hot versions whose Merkle root was pruned.
> 
> **AptosDB / `DbReader`** adds hot chunk proof assembly (`build_hot_value_chunk_proof`), `get_hot_state_snapshot_min_servable_version`, and earliest hot snapshot lookup on the sharded JMT DB. **`HotStateValueChunkWithProof`** is defined in types with `is_last_chunk()`.
> 
> Tests cover mock-DB server round-trips, hot serviceability, summary clamping, and proof verification against JMT restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc07b16a194e913d4ab12a046b2d38ed86b195cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->