### PR TITLE
[framework] Add Nitro enclave attestation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,6 +2064,8 @@ dependencies = [
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "attestation-doc-validation",
+ "aws-nitro-enclaves-cose",
+ "aws-nitro-enclaves-nsm-api",
  "bcs 0.1.4",
  "better_any",
  "blake2-rfc",
@@ -2071,6 +2073,7 @@ dependencies = [
  "byteorder",
  "claims",
  "curve25519-dalek-ng",
+ "ecdsa",
  "either",
  "flate2",
  "hex",
@@ -2083,6 +2086,8 @@ dependencies = [
  "move-vm-types",
  "num-traits",
  "once_cell",
+ "p256",
+ "p384",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ripemd",
@@ -2095,6 +2100,8 @@ dependencies = [
  "smallvec",
  "tiny-keccak",
  "triomphe",
+ "webpki",
+ "x509-parser",
 ]
 
 [[package]]
@@ -5755,7 +5762,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -6090,7 +6097,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_with 2.3.3",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "time",
  "wasm-bindgen",
@@ -14782,7 +14789,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -19025,6 +19032,18 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -21533,7 +21552,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -21612,7 +21631,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
+ "attestation-doc-validation",
  "bcs 0.1.4",
  "better_any",
  "blake2-rfc",
@@ -5010,7 +5011,7 @@ dependencies = [
  "serde-big-array",
  "serde_bytes",
  "serde_json",
- "serde_with",
+ "serde_with 3.4.0",
  "serde_yaml 0.8.26",
  "strum 0.27.1",
  "strum_macros 0.27.1",
@@ -5730,6 +5731,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6028,6 +6068,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attestation-doc-validation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73d09f8ce9c08df11cc4626c2b1ad1c58c52e9470b086622ae3ab7c05cb68500"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "aws-nitro-enclaves-cose",
+ "aws-nitro-enclaves-nsm-api",
+ "base64 0.21.7",
+ "chrono",
+ "der 0.7.8",
+ "ecdsa",
+ "getrandom 0.2.11",
+ "hex",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_with 2.3.3",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+ "time",
+ "wasm-bindgen",
+ "webpki",
+ "x509-parser",
+]
+
+[[package]]
 name = "attribute-derive"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6114,6 +6185,32 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "aws-nitro-enclaves-cose"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a94047bd9c3717c6ca3a145504c0e26b64a5e2d9eb9559b187748433fbc382"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_repr",
+ "serde_with 3.4.0",
+]
+
+[[package]]
+name = "aws-nitro-enclaves-nsm-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92c1f4471b33f6a7af9ea421b249ed18a11c71156564baf6293148fa6ad1b09"
+dependencies = [
+ "libc",
+ "log",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
 ]
 
 [[package]]
@@ -6683,7 +6780,7 @@ checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with",
+ "serde_with 3.4.0",
 ]
 
 [[package]]
@@ -8299,6 +8396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
  "pem-rfc7468 0.7.0",
  "zeroize",
 ]
@@ -8311,6 +8409,31 @@ checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.1",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.4",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8942,6 +9065,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf 0.12.4",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -14339,6 +14463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14638,6 +14771,18 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -17136,6 +17281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17891,6 +18045,22 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros 2.3.3",
+ "time",
+]
+
+[[package]]
+name = "serde_with"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
@@ -17902,8 +18072,20 @@ dependencies = [
  "indexmap 2.7.0",
  "serde",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 3.4.0",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -19236,6 +19418,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -21278,6 +21461,24 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs",
+ "base64 0.13.1",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -302,11 +302,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
 
         // Calibrated with scripts/algebra-gas's SHA2-256 baseline on a 5,281-byte Nitro
         // attestation document plus AWS Nitro Root G1 DER fixture. The benchmark measured
-        // ~4.66ms, with gas_per_ns ~= 285.47, for ~1.33B internal gas.
+        // ~4.66ms, with gas_per_ns ~= 2,854.73, for ~13.3B internal gas.
         [aws_nitro_verify_attestation_base: InternalGas, "aws_nitro_utils.verify_attestation.base", 1_000_000],
-        [aws_nitro_verify_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_attestation.per_byte", 252_000],
+        [aws_nitro_verify_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_attestation.per_byte", 2_520_000],
         [aws_nitro_verify_and_parse_attestation_base: InternalGas, "aws_nitro_utils.verify_and_parse_attestation.base", 1_050_000],
-        [aws_nitro_verify_and_parse_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_and_parse_attestation.per_byte", 252_000],
+        [aws_nitro_verify_and_parse_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_and_parse_attestation.per_byte", 2_520_000],
 
         [transaction_context_get_txn_hash_base: InternalGas, { 10.. => "transaction_context.get_txn_hash.base" }, 7350],
         [transaction_context_get_script_hash_base: InternalGas, "transaction_context.get_script_hash.base", 7350],

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -300,10 +300,13 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [util_from_bytes_base: InternalGas, "util.from_bytes.base", 11020],
         [util_from_bytes_per_byte: InternalGasPerByte, "util.from_bytes.per_byte", 180],
 
-        [aws_nitro_verify_attestation_base: InternalGas, "aws_nitro_utils.verify_attestation.base", 500_000],
-        [aws_nitro_verify_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_attestation.per_byte", 50],
-        [aws_nitro_verify_and_parse_attestation_base: InternalGas, "aws_nitro_utils.verify_and_parse_attestation.base", 550_000],
-        [aws_nitro_verify_and_parse_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_and_parse_attestation.per_byte", 50],
+        // Calibrated with scripts/algebra-gas's SHA2-256 baseline on a 5,281-byte Nitro
+        // attestation document plus AWS Nitro Root G1 DER fixture. The benchmark measured
+        // ~4.66ms, with gas_per_ns ~= 285.47, for ~1.33B internal gas.
+        [aws_nitro_verify_attestation_base: InternalGas, "aws_nitro_utils.verify_attestation.base", 1_000_000],
+        [aws_nitro_verify_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_attestation.per_byte", 252_000],
+        [aws_nitro_verify_and_parse_attestation_base: InternalGas, "aws_nitro_utils.verify_and_parse_attestation.base", 1_050_000],
+        [aws_nitro_verify_and_parse_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_and_parse_attestation.per_byte", 252_000],
 
         [transaction_context_get_txn_hash_base: InternalGas, { 10.. => "transaction_context.get_txn_hash.base" }, 7350],
         [transaction_context_get_script_hash_base: InternalGas, "transaction_context.get_script_hash.base", 7350],

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -300,6 +300,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [util_from_bytes_base: InternalGas, "util.from_bytes.base", 11020],
         [util_from_bytes_per_byte: InternalGasPerByte, "util.from_bytes.per_byte", 180],
 
+        [aws_nitro_verify_attestation_base: InternalGas, "aws_nitro_utils.verify_attestation.base", 500_000],
+        [aws_nitro_verify_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_attestation.per_byte", 50],
+        [aws_nitro_verify_and_parse_attestation_base: InternalGas, "aws_nitro_utils.verify_and_parse_attestation.base", 550_000],
+        [aws_nitro_verify_and_parse_attestation_per_byte: InternalGasPerByte, "aws_nitro_utils.verify_and_parse_attestation.per_byte", 50],
+
         [transaction_context_get_txn_hash_base: InternalGas, { 10.. => "transaction_context.get_txn_hash.base" }, 7350],
         [transaction_context_get_script_hash_base: InternalGas, "transaction_context.get_script_hash.base", 7350],
         // Based on SHA3-256's cost

--- a/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
+++ b/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
@@ -1,0 +1,92 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/// Utilities for verifying AWS Nitro Enclave attestation documents.
+module aptos_framework::aws_nitro_utils {
+    use std::option::{Self, Option};
+    use std::vector;
+
+    /// One Platform Configuration Register (PCR) entry from the attestation document.
+    struct PcrEntry has copy, drop, store {
+        index: u8,
+        value: vector<u8>,
+    }
+
+    /// Parsed attestation document fields (when validation succeeds).
+    struct AttestationDoc has copy, drop, store {
+        /// NitroSecureModule identifier (e.g. NSM module ID).
+        module_id: vector<u8>,
+        /// Unix timestamp in milliseconds when the document was created.
+        timestamp: u64,
+        /// Digest algorithm identifier (e.g. b"SHA384").
+        digest: vector<u8>,
+        /// Platform Configuration Registers: index and value pairs.
+        pcrs: vector<PcrEntry>,
+        /// Signing certificate (DER-encoded).
+        certificate: vector<u8>,
+        /// User-provided data, if present.
+        user_data: Option<vector<u8>>,
+        /// Nonce, if present.
+        nonce: Option<vector<u8>>,
+        /// DER-encoded public key, if present.
+        public_key: Option<vector<u8>>,
+    }
+
+    /// Attestation documents are produced by the AWS Nitro Enclaves NSM (Nitro Security Module)
+    /// in COSE Sign1 format. This module provides natives that verify and parse such documents.
+    ///
+    /// Example (in Move):
+    /// ```move
+    /// use aptos_framework::aws_nitro_utils;
+    /// use std::option;
+    ///
+    /// fun check_attestation(attestation_doc: vector<u8>) {
+    ///     assert!(aws_nitro_utils::verify_attestation(attestation_doc), 0);
+    /// }
+    ///
+    /// fun parse_and_use(attestation_doc: vector<u8>) {
+    ///     let doc_opt = aws_nitro_utils::verify_and_parse_attestation(attestation_doc);
+    ///     if (option::is_some(&doc_opt)) {
+    ///         let doc = option::extract(&mut doc_opt);
+    ///         // use doc.module_id, doc.timestamp, doc.pcrs, etc.
+    ///     }
+    /// }
+    /// ```
+
+    /// Verifies an AWS Nitro Enclave attestation document.
+    ///
+    /// The input must be the raw bytes of a COSE Sign1-encoded attestation document
+    /// as returned by the Nitro Enclave NSM (e.g. from GetAttestationDocument).
+    ///
+    /// Returns `true` if the document is valid; `false` otherwise.
+    public native fun verify_attestation(attestation_doc: vector<u8>): bool;
+
+    /// Verifies and parses an AWS Nitro Enclave attestation document.
+    ///
+    /// Same validation as `verify_attestation`. On success returns `Some(AttestationDoc)` with
+    /// decoded fields (module_id, timestamp, digest, pcrs, certificate, user_data, nonce, public_key).
+    /// Returns `None` if the document is invalid or malformed.
+    public native fun verify_and_parse_attestation(attestation_doc: vector<u8>): Option<AttestationDoc>;
+
+    #[test_only]
+    fun test_invalid_attestation_returns_false() {
+        // Empty input is not valid COSE Sign1
+        assert!(!verify_attestation(vector::empty<u8>()), 0);
+    }
+
+    #[test_only]
+    fun test_garbage_bytes_return_false() {
+        // Random bytes are not a valid attestation document
+        let garbage = vector[
+            0x00u8, 0x01u8, 0x02u8, 0x03u8, 0x04u8, 0x05u8, 0x06u8, 0x07u8,
+            0x08u8, 0x09u8, 0x0au8, 0x0bu8, 0x0cu8, 0x0du8, 0x0eu8, 0x0fu8,
+        ];
+        assert!(!verify_attestation(garbage), 0);
+    }
+
+    #[test_only]
+    fun test_verify_and_parse_invalid_returns_none() {
+        let doc_opt = verify_and_parse_attestation(vector::empty<u8>());
+        assert!(option::is_none(&doc_opt), 0);
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
+++ b/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
@@ -3,7 +3,11 @@
 
 /// Utilities for verifying AWS Nitro Enclave attestation documents.
 module aptos_framework::aws_nitro_utils {
-    use std::option::{Self, Option};
+    use aptos_framework::system_addresses;
+    use aptos_framework::timestamp;
+    use std::error;
+    use std::option;
+    use std::option::Option;
     use std::vector;
 
     /// One Platform Configuration Register (PCR) entry from the attestation document.
@@ -32,13 +36,22 @@ module aptos_framework::aws_nitro_utils {
         public_key: Option<vector<u8>>,
     }
 
+    /// Governance-managed DER-encoded AWS Nitro root certificates trusted by this chain.
+    struct TrustedRoots has key {
+        root_certs: vector<vector<u8>>,
+    }
+
+    const ETRUSTED_ROOTS_ALREADY_INITIALIZED: u64 = 1;
+    const ETRUSTED_ROOTS_NOT_INITIALIZED: u64 = 2;
+    const ETRUSTED_ROOT_ALREADY_EXISTS: u64 = 3;
+    const ETRUSTED_ROOT_NOT_FOUND: u64 = 4;
+
     /// Attestation documents are produced by the AWS Nitro Enclaves NSM (Nitro Security Module)
     /// in COSE Sign1 format. This module provides natives that verify and parse such documents.
     ///
     /// Example (in Move):
     /// ```move
     /// use aptos_framework::aws_nitro_utils;
-    /// use std::option;
     ///
     /// fun check_attestation(attestation_doc: vector<u8>) {
     ///     assert!(aws_nitro_utils::verify_attestation(attestation_doc), 0);
@@ -46,47 +59,473 @@ module aptos_framework::aws_nitro_utils {
     ///
     /// fun parse_and_use(attestation_doc: vector<u8>) {
     ///     let doc_opt = aws_nitro_utils::verify_and_parse_attestation(attestation_doc);
-    ///     if (option::is_some(&doc_opt)) {
-    ///         let doc = option::extract(&mut doc_opt);
-    ///         // use doc.module_id, doc.timestamp, doc.pcrs, etc.
+    ///     if (doc_opt.is_some()) {
+    ///         let doc = doc_opt.extract();
+    ///         let nonce = aws_nitro_utils::nonce(&doc);
+    ///         let pcr0 = aws_nitro_utils::pcr(&doc, 0);
+    ///         // Check nonce, PCRs, user_data, public_key, etc.
     ///     }
     /// }
     /// ```
 
-    /// Verifies an AWS Nitro Enclave attestation document.
+    /// Verifies an AWS Nitro Enclave attestation document using chain-managed
+    /// Nitro roots and consensus time.
     ///
     /// The input must be the raw bytes of a COSE Sign1-encoded attestation document
     /// as returned by the Nitro Enclave NSM (e.g. from GetAttestationDocument).
     ///
-    /// Returns `true` if the document is valid; `false` otherwise.
-    public native fun verify_attestation(attestation_doc: vector<u8>): bool;
+    /// Returns `true` if the document is valid; `false` otherwise. Returns `false`
+    /// if the chain-managed root store has not been initialized.
+    public fun verify_attestation(attestation_doc: vector<u8>): bool {
+        if (!is_initialized()) {
+            return false
+        };
+        verify_attestation_from_store(attestation_doc, timestamp::now_seconds())
+    }
 
-    /// Verifies and parses an AWS Nitro Enclave attestation document.
+    /// Verifies and parses an AWS Nitro Enclave attestation document using
+    /// chain-managed Nitro roots and consensus time.
     ///
     /// Same validation as `verify_attestation`. On success returns `Some(AttestationDoc)` with
     /// decoded fields (module_id, timestamp, digest, pcrs, certificate, user_data, nonce, public_key).
-    /// Returns `None` if the document is invalid or malformed.
-    public native fun verify_and_parse_attestation(attestation_doc: vector<u8>): Option<AttestationDoc>;
+    /// Returns `None` if the document is invalid, malformed, or if the chain-managed
+    /// root store has not been initialized.
+    public fun verify_and_parse_attestation(attestation_doc: vector<u8>): Option<AttestationDoc> {
+        if (!is_initialized()) {
+            return option::none()
+        };
+        verify_and_parse_attestation_from_store(attestation_doc, timestamp::now_seconds())
+    }
 
-    #[test_only]
+    /// Verifies an AWS Nitro Enclave attestation document against caller-provided
+    /// DER-encoded root certificates.
+    ///
+    /// `unix_time_secs` is used for certificate validity checks. Callers should pass
+    /// consensus time, not local wall-clock time.
+    public native fun verify_attestation_with_roots(
+        attestation_doc: vector<u8>,
+        trusted_root_certs: vector<vector<u8>>,
+        unix_time_secs: u64,
+    ): bool;
+
+    /// Verifies and parses an AWS Nitro Enclave attestation document against
+    /// caller-provided DER-encoded root certificates.
+    public native fun verify_and_parse_attestation_with_roots(
+        attestation_doc: vector<u8>,
+        trusted_root_certs: vector<vector<u8>>,
+        unix_time_secs: u64,
+    ): Option<AttestationDoc>;
+
+    /// Initializes the chain-managed Nitro root certificate store.
+    public fun initialize(aptos_framework: &signer, root_certs: vector<vector<u8>>) {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        assert!(
+            !exists<TrustedRoots>(@aptos_framework),
+            error::already_exists(ETRUSTED_ROOTS_ALREADY_INITIALIZED),
+        );
+        move_to(aptos_framework, TrustedRoots { root_certs });
+    }
+
+    /// Returns true iff the chain-managed Nitro root certificate store exists.
+    public fun is_initialized(): bool {
+        exists<TrustedRoots>(@aptos_framework)
+    }
+
+    fun assert_trusted_roots_initialized() {
+        assert!(
+            exists<TrustedRoots>(@aptos_framework),
+            error::not_found(ETRUSTED_ROOTS_NOT_INITIALIZED),
+        );
+    }
+
+    /// Replaces the chain-managed Nitro root certificate set.
+    public fun set_trusted_roots(aptos_framework: &signer, root_certs: vector<vector<u8>>) {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        assert_trusted_roots_initialized();
+
+        let trusted_roots = &mut TrustedRoots[@aptos_framework];
+        trusted_roots.root_certs = root_certs;
+    }
+
+    /// Adds one DER-encoded Nitro root certificate to the chain-managed set.
+    public fun add_trusted_root(aptos_framework: &signer, root_cert: vector<u8>) {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        assert_trusted_roots_initialized();
+
+        let trusted_roots = &mut TrustedRoots[@aptos_framework];
+        assert!(
+            !trusted_roots.root_certs.contains(&root_cert),
+            error::already_exists(ETRUSTED_ROOT_ALREADY_EXISTS),
+        );
+        trusted_roots.root_certs.push_back(root_cert);
+    }
+
+    /// Removes one DER-encoded Nitro root certificate from the chain-managed set.
+    public fun remove_trusted_root(aptos_framework: &signer, root_cert: &vector<u8>) {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        assert_trusted_roots_initialized();
+
+        let root_certs = &mut TrustedRoots[@aptos_framework].root_certs;
+        let len = root_certs.length();
+        let i = 0;
+        while (i < len) {
+            if (root_certs.borrow(i) == root_cert) {
+                root_certs.remove(i);
+                return
+            };
+            i = i + 1;
+        };
+        abort error::not_found(ETRUSTED_ROOT_NOT_FOUND)
+    }
+
+    /// Returns a copy of the chain-managed DER-encoded Nitro root certificates.
+    public fun trusted_roots(): vector<vector<u8>> {
+        assert_trusted_roots_initialized();
+        TrustedRoots[@aptos_framework].root_certs
+    }
+
+    /// Returns the number of chain-managed Nitro root certificates.
+    public fun trusted_root_count(): u64 {
+        assert_trusted_roots_initialized();
+        TrustedRoots[@aptos_framework].root_certs.length()
+    }
+
+    /// Returns true iff `root_cert` is currently trusted by the chain-managed store.
+    public fun contains_trusted_root(root_cert: &vector<u8>): bool {
+        if (!exists<TrustedRoots>(@aptos_framework)) {
+            return false
+        };
+        TrustedRoots[@aptos_framework].root_certs.contains(root_cert)
+    }
+
+    /// Verifies an attestation using the chain-managed Nitro root certificates.
+    public fun verify_attestation_from_store(attestation_doc: vector<u8>, unix_time_secs: u64): bool {
+        if (!is_initialized()) {
+            return false
+        };
+        verify_attestation_with_roots(
+            attestation_doc,
+            TrustedRoots[@aptos_framework].root_certs,
+            unix_time_secs,
+        )
+    }
+
+    /// Verifies and parses an attestation using the chain-managed Nitro root certificates.
+    public fun verify_and_parse_attestation_from_store(
+        attestation_doc: vector<u8>,
+        unix_time_secs: u64,
+    ): Option<AttestationDoc> {
+        if (!is_initialized()) {
+            return option::none()
+        };
+        verify_and_parse_attestation_with_roots(
+            attestation_doc,
+            TrustedRoots[@aptos_framework].root_certs,
+            unix_time_secs,
+        )
+    }
+
+    /// Convenience verifier for key-release policies that bind a Nitro attestation
+    /// to one PCR, nonce, user data, and public key.
+    ///
+    /// For more complex policies, call `verify_and_parse_attestation` and combine
+    /// the accessors below. In ACE-style key release, `expected_public_key` should
+    /// be the requester key that released key shares will be encrypted to, and
+    /// `expected_user_data` should be a domain-separated hash of the full request
+    /// context, such as `(enc_pk, job_id, label_hash, input_hash, nonce)`.
+    public fun verify_attestation_matches(
+        attestation_doc: vector<u8>,
+        pcr_index: u8,
+        expected_pcr: &vector<u8>,
+        expected_nonce: &vector<u8>,
+        expected_user_data: &vector<u8>,
+        expected_public_key: &vector<u8>,
+    ): bool {
+        let doc_opt = verify_and_parse_attestation(attestation_doc);
+        if (doc_opt.is_none()) {
+            return false
+        };
+
+        let doc = doc_opt.extract();
+        pcr_equals(&doc, pcr_index, expected_pcr)
+            && nonce_equals(&doc, expected_nonce)
+            && user_data_equals(&doc, expected_user_data)
+            && public_key_equals(&doc, expected_public_key)
+    }
+
+    /// Same policy helper as `verify_attestation_matches`, but validates against
+    /// caller-provided DER-encoded root certificates and explicit consensus time.
+    public fun verify_attestation_matches_with_roots(
+        attestation_doc: vector<u8>,
+        trusted_root_certs: vector<vector<u8>>,
+        unix_time_secs: u64,
+        pcr_index: u8,
+        expected_pcr: &vector<u8>,
+        expected_nonce: &vector<u8>,
+        expected_user_data: &vector<u8>,
+        expected_public_key: &vector<u8>,
+    ): bool {
+        let doc_opt = verify_and_parse_attestation_with_roots(
+            attestation_doc,
+            trusted_root_certs,
+            unix_time_secs,
+        );
+        if (doc_opt.is_none()) {
+            return false
+        };
+
+        let doc = doc_opt.extract();
+        pcr_equals(&doc, pcr_index, expected_pcr)
+            && nonce_equals(&doc, expected_nonce)
+            && user_data_equals(&doc, expected_user_data)
+            && public_key_equals(&doc, expected_public_key)
+    }
+
+    /// Same policy helper as `verify_attestation_matches`, but validates against
+    /// the chain-managed root certificate store.
+    public fun verify_attestation_matches_from_store(
+        attestation_doc: vector<u8>,
+        unix_time_secs: u64,
+        pcr_index: u8,
+        expected_pcr: &vector<u8>,
+        expected_nonce: &vector<u8>,
+        expected_user_data: &vector<u8>,
+        expected_public_key: &vector<u8>,
+    ): bool {
+        if (!is_initialized()) {
+            return false
+        };
+        verify_attestation_matches_with_roots(
+            attestation_doc,
+            TrustedRoots[@aptos_framework].root_certs,
+            unix_time_secs,
+            pcr_index,
+            expected_pcr,
+            expected_nonce,
+            expected_user_data,
+            expected_public_key,
+        )
+    }
+
+    /// Returns the NitroSecureModule identifier.
+    public fun module_id(doc: &AttestationDoc): vector<u8> {
+        doc.module_id
+    }
+
+    /// Returns the document creation timestamp, in Unix milliseconds.
+    public fun timestamp(doc: &AttestationDoc): u64 {
+        doc.timestamp
+    }
+
+    /// Returns the digest algorithm identifier parsed from the document.
+    public fun digest(doc: &AttestationDoc): vector<u8> {
+        doc.digest
+    }
+
+    /// Returns the signing certificate, DER-encoded.
+    public fun certificate(doc: &AttestationDoc): vector<u8> {
+        doc.certificate
+    }
+
+    /// Returns the optional user-provided data.
+    public fun user_data(doc: &AttestationDoc): Option<vector<u8>> {
+        doc.user_data
+    }
+
+    /// Returns the optional nonce.
+    public fun nonce(doc: &AttestationDoc): Option<vector<u8>> {
+        doc.nonce
+    }
+
+    /// Returns the optional DER-encoded public key.
+    public fun public_key(doc: &AttestationDoc): Option<vector<u8>> {
+        doc.public_key
+    }
+
+    /// Returns the number of PCR entries in the document.
+    public fun pcr_count(doc: &AttestationDoc): u64 {
+        doc.pcrs.length()
+    }
+
+    /// Returns the PCR entry at `offset` as `(index, value)`.
+    public fun pcr_at(doc: &AttestationDoc, offset: u64): (u8, vector<u8>) {
+        let entry = doc.pcrs.borrow(offset);
+        (entry.index, entry.value)
+    }
+
+    /// Returns the PCR value with the requested `index`, if present.
+    public fun pcr(doc: &AttestationDoc, index: u8): Option<vector<u8>> {
+        let len = doc.pcrs.length();
+        let offset = 0;
+        while (offset < len) {
+            let entry = doc.pcrs.borrow(offset);
+            if (entry.index == index) {
+                return option::some(entry.value)
+            };
+            offset = offset + 1;
+        };
+        option::none()
+    }
+
+    /// Returns true iff the requested PCR is present and equals `expected`.
+    public fun pcr_equals(doc: &AttestationDoc, index: u8, expected: &vector<u8>): bool {
+        let pcr_opt = pcr(doc, index);
+        pcr_opt.is_some() && pcr_opt.borrow() == expected
+    }
+
+    /// Returns true iff the attestation's `user_data` is present and equals `expected`.
+    ///
+    /// Dapps should bind `user_data` to their own domain-separated hash, for example
+    /// `hash(enc_pk || job_id || input_hash || nonce)`.
+    public fun user_data_equals(doc: &AttestationDoc, expected: &vector<u8>): bool {
+        doc.user_data.is_some() && doc.user_data.borrow() == expected
+    }
+
+    /// Returns true iff the attestation's `nonce` is present and equals `expected`.
+    public fun nonce_equals(doc: &AttestationDoc, expected: &vector<u8>): bool {
+        doc.nonce.is_some() && doc.nonce.borrow() == expected
+    }
+
+    /// Returns true iff the attestation's `public_key` is present and equals `expected`.
+    public fun public_key_equals(doc: &AttestationDoc, expected: &vector<u8>): bool {
+        doc.public_key.is_some() && doc.public_key.borrow() == expected
+    }
+
+    #[test]
     fun test_invalid_attestation_returns_false() {
         // Empty input is not valid COSE Sign1
         assert!(!verify_attestation(vector::empty<u8>()), 0);
+        assert!(
+            !verify_attestation_with_roots(vector::empty<u8>(), vector[b"fake-root"], 0),
+            1,
+        );
     }
 
-    #[test_only]
+    #[test]
     fun test_garbage_bytes_return_false() {
         // Random bytes are not a valid attestation document
         let garbage = vector[
             0x00u8, 0x01u8, 0x02u8, 0x03u8, 0x04u8, 0x05u8, 0x06u8, 0x07u8,
             0x08u8, 0x09u8, 0x0au8, 0x0bu8, 0x0cu8, 0x0du8, 0x0eu8, 0x0fu8,
         ];
-        assert!(!verify_attestation(garbage), 0);
+        assert!(!verify_attestation(copy garbage), 0);
+        assert!(
+            !verify_attestation_with_roots(garbage, vector[b"fake-root"], 0),
+            1,
+        );
     }
 
-    #[test_only]
+    #[test]
     fun test_verify_and_parse_invalid_returns_none() {
         let doc_opt = verify_and_parse_attestation(vector::empty<u8>());
-        assert!(option::is_none(&doc_opt), 0);
+        assert!(doc_opt.is_none(), 0);
+
+        let doc_opt_with_roots = verify_and_parse_attestation_with_roots(
+            vector::empty<u8>(),
+            vector[b"fake-root"],
+            0,
+        );
+        assert!(doc_opt_with_roots.is_none(), 1);
+        assert!(
+            !verify_attestation_matches(
+                vector::empty<u8>(),
+                0,
+                &b"pcr0",
+                &b"nonce",
+                &b"user-data",
+                &b"public-key",
+            ),
+            2,
+        );
+        assert!(
+            !verify_attestation_matches_with_roots(
+                vector::empty<u8>(),
+                vector[b"fake-root"],
+                0,
+                0,
+                &b"pcr0",
+                &b"nonce",
+                &b"user-data",
+                &b"public-key",
+            ),
+            3,
+        );
+    }
+
+    #[test]
+    fun test_parsed_doc_accessors() {
+        let doc = AttestationDoc {
+            module_id: b"module-1",
+            timestamp: 42,
+            digest: b"SHA384",
+            pcrs: vector[
+                PcrEntry { index: 0, value: b"pcr0" },
+                PcrEntry { index: 8, value: b"pcr8" },
+            ],
+            certificate: b"cert",
+            user_data: option::some(b"user-data"),
+            nonce: option::some(b"nonce"),
+            public_key: option::some(b"public-key"),
+        };
+
+        assert!(module_id(&doc) == b"module-1", 0);
+        assert!(timestamp(&doc) == 42, 1);
+        assert!(digest(&doc) == b"SHA384", 2);
+        assert!(certificate(&doc) == b"cert", 3);
+        assert!(pcr_count(&doc) == 2, 4);
+
+        let (pcr_index, pcr_value) = pcr_at(&doc, 1);
+        assert!(pcr_index == 8, 5);
+        assert!(pcr_value == b"pcr8", 6);
+
+        let pcr0 = pcr(&doc, 0);
+        assert!(pcr0.is_some(), 7);
+        assert!(pcr0.borrow() == &b"pcr0", 8);
+        assert!(pcr(&doc, 1).is_none(), 9);
+        assert!(pcr_equals(&doc, 8, &b"pcr8"), 10);
+        assert!(!pcr_equals(&doc, 8, &b"wrong"), 11);
+
+        assert!(user_data_equals(&doc, &b"user-data"), 12);
+        assert!(!user_data_equals(&doc, &b"wrong"), 13);
+        assert!(nonce_equals(&doc, &b"nonce"), 14);
+        assert!(public_key_equals(&doc, &b"public-key"), 15);
+        assert!(user_data(&doc).borrow() == &b"user-data", 16);
+        assert!(nonce(&doc).borrow() == &b"nonce", 17);
+        assert!(public_key(&doc).borrow() == &b"public-key", 18);
+    }
+
+    #[test(aptos_framework = @0x1)]
+    fun test_trusted_roots_store(aptos_framework: &signer) {
+        initialize(aptos_framework, vector[b"root-a"]);
+        assert!(is_initialized(), 0);
+        assert!(trusted_root_count() == 1, 1);
+        assert!(trusted_roots() == vector[b"root-a"], 2);
+        assert!(contains_trusted_root(&b"root-a"), 3);
+        assert!(!contains_trusted_root(&b"root-b"), 4);
+
+        add_trusted_root(aptos_framework, b"root-b");
+        assert!(trusted_root_count() == 2, 5);
+        assert!(contains_trusted_root(&b"root-b"), 6);
+
+        remove_trusted_root(aptos_framework, &b"root-a");
+        assert!(trusted_roots() == vector[b"root-b"], 7);
+
+        set_trusted_roots(aptos_framework, vector[b"root-c"]);
+        assert!(trusted_roots() == vector[b"root-c"], 8);
+
+        assert!(!verify_attestation_from_store(vector::empty<u8>(), 0), 9);
+        assert!(verify_and_parse_attestation_from_store(vector::empty<u8>(), 0).is_none(), 10);
+        assert!(
+            !verify_attestation_matches_from_store(
+                vector::empty<u8>(),
+                0,
+                0,
+                &b"pcr0",
+                &b"nonce",
+                &b"user-data",
+                &b"public-key",
+            ),
+            11,
+        );
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
+++ b/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
@@ -3,11 +3,14 @@
 
 /// Utilities for verifying AWS Nitro Enclave attestation documents.
 module aptos_framework::aws_nitro_utils {
+    use aptos_framework::aptos_governance;
     use aptos_framework::system_addresses;
     use aptos_framework::timestamp;
     use std::error;
     use std::option;
     use std::option::Option;
+
+    #[test_only]
     use std::vector;
 
     /// One Platform Configuration Register (PCR) entry from the attestation document.
@@ -145,6 +148,15 @@ module aptos_framework::aws_nitro_utils {
         move_to(aptos_framework, TrustedRoots { root_certs });
     }
 
+    /// Initializes the Nitro root certificate store from the core resources account.
+    /// This is intended for localnet/testnet flows where core resources can mint APT and
+    /// has governance signer capabilities.
+    public entry fun initialize_testnet_only(core_resources: &signer, root_certs: vector<vector<u8>>) {
+        let aptos_framework = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
+        initialize(&aptos_framework, root_certs);
+    }
+
+    #[view]
     /// Returns true iff the chain-managed Nitro root certificate store exists.
     public fun is_initialized(): bool {
         exists<TrustedRoots>(@aptos_framework)
@@ -166,6 +178,13 @@ module aptos_framework::aws_nitro_utils {
         trusted_roots.root_certs = root_certs;
     }
 
+    /// Replaces the Nitro root certificate set from the core resources account.
+    /// Intended for localnet/testnet root rotation drills.
+    public entry fun set_trusted_roots_testnet_only(core_resources: &signer, root_certs: vector<vector<u8>>) {
+        let aptos_framework = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
+        set_trusted_roots(&aptos_framework, root_certs);
+    }
+
     /// Adds one DER-encoded Nitro root certificate to the chain-managed set.
     public entry fun add_trusted_root(aptos_framework: &signer, root_cert: vector<u8>) {
         system_addresses::assert_aptos_framework(aptos_framework);
@@ -177,6 +196,13 @@ module aptos_framework::aws_nitro_utils {
             error::already_exists(ETRUSTED_ROOT_ALREADY_EXISTS),
         );
         trusted_roots.root_certs.push_back(root_cert);
+    }
+
+    /// Adds one Nitro root certificate from the core resources account.
+    /// Intended for localnet/testnet root rotation drills.
+    public entry fun add_trusted_root_testnet_only(core_resources: &signer, root_cert: vector<u8>) {
+        let aptos_framework = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
+        add_trusted_root(&aptos_framework, root_cert);
     }
 
     /// Removes one DER-encoded Nitro root certificate from the chain-managed set.
@@ -197,12 +223,21 @@ module aptos_framework::aws_nitro_utils {
         abort error::not_found(ETRUSTED_ROOT_NOT_FOUND)
     }
 
+    /// Removes one Nitro root certificate from the core resources account.
+    /// Intended for localnet/testnet root rotation drills.
+    public entry fun remove_trusted_root_testnet_only(core_resources: &signer, root_cert: vector<u8>) {
+        let aptos_framework = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
+        remove_trusted_root(&aptos_framework, root_cert);
+    }
+
+    #[view]
     /// Returns a copy of the chain-managed DER-encoded Nitro root certificates.
     public fun trusted_roots(): vector<vector<u8>> {
         assert_trusted_roots_initialized();
         TrustedRoots[@aptos_framework].root_certs
     }
 
+    #[view]
     /// Returns the number of chain-managed Nitro root certificates.
     public fun trusted_root_count(): u64 {
         assert_trusted_roots_initialized();

--- a/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
+++ b/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
@@ -136,7 +136,7 @@ module aptos_framework::aws_nitro_utils {
     ): Option<AttestationDoc>;
 
     /// Initializes the chain-managed Nitro root certificate store.
-    public fun initialize(aptos_framework: &signer, root_certs: vector<vector<u8>>) {
+    public entry fun initialize(aptos_framework: &signer, root_certs: vector<vector<u8>>) {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
             !exists<TrustedRoots>(@aptos_framework),
@@ -158,7 +158,7 @@ module aptos_framework::aws_nitro_utils {
     }
 
     /// Replaces the chain-managed Nitro root certificate set.
-    public fun set_trusted_roots(aptos_framework: &signer, root_certs: vector<vector<u8>>) {
+    public entry fun set_trusted_roots(aptos_framework: &signer, root_certs: vector<vector<u8>>) {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert_trusted_roots_initialized();
 
@@ -167,7 +167,7 @@ module aptos_framework::aws_nitro_utils {
     }
 
     /// Adds one DER-encoded Nitro root certificate to the chain-managed set.
-    public fun add_trusted_root(aptos_framework: &signer, root_cert: vector<u8>) {
+    public entry fun add_trusted_root(aptos_framework: &signer, root_cert: vector<u8>) {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert_trusted_roots_initialized();
 
@@ -180,7 +180,7 @@ module aptos_framework::aws_nitro_utils {
     }
 
     /// Removes one DER-encoded Nitro root certificate from the chain-managed set.
-    public fun remove_trusted_root(aptos_framework: &signer, root_cert: &vector<u8>) {
+    public entry fun remove_trusted_root(aptos_framework: &signer, root_cert: vector<u8>) {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert_trusted_roots_initialized();
 
@@ -188,7 +188,7 @@ module aptos_framework::aws_nitro_utils {
         let len = root_certs.length();
         let i = 0;
         while (i < len) {
-            if (root_certs.borrow(i) == root_cert) {
+            if (root_certs.borrow(i) == &root_cert) {
                 root_certs.remove(i);
                 return
             };
@@ -579,7 +579,7 @@ module aptos_framework::aws_nitro_utils {
         assert!(trusted_root_count() == 2, 5);
         assert!(contains_trusted_root(&b"root-b"), 6);
 
-        remove_trusted_root(aptos_framework, &b"root-a");
+        remove_trusted_root(aptos_framework, b"root-a");
         assert!(trusted_roots() == vector[b"root-b"], 7);
 
         set_trusted_roots(aptos_framework, vector[b"root-c"]);

--- a/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
+++ b/aptos-move/framework/aptos-framework/sources/aws_nitro_utils.move
@@ -97,6 +97,25 @@ module aptos_framework::aws_nitro_utils {
         verify_and_parse_attestation_from_store(attestation_doc, timestamp::now_seconds())
     }
 
+    /// Verifies an AWS Nitro Enclave attestation document and checks that its
+    /// `user_data` field equals `expected_user_data`.
+    ///
+    /// This is a small dapp-facing helper for policies that only need to bind
+    /// the attested enclave to an application-specific request or account.
+    public fun verify_attestation_user_data(
+        attestation_doc: vector<u8>,
+        expected_user_data: &vector<u8>,
+    ): bool {
+        if (!is_initialized()) {
+            return false
+        };
+        verify_attestation_user_data_from_store(
+            attestation_doc,
+            timestamp::now_seconds(),
+            expected_user_data,
+        )
+    }
+
     /// Verifies an AWS Nitro Enclave attestation document against caller-provided
     /// DER-encoded root certificates.
     ///
@@ -223,6 +242,46 @@ module aptos_framework::aws_nitro_utils {
             TrustedRoots[@aptos_framework].root_certs,
             unix_time_secs,
         )
+    }
+
+    /// Verifies an attestation using the chain-managed Nitro root certificates
+    /// and checks that its `user_data` field equals `expected_user_data`.
+    public fun verify_attestation_user_data_from_store(
+        attestation_doc: vector<u8>,
+        unix_time_secs: u64,
+        expected_user_data: &vector<u8>,
+    ): bool {
+        if (!is_initialized()) {
+            return false
+        };
+        verify_attestation_user_data_with_roots(
+            attestation_doc,
+            TrustedRoots[@aptos_framework].root_certs,
+            unix_time_secs,
+            expected_user_data,
+        )
+    }
+
+    /// Verifies an attestation against caller-provided DER-encoded root
+    /// certificates and checks that its `user_data` field equals
+    /// `expected_user_data`.
+    public fun verify_attestation_user_data_with_roots(
+        attestation_doc: vector<u8>,
+        trusted_root_certs: vector<vector<u8>>,
+        unix_time_secs: u64,
+        expected_user_data: &vector<u8>,
+    ): bool {
+        let doc_opt = verify_and_parse_attestation_with_roots(
+            attestation_doc,
+            trusted_root_certs,
+            unix_time_secs,
+        );
+        if (doc_opt.is_none()) {
+            return false
+        };
+
+        let doc = doc_opt.extract();
+        user_data_equals(&doc, expected_user_data)
     }
 
     /// Convenience verifier for key-release policies that bind a Nitro attestation
@@ -449,6 +508,19 @@ module aptos_framework::aws_nitro_utils {
                 &b"public-key",
             ),
             3,
+        );
+        assert!(
+            !verify_attestation_user_data(vector::empty<u8>(), &b"user-data"),
+            4,
+        );
+        assert!(
+            !verify_attestation_user_data_with_roots(
+                vector::empty<u8>(),
+                vector[b"fake-root"],
+                0,
+                &b"user-data",
+            ),
+            5,
         );
     }
 

--- a/aptos-move/framework/natives/Cargo.toml
+++ b/aptos-move/framework/natives/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 [features]
 default = []
 fuzzing = ["aptos-types/fuzzing"]
-testing = ["aptos-crypto/fuzzing"]
+testing = ["aptos-aggregator/testing", "aptos-crypto/fuzzing"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -79,3 +79,8 @@ x509-parser = "0.14"
 
 [dev-dependencies]
 claims = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "aws_nitro_utils"
+harness = false

--- a/aptos-move/framework/natives/Cargo.toml
+++ b/aptos-move/framework/natives/Cargo.toml
@@ -33,6 +33,8 @@ aptos-native-interface = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm-types = { workspace = true }
 attestation-doc-validation = "0.10"
+aws-nitro-enclaves-cose = { version = "0.5.2", default-features = false }
+aws-nitro-enclaves-nsm-api = { version = "0.4", default-features = false }
 ark-bls12-381 = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
@@ -45,6 +47,7 @@ blake2-rfc = { workspace = true }
 bulletproofs = { workspace = true }
 byteorder = { workspace = true }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4" }
+ecdsa = "0.16"
 either = { workspace = true }
 flate2 = { workspace = true }
 hex = { workspace = true }
@@ -57,6 +60,8 @@ move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }
+p256 = "0.13"
+p384 = "0.13"
 rand = { workspace = true }
 rand_core = { workspace = true }
 ripemd = { workspace = true }
@@ -69,6 +74,8 @@ siphasher = { workspace = true }
 smallvec = { workspace = true }
 tiny-keccak = { workspace = true }
 triomphe = { workspace = true }
+webpki = "0.22.4"
+x509-parser = "0.14"
 
 [dev-dependencies]
 claims = { workspace = true }

--- a/aptos-move/framework/natives/Cargo.toml
+++ b/aptos-move/framework/natives/Cargo.toml
@@ -32,6 +32,7 @@ aptos-gas-schedule = { workspace = true }
 aptos-native-interface = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm-types = { workspace = true }
+attestation-doc-validation = "0.10"
 ark-bls12-381 = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }

--- a/aptos-move/framework/natives/benches/aws_nitro_utils.rs
+++ b/aptos-move/framework/natives/benches/aws_nitro_utils.rs
@@ -3,6 +3,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::{env, fs, path::PathBuf};
+use webpki::{EndEntityCert, TrustAnchor};
 
 #[allow(dead_code, unused_imports)]
 #[path = "../src/aws_nitro_utils.rs"]
@@ -34,7 +35,26 @@ fn bench_validate_and_parse(c: &mut Criterion) {
             .expect("Nitro attestation fixture should decode");
     let unix_time_secs = decoded_doc.timestamp / 1000;
     let roots = vec![root];
+    let root_cert = roots[0].as_slice();
     let total_bytes = attestation.len() + roots.iter().map(Vec::len).sum::<usize>();
+    let intermediate_certs = decoded_doc
+        .cabundle
+        .iter()
+        .map(|cert| cert.as_slice())
+        .collect::<Vec<_>>();
+    let signing_cert = attestation_doc_validation::parse_cert(&decoded_doc.certificate)
+        .expect("Nitro attestation signing certificate should parse");
+    let pub_key = aws_nitro_utils::NitroPublicKey::new(signing_cert.public_key())
+        .expect("Nitro attestation signing key should parse");
+    let end_entity_cert =
+        EndEntityCert::try_from(decoded_doc.certificate.as_slice()).expect("leaf cert parses");
+    let trust_anchor = TrustAnchor::try_from_cert_der(root_cert).expect("root cert parses");
+    let trust_anchors = vec![trust_anchor];
+    let server_trust_anchors = webpki::TlsServerTrustAnchors(&trust_anchors);
+    let time = webpki::Time::from_seconds_since_unix_epoch(unix_time_secs);
+    let (cose_sign_1_decoded, _) =
+        attestation_doc_validation::attestation_doc::decode_attestation_document(&attestation)
+            .expect("Nitro attestation fixture should decode");
 
     aws_nitro_utils::validate_and_parse_attestation_doc_with_roots(
         &attestation,
@@ -45,8 +65,72 @@ fn bench_validate_and_parse(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("aws_nitro_utils");
     group.throughput(Throughput::Bytes(total_bytes as u64));
+    group.bench_function("decode_attestation_document", |b| {
+        b.iter(|| {
+            attestation_doc_validation::attestation_doc::decode_attestation_document(black_box(
+                &attestation,
+            ))
+            .expect("Nitro attestation fixture should decode")
+        })
+    });
+    group.bench_function("validate_cert_trust_chain_with_roots", |b| {
+        b.iter(|| {
+            aws_nitro_utils::validate_cert_trust_chain_with_roots(
+                black_box(&decoded_doc.certificate),
+                black_box(&intermediate_certs),
+                black_box(&roots),
+                black_box(unix_time_secs),
+            )
+            .expect("Nitro attestation certificate chain should validate")
+        })
+    });
+    group.bench_function("webpki_parse_leaf_cert", |b| {
+        b.iter(|| {
+            EndEntityCert::try_from(black_box(decoded_doc.certificate.as_slice()))
+                .expect("leaf cert parses")
+        })
+    });
+    group.bench_function("webpki_parse_root_trust_anchor", |b| {
+        b.iter(|| TrustAnchor::try_from_cert_der(black_box(root_cert)).expect("root cert parses"))
+    });
+    group.bench_function("webpki_verify_preparsed_chain", |b| {
+        b.iter(|| {
+            end_entity_cert
+                .verify_is_valid_tls_server_cert(
+                    black_box(aws_nitro_utils::SUPPORTED_SIG_ALGS),
+                    black_box(&server_trust_anchors),
+                    black_box(&intermediate_certs),
+                    black_box(time),
+                )
+                .expect("pre-parsed Nitro certificate chain should validate")
+        })
+    });
+    group.bench_function("parse_attestation_signing_cert", |b| {
+        b.iter(|| {
+            attestation_doc_validation::parse_cert(black_box(&decoded_doc.certificate))
+                .expect("Nitro attestation signing certificate should parse")
+        })
+    });
+    group.bench_function("nitro_public_key_from_spki", |b| {
+        b.iter(|| {
+            aws_nitro_utils::NitroPublicKey::new(black_box(signing_cert.public_key()))
+                .expect("Nitro attestation signing key should parse")
+        })
+    });
+    group.bench_function("validate_cose_signature", |b| {
+        b.iter(|| {
+            aws_nitro_utils::validate_cose_signature(
+                black_box(&pub_key),
+                black_box(&cose_sign_1_decoded),
+            )
+            .expect("Nitro attestation COSE signature should validate")
+        })
+    });
     group.bench_with_input(
-        BenchmarkId::new("validate_and_parse_attestation_doc_with_roots", total_bytes),
+        BenchmarkId::new(
+            "full_validate_and_parse_attestation_doc_with_roots",
+            total_bytes,
+        ),
         &total_bytes,
         |b, _| {
             b.iter(|| {

--- a/aptos-move/framework/natives/benches/aws_nitro_utils.rs
+++ b/aptos-move/framework/natives/benches/aws_nitro_utils.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::{env, fs, path::PathBuf};
+
+#[allow(dead_code, unused_imports)]
+#[path = "../src/aws_nitro_utils.rs"]
+mod aws_nitro_utils;
+
+fn fixture_path(env_key: &str, default_path: &str) -> PathBuf {
+    env::var_os(env_key)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(default_path))
+}
+
+fn bench_validate_and_parse(c: &mut Criterion) {
+    let attestation_path = fixture_path("NITRO_ATTESTATION_DOC", "/tmp/attestation-3586.bin");
+    let root_path = fixture_path("NITRO_ROOT_DER", "/tmp/aws-nitro-root.der");
+    let attestation = fs::read(&attestation_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read Nitro attestation fixture {}: {err}",
+            attestation_path.display()
+        )
+    });
+    let root = fs::read(&root_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read Nitro root fixture {}: {err}",
+            root_path.display()
+        )
+    });
+    let (_, decoded_doc) =
+        attestation_doc_validation::attestation_doc::decode_attestation_document(&attestation)
+            .expect("Nitro attestation fixture should decode");
+    let unix_time_secs = decoded_doc.timestamp / 1000;
+    let roots = vec![root];
+    let total_bytes = attestation.len() + roots.iter().map(Vec::len).sum::<usize>();
+
+    aws_nitro_utils::validate_and_parse_attestation_doc_with_roots(
+        &attestation,
+        &roots,
+        unix_time_secs,
+    )
+    .expect("Nitro attestation fixture should validate");
+
+    let mut group = c.benchmark_group("aws_nitro_utils");
+    group.throughput(Throughput::Bytes(total_bytes as u64));
+    group.bench_with_input(
+        BenchmarkId::new("validate_and_parse_attestation_doc_with_roots", total_bytes),
+        &total_bytes,
+        |b, _| {
+            b.iter(|| {
+                aws_nitro_utils::validate_and_parse_attestation_doc_with_roots(
+                    black_box(&attestation),
+                    black_box(&roots),
+                    black_box(unix_time_secs),
+                )
+                .expect("Nitro attestation fixture should validate")
+            })
+        },
+    );
+    group.finish();
+}
+
+criterion_group!(benches, bench_validate_and_parse);
+criterion_main!(benches);

--- a/aptos-move/framework/natives/src/aws_nitro_utils.rs
+++ b/aptos-move/framework/natives/src/aws_nitro_utils.rs
@@ -1,0 +1,203 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Native implementation of AWS Nitro Enclave attestation verification.
+//!
+//! Verifies attestation documents produced by AWS Nitro Enclaves (COSE Sign1 format)
+//! by validating the certificate chain and signature against AWS root of trust.
+
+use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
+use aptos_native_interface::{
+    safely_assert_eq, safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext,
+    SafeNativeResult,
+};
+use move_core_types::{
+    gas_algebra::NumBytes,
+    language_storage::{OPTION_NONE_TAG, OPTION_SOME_TAG},
+};
+use move_vm_runtime::native_functions::NativeFunction;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    values::{Struct, Value},
+};
+use smallvec::{smallvec, SmallVec};
+use std::collections::VecDeque;
+
+fn option_some(context: &SafeNativeContext, value: Value) -> SafeNativeResult<Value> {
+    let enum_option = context.get_feature_flags().is_enum_option_enabled();
+    Ok(if enum_option {
+        Value::struct_(Struct::pack_variant(OPTION_SOME_TAG, vec![value]))
+    } else {
+        Value::struct_(Struct::pack(vec![Value::vector_unchecked(vec![value])?]))
+    })
+}
+
+fn option_none(context: &SafeNativeContext) -> SafeNativeResult<Value> {
+    let enum_option = context.get_feature_flags().is_enum_option_enabled();
+    Ok(if enum_option {
+        Value::struct_(Struct::pack_variant(OPTION_NONE_TAG, vec![]))
+    } else {
+        Value::struct_(Struct::pack(vec![Value::vector_unchecked(vec![])?]))
+    })
+}
+
+/***************************************************************************************************
+ * native fun verify_attestation
+ *
+ *   gas cost: base_cost + unit_cost * bytes_len
+ *
+ *   Returns true if the attestation document (COSE Sign1 bytes from AWS Nitro Enclave)
+ *   is valid: well-formed, signed by the Nitro cert chain, and not expired.
+ *   Returns false for invalid, malformed, or expired attestations.
+ **************************************************************************************************/
+fn native_verify_attestation(
+    context: &mut SafeNativeContext,
+    _ty_args: &[Type],
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    safely_assert_eq!(_ty_args.len(), 0);
+    safely_assert_eq!(args.len(), 1);
+
+    let attestation_bytes = safely_pop_arg!(args, Vec<u8>);
+
+    let cost = AWS_NITRO_VERIFY_ATTESTATION_BASE
+        + AWS_NITRO_VERIFY_ATTESTATION_PER_BYTE * NumBytes::new(attestation_bytes.len() as u64);
+    context.charge(cost)?;
+
+    let valid = attestation_doc_validation::validate_attestation_doc(&attestation_bytes).is_ok();
+
+    Ok(smallvec![Value::bool(valid)])
+}
+
+/***************************************************************************************************
+ * native fun verify_and_parse_attestation
+ *
+ *   gas cost: base_cost + unit_cost * bytes_len
+ *
+ *   Validates the attestation doc and on success returns Some(AttestationDoc) with
+ *   module_id, timestamp, digest, pcrs, certificate, user_data, nonce, public_key.
+ **************************************************************************************************/
+fn native_verify_and_parse_attestation(
+    context: &mut SafeNativeContext,
+    _ty_args: &[Type],
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    safely_assert_eq!(_ty_args.len(), 0);
+    safely_assert_eq!(args.len(), 1);
+
+    let attestation_bytes = safely_pop_arg!(args, Vec<u8>);
+
+    let cost = AWS_NITRO_VERIFY_AND_PARSE_ATTESTATION_BASE
+        + AWS_NITRO_VERIFY_AND_PARSE_ATTESTATION_PER_BYTE
+            * NumBytes::new(attestation_bytes.len() as u64);
+    context.charge(cost)?;
+
+    let opt_doc = match attestation_doc_validation::validate_and_parse_attestation_doc(
+        &attestation_bytes,
+    ) {
+        Ok(doc) => {
+            let module_id = Value::vector_u8(doc.module_id.as_bytes().to_vec());
+            let timestamp = Value::u64(doc.timestamp);
+            let digest = Value::vector_u8(format!("{:?}", doc.digest).into_bytes());
+            let pcrs_vec: Vec<Value> = doc
+                .pcrs
+                .iter()
+                .map(|(idx, val)| {
+                    Value::struct_(Struct::pack(vec![
+                        Value::u8((*idx) as u8),
+                        Value::vector_u8(val.to_vec()),
+                    ]))
+                })
+                .collect();
+            let pcrs_value = Value::vector_unchecked(pcrs_vec)?;
+            let certificate = Value::vector_u8(doc.certificate.to_vec());
+            let user_data = match &doc.user_data {
+                Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
+                None => option_none(context)?,
+            };
+            let nonce = match &doc.nonce {
+                Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
+                None => option_none(context)?,
+            };
+            let public_key = match &doc.public_key {
+                Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
+                None => option_none(context)?,
+            };
+            let attestation_doc = Value::struct_(Struct::pack(vec![
+                module_id,
+                timestamp,
+                digest,
+                pcrs_value,
+                certificate,
+                user_data,
+                nonce,
+                public_key,
+            ]));
+            option_some(context, attestation_doc)?
+        }
+        Err(_) => option_none(context)?,
+    };
+
+    Ok(smallvec![opt_doc])
+}
+
+#[cfg(test)]
+mod tests {
+    /// Tests the same validation logic used by the native (attestation_doc_validation crate).
+    #[test]
+    fn test_empty_attestation_invalid() {
+        assert!(attestation_doc_validation::validate_attestation_doc(&[]).is_err());
+    }
+
+    #[test]
+    fn test_garbage_attestation_invalid() {
+        let garbage = [0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        assert!(attestation_doc_validation::validate_attestation_doc(&garbage).is_err());
+    }
+
+    /// Happy path: real attestation doc from AWS Nitro Enclave.
+    /// Run with: cargo test -p aptos-framework test_real_attestation -- --ignored
+    /// (Requires /tmp/attestation-3586.bin to exist.)
+    #[test]
+    #[ignore = "requires real attestation doc at /tmp/attestation-3586.bin"]
+    fn test_real_attestation_valid() {
+        let path = std::path::Path::new("/tmp/attestation-3586.bin");
+        let bytes = std::fs::read(path).expect("attestation doc at /tmp/attestation-3586.bin");
+        assert!(
+            attestation_doc_validation::validate_attestation_doc(&bytes).is_ok(),
+            "real attestation doc should validate"
+        );
+    }
+
+    /// Happy path for verify_and_parse: real attestation doc parses and has expected fields.
+    /// Run with: cargo test -p aptos-framework test_real_attestation_parse -- --ignored
+    #[test]
+    #[ignore = "requires real attestation doc at /tmp/attestation-3586.bin"]
+    fn test_real_attestation_parse() {
+        let path = std::path::Path::new("/tmp/attestation-3586.bin");
+        let bytes = std::fs::read(path).expect("attestation doc at /tmp/attestation-3586.bin");
+        let doc = attestation_doc_validation::validate_and_parse_attestation_doc(&bytes)
+            .expect("real attestation doc should parse");
+        assert!(!doc.module_id.is_empty(), "module_id non-empty");
+        assert!(!doc.certificate.is_empty(), "certificate non-empty");
+        assert!(!doc.pcrs.is_empty(), "pcrs non-empty");
+    }
+}
+
+/***************************************************************************************************
+ * module
+ *
+ **************************************************************************************************/
+pub fn make_all(
+    builder: &SafeNativeBuilder,
+) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
+    let natives = [
+        ("verify_attestation", native_verify_attestation as RawSafeNative),
+        (
+            "verify_and_parse_attestation",
+            native_verify_and_parse_attestation as RawSafeNative,
+        ),
+    ];
+
+    builder.make_named_natives(natives)
+}

--- a/aptos-move/framework/natives/src/aws_nitro_utils.rs
+++ b/aptos-move/framework/natives/src/aws_nitro_utils.rs
@@ -6,11 +6,19 @@
 //! Verifies attestation documents produced by AWS Nitro Enclaves (COSE Sign1 format)
 //! by validating the certificate chain and signature against AWS root of trust.
 
+use anyhow::{anyhow, bail, Result};
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
 use aptos_native_interface::{
     safely_assert_eq, safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext,
     SafeNativeResult,
 };
+use aws_nitro_enclaves_cose::{
+    crypto::{Hash, MessageDigest, SignatureAlgorithm, SigningPublicKey},
+    error::CoseError,
+    CoseSign1,
+};
+use aws_nitro_enclaves_nsm_api::api::{AttestationDoc, Digest};
+use ecdsa::signature::hazmat::PrehashVerifier;
 use move_core_types::{
     gas_algebra::NumBytes,
     language_storage::{OPTION_NONE_TAG, OPTION_SOME_TAG},
@@ -20,8 +28,26 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{Struct, Value},
 };
+use sha2_0_10_6::{Digest as Sha2Digest, Sha256, Sha384, Sha512};
 use smallvec::{smallvec, SmallVec};
-use std::collections::VecDeque;
+use std::{collections::VecDeque, str::FromStr};
+use webpki::{EndEntityCert, TrustAnchor};
+use x509_parser::x509::SubjectPublicKeyInfo;
+
+static SUPPORTED_SIG_ALGS: &[&webpki::SignatureAlgorithm] = &[
+    &webpki::ECDSA_P256_SHA256,
+    &webpki::ECDSA_P256_SHA384,
+    &webpki::ECDSA_P384_SHA256,
+    &webpki::ECDSA_P384_SHA384,
+    &webpki::ED25519,
+    &webpki::RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
+    &webpki::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
+    &webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
+    &webpki::RSA_PKCS1_2048_8192_SHA256,
+    &webpki::RSA_PKCS1_2048_8192_SHA384,
+    &webpki::RSA_PKCS1_2048_8192_SHA512,
+    &webpki::RSA_PKCS1_3072_8192_SHA384,
+];
 
 fn option_some(context: &SafeNativeContext, value: Value) -> SafeNativeResult<Value> {
     let enum_option = context.get_feature_flags().is_enum_option_enabled();
@@ -41,100 +67,314 @@ fn option_none(context: &SafeNativeContext) -> SafeNativeResult<Value> {
     })
 }
 
+fn digest_name(digest: Digest) -> &'static [u8] {
+    match digest {
+        Digest::SHA256 => b"SHA256",
+        Digest::SHA384 => b"SHA384",
+        Digest::SHA512 => b"SHA512",
+    }
+}
+
+struct NitroCryptoClient;
+
+impl Hash for NitroCryptoClient {
+    fn hash(digest: MessageDigest, data: &[u8]) -> std::result::Result<Vec<u8>, CoseError> {
+        Ok(match digest {
+            MessageDigest::Sha256 => Sha256::digest(data).to_vec(),
+            MessageDigest::Sha384 => Sha384::digest(data).to_vec(),
+            MessageDigest::Sha512 => Sha512::digest(data).to_vec(),
+        })
+    }
+}
+
+macro_rules! verify_cose {
+    ($op:expr) => {
+        $op.map_err(|_| CoseError::UnverifiedSignature)
+    };
+}
+
+macro_rules! verify_signature {
+    ($self:ident, $curve:ident, $digest:ident, $signature:ident) => {{
+        let encoded_point: $curve::EncodedPoint =
+            verify_cose!($curve::EncodedPoint::from_bytes($self.public_key()))?;
+        let verifying_key: $curve::ecdsa::VerifyingKey = verify_cose!(
+            $curve::ecdsa::VerifyingKey::from_encoded_point(&encoded_point,)
+        )?;
+        let hex_string = hex::encode($signature);
+        let sig = verify_cose!($curve::ecdsa::Signature::from_str(&hex_string))?;
+        verify_cose!(verifying_key.verify_prehash($digest, &sig))
+    }};
+}
+
+struct NitroPublicKey<'a> {
+    spki: &'a SubjectPublicKeyInfo<'a>,
+}
+
+impl<'a> NitroPublicKey<'a> {
+    fn new(spki: &'a SubjectPublicKeyInfo<'a>) -> Result<Self> {
+        if spki.algorithm.algorithm.to_id_string() != "1.2.840.10045.2.1" {
+            bail!("attestation signing certificate does not contain an EC public key");
+        }
+        Ok(Self { spki })
+    }
+
+    fn public_key(&self) -> &[u8] {
+        self.spki.subject_public_key.as_ref()
+    }
+
+    fn verify_p256_signature(&self, digest: &[u8], signature: &[u8]) -> Result<(), CoseError> {
+        verify_signature!(self, p256, digest, signature)
+    }
+
+    fn verify_p384_signature(&self, digest: &[u8], signature: &[u8]) -> Result<(), CoseError> {
+        verify_signature!(self, p384, digest, signature)
+    }
+}
+
+impl SigningPublicKey for NitroPublicKey<'_> {
+    fn get_parameters(
+        &self,
+    ) -> std::result::Result<(SignatureAlgorithm, MessageDigest), CoseError> {
+        let parameters = self.spki.algorithm.parameters.as_ref().ok_or_else(|| {
+            CoseError::UnsupportedError("EC public key parameters are missing".to_string())
+        })?;
+        let curve_oid = parameters.as_oid().map_err(|_| {
+            CoseError::UnsupportedError(
+                "EC public key parameters must be a named curve".to_string(),
+            )
+        })?;
+
+        match curve_oid.to_id_string().as_str() {
+            "1.2.840.10045.3.1.7" => Ok((SignatureAlgorithm::ES256, MessageDigest::Sha256)),
+            "1.3.132.0.34" => Ok((SignatureAlgorithm::ES384, MessageDigest::Sha384)),
+            "1.3.132.0.35" => Ok((SignatureAlgorithm::ES512, MessageDigest::Sha512)),
+            oid => Err(CoseError::UnsupportedError(format!(
+                "unsupported EC curve: {oid}"
+            ))),
+        }
+    }
+
+    fn verify(&self, digest: &[u8], signature: &[u8]) -> std::result::Result<bool, CoseError> {
+        let (sig_alg, _) = self.get_parameters()?;
+        let result = match sig_alg {
+            SignatureAlgorithm::ES256 => self.verify_p256_signature(digest, signature),
+            SignatureAlgorithm::ES384 => self.verify_p384_signature(digest, signature),
+            SignatureAlgorithm::ES512 => Err(CoseError::UnsupportedError(
+                "P-521 Nitro attestation signatures are not supported".to_string(),
+            )),
+        };
+        result.map(|()| true).or_else(|_| Ok(false))
+    }
+}
+
+fn total_attestation_and_root_bytes(attestation_bytes: &[u8], trusted_roots: &[Vec<u8>]) -> u64 {
+    trusted_roots
+        .iter()
+        .fold(attestation_bytes.len() as u64, |total, root| {
+            total.saturating_add(root.len().max(1) as u64)
+        })
+}
+
+fn validate_cert_trust_chain_with_roots(
+    target: &[u8],
+    intermediates: &[&[u8]],
+    trusted_root_certs: &[Vec<u8>],
+    unix_time_secs: u64,
+) -> Result<()> {
+    if trusted_root_certs.is_empty() {
+        bail!("no trusted root certificates configured");
+    }
+
+    let end_entity_cert =
+        EndEntityCert::try_from(target).map_err(|_| anyhow!("invalid end-entity certificate"))?;
+    let trust_anchors = trusted_root_certs
+        .iter()
+        .map(|root| {
+            TrustAnchor::try_from_cert_der(root.as_slice())
+                .map_err(|_| anyhow!("invalid trusted root certificate"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let server_trust_anchors = webpki::TlsServerTrustAnchors(&trust_anchors);
+    let time = webpki::Time::from_seconds_since_unix_epoch(unix_time_secs);
+
+    end_entity_cert
+        .verify_is_valid_tls_server_cert(
+            SUPPORTED_SIG_ALGS,
+            &server_trust_anchors,
+            intermediates,
+            time,
+        )
+        .map_err(|err| anyhow!("invalid Nitro attestation certificate chain: {err:?}"))?;
+
+    Ok(())
+}
+
+fn validate_cose_signature(
+    signing_cert_public_key: &dyn SigningPublicKey,
+    cose_sign_1_decoded: &CoseSign1,
+) -> Result<()> {
+    if cose_sign_1_decoded
+        .verify_signature::<NitroCryptoClient>(signing_cert_public_key)
+        .map_err(|err| anyhow!("invalid Nitro attestation COSE envelope: {err}"))?
+    {
+        Ok(())
+    } else {
+        bail!("invalid Nitro attestation COSE signature")
+    }
+}
+
+fn validate_and_parse_attestation_doc_with_roots(
+    attestation_bytes: &[u8],
+    trusted_root_certs: &[Vec<u8>],
+    unix_time_secs: u64,
+) -> Result<AttestationDoc> {
+    let (cose_sign_1_decoded, decoded_attestation_doc) =
+        attestation_doc_validation::attestation_doc::decode_attestation_document(attestation_bytes)
+            .map_err(|err| anyhow!("invalid Nitro attestation document: {err}"))?;
+
+    let intermediate_certs = decoded_attestation_doc
+        .cabundle
+        .iter()
+        .map(|cert| cert.as_slice())
+        .collect::<Vec<_>>();
+    validate_cert_trust_chain_with_roots(
+        &decoded_attestation_doc.certificate,
+        &intermediate_certs,
+        trusted_root_certs,
+        unix_time_secs,
+    )?;
+
+    let attestation_doc_signing_cert =
+        attestation_doc_validation::parse_cert(&decoded_attestation_doc.certificate)
+            .map_err(|err| anyhow!("invalid Nitro attestation signing certificate: {err}"))?;
+    let pub_key = NitroPublicKey::new(attestation_doc_signing_cert.public_key())?;
+    validate_cose_signature(&pub_key, &cose_sign_1_decoded)?;
+
+    Ok(decoded_attestation_doc)
+}
+
+fn attestation_doc_to_move_value(
+    context: &SafeNativeContext,
+    doc: &AttestationDoc,
+) -> SafeNativeResult<Value> {
+    let module_id = Value::vector_u8(doc.module_id.as_bytes().to_vec());
+    let timestamp = Value::u64(doc.timestamp);
+    let digest = Value::vector_u8(digest_name(doc.digest).to_vec());
+    let pcrs_vec: Vec<Value> = doc
+        .pcrs
+        .iter()
+        .map(|(idx, val)| {
+            Value::struct_(Struct::pack(vec![
+                Value::u8((*idx) as u8),
+                Value::vector_u8(val.to_vec()),
+            ]))
+        })
+        .collect();
+    let pcrs_value = Value::vector_unchecked(pcrs_vec)?;
+    let certificate = Value::vector_u8(doc.certificate.to_vec());
+    let user_data = match &doc.user_data {
+        Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
+        None => option_none(context)?,
+    };
+    let nonce = match &doc.nonce {
+        Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
+        None => option_none(context)?,
+    };
+    let public_key = match &doc.public_key {
+        Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
+        None => option_none(context)?,
+    };
+
+    Ok(Value::struct_(Struct::pack(vec![
+        module_id,
+        timestamp,
+        digest,
+        pcrs_value,
+        certificate,
+        user_data,
+        nonce,
+        public_key,
+    ])))
+}
+
 /***************************************************************************************************
- * native fun verify_attestation
+ * native fun verify_attestation_with_roots
  *
- *   gas cost: base_cost + unit_cost * bytes_len
+ *   gas cost: base_cost + unit_cost * (attestation_bytes_len + trusted_root_bytes_len)
  *
- *   Returns true if the attestation document (COSE Sign1 bytes from AWS Nitro Enclave)
- *   is valid: well-formed, signed by the Nitro cert chain, and not expired.
- *   Returns false for invalid, malformed, or expired attestations.
+ *   Same as verify_attestation, but uses caller-provided DER root certificates and an explicit
+ *   Unix timestamp for certificate validity checks.
  **************************************************************************************************/
-fn native_verify_attestation(
+fn native_verify_attestation_with_roots(
     context: &mut SafeNativeContext,
     _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
-    safely_assert_eq!(args.len(), 1);
+    safely_assert_eq!(args.len(), 3);
 
+    let unix_time_secs = safely_pop_arg!(args, u64);
+    let mut trusted_root_certs = vec![];
+    for root in safely_pop_arg!(args, Vec<Value>) {
+        trusted_root_certs.push(root.value_as::<Vec<u8>>()?);
+    }
     let attestation_bytes = safely_pop_arg!(args, Vec<u8>);
 
     let cost = AWS_NITRO_VERIFY_ATTESTATION_BASE
-        + AWS_NITRO_VERIFY_ATTESTATION_PER_BYTE * NumBytes::new(attestation_bytes.len() as u64);
+        + AWS_NITRO_VERIFY_ATTESTATION_PER_BYTE
+            * NumBytes::new(total_attestation_and_root_bytes(
+                &attestation_bytes,
+                &trusted_root_certs,
+            ));
     context.charge(cost)?;
 
-    let valid = attestation_doc_validation::validate_attestation_doc(&attestation_bytes).is_ok();
+    let valid = validate_and_parse_attestation_doc_with_roots(
+        &attestation_bytes,
+        &trusted_root_certs,
+        unix_time_secs,
+    )
+    .is_ok();
 
     Ok(smallvec![Value::bool(valid)])
 }
 
 /***************************************************************************************************
- * native fun verify_and_parse_attestation
+ * native fun verify_and_parse_attestation_with_roots
  *
- *   gas cost: base_cost + unit_cost * bytes_len
+ *   gas cost: base_cost + unit_cost * (attestation_bytes_len + trusted_root_bytes_len)
  *
- *   Validates the attestation doc and on success returns Some(AttestationDoc) with
- *   module_id, timestamp, digest, pcrs, certificate, user_data, nonce, public_key.
+ *   Same as verify_and_parse_attestation, but uses caller-provided DER root certificates and an
+ *   explicit Unix timestamp for certificate validity checks.
  **************************************************************************************************/
-fn native_verify_and_parse_attestation(
+fn native_verify_and_parse_attestation_with_roots(
     context: &mut SafeNativeContext,
     _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
-    safely_assert_eq!(args.len(), 1);
+    safely_assert_eq!(args.len(), 3);
 
+    let unix_time_secs = safely_pop_arg!(args, u64);
+    let mut trusted_root_certs = vec![];
+    for root in safely_pop_arg!(args, Vec<Value>) {
+        trusted_root_certs.push(root.value_as::<Vec<u8>>()?);
+    }
     let attestation_bytes = safely_pop_arg!(args, Vec<u8>);
 
     let cost = AWS_NITRO_VERIFY_AND_PARSE_ATTESTATION_BASE
         + AWS_NITRO_VERIFY_AND_PARSE_ATTESTATION_PER_BYTE
-            * NumBytes::new(attestation_bytes.len() as u64);
+            * NumBytes::new(total_attestation_and_root_bytes(
+                &attestation_bytes,
+                &trusted_root_certs,
+            ));
     context.charge(cost)?;
 
-    let opt_doc = match attestation_doc_validation::validate_and_parse_attestation_doc(
+    let opt_doc = match validate_and_parse_attestation_doc_with_roots(
         &attestation_bytes,
+        &trusted_root_certs,
+        unix_time_secs,
     ) {
-        Ok(doc) => {
-            let module_id = Value::vector_u8(doc.module_id.as_bytes().to_vec());
-            let timestamp = Value::u64(doc.timestamp);
-            let digest = Value::vector_u8(format!("{:?}", doc.digest).into_bytes());
-            let pcrs_vec: Vec<Value> = doc
-                .pcrs
-                .iter()
-                .map(|(idx, val)| {
-                    Value::struct_(Struct::pack(vec![
-                        Value::u8((*idx) as u8),
-                        Value::vector_u8(val.to_vec()),
-                    ]))
-                })
-                .collect();
-            let pcrs_value = Value::vector_unchecked(pcrs_vec)?;
-            let certificate = Value::vector_u8(doc.certificate.to_vec());
-            let user_data = match &doc.user_data {
-                Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
-                None => option_none(context)?,
-            };
-            let nonce = match &doc.nonce {
-                Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
-                None => option_none(context)?,
-            };
-            let public_key = match &doc.public_key {
-                Some(b) => option_some(context, Value::vector_u8(b.to_vec()))?,
-                None => option_none(context)?,
-            };
-            let attestation_doc = Value::struct_(Struct::pack(vec![
-                module_id,
-                timestamp,
-                digest,
-                pcrs_value,
-                certificate,
-                user_data,
-                nonce,
-                public_key,
-            ]));
-            option_some(context, attestation_doc)?
-        }
+        Ok(doc) => option_some(context, attestation_doc_to_move_value(context, &doc)?)?,
         Err(_) => option_none(context)?,
     };
 
@@ -143,28 +383,40 @@ fn native_verify_and_parse_attestation(
 
 #[cfg(test)]
 mod tests {
-    /// Tests the same validation logic used by the native (attestation_doc_validation crate).
+    use super::*;
+
+    /// Tests the same root-aware validation path used by the native.
     #[test]
     fn test_empty_attestation_invalid() {
-        assert!(attestation_doc_validation::validate_attestation_doc(&[]).is_err());
+        assert!(validate_and_parse_attestation_doc_with_roots(&[], &[], 0).is_err());
     }
 
     #[test]
     fn test_garbage_attestation_invalid() {
         let garbage = [0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-        assert!(attestation_doc_validation::validate_attestation_doc(&garbage).is_err());
+        assert!(validate_and_parse_attestation_doc_with_roots(&garbage, &[], 0).is_err());
     }
 
     /// Happy path: real attestation doc from AWS Nitro Enclave.
     /// Run with: cargo test -p aptos-framework test_real_attestation -- --ignored
-    /// (Requires /tmp/attestation-3586.bin to exist.)
+    /// (Requires /tmp/attestation-3586.bin and /tmp/aws-nitro-root.der to exist.)
     #[test]
-    #[ignore = "requires real attestation doc at /tmp/attestation-3586.bin"]
+    #[ignore = "requires real attestation doc at /tmp/attestation-3586.bin and Nitro root DER at /tmp/aws-nitro-root.der"]
     fn test_real_attestation_valid() {
         let path = std::path::Path::new("/tmp/attestation-3586.bin");
         let bytes = std::fs::read(path).expect("attestation doc at /tmp/attestation-3586.bin");
+        let root = std::fs::read("/tmp/aws-nitro-root.der")
+            .expect("Nitro root DER at /tmp/aws-nitro-root.der");
+        let (_, decoded_doc) =
+            attestation_doc_validation::attestation_doc::decode_attestation_document(&bytes)
+                .expect("real attestation doc should decode");
         assert!(
-            attestation_doc_validation::validate_attestation_doc(&bytes).is_ok(),
+            validate_and_parse_attestation_doc_with_roots(
+                &bytes,
+                &[root],
+                decoded_doc.timestamp / 1000,
+            )
+            .is_ok(),
             "real attestation doc should validate"
         );
     }
@@ -172,12 +424,21 @@ mod tests {
     /// Happy path for verify_and_parse: real attestation doc parses and has expected fields.
     /// Run with: cargo test -p aptos-framework test_real_attestation_parse -- --ignored
     #[test]
-    #[ignore = "requires real attestation doc at /tmp/attestation-3586.bin"]
+    #[ignore = "requires real attestation doc at /tmp/attestation-3586.bin and Nitro root DER at /tmp/aws-nitro-root.der"]
     fn test_real_attestation_parse() {
         let path = std::path::Path::new("/tmp/attestation-3586.bin");
         let bytes = std::fs::read(path).expect("attestation doc at /tmp/attestation-3586.bin");
-        let doc = attestation_doc_validation::validate_and_parse_attestation_doc(&bytes)
-            .expect("real attestation doc should parse");
+        let root = std::fs::read("/tmp/aws-nitro-root.der")
+            .expect("Nitro root DER at /tmp/aws-nitro-root.der");
+        let (_, decoded_doc) =
+            attestation_doc_validation::attestation_doc::decode_attestation_document(&bytes)
+                .expect("real attestation doc should decode");
+        let doc = validate_and_parse_attestation_doc_with_roots(
+            &bytes,
+            &[root],
+            decoded_doc.timestamp / 1000,
+        )
+        .expect("real attestation doc should parse");
         assert!(!doc.module_id.is_empty(), "module_id non-empty");
         assert!(!doc.certificate.is_empty(), "certificate non-empty");
         assert!(!doc.pcrs.is_empty(), "pcrs non-empty");
@@ -192,10 +453,13 @@ pub fn make_all(
     builder: &SafeNativeBuilder,
 ) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
     let natives = [
-        ("verify_attestation", native_verify_attestation as RawSafeNative),
         (
-            "verify_and_parse_attestation",
-            native_verify_and_parse_attestation as RawSafeNative,
+            "verify_attestation_with_roots",
+            native_verify_attestation_with_roots as RawSafeNative,
+        ),
+        (
+            "verify_and_parse_attestation_with_roots",
+            native_verify_and_parse_attestation_with_roots as RawSafeNative,
         ),
     ];
 

--- a/aptos-move/framework/natives/src/aws_nitro_utils.rs
+++ b/aptos-move/framework/natives/src/aws_nitro_utils.rs
@@ -223,7 +223,7 @@ fn validate_cose_signature(
     }
 }
 
-fn validate_and_parse_attestation_doc_with_roots(
+pub(crate) fn validate_and_parse_attestation_doc_with_roots(
     attestation_bytes: &[u8],
     trusted_root_certs: &[Vec<u8>],
     unix_time_secs: u64,

--- a/aptos-move/framework/natives/src/aws_nitro_utils.rs
+++ b/aptos-move/framework/natives/src/aws_nitro_utils.rs
@@ -30,11 +30,11 @@ use move_vm_types::{
 };
 use sha2_0_10_6::{Digest as Sha2Digest, Sha256, Sha384, Sha512};
 use smallvec::{smallvec, SmallVec};
-use std::{collections::VecDeque, str::FromStr};
+use std::collections::VecDeque;
 use webpki::{EndEntityCert, TrustAnchor};
 use x509_parser::x509::SubjectPublicKeyInfo;
 
-static SUPPORTED_SIG_ALGS: &[&webpki::SignatureAlgorithm] = &[
+pub(crate) static SUPPORTED_SIG_ALGS: &[&webpki::SignatureAlgorithm] = &[
     &webpki::ECDSA_P256_SHA256,
     &webpki::ECDSA_P256_SHA384,
     &webpki::ECDSA_P384_SHA256,
@@ -100,18 +100,17 @@ macro_rules! verify_signature {
         let verifying_key: $curve::ecdsa::VerifyingKey = verify_cose!(
             $curve::ecdsa::VerifyingKey::from_encoded_point(&encoded_point,)
         )?;
-        let hex_string = hex::encode($signature);
-        let sig = verify_cose!($curve::ecdsa::Signature::from_str(&hex_string))?;
+        let sig = verify_cose!($curve::ecdsa::Signature::from_slice($signature))?;
         verify_cose!(verifying_key.verify_prehash($digest, &sig))
     }};
 }
 
-struct NitroPublicKey<'a> {
+pub(crate) struct NitroPublicKey<'a> {
     spki: &'a SubjectPublicKeyInfo<'a>,
 }
 
 impl<'a> NitroPublicKey<'a> {
-    fn new(spki: &'a SubjectPublicKeyInfo<'a>) -> Result<Self> {
+    pub(crate) fn new(spki: &'a SubjectPublicKeyInfo<'a>) -> Result<Self> {
         if spki.algorithm.algorithm.to_id_string() != "1.2.840.10045.2.1" {
             bail!("attestation signing certificate does not contain an EC public key");
         }
@@ -175,7 +174,7 @@ fn total_attestation_and_root_bytes(attestation_bytes: &[u8], trusted_roots: &[V
         })
 }
 
-fn validate_cert_trust_chain_with_roots(
+pub(crate) fn validate_cert_trust_chain_with_roots(
     target: &[u8],
     intermediates: &[&[u8]],
     trusted_root_certs: &[Vec<u8>],
@@ -209,7 +208,7 @@ fn validate_cert_trust_chain_with_roots(
     Ok(())
 }
 
-fn validate_cose_signature(
+pub(crate) fn validate_cose_signature(
     signing_cert_public_key: &dyn SigningPublicKey,
     cose_sign_1_decoded: &CoseSign1,
 ) -> Result<()> {

--- a/aptos-move/framework/natives/src/lib.rs
+++ b/aptos-move/framework/natives/src/lib.rs
@@ -6,8 +6,8 @@
 pub mod account;
 
 pub mod account_abstraction;
-pub mod aws_nitro_utils;
 pub mod aggregator_natives;
+pub mod aws_nitro_utils;
 pub mod code;
 pub mod consensus_config;
 pub mod create_signer;

--- a/aptos-move/framework/natives/src/lib.rs
+++ b/aptos-move/framework/natives/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod account;
 
 pub mod account_abstraction;
+pub mod aws_nitro_utils;
 pub mod aggregator_natives;
 pub mod code;
 pub mod consensus_config;
@@ -59,6 +60,7 @@ pub fn all_natives(
     }
 
     add_natives_from_module!("account", account::make_all(builder));
+    add_natives_from_module!("aws_nitro_utils", aws_nitro_utils::make_all(builder));
     add_natives_from_module!("create_signer", create_signer::make_all(builder));
     add_natives_from_module!("ed25519", ed25519::make_all(builder));
     add_natives_from_module!("crypto_algebra", cryptography::algebra::make_all(builder));

--- a/aptos-move/move-examples/poker/LOCAL_AWS_E2E.md
+++ b/aptos-move/move-examples/poker/LOCAL_AWS_E2E.md
@@ -1,0 +1,454 @@
+# Localnet + AWS Nitro E2E
+
+This is the repeatable smoke path for running the poker example with:
+
+- an Aptos localnet on your laptop,
+- the AWS Nitro root initialized on-chain,
+- the poker table client running on an AWS EC2 parent instance,
+- a Nitro Enclave producing the table attestation document,
+- the player client running locally.
+
+The flow validated on 2026-06-17 was:
+
+```text
+localnet -> initialize Nitro root store -> publish poker
+AWS Nitro Enclave -> attestation doc bound to table address
+AWS table client -> register_table over SSH reverse tunnel
+local player client -> enter / request_leave
+table signer -> settle_leaving_players
+```
+
+## Prerequisites
+
+- AWS CLI configured for an account that can launch EC2 instances with Nitro Enclaves enabled.
+- Docker available on the AWS parent instance. The commands below install it on Amazon Linux 2.
+- Built local Aptos binaries:
+
+```bash
+cargo build -p aptos --bin aptos
+cargo build -p aptos-framework --bin aptos-framework
+cargo build -p aptos-node --bin aptos-node
+cargo build -p aptos-faucet-service --bin aptos-faucet-service
+```
+
+## 1. Start Localnet
+
+From the repo root:
+
+```bash
+export REPO="$PWD"
+export WORK=/tmp/aptos-poker-e2e
+rm -rf "$WORK"
+mkdir -p "$WORK/framework"
+
+(
+  cd "$WORK/framework"
+  "$REPO/target/debug/aptos-framework" release --target head
+)
+
+"$REPO/target/debug/aptos-node" \
+  --test \
+  --test-dir "$WORK/localnet" \
+  --genesis-framework "$WORK/framework/head.mrb"
+```
+
+In another terminal:
+
+```bash
+"$REPO/target/debug/aptos-faucet-service" run-simple \
+  --node-url http://127.0.0.1:8080 \
+  --chain-id 4 \
+  --key-file-path "$WORK/localnet/mint.key" \
+  --listen-address 0.0.0.0 \
+  --listen-port 8081
+```
+
+## 2. Initialize Nitro Roots
+
+Download the AWS Nitro Enclaves root certificate and convert it to DER:
+
+```bash
+mkdir -p "$WORK/aws-roots"
+curl -fsSL \
+  https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip \
+  -o "$WORK/aws-roots/AWS_NitroEnclaves_Root-G1.zip"
+unzip -o "$WORK/aws-roots/AWS_NitroEnclaves_Root-G1.zip" -d "$WORK/aws-roots"
+openssl x509 -in "$WORK/aws-roots/root.pem" -outform DER -out "$WORK/aws-roots/root.der"
+openssl x509 -in "$WORK/aws-roots/root.pem" -noout -subject -issuer -fingerprint -sha256 -dates
+```
+
+The DER file should be 533 bytes. The root used in this smoke test had SHA-256 fingerprint:
+
+```text
+64:1A:03:21:A3:E2:44:EF:E4:56:46:31:95:D6:06:31:7E:D7:CD:CC:3C:17:56:E0:98:93:F3:C6:8F:79:BB:5B
+```
+
+Initialize the on-chain root store with the localnet core resources key. The sender is `0xa550c18`, not `0x1`; the entry function obtains the `0x1` signer through `aptos_governance::get_signer_testnet_only`.
+
+```bash
+ROOT_HEX="$(xxd -p -c 0 "$WORK/aws-roots/root.der")"
+"$REPO/target/debug/aptos" move run \
+  --url http://127.0.0.1:8080 \
+  --sender-account 0xa550c18 \
+  --private-key-file "$WORK/localnet/mint.key" \
+  --encoding bcs \
+  --function-id 0x1::aws_nitro_utils::initialize_testnet_only \
+  --args "hex:[\"0x${ROOT_HEX}\"]" \
+  --max-gas 100000 \
+  --assume-yes
+
+"$REPO/target/debug/aptos" move view \
+  --url http://127.0.0.1:8080 \
+  --function-id 0x1::aws_nitro_utils::trusted_root_count
+```
+
+Expected result:
+
+```json
+{ "Result": [ "1" ] }
+```
+
+## 3. Create Accounts And Publish Poker
+
+Generate table and player keys:
+
+```bash
+mkdir -p "$WORK/keys"
+"$REPO/target/debug/aptos" key generate --output-file "$WORK/keys/table.key" --encoding hex --assume-yes
+"$REPO/target/debug/aptos" key generate --output-file "$WORK/keys/player.key" --encoding hex --assume-yes
+```
+
+Derive addresses:
+
+```bash
+(
+  cd "$REPO/aptos-move/move-examples/poker/clients"
+  npm install --package-lock=false
+  node - <<'NODE'
+const fs = require("fs");
+const { Account, Ed25519PrivateKey } = require("@aptos-labs/ts-sdk");
+for (const name of ["table", "player"]) {
+  const pk = fs.readFileSync(`/tmp/aptos-poker-e2e/keys/${name}.key`, "utf8").trim();
+  const account = Account.fromPrivateKey({ privateKey: new Ed25519PrivateKey(pk) });
+  console.log(`${name.toUpperCase()}_PRIVATE_KEY=0x${pk}`);
+  console.log(`${name.toUpperCase()}_ADDRESS=${account.accountAddress.toStringLong()}`);
+}
+NODE
+)
+```
+
+Export those values:
+
+```bash
+export TABLE_PRIVATE_KEY=0x...
+export TABLE_ADDRESS=0x...
+export PLAYER_PRIVATE_KEY=0x...
+export PLAYER_ADDRESS=0x...
+```
+
+Fund both accounts:
+
+```bash
+"$REPO/target/debug/aptos" account fund-with-faucet \
+  --url http://127.0.0.1:8080 \
+  --faucet-url http://127.0.0.1:8081 \
+  --account "$TABLE_ADDRESS" \
+  --amount 100000000000
+
+"$REPO/target/debug/aptos" account fund-with-faucet \
+  --url http://127.0.0.1:8080 \
+  --faucet-url http://127.0.0.1:8081 \
+  --account "$PLAYER_ADDRESS" \
+  --amount 100000000000
+```
+
+Publish from a temporary package copy that uses the local framework:
+
+```bash
+rm -rf "$WORK/poker"
+rsync -a --exclude node_modules "$REPO/aptos-move/move-examples/poker/" "$WORK/poker/"
+python3 - <<PY
+from pathlib import Path
+p = Path("$WORK/poker/Move.toml")
+s = p.read_text()
+s = s.replace(
+    'AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }',
+    'AptosFramework = { local = "' + "$REPO" + '/aptos-move/framework/aptos-framework" }',
+)
+p.write_text(s)
+PY
+
+"$REPO/target/debug/aptos" move publish \
+  --url http://127.0.0.1:8080 \
+  --package-dir "$WORK/poker" \
+  --named-addresses poker="$TABLE_ADDRESS" \
+  --sender-account "$TABLE_ADDRESS" \
+  --private-key-file "$WORK/keys/table.key" \
+  --encoding hex \
+  --skip-fetch-latest-git-deps \
+  --max-gas 200000 \
+  --assume-yes
+```
+
+## 4. Launch AWS Parent Instance
+
+These commands create temporary AWS resources. Clean them up at the end.
+
+```bash
+export AWS_REGION=us-west-2
+export AWS_NAME=aptos-poker-e2e
+export MY_IP="$(curl -fsSL https://checkip.amazonaws.com | tr -d '\n')"
+export VPC_ID="$(aws ec2 describe-vpcs \
+  --filters Name=is-default,Values=true \
+  --query 'Vpcs[0].VpcId' \
+  --output text)"
+export SUBNET_ID="$(aws ec2 describe-subnets \
+  --filters Name=default-for-az,Values=true \
+  --query 'Subnets[0].SubnetId' \
+  --output text)"
+export AMI_ID="$(aws ec2 describe-images \
+  --owners amazon \
+  --filters 'Name=name,Values=amzn2-ami-hvm-2.0.*-x86_64-gp2' 'Name=state,Values=available' \
+  --query 'sort_by(Images,&CreationDate)[-1].ImageId' \
+  --output text)"
+
+aws ec2 create-key-pair \
+  --key-name "${AWS_NAME}-key" \
+  --query KeyMaterial \
+  --output text > "$WORK/aws-key.pem"
+chmod 600 "$WORK/aws-key.pem"
+
+export SG_ID="$(aws ec2 create-security-group \
+  --group-name "${AWS_NAME}-sg" \
+  --description "Temporary SSH access for Aptos poker Nitro E2E" \
+  --vpc-id "$VPC_ID" \
+  --query GroupId \
+  --output text)"
+
+aws ec2 authorize-security-group-ingress \
+  --group-id "$SG_ID" \
+  --protocol tcp \
+  --port 22 \
+  --cidr "${MY_IP}/32"
+
+export INSTANCE_ID="$(aws ec2 run-instances \
+  --image-id "$AMI_ID" \
+  --instance-type m5.xlarge \
+  --key-name "${AWS_NAME}-key" \
+  --network-interfaces "DeviceIndex=0,SubnetId=${SUBNET_ID},Groups=${SG_ID},AssociatePublicIpAddress=true" \
+  --enclave-options Enabled=true \
+  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${AWS_NAME}},{Key=Purpose,Value=${AWS_NAME}}]" \
+  --query 'Instances[0].InstanceId' \
+  --output text)"
+
+aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+export PUBLIC_IP="$(aws ec2 describe-instances \
+  --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].PublicIpAddress' \
+  --output text)"
+```
+
+Install dependencies on the AWS parent:
+
+```bash
+ssh -o StrictHostKeyChecking=no -i "$WORK/aws-key.pem" ec2-user@"$PUBLIC_IP" '
+set -euxo pipefail
+sudo amazon-linux-extras install -y aws-nitro-enclaves-cli docker
+sudo yum install -y aws-nitro-enclaves-cli-devel jq gcc make git
+sudo systemctl enable --now docker
+sudo usermod -aG docker,ne ec2-user || true
+sudo sed -i "s/^memory_mib:.*/memory_mib: 2048/" /etc/nitro_enclaves/allocator.yaml
+sudo sed -i "s/^cpu_count:.*/cpu_count: 2/" /etc/nitro_enclaves/allocator.yaml
+sudo systemctl enable --now nitro-enclaves-allocator.service
+'
+```
+
+Amazon Linux 2 cannot install Node 20 from NodeSource because its glibc is too old. Install Node 16 for this smoke client:
+
+```bash
+ssh -i "$WORK/aws-key.pem" ec2-user@"$PUBLIC_IP" '
+set -euxo pipefail
+sudo rm -f /etc/yum.repos.d/nodesource*.repo
+curl -fsSL https://rpm.nodesource.com/setup_16.x | sudo bash -
+sudo yum clean all
+sudo yum install -y nodejs-16.20.2-1nodesource
+node --version
+npm --version
+'
+```
+
+## 5. Build And Run The Nitro Attester
+
+The table attestation must bind to:
+
+```text
+user_data = b"APTOS_POKER_TABLE_V1" || bcs(table_address)
+```
+
+For an Aptos address, `bcs(address)` is the 32-byte address.
+
+```bash
+export USER_DATA_HEX="$(python3 - <<PY
+domain = b"APTOS_POKER_TABLE_V1"
+addr_hex = "$TABLE_ADDRESS"
+addr = bytes.fromhex(addr_hex[2:] if addr_hex.startswith("0x") else addr_hex)
+print((domain + addr).hex())
+PY
+)"
+
+rsync -az -e "ssh -i $WORK/aws-key.pem" \
+  "$REPO/aptos-move/move-examples/poker/e2e/nitro-attester/" \
+  ec2-user@"$PUBLIC_IP":/home/ec2-user/attester/
+
+ssh -i "$WORK/aws-key.pem" ec2-user@"$PUBLIC_IP" "
+set -euxo pipefail
+cd ~/attester
+sudo docker build --build-arg USER_DATA_HEX=$USER_DATA_HEX -t aptos-poker-attester:latest .
+sudo nitro-cli build-enclave --docker-uri aptos-poker-attester:latest --output-file aptos-poker-attester.eif
+sudo nitro-cli run-enclave \
+  --eif-path /home/ec2-user/attester/aptos-poker-attester.eif \
+  --cpu-count 2 \
+  --memory 1024 \
+  --enclave-cid 16 \
+  --debug-mode
+"
+```
+
+For this smoke test, `--debug-mode` is used only so the parent can read stdout through `nitro-cli console`. Production table runners should use a vsock channel and should not run debug enclaves.
+
+Capture the attestation document:
+
+```bash
+ssh -i "$WORK/aws-key.pem" ec2-user@"$PUBLIC_IP"
+ENCLAVE_ID="$(sudo nitro-cli describe-enclaves | jq -r '.[0].EnclaveID')"
+sudo nitro-cli console --enclave-id "$ENCLAVE_ID" | tee ~/attestation_console.txt
+```
+
+After you see `ATTESTATION_DOC_BASE64=...`, press `Ctrl-C`, then decode it:
+
+```bash
+python3 - <<'PY'
+import base64, re, pathlib
+data = pathlib.Path("/home/ec2-user/attestation_console.txt").read_bytes()
+matches = re.findall(rb"ATTESTATION_DOC_BASE64=([A-Za-z0-9+/=\r\n]+)", data)
+assert matches, "missing ATTESTATION_DOC_BASE64"
+s = re.sub(rb"[^A-Za-z0-9+/=]", b"", matches[-1])
+doc = base64.b64decode(s, validate=False)
+pathlib.Path("/home/ec2-user/attestation_doc.bin").write_bytes(doc)
+print(len(doc), doc[:32].hex())
+PY
+```
+
+The run above produced a 4513-byte COSE attestation document.
+
+## 6. Register Table From AWS
+
+Open a reverse tunnel from your laptop to the AWS parent. Keep this terminal open:
+
+```bash
+ssh -N \
+  -o ExitOnForwardFailure=yes \
+  -o ServerAliveInterval=30 \
+  -i "$WORK/aws-key.pem" \
+  -R 8080:127.0.0.1:8080 \
+  ec2-user@"$PUBLIC_IP"
+```
+
+On the AWS parent:
+
+```bash
+rsync -az --exclude node_modules -e "ssh -i $WORK/aws-key.pem" \
+  "$REPO/aptos-move/move-examples/poker/clients/" \
+  ec2-user@"$PUBLIC_IP":/home/ec2-user/poker-clients/
+
+ssh -i "$WORK/aws-key.pem" ec2-user@"$PUBLIC_IP" '
+set -euxo pipefail
+cd ~/poker-clients
+npm install --package-lock=false
+NODE_URL=http://127.0.0.1:8080/v1 \
+TABLE_PRIVATE_KEY='"$TABLE_PRIVATE_KEY"' \
+POKER_MODULE_ADDRESS='"$TABLE_ADDRESS"' \
+ATTESTATION_DOC_PATH=/home/ec2-user/attestation_doc.bin \
+node table-client.js
+'
+```
+
+Expected output includes:
+
+```text
+Table registered. Tx: 0x...
+```
+
+## 7. Run Player Flow Locally
+
+Back on your laptop:
+
+```bash
+cd "$REPO/aptos-move/move-examples/poker/clients"
+npm install --package-lock=false
+
+NODE_URL=http://127.0.0.1:8080/v1 \
+PLAYER_PRIVATE_KEY="$PLAYER_PRIVATE_KEY" \
+POKER_MODULE_ADDRESS="$TABLE_ADDRESS" \
+node player-client.js enter "$TABLE_ADDRESS" 1000
+
+NODE_URL=http://127.0.0.1:8080/v1 \
+PLAYER_PRIVATE_KEY="$PLAYER_PRIVATE_KEY" \
+POKER_MODULE_ADDRESS="$TABLE_ADDRESS" \
+node player-client.js balance "$TABLE_ADDRESS"
+
+NODE_URL=http://127.0.0.1:8080/v1 \
+PLAYER_PRIVATE_KEY="$PLAYER_PRIVATE_KEY" \
+POKER_MODULE_ADDRESS="$TABLE_ADDRESS" \
+node player-client.js leave "$TABLE_ADDRESS"
+```
+
+Settle the leaving player with the table signer:
+
+```bash
+"$REPO/target/debug/aptos" move run \
+  --url http://127.0.0.1:8080 \
+  --sender-account "$TABLE_ADDRESS" \
+  --private-key-file "$WORK/keys/table.key" \
+  --encoding hex \
+  --function-id "${TABLE_ADDRESS}::poker::settle_leaving_players" \
+  --args address:"$TABLE_ADDRESS" "address:[\"$PLAYER_ADDRESS\"]" \
+  --max-gas 100000 \
+  --assume-yes
+
+NODE_URL=http://127.0.0.1:8080/v1 \
+PLAYER_PRIVATE_KEY="$PLAYER_PRIVATE_KEY" \
+POKER_MODULE_ADDRESS="$TABLE_ADDRESS" \
+node player-client.js balance "$TABLE_ADDRESS"
+```
+
+Expected final chip balance:
+
+```text
+Chip balance: [ '0' ]
+```
+
+## Cleanup
+
+Stop local long-running processes:
+
+```bash
+# Stop the localnet, faucet, and SSH tunnel terminals with Ctrl-C.
+```
+
+Terminate the enclave and EC2 resources:
+
+```bash
+ssh -i "$WORK/aws-key.pem" ec2-user@"$PUBLIC_IP" 'sudo nitro-cli terminate-enclave --all || true'
+aws ec2 terminate-instances --instance-ids "$INSTANCE_ID"
+aws ec2 wait instance-terminated --instance-ids "$INSTANCE_ID"
+aws ec2 delete-key-pair --key-name "${AWS_NAME}-key"
+aws ec2 delete-security-group --group-id "$SG_ID"
+rm -f "$WORK/aws-key.pem"
+```
+
+## Notes
+
+- `NODE_URL` is intentionally `http://.../v1` for these JS clients.
+- `initialize_testnet_only` is for localnet/testnet-style development. Production root changes should go through governance.
+- The smoke attester uses console output and debug mode for convenience. A production table runner should keep signing/table logic inside the enclave and send transactions through a parent vsock proxy.

--- a/aptos-move/move-examples/poker/LOCAL_AWS_E2E.md
+++ b/aptos-move/move-examples/poker/LOCAL_AWS_E2E.md
@@ -31,6 +31,18 @@ cargo build -p aptos-node --bin aptos-node
 cargo build -p aptos-faucet-service --bin aptos-faucet-service
 ```
 
+## Gas Notes
+
+The `--max-gas` values below are transaction gas-unit caps, not the gas fee. They are deliberately conservative for localnet repeatability. In the run used to validate this guide, actual `gas_used` was much lower:
+
+```text
+initialize_testnet_only: 6580
+publish poker: 40285
+settle_leaving_players: 131
+```
+
+The paid fee is `gas_used * gas_unit_price`; on this localnet run the CLI used `gas_unit_price = 100` octas.
+
 ## 1. Start Localnet
 
 From the repo root:

--- a/aptos-move/move-examples/poker/Move.toml
+++ b/aptos-move/move-examples/poker/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = 'poker'
+version = '1.0.0'
+
+[addresses]
+poker = "_"
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/poker/README.md
+++ b/aptos-move/move-examples/poker/README.md
@@ -1,0 +1,84 @@
+# Poker (Nitro Enclave Multiplayer Example)
+
+A small multiplayer poker dapp that uses **AWS Nitro Enclave** attestation so the game server (table) runs in a TEE. Players lock APT as chips, play hands, and can leave after the current hand; on exit they receive 95% of their balance (5% fee to the table).
+
+## Architecture
+
+- **On-chain (Move)**  
+  - Table registration (only with valid Nitro attestation).  
+  - Player **enter_table**: lock APT as chips.  
+  - Player **request_leave**: leave after current hand.  
+  - **settle_hand**: table applies hand result (chip deltas).  
+  - **settle_leaving_players**: pay out leavers (95% to player, 5% to table fee pool).
+
+- **Table client (runs in TEE)**  
+  - Creates/funds the table account, gets Nitro attestation, calls `register_table` on-chain.  
+  - Runs hands one after another; if there are not enough players, waits.  
+  - Submits `settle_hand` and `settle_leaving_players` after each hand.
+
+- **Player client**  
+  - **Enter**: send transaction to `enter_table` with table address and APT amount.  
+  - **Leave**: send `request_leave`; balance is returned (minus 5% fee) after the current hand when the table calls `settle_leaving_players`.
+
+## Move API (summary)
+
+| Function | Who | Description |
+|----------|-----|-------------|
+| `register_table(table, attestation_doc)` | Table (TEE) | Register table; requires `aws_nitro_utils::verify_attestation`. |
+| `enter_table(table_addr, player, amount)` | Player | Lock APT as chips and join from next hand. |
+| `request_leave(table_addr, player)` | Player | Request to leave after current hand. |
+| `settle_hand(table, table_addr, deduct_from, deduct_amounts, add_to, add_amounts)` | Table | Apply hand result (conservation: sum deduct = sum add). |
+| `settle_leaving_players(table, table_addr, leaving_players)` | Table | Process leavers: 95% to player, 5% to table. |
+
+Views: `table_exists`, `min_players`, `player_balance`, `player_pending_leave`.
+
+## Table client (TEE)
+
+The table client is intended to run inside an **AWS Nitro Enclave**:
+
+1. **Bootstrap**  
+   - Create/fund the table account (e.g. with Aptos SDK).  
+   - Get attestation document from the Nitro NSM (e.g. `nsm_fd` / GetAttestationDocument).  
+   - Call `register_table(table_signer, attestation_doc)`.
+
+2. **Game loop**  
+   - Wait until at least `min_players` (e.g. 2) are seated (query `player_balance` / events).  
+   - Run one hand (deal, betting, winner) off-chain.  
+   - Build `deduct_from` / `deduct_amounts` and `add_to` / `add_amounts` from the hand result.  
+   - Submit `settle_hand(table, table_addr, deduct_from, deduct_amounts, add_to, add_amounts)`.  
+   - Collect addresses that requested leave (from events or local state) and call  
+     `settle_leaving_players(table, table_addr, leaving_players)`.  
+   - Repeat; if not enough players, wait and retry.
+
+See `clients/` for a minimal table client (dev: mock attestation) and player client.
+
+## Player client
+
+- **Enter table**: sign and submit `enter_table(table_addr, amount)` (must have approved APT).  
+- **Leave**: sign and submit `request_leave(table_addr)`; funds are sent when the table runs `settle_leaving_players` for that hand.
+
+## Fee
+
+- On leave, 5% of the returned balance is kept by the table; 95% is sent back to the player.
+
+## Build and test (Move)
+
+From the repo root, use the Move examples test harness (uses local framework with `aws_nitro_utils`):
+
+```bash
+cargo test -p aptos-move-examples test_poker -- --nocapture
+```
+
+Or compile the package (with a framework that includes Nitro utils):
+
+```bash
+cd aptos-move/move-examples/poker
+aptos move compile
+```
+
+## Test-only entry
+
+For unit tests, attestation is bypassed with:
+
+- `register_table_for_test(table)`  
+  so tests don’t need a real Nitro attestation document.

--- a/aptos-move/move-examples/poker/README.md
+++ b/aptos-move/move-examples/poker/README.md
@@ -52,7 +52,7 @@ The table client is intended to run inside an **AWS Nitro Enclave**:
      `settle_leaving_players(table, table_addr, leaving_players)`.  
    - Repeat; if not enough players, wait and retry.
 
-See `clients/` for a minimal table client (dev: placeholder attestation) and player client.
+See `clients/` for a minimal table client and player client. For the localnet plus AWS Nitro smoke path that was run end to end, see [`LOCAL_AWS_E2E.md`](LOCAL_AWS_E2E.md).
 
 ## Player client
 

--- a/aptos-move/move-examples/poker/README.md
+++ b/aptos-move/move-examples/poker/README.md
@@ -5,7 +5,8 @@ A small multiplayer poker dapp that uses **AWS Nitro Enclave** attestation so th
 ## Architecture
 
 - **On-chain (Move)**  
-  - Table registration (only with valid Nitro attestation).  
+  - Table registration only with a valid Nitro attestation rooted in the chain-managed Nitro root store.
+  - The attestation must bind the TEE to the table account with `user_data = b"APTOS_POKER_TABLE_V1" || bcs(table_address)`.
   - Player **enter_table**: lock APT as chips.  
   - Player **request_leave**: leave after current hand.  
   - **settle_hand**: table applies hand result (chip deltas).  
@@ -24,9 +25,9 @@ A small multiplayer poker dapp that uses **AWS Nitro Enclave** attestation so th
 
 | Function | Who | Description |
 |----------|-----|-------------|
-| `register_table(table, attestation_doc)` | Table (TEE) | Register table; requires `aws_nitro_utils::verify_attestation`. |
-| `enter_table(table_addr, player, amount)` | Player | Lock APT as chips and join from next hand. |
-| `request_leave(table_addr, player)` | Player | Request to leave after current hand. |
+| `register_table(table, attestation_doc)` | Table (TEE) | Register table; verifies Nitro attestation with `aws_nitro_utils::verify_attestation_user_data`, requiring `user_data` to be bound to the table address. |
+| `enter_table(player, table_addr, amount)` | Player | Lock APT as chips and join from next hand. |
+| `request_leave(player, table_addr)` | Player | Request to leave after current hand. |
 | `settle_hand(table, table_addr, deduct_from, deduct_amounts, add_to, add_amounts)` | Table | Apply hand result (conservation: sum deduct = sum add). |
 | `settle_leaving_players(table, table_addr, leaving_players)` | Table | Process leavers: 95% to player, 5% to table. |
 
@@ -37,8 +38,9 @@ Views: `table_exists`, `min_players`, `player_balance`, `player_pending_leave`.
 The table client is intended to run inside an **AWS Nitro Enclave**:
 
 1. **Bootstrap**  
+   - Ensure the chain-managed Nitro root store has been initialized by framework governance with the AWS Nitro root certificate DER bytes.
    - Create/fund the table account (e.g. with Aptos SDK).  
-   - Get attestation document from the Nitro NSM (e.g. `nsm_fd` / GetAttestationDocument).  
+   - Get an attestation document from the Nitro NSM (e.g. `nsm_fd` / GetAttestationDocument) with `user_data = b"APTOS_POKER_TABLE_V1" || bcs(table_address)`.
    - Call `register_table(table_signer, attestation_doc)`.
 
 2. **Game loop**  
@@ -50,7 +52,7 @@ The table client is intended to run inside an **AWS Nitro Enclave**:
      `settle_leaving_players(table, table_addr, leaving_players)`.  
    - Repeat; if not enough players, wait and retry.
 
-See `clients/` for a minimal table client (dev: mock attestation) and player client.
+See `clients/` for a minimal table client (dev: placeholder attestation) and player client.
 
 ## Player client
 

--- a/aptos-move/move-examples/poker/clients/README.md
+++ b/aptos-move/move-examples/poker/clients/README.md
@@ -1,0 +1,40 @@
+# Poker clients
+
+- **table-client** – Runs in TEE: register table (with Nitro attestation), then run the game loop (wait for players, run hand, `settle_hand`, `settle_leaving_players`).
+- **player-client** – Enter table (lock APT as chips) and request leave.
+
+## Setup
+
+```bash
+cd aptos-move/move-examples/poker/clients
+npm install
+```
+
+Set env or edit:
+
+- `NODE_URL` – Aptos node URL (e.g. https://fullnode.devnet.aptoslabs.com).
+- `TABLE_PRIVATE_KEY` – Hex private key for the table account (TEE).
+- `PLAYER_PRIVATE_KEY` – Hex private key for the player (player-client).
+
+Deploy the poker module and set `POKER_MODULE_ADDRESS` (e.g. the address where `poker` is published).
+
+## Table client (TEE)
+
+For **production**, run this binary inside an AWS Nitro Enclave and obtain a real attestation document (e.g. from the NSM) before calling `register_table`.
+
+For **dev/test**, the script uses a placeholder attestation; on-chain `register_table` will abort unless the chain accepts it (e.g. testnet with a modified or mock native). Use `register_table_for_test` only in Move unit tests, not from a client.
+
+1. Create and fund the table account (faucet or transfer).
+2. Run the table client; it will:
+   - Register the table (with attestation doc; in dev you may need to publish a module that skips verification for testing).
+   - Enter a loop: wait for at least 2 players, run a trivial “hand” (e.g. no-op or fixed winner), call `settle_hand` and `settle_leaving_players`.
+
+```bash
+# Example (after deploy and env set)
+node table-client.js
+```
+
+## Player client
+
+- Enter: `node player-client.js enter <table_address> <amount_octas>`
+- Request leave: `node player-client.js leave <table_address>`

--- a/aptos-move/move-examples/poker/clients/README.md
+++ b/aptos-move/move-examples/poker/clients/README.md
@@ -15,18 +15,23 @@ Set env or edit:
 - `NODE_URL` – Aptos node URL (e.g. https://fullnode.devnet.aptoslabs.com).
 - `TABLE_PRIVATE_KEY` – Hex private key for the table account (TEE).
 - `PLAYER_PRIVATE_KEY` – Hex private key for the player (player-client).
+- `ATTESTATION_DOC_PATH` – Optional path to a raw Nitro attestation document for table registration.
 
 Deploy the poker module and set `POKER_MODULE_ADDRESS` (e.g. the address where `poker` is published).
 
 ## Table client (TEE)
 
-For **production**, run this binary inside an AWS Nitro Enclave and obtain a real attestation document (e.g. from the NSM) before calling `register_table`.
+For **production**, run this binary inside an AWS Nitro Enclave and obtain a real attestation document (e.g. from the NSM) before calling `register_table`. The chain-managed Nitro root store must already be initialized, and the NSM request must set `user_data` to:
 
-For **dev/test**, the script uses a placeholder attestation; on-chain `register_table` will abort unless the chain accepts it (e.g. testnet with a modified or mock native). Use `register_table_for_test` only in Move unit tests, not from a client.
+```text
+b"APTOS_POKER_TABLE_V1" || bcs(table_address)
+```
+
+For **dev/test**, omit `ATTESTATION_DOC_PATH` to use a placeholder attestation; on-chain `register_table` will abort unless verification is bypassed in a local test-only package. Use `register_table_for_test` only in Move unit tests, not from a client.
 
 1. Create and fund the table account (faucet or transfer).
 2. Run the table client; it will:
-   - Register the table (with attestation doc; in dev you may need to publish a module that skips verification for testing).
+   - Register the table with an attestation doc bound to the table address.
    - Enter a loop: wait for at least 2 players, run a trivial “hand” (e.g. no-op or fixed winner), call `settle_hand` and `settle_leaving_players`.
 
 ```bash

--- a/aptos-move/move-examples/poker/clients/README.md
+++ b/aptos-move/move-examples/poker/clients/README.md
@@ -19,6 +19,8 @@ Set env or edit:
 
 Deploy the poker module and set `POKER_MODULE_ADDRESS` (e.g. the address where `poker` is published).
 
+For a localnet plus AWS Nitro smoke run, use `NODE_URL=http://127.0.0.1:8080/v1` and follow [`../LOCAL_AWS_E2E.md`](../LOCAL_AWS_E2E.md).
+
 ## Table client (TEE)
 
 For **production**, run this binary inside an AWS Nitro Enclave and obtain a real attestation document (e.g. from the NSM) before calling `register_table`. The chain-managed Nitro root store must already be initialized, and the NSM request must set `user_data` to:
@@ -27,7 +29,7 @@ For **production**, run this binary inside an AWS Nitro Enclave and obtain a rea
 b"APTOS_POKER_TABLE_V1" || bcs(table_address)
 ```
 
-For **dev/test**, omit `ATTESTATION_DOC_PATH` to use a placeholder attestation; on-chain `register_table` will abort unless verification is bypassed in a local test-only package. Use `register_table_for_test` only in Move unit tests, not from a client.
+For **dev/test**, on-chain `register_table` still requires a valid Nitro attestation unless verification is bypassed in a Move unit test. Use `register_table_for_test` only in Move unit tests, not from a client.
 
 1. Create and fund the table account (faucet or transfer).
 2. Run the table client; it will:

--- a/aptos-move/move-examples/poker/clients/package.json
+++ b/aptos-move/move-examples/poker/clients/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "poker-clients",
+  "version": "1.0.0",
+  "description": "Table (TEE) and player clients for poker dapp",
+  "private": true,
+  "scripts": {
+    "table": "node table-client.js",
+    "player": "node player-client.js"
+  },
+  "dependencies": {
+    "@aptos-labs/ts-sdk": "^1.0.0"
+  }
+}

--- a/aptos-move/move-examples/poker/clients/package.json
+++ b/aptos-move/move-examples/poker/clients/package.json
@@ -8,6 +8,6 @@
     "player": "node player-client.js"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.0.0"
+    "@aptos-labs/ts-sdk": "1.33.1"
   }
 }

--- a/aptos-move/move-examples/poker/clients/player-client.js
+++ b/aptos-move/move-examples/poker/clients/player-client.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Player client – enter table (lock APT as chips) and request leave.
+ *
+ * Usage:
+ *   node player-client.js enter <table_address> <amount_octas>
+ *   node player-client.js leave <table_address>
+ *   node player-client.js balance <table_address>
+ *
+ * Env: PLAYER_PRIVATE_KEY (hex), NODE_URL, POKER_MODULE_ADDRESS (module deployer = table addr if same).
+ */
+
+const { Aptos, AptosConfig, Account, Ed25519PrivateKey } = require("@aptos-labs/ts-sdk");
+
+const NODE_URL = process.env.NODE_URL || "https://fullnode.devnet.aptoslabs.com";
+const PLAYER_PRIVATE_KEY = process.env.PLAYER_PRIVATE_KEY;
+const POKER_MODULE_ADDRESS = process.env.POKER_MODULE_ADDRESS;
+
+const cmd = process.argv[2];
+const tableAddr = process.argv[3];
+const amountStr = process.argv[4];
+
+if (!["enter", "leave", "balance"].includes(cmd) || !tableAddr) {
+  console.error("Usage: node player-client.js enter <table_address> <amount_octas> | leave <table_address> | balance <table_address>");
+  process.exit(1);
+}
+
+const config = new AptosConfig({ fullnode: NODE_URL });
+const aptos = new Aptos(config);
+
+const moduleAddr = POKER_MODULE_ADDRESS || tableAddr;
+const MODULE_NAME = "poker";
+const POKER_MODULE = `${moduleAddr}::${MODULE_NAME}::poker`;
+
+async function getPlayerAddress() {
+  if (!PLAYER_PRIVATE_KEY) {
+    console.error("Set PLAYER_PRIVATE_KEY");
+    process.exit(1);
+  }
+  const key = Ed25519PrivateKey.fromString(PLAYER_PRIVATE_KEY.replace(/^0x/, ""));
+  const account = Account.fromPrivateKey({ privateKey: key });
+  return { account, address: account.accountAddress.toStringLong() };
+}
+
+async function enterTable(account, tableAddress, amount) {
+  const payload = {
+    function: `${POKER_MODULE}::enter_table`,
+    typeArguments: [],
+    functionArguments: [tableAddress, amount],
+  };
+  const txn = await aptos.transaction.build.simple({
+    sender: account.accountAddress.toStringLong(),
+    withFeePayer: false,
+    data: {
+      function: payload.function,
+      typeArguments: payload.typeArguments,
+      functionArguments: payload.functionArguments,
+    },
+  });
+  const committed = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
+  await aptos.waitForTransaction({ transactionHash: committed.hash });
+  console.log("Entered table. Tx:", committed.hash);
+}
+
+async function requestLeave(account, tableAddress) {
+  const payload = {
+    function: `${POKER_MODULE}::request_leave`,
+    typeArguments: [],
+    functionArguments: [tableAddress],
+  };
+  const txn = await aptos.transaction.build.simple({
+    sender: account.accountAddress.toStringLong(),
+    withFeePayer: false,
+    data: {
+      function: payload.function,
+      typeArguments: payload.typeArguments,
+      functionArguments: payload.functionArguments,
+    },
+  });
+  const committed = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
+  await aptos.waitForTransaction({ transactionHash: committed.hash });
+  console.log("Leave requested. Tx:", committed.hash);
+}
+
+async function balance(account, tableAddress) {
+  const res = await aptos.view({
+    payload: {
+      function: `${POKER_MODULE}::player_balance`,
+      typeArguments: [],
+      functionArguments: [tableAddress, account.accountAddress.toStringLong()],
+    },
+  });
+  console.log("Chip balance:", res);
+}
+
+async function main() {
+  const { account } = await getPlayerAddress();
+
+  if (cmd === "enter") {
+    const amount = BigInt(amountStr || "0");
+    if (amount <= 0n) {
+      console.error("Provide amount_octas > 0");
+      process.exit(1);
+    }
+    await enterTable(account, tableAddr, amount.toString());
+  } else if (cmd === "leave") {
+    await requestLeave(account, tableAddr);
+  } else if (cmd === "balance") {
+    await balance(account, tableAddr);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/aptos-move/move-examples/poker/clients/player-client.js
+++ b/aptos-move/move-examples/poker/clients/player-client.js
@@ -30,15 +30,19 @@ const aptos = new Aptos(config);
 
 const moduleAddr = POKER_MODULE_ADDRESS || tableAddr;
 const MODULE_NAME = "poker";
-const POKER_MODULE = `${moduleAddr}::${MODULE_NAME}::poker`;
+const POKER_MODULE = `${moduleAddr}::${MODULE_NAME}`;
+
+function accountFromHexPrivateKey(privateKey) {
+  const key = new Ed25519PrivateKey(privateKey.replace(/^0x/, ""));
+  return Account.fromPrivateKey({ privateKey: key });
+}
 
 async function getPlayerAddress() {
   if (!PLAYER_PRIVATE_KEY) {
     console.error("Set PLAYER_PRIVATE_KEY");
     process.exit(1);
   }
-  const key = Ed25519PrivateKey.fromString(PLAYER_PRIVATE_KEY.replace(/^0x/, ""));
-  const account = Account.fromPrivateKey({ privateKey: key });
+  const account = accountFromHexPrivateKey(PLAYER_PRIVATE_KEY);
   return { account, address: account.accountAddress.toStringLong() };
 }
 

--- a/aptos-move/move-examples/poker/clients/table-client.js
+++ b/aptos-move/move-examples/poker/clients/table-client.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Table client – runs in TEE.
+ * 1. Register table on-chain (with Nitro attestation; in prod use real attestation from NSM).
+ * 2. Loop: wait for min players, run hand, submit settle_hand and settle_leaving_players.
+ *
+ * Usage:
+ *   TABLE_PRIVATE_KEY=0x... POKER_MODULE_ADDRESS=0x... NODE_URL=https://... node table-client.js
+ *
+ * For dev: POKER_MODULE_ADDRESS is the address where the poker module is deployed (e.g. table account).
+ */
+
+const { Aptos, AptosConfig } = require("@aptos-labs/ts-sdk");
+
+const NODE_URL = process.env.NODE_URL || "https://fullnode.devnet.aptoslabs.com";
+const TABLE_PRIVATE_KEY = process.env.TABLE_PRIVATE_KEY;
+const POKER_MODULE_ADDRESS = process.env.POKER_MODULE_ADDRESS;
+
+if (!TABLE_PRIVATE_KEY || !POKER_MODULE_ADDRESS) {
+  console.error("Set TABLE_PRIVATE_KEY and POKER_MODULE_ADDRESS");
+  process.exit(1);
+}
+
+const config = new AptosConfig({ fullnode: NODE_URL });
+const aptos = new Aptos(config);
+
+const MODULE_NAME = "poker";
+const POKER_MODULE = `${POKER_MODULE_ADDRESS}::${MODULE_NAME}::poker`;
+
+async function main() {
+  const accountInfo = await aptos.getAccountInfo({ accountAddress: POKER_MODULE_ADDRESS }).catch(() => null);
+  if (!accountInfo) {
+    console.error("Table account not found. Create and fund it first.");
+    process.exit(1);
+  }
+
+  // In production: get attestation bytes from Nitro Enclave NSM (GetAttestationDocument).
+  // Here we use a placeholder; on-chain register_table will fail unless verification is bypassed (test only).
+  const attestationDoc = new Uint8Array(0);
+
+  const { Account, Ed25519PrivateKey } = require("@aptos-labs/ts-sdk");
+  const key = Ed25519PrivateKey.fromString(TABLE_PRIVATE_KEY.replace(/^0x/, ""));
+  const tableAccount = Account.fromPrivateKey({ privateKey: key });
+
+  console.log("Registering table (attestation required in prod)...");
+  const payload = {
+    function: `${POKER_MODULE}::register_table`,
+    typeArguments: [],
+    functionArguments: [Array.from(attestationDoc)],
+  };
+  const txn = await aptos.transaction.build.simple({
+    sender: tableAccount.accountAddress.toStringLong(),
+    withFeePayer: false,
+    data: {
+      function: payload.function,
+      typeArguments: payload.typeArguments,
+      functionArguments: payload.functionArguments,
+    },
+  });
+  try {
+    const committed = await aptos.signAndSubmitTransaction({ signer: tableAccount, transaction: txn });
+    await aptos.waitForTransaction({ transactionHash: committed.hash });
+    console.log("Table registered. Tx:", committed.hash);
+  } catch (e) {
+    console.error("register_table failed (expected if attestation invalid):", e.message);
+  }
+
+  console.log("\nTable client loop (conceptual):");
+  console.log("1. Poll / query players (player_balance view).");
+  console.log("2. When >= min_players, run hand off-chain.");
+  console.log("3. Submit settle_hand(deduct_from, deduct_amounts, add_to, add_amounts).");
+  console.log("4. Submit settle_leaving_players(leaving_players).");
+  console.log("5. Repeat; if not enough players, wait.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/aptos-move/move-examples/poker/clients/table-client.js
+++ b/aptos-move/move-examples/poker/clients/table-client.js
@@ -11,7 +11,7 @@
  */
 
 const fs = require("fs");
-const { Aptos, AptosConfig } = require("@aptos-labs/ts-sdk");
+const { Aptos, AptosConfig, Account, Ed25519PrivateKey } = require("@aptos-labs/ts-sdk");
 
 const NODE_URL = process.env.NODE_URL || "https://fullnode.devnet.aptoslabs.com";
 const TABLE_PRIVATE_KEY = process.env.TABLE_PRIVATE_KEY;
@@ -27,15 +27,14 @@ const config = new AptosConfig({ fullnode: NODE_URL });
 const aptos = new Aptos(config);
 
 const MODULE_NAME = "poker";
-const POKER_MODULE = `${POKER_MODULE_ADDRESS}::${MODULE_NAME}::poker`;
+const POKER_MODULE = `${POKER_MODULE_ADDRESS}::${MODULE_NAME}`;
+
+function accountFromHexPrivateKey(privateKey) {
+  const key = new Ed25519PrivateKey(privateKey.replace(/^0x/, ""));
+  return Account.fromPrivateKey({ privateKey: key });
+}
 
 async function main() {
-  const accountInfo = await aptos.getAccountInfo({ accountAddress: POKER_MODULE_ADDRESS }).catch(() => null);
-  if (!accountInfo) {
-    console.error("Table account not found. Create and fund it first.");
-    process.exit(1);
-  }
-
   // In production, generate this inside the enclave with NSM GetAttestationDocument.
   // The document's user_data must be b"APTOS_POKER_TABLE_V1" || bcs(table_address).
   const attestationDoc = ATTESTATION_DOC_PATH ? fs.readFileSync(ATTESTATION_DOC_PATH) : new Uint8Array(0);
@@ -43,9 +42,7 @@ async function main() {
     console.warn("ATTESTATION_DOC_PATH not set; register_table is expected to fail outside test-only flows.");
   }
 
-  const { Account, Ed25519PrivateKey } = require("@aptos-labs/ts-sdk");
-  const key = Ed25519PrivateKey.fromString(TABLE_PRIVATE_KEY.replace(/^0x/, ""));
-  const tableAccount = Account.fromPrivateKey({ privateKey: key });
+  const tableAccount = accountFromHexPrivateKey(TABLE_PRIVATE_KEY);
 
   console.log("Registering table (attestation required in prod)...");
   const payload = {

--- a/aptos-move/move-examples/poker/clients/table-client.js
+++ b/aptos-move/move-examples/poker/clients/table-client.js
@@ -5,16 +5,18 @@
  * 2. Loop: wait for min players, run hand, submit settle_hand and settle_leaving_players.
  *
  * Usage:
- *   TABLE_PRIVATE_KEY=0x... POKER_MODULE_ADDRESS=0x... NODE_URL=https://... node table-client.js
+ *   TABLE_PRIVATE_KEY=0x... POKER_MODULE_ADDRESS=0x... ATTESTATION_DOC_PATH=/path/doc.bin node table-client.js
  *
  * For dev: POKER_MODULE_ADDRESS is the address where the poker module is deployed (e.g. table account).
  */
 
+const fs = require("fs");
 const { Aptos, AptosConfig } = require("@aptos-labs/ts-sdk");
 
 const NODE_URL = process.env.NODE_URL || "https://fullnode.devnet.aptoslabs.com";
 const TABLE_PRIVATE_KEY = process.env.TABLE_PRIVATE_KEY;
 const POKER_MODULE_ADDRESS = process.env.POKER_MODULE_ADDRESS;
+const ATTESTATION_DOC_PATH = process.env.ATTESTATION_DOC_PATH;
 
 if (!TABLE_PRIVATE_KEY || !POKER_MODULE_ADDRESS) {
   console.error("Set TABLE_PRIVATE_KEY and POKER_MODULE_ADDRESS");
@@ -34,9 +36,12 @@ async function main() {
     process.exit(1);
   }
 
-  // In production: get attestation bytes from Nitro Enclave NSM (GetAttestationDocument).
-  // Here we use a placeholder; on-chain register_table will fail unless verification is bypassed (test only).
-  const attestationDoc = new Uint8Array(0);
+  // In production, generate this inside the enclave with NSM GetAttestationDocument.
+  // The document's user_data must be b"APTOS_POKER_TABLE_V1" || bcs(table_address).
+  const attestationDoc = ATTESTATION_DOC_PATH ? fs.readFileSync(ATTESTATION_DOC_PATH) : new Uint8Array(0);
+  if (!ATTESTATION_DOC_PATH) {
+    console.warn("ATTESTATION_DOC_PATH not set; register_table is expected to fail outside test-only flows.");
+  }
 
   const { Account, Ed25519PrivateKey } = require("@aptos-labs/ts-sdk");
   const key = Ed25519PrivateKey.fromString(TABLE_PRIVATE_KEY.replace(/^0x/, ""));

--- a/aptos-move/move-examples/poker/e2e/nitro-attester/Dockerfile
+++ b/aptos-move/move-examples/poker/e2e/nitro-attester/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.22-bookworm AS builder
+WORKDIR /src
+COPY go.mod ./
+COPY main.go ./
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /attester
+
+FROM scratch
+ARG USER_DATA_HEX
+ENV USER_DATA_HEX=${USER_DATA_HEX}
+COPY --from=builder /attester /attester
+ENTRYPOINT ["/attester"]

--- a/aptos-move/move-examples/poker/e2e/nitro-attester/go.mod
+++ b/aptos-move/move-examples/poker/e2e/nitro-attester/go.mod
@@ -1,0 +1,5 @@
+module aptos-poker-attester
+
+go 1.22
+
+require github.com/hf/nsm v0.0.0-20220930140112-cd181bd646b9

--- a/aptos-move/move-examples/poker/e2e/nitro-attester/main.go
+++ b/aptos-move/move-examples/poker/e2e/nitro-attester/main.go
@@ -1,0 +1,52 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/hf/nsm"
+	"github.com/hf/nsm/request"
+)
+
+func main() {
+	userDataHex := os.Getenv("USER_DATA_HEX")
+	userData, err := hex.DecodeString(userDataHex)
+	if err != nil {
+		panic(fmt.Errorf("invalid USER_DATA_HEX: %w", err))
+	}
+
+	doc, err := attest(userData)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("ATTESTATION_DOC_BASE64=%s\n", base64.StdEncoding.EncodeToString(doc))
+	time.Sleep(10 * time.Minute)
+}
+
+func attest(userData []byte) ([]byte, error) {
+	sess, err := nsm.OpenDefaultSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.Close()
+
+	res, err := sess.Send(&request.Attestation{UserData: userData})
+	if err != nil {
+		return nil, err
+	}
+	if res.Error != "" {
+		return nil, errors.New(string(res.Error))
+	}
+	if res.Attestation == nil || res.Attestation.Document == nil {
+		return nil, errors.New("NSM device did not return an attestation")
+	}
+	return res.Attestation.Document, nil
+}

--- a/aptos-move/move-examples/poker/sources/poker.move
+++ b/aptos-move/move-examples/poker/sources/poker.move
@@ -1,0 +1,294 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Small multiplayer poker dapp leveraging AWS Nitro Enclave attestation.
+// - Table (game server) runs in TEE: registers on-chain with attestation, runs hands, settles.
+// - Players enter with APT locked as chips, request leave after current hand, get 95% back (5% fee to server).
+
+module poker::poker {
+    use std::error;
+    use std::signer;
+    use std::vector;
+
+    use aptos_framework::aws_nitro_utils;
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::event;
+    use aptos_std::table::{Self, Table};
+
+    // Minimum players to run a hand.
+    const MIN_PLAYERS: u64 = 2;
+    // Fee in basis points (500 = 5%).
+    const FEE_BPS: u64 = 500;
+    const BPS_DENOM: u64 = 10000;
+
+    const EINVALID_ATTESTATION: u64 = 1;
+    const ETABLE_ALREADY_EXISTS: u64 = 2;
+    const ETABLE_NOT_FOUND: u64 = 3;
+    const EPLAYER_ALREADY_AT_TABLE: u64 = 4;
+    const EPLAYER_NOT_AT_TABLE: u64 = 5;
+    const EINSUFFICIENT_BALANCE: u64 = 6;
+    const ENOT_TABLE_OWNER: u64 = 7;
+    const EINVALID_SETTLE_SUM: u64 = 8;
+    const EZERO_AMOUNT: u64 = 9;
+    const EMIN_PLAYERS: u64 = 10;
+
+    #[event]
+    struct TableRegistered has drop, store {
+        table: address,
+    }
+
+    #[event]
+    struct PlayerEntered has drop, store {
+        table: address,
+        player: address,
+        amount: u64,
+    }
+
+    #[event]
+    struct LeaveRequested has drop, store {
+        table: address,
+        player: address,
+    }
+
+    #[event]
+    struct PlayerLeft has drop, store {
+        table: address,
+        player: address,
+        payout: u64,
+        fee: u64,
+    }
+
+    #[event]
+    struct HandSettled has drop, store {
+        table: address,
+    }
+
+    struct TableInfo has key {
+        escrow: Coin<AptosCoin>,
+        /// Chip balance per player (logical chips backed by escrow).
+        balances: Table<address, u64>,
+        /// Players who requested to leave after current hand.
+        pending_leave: Table<address, bool>,
+        fee_pool: Coin<AptosCoin>,
+        min_players: u64,
+    }
+
+    /// Register a new table. Only succeeds if attestation is valid (TEE).
+    public entry fun register_table(table: &signer, attestation_doc: vector<u8>) {
+        assert!(aws_nitro_utils::verify_attestation(attestation_doc), error::invalid_argument(EINVALID_ATTESTATION));
+        register_table_internal(table);
+    }
+
+    fun register_table_internal(table: &signer) {
+        let table_addr = signer::address_of(table);
+        assert!(!exists<TableInfo>(table_addr), error::already_exists(ETABLE_ALREADY_EXISTS));
+        let zero = coin::zero<AptosCoin>();
+        move_to(table, TableInfo {
+            escrow: zero,
+            balances: table::new<address, u64>(),
+            pending_leave: table::new<address, bool>(),
+            fee_pool: coin::zero<AptosCoin>(),
+            min_players: MIN_PLAYERS,
+        });
+        event::emit(TableRegistered { table: table_addr });
+    }
+
+    /// Player locks APT as chips and joins the table. They play from the next hand.
+    public entry fun enter_table(table_addr: address, player: &signer, amount: u64) acquires TableInfo {
+        assert!(amount > 0, error::invalid_argument(EZERO_AMOUNT));
+        assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
+        let player_addr = signer::address_of(player);
+        let table = borrow_global_mut<TableInfo>(table_addr);
+        assert!(!table::contains(&table.balances, player_addr), error::invalid_argument(EPLAYER_ALREADY_AT_TABLE));
+
+        let chips = coin::withdraw<AptosCoin>(player, amount);
+        coin::merge<AptosCoin>(&mut table.escrow, chips);
+        table::add(&mut table.balances, player_addr, amount);
+        event::emit(PlayerEntered { table: table_addr, player: player_addr, amount });
+    }
+
+    /// Request to leave after the current hand finishes.
+    public entry fun request_leave(table_addr: address, player: &signer) acquires TableInfo {
+        let player_addr = signer::address_of(player);
+        assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
+        let table = borrow_global_mut<TableInfo>(table_addr);
+        assert!(table::contains(&table.balances, player_addr), error::invalid_argument(EPLAYER_NOT_AT_TABLE));
+        table::add(&mut table.pending_leave, player_addr, true);
+        event::emit(LeaveRequested { table: table_addr, player: player_addr });
+    }
+
+    /// Apply hand result (only table signer). Deduct from losers, add to winners; sum of deduct must equal sum of add.
+    public entry fun settle_hand(
+        table: &signer,
+        table_addr: address,
+        deduct_from: vector<address>,
+        deduct_amounts: vector<u64>,
+        add_to: vector<address>,
+        add_amounts: vector<u64>,
+    ) acquires TableInfo {
+        let table_signer_addr = signer::address_of(table);
+        assert!(table_signer_addr == table_addr, error::permission_denied(ENOT_TABLE_OWNER));
+        assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
+        assert!(vector::length(&deduct_from) == vector::length(&deduct_amounts), error::invalid_argument(EINVALID_SETTLE_SUM));
+        assert!(vector::length(&add_to) == vector::length(&add_amounts), error::invalid_argument(EINVALID_SETTLE_SUM));
+
+        let table_info = borrow_global_mut<TableInfo>(table_addr);
+        let mut total_deduct = 0u64;
+        let mut total_add = 0u64;
+        let len_d = vector::length(&deduct_from);
+        let len_a = vector::length(&add_to);
+        let i = 0u64;
+        while (i < len_d) {
+            let addr = *vector::borrow(&deduct_from, i);
+            let amt = *vector::borrow(&deduct_amounts, i);
+            total_deduct = total_deduct + amt;
+            assert!(table::contains(&table_info.balances, addr), error::invalid_argument(EPLAYER_NOT_AT_TABLE));
+            let bal = table::borrow_mut(&mut table_info.balances, addr);
+            assert!(*bal >= amt, error::invalid_argument(EINSUFFICIENT_BALANCE));
+            *bal = *bal - amt;
+            i = i + 1;
+        };
+        let j = 0u64;
+        while (j < len_a) {
+            let addr = *vector::borrow(&add_to, j);
+            let amt = *vector::borrow(&add_amounts, j);
+            total_add = total_add + amt;
+            assert!(table::contains(&table_info.balances, addr), error::invalid_argument(EPLAYER_NOT_AT_TABLE));
+            let bal = table::borrow_mut(&mut table_info.balances, addr);
+            *bal = *bal + amt;
+            j = j + 1;
+        };
+        assert!(total_deduct == total_add, error::invalid_argument(EINVALID_SETTLE_SUM));
+        event::emit(HandSettled { table: table_addr });
+    }
+
+    /// Process leaving players: send 95% back, 5% to table fee pool. Only table signer.
+    /// Pass the list of player addresses that requested leave (table/TEE tracks this off-chain).
+    public entry fun settle_leaving_players(
+        table: &signer,
+        table_addr: address,
+        leaving_players: vector<address>,
+    ) acquires TableInfo {
+        let table_signer_addr = signer::address_of(table);
+        assert!(table_signer_addr == table_addr, error::permission_denied(ENOT_TABLE_OWNER));
+        assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
+
+        let table_info = borrow_global_mut<TableInfo>(table_addr);
+        vector::for_each_ref(&leaving_players, |addr| {
+            if (table::contains(&table_info.pending_leave, *addr) && table::contains(&table_info.balances, *addr)) {
+                let balance = *table::borrow(&table_info.balances, *addr);
+                if (balance > 0) {
+                    let fee = (balance * FEE_BPS) / BPS_DENOM;
+                    let payout = balance - fee;
+                    let pay_coins = coin::extract<AptosCoin>(&mut table_info.escrow, balance);
+                    let fee_coin = coin::extract<AptosCoin>(&mut pay_coins, fee);
+                    coin::merge<AptosCoin>(&mut table_info.fee_pool, fee_coin);
+                    coin::deposit(*addr, pay_coins);
+                    event::emit(PlayerLeft { table: table_addr, player: *addr, payout, fee });
+                };
+                table::remove(&mut table_info.balances, *addr);
+                table::remove(&mut table_info.pending_leave, *addr);
+            };
+        });
+    }
+
+    #[view]
+    public fun table_exists(table_addr: address): bool {
+        exists<TableInfo>(table_addr)
+    }
+
+    #[view]
+    public fun min_players(table_addr: address): u64 acquires TableInfo {
+        assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
+        borrow_global<TableInfo>(table_addr).min_players
+    }
+
+    #[view]
+    public fun player_balance(table_addr: address, player: address): u64 acquires TableInfo {
+        assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
+        let table = borrow_global<TableInfo>(table_addr);
+        if (table::contains(&table.balances, player)) {
+            *table::borrow(&table.balances, player)
+        } else {
+            0
+        }
+    }
+
+    #[view]
+    public fun player_pending_leave(table_addr: address, player: address): bool acquires TableInfo {
+        assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
+        let table = borrow_global<TableInfo>(table_addr);
+        table::contains(&table.pending_leave, player)
+    }
+
+    // ============ Tests ============
+    #[test_only]
+    use aptos_framework::account;
+    #[test_only]
+    use aptos_framework::aptos_account;
+    #[test_only]
+    use aptos_framework::aptos_coin;
+    #[test_only]
+    use aptos_framework::coin::BurnCapability;
+    #[test_only]
+    use aptos_framework::timestamp;
+
+    #[test_only]
+    fun fake_attestation(): vector<u8> {
+        // In real unit tests verify_attestation will return false for this; use register_table_for_test.
+        vector::empty<u8>()
+    }
+
+    #[test_only]
+    /// Register table without attestation for testing.
+    public entry fun register_table_for_test(table: &signer) {
+        register_table_internal(table);
+    }
+
+    #[test(aptos_framework = @0x1, table = @0xf00d, alice = @0xa11c, bob = @0xb0b)]
+    fun test_register_enter_and_leave_flow(
+        aptos_framework: &signer,
+        table: &signer,
+        alice: &signer,
+        bob: &signer,
+    ) acquires TableInfo {
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        let (burn_cap, mint_cap) = aptos_coin::initialize_for_test(aptos_framework);
+        let table_addr = signer::address_of(table);
+        let alice_addr = signer::address_of(alice);
+        let bob_addr = signer::address_of(bob);
+
+        account::create_account_for_test(table_addr);
+        aptos_account::create_account(alice_addr);
+        aptos_account::create_account(bob_addr);
+        coin::register<AptosCoin>(table);
+        let coins_a = coin::mint<AptosCoin>(1000, &mint_cap);
+        let coins_b = coin::mint<AptosCoin>(1000, &mint_cap);
+        coin::deposit(alice_addr, coins_a);
+        coin::deposit(bob_addr, coins_b);
+        coin::destroy_mint_cap(mint_cap);
+
+        register_table_for_test(table);
+        assert!(table_exists(table_addr), 0);
+        assert!(min_players(table_addr) == MIN_PLAYERS, 1);
+
+        enter_table(table_addr, alice, 100);
+        enter_table(table_addr, bob, 200);
+        assert!(player_balance(table_addr, alice_addr) == 100, 2);
+        assert!(player_balance(table_addr, bob_addr) == 200, 3);
+
+        request_leave(table_addr, alice);
+        assert!(player_pending_leave(table_addr, alice_addr), 4);
+
+        settle_leaving_players(table, table_addr, vector[alice_addr]);
+        assert!(player_balance(table_addr, alice_addr) == 0, 5);
+        assert!(player_balance(table_addr, bob_addr) == 200, 6);
+
+        request_leave(table_addr, bob);
+        settle_leaving_players(table, table_addr, vector[bob_addr]);
+        assert!(player_balance(table_addr, bob_addr) == 0, 7);
+
+        coin::destroy_burn_cap(burn_cap);
+    }
+}

--- a/aptos-move/move-examples/poker/sources/poker.move
+++ b/aptos-move/move-examples/poker/sources/poker.move
@@ -6,15 +6,18 @@
 // - Players enter with APT locked as chips, request leave after current hand, get 95% back (5% fee to server).
 
 module poker::poker {
+    use std::bcs;
     use std::error;
     use std::signer;
     use std::vector;
 
-    use aptos_framework::aws_nitro_utils;
-    use aptos_framework::coin::{Self, Coin};
     use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::aws_nitro_utils;
+    use aptos_framework::coin;
+    use aptos_framework::coin::Coin;
     use aptos_framework::event;
-    use aptos_std::table::{Self, Table};
+    use aptos_std::table;
+    use aptos_std::table::Table;
 
     // Minimum players to run a hand.
     const MIN_PLAYERS: u64 = 2;
@@ -32,6 +35,8 @@ module poker::poker {
     const EINVALID_SETTLE_SUM: u64 = 8;
     const EZERO_AMOUNT: u64 = 9;
     const EMIN_PLAYERS: u64 = 10;
+
+    const TABLE_ATTESTATION_DOMAIN: vector<u8> = b"APTOS_POKER_TABLE_V1";
 
     #[event]
     struct TableRegistered has drop, store {
@@ -74,10 +79,21 @@ module poker::poker {
         min_players: u64,
     }
 
-    /// Register a new table. Only succeeds if attestation is valid (TEE).
+    /// Register a new table. Only succeeds if Nitro attestation is valid and bound to this table.
     public entry fun register_table(table: &signer, attestation_doc: vector<u8>) {
-        assert!(aws_nitro_utils::verify_attestation(attestation_doc), error::invalid_argument(EINVALID_ATTESTATION));
+        let table_addr = signer::address_of(table);
+        let expected_user_data = table_attestation_user_data(table_addr);
+        assert!(
+            aws_nitro_utils::verify_attestation_user_data(attestation_doc, &expected_user_data),
+            error::invalid_argument(EINVALID_ATTESTATION),
+        );
         register_table_internal(table);
+    }
+
+    fun table_attestation_user_data(table_addr: address): vector<u8> {
+        let user_data = TABLE_ATTESTATION_DOMAIN;
+        user_data.append(bcs::to_bytes(&table_addr));
+        user_data
     }
 
     fun register_table_internal(table: &signer) {
@@ -95,7 +111,7 @@ module poker::poker {
     }
 
     /// Player locks APT as chips and joins the table. They play from the next hand.
-    public entry fun enter_table(table_addr: address, player: &signer, amount: u64) acquires TableInfo {
+    public entry fun enter_table(player: &signer, table_addr: address, amount: u64) acquires TableInfo {
         assert!(amount > 0, error::invalid_argument(EZERO_AMOUNT));
         assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
         let player_addr = signer::address_of(player);
@@ -109,7 +125,7 @@ module poker::poker {
     }
 
     /// Request to leave after the current hand finishes.
-    public entry fun request_leave(table_addr: address, player: &signer) acquires TableInfo {
+    public entry fun request_leave(player: &signer, table_addr: address) acquires TableInfo {
         let player_addr = signer::address_of(player);
         assert!(exists<TableInfo>(table_addr), error::not_found(ETABLE_NOT_FOUND));
         let table = borrow_global_mut<TableInfo>(table_addr);
@@ -134,8 +150,8 @@ module poker::poker {
         assert!(vector::length(&add_to) == vector::length(&add_amounts), error::invalid_argument(EINVALID_SETTLE_SUM));
 
         let table_info = borrow_global_mut<TableInfo>(table_addr);
-        let mut total_deduct = 0u64;
-        let mut total_add = 0u64;
+        let total_deduct = 0u64;
+        let total_add = 0u64;
         let len_d = vector::length(&deduct_from);
         let len_a = vector::length(&add_to);
         let i = 0u64;
@@ -230,8 +246,6 @@ module poker::poker {
     #[test_only]
     use aptos_framework::aptos_coin;
     #[test_only]
-    use aptos_framework::coin::BurnCapability;
-    #[test_only]
     use aptos_framework::timestamp;
 
     #[test_only]
@@ -273,19 +287,19 @@ module poker::poker {
         assert!(table_exists(table_addr), 0);
         assert!(min_players(table_addr) == MIN_PLAYERS, 1);
 
-        enter_table(table_addr, alice, 100);
-        enter_table(table_addr, bob, 200);
+        enter_table(alice, table_addr, 100);
+        enter_table(bob, table_addr, 200);
         assert!(player_balance(table_addr, alice_addr) == 100, 2);
         assert!(player_balance(table_addr, bob_addr) == 200, 3);
 
-        request_leave(table_addr, alice);
+        request_leave(alice, table_addr);
         assert!(player_pending_leave(table_addr, alice_addr), 4);
 
         settle_leaving_players(table, table_addr, vector[alice_addr]);
         assert!(player_balance(table_addr, alice_addr) == 0, 5);
         assert!(player_balance(table_addr, bob_addr) == 200, 6);
 
-        request_leave(table_addr, bob);
+        request_leave(bob, table_addr);
         settle_leaving_players(table, table_addr, vector[bob_addr]);
         assert!(player_balance(table_addr, bob_addr) == 0, 7);
 

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -320,3 +320,8 @@ fn test_package_manager() {
     ]);
     run_tests_for_pkg("package_manager", named_address);
 }
+
+#[test]
+fn test_poker() {
+    test_common("poker");
+}

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -100,6 +100,16 @@ fn test_common(pkg: &str) {
     run_tests_for_pkg(pkg, named_address);
 }
 
+fn test_common_with_stack(pkg: &'static str, stack_size: usize) {
+    let handle = std::thread::Builder::new()
+        .stack_size(stack_size)
+        .spawn(move || test_common(pkg))
+        .unwrap();
+    if let Err(err) = handle.join() {
+        std::panic::resume_unwind(err);
+    }
+}
+
 fn test_resource_account_common(pkg: &str) {
     let named_address = BTreeMap::from([(
         String::from(pkg),
@@ -323,5 +333,7 @@ fn test_package_manager() {
 
 #[test]
 fn test_poker() {
-    test_common("poker");
+    // Poker pulls in Nitro attestation utilities; compiling that dependency graph can exceed
+    // the default Rust test-thread stack.
+    test_common_with_stack("poker", 64 * 1024 * 1024);
 }


### PR DESCRIPTION
## Description

Supersedes #18801.

Adds AWS Nitro attestation verification support to `aptos_framework::aws_nitro_utils`. The Move API keeps trusted Nitro root certificates in framework-managed on-chain storage and wraps deterministic native verification that takes explicit trusted roots plus an explicit Unix timestamp.

The native implementation validates the attestation document certificate chain, verifies the COSE signature, and exposes parsed PCR, public key, user data, and nonce fields so Move policy can authorize TEE jobs before ACE-style key release flows.

Also updates the poker Move example to use Shelby/TEE-style table registration semantics: the table enclave must submit a Nitro attestation whose `user_data` is bound to `b"APTOS_POKER_TABLE_V1" || bcs(table_address)`. The example clients and docs now describe the chain-managed Nitro root store and real attestation document path.

## How Has This Been Tested?

- `cargo check -p aptos-framework-natives --lib`
- `cargo build -p aptos --bin aptos`
- `target/debug/aptos move test --package-dir aptos-move/framework/aptos-framework --skip-fetch-latest-git-deps --filter aws_nitro`
- `cargo test -p aptos-move-examples test_poker -- --nocapture`
- `git diff --check`
- `rustfmt --check --config skip_children=true aptos-move/framework/natives/src/aws_nitro_utils.rs aptos-move/framework/natives/src/lib.rs aptos-move/move-examples/tests/move_unit_tests.rs`

## Key Areas to Review

- Trusted root lifecycle in `aptos_framework::aws_nitro_utils`
- Native validation path in `aptos-move/framework/natives/src/aws_nitro_utils.rs`
- Dapp-facing attestation policy helper `verify_attestation_user_data*`
- Poker example's table registration binding via Nitro `user_data`
- Gas parameter placement and dependency wiring after the latest framework native split

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds security-critical attestation and PKIX/COSE verification in the VM and framework-managed trust roots; misconfiguration or bugs could allow bogus TEE authorization or break legitimate enclave flows.
> 
> **Overview**
> Adds **`aptos_framework::aws_nitro_utils`**, a new framework module for verifying AWS Nitro COSE attestation documents on-chain. Governance (or testnet-only helpers) can store trusted Nitro root DER certs; public APIs verify against that store or caller-supplied roots and consensus time, with optional parsing of PCRs, nonce, `user_data`, and public key plus helpers like `verify_attestation_user_data` and `verify_attestation_matches`.
> 
> **VM natives** implement certificate-chain validation (webpki), COSE signature checks, and structured `AttestationDoc` return values. **Gas** for verify vs verify-and-parse is calibrated from a ~5KB attestation benchmark. New crypto crates and a **criterion** bench support the native path.
> 
> The **poker** example is extended so table registration requires a valid attestation whose `user_data` is `APTOS_POKER_TABLE_V1 || bcs(table_address)`, with JS clients, a Go Nitro attester, and **`LOCAL_AWS_E2E.md`** documenting localnet + AWS smoke flow. Move example tests gain a larger-stack `test_poker` harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7ff0237016fabb158dee1745357733d0bfb0c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->