### PR TITLE
[trading-native][vm] Wire native-position writes through VMChangeSet + finalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5094,6 +5094,7 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-mvhashmap",
  "aptos-native-interface",
+ "aptos-position-natives",
  "aptos-table-natives",
  "aptos-transaction-simulation",
  "aptos-types",

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -615,10 +615,11 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 "Can't convert account raw key {:?} to WriteSetChange",
                 state_key
             )),
-            StateKeyInner::TradingNative(_) => Err(format_err!(
-                "Can't convert trading-native key {:?} to WriteSetChange",
-                state_key
-            )),
+            StateKeyInner::TradingNative(_) => {
+                // Not surfaced through the legacy REST WriteSetChange;
+                // queried via dedicated trading-native endpoints instead.
+                Ok(vec![])
+            },
         }
     }
 

--- a/aptos-move/aptos-gas-profiling/src/aggregate.rs
+++ b/aptos-move/aptos-gas-profiling/src/aggregate.rs
@@ -117,7 +117,16 @@ impl ExecutionAndIOCosts {
                     format!("table_item<{},{}>", Render(handle), TableKey { bytes: key },)
                 },
                 Raw(..) => panic!("not supported"),
-                TradingNative(..) => panic!("not supported"),
+                TradingNative(key) => {
+                    use aptos_types::state_store::state_key::inner::TradingNativeKey;
+                    match key {
+                        TradingNativeKey::Position {
+                            exchange,
+                            account,
+                            market,
+                        } => format!("position<{},{},{}>", exchange, account, market),
+                    }
+                },
             };
 
             insert_or_add(&mut storage_writes, key, write.cost);

--- a/aptos-move/aptos-gas-profiling/src/render.rs
+++ b/aptos-move/aptos-gas-profiling/src/render.rs
@@ -118,7 +118,16 @@ impl Display for Render<'_, StateKey> {
                 },)
             },
             Raw(..) => panic!("not supported"),
-            TradingNative(..) => panic!("not supported"),
+            TradingNative(key) => {
+                use aptos_types::state_store::state_key::inner::TradingNativeKey;
+                match key {
+                    TradingNativeKey::Position {
+                        exchange,
+                        account,
+                        market,
+                    } => write!(f, "position<{},{},{}>", exchange, account, market),
+                }
+            },
         }
     }
 }

--- a/aptos-move/aptos-transaction-simulation-session/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/state_store.rs
@@ -84,7 +84,16 @@ impl std::fmt::Display for HumanReadable<&StateKey> {
                 write!(f, "table_item::{}::{}", handle.0, hex::encode(key))
             },
             StateKeyInner::Raw(bytes) => write!(f, "raw::{}", hex::encode(bytes)),
-            StateKeyInner::TradingNative(key) => write!(f, "trading_native::{:?}", key),
+            StateKeyInner::TradingNative(key) => {
+                use aptos_types::state_store::state_key::inner::TradingNativeKey;
+                match key {
+                    TradingNativeKey::Position {
+                        exchange,
+                        account,
+                        market,
+                    } => write!(f, "position::{}::{}::{}", exchange, account, market),
+                }
+            },
         }
     }
 }

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -89,6 +89,10 @@ pub struct VMChangeSet {
     // TODO[agg_v1](cleanup) deprecate aggregator_v1 fields.
     aggregator_v1_write_set: BTreeMap<StateKey, WriteOp>,
     aggregator_v1_delta_set: BTreeMap<StateKey, DeltaOp>,
+
+    /// Native-position writes. These never enter the flat `WriteSet`;
+    /// they're materialized into its `native_positions` sibling bucket.
+    position_write_set: BTreeMap<StateKey, WriteOp>,
 }
 
 macro_rules! squash_writes_pair {
@@ -113,6 +117,7 @@ impl VMChangeSet {
             delayed_field_change_set: BTreeMap::new(),
             aggregator_v1_write_set: BTreeMap::new(),
             aggregator_v1_delta_set: BTreeMap::new(),
+            position_write_set: BTreeMap::new(),
         }
     }
 
@@ -129,7 +134,36 @@ impl VMChangeSet {
             delayed_field_change_set,
             aggregator_v1_write_set,
             aggregator_v1_delta_set,
+            position_write_set: BTreeMap::new(),
         }
+    }
+
+    pub fn position_write_set(&self) -> &BTreeMap<StateKey, WriteOp> {
+        &self.position_write_set
+    }
+
+    /// Replace the Position bucket; validates every key is a Position.
+    pub fn set_position_bucket(
+        &mut self,
+        position_writes: BTreeMap<StateKey, WriteOp>,
+    ) -> PartialVMResult<()> {
+        use aptos_types::state_store::state_key::inner::{StateKeyInner, TradingNativeKey};
+        for key in position_writes.keys() {
+            if !matches!(
+                key.inner(),
+                StateKeyInner::TradingNative(TradingNativeKey::Position { .. })
+            ) {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(
+                            "position_write_set bucket received a non-Position StateKey"
+                                .to_string(),
+                        ),
+                );
+            }
+        }
+        self.position_write_set = position_writes;
+        Ok(())
     }
 
     // TODO[agg_v2](cleanup) see if we can remove in favor of `new`.
@@ -231,6 +265,7 @@ impl VMChangeSet {
             aggregator_v1_delta_set,
             delayed_field_change_set,
             events,
+            position_write_set,
         } = self;
 
         if !aggregator_v1_delta_set.is_empty() {
@@ -262,6 +297,8 @@ impl VMChangeSet {
         );
         write_set_mut.extend(module_write_set.into_write_ops());
         write_set_mut.extend(aggregator_v1_write_set);
+        // Not materialized into the flat WriteSet; see `VMOutput`.
+        let _ = position_write_set;
 
         let events = events.into_iter().map(|(e, _)| e).collect();
         let write_set = write_set_mut
@@ -792,6 +829,7 @@ impl VMChangeSet {
             aggregator_v1_delta_set: additional_aggregator_delta_set,
             delayed_field_change_set: additional_delayed_field_change_set,
             events: additional_events,
+            position_write_set: additional_position_write_set,
         } = additional_change_set;
 
         Self::squash_additional_aggregator_v1_changes(
@@ -809,6 +847,12 @@ impl VMChangeSet {
             &mut self.delayed_field_change_set,
             additional_delayed_field_change_set,
         )?;
+        // Last-wins. No create+delete collapse like the main WriteSet:
+        // the position store is an idempotent KV map, so overwrite is
+        // correct. Cross-TX squashing is handled by MVHashMap.
+        for (key, op) in additional_position_write_set {
+            self.position_write_set.insert(key, op);
+        }
         self.events.extend(additional_events);
         Ok(())
     }

--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -15,7 +15,7 @@ use aptos_types::{
     fee_statement::FeeStatement,
     state_store::state_key::StateKey,
     transaction::{TransactionAuxiliaryData, TransactionOutput, TransactionStatus},
-    write_set::WriteOp,
+    write_set::{NativePositionOp, WriteOp},
 };
 use derivative::Derivative;
 use move_core_types::{
@@ -206,9 +206,21 @@ impl VMOutput {
             ));
         }
 
-        let (write_set, events) = change_set
+        // Snapshot the position bucket into the WriteSet's
+        // `native_positions` sibling bucket before the flat WriteSet
+        // drops it; the storage applier consumes it from there.
+        let native_positions: BTreeMap<StateKey, NativePositionOp> = change_set
+            .position_write_set()
+            .iter()
+            .map(|(k, op)| (k.clone(), NativePositionOp::from_write_op(op.clone())))
+            .collect();
+
+        let (mut write_set, events) = change_set
             .try_combine_into_storage_change_set(module_write_set)?
             .into_inner();
+        if !native_positions.is_empty() {
+            write_set.add_native_positions(native_positions);
+        }
         Ok(TransactionOutput::new(
             write_set,
             events,

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -672,6 +672,68 @@ fn test_squash_standalone_write_then_inplace_delayed_field_gated() {
     );
 }
 
+fn position_key(exchange: &str, account: &str, market: &str) -> StateKey {
+    StateKey::position(
+        AccountAddress::from_hex_literal(exchange).unwrap(),
+        AccountAddress::from_hex_literal(account).unwrap(),
+        AccountAddress::from_hex_literal(market).unwrap(),
+    )
+}
+
+#[test]
+fn test_position_bucket_rejects_non_position_key() {
+    let mut change_set = VMChangeSet::empty();
+    let bad = BTreeMap::from([(StateKey::raw(b"not-a-position"), WriteOp::legacy_deletion())]);
+    assert_err!(change_set.set_position_bucket(bad));
+}
+
+#[test]
+fn test_position_bucket_accepts_position_keys() {
+    let mut change_set = VMChangeSet::empty();
+    let key = position_key("0x5", "0x1", "0x2");
+    let writes = BTreeMap::from([(
+        key.clone(),
+        WriteOp::legacy_creation(Bytes::from_static(b"payload")),
+    )]);
+    assert_ok!(change_set.set_position_bucket(writes));
+    assert_some_eq!(
+        change_set.position_write_set().get(&key),
+        &WriteOp::legacy_creation(Bytes::from_static(b"payload"))
+    );
+}
+
+#[test]
+fn test_squash_position_bucket_last_wins() {
+    let key = position_key("0x1", "0x2", "0x3");
+
+    // creation then deletion -> deletion (last wins, no collapse).
+    let mut cs1 = VMChangeSet::empty();
+    cs1.set_position_bucket(BTreeMap::from([(
+        key.clone(),
+        WriteOp::legacy_creation(Bytes::from_static(b"v")),
+    )]))
+    .unwrap();
+    let mut cs2 = VMChangeSet::empty();
+    cs2.set_position_bucket(BTreeMap::from([(key.clone(), WriteOp::legacy_deletion())]))
+        .unwrap();
+    assert_ok!(cs1.squash_additional_change_set(cs2, true));
+    assert_some_eq!(
+        cs1.position_write_set().get(&key),
+        &WriteOp::legacy_deletion()
+    );
+
+    // deletion then creation -> creation.
+    let creation = WriteOp::legacy_creation(Bytes::from_static(b"w"));
+    let mut cs3 = VMChangeSet::empty();
+    cs3.set_position_bucket(BTreeMap::from([(key.clone(), WriteOp::legacy_deletion())]))
+        .unwrap();
+    let mut cs4 = VMChangeSet::empty();
+    cs4.set_position_bucket(BTreeMap::from([(key.clone(), creation.clone())]))
+        .unwrap();
+    assert_ok!(cs3.squash_additional_change_set(cs4, true));
+    assert_some_eq!(cs3.position_write_set().get(&key), &creation);
+}
+
 // TODO[agg_v2](cleanup) combine utilities with above utilities, and see if tests need cleanup.
 // below are moved from change_set.rs, to consolidate.
 

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -46,6 +46,7 @@ aptos-memory-usage-tracker = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-mvhashmap = { workspace = true }
 aptos-native-interface = { workspace = true }
+aptos-position-natives = { workspace = true }
 aptos-table-natives = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm-environment = { workspace = true }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -229,9 +229,13 @@ where
         let event_context: NativeEventContext = extensions.remove();
         let events = event_context.legacy_into_events();
 
+        // Drain staged position writes into the VMChangeSet bucket.
+        let position_context: aptos_position_natives::NativePositionContext = extensions.remove();
+        let position_writes_map = position_context.into_change_maps();
+
         let woc = WriteOpConverter::new(resolver, is_storage_slot_metadata_enabled);
 
-        let change_set = Self::convert_change_set(
+        let mut change_set = Self::convert_change_set(
             &woc,
             change_set,
             resource_group_change_set,
@@ -241,6 +245,12 @@ where
             configs.legacy_resource_creation_as_modification(),
         )
         .map_err(|e| e.finish(Location::Undefined))?;
+
+        let position_bucket = build_position_writeset(&position_writes_map)
+            .map_err(|e| e.finish(Location::Undefined))?;
+        change_set
+            .set_position_bucket(position_bucket)
+            .map_err(|e| e.finish(Location::Undefined))?;
 
         Ok(change_set)
     }
@@ -580,5 +590,50 @@ where
     extensions.add(NativeStateStorageContext::new(data_view));
     extensions.add(NativeEventContext::default());
     extensions.add(NativeObjectContext::default());
+
+    extensions.add(aptos_position_natives::NativePositionContext::new());
+
     extensions
+}
+
+/// Convert staged position writes (`None` = deletion) into a
+/// `StateKey -> WriteOp` map. Uses legacy creation/deletion since the
+/// staging map doesn't track prior presence.
+fn build_position_writeset(
+    writes: &std::collections::BTreeMap<
+        aptos_types::state_store::state_key::inner::TradingNativeKey,
+        Option<aptos_types::state_store::native_position::NativePosition>,
+    >,
+) -> PartialVMResult<
+    std::collections::BTreeMap<
+        aptos_types::state_store::state_key::StateKey,
+        aptos_types::write_set::WriteOp,
+    >,
+> {
+    use aptos_types::{
+        state_store::state_key::{inner::TradingNativeKey, StateKey},
+        write_set::WriteOp,
+    };
+    let mut out = std::collections::BTreeMap::new();
+    for (key, maybe_position) in writes {
+        let state_key = match key {
+            TradingNativeKey::Position {
+                exchange,
+                account,
+                market,
+            } => StateKey::position(*exchange, *account, *market),
+        };
+        let op = match maybe_position {
+            Some(pos) => {
+                let bytes = pos.serialize().map_err(|e| {
+                    PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR)
+                        .with_message(format!("failed to serialize NativePosition: {}", e))
+                })?;
+                WriteOp::legacy_creation(bytes.into())
+            },
+            None => WriteOp::legacy_deletion(),
+        };
+        out.insert(state_key, op);
+    }
+    Ok(out)
 }

--- a/storage/indexer/src/db_v2.rs
+++ b/storage/indexer/src/db_v2.rs
@@ -250,6 +250,7 @@ impl<'a, R: StateView> TableInfoParser<'a, R> {
                     self.collect_table_info_from_table_item(*handle, bytes)?
                 },
                 StateKeyInner::Raw(_) => (),
+                // Out of scope for table-info collection.
                 StateKeyInner::TradingNative(_) => (),
             }
         }


### PR DESCRIPTION
## Summary

VM-side plumbing that carries native-position writes from the session extension into the transaction output, plus the match arms downstream consumers need for the `StateKeyInner::TradingNative` (Position) variant.

Stacked on #19949.

### aptos-vm-types
- `VMChangeSet.position_write_set`: a dedicated bucket for Position writes that **never** enters the flat WriteSet value bucket. `set_position_bucket` validates every key is a TradingNative Position key. Squash is last-wins per key; creation+deletion pairs are not collapsed because the position store is an idempotent key/value map.
- `VMOutput` materialization snapshots the bucket into the WriteSet's `native_positions` sibling bucket (as `NativePositionOp`); the storage commit applier consumes it via `WriteSet::native_position_iter`.

### aptos-vm
- Session finalize drains the `NativePositionContext` via `into_change_maps()`, converts it with `build_position_writeset` (payload → `WriteOp::legacy_creation`; `None` → `legacy_deletion`), and routes it through `set_position_bucket`. The session builder installs the extension. (Move-side reads of native state are not part of this change.)

### Match arms for the Position variant
- gas-profiling render + aggregate → `position<exchange,account,market>`
- transaction-simulation state_store
- `api/types/convert`: REST `WriteSetChange` returns an empty vec — positions ride in the `native_positions` sibling bucket, not the legacy value bucket
- storage/indexer/db_v2: no-op for table-info collection

## Testing
- `aptos-vm-types` unit tests: bucket validation (rejects non-Position keys) + last-wins squash (create→delete, delete→create).
- `aptos-vm-genesis --lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VM change-set and output materialization for a new state key class; behavior is gated by bucket validation and separate storage path, but errors here could mis-apply or drop position updates at commit time.
> 
> **Overview**
> Adds VM plumbing so **trading-native position** writes from `NativePositionContext` reach transaction output via a dedicated path, separate from the flat `WriteSet`.
> 
> **`VMChangeSet`** gains `position_write_set`: Position keys only (`set_position_bucket` validates), excluded from `try_combine_into_storage_change_set`. Squash is **last-wins** per key (no create+delete collapse). **`VMOutput::into_transaction_output`** copies the bucket into `WriteSet::native_positions` as `NativePositionOp` for the storage applier.
> 
> **`aptos-vm` session** installs `NativePositionContext`, drains it on `finish`, and maps staged writes through `build_position_writeset` (serialize → creation, `None` → deletion). Depends on **`aptos-position-natives`**.
> 
> Downstream: gas profiling / simulation render `TradingNative` Position keys; REST `WriteSetChange` returns **empty** for those keys; indexer table-info skips them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cdcbe70a2df031e7fabd1dd0be7d11504d6cbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->