### PR TITLE
[mono-move] Fix bool deserialization to be canonical

### DIFF
--- a/third_party/move/mono-move/core/src/value_layout.rs
+++ b/third_party/move/mono-move/core/src/value_layout.rs
@@ -55,6 +55,12 @@ bitflags! {
         /// This value has no heap pointers and no padding. That is, it can be
         /// serialized in one `memcpy` and compared for equality with `memcmp`.
         const NO_POINTERS_NO_PADDING = 0b0000_0001;
+        /// Every byte pattern of this value's in-memory image is a valid value,
+        /// so deserialization needs no per-byte validation and can copy the BCS
+        /// bytes in one `memcpy`. Holds for integers and addresses but not for
+        /// `bool` (only `0`/`1` are canonical). An aggregate has this flag only
+        /// when it has no padding, no pointers, and no `bool` reachable.
+        const ALL_BYTE_PATTERNS_VALID = 0b0000_0010;
     }
 }
 
@@ -153,6 +159,13 @@ impl ValueLayout {
         self.flags.contains(LayoutFlags::NO_POINTERS_NO_PADDING)
     }
 
+    /// Returns true if every byte pattern of this value's in-memory size is a
+    /// valid value, so deserialization can blit the BCS bytes without per-byte
+    /// validation. False for anything that reaches a `bool`.
+    pub fn all_byte_patterns_valid(&self) -> bool {
+        self.flags.contains(LayoutFlags::ALL_BYTE_PATTERNS_VALID)
+    }
+
     /// The fixed BCS size of a value of this type, or [`None`] when
     /// data-dependent.
     pub fn fixed_serialized_size(&self) -> Option<u32> {
@@ -236,7 +249,7 @@ impl ValueLayout {
             size: 32,
             align: MAX_ALIGN as u32,
             fixed_bcs_size: Some(32),
-            flags: LayoutFlags::NO_POINTERS_NO_PADDING,
+            flags: LayoutFlags::NO_POINTERS_NO_PADDING | LayoutFlags::ALL_BYTE_PATTERNS_VALID,
             kind: LayoutKind::Address,
         }
     }
@@ -325,7 +338,7 @@ impl ValueLayout {
             size,
             align,
             fixed_bcs_size: Some(size),
-            flags: LayoutFlags::NO_POINTERS_NO_PADDING,
+            flags: LayoutFlags::NO_POINTERS_NO_PADDING | LayoutFlags::ALL_BYTE_PATTERNS_VALID,
             kind: LayoutKind::UnsignedInt,
         }
     }
@@ -335,7 +348,7 @@ impl ValueLayout {
             size,
             align,
             fixed_bcs_size: Some(size),
-            flags: LayoutFlags::NO_POINTERS_NO_PADDING,
+            flags: LayoutFlags::NO_POINTERS_NO_PADDING | LayoutFlags::ALL_BYTE_PATTERNS_VALID,
             kind: LayoutKind::SignedInt,
         }
     }

--- a/third_party/move/mono-move/core/src/vm_error.rs
+++ b/third_party/move/mono-move/core/src/vm_error.rs
@@ -108,6 +108,9 @@ pub enum RuntimeError {
 
     #[error("BCS deserialize: {remaining} trailing byte(s) after value")]
     BCSRemainingInput { remaining: usize },
+
+    #[error("BCS deserialize: non-canonical bool byte {byte}")]
+    BCSInvalidBool { byte: u8 },
 }
 
 impl IntoExecutionError for RuntimeError {
@@ -140,9 +143,11 @@ impl IntoExecutionError for RuntimeError {
             | VecAllocSizeOverflow
             | AbortMessageTooLong { .. } => ExecutionErrorKind::RuntimeLimitExceeded,
 
-            BCSEof | BCSInvalidUleb | BCSSequenceTooLong { .. } | BCSRemainingInput { .. } => {
-                ExecutionErrorKind::InvalidOperation
-            },
+            BCSEof
+            | BCSInvalidUleb
+            | BCSSequenceTooLong { .. }
+            | BCSRemainingInput { .. }
+            | BCSInvalidBool { .. } => ExecutionErrorKind::InvalidOperation,
 
             InvariantViolation(_) => ExecutionErrorKind::InvariantViolation,
             ResourceProvider(e) => e.kind(),

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -595,12 +595,13 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
     // TODO: This walk recurses on struct fields and vector elements; convert it
     // to a non-recursive form to bound stack depth on deeply nested values.
     //
-    // If no padding or no pointers, value's BCS bytes are exactly its
-    // in-memory image.
+    // If every byte pattern is valid (no padding, no pointers, no `bool`), the
+    // value's BCS bytes are exactly its in-memory image. A `bool` is excluded
+    // because only `0`/`1` are canonical and a raw copy would skip that check.
     // TODO(correctness): breaks on big-endian hosts. This writes the
     // little-endian BCS bytes verbatim, but the in-memory representation is
     // native-endian, so the two only match on little-endian hosts.
-    if layout.has_no_pointers_no_padding() {
+    if layout.all_byte_patterns_valid() {
         let n = layout.size as usize;
         let src = read_slice(bytes, cursor, n)?;
         // SAFETY: caller ensures `n` bytes can be written to `dst` and it is
@@ -610,11 +611,19 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
     }
 
     match &layout.kind {
-        LayoutKind::Bool
-        | LayoutKind::UnsignedInt
-        | LayoutKind::SignedInt
-        | LayoutKind::Address => {
-            Err(unreachable("Primitive layouts must be handled by fast-path").into())
+        LayoutKind::Bool => {
+            // BCS encodes a `bool` as a single canonical byte: `0` or `1`. Any
+            // other value is rejected rather than blitted into the slot.
+            let byte = read_slice(bytes, cursor, 1)?[0];
+            if byte > 1 {
+                return Err(RuntimeError::BCSInvalidBool { byte }.into());
+            }
+            // SAFETY: caller ensures one byte can be written to `dst`.
+            unsafe { std::ptr::write(dst, byte) };
+            Ok(())
+        },
+        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => {
+            Err(unreachable("Integer and address layouts must be handled by fast-path").into())
         },
         LayoutKind::Struct { fields } => {
             for field in fields.iter() {
@@ -668,9 +677,10 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
             // as guaranteed by the allocator.
             unsafe { write_u64(vec_ptr, VEC_LENGTH_OFFSET, len) };
 
-            if elem_layout.has_no_pointers_no_padding() {
-                // If elements have no padding and no pointers, element bytes
-                // equal their BCS bytes.
+            if elem_layout.all_byte_patterns_valid() {
+                // If every element byte pattern is valid, element bytes equal
+                // their BCS bytes. A `bool` element is excluded so each byte is
+                // validated by the per-element walk below.
                 // TODO(correctness): breaks on big-endian hosts, for the same
                 // reason as the scalar fast path above: native-endian in-memory
                 // bytes equal the little-endian BCS bytes only on little-endian
@@ -871,7 +881,7 @@ mod tests {
     use mono_move_core::{
         align_up_u32,
         types::U64_TY,
-        value_layout::{U16_LAYOUT_ID, U64_LAYOUT_ID, U8_LAYOUT_ID},
+        value_layout::{BOOL_LAYOUT_ID, U16_LAYOUT_ID, U64_LAYOUT_ID, U8_LAYOUT_ID},
         DescriptorId, FieldValueLayout, LayoutFlags, LayoutId, ValueLayoutTable,
     };
     use serde::Serialize;
@@ -1033,6 +1043,107 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn deserialize_bool_canonical() {
+        let table = ValueLayoutTable::new();
+        let layout = table.layout(BOOL_LAYOUT_ID).unwrap();
+        // A bool reaches the per-byte walk, not the blit fast path.
+        assert!(layout.has_no_pointers_no_padding());
+        assert!(!layout.all_byte_patterns_valid());
+
+        let mut heap = Heap::new(64);
+        for byte in [0u8, 1] {
+            let mut slot = 0xFFu8;
+            let mut cursor = 0;
+            unsafe {
+                deserialize_impl(&table, &mut heap, layout, &[byte], &mut cursor, &mut slot)
+                    .unwrap()
+            };
+            assert_eq!(slot, byte);
+            assert_eq!(cursor, 1);
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_non_canonical_bool() {
+        let table = ValueLayoutTable::new();
+        let layout = table.layout(BOOL_LAYOUT_ID).unwrap();
+        let mut heap = Heap::new(64);
+        let mut slot = 0u8;
+        let mut cursor = 0;
+        let result =
+            unsafe { deserialize_impl(&table, &mut heap, layout, &[2u8], &mut cursor, &mut slot) };
+        assert!(matches!(
+            result,
+            Err(AllocationError::RuntimeError(
+                RuntimeError::BCSInvalidBool { byte: 2 }
+            ))
+        ));
+    }
+
+    #[test]
+    fn deserialize_rejects_non_canonical_bool_in_vector() {
+        let mut table = ValueLayoutTable::new();
+        let vid = table.push(U64_TY, vector_layout(BOOL_LAYOUT_ID));
+        let layout = table.layout(vid).unwrap();
+        let mut heap = Heap::new(4096);
+        // Length 2, then a canonical `1` and a non-canonical `2`.
+        let bytes = [0x02u8, 0x01, 0x02];
+        let mut slot = 0u64;
+        let mut cursor = 0;
+        let result = unsafe {
+            deserialize_impl(
+                &table,
+                &mut heap,
+                layout,
+                &bytes,
+                &mut cursor,
+                &mut slot as *mut u64 as *mut u8,
+            )
+        };
+        assert!(matches!(
+            result,
+            Err(AllocationError::RuntimeError(
+                RuntimeError::BCSInvalidBool { byte: 2 }
+            ))
+        ));
+    }
+
+    #[test]
+    fn deserialize_rejects_non_canonical_bool_in_struct() {
+        // `{u8, bool}`: no padding (BCS 2 == size 2), so blittable for
+        // serialize/equals, but the bool field keeps it off the deserialize
+        // fast path so the bad byte is caught.
+        let mut table = ValueLayoutTable::new();
+        let layout = build_struct_layout(&table, 2, vec![(0, U8_LAYOUT_ID), (1, BOOL_LAYOUT_ID)]);
+        assert!(layout.has_no_pointers_no_padding());
+        assert!(!layout.all_byte_patterns_valid());
+        let id = table.push(U64_TY, layout);
+        let layout = table.layout(id).unwrap();
+
+        let mut heap = Heap::new(64);
+        // u8 = 5, then a non-canonical bool byte.
+        let bytes = [0x05u8, 0x02];
+        let mut slot = [0u8; 2];
+        let mut cursor = 0;
+        let result = unsafe {
+            deserialize_impl(
+                &table,
+                &mut heap,
+                layout,
+                &bytes,
+                &mut cursor,
+                slot.as_mut_ptr(),
+            )
+        };
+        assert!(matches!(
+            result,
+            Err(AllocationError::RuntimeError(
+                RuntimeError::BCSInvalidBool { byte: 2 }
+            ))
+        ));
+    }
+
     /// Builds a struct layout from field offsets/ids and the in-memory size,
     /// deriving the const BCS size and no-padding flag as the specializer does.
     fn build_struct_layout(
@@ -1042,16 +1153,22 @@ mod tests {
     ) -> ValueLayout {
         let mut const_total = 0u64;
         let mut data_dependent = false;
+        let mut all_bytes_valid = true;
         for &(_, id) in &fields {
-            match table.layout(id).unwrap().fixed_serialized_size() {
+            let child = table.layout(id).unwrap();
+            match child.fixed_serialized_size() {
                 Some(n) => const_total += n as u64,
                 None => data_dependent = true,
             }
+            all_bytes_valid &= child.all_byte_patterns_valid();
         }
         let const_bcs = (!data_dependent).then_some(const_total as u32);
         let mut flags = LayoutFlags::empty();
         if const_bcs == Some(size) {
             flags |= LayoutFlags::NO_POINTERS_NO_PADDING;
+            if all_bytes_valid {
+                flags |= LayoutFlags::ALL_BYTE_PATTERNS_VALID;
+            }
         }
         let field_layouts = fields
             .into_iter()

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -1326,6 +1326,7 @@ fn try_build_inline_value_layout(
     let mut layout_fields = Vec::with_capacity(field_layouts.len());
     let mut fixed_bcs_total: u64 = 0;
     let mut data_dependent = false;
+    let mut all_bytes_valid = true;
     for (field, &fid) in field_layouts.iter().zip(field_ids) {
         // A field can be sized yet still lack a published layout (e.g. a
         // `vector<T>` whose element layout is deferred). Defer the aggregate.
@@ -1343,6 +1344,7 @@ fn try_build_inline_value_layout(
             Some(bcs_sz) => fixed_bcs_total = fixed_bcs_total.saturating_add(bcs_sz as u64),
             None => data_dependent = true,
         }
+        all_bytes_valid &= child.all_byte_patterns_valid();
     }
 
     let fixed_bcs_size = if data_dependent || fixed_bcs_total > u32::MAX as u64 {
@@ -1356,6 +1358,11 @@ fn try_build_inline_value_layout(
     let mut flags = LayoutFlags::empty();
     if fixed_bcs_size == Some(total) {
         flags |= LayoutFlags::NO_POINTERS_NO_PADDING;
+        // Blittable on deserialize only when no field reaches a `bool`, which
+        // needs per-byte validation that a single `memcpy` would skip.
+        if all_bytes_valid {
+            flags |= LayoutFlags::ALL_BYTE_PATTERNS_VALID;
+        }
     }
     Ok(Some(ValueLayout::struct_layout(
         total,


### PR DESCRIPTION
## Problem

BCS deserialization in `deserialize_impl` (`value_utils.rs`) blits bytes verbatim whenever a layout has `NO_POINTERS_NO_PADDING`:

```rust
if layout.has_no_pointers_no_padding() {
    // raw copy_nonoverlapping of layout.size bytes
}
```

A `bool` carries that flag, so a bool slot accepted any byte `0..=255`. BCS requires a canonical `0` or `1`, and the legacy MoveVM rejects anything else (`bool::deserialize` via bcs). Non-canonical bytes diverged from the legacy VM, could persist in stored resources, and are undefined behavior when later read as a Rust `bool`.

The same flag also makes aggregates blittable, so `vector<bool>` and no-padding structs containing a `bool` bulk-copied without validation too. So the check could not live only in the `LayoutKind::Bool` match arm — that arm is unreachable whenever a bool sits inside a blittable aggregate.

## Fix

`NO_POINTERS_NO_PADDING` ("in-memory image equals BCS bytes") is sufficient for **serialize** and **equals**, which run on already-valid values. It is not sufficient for **deserialize**, whose input is untrusted. `bool` is the only blittable leaf that needs validation.

Add a second layout flag, `ALL_BYTE_PATTERNS_VALID`, set on integers and addresses but not `bool`, and propagated through aggregates only when no field reaches a `bool`. Deserialization uses the new flag for its blit fast paths; serialize and equals keep `NO_POINTERS_NO_PADDING` and their `memcpy` / `memcmp` fast paths. The `Bool` arm in `deserialize_impl` now reads one byte and rejects any value above `1` with a new `BCSInvalidBool` error.

## Changes

- `core/src/value_layout.rs`: new `ALL_BYTE_PATTERNS_VALID` flag + accessor; set on integer/address constructors, not `bool()`.
- `specializer/src/lower/context.rs`: propagate the flag in `try_build_inline_value_layout` (set only when no field reaches a bool).
- `runtime/src/value_utils.rs`: deserialize fast paths use the new flag; implement the `Bool` arm with the canonical check.
- `runtime/src/error.rs`: add `BCSInvalidBool { byte }`, mapped to `InvalidOperation`.

## Testing

- New rejection tests: standalone bool, `vector<bool>`, and a struct with a bool field, each asserting `BCSInvalidBool`; plus a canonical accept test.
- `cargo test -p mono-move-core`, `-p mono-move-runtime`, `-p specializer` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes untrusted BCS deserialization for stored resources and aligns behavior with legacy VM; scope is bounded to mono-move layout/deserialize paths with new tests.
> 
> **Overview**
> Fixes a **BCS deserialization** bug where layouts with `NO_POINTERS_NO_PADDING` were **memcpy-blitted** from untrusted bytes. **`bool`** (and aggregates like **`vector<bool>`** or packed structs containing **`bool`**) could accept any byte `0..=255`, diverging from legacy MoveVM and risking invalid in-memory **`bool`** values.
> 
> Introduces **`ALL_BYTE_PATTERNS_VALID`**: set on integers and addresses, **not** on **`bool`**, and propagated on struct layouts only when no field reaches a **`bool`**. **Deserialize** fast paths (scalar and vector elements) now require this flag; **serialize** and **equals** still use **`NO_POINTERS_NO_PADDING`**. **`LayoutKind::Bool`** deserialization reads one byte and rejects values **`> 1`** via **`BCSInvalidBool`**.
> 
> The specializer’s **`try_build_inline_value_layout`** sets the new flag using the same “all children valid” rule. Tests cover canonical **`bool`**, rejection in vectors and structs, and updated test helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ec7f8860f70d20d81ef3e6007bceae0ba06f2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->