### PR TITLE
[mono-move] Collapse generic/non-generic call & closure IR twins

### DIFF
--- a/third_party/move/mono-move/specializer/src/destack/analysis.rs
+++ b/third_party/move/mono-move/specializer/src/destack/analysis.rs
@@ -750,13 +750,13 @@ fn assert_xfer_invariants(
     }
 }
 
-/// Returns `(rets, args)` for `Call` / `CallGeneric`. `CallClosure` is
+/// Returns `(rets, args)` for `Call`. `CallClosure` is
 /// intentionally excluded: Xfer precoloring leaves closure calls alone
 /// (they still count as call boundaries via `clobbers_xfer`, just not
 /// destructured for slot inspection).
 #[inline]
 fn call_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[Slot])> {
-    if let Instr::Call(rets, _, args) | Instr::CallGeneric(rets, _, args) = instr {
+    if let Instr::Call(rets, _, _, args) = instr {
         Some((rets, args))
     } else {
         None
@@ -834,9 +834,9 @@ pub(crate) fn assert_xfer_invariants_on_final_ir(
             // (arg positionality).
             if clobbers_xfer(instr) {
                 let (rets, args): (&[Slot], &[Slot]) = match instr {
-                    Instr::Call(rets, _, args)
-                    | Instr::CallGeneric(rets, _, args)
-                    | Instr::CallClosure(rets, _, args) => (rets, args),
+                    Instr::Call(rets, _, _, args) | Instr::CallClosure(rets, _, args) => {
+                        (rets, args)
+                    },
                     _ => unreachable!("clobbers_xfer matches only Call variants"),
                 };
                 // Structural invariants (arg positionality, return Xfer prefix,
@@ -913,6 +913,7 @@ pub(crate) fn assert_xfer_invariants_on_final_ir(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mono_move_core::types::EMPTY_TYPE_LIST;
     use move_binary_format::file_format::FunctionHandleIndex;
 
     /// Wide call signatures (past `SmallBitVec`'s inline-storage
@@ -921,7 +922,12 @@ mod tests {
     fn analyze_handles_wide_call_signatures() {
         // 200 args exercises `SmallBitVec`'s heap-allocated path.
         let args: Vec<Slot> = (0..200).map(Slot::Vid).collect();
-        let instrs = vec![Instr::Call(vec![], FunctionHandleIndex(0), args)];
+        let instrs = vec![Instr::Call(
+            vec![],
+            FunctionHandleIndex(0),
+            EMPTY_TYPE_LIST,
+            args,
+        )];
         let analysis = BlockAnalysis::analyze(&instrs);
         assert_eq!(analysis.max_xfer_positions, 200);
     }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -18,10 +18,10 @@ use mono_move_core::{
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        Bytecode, CodeOffset, FieldHandleIndex, FieldInstantiationIndex,
-        StructDefInstantiationIndex, StructDefinitionIndex, StructFieldInformation,
-        StructVariantInstantiationIndex, VariantFieldHandleIndex, VariantFieldInstantiationIndex,
-        VariantIndex,
+        Bytecode, CodeOffset, FieldHandleIndex, FieldInstantiationIndex, FunctionHandleIndex,
+        FunctionInstantiationIndex, StructDefInstantiationIndex, StructDefinitionIndex,
+        StructFieldInformation, StructVariantInstantiationIndex, VariantFieldHandleIndex,
+        VariantFieldInstantiationIndex, VariantIndex,
     },
 };
 use shared_dsa::{Entry, UnorderedMap};
@@ -251,6 +251,20 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             .interner
             .subst_type(module.interned_variant_field_type_at(inst.handle), ty_args)?;
         Ok((inst.handle, owner, field_ty))
+    }
+
+    /// Given a generic function instantiation, returns its inner (non-generic)
+    /// function handle and interned type arguments.
+    fn fun_inst_parts(
+        &self,
+        module: &PreparedModule,
+        idx: FunctionInstantiationIndex,
+    ) -> (FunctionHandleIndex, InternedTypeList) {
+        let inst = module.function_instantiation_at(idx);
+        let ty_args = self
+            .interner
+            .type_list_of(module.interned_types_at(inst.type_parameters));
+        (inst.handle, ty_args)
     }
 
     // --------------------------------------------------------------------------------------------
@@ -826,18 +840,19 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 for &rty in ret_types {
                     rets.push(self.alloc_vid(rty)?);
                 }
-                self.current_block_instrs
-                    .push(Instr::Call(rets.clone(), *idx, args));
+                self.current_block_instrs.push(Instr::Call(
+                    rets.clone(),
+                    *idx,
+                    ty::EMPTY_TYPE_LIST,
+                    args,
+                ));
                 for r in rets {
                     self.push_slot(r);
                 }
             },
             B::CallGeneric(idx) => {
-                let inst = module.function_instantiation_at(*idx);
-                let handle = module.function_handle_at(inst.handle);
-                let ty_args = self
-                    .interner
-                    .type_list_of(module.interned_types_at(inst.type_parameters));
+                let (handle_idx, ty_args) = self.fun_inst_parts(module, *idx);
+                let handle = module.function_handle_at(handle_idx);
                 let params = module.interned_types_at(handle.parameters);
                 let ret_types = module.interned_types_at(handle.return_);
                 let num_args = params.len();
@@ -847,8 +862,12 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     let rty = self.interner.subst_type(rty, ty_args)?;
                     rets.push(self.alloc_vid(rty)?);
                 }
-                self.current_block_instrs
-                    .push(Instr::CallGeneric(rets.clone(), *idx, args));
+                self.current_block_instrs.push(Instr::Call(
+                    rets.clone(),
+                    handle_idx,
+                    ty_args,
+                    args,
+                ));
                 for r in rets {
                     self.push_slot(r);
                 }
@@ -871,18 +890,20 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     move_core_types::ability::AbilitySet::EMPTY,
                 );
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::PackClosure(dst, *fhi, *mask, captured));
+                self.current_block_instrs.push(Instr::PackClosure(
+                    dst,
+                    *fhi,
+                    ty::EMPTY_TYPE_LIST,
+                    *mask,
+                    captured,
+                ));
                 self.push_slot(dst);
             },
             B::PackClosureGeneric(fii, mask) => {
                 let captured_count = mask.captured_count() as usize;
                 let captured = self.pop_n_reverse(captured_count)?;
-                let inst = &module.function_instantiations[fii.0 as usize];
-                let handle = module.function_handle_at(inst.handle);
-                let ty_args = self
-                    .interner
-                    .type_list_of(module.interned_types_at(inst.type_parameters));
+                let (handle_idx, ty_args) = self.fun_inst_parts(module, *fii);
+                let handle = module.function_handle_at(handle_idx);
                 let params = self
                     .interner
                     .type_list_of(module.interned_types_at(handle.parameters));
@@ -898,8 +919,9 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     move_core_types::ability::AbilitySet::EMPTY,
                 );
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::PackClosureGeneric(dst, *fii, *mask, captured));
+                self.current_block_instrs.push(Instr::PackClosure(
+                    dst, handle_idx, ty_args, *mask, captured,
+                ));
                 self.push_slot(dst);
             },
             B::CallClosure(sig_idx) => {

--- a/third_party/move/mono-move/specializer/src/destack/test_utils.rs
+++ b/third_party/move/mono-move/specializer/src/destack/test_utils.rs
@@ -25,7 +25,7 @@ impl SSAFunction {
     pub(crate) fn with_test_utils_passes(mut self, module: &PreparedModule) -> Result<Self> {
         for block in &mut self.blocks {
             for instr in &mut block.instrs {
-                if let Instr::Call(rets, handle, args) = instr
+                if let Instr::Call(rets, handle, _, args) = instr
                     && is_force_gc(module, *handle)
                 {
                     if !rets.is_empty() || !args.is_empty() {

--- a/third_party/move/mono-move/specializer/src/gas.rs
+++ b/third_party/move/mono-move/specializer/src/gas.rs
@@ -177,14 +177,10 @@ pub(crate) fn instr_cost(instr: &Instr, cx: &impl CostContext) -> Result<u64> {
         | Instr::MutBorrowGlobal(..) => GLOBAL,
 
         // --- Calls ---
-        Instr::Call(rets, _, args) | Instr::CallGeneric(rets, _, args) => {
-            call_cost(cx, args, rets)?
-        },
+        Instr::Call(rets, _, _, args) => call_cost(cx, args, rets)?,
 
         // --- Closures ---
-        Instr::PackClosure(_, _, _, args) | Instr::PackClosureGeneric(_, _, _, args) => {
-            PACK_CLOSURE + sum_move(cx, args)?
-        },
+        Instr::PackClosure(_, _, _, _, args) => PACK_CLOSURE + sum_move(cx, args)?,
         Instr::CallClosure(rets, _, args) => call_cost(cx, args, rets)?,
 
         // --- Vector ---

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -424,6 +424,21 @@ fn callee_identity(
     )
 }
 
+/// Callee `(params, returns)` from its handle signature, substituted under
+/// `ty_args`. The substitution is a no-op when `ty_args` is empty.
+fn instantiate_callee_signature(
+    module: &PreparedModule,
+    interner: &impl Interner,
+    handle_idx: FunctionHandleIndex,
+    ty_args: InternedTypeList,
+) -> Result<(InternedTypeList, InternedTypeList)> {
+    let sig = module.function_signature_at(handle_idx);
+    Ok((
+        interner.subst_type_list(sig.params, ty_args)?,
+        interner.subst_type_list(sig.returns, ty_args)?,
+    ))
+}
+
 /// Try to build a [`LoweringContext`] for a monomorphic function.
 ///
 /// Returns:
@@ -600,9 +615,8 @@ pub fn try_build_context<'a>(
     // TODO: we need to revisit the complexity and performance of this function
     // after support for generic monomorphization is in place.
     // 7. Lay out every callee-frame region in a single IR-order pass: regular
-    //    calls (`Call`/`CallGeneric`) and closures (`PackClosure`/`CallClosure`)
-    //    are disjoint instruction kinds writing disjoint outputs, so one walk
-    //    serves both.
+    //    calls (`Call`) and closures (`PackClosure`/`CallClosure`) are disjoint
+    //    instruction kinds writing disjoint outputs, so one walk serves both.
     let callee_base = frame_data_size + FRAME_METADATA_SIZE as u32;
     let mut call_sites = Vec::new();
     let mut closure_pack_sites = Vec::new();
@@ -610,73 +624,33 @@ pub fn try_build_context<'a>(
     let mut closure_pack_idx = 0usize;
     for instr in func_ir.instrs() {
         let (handle_idx, param_list, ret_list, call_ty_args) = match instr {
-            Instr::Call(_, idx, _) => {
-                let sig = module_ir.module.function_signature_at(*idx);
-                (*idx, sig.params, sig.returns, EMPTY_TYPE_LIST)
+            Instr::Call(_, handle_idx, call_ty_args, _) => {
+                let resolved_ty_args = interner.subst_type_list(*call_ty_args, ty_args)?;
+                let (params, returns) = instantiate_callee_signature(
+                    &module_ir.module,
+                    interner,
+                    *handle_idx,
+                    resolved_ty_args,
+                )?;
+                (*handle_idx, params, returns, resolved_ty_args)
             },
-            Instr::CallGeneric(_, idx, _) => {
-                let inst = module_ir.module.function_instantiation_at(*idx);
-                let sig = module_ir.module.function_instantiation_signature_at(*idx);
-                let params = interner.subst_type_list(sig.params, ty_args)?;
-                let returns = interner.subst_type_list(sig.returns, ty_args)?;
-                let call_ty_args = interner.subst_type_list(sig.ty_args, ty_args)?;
-                (inst.handle, params, returns, call_ty_args)
-            },
-            Instr::PackClosure(_, fhi, _, _) => {
-                if !module_ir
-                    .module
-                    .function_handle_at(*fhi)
-                    .type_parameters
-                    .is_empty()
-                {
-                    return Ok(BuildContextOutcome::Skipped(
-                        "generic closure target not yet lowered",
-                    ));
-                }
-                let (callee_module_id, callee_func_name) = callee_identity(&module_ir.module, *fhi);
+            Instr::PackClosure(_, handle_idx, call_ty_args, _, _) => {
+                let closure_ty_args = interner.subst_type_list(*call_ty_args, ty_args)?;
+                // Bytecode verifier's instruction consistency check should
+                // guarantee the invariant below.
+                debug_assert!(
+                    !call_ty_args.is_empty()
+                        || module_ir
+                            .module
+                            .function_handle_at(*handle_idx)
+                            .type_parameters
+                            .is_empty(),
+                    "non-generic PackClosure must target a non-generic function"
+                );
+                let (callee_module_id, callee_func_name) =
+                    callee_identity(&module_ir.module, *handle_idx);
                 // TODO: support native closure targets. `CallClosure` resolves
                 // via `load_function`, which has no IR for natives, so skip them.
-                if natives
-                    .resolve(callee_module_id, callee_func_name, EMPTY_TYPE_LIST)
-                    .is_some()
-                {
-                    return Ok(BuildContextOutcome::Skipped(
-                        "native closure target not yet lowered",
-                    ));
-                }
-                let func_ref =
-                    interner.function_ref_of(callee_module_id, callee_func_name, EMPTY_TYPE_LIST);
-                // Captured-data layout resolved positionally.
-                let layout = descriptors.closure_captured[closure_pack_idx];
-                closure_pack_idx += 1;
-                let (captured_data_descriptor_id, values_size) = match layout {
-                    CapturedDataLayout::NonCapturing => (None, 0),
-                    CapturedDataLayout::Capturing(info) => {
-                        (Some(info.descriptor_id), info.values_size)
-                    },
-                    CapturedDataLayout::NotDerivable => {
-                        return Ok(BuildContextOutcome::Skipped(
-                            "captured-data layout not derivable",
-                        ));
-                    },
-                };
-                closure_pack_sites.push(ClosurePackInfo {
-                    func_ref,
-                    captured_data_descriptor_id,
-                    values_size,
-                });
-                continue;
-            },
-            Instr::PackClosureGeneric(_, fii, _, _) => {
-                let inst = module_ir.module.function_instantiation_at(*fii);
-                let sig = module_ir.module.function_instantiation_signature_at(*fii);
-                // The closure target's type arguments at this instantiation:
-                // its instantiation type arguments with this function's
-                // `ty_args` substituted in.
-                let closure_ty_args = interner.subst_type_list(sig.ty_args, ty_args)?;
-                let (callee_module_id, callee_func_name) =
-                    callee_identity(&module_ir.module, inst.handle);
-                // TODO: support native closure targets (see `PackClosure`).
                 if natives
                     .resolve(callee_module_id, callee_func_name, closure_ty_args)
                     .is_some()
@@ -1138,23 +1112,18 @@ fn try_discover_types_for_lowering_in_function_impl(
         // still discovered. Otherwise, we need to feed `CallClosure` signature
         // types here and recurse into `Type::Function`.
         let (params, returns, handle_idx, callee_ty_args) = match instr {
-            Instr::Call(_, idx, _) => {
-                let sig = module_ir.module.function_signature_at(*idx);
+            Instr::Call(_, handle_idx, call_ty_args, _) => {
+                let (params, returns) = instantiate_callee_signature(
+                    &module_ir.module,
+                    interner,
+                    *handle_idx,
+                    *call_ty_args,
+                )?;
                 (
-                    Some(sig.params),
-                    Some(sig.returns),
-                    Some(*idx),
-                    EMPTY_TYPE_LIST,
-                )
-            },
-            Instr::CallGeneric(_, idx, _) => {
-                let inst = module_ir.module.function_instantiation_at(*idx);
-                let sig = module_ir.module.function_instantiation_signature_at(*idx);
-                (
-                    Some(sig.params),
-                    Some(sig.returns),
-                    Some(inst.handle),
-                    sig.ty_args,
+                    Some(params),
+                    Some(returns),
+                    Some(*handle_idx),
+                    *call_ty_args,
                 )
             },
             _ => (None, None, None, EMPTY_TYPE_LIST),
@@ -1198,24 +1167,13 @@ fn try_discover_types_for_lowering_in_function_impl(
 
         // `PackClosure`: resolve the captured-data layout and record it
         // positionally, in IR order, for the build pass.
-        if let Instr::PackClosure(_, fhi, mask, _) = instr {
-            let layout =
-                discover_captured_data_descriptor(ctx, interner, module_ir, *fhi, *mask, ty_args)?;
-            descriptors.closure_captured.push(layout);
-        }
-
-        // `PackClosureGeneric`: same as above, with the callee's type arguments
-        // composed from the instantiation signature and the enclosing
-        // function's `ty_args`.
-        if let Instr::PackClosureGeneric(_, fii, mask, _) = instr {
-            let inst = module_ir.module.function_instantiation_at(*fii);
-            let sig = module_ir.module.function_instantiation_signature_at(*fii);
-            let closure_ty_args = interner.subst_type_list(sig.ty_args, ty_args)?;
+        if let Instr::PackClosure(_, handle_idx, call_ty_args, mask, _) = instr {
+            let closure_ty_args = interner.subst_type_list(*call_ty_args, ty_args)?;
             let layout = discover_captured_data_descriptor(
                 ctx,
                 interner,
                 module_ir,
-                inst.handle,
+                *handle_idx,
                 *mask,
                 closure_ty_args,
             )?;

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -1270,10 +1270,7 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Calls ---
-            Instr::Call(rets, _handle_idx, args) => {
-                self.lower_call(func_ir, args, rets)?;
-            },
-            Instr::CallGeneric(rets, _inst_idx, args) => {
+            Instr::Call(rets, _handle_idx, _ty_args, args) => {
                 self.lower_call(func_ir, args, rets)?;
             },
 
@@ -1627,8 +1624,7 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Closures ---
-            Instr::PackClosure(dst, _, mask, captured)
-            | Instr::PackClosureGeneric(dst, _, mask, captured) => {
+            Instr::PackClosure(dst, _, _, mask, captured) => {
                 // Target identity (with composed type arguments for the
                 // generic form) + captured-data descriptor were resolved in
                 // `try_build_context`; read them positionally.

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -5,13 +5,10 @@
 //! entity handles (functions, fields, variants) resolve via `CompiledModule`.
 
 use super::{BinaryOp, CmpKind, FunctionIR, ImmValue, Instr, ModuleIR, Slot, UnaryOp};
-use mono_move_core::types::{display_type, display_type_list};
+use mono_move_core::types::{display_type, display_type_list, InternedTypeList};
 use move_binary_format::{
     access::ModuleAccess,
-    file_format::{
-        FieldHandleIndex, FunctionHandleIndex, FunctionInstantiationIndex, SignatureToken,
-        VariantFieldHandleIndex,
-    },
+    file_format::{FieldHandleIndex, FunctionHandleIndex, SignatureToken, VariantFieldHandleIndex},
     CompiledModule,
 };
 use std::fmt;
@@ -130,9 +127,15 @@ fn func_name(module: &CompiledModule, idx: FunctionHandleIndex) -> String {
     module.identifier_at(handle.name).to_string()
 }
 
-fn func_inst_name(module: &CompiledModule, idx: FunctionInstantiationIndex) -> String {
-    let inst = &module.function_instantiations[idx.0 as usize];
-    func_name(module, inst.handle)
+/// Writes `<t0, t1, ...>` for a call/closure's type arguments, or nothing when
+/// the list is empty (a non-generic target).
+fn write_ty_args(f: &mut fmt::Formatter<'_>, ty_args: InternedTypeList) -> fmt::Result {
+    if !ty_args.is_empty() {
+        write!(f, "<")?;
+        display_type_list(f, ty_args)?;
+        write!(f, ">")?;
+    }
+    Ok(())
 }
 
 fn field_name(module: &CompiledModule, idx: FieldHandleIndex) -> String {
@@ -473,40 +476,19 @@ fn display_instr(
         },
 
         // --- Calls ---
-        Instr::Call(rets, idx, args) => {
+        Instr::Call(rets, idx, ty_args, args) => {
             write_dsts(f, rets)?;
-            write!(f, "call {}, {}", func_name(module, *idx), slot_names(args))
-        },
-        Instr::CallGeneric(rets, idx, args) => {
-            write_dsts(f, rets)?;
-            write!(
-                f,
-                "call {}, {}",
-                func_inst_name(module, *idx),
-                slot_names(args)
-            )
+            write!(f, "call {}", func_name(module, *idx))?;
+            write_ty_args(f, *ty_args)?;
+            write!(f, ", {}", slot_names(args))
         },
 
         // --- Closures ---
-        Instr::PackClosure(d, idx, mask, captured) => {
+        Instr::PackClosure(d, idx, ty_args, mask, captured) => {
             write_dst(f, *d)?;
-            write!(
-                f,
-                "pack_closure {}, {}, {}",
-                func_name(module, *idx),
-                mask,
-                slot_names(captured)
-            )
-        },
-        Instr::PackClosureGeneric(d, idx, mask, captured) => {
-            write_dst(f, *d)?;
-            write!(
-                f,
-                "pack_closure {}, {}, {}",
-                func_inst_name(module, *idx),
-                mask,
-                slot_names(captured)
-            )
+            write!(f, "pack_closure {}", func_name(module, *idx))?;
+            write_ty_args(f, *ty_args)?;
+            write!(f, ", {}, {}", mask, slot_names(captured))
         },
         Instr::CallClosure(rets, sig_types, args) => {
             write_dsts(f, rets)?;

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
@@ -117,14 +117,10 @@ pub(crate) fn remap_source_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> 
 // Other instruction utilities
 // =============================================================================
 
-/// Call-like instructions (`Call`, `CallGeneric`, `CallClosure`) that clobber
-/// Xfer slots.
+/// Call-like instructions (`Call`, `CallClosure`) that clobber Xfer slots.
 #[inline]
 pub(crate) fn clobbers_xfer(instr: &Instr) -> bool {
-    matches!(
-        instr,
-        Instr::Call(..) | Instr::CallGeneric(..) | Instr::CallClosure(..)
-    )
+    matches!(instr, Instr::Call(..) | Instr::CallClosure(..))
 }
 
 /// Resource type carried by a global-storage instruction (`exists`,
@@ -160,7 +156,6 @@ pub(crate) fn resource_type_in_instr(instr: &Instr) -> Option<InternedType> {
         | Instr::ReadVariantField(..)
         | Instr::WriteVariantField(..)
         | Instr::PackClosure(..)
-        | Instr::PackClosureGeneric(..)
         | Instr::CallClosure(..)
         | Instr::VecPack(..)
         | Instr::VecLen(..)
@@ -195,7 +190,6 @@ pub(crate) fn resource_type_in_instr(instr: &Instr) -> Option<InternedType> {
         | Instr::ReadRef(..)
         | Instr::WriteRef(..)
         | Instr::Call(..)
-        | Instr::CallGeneric(..)
         | Instr::Branch(..)
         | Instr::BrTrue(..)
         | Instr::BrFalse(..)
@@ -262,7 +256,6 @@ pub(crate) fn field_layout_nominal_in_instr(instr: &Instr) -> Option<(InternedTy
         | Instr::ImmBorrowGlobal(..)
         | Instr::MutBorrowGlobal(..)
         | Instr::PackClosure(..)
-        | Instr::PackClosureGeneric(..)
         | Instr::CallClosure(..)
         | Instr::VecPack(..)
         | Instr::VecLen(..)
@@ -299,7 +292,6 @@ pub(crate) fn field_layout_nominal_in_instr(instr: &Instr) -> Option<(InternedTy
         | Instr::ReadRef(..)
         | Instr::WriteRef(..)
         | Instr::Call(..)
-        | Instr::CallGeneric(..)
         | Instr::Branch(..)
         | Instr::BrTrue(..)
         | Instr::BrFalse(..)
@@ -369,9 +361,7 @@ pub(crate) fn is_fallthrough_terminator(instr: &Instr) -> bool {
         | Instr::ImmBorrowGlobal(..)
         | Instr::MutBorrowGlobal(..)
         | Instr::Call(..)
-        | Instr::CallGeneric(..)
         | Instr::PackClosure(..)
-        | Instr::PackClosureGeneric(..)
         | Instr::CallClosure(..)
         | Instr::VecPack(..)
         | Instr::VecLen(..)
@@ -445,10 +435,8 @@ pub(crate) fn extract_imm_value(instr: &Instr) -> Option<(Slot, ImmValue)> {
         | Instr::MoveTo(_, _, _)
         | Instr::ImmBorrowGlobal(_, _, _)
         | Instr::MutBorrowGlobal(_, _, _)
-        | Instr::Call(_, _, _)
-        | Instr::CallGeneric(_, _, _)
-        | Instr::PackClosure(_, _, _, _)
-        | Instr::PackClosureGeneric(_, _, _, _)
+        | Instr::Call(_, _, _, _)
+        | Instr::PackClosure(_, _, _, _, _)
         | Instr::CallClosure(_, _, _)
         | Instr::VecPack(_, _, _)
         | Instr::VecLen(_, _, _)
@@ -644,14 +632,11 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
             used::<USES>(*addr, &mut f);
         },
 
-        Instr::Call(rets, _, args)
-        | Instr::CallGeneric(rets, _, args)
-        | Instr::CallClosure(rets, _, args) => {
+        Instr::Call(rets, _, _, args) | Instr::CallClosure(rets, _, args) => {
             defs::<DEFS>(rets, &mut f);
             uses::<USES>(args, &mut f);
         },
-        Instr::PackClosure(dst, _, _, captured)
-        | Instr::PackClosureGeneric(dst, _, _, captured) => {
+        Instr::PackClosure(dst, _, _, _, captured) => {
             def::<DEFS>(*dst, &mut f);
             uses::<USES>(captured, &mut f);
         },
@@ -891,9 +876,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        Instr::Call(rets, _, args)
-        | Instr::CallGeneric(rets, _, args)
-        | Instr::CallClosure(rets, _, args) => {
+        Instr::Call(rets, _, _, args) | Instr::CallClosure(rets, _, args) => {
             if DEFS {
                 rewrite_slots(rets, &mut f);
             }
@@ -901,8 +884,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slots(args, &mut f);
             }
         },
-        Instr::PackClosure(dst, _, _, captured)
-        | Instr::PackClosureGeneric(dst, _, _, captured) => {
+        Instr::PackClosure(dst, _, _, _, captured) => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -15,8 +15,8 @@ use mono_move_core::{
     IntTy, PreparedModule,
 };
 use move_binary_format::file_format::{
-    ConstantPoolIndex, FieldHandleIndex, FunctionHandleIndex, FunctionInstantiationIndex,
-    IdentifierIndex, VariantFieldHandleIndex,
+    ConstantPoolIndex, FieldHandleIndex, FunctionHandleIndex, IdentifierIndex,
+    VariantFieldHandleIndex,
 };
 use move_core_types::{
     function::ClosureMask,
@@ -210,18 +210,23 @@ pub enum Instr {
     ImmBorrowGlobal(Slot, InternedType, Slot),
     MutBorrowGlobal(Slot, InternedType, Slot),
 
-    // TODO: the generic/non-generic call-like pairs (`Call`/`CallGeneric` and
-    // `PackClosure`/`PackClosureGeneric`) could each collapse to one variant
-    // carrying `(inner FunctionHandleIndex, target ty_args)` — EMPTY for the
-    // non-generic form — mirroring how the field-op twins carry their owner
-    // type. Collapse both pairs together so the rule stays uniform.
     // --- Calls ---
-    Call(Vec<Slot>, FunctionHandleIndex, Vec<Slot>),
-    CallGeneric(Vec<Slot>, FunctionInstantiationIndex, Vec<Slot>),
+    //
+    // Carries `(inner FunctionHandleIndex, target ty_args)`: the handle gives the
+    // callee identity; `ty_args` is the instantiation's type arguments, and is
+    // `EMPTY_TYPE_LIST` for a non-generic call. Same type contract as
+    // `Pack`/`Unpack` — inside a generic function the args may still contain the
+    // enclosing function's `TypeParam`s.
+    Call(Vec<Slot>, FunctionHandleIndex, InternedTypeList, Vec<Slot>),
 
-    // --- Closures ---
-    PackClosure(Slot, FunctionHandleIndex, ClosureMask, Vec<Slot>),
-    PackClosureGeneric(Slot, FunctionInstantiationIndex, ClosureMask, Vec<Slot>),
+    // --- Closures (same `(inner handle, target ty_args)` contract as `Call`) ---
+    PackClosure(
+        Slot,
+        FunctionHandleIndex,
+        InternedTypeList,
+        ClosureMask,
+        Vec<Slot>,
+    ),
     /// `CallClosure(rets, signature_types, args)` — `signature_types` is the
     /// interned list of types from the closure's signature (arg types followed
     /// by result types, matching the source `SignatureIndex`).
@@ -306,9 +311,7 @@ impl Instr {
             Instr::ImmBorrowGlobal(..) => "ImmBorrowGlobal",
             Instr::MutBorrowGlobal(..) => "MutBorrowGlobal",
             Instr::Call(..) => "Call",
-            Instr::CallGeneric(..) => "CallGeneric",
             Instr::PackClosure(..) => "PackClosure",
-            Instr::PackClosureGeneric(..) => "PackClosureGeneric",
             Instr::CallClosure(..) => "CallClosure",
             Instr::VecPack(..) => "VecPack",
             Instr::VecLen(..) => "VecLen",

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/call_generic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/call_generic.exp
@@ -14,7 +14,7 @@ fun call_u64(): u64 {
   code:
   L0:
     0: x0 := ld_u64 10
-    1: [x0] := call identity, [x0]
+    1: [x0] := call identity<u64>, [x0]
     2: ret [x0]
 }
 
@@ -23,7 +23,7 @@ fun call_bool(): bool {
   code:
   L0:
     0: x0 := ld_true
-    1: [x0] := call identity, [x0]
+    1: [x0] := call identity<bool>, [x0]
     2: ret [x0]
 }
 === micro-ops ===

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_call.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_call.exp
@@ -26,7 +26,7 @@ fun call_bool(): bool {
   code:
   L0:
     0: x0 := ld_true
-    1: [x0] := call identity, [x0]
+    1: [x0] := call identity<bool>, [x0]
     2: ret [x0]
 }
 
@@ -35,7 +35,7 @@ fun call_u64(): u64 {
   code:
   L0:
     0: x0 := ld_u64 7
-    1: [x0] := call identity, [x0]
+    1: [x0] := call identity<u64>, [x0]
     2: ret [x0]
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_closure_pack.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_closure_pack.exp
@@ -8,7 +8,7 @@ fun call_identity(r0): u64 {
     r2: u64
   code:
   L0:
-    0: r1 := pack_closure identity, 0, []
+    0: r1 := pack_closure identity<u64>, 0, []
     1: [r2] := call_closure [|u64|u64], [r0, r1]
     2: ret [r2]
 }
@@ -23,8 +23,8 @@ fun call_pick(r0): u64 {
     r5: u64
   code:
   L0:
-    0: [r1] := call make_pick, [r0]
-    1: [r2] := call make_pick, [r0]
+    0: [r1] := call make_pick<u64>, [r0]
+    1: [r2] := call make_pick<u64>, [r0]
     2: r3 := add r0, #1
     3: r4 := ld_true
     4: [r3] := call_closure [|u64, bool|u64], [r3, r4, r1]
@@ -50,7 +50,7 @@ fun make_pick(r0): |_0, bool|_0 {
     r1: |_0, _0, bool|_0
   code:
   L0:
-    0: r1 := pack_closure pick, 1, [r0]
+    0: r1 := pack_closure pick<_0>, 1, [r0]
     1: ret [r1]
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_identity.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_identity.exp
@@ -20,7 +20,7 @@ fun call_identity_u64(r0): u64 {
     r0: u64
   code:
   L0:
-    0: [x0] := call identity, [r0]
+    0: [x0] := call identity<u64>, [r0]
     1: ret [x0]
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_multi_param.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_multi_param.exp
@@ -22,7 +22,7 @@ fun entry(r0): u64 {
   code:
   L0:
     0: x1 := ld_u64 99
-    1: [x0] := call pick_first, [r0, x1]
+    1: [x0] := call pick_first<u64, u64>, [r0, x1]
     2: ret [x0]
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_nested.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_nested.exp
@@ -32,7 +32,7 @@ fun entry(r0): u64 {
     r0: u64
   code:
   L0:
-    0: [x0] := call outer, [r0]
+    0: [x0] := call outer<u64>, [r0]
     1: ret [x0]
 }
 
@@ -49,7 +49,7 @@ fun middle(r0): _0 {
     r0: _0
   code:
   L0:
-    0: [x0] := call innermost, [r0]
+    0: [x0] := call innermost<_0>, [r0]
     1: ret [x0]
 }
 
@@ -58,7 +58,7 @@ fun outer(r0): _0 {
     r0: _0
   code:
   L0:
-    0: [x0] := call middle, [r0]
+    0: [x0] := call middle<_0>, [r0]
     1: ret [x0]
 }
 === micro-ops ===

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_partial_inst.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_partial_inst.exp
@@ -29,7 +29,7 @@ fun caller(r0, r1): u64 {
     r1: _0
   code:
   L0:
-    0: [x0] := call identity, [r0, r1]
+    0: [x0] := call identity<u64, _0>, [r0, r1]
     1: ret [x0]
 }
 
@@ -39,7 +39,7 @@ fun entry(r0): u64 {
   code:
   L0:
     0: x0 := ld_u64 42
-    1: [x0] := call caller, [x0, r0]
+    1: [x0] := call caller<u64>, [x0, r0]
     2: ret [x0]
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_repeated_call.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_repeated_call.exp
@@ -36,11 +36,11 @@ fun entry(): u64 {
   code:
   L0:
     0: x0 := ld_u64 10
-    1: [r1] := call identity, [x0]
+    1: [r1] := call identity<u64>, [x0]
     2: x0 := ld_u64 20
-    3: [r2] := call identity, [x0]
+    3: [r2] := call identity<u64>, [x0]
     4: x0 := ld_u64 12
-    5: [r0] := call identity, [x0]
+    5: [r0] := call identity<u64>, [x0]
     6: r2 := add r1, r2
     7: r2 := add r2, r0
     8: ret [r2]

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_swapped_args.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_swapped_args.exp
@@ -22,7 +22,7 @@ fun entry(r0): u64 {
   code:
   L0:
     0: x0 := ld_u64 99
-    1: [x0] := call pick_second, [x0, r0]
+    1: [x0] := call pick_second<u64, u64>, [x0, r0]
     2: ret [x0]
 }
 


### PR DESCRIPTION
## Description

Implemented the standing TODO in the mono-move specializer's stackless execution IR: collapsed the `Call`/`CallGeneric` and `PackClosure`/`PackClosureGeneric` variant pairs into single variants that carry the inner function handle plus an interned type-argument list (empty for the non-generic form), mirroring the existing collapsed field-op twins.

**Highlights**
- Producer now resolves the instantiation into `(handle, ty_args)` once at conversion time via a small shared helper; consumers handle generic and non-generic uniformly, with the non-generic path reducing to a no-op substitution.
- The downstream micro-op layer and runtime behavior are unchanged — purely an IR-representation simplification (fewer variants, one match arm per operation).
- Verified equivalent to the prior behavior; full test suite and differential snapshots pass with no changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches call/closure handling across destack, lowering, and xfer invariants; behavior should be equivalent but the surface area is broad for the specializer pipeline.
> 
> **Overview**
> Unifies the mono-move stackless IR so generic and non-generic calls and closure packs share one instruction shape, aligned with how field ops already carry owner types.
> 
> **`Call`** and **`PackClosure`** now embed `(FunctionHandleIndex, InternedTypeList)` — empty type list for monomorphic bytecode, populated when lowering `CallGeneric` / `PackClosureGeneric`. SSA conversion resolves instantiations once via **`fun_inst_parts`**; lowering uses **`instantiate_callee_signature`** so call-site layout, type discovery, gas, xfer analysis, and display all match on the unified variants.
> 
> Differential test snapshots now print explicit type args on generic calls (e.g. `call identity<u64>`). Runtime micro-ops and semantics are unchanged; this is IR representation and pass plumbing only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103ab8853d492ee83f9ce09e702e7532374c6eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->