### PR TITLE
[mono-move] Simplify Move specializer representation of integer casts

### DIFF
--- a/third_party/move/mono-move/core/src/instruction/unspecialized.rs
+++ b/third_party/move/mono-move/core/src/instruction/unspecialized.rs
@@ -13,7 +13,7 @@
 //! the operand type at runtime.
 
 use super::{CodeOffset, FrameOffset};
-use crate::types::{InternedType, Type};
+use crate::types::{self, InternedType, Type};
 use move_core_types::int256::{I256, U256};
 use std::fmt;
 
@@ -80,6 +80,25 @@ impl IntTy {
             Type::I256 => IntTy::I256,
             _ => return None,
         })
+    }
+
+    /// The interned [`Type`] for this integer type.
+    /// This is the inverse of [`from_type`](Self::from_type).
+    pub const fn interned_ty(self) -> InternedType {
+        match self {
+            IntTy::U8 => types::U8_TY,
+            IntTy::U16 => types::U16_TY,
+            IntTy::U32 => types::U32_TY,
+            IntTy::U64 => types::U64_TY,
+            IntTy::U128 => types::U128_TY,
+            IntTy::U256 => types::U256_TY,
+            IntTy::I8 => types::I8_TY,
+            IntTy::I16 => types::I16_TY,
+            IntTy::I32 => types::I32_TY,
+            IntTy::I64 => types::I64_TY,
+            IntTy::I128 => types::I128_TY,
+            IntTy::I256 => types::I256_TY,
+        }
     }
 }
 
@@ -476,6 +495,29 @@ mod tests {
             CmpKind::Neq,
         ] {
             assert_eq!(kind.negate().negate(), kind);
+        }
+    }
+
+    #[test]
+    fn interned_ty_then_from_type_is_identity() {
+        for ty in [
+            IntTy::U8,
+            IntTy::U16,
+            IntTy::U32,
+            IntTy::U64,
+            IntTy::U128,
+            IntTy::U256,
+            IntTy::I8,
+            IntTy::I16,
+            IntTy::I32,
+            IntTy::I64,
+            IntTy::I128,
+            IntTy::I256,
+        ] {
+            assert_eq!(
+                IntTy::from_type(types::view_type(ty.interned_ty())),
+                Some(ty)
+            );
         }
     }
 }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -13,7 +13,7 @@ use anyhow::{anyhow, bail, ensure, Context, Result};
 use mono_move_core::{
     convert_mut_to_immut_ref, strip_ref,
     types::{self as ty, view_type, view_type_list, InternedType, InternedTypeList, Type},
-    Interner, PreparedModule,
+    IntTy, Interner, PreparedModule,
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -441,18 +441,18 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::And => self.convert_binop(BinaryOp::And, true)?,
 
             // --- Unary ops (result type specified) ---
-            B::CastU8 => self.convert_unop(UnaryOp::CastU8, ty::U8_TY)?,
-            B::CastU16 => self.convert_unop(UnaryOp::CastU16, ty::U16_TY)?,
-            B::CastU32 => self.convert_unop(UnaryOp::CastU32, ty::U32_TY)?,
-            B::CastU64 => self.convert_unop(UnaryOp::CastU64, ty::U64_TY)?,
-            B::CastU128 => self.convert_unop(UnaryOp::CastU128, ty::U128_TY)?,
-            B::CastU256 => self.convert_unop(UnaryOp::CastU256, ty::U256_TY)?,
-            B::CastI8 => self.convert_unop(UnaryOp::CastI8, ty::I8_TY)?,
-            B::CastI16 => self.convert_unop(UnaryOp::CastI16, ty::I16_TY)?,
-            B::CastI32 => self.convert_unop(UnaryOp::CastI32, ty::I32_TY)?,
-            B::CastI64 => self.convert_unop(UnaryOp::CastI64, ty::I64_TY)?,
-            B::CastI128 => self.convert_unop(UnaryOp::CastI128, ty::I128_TY)?,
-            B::CastI256 => self.convert_unop(UnaryOp::CastI256, ty::I256_TY)?,
+            B::CastU8 => self.convert_cast(IntTy::U8)?,
+            B::CastU16 => self.convert_cast(IntTy::U16)?,
+            B::CastU32 => self.convert_cast(IntTy::U32)?,
+            B::CastU64 => self.convert_cast(IntTy::U64)?,
+            B::CastU128 => self.convert_cast(IntTy::U128)?,
+            B::CastU256 => self.convert_cast(IntTy::U256)?,
+            B::CastI8 => self.convert_cast(IntTy::I8)?,
+            B::CastI16 => self.convert_cast(IntTy::I16)?,
+            B::CastI32 => self.convert_cast(IntTy::I32)?,
+            B::CastI64 => self.convert_cast(IntTy::I64)?,
+            B::CastI128 => self.convert_cast(IntTy::I128)?,
+            B::CastI256 => self.convert_cast(IntTy::I256)?,
             B::Not => self.convert_unop(UnaryOp::Not, ty::BOOL_TY)?,
             // --- Unary ops (result type derived from operand) ---
             B::Negate => {
@@ -1069,6 +1069,11 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
         self.current_block_instrs.push(Instr::UnaryOp(dst, op, src));
         self.push_slot(dst);
         Ok(())
+    }
+
+    /// Convert a cast op, whose result type is the cast target itself.
+    fn convert_cast(&mut self, to: IntTy) -> Result<()> {
+        self.convert_unop(UnaryOp::Cast(to), to.interned_ty())
     }
 }
 

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -1037,25 +1037,7 @@ impl<'a> LoweringState<'a> {
 
             // --- Unary ops ---
             Instr::UnaryOp(dst, op, src) => match op {
-                UnaryOp::CastU8
-                | UnaryOp::CastU16
-                | UnaryOp::CastU32
-                | UnaryOp::CastU64
-                | UnaryOp::CastU128
-                | UnaryOp::CastU256
-                | UnaryOp::CastI8
-                | UnaryOp::CastI16
-                | UnaryOp::CastI32
-                | UnaryOp::CastI64
-                | UnaryOp::CastI128
-                | UnaryOp::CastI256 => {
-                    // TODO: collapse UnaryOp::Cast* into UnaryOp::Cast(IntTy)
-                    // instead of matching twice here.
-                    let to = op
-                        .cast_target_ty()
-                        .expect("every cast op has a cast target type");
-                    self.lower_cast(*dst, *src, to)?;
-                },
+                UnaryOp::Cast(to) => self.lower_cast(*dst, *src, *to)?,
                 UnaryOp::Negate => {
                     let src_ty = self.slot_type(*src)?;
                     let signed_ty = IntTy::from_type(src_ty)

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -252,7 +252,8 @@ fn display_instr(
         // --- Unary: dst := op src ---
         Instr::UnaryOp(d, op, s) => {
             write_dst(f, *d)?;
-            write!(f, "{} {}", unary_op_name(op), slot_name(*s))
+            write_unary_op(f, op)?;
+            write!(f, " {}", slot_name(*s))
         },
         // --- Binary: dst := op lhs, rhs ---
         Instr::BinaryOp(d, op, l, r) => {
@@ -599,23 +600,12 @@ fn display_instr(
     }
 }
 
-fn unary_op_name(op: &UnaryOp) -> &'static str {
+fn write_unary_op(f: &mut fmt::Formatter<'_>, op: &UnaryOp) -> fmt::Result {
     match op {
-        UnaryOp::CastU8 => "cast_u8",
-        UnaryOp::CastU16 => "cast_u16",
-        UnaryOp::CastU32 => "cast_u32",
-        UnaryOp::CastU64 => "cast_u64",
-        UnaryOp::CastU128 => "cast_u128",
-        UnaryOp::CastU256 => "cast_u256",
-        UnaryOp::CastI8 => "cast_i8",
-        UnaryOp::CastI16 => "cast_i16",
-        UnaryOp::CastI32 => "cast_i32",
-        UnaryOp::CastI64 => "cast_i64",
-        UnaryOp::CastI128 => "cast_i128",
-        UnaryOp::CastI256 => "cast_i256",
-        UnaryOp::Not => "not",
-        UnaryOp::Negate => "negate",
-        UnaryOp::FreezeRef => "freeze_ref",
+        UnaryOp::Cast(to) => write!(f, "cast_{to}"),
+        UnaryOp::Not => f.write_str("not"),
+        UnaryOp::Negate => f.write_str("negate"),
+        UnaryOp::FreezeRef => f.write_str("freeze_ref"),
     }
 }
 

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -66,43 +66,11 @@ pub struct Label(pub u16);
 /// Unary operations.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UnaryOp {
-    CastU8,
-    CastU16,
-    CastU32,
-    CastU64,
-    CastU128,
-    CastU256,
-    CastI8,
-    CastI16,
-    CastI32,
-    CastI64,
-    CastI128,
-    CastI256,
+    /// Cast the operand to the given integer type, aborting if it doesn't fit.
+    Cast(IntTy),
     Not,
     Negate,
     FreezeRef,
-}
-
-impl UnaryOp {
-    /// Returns the target [`IntTy`] if the operation is a cast operation,
-    /// otherwise `None`.
-    pub fn cast_target_ty(self) -> Option<IntTy> {
-        Some(match self {
-            UnaryOp::CastU8 => IntTy::U8,
-            UnaryOp::CastU16 => IntTy::U16,
-            UnaryOp::CastU32 => IntTy::U32,
-            UnaryOp::CastU64 => IntTy::U64,
-            UnaryOp::CastU128 => IntTy::U128,
-            UnaryOp::CastU256 => IntTy::U256,
-            UnaryOp::CastI8 => IntTy::I8,
-            UnaryOp::CastI16 => IntTy::I16,
-            UnaryOp::CastI32 => IntTy::I32,
-            UnaryOp::CastI64 => IntTy::I64,
-            UnaryOp::CastI128 => IntTy::I128,
-            UnaryOp::CastI256 => IntTy::I256,
-            UnaryOp::Not | UnaryOp::Negate | UnaryOp::FreezeRef => return None,
-        })
-    }
 }
 
 /// Binary operations.

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/int_cast_widths.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/int_cast_widths.exp
@@ -1,0 +1,384 @@
+=== stackless ===
+// module 0x1::cast_widths
+
+fun u8_to_u8(r0): u8 {
+  slots: params(1), locals(0), temps(1)
+    r0: u8
+    r1: u8
+  code:
+  L0:
+    0: r1 := cast_u8 r0
+    1: ret [r1]
+}
+
+fun u16_to_u16(r0): u16 {
+  slots: params(1), locals(0), temps(1)
+    r0: u16
+    r1: u16
+  code:
+  L0:
+    0: r1 := cast_u16 r0
+    1: ret [r1]
+}
+
+fun i8_to_i8(r0): i8 {
+  slots: params(1), locals(0), temps(1)
+    r0: i8
+    r1: i8
+  code:
+  L0:
+    0: r1 := cast_i8 r0
+    1: ret [r1]
+}
+
+fun i32_to_i32(r0): i32 {
+  slots: params(1), locals(0), temps(1)
+    r0: i32
+    r1: i32
+  code:
+  L0:
+    0: r1 := cast_i32 r0
+    1: ret [r1]
+}
+
+fun u8_to_u256(r0): u256 {
+  slots: params(1), locals(0), temps(1)
+    r0: u8
+    r1: u256
+  code:
+  L0:
+    0: r1 := cast_u256 r0
+    1: ret [r1]
+}
+
+fun u16_to_u32(r0): u32 {
+  slots: params(1), locals(0), temps(1)
+    r0: u16
+    r1: u32
+  code:
+  L0:
+    0: r1 := cast_u32 r0
+    1: ret [r1]
+}
+
+fun u8_to_u64(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u8
+    r1: u64
+  code:
+  L0:
+    0: r1 := cast_u64 r0
+    1: ret [r1]
+}
+
+fun u32_to_u8(r0): u8 {
+  slots: params(1), locals(0), temps(1)
+    r0: u32
+    r1: u8
+  code:
+  L0:
+    0: r1 := cast_u8 r0
+    1: ret [r1]
+}
+
+fun u256_to_u8(r0): u8 {
+  slots: params(1), locals(0), temps(1)
+    r0: u256
+    r1: u8
+  code:
+  L0:
+    0: r1 := cast_u8 r0
+    1: ret [r1]
+}
+
+fun u64_to_u16(r0): u16 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u16
+  code:
+  L0:
+    0: r1 := cast_u16 r0
+    1: ret [r1]
+}
+
+fun i8_to_i64(r0): i64 {
+  slots: params(1), locals(0), temps(1)
+    r0: i8
+    r1: i64
+  code:
+  L0:
+    0: r1 := cast_i64 r0
+    1: ret [r1]
+}
+
+fun i16_to_i256(r0): i256 {
+  slots: params(1), locals(0), temps(1)
+    r0: i16
+    r1: i256
+  code:
+  L0:
+    0: r1 := cast_i256 r0
+    1: ret [r1]
+}
+
+fun i64_to_i8(r0): i8 {
+  slots: params(1), locals(0), temps(1)
+    r0: i64
+    r1: i8
+  code:
+  L0:
+    0: r1 := cast_i8 r0
+    1: ret [r1]
+}
+
+fun i32_to_i16(r0): i16 {
+  slots: params(1), locals(0), temps(1)
+    r0: i32
+    r1: i16
+  code:
+  L0:
+    0: r1 := cast_i16 r0
+    1: ret [r1]
+}
+
+fun u8_to_i8(r0): i8 {
+  slots: params(1), locals(0), temps(1)
+    r0: u8
+    r1: i8
+  code:
+  L0:
+    0: r1 := cast_i8 r0
+    1: ret [r1]
+}
+
+fun u16_to_i8(r0): i8 {
+  slots: params(1), locals(0), temps(1)
+    r0: u16
+    r1: i8
+  code:
+  L0:
+    0: r1 := cast_i8 r0
+    1: ret [r1]
+}
+
+fun i8_to_u8(r0): u8 {
+  slots: params(1), locals(0), temps(1)
+    r0: i8
+    r1: u8
+  code:
+  L0:
+    0: r1 := cast_u8 r0
+    1: ret [r1]
+}
+
+fun i8_to_u64(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: i8
+    r1: u64
+  code:
+  L0:
+    0: r1 := cast_u64 r0
+    1: ret [r1]
+}
+
+fun i256_to_i8(r0): i8 {
+  slots: params(1), locals(0), temps(1)
+    r0: i256
+    r1: i8
+  code:
+  L0:
+    0: r1 := cast_i8 r0
+    1: ret [r1]
+}
+
+fun u8_to_i256(r0): i256 {
+  slots: params(1), locals(0), temps(1)
+    r0: u8
+    r1: i256
+  code:
+  L0:
+    0: r1 := cast_i256 r0
+    1: ret [r1]
+}
+=== micro-ops ===
+// module 0x1::cast_widths
+
+fun u8_to_u8() {
+  frame_data_size: 8
+  entry_gas: 17
+  code:
+    0: IntCast.u8->u8 [1] <- [0]
+    1: Move(1) [0] <- [1]
+    2: Return
+}
+
+fun u16_to_u16() {
+  frame_data_size: 8
+  entry_gas: 23
+  code:
+    0: IntCast.u16->u16 [2] <- [0]
+    1: Move(2) [0] <- [2]
+    2: Return
+}
+
+fun i8_to_i8() {
+  frame_data_size: 8
+  entry_gas: 17
+  code:
+    0: IntCast.i8->i8 [1] <- [0]
+    1: Move(1) [0] <- [1]
+    2: Return
+}
+
+fun i32_to_i32() {
+  frame_data_size: 8
+  entry_gas: 35
+  code:
+    0: IntCast.i32->i32 [4] <- [0]
+    1: Move(4) [0] <- [4]
+    2: Return
+}
+
+fun u8_to_u256() {
+  frame_data_size: 40
+  entry_gas: 203
+  code:
+    0: IntCast.u8->u256 [8] <- [0]
+    1: Move(32) [0] <- [8]
+    2: Return
+}
+
+fun u16_to_u32() {
+  frame_data_size: 8
+  entry_gas: 35
+  code:
+    0: IntCast.u16->u32 [4] <- [0]
+    1: Move(4) [0] <- [4]
+    2: Return
+}
+
+fun u8_to_u64() {
+  frame_data_size: 16
+  entry_gas: 59
+  code:
+    0: IntCast.u8->u64 [8] <- [0]
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun u32_to_u8() {
+  frame_data_size: 8
+  entry_gas: 17
+  code:
+    0: IntCast.u32->u8 [4] <- [0]
+    1: Move(1) [0] <- [4]
+    2: Return
+}
+
+fun u256_to_u8() {
+  frame_data_size: 40
+  entry_gas: 17
+  code:
+    0: IntCast.u256->u8 [32] <- [0]
+    1: Move(1) [0] <- [32]
+    2: Return
+}
+
+fun u64_to_u16() {
+  frame_data_size: 16
+  entry_gas: 23
+  code:
+    0: IntCast.u64->u16 [8] <- [0]
+    1: Move(2) [0] <- [8]
+    2: Return
+}
+
+fun i8_to_i64() {
+  frame_data_size: 16
+  entry_gas: 59
+  code:
+    0: IntCast.i8->i64 [8] <- [0]
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun i16_to_i256() {
+  frame_data_size: 40
+  entry_gas: 203
+  code:
+    0: IntCast.i16->i256 [8] <- [0]
+    1: Move(32) [0] <- [8]
+    2: Return
+}
+
+fun i64_to_i8() {
+  frame_data_size: 16
+  entry_gas: 17
+  code:
+    0: IntCast.i64->i8 [8] <- [0]
+    1: Move(1) [0] <- [8]
+    2: Return
+}
+
+fun i32_to_i16() {
+  frame_data_size: 8
+  entry_gas: 23
+  code:
+    0: IntCast.i32->i16 [4] <- [0]
+    1: Move(2) [0] <- [4]
+    2: Return
+}
+
+fun u8_to_i8() {
+  frame_data_size: 8
+  entry_gas: 17
+  code:
+    0: IntCast.u8->i8 [1] <- [0]
+    1: Move(1) [0] <- [1]
+    2: Return
+}
+
+fun u16_to_i8() {
+  frame_data_size: 8
+  entry_gas: 17
+  code:
+    0: IntCast.u16->i8 [2] <- [0]
+    1: Move(1) [0] <- [2]
+    2: Return
+}
+
+fun i8_to_u8() {
+  frame_data_size: 8
+  entry_gas: 17
+  code:
+    0: IntCast.i8->u8 [1] <- [0]
+    1: Move(1) [0] <- [1]
+    2: Return
+}
+
+fun i8_to_u64() {
+  frame_data_size: 16
+  entry_gas: 59
+  code:
+    0: IntCast.i8->u64 [8] <- [0]
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun i256_to_i8() {
+  frame_data_size: 40
+  entry_gas: 17
+  code:
+    0: IntCast.i256->i8 [32] <- [0]
+    1: Move(1) [0] <- [32]
+    2: Return
+}
+
+fun u8_to_i256() {
+  frame_data_size: 40
+  entry_gas: 203
+  code:
+    0: IntCast.u8->i256 [8] <- [0]
+    1: Move(32) [0] <- [8]
+    2: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/int_cast_widths.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/int_cast_widths.masm
@@ -1,0 +1,239 @@
+// RUN: publish --print(stackless,micro-ops)
+module 0x1::cast_widths
+
+// --- Identity, small widths. ---
+
+fun u8_to_u8(a: u8): u8
+    copy_loc a
+    cast_u8
+    ret
+
+fun u16_to_u16(a: u16): u16
+    copy_loc a
+    cast_u16
+    ret
+
+fun i8_to_i8(a: i8): i8
+    copy_loc a
+    cast_i8
+    ret
+
+fun i32_to_i32(a: i32): i32
+    copy_loc a
+    cast_i32
+    ret
+
+// --- Widening, unsigned. ---
+
+fun u8_to_u256(a: u8): u256
+    copy_loc a
+    cast_u256
+    ret
+
+fun u16_to_u32(a: u16): u32
+    copy_loc a
+    cast_u32
+    ret
+
+fun u8_to_u64(a: u8): u64
+    copy_loc a
+    cast_u64
+    ret
+
+// --- Narrowing, unsigned. ---
+
+fun u32_to_u8(a: u32): u8
+    copy_loc a
+    cast_u8
+    ret
+
+fun u256_to_u8(a: u256): u8
+    copy_loc a
+    cast_u8
+    ret
+
+fun u64_to_u16(a: u64): u16
+    copy_loc a
+    cast_u16
+    ret
+
+// --- Signed widening, sign-extends negatives. ---
+
+fun i8_to_i64(a: i8): i64
+    copy_loc a
+    cast_i64
+    ret
+
+fun i16_to_i256(a: i16): i256
+    copy_loc a
+    cast_i256
+    ret
+
+// --- Signed narrowing. ---
+
+fun i64_to_i8(a: i64): i8
+    copy_loc a
+    cast_i8
+    ret
+
+fun i32_to_i16(a: i32): i16
+    copy_loc a
+    cast_i16
+    ret
+
+// --- Unsigned -> signed. ---
+
+fun u8_to_i8(a: u8): i8
+    copy_loc a
+    cast_i8
+    ret
+
+fun u16_to_i8(a: u16): i8
+    copy_loc a
+    cast_i8
+    ret
+
+// --- Signed -> unsigned. ---
+
+fun i8_to_u8(a: i8): u8
+    copy_loc a
+    cast_u8
+    ret
+
+fun i8_to_u64(a: i8): u64
+    copy_loc a
+    cast_u64
+    ret
+
+// --- 256-bit extremes. ---
+
+fun i256_to_i8(a: i256): i8
+    copy_loc a
+    cast_i8
+    ret
+
+fun u8_to_i256(a: u8): i256
+    copy_loc a
+    cast_i256
+    ret
+
+// --- Identity, small widths: never aborts, endpoints included. ---
+
+// RUN: execute 0x1::cast_widths::u8_to_u8 --args 0
+// CHECK: results: 0
+// RUN: execute 0x1::cast_widths::u8_to_u8 --args 255
+// CHECK: results: 255
+// RUN: execute 0x1::cast_widths::i8_to_i8 --args -128
+// CHECK: results: -128
+// RUN: execute 0x1::cast_widths::i8_to_i8 --args 127
+// CHECK: results: 127
+// RUN: execute 0x1::cast_widths::u16_to_u16 --args 65535
+// CHECK: results: 65535
+// RUN: execute 0x1::cast_widths::i32_to_i32 --args -2147483648
+// CHECK: results: -2147483648
+
+// --- Widening, unsigned: always fits. ---
+
+// RUN: execute 0x1::cast_widths::u8_to_u256 --args 255
+// CHECK: results: 255
+// RUN: execute 0x1::cast_widths::u16_to_u32 --args 65535
+// CHECK: results: 65535
+// RUN: execute 0x1::cast_widths::u8_to_u64 --args 255
+// CHECK: results: 255
+
+// --- Narrowing, unsigned: boundary at the target max. ---
+
+// 255 fits u8, 256 does not.
+// RUN: execute 0x1::cast_widths::u32_to_u8 --args 255
+// CHECK: results: 255
+// RUN: execute 0x1::cast_widths::u32_to_u8 --args 256
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// RUN: execute 0x1::cast_widths::u256_to_u8 --args 255
+// CHECK: results: 255
+// RUN: execute 0x1::cast_widths::u256_to_u8 --args 256
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+// u256::MAX is far above u8::MAX.
+// RUN: execute 0x1::cast_widths::u256_to_u8 --args 115792089237316195423570985008687907853269984665640564039457584007913129639935
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// 65535 fits u16, 65536 does not.
+// RUN: execute 0x1::cast_widths::u64_to_u16 --args 65535
+// CHECK: results: 65535
+// RUN: execute 0x1::cast_widths::u64_to_u16 --args 65536
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// --- Signed widening: sign-extends negatives. ---
+
+// RUN: execute 0x1::cast_widths::i8_to_i64 --args -128
+// CHECK: results: -128
+// RUN: execute 0x1::cast_widths::i8_to_i64 --args 127
+// CHECK: results: 127
+// RUN: execute 0x1::cast_widths::i8_to_i64 --args 0
+// CHECK: results: 0
+// RUN: execute 0x1::cast_widths::i16_to_i256 --args -32768
+// CHECK: results: -32768
+
+// --- Signed narrowing: boundary at both ends of [-128, 127] / [-32768, 32767]. ---
+
+// RUN: execute 0x1::cast_widths::i64_to_i8 --args 127
+// CHECK: results: 127
+// RUN: execute 0x1::cast_widths::i64_to_i8 --args -128
+// CHECK: results: -128
+// RUN: execute 0x1::cast_widths::i64_to_i8 --args 128
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+// RUN: execute 0x1::cast_widths::i64_to_i8 --args -129
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// RUN: execute 0x1::cast_widths::i32_to_i16 --args 32767
+// CHECK: results: 32767
+// RUN: execute 0x1::cast_widths::i32_to_i16 --args -32768
+// CHECK: results: -32768
+// RUN: execute 0x1::cast_widths::i32_to_i16 --args 32768
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+// RUN: execute 0x1::cast_widths::i32_to_i16 --args -32769
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// --- Unsigned -> signed: boundary at the signed max. ---
+
+// 127 fits i8; 128 exceeds i8::MAX.
+// RUN: execute 0x1::cast_widths::u8_to_i8 --args 127
+// CHECK: results: 127
+// RUN: execute 0x1::cast_widths::u8_to_i8 --args 128
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+// RUN: execute 0x1::cast_widths::u16_to_i8 --args 200
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// --- Signed -> unsigned: negatives abort, even when widening. ---
+
+// RUN: execute 0x1::cast_widths::i8_to_u8 --args 0
+// CHECK: results: 0
+// RUN: execute 0x1::cast_widths::i8_to_u8 --args 127
+// CHECK: results: 127
+// RUN: execute 0x1::cast_widths::i8_to_u8 --args -1
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+// RUN: execute 0x1::cast_widths::i8_to_u64 --args -1
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// --- 256-bit extremes. ---
+
+// i256::MIN cannot narrow to i8.
+// RUN: execute 0x1::cast_widths::i256_to_i8 --args -57896044618658097711785492504343953926634992332820282019728792003956564819968
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+// RUN: execute 0x1::cast_widths::i256_to_i8 --args -128
+// CHECK: results: -128
+// RUN: execute 0x1::cast_widths::u8_to_i256 --args 255
+// CHECK: results: 255


### PR DESCRIPTION
## Description

- **Collapsed the cast IR op** — replaced the dozen separate per-type cast variants in the stackless-exec IR with a single cast op parameterized by the integer type. This resolved a standing TODO and aligns the IR with its lowering target (which already used the unified form), removing a redundant double-dispatch.

- **Added comprehensive cast tests** — new differential tests exercise integer casts across all widths and sign crossings, covering identity, widening, narrowing, signed↔unsigned, exact boundaries, and abort behavior, validated against the legacy VM and pinned with golden IR. Note: casts were added in parallel to the lowering support of narrow widths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how integer casts are represented and lowered across the specializer pipeline; behavior is intended to be unchanged but cast range/abort semantics are security-relevant and now heavily tested.
> 
> **Overview**
> **Collapses integer casts in the stackless exec IR** from twelve separate `UnaryOp::CastU8` … `CastI256` variants into a single **`UnaryOp::Cast(IntTy)`**, removing `cast_target_ty()` and the redundant lowering match that duplicated cast detection.
> 
> Bytecode→SSA conversion now routes all `Cast*` bytecodes through **`convert_cast`**, which emits `UnaryOp::Cast(to)` with the result type from new **`IntTy::interned_ty()`** (inverse of `from_type`, covered by a unit test). Lowering handles casts with one **`UnaryOp::Cast(to) => lower_cast(...)`** arm into existing **`MicroOp::IntCast`**. IR display prints casts as `cast_{to}` (e.g. `cast_u8`).
> 
> **Adds differential tests** (`int_cast_widths.masm` / `.exp`) for widening, narrowing, signed↔unsigned, boundaries, and abort behavior, with golden stackless and micro-op output and execution checks against the legacy VM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4abbaeb956989ce290fce00f2bb52a8abe80c918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->