### PR TITLE
[consensus] Exclude retryable encrypted txns from execution

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -76,7 +76,6 @@ use aptos_types::{
             AbstractAuthenticationData, AnySignature, AuthenticationProof, TransactionAuthenticator,
         },
         block_epilogue::{BlockEpiloguePayload, FeeDistribution},
-        encrypted_payload::DecryptionFailureReason,
         signature_verified_transaction::SignatureVerifiedTransaction,
         AuxiliaryInfo, BlockOutput, EntryFunction, ExecutionError, ExecutionStatus, ModuleBundle,
         MultisigTransactionPayload, ReplayProtector, Script, SignedTransaction, Transaction,
@@ -2185,47 +2184,21 @@ impl AptosVM {
             Err(_) => return unwrap_or_discard!(Err(deprecated_module_bundle!())),
         };
 
-        // Re-queue without charging gas or bumping the sequence number when the
-        // decryption pipeline marked this txn for retry: either the per-block
-        // batch limit was reached, or the block carried an epoch-ending vtxn so
-        // decryption was skipped to avoid leaking sender intent.
-        if let Some(reason) = txn.payload().decryption_failure_reason() {
-            let message = match reason {
-                DecryptionFailureReason::BatchLimitReached => {
-                    Some("Encrypted transaction exceeded batch limit; retrying")
-                },
-                DecryptionFailureReason::ExecuteBlockLimitReached => {
-                    Some("Encrypted transaction exceeded execute-block limit; retrying")
-                },
-                DecryptionFailureReason::EpochEndRetry => {
-                    Some("Block contained an epoch-ending vtxn; retrying encrypted txn next epoch")
-                },
-                // TODO(ibalajiarun): TrustedSetupExhausted is an operational
-                // condition (the epoch outlived the trusted setup's num_rounds);
-                // falling through here charges the user gas + bumps their seq#
-                // for a system issue. Alert on the
-                // `aptos_consensus_decryption_pipeline_txns_count{category="trusted_setup_exhausted"}`
-                // counter so ops can extend the setup before users are affected.
-                // Revisit to use a Discard path that does not charge.
-                DecryptionFailureReason::CryptoFailure
-                | DecryptionFailureReason::ConfigUnavailable
-                | DecryptionFailureReason::DecryptionKeyUnavailable
-                | DecryptionFailureReason::ClaimedEntryFunctionMismatch
-                | DecryptionFailureReason::PayloadHashMismatch
-                | DecryptionFailureReason::EpochMismatch
-                | DecryptionFailureReason::TrustedSetupExhausted => None,
-            };
-            if let Some(message) = message {
-                return (
-                    VMStatus::Error {
-                        status_code: StatusCode::UNKNOWN_STATUS,
-                        sub_status: None,
-                        message: Some(message.to_string()),
-                    },
-                    VMOutput::empty_with_status(TransactionStatus::Retry),
-                );
-            }
-        }
+        // Retryable decryption failures (BatchLimitReached / ExecuteBlockLimitReached
+        // / EpochEndRetry) are kept out of the executed block by the consensus
+        // decryption pipeline (see `DecryptionResult::retry_txns`): they stay
+        // uncommitted and are re-proposed via the quorum store. They must never
+        // reach execution — emitting a `TransactionStatus::Retry` output here would
+        // be committed/materialized by Block-STM and violate its materialization
+        // invariant (`check_materialization`). Non-retryable failures (e.g.
+        // CryptoFailure, TrustedSetupExhausted) still execute and discard as usual.
+        debug_assert!(
+            !txn.payload()
+                .decryption_failure_reason()
+                .is_some_and(|reason| reason.is_retryable()),
+            "retryable decryption failure reached the VM; consensus must exclude it \
+             from the executed set"
+        );
 
         let multisig_address = txn.multisig_address();
         let result = if let Some(multisig_address) = multisig_address {

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -97,7 +97,11 @@ pub enum DecryptionOutcome {
 
 #[derive(Clone, Debug)]
 pub struct DecryptionResult {
+    /// Txns to execute (decrypted + non-retryable failures, which discard).
     pub decrypted_txns: Vec<SignedTransaction>,
+    /// Retryable failures, excluded from execution and re-proposed via the
+    /// quorum store. Carried for metrics only.
+    pub retry_txns: Vec<SignedTransaction>,
     pub regular_txns: Vec<SignedTransaction>,
     pub max_txns_from_block_to_execute: Option<u64>,
     pub block_gas_limit: Option<u64>,

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -150,6 +150,7 @@ impl PipelineBuilder {
             );
             return Ok(DecryptionResult {
                 decrypted_txns: failed_txns,
+                retry_txns: Vec::new(),
                 regular_txns,
                 max_txns_from_block_to_execute,
                 block_gas_limit,
@@ -172,6 +173,7 @@ impl PipelineBuilder {
                 );
                 return Ok(DecryptionResult {
                     decrypted_txns: failed_txns,
+                    retry_txns: Vec::new(),
                     regular_txns,
                     max_txns_from_block_to_execute,
                     block_gas_limit,
@@ -265,6 +267,7 @@ async fn decrypt_observer_path(
     };
     Ok(DecryptionResult {
         decrypted_txns,
+        retry_txns: Vec::new(),
         regular_txns,
         max_txns_from_block_to_execute,
         block_gas_limit,
@@ -307,6 +310,7 @@ async fn decrypt_validator_path(
         let _ = derived_self_key_share_tx.send(None);
         return Ok(DecryptionResult {
             decrypted_txns: Vec::new(),
+            retry_txns: Vec::new(),
             regular_txns,
             max_txns_from_block_to_execute,
             block_gas_limit,
@@ -334,6 +338,7 @@ async fn decrypt_validator_path(
         );
         return Ok(DecryptionResult {
             decrypted_txns: failed_txns,
+            retry_txns: Vec::new(),
             regular_txns,
             max_txns_from_block_to_execute,
             block_gas_limit,
@@ -351,10 +356,11 @@ async fn decrypt_validator_path(
             encrypted_txns.len()
         );
         let _ = derived_self_key_share_tx.send(None);
-        let failed_txns =
+        let retry_txns =
             mark_txns_failed_decryption(encrypted_txns, DecryptionFailureReason::EpochEndRetry);
         return Ok(DecryptionResult {
-            decrypted_txns: failed_txns,
+            decrypted_txns: Vec::new(),
+            retry_txns,
             regular_txns,
             max_txns_from_block_to_execute,
             block_gas_limit,
@@ -407,9 +413,10 @@ async fn decrypt_validator_path(
     // If the cap left no encrypted txns to decrypt, short-circuit before crypto.
     if encrypted_txns.is_empty() {
         let _ = derived_self_key_share_tx.send(None);
-        let decrypted_txns = [batch_limit_exceeded_txns, execute_limit_exceeded_txns].concat();
+        let retry_txns = [batch_limit_exceeded_txns, execute_limit_exceeded_txns].concat();
         return Ok(DecryptionResult {
-            decrypted_txns,
+            decrypted_txns: Vec::new(),
+            retry_txns,
             regular_txns,
             max_txns_from_block_to_execute,
             block_gas_limit,
@@ -543,14 +550,10 @@ async fn decrypt_validator_path(
                 )
             })
             .collect();
-        let decrypted_txns = [
-            failed_txns,
-            batch_limit_exceeded_txns,
-            execute_limit_exceeded_txns,
-        ]
-        .concat();
+        let retry_txns = [batch_limit_exceeded_txns, execute_limit_exceeded_txns].concat();
         return Ok(DecryptionResult {
-            decrypted_txns,
+            decrypted_txns: failed_txns,
+            retry_txns,
             regular_txns,
             max_txns_from_block_to_execute,
             block_gas_limit,
@@ -643,12 +646,7 @@ async fn decrypt_validator_path(
         execute_limit_exceeded_txns.len(),
         regular_txns.len(),
     );
-    let decrypted_txns = [
-        decrypted_txns,
-        batch_limit_exceeded_txns,
-        execute_limit_exceeded_txns,
-    ]
-    .concat();
+    let retry_txns = [batch_limit_exceeded_txns, execute_limit_exceeded_txns].concat();
 
     let block_txn_dec_key = BlockTxnDecryptionKey::from_secret_shared_key(&decryption_key)
         .context("Decryption key serialization failed")?;
@@ -662,6 +660,7 @@ async fn decrypt_validator_path(
 
     Ok(DecryptionResult {
         decrypted_txns,
+        retry_txns,
         regular_txns,
         max_txns_from_block_to_execute,
         block_gas_limit,
@@ -682,7 +681,10 @@ fn record_decryption_metrics(result: &DecryptionResult) {
     let mut trusted_setup_exhausted = 0u64;
     let mut entry_fun_mismatch = 0u64;
 
-    for txn in &result.decrypted_txns {
+    // retry_txns hold the retryable failures (batch/execute-limit, epoch-end);
+    // chain them in so their reason counters stay accurate now that they no
+    // longer live in decrypted_txns.
+    for txn in result.decrypted_txns.iter().chain(result.retry_txns.iter()) {
         let Some(ep) = txn.payload().as_encrypted_payload() else {
             continue;
         };
@@ -944,6 +946,7 @@ mod tests {
         async move {
             Ok(DecryptionResult {
                 decrypted_txns: Vec::new(),
+                retry_txns: Vec::new(),
                 regular_txns: Vec::new(),
                 max_txns_from_block_to_execute: None,
                 block_gas_limit: None,
@@ -1071,19 +1074,22 @@ mod tests {
             .collect();
 
         // One txn per FailedDecryption variant + one Decrypted + two regular.
+        // The retryable reasons live in retry_txns; metrics must count both vecs.
         let result = DecryptionResult {
             decrypted_txns: vec![
                 make_decrypted_txn(),
                 make_failed_decryption_txn(DecryptionFailureReason::CryptoFailure),
-                make_failed_decryption_txn(DecryptionFailureReason::BatchLimitReached),
                 make_failed_decryption_txn(DecryptionFailureReason::ConfigUnavailable),
                 make_failed_decryption_txn(DecryptionFailureReason::DecryptionKeyUnavailable),
                 make_failed_decryption_txn(DecryptionFailureReason::PayloadHashMismatch),
                 make_failed_decryption_txn(DecryptionFailureReason::EpochMismatch),
-                make_failed_decryption_txn(DecryptionFailureReason::EpochEndRetry),
                 make_failed_decryption_txn(DecryptionFailureReason::ClaimedEntryFunctionMismatch),
-                make_failed_decryption_txn(DecryptionFailureReason::ExecuteBlockLimitReached),
                 make_failed_decryption_txn(DecryptionFailureReason::TrustedSetupExhausted),
+            ],
+            retry_txns: vec![
+                make_failed_decryption_txn(DecryptionFailureReason::BatchLimitReached),
+                make_failed_decryption_txn(DecryptionFailureReason::EpochEndRetry),
+                make_failed_decryption_txn(DecryptionFailureReason::ExecuteBlockLimitReached),
             ],
             regular_txns: vec![make_regular_txn(), make_regular_txn()],
             max_txns_from_block_to_execute: None,
@@ -1397,8 +1403,9 @@ mod tests {
         .await
         .expect("should succeed");
 
-        assert_eq!(result.decrypted_txns.len(), 2);
-        for txn in &result.decrypted_txns {
+        assert!(result.decrypted_txns.is_empty());
+        assert_eq!(result.retry_txns.len(), 2);
+        for txn in &result.retry_txns {
             assert_failed_with(txn, &DecryptionFailureReason::EpochEndRetry);
         }
         assert_eq!(result.regular_txns.len(), 1);
@@ -1431,9 +1438,10 @@ mod tests {
         .await
         .expect("should succeed");
 
-        assert_eq!(result.decrypted_txns.len(), 1);
+        assert!(result.decrypted_txns.is_empty());
+        assert_eq!(result.retry_txns.len(), 1);
         assert_failed_with(
-            &result.decrypted_txns[0],
+            &result.retry_txns[0],
             &DecryptionFailureReason::EpochEndRetry,
         );
         assert_eq!(result.outcome, tracked_no_key(0));
@@ -1548,11 +1556,65 @@ mod tests {
         .await
         .expect("should succeed");
 
-        assert_eq!(result.decrypted_txns.len(), 3);
-        for txn in &result.decrypted_txns {
+        assert!(result.decrypted_txns.is_empty());
+        assert_eq!(result.retry_txns.len(), 3);
+        for txn in &result.retry_txns {
             assert_failed_with(txn, &DecryptionFailureReason::ExecuteBlockLimitReached);
         }
         assert_eq!(result.regular_txns.len(), 1);
+        assert_eq!(result.outcome, tracked_no_key(0));
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn validator_path_batch_limit_marks_excess_as_retry() {
+        // max_batch_size=2 fires the batch limit; max_txns=0 caps the remainder,
+        // keeping the path on the pre-crypto short-circuit. Both the batch-limit
+        // and execute-limit excess must land in retry_txns (not decrypted_txns).
+        let ctx = TestContext::new_with_capacity(vec![100], 2, 2);
+        let block = make_block(None);
+        let encrypted = vec![
+            make_encrypted_txn(),
+            make_encrypted_txn(),
+            make_encrypted_txn(),
+            make_encrypted_txn(),
+        ];
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let result = decrypt_validator_path(
+            encrypted,
+            vec![],
+            &block,
+            ctx.authors[0],
+            &ctx.secret_share_config,
+            key_share_tx,
+            skey_rx,
+            Some(0),
+            None,
+            Some(0),
+        )
+        .await
+        .expect("should succeed");
+
+        assert!(result.decrypted_txns.is_empty());
+        // 2 over the batch limit + 2 over the execute limit, all re-queued.
+        assert_eq!(result.retry_txns.len(), 4);
+        let batch_limited = result
+            .retry_txns
+            .iter()
+            .filter(|txn| {
+                matches!(
+                    txn.payload().as_encrypted_payload(),
+                    Some(EncryptedPayload::FailedDecryption {
+                        reason: DecryptionFailureReason::BatchLimitReached,
+                        ..
+                    })
+                )
+            })
+            .count();
+        assert_eq!(batch_limited, 2);
         assert_eq!(result.outcome, tracked_no_key(0));
         assert!(key_share_rx.await.unwrap().is_none());
     }

--- a/consensus/src/pipeline/pipeline_builder.rs
+++ b/consensus/src/pipeline/pipeline_builder.rs
@@ -408,6 +408,7 @@ impl PipelineBuilder {
         };
         let decryption_fut = spawn_ready_fut(DecryptionResult {
             decrypted_txns: Vec::new(),
+            retry_txns: Vec::new(),
             regular_txns: Vec::new(),
             max_txns_from_block_to_execute: None,
             block_gas_limit: None,
@@ -776,6 +777,8 @@ impl PipelineBuilder {
         let mut tracker = Tracker::start_waiting("prepare", &block);
         let DecryptionResult {
             decrypted_txns,
+            // Excluded from execution; re-proposed via the quorum store.
+            retry_txns: _,
             regular_txns,
             max_txns_from_block_to_execute,
             block_gas_limit,

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -98,6 +98,18 @@ pub enum DecryptionFailureReason {
     ExecuteBlockLimitReached,
 }
 
+impl DecryptionFailureReason {
+    /// Reasons that re-queue the txn for a future block (rather than charging
+    /// gas / discarding it). Such txns are kept out of the executed set entirely
+    /// (see `DecryptionResult::retry_txns`) and re-proposed via the quorum store.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::BatchLimitReached | Self::ExecuteBlockLimitReached | Self::EpochEndRetry
+        )
+    }
+}
+
 // Mirrors EntryFunction in types/src/transaction/script.rs
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ClaimedEntryFunction {


### PR DESCRIPTION
## Problem

Encrypted txns flagged with a **retryable** decryption failure (`BatchLimitReached` / `ExecuteBlockLimitReached` / `EpochEndRetry`) were emitted by the VM as `TransactionStatus::Retry` during block execution (`aptos_vm.rs`).

When such a txn sits mid-block, Block-STM commits/materializes its output, which trips the `check_materialization` invariant in `block_executor/mod.rs`:

> Committed output must not have is_retry set.

This surfaces as a `PanicError` that forces a fallback from parallel to sequential execution. Block-STM's `Retry` placeholders are only ever a trailing suffix (from `skip_output()` after a gas-limit/SkipRest halt); a `Retry` coming **out of executing an individual transaction** is not a concept it models.

## Approach

Rather than teach Block-STM about mid-block retries (a new core invariant), **keep these txns out of the executed set entirely** — handled in the layer that already owns retry semantics, the consensus decryption pipeline.

- `DecryptionResult` gains a `retry_txns` field. The decryption pipeline routes the three retryable reasons there instead of concatenating them into `decrypted_txns`.
- `prepare()` builds `input_txns` from `decrypted_txns + regular_txns` only, so the retries never reach the executor or Block-STM.
- The VM's `Retry` branch is deleted; a `debug_assert` tripwire remains in case a retryable txn ever slips through (consensus is now responsible for excluding them).

## Why re-queue still works (no notification needed)

A `Retry` txn was never explicitly re-queued — the mechanism is implicit. The txn is never acked-out of mempool (not committed via state sync, not discarded via `RejectNotification`). On block commit, `notify_commit` frees **every batch in the block's payload** at batch granularity (`quorum_store_payload_manager.rs`), regardless of per-txn outcome, so the txn drops out of `txns_in_progress_sorted` and is re-pulled into a future batch and re-proposed.

That holds whether or not the txn is executed, so excluding it from execution changes nothing about re-queue. `notify_failed_txn` only acting on `Discard` is correct and unchanged.

## Scope

- **Untouched:** Block-STM (`block-executor/`), `do_get_execution_output`, the mempool notifier.
- **Metrics:** `record_decryption_metrics` now chains `retry_txns`, so the existing `batch_limit_exceeded` / `execute_block_limit_exceeded` / `epoch_end_retry` counters stay accurate.

## Assumptions to confirm

- All validators compute an identical `retry_txns` split. The three reasons are config/count-derived (pre-decryption), so this should be deterministic — worth an explicit check.
- Observer consistency: observers receive `decrypted_txns` (now the executed set) via `set_decrypted_txns` and execute the same set; they don't re-queue, so they don't need `retry_txns`.

## Testing

- `cargo test -p aptos-consensus --lib pipeline::decryption_pipeline_builder` — 28 passed (includes updated EpochEndRetry / ExecuteBlockLimitReached / metrics tests).
- `cargo check` + `cargo clippy` clean on `aptos-consensus`, `aptos-vm`, `aptos-consensus-types`, `aptos-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)