### PR TITLE
[execution] Enable Block-STM v2 by default

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -491,11 +491,11 @@ impl AptosVM {
         BLOCKSTM_V2_ENABLED.set(blockstm_v2_enabled).ok();
     }
 
-    /// Get the blockstm v2 enabled flag if already set, otherwise return default (true)
+    /// Get the blockstm v2 enabled flag if already set, otherwise return default (false)
     pub fn get_blockstm_v2_enabled() -> bool {
         match BLOCKSTM_V2_ENABLED.get() {
             Some(blockstm_v2_enabled) => *blockstm_v2_enabled,
-            None => true,
+            None => false,
         }
     }
 

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -491,11 +491,11 @@ impl AptosVM {
         BLOCKSTM_V2_ENABLED.set(blockstm_v2_enabled).ok();
     }
 
-    /// Get the blockstm v2 enabled flag if already set, otherwise return default (false)
+    /// Get the blockstm v2 enabled flag if already set, otherwise return default (true)
     pub fn get_blockstm_v2_enabled() -> bool {
         match BLOCKSTM_V2_ENABLED.get() {
             Some(blockstm_v2_enabled) => *blockstm_v2_enabled,
-            None => false,
+            None => true,
         }
     }
 

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -1006,7 +1006,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         #[allow(unused_mut)]
         let mut config: BlockExecutorConfig = BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
-                blockstm_v2: false,
+                blockstm_v2: true,
                 concurrency_level: 1,
                 allow_fallback: self.allow_block_executor_fallback,
                 discard_failed_blocks: false,

--- a/aptos-move/replay-benchmark/src/execution.rs
+++ b/aptos-move/replay-benchmark/src/execution.rs
@@ -22,7 +22,7 @@ pub(crate) fn execute_workload(
 ) -> Vec<TransactionOutput> {
     let config = BlockExecutorConfig {
         local: BlockExecutorLocalConfig {
-            blockstm_v2: false,
+            blockstm_v2: true,
             concurrency_level,
             allow_fallback: true,
             discard_failed_blocks: false,

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -104,7 +104,7 @@ impl Default for ExecutionConfig {
             discard_failed_blocks: false,
             processed_transactions_detailed_counters: false,
             genesis_waypoint: None,
-            blockstm_v2_enabled: false,
+            blockstm_v2_enabled: true,
             layout_caches_enabled: true,
             async_runtime_checks: true,
             enable_pre_write: true,

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -341,8 +341,8 @@ struct Opt {
     #[clap(long)]
     skip_paranoid_checks: bool,
 
-    #[clap(long, default_value_t = true)]
-    use_blockstm_v2: bool,
+    #[clap(long)]
+    use_blockstm_v1: bool,
 }
 
 impl Opt {
@@ -654,7 +654,7 @@ fn main() {
     AptosVM::set_concurrency_level_once(execution_threads_per_shard);
     NativeConfig::set_concurrency_level_once(execution_threads_per_shard);
     AptosVM::set_processed_transactions_detailed_counters();
-    AptosVM::set_blockstm_v2_enabled_once(opt.use_blockstm_v2);
+    AptosVM::set_blockstm_v2_enabled_once(!opt.use_blockstm_v1);
 
     let config = ProfilerConfig::new_with_defaults();
     let handler = ProfilerHandler::new(config);

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -341,7 +341,7 @@ struct Opt {
     #[clap(long)]
     skip_paranoid_checks: bool,
 
-    #[clap(long)]
+    #[clap(long, default_value_t = true)]
     use_blockstm_v2: bool,
 }
 

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -71,7 +71,7 @@ impl BlockExecutorLocalConfig {
     ///   - Default module cache configs.
     pub fn default_with_concurrency_level(concurrency_level: usize) -> Self {
         Self {
-            blockstm_v2: false,
+            blockstm_v2: true,
             concurrency_level,
             allow_fallback: true,
             discard_failed_blocks: false,


### PR DESCRIPTION
## Summary

- Set `blockstm_v2_enabled: true` in `ExecutionConfig::default()` (node config)
- Set `blockstm_v2: true` in `BlockExecutorLocalConfig::default_with_concurrency_level()`
- Changed `AptosVM::get_blockstm_v2_enabled()` fallback (when `OnceCell` not yet set) from `false` to `true`
- Set `blockstm_v2: true` in e2e-tests executor and replay-benchmark
- Set `default_value_t = true` on the `--use-blockstm-v2` CLI flag in executor-benchmark

## Test plan

- [ ] `cargo check` passes on all modified crates
- [ ] `cargo xclippy` passes (no errors)
- [ ] `cargo +nightly fmt --check` passes
- [ ] CI runs existing Block-STM v2 tests under the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flips the default block parallel scheduler for validators and benchmarks; behavior change is broad but limited to selecting the existing v2 executor rather than new consensus or auth logic.
> 
> **Overview**
> **Block-STM v2 becomes the default parallel execution path** across node configuration, block-executor local defaults, and test/benchmark harnesses that build `BlockExecutorConfig` directly.
> 
> `ExecutionConfig::default()` now sets `blockstm_v2_enabled: true`, so new or unset node configs use v2 unless overridden. `BlockExecutorLocalConfig::default_with_concurrency_level()` sets `blockstm_v2: true`, aligning programmatic defaults with that choice. E2E fake executor and replay-benchmark workloads hard-code `blockstm_v2: true` in their local executor config.
> 
> In **executor-benchmark**, the CLI flag is inverted: `--use-blockstm-v2` becomes `--use-blockstm-v1`, and `AptosVM::set_blockstm_v2_enabled_once` is called with `!opt.use_blockstm_v1` so v2 is on unless v1 is explicitly requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a879a2c5fedea2f8e130e932bdf53b5d75aa90c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->