### PR TITLE
[release] Add aptos-release-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3950,6 +3950,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",
+ "regex",
  "reqwest 0.11.23",
  "serde",
  "serde_json",
@@ -3975,6 +3976,29 @@ dependencies = [
  "move-core-types",
  "move-model",
  "serde",
+]
+
+[[package]]
+name = "aptos-release-tool"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-release-builder",
+ "aptos-rest-client",
+ "aptos-types",
+ "chrono",
+ "clap 4.5.60",
+ "git2 0.16.1",
+ "hex",
+ "move-command-line-common",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "sha2 0.9.9",
+ "tempfile",
+ "tokio",
+ "toml 0.7.8",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "aptos-move/aptos-memory-usage-tracker",
     "aptos-move/aptos-native-interface",
     "aptos-move/aptos-release-builder",
+    "aptos-move/aptos-release-tool",
     "aptos-move/aptos-resource-viewer",
     "aptos-move/aptos-sdk-builder",
     "aptos-move/aptos-transaction-benchmarks",
@@ -441,6 +442,7 @@ aptos-protos = { path = "protos/rust" }
 aptos-proxy = { path = "crates/proxy" }
 aptos-push-metrics = { path = "crates/aptos-push-metrics" }
 aptos-release-builder = { path = "aptos-move/aptos-release-builder" }
+aptos-release-tool = { path = "aptos-move/aptos-release-tool" }
 aptos-release-bundle = { path = "aptos-move/framework/release-bundle" }
 aptos-reliable-broadcast = { path = "crates/reliable-broadcast" }
 aptos-replay-benchmark = { path = "aptos-move/replay-benchmark" }

--- a/aptos-move/aptos-release-builder/Cargo.toml
+++ b/aptos-move/aptos-release-builder/Cargo.toml
@@ -53,6 +53,7 @@ move-model = { workspace = true }
 move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true }
 once_cell = { workspace = true }
+regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -28,6 +28,7 @@ use futures::executor::block_on;
 use handlebars::Handlebars;
 use move_binary_format::file_format_common::VERSION_DEFAULT;
 use once_cell::sync::Lazy;
+use regex::Regex;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     collections::HashMap,
@@ -193,25 +194,75 @@ impl<'de> Deserialize<'de> for GasScheduleLocator {
     }
 }
 
+/// Raw base URL for published gas schedules in `aptos-labs/aptos-networks`.
+const APTOS_NETWORKS_RAW: &str = "https://raw.githubusercontent.com/aptos-labs/aptos-networks/main";
+
+/// A release version like `v1.45.1` or `v1.16.1-rc` (vs. a URL or file path): a
+/// leading `v`, three numeric components, and an optional pre-release suffix.
+static GAS_VERSION_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^v\d+\.\d+\.\d+(-[\w.-]+)?$").expect("valid version regex"));
+
 impl GasScheduleLocator {
-    async fn fetch_gas_schedule(&self) -> Result<GasScheduleV2> {
-        println!("{:?}", self);
+    pub async fn fetch_gas_schedule(&self) -> Result<GasScheduleV2> {
         match self {
+            // A plain version (e.g. `v1.45.1`) has no dedicated locator variant,
+            // so it deserializes as a "local file"; detect and resolve it against
+            // aptos-networks before treating the string as a real path.
+            GasScheduleLocator::LocalFile(s) if GAS_VERSION_RE.is_match(s) => {
+                fetch_gas_by_version(s).await
+            },
             GasScheduleLocator::LocalFile(path) => {
-                let file_contents = fs::read_to_string(path)?;
-                let gas_schedule: GasScheduleV2 = serde_json::from_str(&file_contents)?;
-                Ok(gas_schedule)
+                let file_contents = fs::read_to_string(path)
+                    .with_context(|| format!("failed to read gas schedule from {}", path))?;
+                serde_json::from_str(&file_contents)
+                    .with_context(|| format!("failed to parse gas schedule from {}", path))
             },
-            GasScheduleLocator::RemoteFile(url) => {
-                let response = reqwest::get(url.as_str()).await?;
-                let gas_schedule: GasScheduleV2 = response.json().await?;
-                Ok(gas_schedule)
-            },
+            GasScheduleLocator::RemoteFile(url) => fetch_gas_url(url.as_str()).await,
             GasScheduleLocator::Current => Ok(aptos_gas_schedule_updator::current_gas_schedule(
                 LATEST_GAS_FEATURE_VERSION,
             )),
         }
     }
+}
+
+/// Fetch a published gas schedule for `version` from aptos-networks, trying the
+/// bundle location first and the legacy `gas/` directory second.
+async fn fetch_gas_by_version(version: &str) -> Result<GasScheduleV2> {
+    let candidates = [
+        format!(
+            "{}/framework-releases/{}/gas/new.json",
+            APTOS_NETWORKS_RAW, version
+        ),
+        format!("{}/gas/{}.json", APTOS_NETWORKS_RAW, version),
+    ];
+    let mut last_err = None;
+    for url in &candidates {
+        match fetch_gas_url(url).await {
+            Ok(schedule) => return Ok(schedule),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(anyhow!(
+        "could not fetch gas schedule for version {} from aptos-networks; tried {} and {} (last error: {})",
+        version,
+        candidates[0],
+        candidates[1],
+        last_err.expect("at least one candidate is always tried"),
+    ))
+}
+
+/// HTTP-fetch and parse a gas schedule, treating a non-success status (e.g. 404)
+/// as an error so callers can fall back to another location.
+async fn fetch_gas_url(url: &str) -> Result<GasScheduleV2> {
+    let response = reqwest::get(url)
+        .await
+        .with_context(|| format!("request to {} failed", url))?
+        .error_for_status()
+        .with_context(|| format!("{} returned an error status", url))?;
+    response
+        .json()
+        .await
+        .with_context(|| format!("failed to parse gas schedule from {}", url))
 }
 
 impl ReleaseEntry {
@@ -888,3 +939,27 @@ fn get_signer_arg(is_testnet: bool, next_execution_hash: &Option<HashValue>) -> 
 
 /// Estimated async reconfiguration time.
 static MAX_ASYNC_RECONFIG_TIME: Lazy<Duration> = Lazy::new(|| Duration::from_secs(60));
+
+#[cfg(test)]
+mod tests {
+    use super::GAS_VERSION_RE;
+
+    #[test]
+    fn gas_version_vs_path() {
+        for v in ["v1.45.1", "v1.16.1-rc", "v1.16.1-rc.1", "v10.0.0"] {
+            assert!(GAS_VERSION_RE.is_match(v), "{v} should match");
+        }
+        for p in [
+            "gas.json",
+            "/tmp/x.json",
+            "v1.45.1.json",
+            "vX.WW.Z",
+            "1.45.1",
+            "v1.45",
+            "current",
+            "",
+        ] {
+            assert!(!GAS_VERSION_RE.is_match(p), "{p} should not match");
+        }
+    }
+}

--- a/aptos-move/aptos-release-tool/Cargo.toml
+++ b/aptos-move/aptos-release-tool/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "aptos-release-tool"
+description = "Tooling for building, verifying, and deploying self-contained framework release bundles"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[[bin]]
+name = "aptos-release-tool"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-release-builder = { workspace = true }
+aptos-rest-client = { workspace = true }
+aptos-types = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+git2 = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+sha2 = { workspace = true }
+tokio = { workspace = true }
+toml = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+move-command-line-common = { workspace = true }
+tempfile = { workspace = true }

--- a/aptos-move/aptos-release-tool/README.md
+++ b/aptos-move/aptos-release-tool/README.md
@@ -1,0 +1,579 @@
+# Framework Release Process
+
+`aptos-release-tool` (this directory) is the centerpiece of an improved framework
+release process. This document covers that process end to end — the current
+process and its friction points (sections 1–2), and the bundle-based design the
+tool implements (section 3 onward) — so it serves as both the README for the tool
+and the design reference for the release process as a whole.
+
+## Status: Partially implemented
+
+The bundle format and the `aptos-release-tool` CLI (`generate-bundle`,
+`verify-bundle`, `simulate`, `verify-framework-deployment`) are implemented. The
+GitHub Actions workflows that orchestrate the process (section 3.3) live in
+`internal-ops` and are added separately.
+
+---
+
+## 1. Current Process Overview
+
+The framework release process spans two networks (testnet then mainnet), multiple
+repositories, and several manual handoffs. A simplified view:
+
+**Testnet:**
+1. Checkout release branch
+2. Generate gas schedule JSON, PR it to `aptos-networks`
+3. Edit `release.yaml` (endpoint, gas refs, name), PR with 2 approvals
+4. Run `generate-proposals --simulate testnet`
+5. Trigger `release-framework` GH Action (internal-ops)
+6. Verify on-chain (Grafana, Explorer)
+7. Push framework tag
+
+**Mainnet:**
+1. Run `generate-proposals` from release branch
+2. Run `simulate --network mainnet`
+3. Fork Foundation repo, manually copy artifacts, PR to `mainnet-proposals`
+4. Coordinate with operator to create on-chain governance proposal
+5. Submit proposal to mainnet for voting (3-day window)
+6. Execute proposal (operator or self-serve)
+7. Verify on-chain (Explorer: PackageRegistry / GasScheduleV2)
+8. Push mainnet branch (internal-ops workflow)
+
+### Repositories involved
+| Repo | Role |
+|------|------|
+| `aptos-labs/aptos-core` | Source of truth: framework code, release.yaml, release-builder CLI |
+| `aptos-labs/aptos-networks` | Stores gas schedule snapshots (JSON) in `gas/` directory |
+| `aptos-foundation/mainnet-proposals` | Stores mainnet governance proposal artifacts (metadata + sources) |
+| `aptos-labs/internal-ops` | GH Actions for `release-framework`, `push-branch`, validator removal |
+
+### Existing tooling (`aptos-release-builder` CLI)
+| Subcommand | What it does |
+|------------|-------------|
+| `generate-proposals` | Generates Move scripts + metadata from release.yaml; optional `--simulate` |
+| `simulate` | Runs generated proposals against live network state (in-memory VM) |
+| `generate-gas-schedule` | Dumps current gas params as JSON |
+| `validate-proposals` | Submits & executes proposals on a test network |
+| `write-default` | Emits a template release.yaml |
+| `print-configs` | Fetches on-chain configs (consensus, execution, gas, features, etc.) |
+| `print-package-metadata` | Inspects on-chain package info |
+
+---
+
+## 2. Identified Friction Points
+
+### A. Scattered, Loosely Coupled Artifacts
+
+A single release produces artifacts across three repos (gas JSON in `aptos-networks`,
+release config in `aptos-core`, metadata + sources in `mainnet-proposals`), connected
+only by naming convention. No machine-readable link between them — mismatches are
+caught only by human review or simulation failures that require tribal knowledge to
+debug.
+
+### B. No Self-Verification / Lack of Voter Transparency
+
+No way to verify that metadata matches sources, gas schedules are consistent, or
+bytecode was compiled from the claimed revision. Beyond internal correctness, there is
+a transparency gap for governance voters: validator operators voting on proposals have
+no structured way to trace from the on-chain proposal back to exact source code, build
+inputs, and simulation results. They largely have to trust the release captain.
+
+### C. Foundation Repo Fork Dance
+
+Mainnet artifacts must be uploaded to `aptos-foundation/mainnet-proposals` via a
+personal fork. The captain must keep the fork in sync, manually recreate the expected
+directory layout (`metadata/v1.X.Y/`, `sources/v1.X.Y/proposal_1_.../`), and copy
+files from their local machine into the correct structure. The layout is a silent
+contract with the governance tooling — no validation that it's correct until someone
+tries to use it. The runbook includes steps like "drag folders into terminal to see
+the addresses" and hardcoded absolute paths.
+
+### D. Local-Machine-Dependent Steps
+
+Gas generation, proposal generation, and simulation all run on the captain's laptop.
+Results depend on local toolchain, checkout state, and network conditions. Builds are
+slow (`--profile release`), and simulation can fail from rate limiting without an API
+key.
+
+### E. Gas Schedule Upload Ceremony
+
+Gas snapshot must be generated locally, PR'd into `aptos-networks`, merged, then its
+raw GitHub URL manually pasted into `release.yaml`. Multiple PRs across repos for one
+logical operation.
+
+### F. Manual Post-Release Verification
+
+Verification involves eyeballing Grafana, manually looking up `GasScheduleV2` and
+`PackageRegistry` on Explorer, and cross-referencing with source code. Easy to skip,
+no automated pass/fail.
+
+### G. Manual `release.yaml` Editing (lower priority)
+
+Each release requires hand-editing `release.yaml` to swap endpoints, update gas URLs,
+and toggle commented-out blocks. Annoying but manageable — experienced captains know
+the drill. Nice-to-have improvement, not a blocker.
+
+### H. Multi-Channel Coordination (out of scope)
+
+Real friction (multiple Slack channels, async handoffs), but organizational rather
+than tooling. Out of scope for this effort.
+
+---
+
+## 3. Proposed Improvements
+
+### 3.1 Release Artifact Bundle
+
+Replace the current scattered-files approach with a single, self-contained **release
+bundle** — a directory (or archive) that contains everything needed for a framework
+release and can be moved as a unit.
+
+#### Bundle Structure
+
+```
+aptos-framework-v1.45.1/
+├── bundle.toml                          # Bundle manifest (see below)
+├── config.yaml                          # The release config used to generate this bundle
+├── metadata.json                        # Proposal metadata (title, description, URLs)
+├── gas/                                 # Present only when the release changes the gas schedule
+│   ├── old.json                         # Previous gas schedule snapshot
+│   └── new.json                         # New gas schedule snapshot
+├── scripts/                             # The proposal's multi-step governance scripts
+│   ├── 0-....move
+│   ├── 1-....move
+│   └── ...
+└── summary/                             # Human-reviewable change summaries
+    ├── gas-schedule-changes.md          # Gas parameter diff with sign-off checkboxes
+    └── feature-flags.md                 # Feature flag changes with sign-off checkboxes
+```
+
+A bundle holds exactly one governance proposal — a framework release or an ad-hoc
+change — emitted as a single multi-step proposal whose steps are the numbered Move
+scripts under `scripts/`, with `metadata.json` holding the proposal's metadata.
+`config.yaml` is the exact release config the bundle was generated from, copied
+verbatim, so the bundle is self-describing.
+
+The `summary/` directory contains auto-generated, human-readable summaries of key
+changes. These serve two purposes: (1) giving reviewers a quick overview without
+reading raw Move scripts, and (2) optionally acting as a sign-off mechanism (see
+below).
+
+#### `bundle.toml` — Manifest
+
+```toml
+format_version = 1                       # bundle format version, for forward compatibility
+
+[bundle]
+name = "aptos-framework-v1.45.1"         # the bundle's identity; matches config.yaml's name
+created_at = "2026-04-01T18:30:00Z"
+
+[source]
+branch = "aptos-release-v1.45"           # optional
+commit = "abc123def456..."               # the revision the framework was built from
+
+[integrity]
+# A single content digest over the whole bundle (see "Bundle Integrity" below).
+digest = "deadbeef..."
+
+# SHA-256 of every bundle file (excluding bundle.toml itself), inline for
+# self-containment.
+[checksums]
+"config.yaml" = "a1b2c3..."
+"metadata.json" = "def012..."
+"gas/old.json" = "d4e5f6..."
+"gas/new.json" = "789abc..."
+"scripts/0-....move" = "345678..."
+# ... etc
+```
+
+#### `summary/` — Reviewable Change Summaries with Optional Sign-off
+
+The release tooling auto-generates summary files that highlight what changed in a
+human-readable format. For example, `gas-schedule-changes.md`:
+
+```markdown
+# Gas Schedule Changes
+
+Gas feature version: 30 -> 31
+
+- [ ] I have reviewed the gas schedule changes below.
+
+## Changes
+
+| change   | parameter             |       old |        new | sign-off |
+| -------- | --------------------- | --------: | ---------: | -------- |
+| modified | instr.add             |        50 |         65 |          |
+| added    | instr.mul             |         / |         90 |          |
+| removed  | instr.sub             |        80 |          / |          |
+| modified | txn.max_execution_gas | 920000000 | 1000000000 | [ ]      |
+```
+
+The top checkbox ensures the reviewer scans the changes before signing off. Critical
+gas parameters (e.g. `txn.max_execution_gas`, `txn.max_io_gas`,
+`txn.max_transaction_size_in_bytes`) additionally get their own per-change `[ ]` in the
+sign-off column, forcing explicit acknowledgment. 
+
+`verify-bundle --require-signoff` optionally enforces that every box is ticked; 
+it is opt-in (off by default) to avoid friction. Ticking boxes never invalidates 
+the bundle's checksums — summary checkboxes are normalized away before hashing 
+(see Bundle Integrity).
+
+#### Bundle Integrity
+
+Integrity is two-layered:
+
+1. **Per-file checksums** — `[checksums]` holds a SHA-256 of every bundle file
+   (except `bundle.toml`), catching any changed, added, or removed file.
+2. **Global digest** — `integrity.digest` is a single hash over the bundle's identity,
+   computed using its name, the source commit, and the sorted list of per-file checksums. 
+   It excludes volatile fields (`created_at`, `branch`, `format_version`) so regenerating 
+   from the same source reproduces the same digest.
+
+`verify-bundle` checks the bundle is internally self-consistent:
+
+```bash
+cargo run -p aptos-release-tool -- verify-bundle --bundle aptos-framework-v1.45.1/
+```
+
+It confirms the checksums and global digest match, the manifest and `config.yaml`
+agree, and the expected layout is present; `--require-signoff` additionally requires
+every summary checkbox to be ticked.
+
+Note this verifies self-consistency, not provenance — it does not by itself confirm the
+bundle was built from the commit it claims.
+
+---
+
+### 3.2 New CLI Commands
+
+Every step of the release process maps to a CLI subcommand in a new tool (separate
+from `aptos-release-builder`). The GitHub Actions workflows (section 3.3) are
+convenience wrappers around these commands — if automation fails, the captain can
+fall back to running the same commands manually.
+
+| Command | What it does |
+|---------|-------------|
+| `generate-bundle` | Builds a complete bundle from a release config, and self-verifies it before returning. |
+| `verify-bundle` | Checks the bundle is internally self-consistent; `--require-signoff` also requires every summary checkbox to be ticked. |
+| `simulate` | Simulates the bundle's governance proposal against a network (reuses `aptos-release-builder`). |
+| `verify-framework-deployment` | Checks a deployed framework release on-chain against the bundle — currently the gas schedule only (bytecode verification is a TODO). |
+
+Example usage:
+
+```bash
+# Generate a bundle (it self-verifies before returning)
+cargo run -p aptos-release-tool -- generate-bundle \
+    --release-config aptos-move/aptos-release-tool/data/framework-release.yaml \
+    --bundle "$BUNDLE_DIR"
+
+# Verify it
+cargo run -p aptos-release-tool -- verify-bundle \
+    --bundle "$BUNDLE_DIR"
+
+# Simulate against testnet
+cargo run -p aptos-release-tool -- simulate \
+    --bundle "$BUNDLE_DIR" \
+    --network testnet
+
+# After deployment, verify the framework release on-chain
+cargo run -p aptos-release-tool -- verify-framework-deployment \
+    --bundle "$BUNDLE_DIR" \
+    --network testnet
+```
+
+---
+
+### 3.3 GitHub Actions Workflows
+
+Three workflows (which live in `internal-ops`) automate the release process. All operate
+on release bundles committed to `aptos-networks`. Gas schedule snapshots are part of the
+bundle — no separate upload required.
+
+#### Workflow 1: Generate Release Bundle
+
+Produces a bundle from a release branch and opens a PR adding it to `aptos-networks`
+under `framework-releases/<version>/`.
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:   # e.g. aptos-release-v1.45 (required)
+      release_config:   # path on that branch; defaults to data/framework-release.yaml
+      dry_run:          # generate + verify only, skip the PR
+```
+
+The tool is **built from the release branch**, not main: the new ("current") gas
+schedule is compiled into the binary, so it must come from the branch being released.
+The bundle name — and the `framework-releases/<version>` directory it lands in — is
+derived from the config's `name` (with the `aptos-framework-` prefix stripped for the
+version).
+
+```
+Steps:
+  1. Checkout the release branch
+  2. Build aptos-release-tool from the branch
+  3. generate-bundle --release-config <config> --bundle <name>
+     (gas snapshots, scripts, metadata, summaries, bundle.toml; self-verifies)
+  4. verify-bundle (dedicated step, so verification is visible in the job UI)
+  5. Upload the bundle as a CI artifact
+  6. Unless dry_run: PR the bundle into aptos-networks/framework-releases/<version>
+```
+
+Ideally the same bundle generated for testnet is reused for mainnet. If new changes are
+cherry-picked onto the release branch after testnet deployment (or after initial
+generation), the bundle must be regenerated; the PR branch name is deterministic, so
+regenerating updates the existing PR rather than opening a new one.
+
+#### Workflow 2: Deploy to Testnet (planned, not yet implemented)
+
+Takes a committed bundle, simulates it against testnet, and if successful, executes
+the full testnet release — including the governance proposal, framework tag, branch
+update, and post-deploy verification.
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      bundle_name:
+        description: "Bundle name (e.g. aptos-framework-v1.45.1)"
+        required: true
+```
+
+```
+Steps:
+  1. Fetch the bundle from aptos-networks
+  2. Run simulate --network testnet
+  3. Run verify-bundle
+  4. Trigger release-framework (internal-ops)
+  5. Update testnet branch (push-branch workflow)
+  6. Verify deployment on-chain (gas version, package registry)
+  7. Push framework tag (aptos-framework-vX.Y.Z)
+```
+
+This replaces the current process where the captain runs simulation locally, triggers
+the internal-ops workflow from the GitHub UI, manually checks Explorer, and pushes the
+tag from their laptop.
+
+#### Workflow 3: Simulate Governance Proposals (planned, not yet implemented)
+
+Runs simulation on a committed bundle against a specified network. Does not deploy
+anything — purely a verification step.
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      bundle_name:
+        description: "Bundle name (e.g. aptos-framework-v1.45.1)"
+        required: true
+      network:
+        description: "Network to simulate against"
+        required: true
+        type: choice
+        options: [testnet, mainnet]
+```
+
+```
+Steps:
+  1. Fetch the bundle from aptos-networks
+  2. Run simulate --network $network
+  3. Run verify-bundle
+  4. Report pass/fail
+```
+
+The primary use case is simulating against mainnet before announcing a release to
+validator operators. The captain runs this on the same bundle that was deployed to
+testnet, confirming it works against current mainnet state before coordinating with
+operators and the Foundation.
+
+---
+
+## 4. New Release Process
+
+### 4.1 Automated Release Process (End-to-End)
+
+How a release captain uses the three workflows to complete a full release cycle.
+
+#### Testnet Release
+
+```
+┌─────────────────────────────────────┐
+│ Trigger "Generate Bundle" workflow  │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────┐
+│ Review bundle PR in aptos-networks  │
+│ (check summary files, sign off,     │
+│  merge)                             │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────┐
+│ Trigger "Deploy to Testnet"         │
+│ workflow                            │
+│                                     │
+│ (automated: simulate, deploy,       │
+│  verify, tag, update branch)        │
+└─────────────────────────────────────┘
+```
+
+#### Mainnet Release
+
+```
+┌─────────────────────────────────────┐
+│ Cherry-picks since testnet?         │
+└──────┬─────────────────┬────────────┘
+       │                 │
+      yes                no
+       │                 │
+       ▼                 │
+┌──────────────────┐     │
+│ Regenerate       │     │
+│ bundle           │     │
+└───────┬──────────┘     │
+        │                │
+        ▼                ▼
+┌─────────────────────────────────────┐
+│ Trigger "Simulate" workflow         │
+│ (mainnet)                           │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────┐
+│ Coordinate with operator &          │
+│ Foundation (create on-chain         │
+│ proposal, initiate voting,          │
+│ 3-day window)                       │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────┐
+│ Execute proposal (simulation runs   │
+│ before executing for real, verify   │
+│ on-chain after)                     │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────┐
+│ Update mainnet branch (push-branch) │
+└─────────────────────────────────────┘
+```
+
+Note: mainnet deployment still involves manual coordination (operator, Foundation,
+voting). The automation covers artifact generation, simulation, and verification.
+
+---
+
+### 4.2 Manual Process (Fallback)
+
+If the GitHub Actions workflows are unavailable or fail partway through, the captain
+can complete the release manually using the CLI commands from section 3.2. The bundle
+is the same artifact regardless of whether CI or a human drives the process.
+
+#### Testnet Release (manual)
+
+```
+1. Generate the bundle (verify-bundle runs automatically):
+     generate-bundle --release-config framework-release.yaml --bundle aptos-framework-v1.45.1
+
+2. Review summary files, tick checkboxes if required
+
+3. (Optional) Simulate against testnet:
+     simulate --bundle aptos-framework-v1.45.1 --network testnet
+
+4. Commit the bundle to aptos-networks (manual PR)
+
+5. Trigger release-framework workflow (internal-ops GitHub UI)
+
+6. Update testnet branch (push-branch workflow in internal-ops)
+   — may be done automatically by the release workflow
+
+7. Verify the framework release on-chain:
+     verify-framework-deployment --bundle aptos-framework-v1.45.1 --network testnet
+
+8. Push framework tag:
+     git tag -f aptos-framework-v1.45.1 && git push -f origin refs/tags/aptos-framework-v1.45.1
+```
+
+#### Mainnet Release (manual)
+
+```
+1. If cherry-picks landed since testnet, regenerate:
+     generate-bundle --release-config framework-release.yaml --bundle aptos-framework-v1.45.1
+   Otherwise, reuse the testnet bundle.
+
+2. Simulate against mainnet:
+     simulate --bundle aptos-framework-v1.45.1 --network mainnet
+
+3. Coordinate with operator & Foundation (create on-chain proposal,
+   initiate voting, 3-day window)
+
+4. Execute proposal (simulation runs before executing for real,
+   verify on-chain after)
+
+5. Update mainnet branch (push-branch workflow in internal-ops)
+```
+
+The manual process is intentionally similar to today's, but with less friction: the
+bundle eliminates scattered artifacts, `verify-bundle` catches mismatches early,
+`verify-framework-deployment` automates the on-chain gas-schedule check, and the summary
+files provide a clear review surface.
+
+---
+
+## 5. Migration Path
+
+### Phase 1: Build new tooling alongside existing
+- Build a new CLI tool (separate from `aptos-release-builder`) with the new commands
+  (`generate-bundle`, `verify-bundle`, `simulate`, `verify-framework-deployment`), and
+  the three GitHub Actions workflows (generate, deploy-testnet, simulate)
+- Leave `aptos-release-builder` and existing workflows in place — ongoing releases
+  continue to use the existing process without disruption
+
+### Phase 2: Trial run
+- Use the new tools and workflows for one release end-to-end
+- Fall back to the existing process if issues arise
+
+### Phase 3: Deprecate old tooling
+- Once confident the new process is stable, remove the old tooling and workflows
+
+---
+
+## 6. Open Questions
+
+1. **Where should bundles live?** Using `aptos-networks` for now.
+   `mainnet-proposals` would be a more natural home since it already stores mainnet
+   release artifacts, but the name is restrictive — it doesn't fit testnet-only
+   releases. A rename of that repo could resolve this.
+
+2. **Operator coordination**: Can governance proposal submission be automated via
+   a GitHub workflow, or does it inherently require the operator? What does the
+   operator actually do that tooling can't?
+
+3. **Sign-off enforcement**: Should summary checkboxes be enforced by tooling
+   (`verify-bundle --require-signoff`) or by process (PR review)? Needs evaluation
+   of friction before deciding.
+
+4. **Scope of `internal-ops`**: The `release-framework` and `push-branch` workflows
+   live in internal-ops. Should the deploy-testnet workflow call them as-is, or
+   should they be migrated?
+
+---
+
+## 7. TODO
+
+1. **Private releases**: How should releases from `aptos-core-private` (security
+   fixes) be handled? The bundle and verification tooling should work, but the
+   process around visibility, artifact storage, and review needs to be defined.
+
+2. **Ad-hoc governance proposals**: The same release tooling (bundles, governance
+   simulation, proposal submission, etc.) needs to work for ad-hoc governance
+   proposals that are not part of a regular framework release. However, some of
+   the GitHub workflows (e.g., generate bundle from a release branch) may not
+   apply. What process should ad-hoc proposals follow?
+
+3. **Framework source diff in summaries**: Add a framework diff (against the
+   prior release) under `summary/`, optionally with an AI-generated summary, so
+   reviewers can see what Move code changed in each release.

--- a/aptos-move/aptos-release-tool/data/framework-release.yaml
+++ b/aptos-move/aptos-release-tool/data/framework-release.yaml
@@ -1,0 +1,18 @@
+---
+# Config for the regular framework releases.
+#
+# Replace `vX.YY.Z` with the actual version number to prepare for an actual release.
+name: "aptos-framework-vX.YY.Z"
+metadata:
+  title: "Multi-step proposal to upgrade mainnet framework, version vX.YY.Z"
+  description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-vX.YY.Z"
+update_sequence:
+  - Gas:
+      # The previous release's published gas schedule, looked up in aptos-networks
+      # by version (e.g. v1.44.0). A full URL or local path also works.
+      old: vX.WW.Z
+      # The new schedule is the one from the current branch
+      new: current
+  - Framework:
+      bytecode_version: 10
+      git_hash: ~

--- a/aptos-move/aptos-release-tool/src/bundle.rs
+++ b/aptos-move/aptos-release-tool/src/bundle.rs
@@ -1,0 +1,289 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! On-disk layout and `bundle.toml` manifest for a governance bundle.
+//!
+//! A governance bundle is a single self-contained directory packaging one
+//! on-chain governance proposal, along with additional artifacts for
+//! reviews and integrity.
+//!
+//! ```text
+//! bundle-root/
+//! ├── bundle.toml            # this manifest (checksums of every other file)
+//! ├── config.yaml            # the config used to generate the bundle
+//! ├── metadata.json          # the governance proposal's metadata
+//! ├── gas/{old,new}.json     # gas schedule snapshots
+//! ├── scripts/N-*.move       # the proposal's multi-step governance scripts
+//! └── summary/*.md           # human-reviewable change summaries
+//! ```
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Bumped on a breaking change to the bundle layout or manifest schema, so a
+/// tool can reject a format it doesn't understand.
+pub const BUNDLE_FORMAT_VERSION: u32 = 1;
+
+/// Manifest file name, relative to the bundle root.
+pub const BUNDLE_TOML: &str = "bundle.toml";
+/// Copy of the config used to generate the bundle, relative to the bundle root.
+pub const CONFIG_YAML: &str = "config.yaml";
+/// Directory holding gas schedule snapshots.
+pub const GAS_DIR: &str = "gas";
+/// Directory holding the proposal's governance scripts.
+pub const SCRIPTS_DIR: &str = "scripts";
+/// Directory holding human-reviewable summaries.
+pub const SUMMARY_DIR: &str = "summary";
+/// Governance proposal metadata file name (bundle top level).
+pub const METADATA_JSON: &str = "metadata.json";
+
+/// The full `bundle.toml` manifest.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BundleManifest {
+    /// Bundle format version (see [`BUNDLE_FORMAT_VERSION`]).
+    pub format_version: u32,
+    pub bundle: BundleSection,
+    pub source: SourceSection,
+    /// A single digest over the bundle's content (see [`IntegritySection`]).
+    pub integrity: IntegritySection,
+    /// Per-file SHA-256, keyed by bundle-relative path (excludes `bundle.toml`).
+    #[serde(default)]
+    pub checksums: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BundleSection {
+    pub name: String,
+    pub created_at: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SourceSection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    pub commit: String,
+    // Deliberately no `tag` field: we record the commit, not a tag derived from
+    // the name.
+}
+
+/// Integrity data for verifying the bundle.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IntegritySection {
+    /// A single content digest over the bundle: recomputing it locally checks
+    /// integrity, and matching it against a trusted external anchor (a signed
+    /// git tag, the on-chain proposal) establishes provenance.
+    pub digest: String,
+}
+
+impl BundleManifest {
+    /// Serialize and write the manifest to `<bundle_dir>/bundle.toml`.
+    pub fn write(&self, bundle_dir: &Path) -> Result<()> {
+        let contents = toml::to_string_pretty(self)
+            .map_err(|e| anyhow!("failed to serialize bundle.toml: {}", e))?;
+        let path = bundle_dir.join(BUNDLE_TOML);
+        fs::write(&path, contents)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Compute the bundle's content digest, excluding `created_at`/`branch` so
+    /// regenerating from the same source reproduces the same digest.
+    pub fn compute_digest(&self) -> String {
+        // Hash each field to a fixed-size block, so the concatenation is
+        // unambiguous without separators.
+        let h = |s: &str| Sha256::digest(s.as_bytes());
+
+        let mut hasher = Sha256::new();
+        hasher.update(h(&self.bundle.name));
+        hasher.update(h(&self.source.commit));
+        for (path, hash) in &self.checksums {
+            hasher.update(h(path));
+            hasher.update(h(hash));
+        }
+        hex::encode(hasher.finalize())
+    }
+
+    /// Read and parse `<bundle_dir>/bundle.toml`, rejecting a format version the
+    /// tool does not understand.
+    pub fn read(bundle_dir: &Path) -> Result<Self> {
+        let path = bundle_dir.join(BUNDLE_TOML);
+        let contents = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let manifest: Self = toml::from_str(&contents)
+            .map_err(|e| anyhow!("failed to parse {}: {}", path.display(), e))?;
+        if manifest.format_version != BUNDLE_FORMAT_VERSION {
+            bail!(
+                "unsupported bundle format version {} (this tool supports {})",
+                manifest.format_version,
+                BUNDLE_FORMAT_VERSION
+            );
+        }
+        Ok(manifest)
+    }
+}
+
+/// Per-file SHA-256 keyed by bundle-relative path, excluding `bundle.toml`
+/// (which can't checksum itself).
+pub fn compute_checksums(bundle_dir: &Path) -> Result<BTreeMap<String, String>> {
+    let mut out = BTreeMap::new();
+    visit_files(bundle_dir, bundle_dir, &mut out)?;
+    Ok(out)
+}
+
+fn visit_files(dir: &Path, root: &Path, out: &mut BTreeMap<String, String>) -> Result<()> {
+    let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+        .with_context(|| format!("failed to read directory {}", dir.display()))?
+        .map(|e| e.map(|e| e.path()))
+        .collect::<std::io::Result<_>>()?;
+    entries.sort();
+
+    for path in entries {
+        if path.is_dir() {
+            visit_files(&path, root, out)?;
+        } else {
+            let rel = path
+                .strip_prefix(root)
+                .map_err(|e| anyhow!("path outside bundle root: {}", e))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            if rel == BUNDLE_TOML {
+                continue;
+            }
+            let bytes =
+                fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
+            let to_hash = normalize_for_checksum(&rel, &bytes);
+            out.insert(rel, hex::encode(Sha256::digest(to_hash.as_ref())));
+        }
+    }
+    Ok(())
+}
+
+/// Summary files are hashed with sign-off checkboxes and incidental whitespace
+/// normalized away, so ticking a box during review doesn't break the checksum
+/// while content changes still do. Other files are hashed verbatim.
+fn normalize_for_checksum<'a>(rel: &str, bytes: &'a [u8]) -> Cow<'a, [u8]> {
+    let summary_prefix = format!("{}/", SUMMARY_DIR);
+    if rel.starts_with(&summary_prefix) {
+        let normalized = String::from_utf8_lossy(bytes)
+            .replace("[x]", "[ ]")
+            .replace("[X]", "[ ]")
+            .lines()
+            .map(|line| line.trim_end())
+            .collect::<Vec<_>>()
+            .join("\n");
+        Cow::Owned(normalized.into_bytes())
+    } else {
+        Cow::Borrowed(bytes)
+    }
+}
+
+/// A single difference found while comparing recorded checksums against the
+/// files actually present on disk.
+#[derive(Debug)]
+pub enum ChecksumError {
+    /// File is listed in the manifest but missing on disk.
+    Missing(String),
+    /// File is present on disk but not listed in the manifest.
+    Extra(String),
+    /// File exists but its hash differs from the manifest.
+    Mismatch {
+        path: String,
+        expected: String,
+        actual: String,
+    },
+}
+
+impl std::fmt::Display for ChecksumError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ChecksumError::Missing(p) => write!(f, "missing file (listed in manifest): {}", p),
+            ChecksumError::Extra(p) => write!(f, "unexpected file (not in manifest): {}", p),
+            ChecksumError::Mismatch {
+                path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "checksum mismatch for {}:\n      expected {}\n      actual   {}",
+                path, expected, actual
+            ),
+        }
+    }
+}
+
+/// Compare the manifest's recorded checksums against the files on disk.
+pub fn verify_checksums(
+    bundle_dir: &Path,
+    expected: &BTreeMap<String, String>,
+) -> Result<Vec<ChecksumError>> {
+    let actual = compute_checksums(bundle_dir)?;
+    let mut errors = vec![];
+
+    for (path, expected_hash) in expected {
+        match actual.get(path) {
+            None => errors.push(ChecksumError::Missing(path.clone())),
+            Some(actual_hash) if actual_hash != expected_hash => {
+                errors.push(ChecksumError::Mismatch {
+                    path: path.clone(),
+                    expected: expected_hash.clone(),
+                    actual: actual_hash.clone(),
+                })
+            },
+            Some(_) => {},
+        }
+    }
+    for path in actual.keys() {
+        if !expected.contains_key(path) {
+            errors.push(ChecksumError::Extra(path.clone()));
+        }
+    }
+
+    Ok(errors)
+}
+
+/// Git revision and branch the bundle was generated from, read from the working
+/// tree at `core_path`.
+pub struct SourceInfo {
+    pub commit: String,
+    pub branch: Option<String>,
+}
+
+/// Read the current commit and branch from the git repository containing
+/// `core_path`.
+pub fn read_source_info(core_path: &Path) -> Result<SourceInfo> {
+    let repo = git2::Repository::discover(core_path)
+        .with_context(|| format!("failed to open git repo at {}", core_path.display()))?;
+    let head = repo.head().context("failed to resolve git HEAD")?;
+    let commit = head
+        .peel_to_commit()
+        .context("failed to peel HEAD to a commit")?
+        .id()
+        .to_string();
+    // Only report an actual branch (a detached HEAD's shorthand is a commit hash).
+    let branch = if head.is_branch() {
+        head.shorthand().map(|s| s.to_string())
+    } else {
+        None
+    };
+    Ok(SourceInfo { commit, branch })
+}
+
+/// Create the bundle directory, refusing to overwrite an existing one.
+pub fn create_bundle_dir(bundle_dir: &Path) -> Result<()> {
+    if bundle_dir.exists() {
+        bail!(
+            "bundle directory already exists: {}\n  refusing to overwrite an existing bundle",
+            bundle_dir.display()
+        );
+    }
+    fs::create_dir_all(bundle_dir)
+        .with_context(|| format!("failed to create {}", bundle_dir.display()))?;
+    Ok(())
+}

--- a/aptos-move/aptos-release-tool/src/commands/generate.rs
+++ b/aptos-move/aptos-release-tool/src/commands/generate.rs
@@ -1,0 +1,171 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{bundle, config::BundleConfig, release, summary};
+use anyhow::{Context, Result};
+use aptos_release_builder::{components::get_execution_hash, ExecutionMode};
+use aptos_types::on_chain_config::GasScheduleV2;
+use chrono::Utc;
+use std::{fs, path::Path};
+
+/// The gas schedule snapshots materialized into the bundle from the proposal's
+/// `Gas` entry.
+struct GasArtifacts {
+    old_sched: Option<GasScheduleV2>,
+    new_sched: GasScheduleV2,
+}
+
+/// Produces a complete, self-contained governance bundle from a config.
+pub async fn run(release_config_path: &Path, bundle_path: &Path, core_path: &Path) -> Result<()> {
+    let config = BundleConfig::load(release_config_path)?;
+
+    bundle::create_bundle_dir(bundle_path)?;
+
+    // On failure, remove the partial bundle so the command stays retryable.
+    let result = build_bundle(&config, release_config_path, bundle_path, core_path).await;
+    if result.is_err() {
+        let _ = fs::remove_dir_all(bundle_path);
+    }
+    result?;
+
+    println!("\nBundle generated at {}", bundle_path.display());
+    Ok(())
+}
+
+/// Build the bundle contents under the (already-created) `bundle_path`.
+async fn build_bundle(
+    config: &BundleConfig,
+    release_config_path: &Path,
+    bundle_path: &Path,
+    core_path: &Path,
+) -> Result<()> {
+    // 1. Generate the proposal scripts and metadata.
+    println!("Generating proposal scripts...");
+    generate_scripts(config, bundle_path).await?;
+
+    // 2. Materialize gas schedule snapshots.
+    let gas = materialize_gas(config, bundle_path).await?;
+
+    // 3. Generate human-reviewable summaries.
+    println!("Writing summaries...");
+    let summary_dir = bundle_path.join(bundle::SUMMARY_DIR);
+    fs::create_dir_all(&summary_dir)?;
+    if let Some(gas) = &gas {
+        summary::write_gas_summary(&summary_dir, gas.old_sched.as_ref(), &gas.new_sched)?;
+    }
+    let (enabled, disabled) = release::collect_feature_changes(&config.update_sequence);
+    summary::write_feature_flag_summary(&summary_dir, &enabled, &disabled)?;
+
+    // 4. Copy the config verbatim into the bundle.
+    fs::copy(release_config_path, bundle_path.join(bundle::CONFIG_YAML))
+        .context("failed to copy config into bundle")?;
+
+    // 5. Build and write the manifest (with checksums computed last).
+    println!("Building manifest...");
+    let source = bundle::read_source_info(core_path)?;
+    let mut manifest = bundle::BundleManifest {
+        format_version: bundle::BUNDLE_FORMAT_VERSION,
+        bundle: bundle::BundleSection {
+            name: config.name.clone(),
+            created_at: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        },
+        source: bundle::SourceSection {
+            branch: source.branch,
+            commit: source.commit,
+        },
+        integrity: bundle::IntegritySection {
+            digest: String::new(),
+        },
+        checksums: Default::default(),
+    };
+    manifest.checksums = bundle::compute_checksums(bundle_path)?;
+    manifest.integrity.digest = manifest.compute_digest();
+    manifest.write(bundle_path)?;
+
+    // 6. Verify integrity before declaring success.
+    println!("Verifying bundle integrity...");
+    crate::commands::verify::run(bundle_path, false)?;
+    Ok(())
+}
+
+/// Materialize the bundle's gas snapshots (`gas/{old,new}.json`) from the
+/// proposal's `Gas` entry, or `None` if there is none or the change is a no-op
+/// (`old == new`, for which no gas script is emitted).
+async fn materialize_gas(
+    config: &BundleConfig,
+    bundle_path: &Path,
+) -> Result<Option<GasArtifacts>> {
+    let Some(gas) = release::find_gas_entry(&config.update_sequence) else {
+        return Ok(None);
+    };
+    println!("Materializing gas schedule snapshots...");
+
+    let new_sched = gas.new.fetch_gas_schedule().await?;
+    let old_sched = match &gas.old {
+        Some(old) => Some(old.fetch_gas_schedule().await?),
+        None => None,
+    };
+
+    if let Some(old) = &old_sched
+        && old == &new_sched
+    {
+        println!("Gas entry is a no-op (old == new); skipping gas artifacts.");
+        return Ok(None);
+    }
+
+    let gas_dir = bundle_path.join(bundle::GAS_DIR);
+    fs::create_dir_all(&gas_dir)?;
+    fs::write(
+        gas_dir.join("new.json"),
+        serde_json::to_string_pretty(&new_sched)?,
+    )?;
+    if let Some(old) = &old_sched {
+        fs::write(gas_dir.join("old.json"), serde_json::to_string_pretty(old)?)?;
+    }
+
+    Ok(Some(GasArtifacts {
+        old_sched,
+        new_sched,
+    }))
+}
+
+/// Generate the proposal's multi-step governance scripts into `scripts/N-*.move`
+/// and its metadata into top-level `metadata.json`.
+async fn generate_scripts(config: &BundleConfig, bundle_path: &Path) -> Result<()> {
+    let mut result: Vec<(String, String)> = vec![];
+    for entry in config.update_sequence.iter().rev() {
+        entry
+            .generate_release_script(None, &mut result, ExecutionMode::MultiStep)
+            .await?;
+    }
+    result.reverse();
+
+    let scripts_dir = bundle_path.join(bundle::SCRIPTS_DIR);
+    fs::create_dir_all(&scripts_dir)?;
+    // Zero-pad the index so lexical order matches numeric step order at >= 10 scripts.
+    let width = result.len().saturating_sub(1).to_string().len();
+    for (idx, (script_name, script)) in result.iter().enumerate() {
+        let file_name = format!("{:0width$}-{}.move", idx, script_name, width = width);
+        let path = scripts_dir.join(&file_name);
+        fs::write(&path, prepend_script_hash(script_name, script))
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+
+    let metadata_path = bundle_path.join(bundle::METADATA_JSON);
+    fs::write(
+        &metadata_path,
+        serde_json::to_string_pretty(&config.metadata)?,
+    )
+    .with_context(|| format!("failed to write {}", metadata_path.display()))?;
+    Ok(())
+}
+
+/// Prepend the script's on-chain execution hash as a comment (the hash
+/// governance voters approve).
+fn prepend_script_hash(script_name: &str, script: &str) -> String {
+    let single = [(script_name.to_string(), script.to_string())];
+    match get_execution_hash(&single) {
+        Some(hash) => format!("// Script hash: {}\n{}", hash, script),
+        None => script.to_string(),
+    }
+}

--- a/aptos-move/aptos-release-tool/src/commands/mod.rs
+++ b/aptos-move/aptos-release-tool/src/commands/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+pub mod generate;
+pub mod simulate;
+pub mod verify;
+pub mod verify_framework_deployment;
+
+/// Collapse a non-empty list of errors into a single aggregated error.
+pub(crate) fn combine_errors(label: &str, errors: &[String]) -> anyhow::Error {
+    let mut msg = format!("{} found {} error(s):\n", label, errors.len());
+    for error in errors {
+        msg.push_str(&format!("  - {}\n", error));
+    }
+    anyhow::anyhow!(msg)
+}

--- a/aptos-move/aptos-release-tool/src/commands/simulate.rs
+++ b/aptos-move/aptos-release-tool/src/commands/simulate.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `simulate`: run governance proposal simulation against a live network.
+//!
+//! This is a thin wrapper over `aptos-release-builder`'s simulation, which walks
+//! any directory tree for `*.move` scripts — so it works directly on a bundle's
+//! `scripts/` directory (or the bundle root).
+
+use crate::network::NetworkSelection;
+use anyhow::Result;
+use std::path::Path;
+
+pub async fn run(
+    bundle_path: &Path,
+    network: &NetworkSelection,
+    profile_gas: bool,
+    node_api_key: Option<String>,
+) -> Result<()> {
+    // Gate on the bundle's own integrity before simulating its scripts.
+    crate::commands::verify::run(bundle_path, false)?;
+
+    aptos_release_builder::simulate::simulate_all_proposals(
+        network.to_url()?,
+        bundle_path,
+        profile_gas,
+        node_api_key,
+    )
+    .await
+}

--- a/aptos-move/aptos-release-tool/src/commands/verify.rs
+++ b/aptos-move/aptos-release-tool/src/commands/verify.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `verify-bundle`: validate that a bundle is internally self-consistent.
+
+use crate::{bundle, commands::combine_errors, config::BundleConfig, summary};
+use anyhow::Result;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+pub fn run(bundle_path: &Path, require_signoff: bool) -> Result<()> {
+    let mut errors: Vec<String> = vec![];
+
+    let manifest = bundle::BundleManifest::read(bundle_path)?;
+
+    let config_yaml = bundle_path.join(bundle::CONFIG_YAML);
+    let config = match BundleConfig::load(&config_yaml) {
+        Ok(c) => Some(c),
+        Err(e) => {
+            errors.push(format!("failed to load {}: {}", config_yaml.display(), e));
+            None
+        },
+    };
+
+    // 1. Checksums: every file matches the manifest, with none missing or extra.
+    match bundle::verify_checksums(bundle_path, &manifest.checksums) {
+        Ok(checksum_errors) => {
+            for p in checksum_errors {
+                errors.push(p.to_string());
+            }
+        },
+        Err(e) => errors.push(format!("failed to verify checksums: {}", e)),
+    }
+
+    // 1b. Global digest: the recorded digest must match the manifest's content.
+    let computed = manifest.compute_digest();
+    if computed != manifest.integrity.digest {
+        errors.push(format!(
+            "bundle digest mismatch:\n      recorded {}\n      computed {}",
+            manifest.integrity.digest, computed
+        ));
+    }
+
+    // 2. Consistency between bundle.toml and config.yaml, plus layout.
+    if let Some(config) = &config
+        && manifest.bundle.name != config.name
+    {
+        errors.push(format!(
+            "bundle.toml name ({}) does not match config.yaml name ({})",
+            manifest.bundle.name, config.name
+        ));
+    }
+    check_layout(bundle_path, &mut errors);
+
+    // 3. Optional sign-off enforcement.
+    if require_signoff {
+        check_signoff(bundle_path, &mut errors);
+    }
+
+    // Informational: report which summaries have been signed off.
+    report_signoff_info(bundle_path);
+
+    if errors.is_empty() {
+        println!("verify-bundle: OK ({})", bundle_path.display());
+        Ok(())
+    } else {
+        Err(combine_errors("verify-bundle", &errors))
+    }
+}
+
+/// Check the single-proposal layout: a top-level `metadata.json` and a
+/// non-empty `scripts/` directory.
+fn check_layout(bundle_path: &Path, errors: &mut Vec<String>) {
+    if !bundle_path.join(bundle::METADATA_JSON).is_file() {
+        errors.push(format!("missing {}", bundle::METADATA_JSON));
+    }
+
+    let scripts_dir = bundle_path.join(bundle::SCRIPTS_DIR);
+    let has_move = fs::read_dir(&scripts_dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .any(|e| e.path().extension().map(|x| x == "move").unwrap_or(false))
+        })
+        .unwrap_or(false);
+    if !has_move {
+        errors.push(format!("{}/ has no .move scripts", bundle::SCRIPTS_DIR));
+    }
+}
+
+/// Every `*.md` file under `summary/` as `(path, contents)`, sorted by path;
+/// unreadable or absent files are skipped.
+fn summary_files(bundle_path: &Path) -> Vec<(PathBuf, String)> {
+    let summary_dir = bundle_path.join(bundle::SUMMARY_DIR);
+    let Ok(entries) = fs::read_dir(&summary_dir) else {
+        return vec![];
+    };
+    let mut files: Vec<(PathBuf, String)> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "md").unwrap_or(false))
+        .filter_map(|p| fs::read_to_string(&p).ok().map(|c| (p, c)))
+        .collect();
+    files.sort();
+    files
+}
+
+/// Print each summary file's sign-off state (informational; box ticks are
+/// checksum-neutral).
+fn report_signoff_info(bundle_path: &Path) {
+    for (path, contents) in summary_files(bundle_path) {
+        let (ticked, total) = summary::box_counts(&contents);
+        if total == 0 {
+            continue;
+        }
+        let status = if ticked == total {
+            "fully signed off"
+        } else if ticked > 0 {
+            "partially signed off"
+        } else {
+            "not signed off"
+        };
+        println!(
+            "info: {} ({}/{}) in {}",
+            status,
+            ticked,
+            total,
+            path.file_name().unwrap_or_default().to_string_lossy()
+        );
+    }
+}
+
+fn check_signoff(bundle_path: &Path, errors: &mut Vec<String>) {
+    for (path, contents) in summary_files(bundle_path) {
+        if summary::has_unchecked_boxes(&contents) {
+            errors.push(format!(
+                "sign-off required but {} has unchecked boxes",
+                path.file_name().unwrap_or_default().to_string_lossy()
+            ));
+        }
+    }
+}

--- a/aptos-move/aptos-release-tool/src/commands/verify_framework_deployment.rs
+++ b/aptos-move/aptos-release-tool/src/commands/verify_framework_deployment.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `verify-framework-deployment`: check that a deployed framework release matches
+//! its bundle by comparing on-chain state against it.
+//!
+//! TODO: this does not yet verify that the framework packages' bytecode was
+//! actually published; for now we rely solely on the gas schedule change as the
+//! signal that the release executed. Add a real framework-code check in the
+//! future -- this may not be trivial and might require significant work.
+
+use crate::{bundle, network::NetworkSelection};
+use anyhow::{bail, Context, Result};
+use aptos_release_builder::components::fetch_config;
+use aptos_rest_client::{AptosBaseUrl, Client};
+use aptos_types::on_chain_config::GasScheduleV2;
+use std::{fs, path::Path};
+
+pub async fn run(
+    bundle_path: &Path,
+    network: &NetworkSelection,
+    node_api_key: Option<String>,
+) -> Result<()> {
+    // Gate on the bundle's own integrity first, so we compare the chain against
+    // trusted expected values.
+    crate::commands::verify::run(bundle_path, false)?;
+
+    let mut client = Client::builder(AptosBaseUrl::Custom(network.to_url()?));
+    if let Some(key) = node_api_key.as_ref() {
+        client = client.api_key(key)?;
+    }
+    let client = client.build();
+
+    check_gas(bundle_path, &client)?;
+
+    println!("\nverify-framework-deployment: OK");
+    Ok(())
+}
+
+fn check_gas(bundle_path: &Path, client: &Client) -> Result<()> {
+    let gas_new = bundle_path.join(bundle::GAS_DIR).join("new.json");
+    if !gas_new.is_file() {
+        bail!(
+            "bundle has no gas schedule ({} missing); verify-framework-deployment relies \
+             solely on the gas schedule to confirm the release, so there is nothing to check",
+            gas_new.display()
+        );
+    }
+    let contents = fs::read_to_string(&gas_new)
+        .with_context(|| format!("failed to read {}", gas_new.display()))?;
+    let expected: GasScheduleV2 = serde_json::from_str(&contents)
+        .with_context(|| format!("failed to parse {}", gas_new.display()))?;
+
+    let on_chain =
+        fetch_config::<GasScheduleV2>(client).context("failed to fetch on-chain gas schedule")?;
+
+    if on_chain.feature_version != expected.feature_version {
+        bail!(
+            "gas feature version on-chain ({}) != bundle ({})",
+            on_chain.feature_version,
+            expected.feature_version
+        );
+    }
+    let diff = GasScheduleV2::diff(&expected, &on_chain);
+    if !diff.is_empty() {
+        for name in diff.keys().take(20) {
+            println!("      differs: {}", name);
+        }
+        bail!(
+            "gas schedule differs from bundle in {} parameter(s)",
+            diff.len()
+        );
+    }
+    println!(
+        "  gas schedule: MATCH (feature version {})",
+        on_chain.feature_version
+    );
+    Ok(())
+}

--- a/aptos-move/aptos-release-tool/src/config.rs
+++ b/aptos-move/aptos-release-tool/src/config.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! The tool's own config format used for generating a bundle.
+//!
+//! Supports only one multi-step governance proposal, which is all we need.
+
+use anyhow::{bail, Context, Result};
+use aptos_release_builder::{components::ProposalMetadata, ReleaseEntry};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeSet, path::Path};
+
+/// A config for generating a governance bundle.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BundleConfig {
+    /// Release / proposal name, e.g. `v1.45.1`; also the bundle's identity.
+    pub name: String,
+    /// Governance proposal metadata (title, description, URLs).
+    pub metadata: ProposalMetadata,
+    /// The ordered changes the proposal enacts.
+    pub update_sequence: Vec<ReleaseEntry>,
+}
+
+impl BundleConfig {
+    /// Load and validate a bundle config from a YAML file.
+    pub fn load(path: &Path) -> Result<Self> {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read bundle config {}", path.display()))?;
+        let config: BundleConfig = serde_yaml::from_str(&contents)
+            .with_context(|| format!("failed to parse bundle config {}", path.display()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Enforce that the proposal touches each on-chain config kind at most once.
+    /// Each is a single global resource (the gas schedule, feature flags, the
+    /// version, ...), so setting it twice in one proposal is incoherent. Raw
+    /// scripts are exempt — they are arbitrary and may legitimately repeat.
+    pub fn validate(&self) -> Result<()> {
+        let mut seen = BTreeSet::new();
+        for entry in &self.update_sequence {
+            if let Some(kind) = config_kind(entry)
+                && !seen.insert(kind)
+            {
+                bail!("a governance bundle may set {} at most once", kind);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The on-chain config kind an entry sets, or `None` for entries that may
+/// legitimately appear more than once (raw scripts).
+fn config_kind(entry: &ReleaseEntry) -> Option<&'static str> {
+    match entry {
+        ReleaseEntry::Framework(_) => Some("the framework"),
+        ReleaseEntry::Gas { .. } => Some("the gas schedule"),
+        ReleaseEntry::Version(_) => Some("the version"),
+        ReleaseEntry::FeatureFlag(_) => Some("feature flags"),
+        ReleaseEntry::Consensus(_) => Some("the consensus config"),
+        ReleaseEntry::Execution(_) => Some("the execution config"),
+        ReleaseEntry::JwkConsensus(_) => Some("the JWK consensus config"),
+        ReleaseEntry::Randomness(_) => Some("the randomness config"),
+        ReleaseEntry::OidcProviderOps(_) => Some("OIDC providers"),
+        ReleaseEntry::RawScript(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The committed template config (the workflow's default `--release-config`)
+    /// must always parse and validate as a `BundleConfig`.
+    #[test]
+    fn template_config_is_valid() {
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("data/framework-release.yaml");
+        BundleConfig::load(&path).expect("data/framework-release.yaml must parse and validate");
+    }
+}

--- a/aptos-move/aptos-release-tool/src/lib.rs
+++ b/aptos-move/aptos-release-tool/src/lib.rs
@@ -1,0 +1,151 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `aptos-release-tool` manages on-chain governance proposals — framework
+//! releases and ad-hoc changes alike — around a single, self-contained
+//! *governance bundle*.
+//!
+//! It can generate a bundle from a config, verify the bundle's internal integrity,
+//! simulate its governance proposal against a network, and verify on-chain state
+//! after deployment.
+
+pub mod bundle;
+pub mod commands;
+pub mod config;
+pub mod network;
+pub mod release;
+pub mod summary;
+pub mod table;
+
+use crate::network::NetworkSelection;
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use std::path::{Path, PathBuf};
+
+#[derive(Parser)]
+#[clap(author, version, about)]
+pub struct Argument {
+    #[clap(subcommand)]
+    cmd: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate a complete release bundle from a release config.
+    GenerateBundle {
+        /// Path to the release config (e.g. framework-release.yaml).
+        #[clap(short, long)]
+        release_config: PathBuf,
+
+        /// Bundle directory to create. Must not already exist.
+        #[clap(short, long)]
+        bundle: PathBuf,
+    },
+
+    /// Validate that a bundle is internally self-consistent.
+    VerifyBundle {
+        /// Path to the bundle directory.
+        #[clap(short, long)]
+        bundle: PathBuf,
+
+        /// Also require that all summary sign-off checkboxes are ticked.
+        #[clap(long)]
+        require_signoff: bool,
+    },
+
+    /// Simulate a bundle's governance proposals against a network.
+    Simulate {
+        /// Path to the bundle directory.
+        #[clap(short, long)]
+        bundle: PathBuf,
+
+        /// Network to simulate against.
+        ///
+        /// Possible values: devnet, testnet, mainnet, <url to rest endpoint>
+        #[clap(long)]
+        network: NetworkSelection,
+
+        /// Enable the gas profiler.
+        #[clap(long, default_value_t = false)]
+        profile_gas: bool,
+
+        /// API key for node API ratelimiting.
+        /// May also be set via the NODE_API_KEY environment variable.
+        #[clap(long, env)]
+        node_api_key: Option<String>,
+    },
+
+    /// Verify a deployed framework release on-chain against a bundle.
+    VerifyFrameworkDeployment {
+        /// Path to the bundle directory.
+        #[clap(short, long)]
+        bundle: PathBuf,
+
+        /// Network to check.
+        ///
+        /// Possible values: devnet, testnet, mainnet, <url to rest endpoint>
+        #[clap(long)]
+        network: NetworkSelection,
+
+        /// API key for node API ratelimiting (`Authorization: Bearer <key>`).
+        /// May also be set via the NODE_API_KEY environment variable.
+        #[clap(long, env)]
+        node_api_key: Option<String>,
+    },
+}
+
+/// Repo root, derived from this crate's location at build time.
+fn aptos_core_path() -> PathBuf {
+    let mut path = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
+    path.pop(); // aptos-move
+    path.pop(); // repo root
+    path.canonicalize().unwrap_or(path)
+}
+
+/// Compute the repo root and register it with `aptos-release-builder`, whose
+/// framework script generation reads it as a global to locate the framework
+/// sources. Returns the path for callers that also need it directly (e.g. to
+/// read source provenance).
+pub fn init_core_path() -> PathBuf {
+    let core_path = aptos_core_path();
+    aptos_release_builder::initialize_aptos_core_path(Some(core_path.clone()));
+    core_path
+}
+
+/// Dispatch a parsed CLI invocation.
+pub async fn run(args: Argument) -> Result<()> {
+    let core_path = init_core_path();
+
+    match args.cmd {
+        Commands::GenerateBundle {
+            release_config,
+            bundle,
+        } => commands::generate::run(&release_config, &bundle, &core_path).await,
+        Commands::VerifyBundle {
+            bundle,
+            require_signoff,
+        } => commands::verify::run(&bundle, require_signoff),
+        Commands::Simulate {
+            bundle,
+            network,
+            profile_gas,
+            node_api_key,
+        } => commands::simulate::run(&bundle, &network, profile_gas, node_api_key).await,
+        Commands::VerifyFrameworkDeployment {
+            bundle,
+            network,
+            node_api_key,
+        } => commands::verify_framework_deployment::run(&bundle, &network, node_api_key).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_tool() {
+        Argument::command().debug_assert()
+    }
+}

--- a/aptos-move/aptos-release-tool/src/main.rs
+++ b/aptos-move/aptos-release-tool/src/main.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::Result;
+use aptos_release_tool::{run, Argument};
+use clap::Parser;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    run(Argument::parse()).await
+}

--- a/aptos-move/aptos-release-tool/src/network.rs
+++ b/aptos-move/aptos-release-tool/src/network.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use std::str::FromStr;
+use url::Url;
+
+/// A network to talk to, either one of the well-known ones or an arbitrary REST endpoint.
+//
+// TODO: unify with the identical enum in `aptos-release-builder` once the old tool is retired.
+#[derive(Clone, Debug)]
+pub enum NetworkSelection {
+    Mainnet,
+    Testnet,
+    Devnet,
+    RestEndpoint(String),
+}
+
+impl FromStr for NetworkSelection {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, anyhow::Error> {
+        Ok(match s {
+            "mainnet" => Self::Mainnet,
+            "testnet" => Self::Testnet,
+            "devnet" => Self::Devnet,
+            _ => Self::RestEndpoint(s.to_owned()),
+        })
+    }
+}
+
+impl NetworkSelection {
+    pub fn to_url(&self) -> anyhow::Result<Url> {
+        use NetworkSelection::*;
+
+        let s = match self {
+            Mainnet => "https://fullnode.mainnet.aptoslabs.com",
+            Testnet => "https://fullnode.testnet.aptoslabs.com",
+            Devnet => "https://fullnode.devnet.aptoslabs.com",
+            RestEndpoint(url) => url,
+        };
+
+        Ok(Url::parse(s)?)
+    }
+}

--- a/aptos-move/aptos-release-tool/src/release.rs
+++ b/aptos-move/aptos-release-tool/src/release.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Helpers that extract structured info out of a proposal's `update_sequence`
+//! of `ReleaseEntry`s (the entry type is reused from `aptos-release-builder`).
+
+use aptos_release_builder::{components::GasScheduleLocator, ReleaseEntry};
+
+/// The gas snapshots referenced by a release's `Gas` entry, if any.
+pub struct GasEntry {
+    pub old: Option<GasScheduleLocator>,
+    pub new: GasScheduleLocator,
+}
+
+/// Find the `Gas` entry, if any.
+pub fn find_gas_entry(entries: &[ReleaseEntry]) -> Option<GasEntry> {
+    entries.iter().find_map(|entry| {
+        if let ReleaseEntry::Gas { old, new } = entry {
+            Some(GasEntry {
+                old: old.clone(),
+                new: new.clone(),
+            })
+        } else {
+            None
+        }
+    })
+}
+
+/// Collect the feature flags enabled / disabled by the `FeatureFlag` entry,
+/// formatted as display strings.
+pub fn collect_feature_changes(entries: &[ReleaseEntry]) -> (Vec<String>, Vec<String>) {
+    let mut enabled = vec![];
+    let mut disabled = vec![];
+    for entry in entries {
+        if let ReleaseEntry::FeatureFlag(features) = entry {
+            enabled.extend(features.enabled.iter().map(|f| format!("{:?}", f)));
+            disabled.extend(features.disabled.iter().map(|f| format!("{:?}", f)));
+        }
+    }
+    (enabled, disabled)
+}

--- a/aptos-move/aptos-release-tool/src/summary.rs
+++ b/aptos-move/aptos-release-tool/src/summary.rs
@@ -1,0 +1,229 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Auto-generated, human-reviewable change summaries written under the bundle's
+//! `summary/` directory. They give reviewers a quick overview without reading
+//! raw Move scripts, and carry sign-off checkboxes (see `verify --require-signoff`).
+
+use crate::table::{self, Align};
+use anyhow::{Context, Result};
+use aptos_types::on_chain_config::{DiffItem, GasScheduleV2};
+use std::{collections::BTreeMap, fmt::Write as _, fs, path::Path};
+
+pub const GAS_SUMMARY: &str = "gas-schedule-changes.md";
+pub const FEATURE_FLAG_SUMMARY: &str = "feature-flags.md";
+
+/// Gas parameters whose changes warrant explicit, per-change acknowledgment.
+/// Each gets its own checkbox in the summary.
+const CRITICAL_GAS_PARAMS: &[&str] = &[
+    "txn.max_execution_gas",
+    "txn.max_io_gas",
+    "txn.max_storage_fee",
+    "txn.max_transaction_size_in_bytes",
+    "txn.maximum_number_of_gas_units",
+    "txn.gas_unit_scaling_factor",
+];
+
+/// Write `summary/gas-schedule-changes.md`. When `old` is absent (no previous
+/// snapshot to diff against), only the feature version and a note are emitted.
+pub fn write_gas_summary(
+    summary_dir: &Path,
+    old: Option<&GasScheduleV2>,
+    new: &GasScheduleV2,
+) -> Result<()> {
+    let mut out = String::new();
+
+    match old {
+        Some(old) => {
+            writeln!(out, "# Gas Schedule Changes").ok();
+            writeln!(out).ok();
+            writeln!(
+                out,
+                "Gas feature version: {} -> {}",
+                old.feature_version, new.feature_version
+            )
+            .ok();
+        },
+        None => {
+            writeln!(out, "# Gas Schedule").ok();
+            writeln!(out).ok();
+            writeln!(out, "Gas feature version: {}", new.feature_version).ok();
+            writeln!(out).ok();
+            writeln!(
+                out,
+                "_No previous gas schedule was provided, so a parameter diff cannot be shown._"
+            )
+            .ok();
+        },
+    }
+    writeln!(out).ok();
+    writeln!(out, "- [ ] I have reviewed the gas schedule changes below.").ok();
+    writeln!(out).ok();
+
+    if let Some(old) = old {
+        writeln!(out, "## Changes").ok();
+        writeln!(out).ok();
+
+        let changes = GasScheduleV2::diff(old, new);
+        if changes.is_empty() {
+            writeln!(out, "_No parameter changes._").ok();
+        } else {
+            emit_gas_change_table(&mut out, &changes);
+        }
+    }
+
+    let path = summary_dir.join(GAS_SUMMARY);
+    fs::write(&path, out).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/// Render the gas parameter changes as a source-aligned markdown table.
+fn emit_gas_change_table(out: &mut String, changes: &BTreeMap<&str, DiffItem<u64>>) {
+    let rows: Vec<Vec<String>> = changes
+        .iter()
+        .map(|(name, delta)| {
+            let (change, old_val, new_val) = match delta {
+                DiffItem::Modify { old_val, new_val } => {
+                    ("modified", old_val.to_string(), new_val.to_string())
+                },
+                DiffItem::Add { new_val } => ("added", "/".to_string(), new_val.to_string()),
+                DiffItem::Delete { old_val } => ("removed", old_val.to_string(), "/".to_string()),
+            };
+            let signoff = if CRITICAL_GAS_PARAMS.contains(name) {
+                "[ ]"
+            } else {
+                ""
+            };
+            vec![
+                change.to_string(),
+                name.to_string(),
+                old_val,
+                new_val,
+                signoff.to_string(),
+            ]
+        })
+        .collect();
+
+    let headers = ["change", "parameter", "old", "new", "sign-off"];
+    let aligns = [
+        Align::Left,
+        Align::Left,
+        Align::Right,
+        Align::Right,
+        Align::Left,
+    ];
+    out.push_str(&table::render(&headers, &aligns, &rows));
+}
+
+/// Write `summary/feature-flags.md`. When there are no feature flag changes, a
+/// note is written and no sign-off checkbox is emitted (nothing to review).
+pub fn write_feature_flag_summary(
+    summary_dir: &Path,
+    enabled: &[String],
+    disabled: &[String],
+) -> Result<()> {
+    let mut out = String::new();
+    writeln!(out, "# Feature Flag Changes").ok();
+    writeln!(out).ok();
+
+    if enabled.is_empty() && disabled.is_empty() {
+        writeln!(out, "_No feature flag changes in this release._").ok();
+    } else {
+        writeln!(out, "- [ ] I have reviewed the feature flag changes below.").ok();
+        writeln!(out).ok();
+
+        if !enabled.is_empty() {
+            writeln!(out, "## Enabling").ok();
+            writeln!(out).ok();
+            for flag in enabled {
+                writeln!(out, "- {}", flag).ok();
+            }
+            writeln!(out).ok();
+        }
+        if !disabled.is_empty() {
+            writeln!(out, "## Disabling").ok();
+            writeln!(out).ok();
+            for flag in disabled {
+                writeln!(out, "- {}", flag).ok();
+            }
+            writeln!(out).ok();
+        }
+    }
+
+    let path = summary_dir.join(FEATURE_FLAG_SUMMARY);
+    fs::write(&path, out).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/// Scan a summary file's contents for unchecked checkboxes (`[ ]`). Used by
+/// `verify --require-signoff`.
+pub fn has_unchecked_boxes(contents: &str) -> bool {
+    contents.contains("[ ]")
+}
+
+/// Count `(ticked, total)` checkboxes in a summary file's contents.
+pub fn box_counts(contents: &str) -> (usize, usize) {
+    let ticked = contents.matches("[x]").count() + contents.matches("[X]").count();
+    let unchecked = contents.matches("[ ]").count();
+    (ticked, ticked + unchecked)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_command_line_common::testing::read_env_update_baseline;
+    use std::path::{Path, PathBuf};
+
+    fn test_data_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data")
+    }
+
+    fn load_gas(name: &str) -> GasScheduleV2 {
+        let path = test_data_dir().join(name);
+        let contents =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+        serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("parse {}: {}", path.display(), e))
+    }
+
+    /// Compare `actual` against the committed golden, or rewrite the golden when
+    /// the repo's baseline-update env var is set (`UPDATE_BASELINE=1`, `UB=1`):
+    ///
+    ///   UB=1 cargo test -p aptos-release-tool --lib
+    fn assert_or_update_golden(golden_path: &Path, actual: &str) {
+        if read_env_update_baseline() {
+            fs::write(golden_path, actual)
+                .unwrap_or_else(|e| panic!("write golden {}: {}", golden_path.display(), e));
+            return;
+        }
+        let expected = fs::read_to_string(golden_path).unwrap_or_else(|e| {
+            panic!(
+                "read golden {} (set UB=1 to create it): {}",
+                golden_path.display(),
+                e
+            )
+        });
+        assert_eq!(
+            actual,
+            expected,
+            "golden {} is stale; re-run with UB=1 to update",
+            golden_path.display()
+        );
+    }
+
+    /// `write_gas_summary` renders the synthetic modify/add/remove diff exactly
+    /// as the committed golden. This is pure (no framework compilation), so it
+    /// stays green even when a framework change breaks the end-to-end test, and
+    /// is the fast entry point for updating the golden (see above).
+    #[test]
+    fn gas_summary_matches_golden() {
+        let old = load_gas("gas_old.json");
+        let new = load_gas("gas_new.json");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_gas_summary(dir.path(), Some(&old), &new).expect("write summary");
+        let actual = fs::read_to_string(dir.path().join(GAS_SUMMARY)).expect("read summary");
+
+        assert_or_update_golden(&test_data_dir().join("expected_gas_summary.md"), &actual);
+    }
+}

--- a/aptos-move/aptos-release-tool/src/table.rs
+++ b/aptos-move/aptos-release-tool/src/table.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Minimal, content-agnostic markdown table rendering.
+
+/// Per-column horizontal alignment.
+#[derive(Clone, Copy)]
+pub enum Align {
+    Left,
+    Right,
+}
+
+/// Render a markdown table. `headers` defines the columns, `aligns` has one
+/// entry per column, and every row must have `headers.len()` cells.
+///
+/// Cells are padded at the source level, so the raw `.md` is aligned and readable, not
+/// just the rendered view.
+pub fn render(headers: &[&str], aligns: &[Align], rows: &[Vec<String>]) -> String {
+    assert_eq!(headers.len(), aligns.len(), "one alignment per column");
+
+    // Column width = widest cell (header or body), min 3 so the separator
+    // (`---`) stays well-formed for narrow or empty columns.
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.chars().count().max(3)).collect();
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cell.chars().count());
+        }
+    }
+
+    let mut out = String::new();
+    push_row(
+        &mut out,
+        headers.iter().map(|h| h.to_string()),
+        aligns,
+        &widths,
+    );
+    push_separator(&mut out, aligns, &widths);
+    for row in rows {
+        push_row(&mut out, row.iter().cloned(), aligns, &widths);
+    }
+    out
+}
+
+fn push_row(
+    out: &mut String,
+    cells: impl Iterator<Item = String>,
+    aligns: &[Align],
+    widths: &[usize],
+) {
+    out.push('|');
+    for ((cell, align), width) in cells.zip(aligns).zip(widths) {
+        let w = *width;
+        let cell = match align {
+            Align::Left => format!("{:<width$}", cell, width = w),
+            Align::Right => format!("{:>width$}", cell, width = w),
+        };
+        out.push_str(&format!(" {} |", cell));
+    }
+    out.push('\n');
+}
+
+fn push_separator(out: &mut String, aligns: &[Align], widths: &[usize]) {
+    out.push('|');
+    for (align, width) in aligns.iter().zip(widths) {
+        let w = *width;
+        // GFM alignment markers: `---` left (default), `--:` right.
+        let bar = match align {
+            Align::Left => "-".repeat(w),
+            Align::Right => format!("{}:", "-".repeat(w - 1)),
+        };
+        out.push_str(&format!(" {} |", bar));
+    }
+    out.push('\n');
+}

--- a/aptos-move/aptos-release-tool/tests/data/config.yaml
+++ b/aptos-move/aptos-release-tool/tests/data/config.yaml
@@ -1,0 +1,18 @@
+---
+# Config used by the crate's end-to-end test. It is deliberately minimal:
+# - the framework release is limited to move-stdlib to keep compilation fast;
+# - the gas change points at the synthetic snapshots in this directory so the
+#   generated summary is fully deterministic.
+name: "aptos-framework-test"
+metadata:
+  title: "Test framework release"
+  description: "Synthetic bundle used by aptos-release-tool's tests."
+update_sequence:
+  - Gas:
+      old: tests/data/gas_old.json
+      new: tests/data/gas_new.json
+  - Framework:
+      bytecode_version: 10
+      git_hash: ~
+      packages:
+        - move-stdlib

--- a/aptos-move/aptos-release-tool/tests/data/expected_gas_summary.md
+++ b/aptos-move/aptos-release-tool/tests/data/expected_gas_summary.md
@@ -1,0 +1,14 @@
+# Gas Schedule Changes
+
+Gas feature version: 30 -> 31
+
+- [ ] I have reviewed the gas schedule changes below.
+
+## Changes
+
+| change   | parameter             |       old |        new | sign-off |
+| -------- | --------------------- | --------: | ---------: | -------- |
+| modified | instr.add             |        50 |         65 |          |
+| added    | instr.mul             |         / |         90 |          |
+| removed  | instr.sub             |        80 |          / |          |
+| modified | txn.max_execution_gas | 920000000 | 1000000000 | [ ]      |

--- a/aptos-move/aptos-release-tool/tests/data/gas_new.json
+++ b/aptos-move/aptos-release-tool/tests/data/gas_new.json
@@ -1,0 +1,9 @@
+{
+  "feature_version": 31,
+  "entries": [
+    ["txn.large_transaction_cutoff", 600],
+    ["txn.max_execution_gas", 1000000000],
+    ["instr.add", 65],
+    ["instr.mul", 90]
+  ]
+}

--- a/aptos-move/aptos-release-tool/tests/data/gas_old.json
+++ b/aptos-move/aptos-release-tool/tests/data/gas_old.json
@@ -1,0 +1,9 @@
+{
+  "feature_version": 30,
+  "entries": [
+    ["txn.large_transaction_cutoff", 600],
+    ["txn.max_execution_gas", 920000000],
+    ["instr.add", 50],
+    ["instr.sub", 80]
+  ]
+}

--- a/aptos-move/aptos-release-tool/tests/e2e.rs
+++ b/aptos-move/aptos-release-tool/tests/e2e.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! End-to-end: generate a (move-stdlib-only) bundle from the synthetic config,
+//! verify it, and check the expected file layout.
+
+use aptos_release_tool::{bundle, commands, init_core_path};
+use std::path::PathBuf;
+
+fn test_data_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data")
+}
+
+/// Runs on a dedicated large-stack thread: the Move framework compiler recurses
+/// deeply and overflows a default test-thread stack (the real CLI gets the room
+/// from the process main thread).
+#[test]
+fn generate_then_verify_bundle() {
+    const STACK_SIZE: usize = 256 * 1024 * 1024;
+    std::thread::Builder::new()
+        .stack_size(STACK_SIZE)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build runtime")
+                .block_on(generate_then_verify_bundle_inner());
+        })
+        .expect("spawn test thread")
+        .join()
+        .expect("test thread panicked");
+}
+
+async fn generate_then_verify_bundle_inner() {
+    let core_path = init_core_path();
+
+    let config_path = test_data_dir().join("config.yaml");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bundle_path = tmp.path().join("bundle");
+
+    // `generate` self-verifies (checksums, digest, layout) before returning, so
+    // no need to call `verify` manually.
+    commands::generate::run(&config_path, &bundle_path, &core_path)
+        .await
+        .expect("generate bundle");
+
+    // The deterministic, framework-independent files are all present.
+    for rel in [
+        bundle::BUNDLE_TOML,
+        bundle::CONFIG_YAML,
+        bundle::METADATA_JSON,
+        "gas/old.json",
+        "gas/new.json",
+        "summary/gas-schedule-changes.md",
+        "summary/feature-flags.md",
+    ] {
+        assert!(bundle_path.join(rel).is_file(), "missing {}", rel);
+    }
+    let has_move = std::fs::read_dir(bundle_path.join(bundle::SCRIPTS_DIR))
+        .expect("read scripts dir")
+        .filter_map(Result::ok)
+        .any(|e| e.path().extension().is_some_and(|x| x == "move"));
+    assert!(has_move, "no .move scripts were generated");
+}


### PR DESCRIPTION
## What

A standalone CLI (`aptos-move/aptos-release-tool`) that manages framework and ad-hoc governance releases around a single, self-contained **governance bundle**, replacing the artifacts scattered across `aptos-core`, `aptos-networks`, and `mainnet-proposals` that are linked today only by naming convention.

## The bundle

One governance proposal (a framework release or an ad-hoc change) materialized as a directory:

- `config.yaml` — the release config it was generated from (self-describing)
- `scripts/` — the multi-step governance Move scripts
- `metadata.json` — proposal metadata
- `gas/{old,new}.json` — gas-schedule snapshots
- `summary/*.md` — human-reviewable change summaries with sign-off checkboxes
- `bundle.toml` — manifest

Integrity is two-layered: a per-file SHA-256 checksum set plus a single global digest over the bundle's identity that is reproducible from the source commit, so it doubles as a provenance anchor.

## Commands

| Command | What it does |
|---|---|
| `generate-bundle` | Build a bundle from a release config (self-verifies) |
| `verify-bundle` | Check the bundle is internally self-consistent |
| `simulate` | Simulate the proposal against a network |
| `verify-framework-deployment` | Compare on-chain state to the bundle |

## Workflow

A "Generate Release Bundle" GitHub workflow builds the tool from a release branch, generates a bundle, and opens a PR adding it to `aptos-networks` under `framework-releases/<version>/`.

## Notes

- For now the tool reuses `aptos-release-builder` for the release-entry config format, proposal/script generation, and simulation. The eventual goal is to absorb what it needs and **retire `aptos-release-builder` entirely**.
- Tests: a fast unit test pins the gas-summary rendering against a golden, and an end-to-end test generates and verifies a move-stdlib-only bundle.
- See `aptos-move/aptos-release-tool/framework_release_improvement.md` for the motivation and design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches framework governance release paths and on-chain gas verification, but changes are additive tooling alongside `aptos-release-builder`; deployment verification is incomplete until bytecode checks exist.
> 
> **Overview**
> Introduces **`aptos-release-tool`**, a new workspace crate and binary that packages a single governance proposal into a self-contained **release bundle** (config, scripts, metadata, gas snapshots, review summaries, and `bundle.toml` with per-file checksums and a reproducible digest).
> 
> **`generate-bundle`** builds that layout from a YAML config (reusing `aptos-release-builder` for script generation), materializes gas JSON, writes markdown summaries with optional sign-off checkboxes (checksum-neutral when ticked), records git provenance, and self-runs **`verify-bundle`**. **`simulate`** and **`verify-framework-deployment`** verify the bundle first, then delegate simulation to the release builder or compare on-chain `GasScheduleV2` to `gas/new.json` (framework bytecode check is explicitly TODO).
> 
> **`aptos-release-builder`** gains **`pub`** `fetch_gas_schedule`, version strings like `v1.45.1` resolved from `aptos-networks` (`framework-releases/...` then legacy `gas/`), stricter HTTP/error context, and a unit test for the version regex. A template **`framework-release.yaml`** and a large **README** document the intended bundle-based release workflow (CI workflows still planned in `internal-ops`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5592a0212c0ae149667ec87087f69a753667b403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->