### PR TITLE
[mono-move] LdConst GC test

### DIFF
--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -1896,10 +1896,6 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
 
         // SAFETY: `dst` is a verified 8-byte frame slot for a vector pointer
         // and is writable (no aliasing to the heap).
-        // TODO(testing): add an ld_const test that fills the heap so the first
-        // deserialize fails and the GC-then-retry path inside `deserialize_or_gc`
-        // runs. Needs a `ForceGC` native to drive it deterministically in the
-        // differential suite.
         unsafe {
             let dst = self.frame_ptr.add(usize::from(dst));
             deserialize_or_gc(

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_gc_retry.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_gc_retry.move
@@ -1,0 +1,28 @@
+// RUN: publish
+module 0x42::ld_const_gc_retry {
+    const FILLER: vector<u64> = vector[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const BLOB: vector<u64> = vector[10, 20, 30, 40, 50];
+
+    // Loads FILLER and returns only its length. Once this frame is popped, no
+    // live slot holds FILLER, so it is dead heap until a collection runs.
+    fun fill_and_measure(): u64 {
+        let filler = FILLER;
+        std::vector::length(&filler)
+    }
+
+    public fun ld_const_after_gc(with_filler: bool): u64 {
+        let filler_len = if (with_filler) fill_and_measure() else 0;
+        let blob = BLOB;
+        filler_len + std::vector::length(&blob)
+    }
+}
+
+// FILLER (96 B) + BLOB does not fit a 128 B heap: BLOB's ld_const triggers one GC.
+// RUN: execute 0x42::ld_const_gc_retry::ld_const_after_gc --args true --heap-size 128
+// CHECK: results: 15
+// CHECK-GC-COUNT: 1
+
+// BLOB alone fits a 128 B heap, so no GC runs.
+// RUN: execute 0x42::ld_const_gc_retry::ld_const_after_gc --args false --heap-size 128
+// CHECK: results: 5
+// CHECK-GC-COUNT: 0


### PR DESCRIPTION
## Description

Adds a differential test for the OOM-then-GC retry path in `deserialize_or_gc`, which `exec_store_imm_vec` (`ld_const` of a constant vector) reaches when its first heap allocation fails. No existing test filled the heap before an `ld_const`, so that branch was uncovered. This was tracked by a `TODO(testing)` in `exec_store_imm_vec`, now removed.

The test runs under a `--heap-size 128` heap. A helper `fill_and_measure` loads a `FILLER` constant vector (96 B) and returns only its length; once that frame is popped, no live slot holds FILLER, so it is dead but still occupies heap bytes the bump allocator won't reclaim until a collection runs. `ld_const_after_gc(with_filler)` then loads `BLOB`:

- `with_filler = true`: FILLER + BLOB don't fit, so BLOB's `ld_const` overflows, runs one GC to reclaim the dead FILLER, then succeeds on retry. Asserts `results: 15`, `CHECK-GC-COUNT: 1`.
- `with_filler = false`: BLOB alone fits, no GC. Asserts `results: 5`, `CHECK-GC-COUNT: 0`.

The boolean toggles only the heap pressure, so the two runs isolate the single GC to BLOB's overflow rather than the FILLER load.

The `ForceGC` native the old TODO asked for is unnecessary: `force_gc` already exists but triggers a collection at an explicit point and never makes the first deserialize fail, so it would not cover this branch. `--heap-size` does.

## How Has This Been Tested?

`cargo test -p mono-move-testsuite --test differential` — full suite green (191 tests). New case: `tests/test_cases/differential/constants/ld_const_gc_retry.move`.

## Type of Change
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change plus comment removal; no interpreter or GC logic modifications.
> 
> **Overview**
> Adds a differential test that forces **mono-move**’s `ld_const` path (`StoreImmVec` → `deserialize_or_gc`) through **OOM then GC retry** on a **128-byte** heap.
> 
> A helper loads a large constant vector (`FILLER`) and returns only its length so the vector becomes **dead heap** after the frame pops; loading `BLOB` then fails the first deserialize, runs **one** GC, and succeeds on retry (`CHECK-GC-COUNT: 1`). With `with_filler = false`, only `BLOB` is loaded and **no** GC runs (`CHECK-GC-COUNT: 0`).
> 
> Removes the **`TODO(testing)`** in `exec_store_imm_vec` that called for this scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6535b66cd35c80c622a835fa124ee51692db6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->