### PR TITLE
[api] Make API blocking threads configurable

### DIFF
--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -49,7 +49,12 @@ pub fn bootstrap(
     port_tx: Option<oneshot::Sender<u16>>,
 ) -> anyhow::Result<Runtime> {
     let max_runtime_workers = get_max_runtime_workers(&config.api);
-    let runtime = aptos_runtimes::spawn_named_runtime("api".into(), Some(max_runtime_workers));
+    let max_blocking_threads = get_max_blocking_threads(&config.api);
+    let runtime = aptos_runtimes::spawn_named_runtime_with_blocking_threads(
+        "api".into(),
+        Some(max_runtime_workers),
+        Some(max_blocking_threads),
+    );
 
     let context = Context::new(chain_id, db, mp_sender, config.clone(), indexer_reader);
 
@@ -299,10 +304,16 @@ fn get_max_runtime_workers(api_config: &ApiConfig) -> usize {
         .unwrap_or_else(|| num_cpus::get() * api_config.runtime_worker_multiplier)
 }
 
+fn get_max_blocking_threads(api_config: &ApiConfig) -> usize {
+    api_config
+        .max_blocking_threads
+        .unwrap_or(aptos_runtimes::DEFAULT_MAX_BLOCKING_THREADS)
+}
+
 #[cfg(test)]
 mod tests {
     use super::bootstrap;
-    use crate::runtime::get_max_runtime_workers;
+    use crate::runtime::{get_max_blocking_threads, get_max_runtime_workers};
     use aptos_api_test_context::{new_test_context, TestContext};
     use aptos_config::config::{ApiConfig, NodeConfig};
     use aptos_types::chain_id::ChainId;
@@ -353,6 +364,27 @@ mod tests {
         assert_eq!(
             get_max_runtime_workers(&api_config),
             num_cpus::get() * api_config.runtime_worker_multiplier
+        );
+    }
+
+    #[test]
+    fn test_max_blocking_threads() {
+        let max_blocking_threads = 256;
+        let api_config = ApiConfig {
+            max_blocking_threads: Some(max_blocking_threads),
+            ..Default::default()
+        };
+
+        assert_eq!(get_max_blocking_threads(&api_config), max_blocking_threads);
+
+        let api_config = ApiConfig {
+            max_blocking_threads: None,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            get_max_blocking_threads(&api_config),
+            aptos_runtimes::DEFAULT_MAX_BLOCKING_THREADS
         );
     }
 

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -24,9 +24,16 @@ use aptos_vm_types::storage::StorageGasParameters;
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
 use move_vm_runtime::{config::VMConfig, RuntimeEnvironment, WithRuntimeEnvironment};
+use once_cell::sync::Lazy;
 use sha3::{Digest, Sha3_256};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 use triomphe::Arc as TriompheArc;
+
+static KEYLESS_PVK_CACHE: Lazy<Mutex<HashMap<[u8; 32], Arc<PreparedVerifyingKey<Bn254>>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// A runtime environment which can be used for VM initialization and more. Contains features
 /// used by execution, gas parameters, VM configs and global caches. Note that it is the user's
@@ -88,7 +95,7 @@ impl AptosEnvironment {
     /// Returns the prepared verifying key for keyless validation.
     #[inline]
     pub fn keyless_pvk(&self) -> Option<&PreparedVerifyingKey<Bn254>> {
-        self.0.keyless_pvk.as_ref()
+        self.0.keyless_pvk.as_deref()
     }
 
     /// Returns keyless configurations.
@@ -174,7 +181,7 @@ struct Environment {
 
     /// The prepared verification key for keyless accounts. Optional because it might not be set
     /// on-chain or might fail to parse.
-    keyless_pvk: Option<PreparedVerifyingKey<Bn254>>,
+    keyless_pvk: Option<Arc<PreparedVerifyingKey<Bn254>>>,
     /// Some keyless configurations which are not frequently updated.
     keyless_configuration: Option<Configuration>,
 
@@ -283,7 +290,7 @@ impl Environment {
         let keyless_pvk =
             Groth16VerificationKey::fetch_keyless_config(state_view).and_then(|(vk, vk_bytes)| {
                 sha3_256.update(&vk_bytes);
-                vk.try_into().ok()
+                cached_keyless_pvk(vk, &vk_bytes)
             });
         let keyless_configuration =
             Configuration::fetch_keyless_config(state_view).map(|(config, config_bytes)| {
@@ -316,6 +323,27 @@ impl Environment {
         }
         self
     }
+}
+
+fn cached_keyless_pvk(
+    vk: Groth16VerificationKey,
+    vk_bytes: &[u8],
+) -> Option<Arc<PreparedVerifyingKey<Bn254>>> {
+    let key = Sha3_256::digest(vk_bytes).into();
+    let mut cache = KEYLESS_PVK_CACHE
+        .lock()
+        .expect("keyless prepared verifying key cache mutex poisoned");
+
+    if let Some(pvk) = cache.get(&key) {
+        return Some(pvk.clone());
+    }
+
+    let pvk: Arc<PreparedVerifyingKey<Bn254>> = Arc::new(vk.try_into().ok()?);
+    if cache.len() >= 16 {
+        cache.clear();
+    }
+    cache.insert(key, pvk.clone());
+    Some(pvk)
 }
 
 /// Fetches config from storage and updates the hash if it exists. Returns the fetched config.

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -24,16 +24,9 @@ use aptos_vm_types::storage::StorageGasParameters;
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
 use move_vm_runtime::{config::VMConfig, RuntimeEnvironment, WithRuntimeEnvironment};
-use once_cell::sync::Lazy;
 use sha3::{Digest, Sha3_256};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::sync::Arc;
 use triomphe::Arc as TriompheArc;
-
-static KEYLESS_PVK_CACHE: Lazy<Mutex<HashMap<[u8; 32], Arc<PreparedVerifyingKey<Bn254>>>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// A runtime environment which can be used for VM initialization and more. Contains features
 /// used by execution, gas parameters, VM configs and global caches. Note that it is the user's
@@ -95,7 +88,7 @@ impl AptosEnvironment {
     /// Returns the prepared verifying key for keyless validation.
     #[inline]
     pub fn keyless_pvk(&self) -> Option<&PreparedVerifyingKey<Bn254>> {
-        self.0.keyless_pvk.as_deref()
+        self.0.keyless_pvk.as_ref()
     }
 
     /// Returns keyless configurations.
@@ -181,7 +174,7 @@ struct Environment {
 
     /// The prepared verification key for keyless accounts. Optional because it might not be set
     /// on-chain or might fail to parse.
-    keyless_pvk: Option<Arc<PreparedVerifyingKey<Bn254>>>,
+    keyless_pvk: Option<PreparedVerifyingKey<Bn254>>,
     /// Some keyless configurations which are not frequently updated.
     keyless_configuration: Option<Configuration>,
 
@@ -290,7 +283,7 @@ impl Environment {
         let keyless_pvk =
             Groth16VerificationKey::fetch_keyless_config(state_view).and_then(|(vk, vk_bytes)| {
                 sha3_256.update(&vk_bytes);
-                cached_keyless_pvk(vk, &vk_bytes)
+                vk.try_into().ok()
             });
         let keyless_configuration =
             Configuration::fetch_keyless_config(state_view).map(|(config, config_bytes)| {
@@ -323,27 +316,6 @@ impl Environment {
         }
         self
     }
-}
-
-fn cached_keyless_pvk(
-    vk: Groth16VerificationKey,
-    vk_bytes: &[u8],
-) -> Option<Arc<PreparedVerifyingKey<Bn254>>> {
-    let key = Sha3_256::digest(vk_bytes).into();
-    let mut cache = KEYLESS_PVK_CACHE
-        .lock()
-        .expect("keyless prepared verifying key cache mutex poisoned");
-
-    if let Some(pvk) = cache.get(&key) {
-        return Some(pvk.clone());
-    }
-
-    let pvk: Arc<PreparedVerifyingKey<Bn254>> = Arc::new(vk.try_into().ok()?);
-    if cache.len() >= 16 {
-        cache.clear();
-    }
-    cache.insert(key, pvk.clone());
-    Some(pvk)
 }
 
 /// Fetches config from storage and updates the hash if it exists. Returns the fetched config.

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -70,6 +70,11 @@ pub struct ApiConfig {
     ///
     /// If not set, `runtime_worker_multiplier` will multiply times the number of CPU cores on the machine
     pub max_runtime_workers: Option<usize>,
+    /// Optional: Maximum number of blocking threads for synchronous REST API work.
+    ///
+    /// If not set, this defaults to the runtime default. Dedicated high-throughput
+    /// API nodes may increase this to allow more concurrent blocking API requests.
+    pub max_blocking_threads: Option<usize>,
     /// Multiplier for number of worker threads with number of CPU cores
     ///
     /// If `max_runtime_workers` is set, this is ignored
@@ -134,6 +139,7 @@ impl Default for ApiConfig {
             max_account_modules_page_size: DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE,
             max_gas_view_function: DEFAULT_MAX_VIEW_GAS,
             max_runtime_workers: None,
+            max_blocking_threads: None,
             runtime_worker_multiplier: 2,
             gas_estimation: GasEstimationConfig::default(),
             periodic_gas_estimation_ms: Some(30_000),
@@ -189,6 +195,12 @@ impl ConfigSanitizer for ApiConfig {
             return Err(Error::ConfigSanitizerFailed(
                 sanitizer_name,
                 "runtime_worker_multiplier must be greater than 0!".into(),
+            ));
+        }
+        if api_config.max_blocking_threads == Some(0) {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "max_blocking_threads must be greater than 0!".into(),
             ));
         }
 
@@ -302,6 +314,23 @@ mod tests {
 
         // Sanitize the config and verify that it fails because
         // the runtime worker multiplier is invalid.
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_invalid_blocking_threads() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                max_blocking_threads: Some(0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
         let error =
             ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
                 .unwrap_err();

--- a/crates/aptos-runtimes/src/lib.rs
+++ b/crates/aptos-runtimes/src/lib.rs
@@ -10,10 +10,25 @@ use tokio::runtime::{Builder, Runtime};
 /// we need to leave space for the thread IDs.
 const MAX_THREAD_NAME_LENGTH: usize = 12;
 
+pub const DEFAULT_MAX_BLOCKING_THREADS: usize = 64;
+
 /// Returns a tokio runtime with named threads.
 /// This is useful for tracking threads when debugging.
 pub fn spawn_named_runtime(thread_name: String, num_worker_threads: Option<usize>) -> Runtime {
     spawn_named_runtime_with_start_hook(thread_name, num_worker_threads, || {})
+}
+
+pub fn spawn_named_runtime_with_blocking_threads(
+    thread_name: String,
+    num_worker_threads: Option<usize>,
+    max_blocking_threads: Option<usize>,
+) -> Runtime {
+    spawn_named_runtime_with_start_hook_and_blocking_threads(
+        thread_name,
+        num_worker_threads,
+        max_blocking_threads,
+        || {},
+    )
 }
 
 pub fn spawn_named_runtime_with_start_hook<F>(
@@ -24,8 +39,23 @@ pub fn spawn_named_runtime_with_start_hook<F>(
 where
     F: Fn() + Send + Sync + 'static,
 {
-    const MAX_BLOCKING_THREADS: usize = 64;
+    spawn_named_runtime_with_start_hook_and_blocking_threads(
+        thread_name,
+        num_worker_threads,
+        None,
+        on_thread_start,
+    )
+}
 
+pub fn spawn_named_runtime_with_start_hook_and_blocking_threads<F>(
+    thread_name: String,
+    num_worker_threads: Option<usize>,
+    max_blocking_threads: Option<usize>,
+    on_thread_start: F,
+) -> Runtime
+where
+    F: Fn() + Send + Sync + 'static,
+{
     // Verify the given name has an appropriate length
     if thread_name.len() > MAX_THREAD_NAME_LENGTH {
         panic!(
@@ -47,7 +77,7 @@ where
         .disable_lifo_slot()
         // Limit concurrent blocking tasks from spawn_blocking(), in case, for example, too many
         // Rest API calls overwhelm the node.
-        .max_blocking_threads(MAX_BLOCKING_THREADS)
+        .max_blocking_threads(max_blocking_threads.unwrap_or(DEFAULT_MAX_BLOCKING_THREADS))
         .enable_all();
     if let Some(num_worker_threads) = num_worker_threads {
         builder.worker_threads(num_worker_threads);


### PR DESCRIPTION
## Summary
- add an optional `api.max_blocking_threads` config for the REST API runtime
- preserve the existing default of 64 blocking threads when the option is unset
- add a runtime helper that allows callers to override Tokio's `max_blocking_threads` without changing existing `spawn_named_runtime(...)` call sites

## Motivation
REST API endpoints that perform synchronous work, including account/resource reads and view calls, share the API runtime's `spawn_blocking` pool. The current hard-coded 64-thread cap is a useful default guardrail for general-purpose nodes, but dedicated high-throughput API PFNs may need to opt into a larger limit without changing behavior for everyone else.

## Tests
- `cargo test -p aptos-runtimes`
- `cargo test -p aptos-config test_sanitize_invalid_blocking_threads`
- `cargo test -p aptos-config test_sanitize_invalid_workers`
- `cargo test -p aptos-api test_max_blocking_threads`
- `cargo test -p aptos-api test_max_runtime_workers`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mis-tuning the blocking pool can overload dedicated API nodes or change REST concurrency under load, though defaults and validation preserve prior behavior for unchanged configs.
> 
> **Overview**
> Adds optional **`api.max_blocking_threads`** so operators can tune how many Tokio blocking threads the REST API runtime uses for synchronous work (e.g. reads and view calls via `spawn_blocking`). When unset, behavior stays at the existing **64**-thread cap via `DEFAULT_MAX_BLOCKING_THREADS`.
> 
> API bootstrap now builds the runtime with **`spawn_named_runtime_with_blocking_threads`** instead of the generic named runtime helper. **`aptos-runtimes`** exposes the default constant and threads the limit through a shared builder path so other **`spawn_named_runtime`** call sites keep the same default without config changes.
> 
> Config **sanitization** rejects `max_blocking_threads: 0`; unit tests cover resolution and invalid values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e95312ce2e5bb9e0949cf02239a4f05a713019b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->