### PR TITLE
[mono-move] Hoist interpreter machine registers into the run loop

### DIFF
--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -40,24 +40,18 @@ use std::ptr::NonNull;
 
 /// Call-site sugar for the allocation and GC free functions in this module.
 ///
-/// Each macro forwards to an eponymous free function, unpacking the fields
-/// of an `InterpreterContext` binding (`heap`, `descriptors`,
-/// `root_pool`, `current_func`, `pc`, `frame_ptr`) as individual
-/// arguments.
+/// Each macro forwards to an eponymous free function, unpacking the fields of an
+/// `InterpreterContext`.
 ///
 /// ```ignore
-/// let ptr = heap::macros::alloc_obj!(self, fp, desc_id)?;
+/// let ptr = heap::macros::alloc_obj!(self, fp, pc, func, desc_id)?;
 /// ```
 ///
 /// # Why macros and not methods
 ///
 /// Rust lacks partial-borrow syntax: a method on `InterpreterContext` that
-/// mutates `heap` would borrow `self` as `&mut`, conflicting with any
-/// outstanding borrow of an unrelated field (e.g. a root handle that holds
-/// `&self.root_pool`). Spelling out the individual field borrows at the
-/// call site lets the compiler see that the borrows are disjoint. The
-/// macro hides that boilerplate while preserving the field-level borrow
-/// granularity.
+/// mutates a field would borrow `self` as `&mut`, conflicting with any
+/// outstanding borrow of an unrelated field.
 ///
 /// The macros live in a submodule so their `macro_rules!` names don't
 /// collide with the free functions in the value namespace of this module
@@ -66,7 +60,7 @@ pub(crate) mod macros {
     /// Forwards to [`super::alloc_obj`]. Arguments: (`$ctx`, `$fp`,
     /// `$descriptor_id`).
     macro_rules! alloc_obj {
-        ($ctx:ident, $fp:expr, $descriptor_id:expr $(,)?) => {
+        ($ctx:ident, $fp:expr, $pc:expr, $func:expr, $descriptor_id:expr $(,)?) => {
             $crate::heap::alloc_obj(
                 &mut $ctx.heap,
                 $ctx.exec_ctx,
@@ -75,8 +69,8 @@ pub(crate) mod macros {
                 $ctx.exec_ctx.extensions(),
                 $fp,
                 $crate::heap::TopFrame::Function {
-                    func: $ctx.current_func,
-                    pc: $ctx.pc,
+                    func: $func,
+                    pc: $pc,
                 },
                 $descriptor_id,
             )
@@ -90,6 +84,8 @@ pub(crate) mod macros {
         (
             $ctx:ident,
             $fp:expr,
+            $pc:expr,
+            $func:expr,
             $descriptor_id:expr,
             $elem_size:expr,
             $capacity_in_elems:expr $(,)?
@@ -102,8 +98,8 @@ pub(crate) mod macros {
                 $ctx.exec_ctx.extensions(),
                 $fp,
                 $crate::heap::TopFrame::Function {
-                    func: $ctx.current_func,
-                    pc: $ctx.pc,
+                    func: $func,
+                    pc: $pc,
                 },
                 $descriptor_id,
                 $elem_size,
@@ -116,7 +112,14 @@ pub(crate) mod macros {
     /// Forwards to [`super::alloc_captured_data`]. Arguments: (`$ctx`, `$fp`,
     /// `$values_size`, `$descriptor_id`).
     macro_rules! alloc_captured_data {
-        ($ctx:ident, $fp:expr, $values_size:expr, $descriptor_id:expr $(,)?) => {
+        (
+            $ctx:ident,
+            $fp:expr,
+            $pc:expr,
+            $func:expr,
+            $values_size:expr,
+            $descriptor_id:expr $(,)?
+        ) => {
             $crate::heap::alloc_captured_data(
                 &mut $ctx.heap,
                 $ctx.exec_ctx,
@@ -125,8 +128,8 @@ pub(crate) mod macros {
                 $ctx.exec_ctx.extensions(),
                 $fp,
                 $crate::heap::TopFrame::Function {
-                    func: $ctx.current_func,
-                    pc: $ctx.pc,
+                    func: $func,
+                    pc: $pc,
                 },
                 $values_size,
                 $descriptor_id,
@@ -141,6 +144,8 @@ pub(crate) mod macros {
         (
             $ctx:ident,
             $fp:expr,
+            $pc:expr,
+            $func:expr,
             $vec_ref_offset:expr,
             $elem_size:expr,
             $required_cap_in_elems:expr $(,)?
@@ -152,8 +157,8 @@ pub(crate) mod macros {
                 &$ctx.root_pool,
                 $ctx.exec_ctx.extensions(),
                 $crate::heap::TopFrame::Function {
-                    func: $ctx.current_func,
-                    pc: $ctx.pc,
+                    func: $func,
+                    pc: $pc,
                 },
                 $fp,
                 $vec_ref_offset,
@@ -166,17 +171,17 @@ pub(crate) mod macros {
 
     /// Forwards to [`super::gc_collect`]. Arguments: (`$ctx`,).
     macro_rules! gc_collect {
-        ($ctx:ident $(,)?) => {
+        ($ctx:ident, $fp:expr, $pc:expr, $func:expr $(,)?) => {
             $crate::heap::gc_collect(
                 &mut $ctx.heap,
                 $ctx.exec_ctx,
                 &mut $ctx.read_write_set,
                 &$ctx.root_pool,
                 $ctx.exec_ctx.extensions(),
-                $ctx.frame_ptr,
+                $fp,
                 $crate::heap::TopFrame::Function {
-                    func: $ctx.current_func,
-                    pc: $ctx.pc,
+                    func: $func,
+                    pc: $pc,
                 },
             )
         };

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -24,9 +24,8 @@ use crate::{
     },
     native_context::ProductionNativeContext,
     types::{
-        StepResult, ABORT_MESSAGE_SIZE_LIMIT, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE,
-        META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
-        VEC_LENGTH_OFFSET,
+        ABORT_MESSAGE_SIZE_LIMIT, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, META_SAVED_FP_OFFSET,
+        META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
     },
     value_utils, ExecutionContext,
 };
@@ -55,19 +54,30 @@ use std::ptr::{null, NonNull};
 // Runtime state
 // ---------------------------------------------------------------------------
 
+/// The interpreter's machine registers.
+///
+/// It is intended that the dispatch loop copies these into a local copy, which
+/// hopefully gets mapped to real CPU registers.
+///
+/// Taking references against these registers should be handled with utmost care --
+/// a reference mustn't escape into a non-inlined function, otherwise it may force
+/// the compiler to spill the registers to the stack.
+#[derive(Clone, Copy)]
+pub(crate) struct MachineRegisters {
+    pub(crate) pc: usize,
+    pub(crate) fp: *mut u8,
+    pub(crate) func: NonNull<Function>,
+}
+
 /// Interpreter context with a unified call stack and a GC-managed heap.
 pub struct InterpreterContext<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> {
     /// Per-transaction context (function resolution, gas counters,
     /// descriptor table, etc.).
     pub(crate) exec_ctx: &'a mut T,
 
-    pub(crate) pc: usize,
-    /// Pointer to the currently executing function.
-    pub(crate) current_func: NonNull<Function>,
-    /// Absolute pointer into the linear stack memory. Operand accesses are a
-    /// single addition (`fp + offset`).
-    /// Recomputed only during calls and returns.
-    pub(crate) frame_ptr: *mut u8,
+    /// Machine registers at rest. The dispatch loop works on a local copy and
+    /// writes it back here on exit.
+    pub(crate) registers: MachineRegisters,
 
     pub(crate) stack: MemoryRegion,
     pub(crate) heap: Heap,
@@ -112,9 +122,11 @@ impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterC
 
         Self {
             exec_ctx,
-            pc: 0,
-            current_func: NonNull::from(entry),
-            frame_ptr,
+            registers: MachineRegisters {
+                pc: 0,
+                fp: frame_ptr,
+                func: NonNull::from(entry),
+            },
             stack,
             heap: Heap::new(heap_size),
             root_pool: RootPool::new(),
@@ -193,9 +205,9 @@ impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterC
         let base = self.stack.as_ptr();
 
         // Reset execution state to root frame.
-        self.frame_ptr = unsafe { base.add(FRAME_METADATA_SIZE) };
-        self.pc = 0;
-        self.current_func = NonNull::from(func);
+        self.registers.fp = unsafe { base.add(FRAME_METADATA_SIZE) };
+        self.registers.pc = 0;
+        self.registers.func = NonNull::from(func);
 
         // Re-write sentinel metadata so Return from root triggers Done.
         unsafe {
@@ -209,7 +221,7 @@ impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterC
         if func.zero_frame {
             unsafe {
                 std::ptr::write_bytes(
-                    self.frame_ptr.add(func.param_region_size),
+                    self.registers.fp.add(func.param_region_size),
                     0,
                     func.extended_frame_size - func.param_region_size,
                 );
@@ -313,7 +325,15 @@ impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterC
         values: &[u64],
     ) -> RuntimeResult<u64> {
         let n = values.len() as u64;
-        let ptr = alloc_vec!(self, self.frame_ptr, descriptor_id, 8, n)?;
+        let ptr = alloc_vec!(
+            self,
+            self.registers.fp,
+            self.registers.pc,
+            self.registers.func,
+            descriptor_id,
+            8,
+            n
+        )?;
         unsafe {
             write_u64(ptr, VEC_LENGTH_OFFSET, n);
             let data = ptr.add(VEC_DATA_OFFSET);
@@ -842,45 +862,59 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         target: CodeOffset,
         gas_taken: u64,
         gas_fallthrough: u64,
-    ) -> RuntimeResult<StepResult> {
+        regs: &mut MachineRegisters,
+    ) -> RuntimeResult<()> {
         if cond {
             self.exec_ctx.gas_meter().charge(gas_taken)?;
-            self.pc = target.into();
+            regs.pc = target.into();
         } else {
             self.exec_ctx.gas_meter().charge(gas_fallthrough)?;
-            self.pc += 1;
+            regs.pc += 1;
         }
-        Ok(StepResult::Continue)
+        Ok(())
     }
 
-    #[inline(always)]
-    pub fn step(&mut self) -> RuntimeResult<StepResult> {
-        // SAFETY: Current function is always a valid, non-null pointer because
-        // it is derived from function reference (e.g., entrypoint) or when
-        // executing a call instruction, which stores a valid pointer.
-        let func = unsafe { self.current_func.as_ref() };
+    // TEMP(review): `#[rustfmt::skip]` keeps `run`'s body at the pre-fold
+    // indentation so the diff shows only real changes. Remove before landing
+    // (then `cargo +nightly fmt` re-indents the loop body).
+    #[rustfmt::skip]
+    pub fn run(&mut self) -> RuntimeResult<RuntimeStatus> {
+        // Hoist the machine registers into a local so the dispatch loop keeps
+        // them in CPU registers rather than reloading from `self.registers`
+        // each iteration. Only sync back to `self` on exit.
+        let mut regs = self.registers;
 
-        let code = func.code.get();
+        // Charge the entry function's entry block before any of its instructions run.
+        let entry_gas = unsafe { regs.func.as_ref() }.entry_gas;
+        self.exec_ctx.gas_meter().charge(entry_gas)?;
 
-        if self.pc >= code.len() {
-            invariant_violation!(PcOutOfBounds {
-                pc: self.pc,
-                func_name: func.name().to_string(),
-                code_len: code.len(),
-            });
-        }
+        let outcome = loop {
+            // SAFETY: Current function is always a valid, non-null pointer because
+            // it is derived from function reference (e.g., entrypoint) or when
+            // executing a call instruction, which stores a valid pointer.
+            let func = unsafe { regs.func.as_ref() };
 
-        let fp = self.frame_ptr;
-        let instr = &code[self.pc];
+            let code = func.code.get();
 
-        // SAFETY: fp points into the interpreter's linear stack; all byte
-        // offsets are within the current frame (enforced by the bytecode
-        // compiler). Heap pointers read from the frame are kept valid by GC.
-        unsafe {
-            // TODO(perf): explore faster dispatch -- super-instructions (fuse
-            // common sequences like load+compare+branch), threaded/computed-goto
-            // dispatch, and copy-and-patch JIT.
-            match *instr {
+            if regs.pc >= code.len() {
+                invariant_violation!(PcOutOfBounds {
+                    pc: regs.pc,
+                    func_name: func.name().to_string(),
+                    code_len: code.len(),
+                });
+            }
+
+            let fp = regs.fp;
+            let instr = &code[regs.pc];
+
+            // SAFETY: fp points into the interpreter's linear stack; all byte
+            // offsets are within the current frame (enforced by the bytecode
+            // compiler). Heap pointers read from the frame are kept valid by GC.
+            unsafe {
+                // TODO(perf): explore faster dispatch -- super-instructions (fuse
+                // common sequences like load+compare+branch), threaded/computed-goto
+                // dispatch, and copy-and-patch JIT.
+                match *instr {
                 // ----- Control flow (set pc explicitly, return early) -----
                 MicroOp::CallIndirect {
                     module_id,
@@ -902,10 +936,12 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                         .map_err(RuntimeError::Loader)?;
                     // SAFETY: `target` points to a `Function`, which is not reclaimed during
                     // execution as guaranteed by the execution guard.
-                    return self.call(func, fp, target.as_ref_unchecked());
+                    self.call(func, &mut regs, target.as_ref_unchecked())?;
+                    continue;
                 },
                 MicroOp::CallDirect { ptr } => {
-                    return self.call(func, fp, ptr.as_ref_unchecked());
+                    self.call(func, &mut regs, ptr.as_ref_unchecked())?;
+                    continue;
                 },
 
                 MicroOp::CallNative {
@@ -913,7 +949,13 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     ty_args,
                     ref abi,
                 } => {
-                    return self.exec_call_native(func, fp, native_idx, ty_args, abi);
+                    // On abort, halt; otherwise native success falls through to
+                    // the common tail, which advances the pc by one.
+                    if let Some((code, message)) =
+                        self.exec_call_native(func, regs, native_idx, ty_args, abi)?
+                    {
+                        break RuntimeStatus::Aborted { code, message };
+                    }
                 },
 
                 MicroOp::JumpNotZeroU64 {
@@ -922,12 +964,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     gas_taken,
                     gas_fallthrough,
                 } => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u64(fp, src) != 0,
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpNotZeroByte {
@@ -938,12 +982,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 } => {
                     // Read as `u8` only to test against zero; the byte's sign is
                     // irrelevant.
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u8(fp, src) != 0,
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpZeroByte {
@@ -954,21 +1000,25 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 } => {
                     // Read as `u8` only to test against zero; the byte's sign is
                     // irrelevant.
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u8(fp, src) == 0,
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpIntCmp(ref op) => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         int_cmp_bool(fp, op.lhs, op.op, &op.rhs),
                         op.target,
                         op.gas_taken,
                         op.gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpValueCmp(ref op) => {
@@ -977,12 +1027,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let a = fp.add(op.lhs.into());
                     let b = fp.add(op.rhs.into());
                     let eq = value_utils::equals(self.exec_ctx, a, b, op.ty)?;
-                    return self.cond_branch(
+                    self.cond_branch(
                         eq ^ op.negate,
                         op.target,
                         op.gas_taken,
                         op.gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpValueRefCmp(ref op) => {
@@ -996,12 +1048,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                         rb.add(ro as usize),
                         op.ty,
                     )?;
-                    return self.cond_branch(
+                    self.cond_branch(
                         eq ^ op.negate,
                         op.target,
                         op.gas_taken,
                         op.gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpGreaterEqualU64Imm {
@@ -1011,12 +1065,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     gas_taken,
                     gas_fallthrough,
                 } => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u64(fp, src) >= imm,
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpLessU64Imm {
@@ -1026,12 +1082,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     gas_taken,
                     gas_fallthrough,
                 } => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u64(fp, src) < imm,
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpGreaterU64Imm {
@@ -1041,12 +1099,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     gas_taken,
                     gas_fallthrough,
                 } => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u64(fp, src) > imm,
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpLessEqualU64Imm {
@@ -1056,12 +1116,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     gas_taken,
                     gas_fallthrough,
                 } => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u64(fp, src) <= imm,
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpLessU64 {
@@ -1071,12 +1133,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     gas_taken,
                     gas_fallthrough,
                 } => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u64(fp, lhs) < read_u64(fp, rhs),
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpGreaterEqualU64 {
@@ -1086,12 +1150,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     gas_taken,
                     gas_fallthrough,
                 } => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u64(fp, lhs) >= read_u64(fp, rhs),
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::JumpNotEqualU64 {
@@ -1101,18 +1167,20 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     gas_taken,
                     gas_fallthrough,
                 } => {
-                    return self.cond_branch(
+                    self.cond_branch(
                         read_u64(fp, lhs) != read_u64(fp, rhs),
                         target,
                         gas_taken,
                         gas_fallthrough,
-                    );
+                        &mut regs,
+                    )?;
+                    continue;
                 },
 
                 MicroOp::Jump { target, gas } => {
                     self.exec_ctx.gas_meter().charge(gas)?;
-                    self.pc = target.into();
-                    return Ok(StepResult::Continue);
+                    regs.pc = target.into();
+                    continue;
                 },
 
                 MicroOp::Return => {
@@ -1121,23 +1189,23 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let saved_func_ptr =
                         read_ptr(meta, META_SAVED_FUNC_PTR_OFFSET) as *const Function;
                     if saved_func_ptr.is_null() {
-                        return Ok(StepResult::Done);
+                        break RuntimeStatus::Success;
                     }
                     // SAFETY: We have just checked that the saved function
                     // pointer is non-null.
-                    self.current_func = NonNull::new_unchecked(saved_func_ptr as *mut Function);
+                    regs.func = NonNull::new_unchecked(saved_func_ptr as *mut Function);
 
-                    self.pc = read_u64(meta, META_SAVED_PC_OFFSET) as usize;
-                    self.frame_ptr = read_ptr(meta, META_SAVED_FP_OFFSET);
-                    return Ok(StepResult::Continue);
+                    regs.pc = read_u64(meta, META_SAVED_PC_OFFSET) as usize;
+                    regs.fp = read_ptr(meta, META_SAVED_FP_OFFSET);
+                    continue;
                 },
 
                 MicroOp::Abort { code } => {
                     let code = read_u64(fp, code);
-                    return Ok(StepResult::Aborted {
+                    break RuntimeStatus::Aborted {
                         code,
                         message: None,
-                    });
+                    };
                 },
 
                 MicroOp::AbortMsg { code, message } => {
@@ -1161,10 +1229,10 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                         String::from_utf8(std::slice::from_raw_parts(data, len).to_vec())
                             .map_err(|_| RuntimeError::InvalidAbortMessage)?
                     };
-                    return Ok(StepResult::Aborted {
+                    break RuntimeStatus::Aborted {
                         code,
                         message: Some(message),
-                    });
+                    };
                 },
 
                 // ----- Arithmetic -----
@@ -1175,7 +1243,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 MicroOp::StoreImm16 { dst, ref imm } => write_int::<[u8; 16]>(fp, dst, **imm),
                 MicroOp::StoreImm32 { dst, ref imm } => write_int::<[u8; 32]>(fp, dst, **imm),
                 MicroOp::StoreImmVec { dst, idx } => {
-                    self.exec_store_imm_vec(dst, idx)?;
+                    self.exec_store_imm_vec(regs, dst, idx)?;
                 },
 
                 // Add
@@ -1188,12 +1256,12 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     })?
                 },
                 MicroOp::AddU64Imm { dst, src, imm } => {
-                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_add).ok_or_else(|| {
-                        RuntimeError::ArithmeticOverflow {
+                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_add).ok_or_else(
+                        || RuntimeError::ArithmeticOverflow {
                             op: ArithOp::Add,
                             ty: IntTy::U64,
-                        }
-                    })?
+                        },
+                    )?
                 },
 
                 // Sub
@@ -1206,12 +1274,12 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     })?
                 },
                 MicroOp::SubU64Imm { dst, src, imm } => {
-                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_sub).ok_or_else(|| {
-                        RuntimeError::ArithmeticUnderflow {
+                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_sub).ok_or_else(
+                        || RuntimeError::ArithmeticUnderflow {
                             op: ArithOp::Sub,
                             ty: IntTy::U64,
-                        }
-                    })?
+                        },
+                    )?
                 },
                 // dst = imm - src, so flip the operand order.
                 MicroOp::RSubU64Imm { dst, src, imm } => {
@@ -1232,12 +1300,12 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     })?
                 },
                 MicroOp::MulU64Imm { dst, src, imm } => {
-                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_mul).ok_or_else(|| {
-                        RuntimeError::ArithmeticOverflow {
+                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_mul).ok_or_else(
+                        || RuntimeError::ArithmeticOverflow {
                             op: ArithOp::Mul,
                             ty: IntTy::U64,
-                        }
-                    })?
+                        },
+                    )?
                 },
 
                 // Div / Mod
@@ -1279,18 +1347,26 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 },
 
                 // Bitwise (infallible)
-                MicroOp::BitAndU64 { dst, lhs, rhs } => binop_u64(fp, dst, lhs, rhs, |a, b| a & b),
-                MicroOp::BitOrU64 { dst, lhs, rhs } => binop_u64(fp, dst, lhs, rhs, |a, b| a | b),
-                MicroOp::BitXorU64 { dst, lhs, rhs } => binop_u64(fp, dst, lhs, rhs, |a, b| a ^ b),
+                MicroOp::BitAndU64 { dst, lhs, rhs } => {
+                    binop_u64(fp, dst, lhs, rhs, |a, b| a & b)
+                },
+                MicroOp::BitOrU64 { dst, lhs, rhs } => {
+                    binop_u64(fp, dst, lhs, rhs, |a, b| a | b)
+                },
+                MicroOp::BitXorU64 { dst, lhs, rhs } => {
+                    binop_u64(fp, dst, lhs, rhs, |a, b| a ^ b)
+                },
 
                 // Shifts
-                MicroOp::ShlU64 { dst, lhs, rhs } => shift_u64(fp, dst, lhs, rhs, |v, s| v << s)
-                    .map_err(|shift_amount| RuntimeError::ShiftAmountOutOfRange {
-                        op: ArithOp::Shl,
-                        ty: IntTy::U64,
-                        shift_amount,
-                        bit_width: 64,
-                    })?,
+                MicroOp::ShlU64 { dst, lhs, rhs } => shift_u64(fp, dst, lhs, rhs, |v, s| {
+                    v << s
+                })
+                .map_err(|shift_amount| RuntimeError::ShiftAmountOutOfRange {
+                    op: ArithOp::Shl,
+                    ty: IntTy::U64,
+                    shift_amount,
+                    bit_width: 64,
+                })?,
                 // INVARIANT: the verifier rejects `imm >= 64`, so plain `s << imm`
                 // cannot wrap or trigger UB. Asserted below in debug builds as a
                 // defensive check.
@@ -1298,13 +1374,15 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     debug_assert!(imm < 64, "ShlU64Imm: imm must be < 64 (verifier invariant)");
                     imm_op_u64(fp, dst, src, imm as u64, |s, i| s << i)
                 },
-                MicroOp::ShrU64 { dst, lhs, rhs } => shift_u64(fp, dst, lhs, rhs, |v, s| v >> s)
-                    .map_err(|shift_amount| RuntimeError::ShiftAmountOutOfRange {
-                        op: ArithOp::Shr,
-                        ty: IntTy::U64,
-                        shift_amount,
-                        bit_width: 64,
-                    })?,
+                MicroOp::ShrU64 { dst, lhs, rhs } => shift_u64(fp, dst, lhs, rhs, |v, s| {
+                    v >> s
+                })
+                .map_err(|shift_amount| RuntimeError::ShiftAmountOutOfRange {
+                    op: ArithOp::Shr,
+                    ty: IntTy::U64,
+                    shift_amount,
+                    bit_width: 64,
+                })?,
                 // INVARIANT: the verifier rejects `imm >= 64`, so plain `s >> imm`
                 // cannot wrap or trigger UB. Asserted below in debug builds as a
                 // defensive check.
@@ -1319,7 +1397,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 },
 
                 MicroOp::ForceGC => {
-                    gc_collect!(self)?;
+                    gc_collect!(self, regs.fp, regs.pc, regs.func)?;
                 },
 
                 MicroOp::Move8 { dst, src } => {
@@ -1356,7 +1434,8 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let mut vec_ptr = read_ptr(ref_base, ref_off as usize);
 
                     if vec_ptr.is_null() {
-                        vec_ptr = alloc_vec!(self, fp, descriptor_id, elem_size, 4)?;
+                        vec_ptr =
+                            alloc_vec!(self, fp, regs.pc, regs.func, descriptor_id, elem_size, 4)?;
                         // Re-read base after potential GC.
                         let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
                         write_ptr(ref_base, ref_off as usize, vec_ptr);
@@ -1368,7 +1447,15 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                         / elem_size as usize) as u64;
 
                     if len >= cap_in_elems {
-                        vec_ptr = grow_vec_ref!(self, fp, vec_ref.into(), elem_size, len + 1)?;
+                        vec_ptr = grow_vec_ref!(
+                            self,
+                            fp,
+                            regs.pc,
+                            regs.func,
+                            vec_ref.into(),
+                            elem_size,
+                            len + 1
+                        )?;
                     }
 
                     std::ptr::copy_nonoverlapping(
@@ -1448,7 +1535,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 },
 
                 MicroOp::VecPack(ref op) => {
-                    self.exec_vec_pack(fp, op)?;
+                    self.exec_vec_pack(regs, op)?;
                 },
 
                 MicroOp::VecUnpack(ref op) => {
@@ -1562,7 +1649,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
 
                 // ----- Heap object instructions (structs and enums) -----
                 MicroOp::HeapNew { dst, descriptor_id } => {
-                    let ptr = alloc_obj!(self, fp, descriptor_id)?;
+                    let ptr = alloc_obj!(self, fp, regs.pc, regs.func, descriptor_id)?;
                     write_ptr(fp, dst, ptr);
                 },
 
@@ -1637,10 +1724,11 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 },
 
                 MicroOp::PackClosure(ref op) => {
-                    self.exec_pack_closure(fp, op)?;
+                    self.exec_pack_closure(regs, op)?;
                 },
                 MicroOp::CallClosure(ref op) => {
-                    return self.exec_call_closure(func, fp, op);
+                    regs = self.exec_call_closure(func, regs, op)?;
+                    continue;
                 },
 
                 MicroOp::IntAdd(ref op) => exec_int_add(fp, op)?,
@@ -1685,7 +1773,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     {
                         EntryPtr::Writable(ptr) => ptr,
                         EntryPtr::NonWritable(ptr) => {
-                            let ptr = self.deep_copy(ptr)?;
+                            let ptr = self.deep_copy(regs, ptr)?;
                             self.read_write_set.commit_borrow_global_mut(&key, ptr);
                             ptr
                         },
@@ -1704,7 +1792,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let ptr = match entry_ptr {
                         EntryPtr::Writable(ptr) => ptr,
                         EntryPtr::NonWritable(ptr) => {
-                            let ptr = self.deep_copy(ptr)?;
+                            let ptr = self.deep_copy(regs, ptr)?;
                             self.read_write_set.commit_move_from(&key);
                             ptr
                         },
@@ -1821,7 +1909,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     descriptor_id,
                     variant,
                 } => {
-                    let obj_ptr = alloc_obj!(self, fp, descriptor_id)?;
+                    let obj_ptr = alloc_obj!(self, fp, regs.pc, regs.func, descriptor_id)?;
                     // No safe point between the allocation and these
                     // non-allocating writes: stamp the tag through the fresh
                     // pointer, then publish it to `dst`.
@@ -1892,46 +1980,52 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                         // pointer at one offset. Uses single-root `deep_copy`,
                         // avoiding the batch's per-op `Vec`s.
                         if let Some(src) = NonNull::new(read_ptr(fp, (base.0 + off) as usize)) {
-                            let new = self.deep_copy(src)?;
+                            let new = self.deep_copy(regs, src)?;
                             write_ptr(fp, (base.0 + off) as usize, new.as_ptr());
                         }
                     } else {
                         let mut live_offsets: Vec<u32> = Vec::with_capacity(offsets.len());
                         let mut sources: Vec<NonNull<u8>> = Vec::with_capacity(offsets.len());
                         for &off in offsets.iter() {
-                            if let Some(src) = NonNull::new(read_ptr(fp, (base.0 + off) as usize)) {
+                            if let Some(src) =
+                                NonNull::new(read_ptr(fp, (base.0 + off) as usize))
+                            {
                                 live_offsets.push(off);
                                 sources.push(src);
                             }
                         }
-                        let copies = self.deep_copy_batch(&sources)?;
+                        let copies = self.deep_copy_batch(regs, &sources)?;
                         for (off, new) in live_offsets.iter().zip(copies) {
                             write_ptr(fp, (base.0 + off) as usize, new.as_ptr());
                         }
                     }
                 },
             }
-        }
+            }
 
-        self.pc += 1;
-        Ok(StepResult::Continue)
+            regs.pc += 1;
+        };
+
+        self.registers = regs;
+        Ok(outcome)
     }
 
     /// Allocates vector from constant pool and writes data pointer into `dst`.
+    #[inline(never)]
     fn exec_store_imm_vec(
         &mut self,
+        regs: MachineRegisters,
         dst: FrameOffset,
         idx: ConstantPoolIndex,
     ) -> RuntimeResult<()> {
-        // SAFETY: `current_func` points to the live, currently-executing
-        // function.
-        let module_id = unsafe { self.current_func.as_ref() }.module_id;
+        // SAFETY: `regs.func` points to the live, currently-executing function.
+        let module_id = unsafe { regs.func.as_ref() }.module_id;
         let (ty, bytes) = self.exec_ctx.load_constant(module_id, idx)?;
 
         // SAFETY: `dst` is a verified 8-byte frame slot for a vector pointer
         // and is writable (no aliasing to the heap).
         unsafe {
-            let dst = self.frame_ptr.add(usize::from(dst));
+            let dst = regs.fp.add(usize::from(dst));
             deserialize_or_gc(
                 self.exec_ctx,
                 &mut self.heap,
@@ -1942,10 +2036,10 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 &mut self.read_write_set,
                 &self.root_pool,
                 self.exec_ctx.extensions(),
-                self.frame_ptr,
+                regs.fp,
                 crate::heap::TopFrame::Function {
-                    func: self.current_func,
-                    pc: self.pc,
+                    func: regs.func,
+                    pc: regs.pc,
                 },
             )
         }
@@ -1958,16 +2052,32 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     ///
     /// # Safety
     ///
-    /// - `fp` is the current frame pointer.
+    /// - `regs.fp` is the current frame pointer.
     /// - `op.dst` and each `op.srcs` slot are in-bounds for the current frame.
-    unsafe fn exec_vec_pack(&mut self, fp: *mut u8, op: &VecPackOp) -> RuntimeResult<()> {
+    // Outlined to keep the dispatch loop small: an inlined body here adds to
+    // the register pressure that competes for `fp`'s register across the loop.
+    #[inline(never)]
+    unsafe fn exec_vec_pack(
+        &mut self,
+        regs: MachineRegisters,
+        op: &VecPackOp,
+    ) -> RuntimeResult<()> {
+        let fp = regs.fp;
         let count = op.srcs.len() as u64;
         // TODO(perf): `alloc_vec!` zero-fills the whole allocation, but every
         // payload byte is overwritten below before the op returns and no GC can
         // intervene afterwards. A fully-initialized-payload alloc variant would
         // avoid the dead memset. Padding needs to be carefully considered for
         // the optimization.
-        let vec_ptr = alloc_vec!(self, fp, op.descriptor_id, op.elem_size, count)?;
+        let vec_ptr = alloc_vec!(
+            self,
+            fp,
+            regs.pc,
+            regs.func,
+            op.descriptor_id,
+            op.elem_size,
+            count
+        )?;
         unsafe {
             write_u64(vec_ptr, VEC_LENGTH_OFFSET, count);
             for (elem_idx, src) in op.srcs.iter().enumerate() {
@@ -2022,7 +2132,11 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     ///
     /// Source must point to the data region of a live object whose header is
     /// at `src - OBJECT_HEADER_SIZE`.
-    unsafe fn deep_copy(&mut self, root: NonNull<u8>) -> RuntimeResult<NonNull<u8>> {
+    unsafe fn deep_copy(
+        &mut self,
+        regs: MachineRegisters,
+        root: NonNull<u8>,
+    ) -> RuntimeResult<NonNull<u8>> {
         // SAFETY: by this function's contract `root` points to a live object.
         unsafe {
             deep_copy_or_gc(
@@ -2031,10 +2145,10 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 &mut self.read_write_set,
                 &self.root_pool,
                 self.exec_ctx.extensions(),
-                self.frame_ptr,
+                regs.fp,
                 TopFrame::Function {
-                    func: self.current_func,
-                    pc: self.pc,
+                    func: regs.func,
+                    pc: regs.pc,
                 },
                 root,
             )
@@ -2058,6 +2172,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     /// header is at `source - OBJECT_HEADER_SIZE`.
     unsafe fn deep_copy_batch(
         &mut self,
+        regs: MachineRegisters,
         sources: &[NonNull<u8>],
     ) -> RuntimeResult<Vec<NonNull<u8>>> {
         // SAFETY: each source is a live object (caller contract); the handle
@@ -2089,7 +2204,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         if !needs_gc {
             return Ok(out);
         }
-        gc_collect!(self)?;
+        gc_collect!(self, regs.fp, regs.pc, regs.func)?;
         out.clear();
         for guard in &guards {
             // SAFETY: as above, after relocation.
@@ -2128,20 +2243,26 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     ///
     /// # Safety
     ///
-    /// - `fp` is the current frame pointer.
+    /// - `regs.fp` is the current frame pointer.
     /// - Each `op.captured` slot is in-bounds for the current frame (the
     ///   verifier checks this).
     /// - The closure descriptor must list `CLOSURE_CAPTURED_DATA_PTR_OFFSET`
     ///   (relative to the data segment, so `32 - 8 = 24`) in its
     ///   `pointer_offsets`, so GC traces the captured-data pointer after
     ///   the closure is reachable via the frame slot.
-    unsafe fn exec_pack_closure(&mut self, fp: *mut u8, op: &PackClosureOp) -> RuntimeResult<()> {
+    #[inline(never)]
+    unsafe fn exec_pack_closure(
+        &mut self,
+        regs: MachineRegisters,
+        op: &PackClosureOp,
+    ) -> RuntimeResult<()> {
+        let fp = regs.fp;
         unsafe {
             // Fast path: non-capturing closure. Skip the second allocation
             // and leave `captured_data_ptr` as the zeroed/null value written
             // by `alloc_obj`. No pinning needed — only one allocation.
             if op.captured.is_empty() {
-                let closure = alloc_obj!(self, fp, CLOSURE_DESCRIPTOR_ID)?;
+                let closure = alloc_obj!(self, fp, regs.pc, regs.func, CLOSURE_DESCRIPTOR_ID)?;
                 self.write_closure_func_ref_and_mask(closure, op);
                 write_ptr(fp, op.dst, closure);
                 return Ok(());
@@ -2155,7 +2276,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
             // skipped). Rooting keeps the closure live across the second
             // allocation and lets GC update the rooted slot in-place if
             // the object is relocated.
-            let closure_ptr = alloc_obj!(self, fp, CLOSURE_DESCRIPTOR_ID)?;
+            let closure_ptr = alloc_obj!(self, fp, regs.pc, regs.func, CLOSURE_DESCRIPTOR_ID)?;
             // SAFETY: `alloc_obj!` returns a live, freshly-allocated object.
             let closure_root = self.root_pool.root_object(closure_ptr);
 
@@ -2167,7 +2288,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
             let captured_desc_id = op
                 .captured_data_descriptor_id
                 .expect("verifier ensures Some when captured is non-empty");
-            let captured_data = alloc_captured_data!(self, fp, op.values_size, captured_desc_id)?;
+            let captured_data = alloc_captured_data!(
+                self,
+                fp,
+                regs.pc,
+                regs.func,
+                op.values_size,
+                captured_desc_id
+            )?;
             *captured_data.add(CAPTURED_DATA_TAG_OFFSET) = CAPTURED_DATA_TAG_MATERIALIZED;
             // Persist the exact values-region size so `CallClosure` can validate
             // a lazily-resolved callee's captured layout against it; the header
@@ -2250,7 +2378,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     /// # Safety
     ///
     /// - `func` is the currently executing function (caller).
-    /// - `fp` is the current frame pointer.
+    /// - `regs` carries the caller's machine registers.
     /// - `op.closure_src` holds a non-null heap pointer to a valid closure
     ///   object.
     /// - The callee's `param_slots` list has one (offset, size) entry per
@@ -2259,12 +2387,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     /// - The captured values in the captured-data object are packed in
     ///   param order and their sizes match the corresponding `param_slots`
     ///   entries (enforced by `PackClosure`).
+    #[inline(never)]
     unsafe fn exec_call_closure(
         &mut self,
         func: &Function,
-        fp: *mut u8,
+        mut regs: MachineRegisters,
         op: &CallClosureOp,
-    ) -> RuntimeResult<StepResult> {
+    ) -> RuntimeResult<MachineRegisters> {
+        let fp = regs.fp;
         unsafe {
             let closure = read_ptr(fp, op.closure_src);
             if closure.is_null() {
@@ -2449,7 +2579,8 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
             // Standard call protocol: save metadata and switch to the
             // callee frame. Use the unchecked variant — we already
             // validated the stack above.
-            self.call_unchecked(func, fp, callee, new_fp)
+            self.call_unchecked(func, &mut regs, callee, new_fp)?;
+            Ok(regs)
         }
     }
 
@@ -2482,17 +2613,19 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     ///
     /// # Safety
     ///
-    /// `callee` must point to a valid, live `Function`. `fp` must be the
-    /// current frame pointer and `caller` the currently executing function.
+    /// `callee` must point to a valid, live `Function`. `regs` must carry the
+    /// caller's machine registers and `caller` be the currently executing
+    /// function.
     #[inline(always)]
     unsafe fn call(
         &mut self,
         caller: &Function,
-        fp: *mut u8,
+        regs: &mut MachineRegisters,
         callee: &Function,
-    ) -> RuntimeResult<StepResult> {
-        let new_fp = unsafe { self.check_stack_for_call(caller, fp, callee.extended_frame_size)? };
-        unsafe { self.call_unchecked(caller, fp, callee, new_fp) }
+    ) -> RuntimeResult<()> {
+        let new_fp =
+            unsafe { self.check_stack_for_call(caller, regs.fp, callee.extended_frame_size)? };
+        unsafe { self.call_unchecked(caller, regs, callee, new_fp) }
     }
 
     /// Perform the standard call protocol after the caller has already
@@ -2503,7 +2636,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     /// # Safety
     ///
     /// In addition to the contract on [`Self::call`], `new_fp` must equal
-    /// `fp + caller.param_and_local_sizes_sum + FRAME_METADATA_SIZE`, and
+    /// `regs.fp + caller.param_and_local_sizes_sum + FRAME_METADATA_SIZE`, and
     /// `new_fp + callee.extended_frame_size` must be within the stack
     /// (i.e., the caller has already passed the check that
     /// [`Self::check_stack_for_call`] performs).
@@ -2511,10 +2644,10 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     unsafe fn call_unchecked(
         &mut self,
         caller: &Function,
-        fp: *mut u8,
+        regs: &mut MachineRegisters,
         callee: &Function,
         new_fp: *mut u8,
-    ) -> RuntimeResult<StepResult> {
+    ) -> RuntimeResult<()> {
         // Charge the callee's entry block before any of its instructions run.
         self.exec_ctx.gas_meter().charge(callee.entry_gas)?;
         unsafe {
@@ -2526,12 +2659,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 let zero_size = callee.extended_frame_size - callee.param_region_size;
                 std::ptr::write_bytes(new_fp.add(callee.param_region_size), 0, zero_size);
             }
-            self.write_frame_metadata(caller, fp);
-            self.frame_ptr = new_fp;
+            // Save the caller's registers into its frame metadata before
+            // switching `regs` to the callee.
+            self.write_frame_metadata(caller, regs);
         }
-        self.pc = 0;
-        self.current_func = NonNull::from(callee);
-        Ok(StepResult::Continue)
+        regs.fp = new_fp;
+        regs.pc = 0;
+        regs.func = NonNull::from(callee);
+        Ok(())
     }
 
     /// Write the calling-convention frame metadata `(saved_pc, saved_fp,
@@ -2541,18 +2676,18 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     ///
     /// # Safety
     ///
-    /// `caller` must be the currently executing function and `fp` the
-    /// current frame pointer.
+    /// `caller` must be the currently executing function and `regs` must carry the
+    /// caller's machine registers.
     #[inline(always)]
-    unsafe fn write_frame_metadata(&self, caller: &Function, fp: *mut u8) {
+    unsafe fn write_frame_metadata(&self, caller: &Function, regs: &MachineRegisters) {
         unsafe {
-            let meta = fp.add(caller.param_and_local_sizes_sum);
-            write_u64(meta, META_SAVED_PC_OFFSET, (self.pc + 1) as u64);
-            write_ptr(meta, META_SAVED_FP_OFFSET, fp);
+            let meta = regs.fp.add(caller.param_and_local_sizes_sum);
+            write_u64(meta, META_SAVED_PC_OFFSET, (regs.pc + 1) as u64);
+            write_ptr(meta, META_SAVED_FP_OFFSET, regs.fp);
             write_ptr(
                 meta,
                 META_SAVED_FUNC_PTR_OFFSET,
-                self.current_func.as_ptr() as *const u8,
+                regs.func.as_ptr() as *const u8,
             );
         }
     }
@@ -2561,23 +2696,23 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     ///
     /// # Safety
     ///
-    /// `caller` must be the currently executing function and `fp` the
-    /// current frame pointer.
+    /// `caller` must be the currently executing function and `regs` must carry the
+    /// caller's machine registers.
     unsafe fn exec_call_native(
         &mut self,
         caller: &Function,
-        fp: *mut u8,
+        regs: MachineRegisters,
         native_idx: NativeIdx,
         ty_args: InternedTypeList,
         abi: &NativeABI,
-    ) -> RuntimeResult<StepResult> {
+    ) -> RuntimeResult<Option<(u64, Option<String>)>> {
         // Check if we have enough space on the stack to allocate the native's frame.
         let new_fp =
-            unsafe { self.check_stack_for_call(caller, fp, abi.total_frame_size() as usize)? };
+            unsafe { self.check_stack_for_call(caller, regs.fp, abi.total_frame_size() as usize)? };
 
         // Write frame metadata just like normal calls. This is still needed
         // as some natives may want to inspect the call stack.
-        unsafe { self.write_frame_metadata(caller, fp) };
+        unsafe { self.write_frame_metadata(caller, &regs) };
 
         // Zero out return-slot bytes that extend past the args, for extra safety.
         if abi.total_frame_size() > abi.args_end() {
@@ -2590,8 +2725,11 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
             }
         }
 
-        let saved_fp = self.frame_ptr;
-        self.frame_ptr = new_fp;
+        // The native's own allocations scan GC roots from `self.registers.fp`,
+        // so point it at the native frame for the duration of the call, then
+        // restore the caller frame.
+        let saved_fp = regs.fp;
+        self.registers.fp = new_fp;
         let result = {
             let (registry, provider, layouts, resource_provider, gas_meter, extensions) =
                 self.exec_ctx.native_call_borrows();
@@ -2621,35 +2759,14 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
             );
             func(&ctx)
         };
-        self.frame_ptr = saved_fp;
+        self.registers.fp = saved_fp;
 
         match result {
-            Ok(NativeStatus::Success) => {
-                self.pc += 1;
-                Ok(StepResult::Continue)
-            },
-            Ok(NativeStatus::Abort { code, message }) => Ok(StepResult::Aborted { code, message }),
+            // `None` => the caller (`run`) advances the pc past the native call
+            // via the common fall-through tail; `Some` halts with an abort.
+            Ok(NativeStatus::Success) => Ok(None),
+            Ok(NativeStatus::Abort { code, message }) => Ok(Some((code, message))),
             Err(e) => Err(e.into_runtime_error()),
-        }
-    }
-
-    // TODO(perf): Hoist pc, fp, and current_func into local variables in the run loop
-    // instead of reading/writing self.pc, self.frame_ptr, self.current_func each
-    // iteration. LLVM can't keep them in registers because heap operations
-    // (VecPushBack, etc.) take &mut self, which may alias these fields.
-    // Write back only on CallFunc/Return.
-    pub fn run(&mut self) -> RuntimeResult<RuntimeStatus> {
-        // Charge the entry function's entry block before any of its instructions run.
-        let func = unsafe { self.current_func.as_ref() };
-        self.exec_ctx.gas_meter().charge(func.entry_gas)?;
-        loop {
-            match self.step()? {
-                StepResult::Continue => {},
-                StepResult::Done => return Ok(RuntimeStatus::Success),
-                StepResult::Aborted { code, message } => {
-                    return Ok(RuntimeStatus::Aborted { code, message })
-                },
-            }
         }
     }
 }

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -26,6 +26,7 @@ use crate::{
     types::{
         ABORT_MESSAGE_SIZE_LIMIT, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, META_SAVED_FP_OFFSET,
         META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
+        VEC_PUSHBACK_INIT_CAPACITY,
     },
     value_utils, ExecutionContext,
 };
@@ -54,19 +55,35 @@ use std::ptr::{null, NonNull};
 // Runtime state
 // ---------------------------------------------------------------------------
 
-/// The interpreter's machine registers.
+/// The VM's virtual registers.
 ///
-/// It is intended that the dispatch loop copies these into a local copy, which
-/// hopefully gets mapped to real CPU registers.
+/// # Performance note
 ///
-/// Taking references against these registers should be handled with utmost care --
-/// a reference mustn't escape into a non-inlined function, otherwise it may force
-/// the compiler to spill the registers to the stack.
+/// The dispatch loop operates on a local copy that the compiler can hopefully
+/// keep in real CPU registers, writing it back only on entry/exit. A reference
+/// to these must never escape into a non-inlined function, or the compiler may
+/// be forced to spill them to the stack.
 #[derive(Clone, Copy)]
-pub(crate) struct MachineRegisters {
+pub(crate) struct VMRegisters {
+    /// Index of the next instruction to execute within `func`'s code.
     pub(crate) pc: usize,
+    /// Frame pointer of the current call frame.
     pub(crate) fp: *mut u8,
+    /// The function currently executing.
     pub(crate) func: NonNull<Function>,
+}
+
+impl VMRegisters {
+    /// Registers initialized with a fresh root frame, ready to begin execution.
+    fn new(stack_base: *mut u8, func: &Function) -> Self {
+        Self {
+            pc: 0,
+            // SAFETY: `stack_base` points to a stack allocation far larger than
+            // `FRAME_METADATA_SIZE`, so the offset stays in bounds.
+            fp: unsafe { stack_base.add(FRAME_METADATA_SIZE) },
+            func: NonNull::from(func),
+        }
+    }
 }
 
 /// Interpreter context with a unified call stack and a GC-managed heap.
@@ -75,9 +92,9 @@ pub struct InterpreterContext<'a, T: ExecutionContext + DescriptorProvider + Lay
     /// descriptor table, etc.).
     pub(crate) exec_ctx: &'a mut T,
 
-    /// Machine registers at rest. The dispatch loop works on a local copy and
-    /// writes it back here on exit.
-    pub(crate) registers: MachineRegisters,
+    /// The VM registers; the dispatch loop works on a local copy and writes it
+    /// back here on exit.
+    pub(crate) registers: VMRegisters,
 
     pub(crate) stack: MemoryRegion,
     pub(crate) heap: Heap,
@@ -112,7 +129,6 @@ impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterC
 
         let stack = MemoryRegion::new(DEFAULT_STACK_SIZE);
         let base = stack.as_ptr();
-        let frame_ptr = unsafe { base.add(FRAME_METADATA_SIZE) };
 
         unsafe {
             write_u64(base, META_SAVED_PC_OFFSET, 0);
@@ -122,11 +138,7 @@ impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterC
 
         Self {
             exec_ctx,
-            registers: MachineRegisters {
-                pc: 0,
-                fp: frame_ptr,
-                func: NonNull::from(entry),
-            },
+            registers: VMRegisters::new(base, entry),
             stack,
             heap: Heap::new(heap_size),
             root_pool: RootPool::new(),
@@ -205,9 +217,7 @@ impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterC
         let base = self.stack.as_ptr();
 
         // Reset execution state to root frame.
-        self.registers.fp = unsafe { base.add(FRAME_METADATA_SIZE) };
-        self.registers.pc = 0;
-        self.registers.func = NonNull::from(func);
+        self.registers = VMRegisters::new(base, func);
 
         // Re-write sentinel metadata so Return from root triggers Done.
         unsafe {
@@ -862,7 +872,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         target: CodeOffset,
         gas_taken: u64,
         gas_fallthrough: u64,
-        regs: &mut MachineRegisters,
+        regs: &mut VMRegisters,
     ) -> RuntimeResult<()> {
         if cond {
             self.exec_ctx.gas_meter().charge(gas_taken)?;
@@ -874,12 +884,8 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         Ok(())
     }
 
-    // TEMP(review): `#[rustfmt::skip]` keeps `run`'s body at the pre-fold
-    // indentation so the diff shows only real changes. Remove before landing
-    // (then `cargo +nightly fmt` re-indents the loop body).
-    #[rustfmt::skip]
     pub fn run(&mut self) -> RuntimeResult<RuntimeStatus> {
-        // Hoist the machine registers into a local so the dispatch loop keeps
+        // Hoist the VM registers into a local so the dispatch loop keeps
         // them in CPU registers rather than reloading from `self.registers`
         // each iteration. Only sync back to `self` on exit.
         let mut regs = self.registers;
@@ -915,1092 +921,1099 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 // common sequences like load+compare+branch), threaded/computed-goto
                 // dispatch, and copy-and-patch JIT.
                 match *instr {
-                // ----- Control flow (set pc explicitly, return early) -----
-                MicroOp::CallIndirect {
-                    module_id,
-                    func_name,
-                    ty_args,
-                } => {
-                    // TODO(perf): full flow should be like this:
-                    //
-                    //   1. IC lookup:
-                    //      - Hit:  return pointer,
-                    //      - Miss: goto 2.
-                    //   2. target = load_function(...)
-                    //   3. IC insert target
-                    //   4. Patching:
-                    //      If can patch caller, try it.
-                    let target = self
-                        .exec_ctx
-                        .load_function(module_id, func_name, ty_args)
-                        .map_err(RuntimeError::Loader)?;
-                    // SAFETY: `target` points to a `Function`, which is not reclaimed during
-                    // execution as guaranteed by the execution guard.
-                    self.call(func, &mut regs, target.as_ref_unchecked())?;
-                    continue;
-                },
-                MicroOp::CallDirect { ptr } => {
-                    self.call(func, &mut regs, ptr.as_ref_unchecked())?;
-                    continue;
-                },
+                    // ----- Control flow (set pc explicitly, return early) -----
+                    MicroOp::CallIndirect {
+                        module_id,
+                        func_name,
+                        ty_args,
+                    } => {
+                        // TODO(perf): full flow should be like this:
+                        //
+                        //   1. IC lookup:
+                        //      - Hit:  return pointer,
+                        //      - Miss: goto 2.
+                        //   2. target = load_function(...)
+                        //   3. IC insert target
+                        //   4. Patching:
+                        //      If can patch caller, try it.
+                        let target = self
+                            .exec_ctx
+                            .load_function(module_id, func_name, ty_args)
+                            .map_err(RuntimeError::Loader)?;
+                        // SAFETY: `target` points to a `Function`, which is not reclaimed during
+                        // execution as guaranteed by the execution guard.
+                        self.call(func, &mut regs, target.as_ref_unchecked())?;
+                        continue;
+                    },
+                    MicroOp::CallDirect { ptr } => {
+                        self.call(func, &mut regs, ptr.as_ref_unchecked())?;
+                        continue;
+                    },
 
-                MicroOp::CallNative {
-                    native_idx,
-                    ty_args,
-                    ref abi,
-                } => {
-                    // On abort, halt; otherwise native success falls through to
-                    // the common tail, which advances the pc by one.
-                    if let Some((code, message)) =
-                        self.exec_call_native(func, regs, native_idx, ty_args, abi)?
-                    {
-                        break RuntimeStatus::Aborted { code, message };
-                    }
-                },
-
-                MicroOp::JumpNotZeroU64 {
-                    target,
-                    src,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    self.cond_branch(
-                        read_u64(fp, src) != 0,
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpNotZeroByte {
-                    target,
-                    src,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    // Read as `u8` only to test against zero; the byte's sign is
-                    // irrelevant.
-                    self.cond_branch(
-                        read_u8(fp, src) != 0,
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpZeroByte {
-                    target,
-                    src,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    // Read as `u8` only to test against zero; the byte's sign is
-                    // irrelevant.
-                    self.cond_branch(
-                        read_u8(fp, src) == 0,
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpIntCmp(ref op) => {
-                    self.cond_branch(
-                        int_cmp_bool(fp, op.lhs, op.op, &op.rhs),
-                        op.target,
-                        op.gas_taken,
-                        op.gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpValueCmp(ref op) => {
-                    // Operands are the aggregate values at their slots; a
-                    // vector slot holds a pointer read through to its heap data.
-                    let a = fp.add(op.lhs.into());
-                    let b = fp.add(op.rhs.into());
-                    let eq = value_utils::equals(self.exec_ctx, a, b, op.ty)?;
-                    self.cond_branch(
-                        eq ^ op.negate,
-                        op.target,
-                        op.gas_taken,
-                        op.gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpValueRefCmp(ref op) => {
-                    // Operands are references; read through the fat pointers to
-                    // obtain the operand data pointers.
-                    let (lb, lo) = read_fat_ptr(fp, op.lhs);
-                    let (rb, ro) = read_fat_ptr(fp, op.rhs);
-                    let eq = value_utils::equals(
-                        self.exec_ctx,
-                        lb.add(lo as usize),
-                        rb.add(ro as usize),
-                        op.ty,
-                    )?;
-                    self.cond_branch(
-                        eq ^ op.negate,
-                        op.target,
-                        op.gas_taken,
-                        op.gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpGreaterEqualU64Imm {
-                    target,
-                    src,
-                    imm,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    self.cond_branch(
-                        read_u64(fp, src) >= imm,
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpLessU64Imm {
-                    target,
-                    src,
-                    imm,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    self.cond_branch(
-                        read_u64(fp, src) < imm,
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpGreaterU64Imm {
-                    target,
-                    src,
-                    imm,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    self.cond_branch(
-                        read_u64(fp, src) > imm,
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpLessEqualU64Imm {
-                    target,
-                    src,
-                    imm,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    self.cond_branch(
-                        read_u64(fp, src) <= imm,
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpLessU64 {
-                    target,
-                    lhs,
-                    rhs,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    self.cond_branch(
-                        read_u64(fp, lhs) < read_u64(fp, rhs),
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpGreaterEqualU64 {
-                    target,
-                    lhs,
-                    rhs,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    self.cond_branch(
-                        read_u64(fp, lhs) >= read_u64(fp, rhs),
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::JumpNotEqualU64 {
-                    target,
-                    lhs,
-                    rhs,
-                    gas_taken,
-                    gas_fallthrough,
-                } => {
-                    self.cond_branch(
-                        read_u64(fp, lhs) != read_u64(fp, rhs),
-                        target,
-                        gas_taken,
-                        gas_fallthrough,
-                        &mut regs,
-                    )?;
-                    continue;
-                },
-
-                MicroOp::Jump { target, gas } => {
-                    self.exec_ctx.gas_meter().charge(gas)?;
-                    regs.pc = target.into();
-                    continue;
-                },
-
-                MicroOp::Return => {
-                    let meta = fp.sub(FRAME_METADATA_SIZE);
-
-                    let saved_func_ptr =
-                        read_ptr(meta, META_SAVED_FUNC_PTR_OFFSET) as *const Function;
-                    if saved_func_ptr.is_null() {
-                        break RuntimeStatus::Success;
-                    }
-                    // SAFETY: We have just checked that the saved function
-                    // pointer is non-null.
-                    regs.func = NonNull::new_unchecked(saved_func_ptr as *mut Function);
-
-                    regs.pc = read_u64(meta, META_SAVED_PC_OFFSET) as usize;
-                    regs.fp = read_ptr(meta, META_SAVED_FP_OFFSET);
-                    continue;
-                },
-
-                MicroOp::Abort { code } => {
-                    let code = read_u64(fp, code);
-                    break RuntimeStatus::Aborted {
-                        code,
-                        message: None,
-                    };
-                },
-
-                MicroOp::AbortMsg { code, message } => {
-                    let code = read_u64(fp, code);
-                    let vec_ptr = read_ptr(fp, message);
-                    let len = read_vec_len(vec_ptr) as usize;
-                    let message = if len == 0 {
-                        String::new()
-                    } else {
-                        // TODO(metering): charge gas for abort message bytes.
-                        if len > ABORT_MESSAGE_SIZE_LIMIT {
-                            return Err(RuntimeError::AbortMessageTooLong {
-                                len,
-                                max: ABORT_MESSAGE_SIZE_LIMIT,
-                            });
+                    MicroOp::CallNative {
+                        native_idx,
+                        ty_args,
+                        ref abi,
+                    } => {
+                        // On abort, halt; otherwise native success falls through to
+                        // the common tail, which advances the pc by one.
+                        if let Some((code, message)) =
+                            self.exec_call_native(func, regs, native_idx, ty_args, abi)?
+                        {
+                            break RuntimeStatus::Aborted { code, message };
                         }
-                        // SAFETY: `vec_ptr` is non-null for non-zero lengths
-                        // and points at a heap vector with `len` initialized
-                        // bytes at `VEC_DATA_OFFSET`.
-                        let data = vec_ptr.add(VEC_DATA_OFFSET);
-                        String::from_utf8(std::slice::from_raw_parts(data, len).to_vec())
-                            .map_err(|_| RuntimeError::InvalidAbortMessage)?
-                    };
-                    break RuntimeStatus::Aborted {
-                        code,
-                        message: Some(message),
-                    };
-                },
+                    },
 
-                // ----- Arithmetic -----
-                MicroOp::StoreImm1 { dst, imm } => write_u8(fp, dst, imm),
-                MicroOp::StoreImm2 { dst, ref imm } => write_int::<[u8; 2]>(fp, dst, *imm),
-                MicroOp::StoreImm4 { dst, ref imm } => write_int::<[u8; 4]>(fp, dst, *imm),
-                MicroOp::StoreImm8 { dst, ref imm } => write_int::<[u8; 8]>(fp, dst, *imm),
-                MicroOp::StoreImm16 { dst, ref imm } => write_int::<[u8; 16]>(fp, dst, **imm),
-                MicroOp::StoreImm32 { dst, ref imm } => write_int::<[u8; 32]>(fp, dst, **imm),
-                MicroOp::StoreImmVec { dst, idx } => {
-                    self.exec_store_imm_vec(regs, dst, idx)?;
-                },
-
-                // Add
-                MicroOp::AddU64 { dst, lhs, rhs } => {
-                    checked_binop_u64(fp, dst, lhs, rhs, u64::checked_add).ok_or_else(|| {
-                        RuntimeError::ArithmeticOverflow {
-                            op: ArithOp::Add,
-                            ty: IntTy::U64,
-                        }
-                    })?
-                },
-                MicroOp::AddU64Imm { dst, src, imm } => {
-                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_add).ok_or_else(
-                        || RuntimeError::ArithmeticOverflow {
-                            op: ArithOp::Add,
-                            ty: IntTy::U64,
-                        },
-                    )?
-                },
-
-                // Sub
-                MicroOp::SubU64 { dst, lhs, rhs } => {
-                    checked_binop_u64(fp, dst, lhs, rhs, u64::checked_sub).ok_or_else(|| {
-                        RuntimeError::ArithmeticUnderflow {
-                            op: ArithOp::Sub,
-                            ty: IntTy::U64,
-                        }
-                    })?
-                },
-                MicroOp::SubU64Imm { dst, src, imm } => {
-                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_sub).ok_or_else(
-                        || RuntimeError::ArithmeticUnderflow {
-                            op: ArithOp::Sub,
-                            ty: IntTy::U64,
-                        },
-                    )?
-                },
-                // dst = imm - src, so flip the operand order.
-                MicroOp::RSubU64Imm { dst, src, imm } => {
-                    checked_imm_op_u64(fp, dst, src, imm, |s, i| u64::checked_sub(i, s))
-                        .ok_or_else(|| RuntimeError::ArithmeticUnderflow {
-                            op: ArithOp::Sub,
-                            ty: IntTy::U64,
-                        })?
-                },
-
-                // Mul
-                MicroOp::MulU64 { dst, lhs, rhs } => {
-                    checked_binop_u64(fp, dst, lhs, rhs, u64::checked_mul).ok_or_else(|| {
-                        RuntimeError::ArithmeticOverflow {
-                            op: ArithOp::Mul,
-                            ty: IntTy::U64,
-                        }
-                    })?
-                },
-                MicroOp::MulU64Imm { dst, src, imm } => {
-                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_mul).ok_or_else(
-                        || RuntimeError::ArithmeticOverflow {
-                            op: ArithOp::Mul,
-                            ty: IntTy::U64,
-                        },
-                    )?
-                },
-
-                // Div / Mod
-                MicroOp::DivU64 { dst, lhs, rhs } => {
-                    checked_binop_u64(fp, dst, lhs, rhs, u64::checked_div).ok_or_else(|| {
-                        RuntimeError::DivisionByZero {
-                            op: ArithOp::Div,
-                            ty: IntTy::U64,
-                        }
-                    })?
-                },
-                // INVARIANT: the verifier rejects `imm == 0`, so plain `s / imm`
-                // cannot trigger Rust's div-by-zero panic. Asserted below in
-                // debug builds as a defensive check.
-                MicroOp::DivU64Imm { dst, src, imm } => {
-                    debug_assert!(
-                        imm != 0,
-                        "DivU64Imm: imm must be non-zero (verifier invariant)"
-                    );
-                    imm_op_u64(fp, dst, src, imm, |s, i| s / i)
-                },
-                MicroOp::ModU64 { dst, lhs, rhs } => {
-                    checked_binop_u64(fp, dst, lhs, rhs, u64::checked_rem).ok_or_else(|| {
-                        RuntimeError::DivisionByZero {
-                            op: ArithOp::Mod,
-                            ty: IntTy::U64,
-                        }
-                    })?
-                },
-                // INVARIANT: the verifier rejects `imm == 0`, so plain `s % imm`
-                // cannot trigger Rust's div-by-zero panic. Asserted below in
-                // debug builds as a defensive check.
-                MicroOp::ModU64Imm { dst, src, imm } => {
-                    debug_assert!(
-                        imm != 0,
-                        "ModU64Imm: imm must be non-zero (verifier invariant)"
-                    );
-                    imm_op_u64(fp, dst, src, imm, |s, i| s % i)
-                },
-
-                // Bitwise (infallible)
-                MicroOp::BitAndU64 { dst, lhs, rhs } => {
-                    binop_u64(fp, dst, lhs, rhs, |a, b| a & b)
-                },
-                MicroOp::BitOrU64 { dst, lhs, rhs } => {
-                    binop_u64(fp, dst, lhs, rhs, |a, b| a | b)
-                },
-                MicroOp::BitXorU64 { dst, lhs, rhs } => {
-                    binop_u64(fp, dst, lhs, rhs, |a, b| a ^ b)
-                },
-
-                // Shifts
-                MicroOp::ShlU64 { dst, lhs, rhs } => shift_u64(fp, dst, lhs, rhs, |v, s| {
-                    v << s
-                })
-                .map_err(|shift_amount| RuntimeError::ShiftAmountOutOfRange {
-                    op: ArithOp::Shl,
-                    ty: IntTy::U64,
-                    shift_amount,
-                    bit_width: 64,
-                })?,
-                // INVARIANT: the verifier rejects `imm >= 64`, so plain `s << imm`
-                // cannot wrap or trigger UB. Asserted below in debug builds as a
-                // defensive check.
-                MicroOp::ShlU64Imm { dst, src, imm } => {
-                    debug_assert!(imm < 64, "ShlU64Imm: imm must be < 64 (verifier invariant)");
-                    imm_op_u64(fp, dst, src, imm as u64, |s, i| s << i)
-                },
-                MicroOp::ShrU64 { dst, lhs, rhs } => shift_u64(fp, dst, lhs, rhs, |v, s| {
-                    v >> s
-                })
-                .map_err(|shift_amount| RuntimeError::ShiftAmountOutOfRange {
-                    op: ArithOp::Shr,
-                    ty: IntTy::U64,
-                    shift_amount,
-                    bit_width: 64,
-                })?,
-                // INVARIANT: the verifier rejects `imm >= 64`, so plain `s >> imm`
-                // cannot wrap or trigger UB. Asserted below in debug builds as a
-                // defensive check.
-                MicroOp::ShrU64Imm { dst, src, imm } => {
-                    debug_assert!(imm < 64, "ShrU64Imm: imm must be < 64 (verifier invariant)");
-                    imm_op_u64(fp, dst, src, imm as u64, |s, i| s >> i)
-                },
-
-                MicroOp::StoreRandomU64 { dst } => {
-                    let val: u64 = self.rng.r#gen();
-                    write_u64(fp, dst, val);
-                },
-
-                MicroOp::ForceGC => {
-                    gc_collect!(self, regs.fp, regs.pc, regs.func)?;
-                },
-
-                MicroOp::Move8 { dst, src } => {
-                    let v = read_u64(fp, src);
-                    write_u64(fp, dst, v);
-                },
-
-                MicroOp::Move { dst, src, size } => {
-                    // TODO(perf): consider adding a provably non-overlapping variant of this op.
-                    // Overlap-safe `copy`: `dst` and `src` may partially overlap.
-                    // E.g. the return-value shuffle may move results in the same home region.
-                    std::ptr::copy(fp.add(src.into()), fp.add(dst.into()), size as usize);
-                },
-
-                // ----- Vector instructions -----
-                MicroOp::VecNew { dst } => {
-                    write_ptr(fp, dst, std::ptr::null());
-                },
-
-                MicroOp::VecLen { dst, vec_ref } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
-                    let vec_ptr = read_ptr(ref_base, ref_off as usize);
-                    let len = read_vec_len(vec_ptr);
-                    write_u64(fp, dst, len);
-                },
-
-                MicroOp::VecPushBack {
-                    vec_ref,
-                    elem,
-                    elem_size,
-                    descriptor_id,
-                } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
-                    let mut vec_ptr = read_ptr(ref_base, ref_off as usize);
-
-                    if vec_ptr.is_null() {
-                        vec_ptr =
-                            alloc_vec!(self, fp, regs.pc, regs.func, descriptor_id, elem_size, 4)?;
-                        // Re-read base after potential GC.
-                        let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
-                        write_ptr(ref_base, ref_off as usize, vec_ptr);
-                    }
-
-                    let len = read_vec_len(vec_ptr);
-                    let total = read_obj_size(vec_ptr) as usize;
-                    let cap_in_elems = ((total - OBJECT_HEADER_SIZE - VEC_DATA_OFFSET)
-                        / elem_size as usize) as u64;
-
-                    if len >= cap_in_elems {
-                        vec_ptr = grow_vec_ref!(
-                            self,
-                            fp,
-                            regs.pc,
-                            regs.func,
-                            vec_ref.into(),
-                            elem_size,
-                            len + 1
+                    MicroOp::JumpNotZeroU64 {
+                        target,
+                        src,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        self.cond_branch(
+                            read_u64(fp, src) != 0,
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
                         )?;
-                    }
+                        continue;
+                    },
 
-                    std::ptr::copy_nonoverlapping(
-                        fp.add(elem.into()),
-                        vec_elem_ptr(vec_ptr, len, elem_size) as *mut u8,
-                        elem_size as usize,
-                    );
-                    write_u64(vec_ptr, VEC_LENGTH_OFFSET, len + 1);
-                },
+                    MicroOp::JumpNotZeroByte {
+                        target,
+                        src,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        // Read as `u8` only to test against zero; the byte's sign is
+                        // irrelevant.
+                        self.cond_branch(
+                            read_u8(fp, src) != 0,
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
 
-                MicroOp::VecPopBack {
-                    dst,
-                    vec_ref,
-                    elem_size,
-                } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
-                    let vec_ptr = read_ptr(ref_base, ref_off as usize);
-                    let len = read_vec_len(vec_ptr);
-                    if len == 0 {
-                        return Err(RuntimeError::PopFromEmptyVector);
-                    }
-                    let new_len = len - 1;
-                    std::ptr::copy_nonoverlapping(
-                        vec_elem_ptr(vec_ptr, new_len, elem_size),
-                        fp.add(dst.into()),
-                        elem_size as usize,
-                    );
-                    write_u64(vec_ptr, VEC_LENGTH_OFFSET, new_len);
-                },
+                    MicroOp::JumpZeroByte {
+                        target,
+                        src,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        // Read as `u8` only to test against zero; the byte's sign is
+                        // irrelevant.
+                        self.cond_branch(
+                            read_u8(fp, src) == 0,
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
 
-                MicroOp::VecLoadElem {
-                    dst,
-                    vec_ref,
-                    idx,
-                    elem_size,
-                } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
-                    let vec_ptr = read_ptr(ref_base, ref_off as usize);
-                    let idx = read_u64(fp, idx);
-                    let len = read_vec_len(vec_ptr);
-                    if idx >= len {
-                        return Err(RuntimeError::VectorIndexOutOfBounds {
-                            op: VecOp::LoadElem,
-                            idx,
-                            len,
-                        });
-                    }
-                    std::ptr::copy_nonoverlapping(
-                        vec_elem_ptr(vec_ptr, idx, elem_size),
-                        fp.add(dst.into()),
-                        elem_size as usize,
-                    );
-                },
+                    MicroOp::JumpIntCmp(ref op) => {
+                        self.cond_branch(
+                            int_cmp_bool(fp, op.lhs, op.op, &op.rhs),
+                            op.target,
+                            op.gas_taken,
+                            op.gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
 
-                MicroOp::VecStoreElem {
-                    vec_ref,
-                    idx,
-                    src,
-                    elem_size,
-                } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
-                    let vec_ptr = read_ptr(ref_base, ref_off as usize);
-                    let idx = read_u64(fp, idx);
-                    let len = read_vec_len(vec_ptr);
-                    if idx >= len {
-                        return Err(RuntimeError::VectorIndexOutOfBounds {
-                            op: VecOp::StoreElem,
-                            idx,
-                            len,
-                        });
-                    }
-                    std::ptr::copy_nonoverlapping(
-                        fp.add(src.into()),
-                        vec_elem_ptr(vec_ptr, idx, elem_size) as *mut u8,
-                        elem_size as usize,
-                    );
-                },
+                    MicroOp::JumpValueCmp(ref op) => {
+                        // Operands are the aggregate values at their slots; a
+                        // vector slot holds a pointer read through to its heap data.
+                        let a = fp.add(op.lhs.into());
+                        let b = fp.add(op.rhs.into());
+                        let eq = value_utils::equals(self.exec_ctx, a, b, op.ty)?;
+                        self.cond_branch(
+                            eq ^ op.negate,
+                            op.target,
+                            op.gas_taken,
+                            op.gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
 
-                MicroOp::VecPack(ref op) => {
-                    self.exec_vec_pack(regs, op)?;
-                },
+                    MicroOp::JumpValueRefCmp(ref op) => {
+                        // Operands are references; read through the fat pointers to
+                        // obtain the operand data pointers.
+                        let (lb, lo) = read_fat_ptr(fp, op.lhs);
+                        let (rb, ro) = read_fat_ptr(fp, op.rhs);
+                        let eq = value_utils::equals(
+                            self.exec_ctx,
+                            lb.add(lo as usize),
+                            rb.add(ro as usize),
+                            op.ty,
+                        )?;
+                        self.cond_branch(
+                            eq ^ op.negate,
+                            op.target,
+                            op.gas_taken,
+                            op.gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
 
-                MicroOp::VecUnpack(ref op) => {
-                    self.exec_vec_unpack(fp, op)?;
-                },
+                    MicroOp::JumpGreaterEqualU64Imm {
+                        target,
+                        src,
+                        imm,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        self.cond_branch(
+                            read_u64(fp, src) >= imm,
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
 
-                MicroOp::VecSwap {
-                    vec_ref,
-                    idx_a,
-                    idx_b,
-                    elem_size,
-                } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
-                    let vec_ptr = read_ptr(ref_base, ref_off as usize);
-                    let idx_a = read_u64(fp, idx_a);
-                    let idx_b = read_u64(fp, idx_b);
-                    let len = read_vec_len(vec_ptr);
-                    // Indices are checked before the equal-indices no-op.
-                    for idx in [idx_a, idx_b] {
+                    MicroOp::JumpLessU64Imm {
+                        target,
+                        src,
+                        imm,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        self.cond_branch(
+                            read_u64(fp, src) < imm,
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
+
+                    MicroOp::JumpGreaterU64Imm {
+                        target,
+                        src,
+                        imm,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        self.cond_branch(
+                            read_u64(fp, src) > imm,
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
+
+                    MicroOp::JumpLessEqualU64Imm {
+                        target,
+                        src,
+                        imm,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        self.cond_branch(
+                            read_u64(fp, src) <= imm,
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
+
+                    MicroOp::JumpLessU64 {
+                        target,
+                        lhs,
+                        rhs,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        self.cond_branch(
+                            read_u64(fp, lhs) < read_u64(fp, rhs),
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
+
+                    MicroOp::JumpGreaterEqualU64 {
+                        target,
+                        lhs,
+                        rhs,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        self.cond_branch(
+                            read_u64(fp, lhs) >= read_u64(fp, rhs),
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
+
+                    MicroOp::JumpNotEqualU64 {
+                        target,
+                        lhs,
+                        rhs,
+                        gas_taken,
+                        gas_fallthrough,
+                    } => {
+                        self.cond_branch(
+                            read_u64(fp, lhs) != read_u64(fp, rhs),
+                            target,
+                            gas_taken,
+                            gas_fallthrough,
+                            &mut regs,
+                        )?;
+                        continue;
+                    },
+
+                    MicroOp::Jump { target, gas } => {
+                        self.exec_ctx.gas_meter().charge(gas)?;
+                        regs.pc = target.into();
+                        continue;
+                    },
+
+                    MicroOp::Return => {
+                        let meta = fp.sub(FRAME_METADATA_SIZE);
+
+                        let saved_func_ptr =
+                            read_ptr(meta, META_SAVED_FUNC_PTR_OFFSET) as *const Function;
+                        if saved_func_ptr.is_null() {
+                            break RuntimeStatus::Success;
+                        }
+                        // SAFETY: We have just checked that the saved function
+                        // pointer is non-null.
+                        regs.func = NonNull::new_unchecked(saved_func_ptr as *mut Function);
+
+                        regs.pc = read_u64(meta, META_SAVED_PC_OFFSET) as usize;
+                        regs.fp = read_ptr(meta, META_SAVED_FP_OFFSET);
+                        continue;
+                    },
+
+                    MicroOp::Abort { code } => {
+                        let code = read_u64(fp, code);
+                        break RuntimeStatus::Aborted {
+                            code,
+                            message: None,
+                        };
+                    },
+
+                    MicroOp::AbortMsg { code, message } => {
+                        let code = read_u64(fp, code);
+                        let vec_ptr = read_ptr(fp, message);
+                        let len = read_vec_len(vec_ptr) as usize;
+                        let message = if len == 0 {
+                            String::new()
+                        } else {
+                            // TODO(metering): charge gas for abort message bytes.
+                            if len > ABORT_MESSAGE_SIZE_LIMIT {
+                                return Err(RuntimeError::AbortMessageTooLong {
+                                    len,
+                                    max: ABORT_MESSAGE_SIZE_LIMIT,
+                                });
+                            }
+                            // SAFETY: `vec_ptr` is non-null for non-zero lengths
+                            // and points at a heap vector with `len` initialized
+                            // bytes at `VEC_DATA_OFFSET`.
+                            let data = vec_ptr.add(VEC_DATA_OFFSET);
+                            String::from_utf8(std::slice::from_raw_parts(data, len).to_vec())
+                                .map_err(|_| RuntimeError::InvalidAbortMessage)?
+                        };
+                        break RuntimeStatus::Aborted {
+                            code,
+                            message: Some(message),
+                        };
+                    },
+
+                    // ----- Arithmetic -----
+                    MicroOp::StoreImm1 { dst, imm } => write_u8(fp, dst, imm),
+                    MicroOp::StoreImm2 { dst, ref imm } => write_int::<[u8; 2]>(fp, dst, *imm),
+                    MicroOp::StoreImm4 { dst, ref imm } => write_int::<[u8; 4]>(fp, dst, *imm),
+                    MicroOp::StoreImm8 { dst, ref imm } => write_int::<[u8; 8]>(fp, dst, *imm),
+                    MicroOp::StoreImm16 { dst, ref imm } => write_int::<[u8; 16]>(fp, dst, **imm),
+                    MicroOp::StoreImm32 { dst, ref imm } => write_int::<[u8; 32]>(fp, dst, **imm),
+                    MicroOp::StoreImmVec { dst, idx } => {
+                        self.exec_store_imm_vec(regs, dst, idx)?;
+                    },
+
+                    // Add
+                    MicroOp::AddU64 { dst, lhs, rhs } => {
+                        checked_binop_u64(fp, dst, lhs, rhs, u64::checked_add).ok_or_else(|| {
+                            RuntimeError::ArithmeticOverflow {
+                                op: ArithOp::Add,
+                                ty: IntTy::U64,
+                            }
+                        })?
+                    },
+                    MicroOp::AddU64Imm { dst, src, imm } => {
+                        checked_imm_op_u64(fp, dst, src, imm, u64::checked_add).ok_or_else(
+                            || RuntimeError::ArithmeticOverflow {
+                                op: ArithOp::Add,
+                                ty: IntTy::U64,
+                            },
+                        )?
+                    },
+
+                    // Sub
+                    MicroOp::SubU64 { dst, lhs, rhs } => {
+                        checked_binop_u64(fp, dst, lhs, rhs, u64::checked_sub).ok_or_else(|| {
+                            RuntimeError::ArithmeticUnderflow {
+                                op: ArithOp::Sub,
+                                ty: IntTy::U64,
+                            }
+                        })?
+                    },
+                    MicroOp::SubU64Imm { dst, src, imm } => {
+                        checked_imm_op_u64(fp, dst, src, imm, u64::checked_sub).ok_or_else(
+                            || RuntimeError::ArithmeticUnderflow {
+                                op: ArithOp::Sub,
+                                ty: IntTy::U64,
+                            },
+                        )?
+                    },
+                    // dst = imm - src, so flip the operand order.
+                    MicroOp::RSubU64Imm { dst, src, imm } => {
+                        checked_imm_op_u64(fp, dst, src, imm, |s, i| u64::checked_sub(i, s))
+                            .ok_or_else(|| RuntimeError::ArithmeticUnderflow {
+                                op: ArithOp::Sub,
+                                ty: IntTy::U64,
+                            })?
+                    },
+
+                    // Mul
+                    MicroOp::MulU64 { dst, lhs, rhs } => {
+                        checked_binop_u64(fp, dst, lhs, rhs, u64::checked_mul).ok_or_else(|| {
+                            RuntimeError::ArithmeticOverflow {
+                                op: ArithOp::Mul,
+                                ty: IntTy::U64,
+                            }
+                        })?
+                    },
+                    MicroOp::MulU64Imm { dst, src, imm } => {
+                        checked_imm_op_u64(fp, dst, src, imm, u64::checked_mul).ok_or_else(
+                            || RuntimeError::ArithmeticOverflow {
+                                op: ArithOp::Mul,
+                                ty: IntTy::U64,
+                            },
+                        )?
+                    },
+
+                    // Div / Mod
+                    MicroOp::DivU64 { dst, lhs, rhs } => {
+                        checked_binop_u64(fp, dst, lhs, rhs, u64::checked_div).ok_or_else(|| {
+                            RuntimeError::DivisionByZero {
+                                op: ArithOp::Div,
+                                ty: IntTy::U64,
+                            }
+                        })?
+                    },
+                    // INVARIANT: the verifier rejects `imm == 0`, so plain `s / imm`
+                    // cannot trigger Rust's div-by-zero panic. Asserted below in
+                    // debug builds as a defensive check.
+                    MicroOp::DivU64Imm { dst, src, imm } => {
+                        debug_assert!(
+                            imm != 0,
+                            "DivU64Imm: imm must be non-zero (verifier invariant)"
+                        );
+                        imm_op_u64(fp, dst, src, imm, |s, i| s / i)
+                    },
+                    MicroOp::ModU64 { dst, lhs, rhs } => {
+                        checked_binop_u64(fp, dst, lhs, rhs, u64::checked_rem).ok_or_else(|| {
+                            RuntimeError::DivisionByZero {
+                                op: ArithOp::Mod,
+                                ty: IntTy::U64,
+                            }
+                        })?
+                    },
+                    // INVARIANT: the verifier rejects `imm == 0`, so plain `s % imm`
+                    // cannot trigger Rust's div-by-zero panic. Asserted below in
+                    // debug builds as a defensive check.
+                    MicroOp::ModU64Imm { dst, src, imm } => {
+                        debug_assert!(
+                            imm != 0,
+                            "ModU64Imm: imm must be non-zero (verifier invariant)"
+                        );
+                        imm_op_u64(fp, dst, src, imm, |s, i| s % i)
+                    },
+
+                    // Bitwise (infallible)
+                    MicroOp::BitAndU64 { dst, lhs, rhs } => {
+                        binop_u64(fp, dst, lhs, rhs, |a, b| a & b)
+                    },
+                    MicroOp::BitOrU64 { dst, lhs, rhs } => {
+                        binop_u64(fp, dst, lhs, rhs, |a, b| a | b)
+                    },
+                    MicroOp::BitXorU64 { dst, lhs, rhs } => {
+                        binop_u64(fp, dst, lhs, rhs, |a, b| a ^ b)
+                    },
+
+                    // Shifts
+                    MicroOp::ShlU64 { dst, lhs, rhs } => shift_u64(fp, dst, lhs, rhs, |v, s| {
+                        v << s
+                    })
+                    .map_err(|shift_amount| RuntimeError::ShiftAmountOutOfRange {
+                        op: ArithOp::Shl,
+                        ty: IntTy::U64,
+                        shift_amount,
+                        bit_width: 64,
+                    })?,
+                    // INVARIANT: the verifier rejects `imm >= 64`, so plain `s << imm`
+                    // cannot wrap or trigger UB. Asserted below in debug builds as a
+                    // defensive check.
+                    MicroOp::ShlU64Imm { dst, src, imm } => {
+                        debug_assert!(imm < 64, "ShlU64Imm: imm must be < 64 (verifier invariant)");
+                        imm_op_u64(fp, dst, src, imm as u64, |s, i| s << i)
+                    },
+                    MicroOp::ShrU64 { dst, lhs, rhs } => shift_u64(fp, dst, lhs, rhs, |v, s| {
+                        v >> s
+                    })
+                    .map_err(|shift_amount| RuntimeError::ShiftAmountOutOfRange {
+                        op: ArithOp::Shr,
+                        ty: IntTy::U64,
+                        shift_amount,
+                        bit_width: 64,
+                    })?,
+                    // INVARIANT: the verifier rejects `imm >= 64`, so plain `s >> imm`
+                    // cannot wrap or trigger UB. Asserted below in debug builds as a
+                    // defensive check.
+                    MicroOp::ShrU64Imm { dst, src, imm } => {
+                        debug_assert!(imm < 64, "ShrU64Imm: imm must be < 64 (verifier invariant)");
+                        imm_op_u64(fp, dst, src, imm as u64, |s, i| s >> i)
+                    },
+
+                    MicroOp::StoreRandomU64 { dst } => {
+                        let val: u64 = self.rng.r#gen();
+                        write_u64(fp, dst, val);
+                    },
+
+                    MicroOp::ForceGC => {
+                        gc_collect!(self, regs.fp, regs.pc, regs.func)?;
+                    },
+
+                    MicroOp::Move8 { dst, src } => {
+                        let v = read_u64(fp, src);
+                        write_u64(fp, dst, v);
+                    },
+
+                    MicroOp::Move { dst, src, size } => {
+                        // TODO(perf): consider adding a provably non-overlapping variant of this op.
+                        // Overlap-safe `copy`: `dst` and `src` may partially overlap.
+                        // E.g. the return-value shuffle may move results in the same home region.
+                        std::ptr::copy(fp.add(src.into()), fp.add(dst.into()), size as usize);
+                    },
+
+                    // ----- Vector instructions -----
+                    MicroOp::VecNew { dst } => {
+                        write_ptr(fp, dst, std::ptr::null());
+                    },
+
+                    MicroOp::VecLen { dst, vec_ref } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                        let vec_ptr = read_ptr(ref_base, ref_off as usize);
+                        let len = read_vec_len(vec_ptr);
+                        write_u64(fp, dst, len);
+                    },
+
+                    MicroOp::VecPushBack {
+                        vec_ref,
+                        elem,
+                        elem_size,
+                        descriptor_id,
+                    } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                        let mut vec_ptr = read_ptr(ref_base, ref_off as usize);
+
+                        if vec_ptr.is_null() {
+                            vec_ptr = alloc_vec!(
+                                self,
+                                fp,
+                                regs.pc,
+                                regs.func,
+                                descriptor_id,
+                                elem_size,
+                                VEC_PUSHBACK_INIT_CAPACITY
+                            )?;
+                            // Re-read base after potential GC.
+                            let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                            write_ptr(ref_base, ref_off as usize, vec_ptr);
+                        }
+
+                        let len = read_vec_len(vec_ptr);
+                        let total = read_obj_size(vec_ptr) as usize;
+                        let cap_in_elems = ((total - OBJECT_HEADER_SIZE - VEC_DATA_OFFSET)
+                            / elem_size as usize) as u64;
+
+                        if len >= cap_in_elems {
+                            vec_ptr = grow_vec_ref!(
+                                self,
+                                fp,
+                                regs.pc,
+                                regs.func,
+                                vec_ref.into(),
+                                elem_size,
+                                len + 1
+                            )?;
+                        }
+
+                        std::ptr::copy_nonoverlapping(
+                            fp.add(elem.into()),
+                            vec_elem_ptr(vec_ptr, len, elem_size) as *mut u8,
+                            elem_size as usize,
+                        );
+                        write_u64(vec_ptr, VEC_LENGTH_OFFSET, len + 1);
+                    },
+
+                    MicroOp::VecPopBack {
+                        dst,
+                        vec_ref,
+                        elem_size,
+                    } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                        let vec_ptr = read_ptr(ref_base, ref_off as usize);
+                        let len = read_vec_len(vec_ptr);
+                        if len == 0 {
+                            return Err(RuntimeError::PopFromEmptyVector);
+                        }
+                        let new_len = len - 1;
+                        std::ptr::copy_nonoverlapping(
+                            vec_elem_ptr(vec_ptr, new_len, elem_size),
+                            fp.add(dst.into()),
+                            elem_size as usize,
+                        );
+                        write_u64(vec_ptr, VEC_LENGTH_OFFSET, new_len);
+                    },
+
+                    MicroOp::VecLoadElem {
+                        dst,
+                        vec_ref,
+                        idx,
+                        elem_size,
+                    } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                        let vec_ptr = read_ptr(ref_base, ref_off as usize);
+                        let idx = read_u64(fp, idx);
+                        let len = read_vec_len(vec_ptr);
                         if idx >= len {
                             return Err(RuntimeError::VectorIndexOutOfBounds {
-                                op: VecOp::Swap,
+                                op: VecOp::LoadElem,
                                 idx,
                                 len,
                             });
                         }
-                    }
-                    // Equal pointers are UB for `swap_nonoverlapping`; distinct
-                    // in-bounds indices guarantee disjoint element ranges.
-                    if idx_a != idx_b {
-                        std::ptr::swap_nonoverlapping(
-                            vec_elem_ptr(vec_ptr, idx_a, elem_size) as *mut u8,
-                            vec_elem_ptr(vec_ptr, idx_b, elem_size) as *mut u8,
+                        std::ptr::copy_nonoverlapping(
+                            vec_elem_ptr(vec_ptr, idx, elem_size),
+                            fp.add(dst.into()),
                             elem_size as usize,
                         );
-                    }
-                },
+                    },
 
-                // ----- Reference (fat pointer) instructions -----
-                MicroOp::VecBorrow {
-                    dst,
-                    vec_ref,
-                    idx,
-                    elem_size,
-                } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
-                    let vec_ptr = read_ptr(ref_base, ref_off as usize);
-                    let idx = read_u64(fp, idx);
-                    let len = read_vec_len(vec_ptr);
-                    if idx >= len {
-                        return Err(RuntimeError::VectorIndexOutOfBounds {
-                            op: VecOp::Borrow,
-                            idx,
-                            len,
-                        });
-                    }
-                    let offset = VEC_DATA_OFFSET as u64 + idx * elem_size as u64;
-                    write_fat_ptr(fp, dst, vec_ptr, offset);
-                },
-
-                MicroOp::SlotBorrow { dst, local } => {
-                    write_fat_ptr(fp, dst, fp.add(local.into()), 0);
-                },
-
-                MicroOp::ReadRef { dst, ref_ptr, size } => {
-                    let (base, offset) = read_fat_ptr(fp, ref_ptr);
-                    let target = base.add(offset as usize);
-                    // Overlap-safe `copy`: `dst` and `*ref` may alias.
-                    std::ptr::copy(target, fp.add(dst.into()), size as usize);
-                },
-
-                MicroOp::WriteRef { ref_ptr, src, size } => {
-                    let (base, offset) = read_fat_ptr(fp, ref_ptr);
-                    let target = base.add(offset as usize);
-                    // Overlap-safe `copy`: `src` and `*ref` may alias.
-                    std::ptr::copy(fp.add(src.into()), target, size as usize);
-                },
-
-                MicroOp::DeriveRefOffsetImm {
-                    dst_ref,
-                    src_ref,
-                    offset,
-                } => {
-                    let (base, src_off) = read_fat_ptr(fp, src_ref);
-                    write_fat_ptr(fp, dst_ref, base, src_off + offset as u64);
-                },
-
-                MicroOp::ReadRefOffset {
-                    dst,
-                    ref_ptr,
-                    offset,
-                    size,
-                } => {
-                    let (base, ref_off) = read_fat_ptr(fp, ref_ptr);
-                    let target = base.add(ref_off as usize + offset as usize);
-                    // Overlap-safe `copy`: `dst` and `*ref` may alias.
-                    std::ptr::copy(target, fp.add(dst.into()), size as usize);
-                },
-
-                MicroOp::WriteRefOffset {
-                    ref_ptr,
-                    offset,
-                    src,
-                    size,
-                } => {
-                    let (base, ref_off) = read_fat_ptr(fp, ref_ptr);
-                    let target = base.add(ref_off as usize + offset as usize);
-                    // Overlap-safe `copy`: `src` and `*ref` may alias.
-                    std::ptr::copy(fp.add(src.into()), target, size as usize);
-                },
-
-                // ----- Heap object instructions (structs and enums) -----
-                MicroOp::HeapNew { dst, descriptor_id } => {
-                    let ptr = alloc_obj!(self, fp, regs.pc, regs.func, descriptor_id)?;
-                    write_ptr(fp, dst, ptr);
-                },
-
-                MicroOp::HeapMoveFrom8 {
-                    dst,
-                    heap_ptr,
-                    offset,
-                } => {
-                    let obj_ptr = read_ptr(fp, heap_ptr);
-                    let val = read_u64(obj_ptr, offset as usize);
-                    write_u64(fp, dst, val);
-                },
-
-                MicroOp::HeapMoveFrom {
-                    dst,
-                    heap_ptr,
-                    offset,
-                    size,
-                } => {
-                    let obj_ptr = read_ptr(fp, heap_ptr);
-                    std::ptr::copy_nonoverlapping(
-                        obj_ptr.add(offset as usize),
-                        fp.add(dst.into()),
-                        size as usize,
-                    );
-                },
-
-                MicroOp::HeapMoveTo8 {
-                    heap_ptr,
-                    offset,
-                    src,
-                } => {
-                    let obj_ptr = read_ptr(fp, heap_ptr);
-                    let val = read_u64(fp, src);
-                    write_u64(obj_ptr, offset as usize, val);
-                },
-
-                MicroOp::HeapMoveToImm8 {
-                    heap_ptr,
-                    offset,
-                    imm,
-                } => {
-                    let obj_ptr = read_ptr(fp, heap_ptr);
-                    write_u64(obj_ptr, offset as usize, imm);
-                },
-
-                MicroOp::HeapMoveTo {
-                    heap_ptr,
-                    offset,
-                    src,
-                    size,
-                } => {
-                    let obj_ptr = read_ptr(fp, heap_ptr);
-                    std::ptr::copy_nonoverlapping(
-                        fp.add(src.into()),
-                        obj_ptr.add(offset as usize),
-                        size as usize,
-                    );
-                },
-
-                MicroOp::HeapBorrow {
-                    dst,
-                    obj_ref,
-                    offset,
-                } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, obj_ref);
-                    let obj_ptr = read_ptr(ref_base, ref_off as usize);
-                    // Unlike vectors, heap objects are never null — they
-                    // are always allocated by HeapNew before being borrowed.
-                    debug_assert!(!obj_ptr.is_null(), "HeapBorrow: null object pointer");
-                    write_fat_ptr(fp, dst, obj_ptr, offset as u64);
-                },
-
-                MicroOp::PackClosure(ref op) => {
-                    self.exec_pack_closure(regs, op)?;
-                },
-                MicroOp::CallClosure(ref op) => {
-                    regs = self.exec_call_closure(func, regs, op)?;
-                    continue;
-                },
-
-                MicroOp::IntAdd(ref op) => exec_int_add(fp, op)?,
-                MicroOp::IntSub(ref op) => exec_int_sub(fp, op)?,
-                MicroOp::IntMul(ref op) => exec_int_mul(fp, op)?,
-                MicroOp::IntDiv(ref op) => exec_int_div(fp, op)?,
-                MicroOp::IntMod(ref op) => exec_int_mod(fp, op)?,
-                MicroOp::IntBitAnd(ref op) => exec_int_bit_and(fp, op)?,
-                MicroOp::IntBitOr(ref op) => exec_int_bit_or(fp, op)?,
-                MicroOp::IntBitXor(ref op) => exec_int_bit_xor(fp, op)?,
-                MicroOp::IntShl(ref op) => exec_int_shl(fp, op)?,
-                MicroOp::IntShr(ref op) => exec_int_shr(fp, op)?,
-                MicroOp::IntNegate(ref op) => exec_int_negate(fp, op)?,
-                MicroOp::IntCast(ref op) => exec_int_cast(fp, op)?,
-
-                MicroOp::Exists { addr, ty, dst } => {
-                    let address = read_account_address(fp, addr);
-                    let exists = self.read_write_set.exists(
-                        self.exec_ctx.resource_provider(),
-                        &InMemoryStorageKey::resource(address, ty),
-                    )?;
-                    write_bool(fp, dst, exists);
-                },
-
-                MicroOp::BorrowGlobal { addr, ty, dst } => {
-                    let address = read_account_address(fp, addr);
-                    let ptr = self.read_write_set.borrow_global(
-                        self.exec_ctx.resource_provider(),
-                        &InMemoryStorageKey::resource(address, ty),
-                    )?;
-                    // A reference is a 16-byte fat pointer; the borrow points
-                    // at the start of the resource, so the offset half is 0.
-                    write_fat_ptr(fp, dst, ptr.as_ptr(), 0);
-                },
-
-                MicroOp::BorrowGlobalMut { addr, ty, dst } => {
-                    let address = read_account_address(fp, addr);
-                    let key = InMemoryStorageKey::resource(address, ty);
-                    let ptr = match self
-                        .read_write_set
-                        .try_borrow_global_mut(self.exec_ctx.resource_provider(), &key)?
-                    {
-                        EntryPtr::Writable(ptr) => ptr,
-                        EntryPtr::NonWritable(ptr) => {
-                            let ptr = self.deep_copy(regs, ptr)?;
-                            self.read_write_set.commit_borrow_global_mut(&key, ptr);
-                            ptr
-                        },
-                    };
-                    // A reference is a 16-byte fat pointer; the borrow points
-                    // at the start of the resource, so the offset half is 0.
-                    write_fat_ptr(fp, dst, ptr.as_ptr(), 0);
-                },
-
-                MicroOp::MoveFrom { addr, ty, dst } => {
-                    let address = read_account_address(fp, addr);
-                    let key = InMemoryStorageKey::resource(address, ty);
-                    let entry_ptr = self
-                        .read_write_set
-                        .try_move_from(self.exec_ctx.resource_provider(), &key)?;
-                    let ptr = match entry_ptr {
-                        EntryPtr::Writable(ptr) => ptr,
-                        EntryPtr::NonWritable(ptr) => {
-                            let ptr = self.deep_copy(regs, ptr)?;
-                            self.read_write_set.commit_move_from(&key);
-                            ptr
-                        },
-                    };
-                    write_ptr(fp, dst, ptr.as_ptr());
-                },
-
-                MicroOp::MoveTo {
-                    signer_ref,
-                    ty,
-                    src,
-                } => {
-                    // Dereference the `&signer` to obtain the 32-byte publishing address
-                    let (base, offset) = read_fat_ptr(fp, signer_ref);
-                    let address = read_account_address(base, offset as usize);
-                    let Some(ptr) = NonNull::new(read_ptr(fp, src)) else {
-                        invariant_violation!(MoveToNullSource);
-                    };
-
-                    self.read_write_set.move_to(
-                        self.exec_ctx.resource_provider(),
-                        &InMemoryStorageKey::resource(address, ty),
-                        ptr,
-                    )?;
-                },
-                MicroOp::IntCmp(ref op) => {
-                    let result = int_cmp_bool(fp, op.lhs, op.op, &op.rhs);
-                    write_u8(fp, op.dst, result as u8);
-                },
-                MicroOp::ValueCmp(ref op) => {
-                    // Operands are the aggregate values at their slots; a
-                    // vector slot holds a pointer read through to its heap data.
-                    let a = fp.add(op.lhs.into());
-                    let b = fp.add(op.rhs.into());
-                    let eq = value_utils::equals(&*self.exec_ctx, a, b, op.ty)?;
-                    write_bool(fp, op.dst, eq ^ op.negate);
-                },
-                MicroOp::ValueRefCmp(ref op) => {
-                    // Operands are references; read through the fat pointers to
-                    // obtain the operand data pointers.
-                    let (lb, lo) = read_fat_ptr(fp, op.lhs);
-                    let (rb, ro) = read_fat_ptr(fp, op.rhs);
-                    let eq = value_utils::equals(
-                        &*self.exec_ctx,
-                        lb.add(lo as usize),
-                        rb.add(ro as usize),
-                        op.ty,
-                    )?;
-                    write_bool(fp, op.dst, eq ^ op.negate);
-                },
-                MicroOp::BoolNot { dst, src } => write_bool(fp, dst, !read_bool(fp, src)),
-                MicroOp::BoolAnd { dst, lhs, rhs } => {
-                    let left = read_bool(fp, lhs);
-                    let right = read_bool(fp, rhs);
-                    write_bool(fp, dst, left && right)
-                },
-                MicroOp::BoolOr { dst, lhs, rhs } => {
-                    let left = read_bool(fp, lhs);
-                    let right = read_bool(fp, rhs);
-                    write_bool(fp, dst, left || right)
-                },
-                MicroOp::EnumTestTag {
-                    dst,
-                    enum_ref,
-                    variant,
-                } => {
-                    // Deref the enum fat pointer to the heap object, then read the tag.
-                    let (ref_base, ref_off) = read_fat_ptr(fp, enum_ref);
-                    let obj_ptr = read_ptr(ref_base, ref_off as usize);
-                    let tag = read_enum_tag(obj_ptr);
-                    write_bool(fp, dst, tag == variant);
-                },
-
-                MicroOp::EnumBorrowVariantField {
-                    dst,
-                    enum_ref,
-                    ref offsets,
-                } => {
-                    // Deref the enum fat pointer to the heap object, read the
-                    // tag, then borrow the field at that variant's offset.
-                    let (ref_base, ref_off) = read_fat_ptr(fp, enum_ref);
-                    let obj_ptr = read_ptr(ref_base, ref_off as usize);
-                    let tag = read_enum_tag(obj_ptr);
-                    let Some(variant_offset) = offsets.get(tag as usize) else {
-                        // A tag past the variant table is heap corruption (a
-                        // well-formed enum's tag is always in range), not a
-                        // user-level mismatch. Surface it as an invariant
-                        // violation.
-                        invariant_violation!(EnumTagOutOfRange {
-                            tag,
-                            variant_count: offsets.len(),
-                        });
-                    };
-                    match variant_offset {
-                        Some(offset) => write_fat_ptr(fp, dst, obj_ptr, *offset as u64),
-                        // Tag in range but this variant does not declare the
-                        // field (move semantics for this is a runtime error).
-                        None => return Err(RuntimeError::EnumVariantMismatch { tag }),
-                    }
-                },
-
-                MicroOp::EnumCheckVariant { enum_ptr, variant } => {
-                    // `enum_ptr` is the heap-pointer value; runtime error if
-                    // its tag is not the expected variant.
-                    let obj_ptr = read_ptr(fp, enum_ptr);
-                    let tag = read_enum_tag(obj_ptr);
-                    if tag != variant {
-                        return Err(RuntimeError::EnumVariantMismatch { tag });
-                    }
-                },
-
-                MicroOp::EnumNew {
-                    dst,
-                    descriptor_id,
-                    variant,
-                } => {
-                    let obj_ptr = alloc_obj!(self, fp, regs.pc, regs.func, descriptor_id)?;
-                    // No safe point between the allocation and these
-                    // non-allocating writes: stamp the tag through the fresh
-                    // pointer, then publish it to `dst`.
-                    write_enum_tag(obj_ptr, variant);
-                    write_ptr(fp, dst, obj_ptr);
-                },
-
-                MicroOp::EnumReadVariantField {
-                    dst,
-                    enum_ref,
-                    offset,
-                    size,
-                } => {
-                    // Double deref of the enum fat pointer to the heap object,
-                    // then copy the field bytes directly — no intermediate
-                    // scratch reference. The offset is a static uniform offset
-                    // (no tag dispatch).
-                    let (ref_base, ref_off) = read_fat_ptr(fp, enum_ref);
-                    let obj_ptr = read_ptr(ref_base, ref_off as usize);
-                    // Non-overlapping: `dst` is a stack-region slot, the field
-                    // is heap-object bytes.
-                    std::ptr::copy_nonoverlapping(
-                        obj_ptr.add(offset as usize),
-                        fp.add(dst.into()),
-                        size as usize,
-                    );
-                },
-
-                MicroOp::EnumWriteVariantField {
-                    enum_ref,
-                    offset,
-                    src,
-                    size,
-                } => {
-                    let (ref_base, ref_off) = read_fat_ptr(fp, enum_ref);
-                    let obj_ptr = read_ptr(ref_base, ref_off as usize);
-                    // Non-overlapping: `src` is a stack-region slot, the field
-                    // is heap-object bytes.
-                    std::ptr::copy_nonoverlapping(
-                        fp.add(src.into()),
-                        obj_ptr.add(offset as usize),
-                        size as usize,
-                    );
-                },
-
-                MicroOp::DeepCopyHeapPtrs { base, ref offsets } => {
-                    // Pre-condition: each `base + off` holds a heap pointer
-                    // byte-copied from another value, so the pointee is still
-                    // shared with that value. Replace each non-null pointer
-                    // with a pointer to a fresh deep copy, making the value at
-                    // `base` independent (Move value semantics). Null (e.g. an
-                    // empty vector) stays null.
-                    //
-                    // TODO(metering): the IR-level cost of the materializing
-                    // instruction charges only the shallow byte move, not this
-                    // heap-graph copy. Change charging to reflect at least the
-                    // amount of work done.
-                    //
-                    // TODO(perf): the materializing op currently emits a byte
-                    // move into `base` followed by this in-place fixup that
-                    // re-reads from `base`. A fused `src -> dst` deep copy
-                    // would drop the separate move and the re-read. It would
-                    // need deep-copying variants of `ReadRef`, `Read*Field`,
-                    // etc.
-                    if let &[off] = offsets.as_ref() {
-                        // Fast path for copying whole-enum / whole-vector /
-                        // aggregate with one heap backed field: a single owned
-                        // pointer at one offset. Uses single-root `deep_copy`,
-                        // avoiding the batch's per-op `Vec`s.
-                        if let Some(src) = NonNull::new(read_ptr(fp, (base.0 + off) as usize)) {
-                            let new = self.deep_copy(regs, src)?;
-                            write_ptr(fp, (base.0 + off) as usize, new.as_ptr());
+                    MicroOp::VecStoreElem {
+                        vec_ref,
+                        idx,
+                        src,
+                        elem_size,
+                    } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                        let vec_ptr = read_ptr(ref_base, ref_off as usize);
+                        let idx = read_u64(fp, idx);
+                        let len = read_vec_len(vec_ptr);
+                        if idx >= len {
+                            return Err(RuntimeError::VectorIndexOutOfBounds {
+                                op: VecOp::StoreElem,
+                                idx,
+                                len,
+                            });
                         }
-                    } else {
-                        let mut live_offsets: Vec<u32> = Vec::with_capacity(offsets.len());
-                        let mut sources: Vec<NonNull<u8>> = Vec::with_capacity(offsets.len());
-                        for &off in offsets.iter() {
-                            if let Some(src) =
-                                NonNull::new(read_ptr(fp, (base.0 + off) as usize))
-                            {
-                                live_offsets.push(off);
-                                sources.push(src);
+                        std::ptr::copy_nonoverlapping(
+                            fp.add(src.into()),
+                            vec_elem_ptr(vec_ptr, idx, elem_size) as *mut u8,
+                            elem_size as usize,
+                        );
+                    },
+
+                    MicroOp::VecPack(ref op) => {
+                        self.exec_vec_pack(regs, op)?;
+                    },
+
+                    MicroOp::VecUnpack(ref op) => {
+                        self.exec_vec_unpack(fp, op)?;
+                    },
+
+                    MicroOp::VecSwap {
+                        vec_ref,
+                        idx_a,
+                        idx_b,
+                        elem_size,
+                    } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                        let vec_ptr = read_ptr(ref_base, ref_off as usize);
+                        let idx_a = read_u64(fp, idx_a);
+                        let idx_b = read_u64(fp, idx_b);
+                        let len = read_vec_len(vec_ptr);
+                        // Indices are checked before the equal-indices no-op.
+                        for idx in [idx_a, idx_b] {
+                            if idx >= len {
+                                return Err(RuntimeError::VectorIndexOutOfBounds {
+                                    op: VecOp::Swap,
+                                    idx,
+                                    len,
+                                });
                             }
                         }
-                        let copies = self.deep_copy_batch(regs, &sources)?;
-                        for (off, new) in live_offsets.iter().zip(copies) {
-                            write_ptr(fp, (base.0 + off) as usize, new.as_ptr());
+                        // Equal pointers are UB for `swap_nonoverlapping`; distinct
+                        // in-bounds indices guarantee disjoint element ranges.
+                        if idx_a != idx_b {
+                            std::ptr::swap_nonoverlapping(
+                                vec_elem_ptr(vec_ptr, idx_a, elem_size) as *mut u8,
+                                vec_elem_ptr(vec_ptr, idx_b, elem_size) as *mut u8,
+                                elem_size as usize,
+                            );
                         }
-                    }
-                },
-            }
+                    },
+
+                    // ----- Reference (fat pointer) instructions -----
+                    MicroOp::VecBorrow {
+                        dst,
+                        vec_ref,
+                        idx,
+                        elem_size,
+                    } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
+                        let vec_ptr = read_ptr(ref_base, ref_off as usize);
+                        let idx = read_u64(fp, idx);
+                        let len = read_vec_len(vec_ptr);
+                        if idx >= len {
+                            return Err(RuntimeError::VectorIndexOutOfBounds {
+                                op: VecOp::Borrow,
+                                idx,
+                                len,
+                            });
+                        }
+                        let offset = VEC_DATA_OFFSET as u64 + idx * elem_size as u64;
+                        write_fat_ptr(fp, dst, vec_ptr, offset);
+                    },
+
+                    MicroOp::SlotBorrow { dst, local } => {
+                        write_fat_ptr(fp, dst, fp.add(local.into()), 0);
+                    },
+
+                    MicroOp::ReadRef { dst, ref_ptr, size } => {
+                        let (base, offset) = read_fat_ptr(fp, ref_ptr);
+                        let target = base.add(offset as usize);
+                        // Overlap-safe `copy`: `dst` and `*ref` may alias.
+                        std::ptr::copy(target, fp.add(dst.into()), size as usize);
+                    },
+
+                    MicroOp::WriteRef { ref_ptr, src, size } => {
+                        let (base, offset) = read_fat_ptr(fp, ref_ptr);
+                        let target = base.add(offset as usize);
+                        // Overlap-safe `copy`: `src` and `*ref` may alias.
+                        std::ptr::copy(fp.add(src.into()), target, size as usize);
+                    },
+
+                    MicroOp::DeriveRefOffsetImm {
+                        dst_ref,
+                        src_ref,
+                        offset,
+                    } => {
+                        let (base, src_off) = read_fat_ptr(fp, src_ref);
+                        write_fat_ptr(fp, dst_ref, base, src_off + offset as u64);
+                    },
+
+                    MicroOp::ReadRefOffset {
+                        dst,
+                        ref_ptr,
+                        offset,
+                        size,
+                    } => {
+                        let (base, ref_off) = read_fat_ptr(fp, ref_ptr);
+                        let target = base.add(ref_off as usize + offset as usize);
+                        // Overlap-safe `copy`: `dst` and `*ref` may alias.
+                        std::ptr::copy(target, fp.add(dst.into()), size as usize);
+                    },
+
+                    MicroOp::WriteRefOffset {
+                        ref_ptr,
+                        offset,
+                        src,
+                        size,
+                    } => {
+                        let (base, ref_off) = read_fat_ptr(fp, ref_ptr);
+                        let target = base.add(ref_off as usize + offset as usize);
+                        // Overlap-safe `copy`: `src` and `*ref` may alias.
+                        std::ptr::copy(fp.add(src.into()), target, size as usize);
+                    },
+
+                    // ----- Heap object instructions (structs and enums) -----
+                    MicroOp::HeapNew { dst, descriptor_id } => {
+                        let ptr = alloc_obj!(self, fp, regs.pc, regs.func, descriptor_id)?;
+                        write_ptr(fp, dst, ptr);
+                    },
+
+                    MicroOp::HeapMoveFrom8 {
+                        dst,
+                        heap_ptr,
+                        offset,
+                    } => {
+                        let obj_ptr = read_ptr(fp, heap_ptr);
+                        let val = read_u64(obj_ptr, offset as usize);
+                        write_u64(fp, dst, val);
+                    },
+
+                    MicroOp::HeapMoveFrom {
+                        dst,
+                        heap_ptr,
+                        offset,
+                        size,
+                    } => {
+                        let obj_ptr = read_ptr(fp, heap_ptr);
+                        std::ptr::copy_nonoverlapping(
+                            obj_ptr.add(offset as usize),
+                            fp.add(dst.into()),
+                            size as usize,
+                        );
+                    },
+
+                    MicroOp::HeapMoveTo8 {
+                        heap_ptr,
+                        offset,
+                        src,
+                    } => {
+                        let obj_ptr = read_ptr(fp, heap_ptr);
+                        let val = read_u64(fp, src);
+                        write_u64(obj_ptr, offset as usize, val);
+                    },
+
+                    MicroOp::HeapMoveToImm8 {
+                        heap_ptr,
+                        offset,
+                        imm,
+                    } => {
+                        let obj_ptr = read_ptr(fp, heap_ptr);
+                        write_u64(obj_ptr, offset as usize, imm);
+                    },
+
+                    MicroOp::HeapMoveTo {
+                        heap_ptr,
+                        offset,
+                        src,
+                        size,
+                    } => {
+                        let obj_ptr = read_ptr(fp, heap_ptr);
+                        std::ptr::copy_nonoverlapping(
+                            fp.add(src.into()),
+                            obj_ptr.add(offset as usize),
+                            size as usize,
+                        );
+                    },
+
+                    MicroOp::HeapBorrow {
+                        dst,
+                        obj_ref,
+                        offset,
+                    } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, obj_ref);
+                        let obj_ptr = read_ptr(ref_base, ref_off as usize);
+                        // Unlike vectors, heap objects are never null — they
+                        // are always allocated by HeapNew before being borrowed.
+                        debug_assert!(!obj_ptr.is_null(), "HeapBorrow: null object pointer");
+                        write_fat_ptr(fp, dst, obj_ptr, offset as u64);
+                    },
+
+                    MicroOp::PackClosure(ref op) => {
+                        self.exec_pack_closure(regs, op)?;
+                    },
+                    MicroOp::CallClosure(ref op) => {
+                        regs = self.exec_call_closure(func, regs, op)?;
+                        continue;
+                    },
+
+                    MicroOp::IntAdd(ref op) => exec_int_add(fp, op)?,
+                    MicroOp::IntSub(ref op) => exec_int_sub(fp, op)?,
+                    MicroOp::IntMul(ref op) => exec_int_mul(fp, op)?,
+                    MicroOp::IntDiv(ref op) => exec_int_div(fp, op)?,
+                    MicroOp::IntMod(ref op) => exec_int_mod(fp, op)?,
+                    MicroOp::IntBitAnd(ref op) => exec_int_bit_and(fp, op)?,
+                    MicroOp::IntBitOr(ref op) => exec_int_bit_or(fp, op)?,
+                    MicroOp::IntBitXor(ref op) => exec_int_bit_xor(fp, op)?,
+                    MicroOp::IntShl(ref op) => exec_int_shl(fp, op)?,
+                    MicroOp::IntShr(ref op) => exec_int_shr(fp, op)?,
+                    MicroOp::IntNegate(ref op) => exec_int_negate(fp, op)?,
+                    MicroOp::IntCast(ref op) => exec_int_cast(fp, op)?,
+
+                    MicroOp::Exists { addr, ty, dst } => {
+                        let address = read_account_address(fp, addr);
+                        let exists = self.read_write_set.exists(
+                            self.exec_ctx.resource_provider(),
+                            &InMemoryStorageKey::resource(address, ty),
+                        )?;
+                        write_bool(fp, dst, exists);
+                    },
+
+                    MicroOp::BorrowGlobal { addr, ty, dst } => {
+                        let address = read_account_address(fp, addr);
+                        let ptr = self.read_write_set.borrow_global(
+                            self.exec_ctx.resource_provider(),
+                            &InMemoryStorageKey::resource(address, ty),
+                        )?;
+                        // A reference is a 16-byte fat pointer; the borrow points
+                        // at the start of the resource, so the offset half is 0.
+                        write_fat_ptr(fp, dst, ptr.as_ptr(), 0);
+                    },
+
+                    MicroOp::BorrowGlobalMut { addr, ty, dst } => {
+                        let address = read_account_address(fp, addr);
+                        let key = InMemoryStorageKey::resource(address, ty);
+                        let ptr = match self
+                            .read_write_set
+                            .try_borrow_global_mut(self.exec_ctx.resource_provider(), &key)?
+                        {
+                            EntryPtr::Writable(ptr) => ptr,
+                            EntryPtr::NonWritable(ptr) => {
+                                let ptr = self.deep_copy(regs, ptr)?;
+                                self.read_write_set.commit_borrow_global_mut(&key, ptr);
+                                ptr
+                            },
+                        };
+                        // A reference is a 16-byte fat pointer; the borrow points
+                        // at the start of the resource, so the offset half is 0.
+                        write_fat_ptr(fp, dst, ptr.as_ptr(), 0);
+                    },
+
+                    MicroOp::MoveFrom { addr, ty, dst } => {
+                        let address = read_account_address(fp, addr);
+                        let key = InMemoryStorageKey::resource(address, ty);
+                        let entry_ptr = self
+                            .read_write_set
+                            .try_move_from(self.exec_ctx.resource_provider(), &key)?;
+                        let ptr = match entry_ptr {
+                            EntryPtr::Writable(ptr) => ptr,
+                            EntryPtr::NonWritable(ptr) => {
+                                let ptr = self.deep_copy(regs, ptr)?;
+                                self.read_write_set.commit_move_from(&key);
+                                ptr
+                            },
+                        };
+                        write_ptr(fp, dst, ptr.as_ptr());
+                    },
+
+                    MicroOp::MoveTo {
+                        signer_ref,
+                        ty,
+                        src,
+                    } => {
+                        // Dereference the `&signer` to obtain the 32-byte publishing address
+                        let (base, offset) = read_fat_ptr(fp, signer_ref);
+                        let address = read_account_address(base, offset as usize);
+                        let Some(ptr) = NonNull::new(read_ptr(fp, src)) else {
+                            invariant_violation!(MoveToNullSource);
+                        };
+
+                        self.read_write_set.move_to(
+                            self.exec_ctx.resource_provider(),
+                            &InMemoryStorageKey::resource(address, ty),
+                            ptr,
+                        )?;
+                    },
+                    MicroOp::IntCmp(ref op) => {
+                        let result = int_cmp_bool(fp, op.lhs, op.op, &op.rhs);
+                        write_u8(fp, op.dst, result as u8);
+                    },
+                    MicroOp::ValueCmp(ref op) => {
+                        // Operands are the aggregate values at their slots; a
+                        // vector slot holds a pointer read through to its heap data.
+                        let a = fp.add(op.lhs.into());
+                        let b = fp.add(op.rhs.into());
+                        let eq = value_utils::equals(&*self.exec_ctx, a, b, op.ty)?;
+                        write_bool(fp, op.dst, eq ^ op.negate);
+                    },
+                    MicroOp::ValueRefCmp(ref op) => {
+                        // Operands are references; read through the fat pointers to
+                        // obtain the operand data pointers.
+                        let (lb, lo) = read_fat_ptr(fp, op.lhs);
+                        let (rb, ro) = read_fat_ptr(fp, op.rhs);
+                        let eq = value_utils::equals(
+                            &*self.exec_ctx,
+                            lb.add(lo as usize),
+                            rb.add(ro as usize),
+                            op.ty,
+                        )?;
+                        write_bool(fp, op.dst, eq ^ op.negate);
+                    },
+                    MicroOp::BoolNot { dst, src } => write_bool(fp, dst, !read_bool(fp, src)),
+                    MicroOp::BoolAnd { dst, lhs, rhs } => {
+                        let left = read_bool(fp, lhs);
+                        let right = read_bool(fp, rhs);
+                        write_bool(fp, dst, left && right)
+                    },
+                    MicroOp::BoolOr { dst, lhs, rhs } => {
+                        let left = read_bool(fp, lhs);
+                        let right = read_bool(fp, rhs);
+                        write_bool(fp, dst, left || right)
+                    },
+                    MicroOp::EnumTestTag {
+                        dst,
+                        enum_ref,
+                        variant,
+                    } => {
+                        // Deref the enum fat pointer to the heap object, then read the tag.
+                        let (ref_base, ref_off) = read_fat_ptr(fp, enum_ref);
+                        let obj_ptr = read_ptr(ref_base, ref_off as usize);
+                        let tag = read_enum_tag(obj_ptr);
+                        write_bool(fp, dst, tag == variant);
+                    },
+
+                    MicroOp::EnumBorrowVariantField {
+                        dst,
+                        enum_ref,
+                        ref offsets,
+                    } => {
+                        // Deref the enum fat pointer to the heap object, read the
+                        // tag, then borrow the field at that variant's offset.
+                        let (ref_base, ref_off) = read_fat_ptr(fp, enum_ref);
+                        let obj_ptr = read_ptr(ref_base, ref_off as usize);
+                        let tag = read_enum_tag(obj_ptr);
+                        let Some(variant_offset) = offsets.get(tag as usize) else {
+                            // A tag past the variant table is heap corruption (a
+                            // well-formed enum's tag is always in range), not a
+                            // user-level mismatch. Surface it as an invariant
+                            // violation.
+                            invariant_violation!(EnumTagOutOfRange {
+                                tag,
+                                variant_count: offsets.len(),
+                            });
+                        };
+                        match variant_offset {
+                            Some(offset) => write_fat_ptr(fp, dst, obj_ptr, *offset as u64),
+                            // Tag in range but this variant does not declare the
+                            // field (move semantics for this is a runtime error).
+                            None => return Err(RuntimeError::EnumVariantMismatch { tag }),
+                        }
+                    },
+
+                    MicroOp::EnumCheckVariant { enum_ptr, variant } => {
+                        // `enum_ptr` is the heap-pointer value; runtime error if
+                        // its tag is not the expected variant.
+                        let obj_ptr = read_ptr(fp, enum_ptr);
+                        let tag = read_enum_tag(obj_ptr);
+                        if tag != variant {
+                            return Err(RuntimeError::EnumVariantMismatch { tag });
+                        }
+                    },
+
+                    MicroOp::EnumNew {
+                        dst,
+                        descriptor_id,
+                        variant,
+                    } => {
+                        let obj_ptr = alloc_obj!(self, fp, regs.pc, regs.func, descriptor_id)?;
+                        // No safe point between the allocation and these
+                        // non-allocating writes: stamp the tag through the fresh
+                        // pointer, then publish it to `dst`.
+                        write_enum_tag(obj_ptr, variant);
+                        write_ptr(fp, dst, obj_ptr);
+                    },
+
+                    MicroOp::EnumReadVariantField {
+                        dst,
+                        enum_ref,
+                        offset,
+                        size,
+                    } => {
+                        // Double deref of the enum fat pointer to the heap object,
+                        // then copy the field bytes directly — no intermediate
+                        // scratch reference. The offset is a static uniform offset
+                        // (no tag dispatch).
+                        let (ref_base, ref_off) = read_fat_ptr(fp, enum_ref);
+                        let obj_ptr = read_ptr(ref_base, ref_off as usize);
+                        // Non-overlapping: `dst` is a stack-region slot, the field
+                        // is heap-object bytes.
+                        std::ptr::copy_nonoverlapping(
+                            obj_ptr.add(offset as usize),
+                            fp.add(dst.into()),
+                            size as usize,
+                        );
+                    },
+
+                    MicroOp::EnumWriteVariantField {
+                        enum_ref,
+                        offset,
+                        src,
+                        size,
+                    } => {
+                        let (ref_base, ref_off) = read_fat_ptr(fp, enum_ref);
+                        let obj_ptr = read_ptr(ref_base, ref_off as usize);
+                        // Non-overlapping: `src` is a stack-region slot, the field
+                        // is heap-object bytes.
+                        std::ptr::copy_nonoverlapping(
+                            fp.add(src.into()),
+                            obj_ptr.add(offset as usize),
+                            size as usize,
+                        );
+                    },
+
+                    MicroOp::DeepCopyHeapPtrs { base, ref offsets } => {
+                        // Pre-condition: each `base + off` holds a heap pointer
+                        // byte-copied from another value, so the pointee is still
+                        // shared with that value. Replace each non-null pointer
+                        // with a pointer to a fresh deep copy, making the value at
+                        // `base` independent (Move value semantics). Null (e.g. an
+                        // empty vector) stays null.
+                        //
+                        // TODO(metering): the IR-level cost of the materializing
+                        // instruction charges only the shallow byte move, not this
+                        // heap-graph copy. Change charging to reflect at least the
+                        // amount of work done.
+                        //
+                        // TODO(perf): the materializing op currently emits a byte
+                        // move into `base` followed by this in-place fixup that
+                        // re-reads from `base`. A fused `src -> dst` deep copy
+                        // would drop the separate move and the re-read. It would
+                        // need deep-copying variants of `ReadRef`, `Read*Field`,
+                        // etc.
+                        if let &[off] = offsets.as_ref() {
+                            // Fast path for copying whole-enum / whole-vector /
+                            // aggregate with one heap backed field: a single owned
+                            // pointer at one offset. Uses single-root `deep_copy`,
+                            // avoiding the batch's per-op `Vec`s.
+                            if let Some(src) = NonNull::new(read_ptr(fp, (base.0 + off) as usize)) {
+                                let new = self.deep_copy(regs, src)?;
+                                write_ptr(fp, (base.0 + off) as usize, new.as_ptr());
+                            }
+                        } else {
+                            let mut live_offsets: Vec<u32> = Vec::with_capacity(offsets.len());
+                            let mut sources: Vec<NonNull<u8>> = Vec::with_capacity(offsets.len());
+                            for &off in offsets.iter() {
+                                if let Some(src) =
+                                    NonNull::new(read_ptr(fp, (base.0 + off) as usize))
+                                {
+                                    live_offsets.push(off);
+                                    sources.push(src);
+                                }
+                            }
+                            let copies = self.deep_copy_batch(regs, &sources)?;
+                            for (off, new) in live_offsets.iter().zip(copies) {
+                                write_ptr(fp, (base.0 + off) as usize, new.as_ptr());
+                            }
+                        }
+                    },
+                }
             }
 
             regs.pc += 1;
@@ -2014,7 +2027,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     #[inline(never)]
     fn exec_store_imm_vec(
         &mut self,
-        regs: MachineRegisters,
+        regs: VMRegisters,
         dst: FrameOffset,
         idx: ConstantPoolIndex,
     ) -> RuntimeResult<()> {
@@ -2057,11 +2070,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     // Outlined to keep the dispatch loop small: an inlined body here adds to
     // the register pressure that competes for `fp`'s register across the loop.
     #[inline(never)]
-    unsafe fn exec_vec_pack(
-        &mut self,
-        regs: MachineRegisters,
-        op: &VecPackOp,
-    ) -> RuntimeResult<()> {
+    unsafe fn exec_vec_pack(&mut self, regs: VMRegisters, op: &VecPackOp) -> RuntimeResult<()> {
         let fp = regs.fp;
         let count = op.srcs.len() as u64;
         // TODO(perf): `alloc_vec!` zero-fills the whole allocation, but every
@@ -2134,7 +2143,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     /// at `src - OBJECT_HEADER_SIZE`.
     unsafe fn deep_copy(
         &mut self,
-        regs: MachineRegisters,
+        regs: VMRegisters,
         root: NonNull<u8>,
     ) -> RuntimeResult<NonNull<u8>> {
         // SAFETY: by this function's contract `root` points to a live object.
@@ -2172,7 +2181,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     /// header is at `source - OBJECT_HEADER_SIZE`.
     unsafe fn deep_copy_batch(
         &mut self,
-        regs: MachineRegisters,
+        regs: VMRegisters,
         sources: &[NonNull<u8>],
     ) -> RuntimeResult<Vec<NonNull<u8>>> {
         // SAFETY: each source is a live object (caller contract); the handle
@@ -2253,7 +2262,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     #[inline(never)]
     unsafe fn exec_pack_closure(
         &mut self,
-        regs: MachineRegisters,
+        regs: VMRegisters,
         op: &PackClosureOp,
     ) -> RuntimeResult<()> {
         let fp = regs.fp;
@@ -2378,7 +2387,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     /// # Safety
     ///
     /// - `func` is the currently executing function (caller).
-    /// - `regs` carries the caller's machine registers.
+    /// - `regs` carries the caller's VM registers.
     /// - `op.closure_src` holds a non-null heap pointer to a valid closure
     ///   object.
     /// - The callee's `param_slots` list has one (offset, size) entry per
@@ -2391,9 +2400,9 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     unsafe fn exec_call_closure(
         &mut self,
         func: &Function,
-        mut regs: MachineRegisters,
+        mut regs: VMRegisters,
         op: &CallClosureOp,
-    ) -> RuntimeResult<MachineRegisters> {
+    ) -> RuntimeResult<VMRegisters> {
         let fp = regs.fp;
         unsafe {
             let closure = read_ptr(fp, op.closure_src);
@@ -2614,13 +2623,13 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     /// # Safety
     ///
     /// `callee` must point to a valid, live `Function`. `regs` must carry the
-    /// caller's machine registers and `caller` be the currently executing
+    /// caller's VM registers and `caller` be the currently executing
     /// function.
     #[inline(always)]
     unsafe fn call(
         &mut self,
         caller: &Function,
-        regs: &mut MachineRegisters,
+        regs: &mut VMRegisters,
         callee: &Function,
     ) -> RuntimeResult<()> {
         let new_fp =
@@ -2644,7 +2653,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     unsafe fn call_unchecked(
         &mut self,
         caller: &Function,
-        regs: &mut MachineRegisters,
+        regs: &mut VMRegisters,
         callee: &Function,
         new_fp: *mut u8,
     ) -> RuntimeResult<()> {
@@ -2676,10 +2685,10 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     ///
     /// # Safety
     ///
-    /// `caller` must be the currently executing function and `regs` must carry the
-    /// caller's machine registers.
+    /// `caller` must be the currently executing function and `regs` must carry
+    /// the caller's VM registers.
     #[inline(always)]
-    unsafe fn write_frame_metadata(&self, caller: &Function, regs: &MachineRegisters) {
+    unsafe fn write_frame_metadata(&self, caller: &Function, regs: &VMRegisters) {
         unsafe {
             let meta = regs.fp.add(caller.param_and_local_sizes_sum);
             write_u64(meta, META_SAVED_PC_OFFSET, (regs.pc + 1) as u64);
@@ -2696,12 +2705,12 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
     ///
     /// # Safety
     ///
-    /// `caller` must be the currently executing function and `regs` must carry the
-    /// caller's machine registers.
+    /// `caller` must be the currently executing function and `regs` must carry
+    /// the caller's VM registers.
     unsafe fn exec_call_native(
         &mut self,
         caller: &Function,
-        regs: MachineRegisters,
+        regs: VMRegisters,
         native_idx: NativeIdx,
         ty_args: InternedTypeList,
         abi: &NativeABI,
@@ -2762,8 +2771,6 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         self.registers.fp = saved_fp;
 
         match result {
-            // `None` => the caller (`run`) advances the pc past the native call
-            // via the common fall-through tail; `Some` halts with an abort.
             Ok(NativeStatus::Success) => Ok(None),
             Ok(NativeStatus::Abort { code, message }) => Ok(Some((code, message))),
             Err(e) => Err(e.into_runtime_error()),

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -34,6 +34,6 @@ pub use native_context::{
     ProductionNativeRegistry,
 };
 pub use transaction_context::TransactionContext;
-pub use types::{StepResult, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
+pub use types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
 pub use value_utils::{deserialize_into, serialize};
 pub use verifier::{verify_function, verify_program, VerificationError};

--- a/third_party/move/mono-move/runtime/src/types.rs
+++ b/third_party/move/mono-move/runtime/src/types.rs
@@ -15,6 +15,10 @@ pub(crate) const DEFAULT_STACK_SIZE: usize = 1024 * 1024; // 1 MiB
 
 pub(crate) const DEFAULT_HEAP_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
 
+/// Initial capacity, in elements, of a vector allocated lazily on its first
+/// `push_back`.
+pub(crate) const VEC_PUSHBACK_INIT_CAPACITY: u64 = 4;
+
 /// Maximum size of an `AbortMsg` message, in bytes.
 /// TODO(cleanup): make this configurable in some VM config.
 pub(crate) const ABORT_MESSAGE_SIZE_LIMIT: usize = 1024;

--- a/third_party/move/mono-move/runtime/src/types.rs
+++ b/third_party/move/mono-move/runtime/src/types.rs
@@ -8,21 +8,6 @@
 pub use mono_move_core::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
 
 // ---------------------------------------------------------------------------
-// Step result
-// ---------------------------------------------------------------------------
-
-#[derive(Debug)]
-pub enum StepResult {
-    /// There are more instructions to execute.
-    Continue,
-    /// The outermost function has returned — execution is complete.
-    Done,
-    /// Execution hit an `Abort` / `AbortMsg` micro-op. The code is the
-    /// u64 abort code; the message is populated when `AbortMsg` ran.
-    Aborted { code: u64, message: Option<String> },
-}
-
-// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Optimize the MonoMove interpreter's dispatch loop so the hot "machine
registers" — the program counter, frame pointer, and current-function
pointer — stay in CPU registers across iterations instead of being
round-tripped through `InterpreterContext` fields.

## Why

`step()` read `self.pc` / `self.frame_ptr` / `self.current_func` from memory
each iteration and wrote them back after each op. LLVM couldn't keep them in
registers because `&mut self` escapes into opaque callees (gas meter, heap/GC,
natives), so it conservatively reloaded them at the top of every step and
stored them back after every fall-through op. This was confirmed in the
release-build asm: a per-iteration store of `pc` plus reloads of all three
fields, on the hottest path in the VM.

## The change (three steps, each verified in the asm)

1. **Hoist into a `Machine` local.** `run()` holds `pc`/`fp`/`func` in a local
   `Machine` struct; the allocation/GC and call/native helpers take them as
   explicit parameters, and they sync back to `self` only on entry/exit. This
   removed the per-iteration `self`-field round-trip — but raised register
   pressure enough that `fp` spilled to the stack.
2. **Fold the dispatch into `run()` and drop `StepResult`.** Removing the
   per-instruction enum construct-and-rematch deleted ~13 instructions/iter and
   freed registers.
3. **Outline the cold dispatch arms.** Four large helpers
   (`exec_vec_pack`, `exec_pack_closure`, `exec_store_imm_vec`,
   `exec_call_closure`) were being inlined into the loop, inflating register
   pressure; marking them `#[inline(never)]` shrinks the hot loop so `fp` lands
   in a callee-saved register. Per-op `fp` reloads dropped from ~157 to a
   handful on slow paths.

## Results

Bench profile, single-threaded (`taskset -c 3`), criterion medians. VM time
before vs. after; `+%` = throughput gain.

| benchmark              | before    | after     | improvement |
|------------------------|-----------|-----------|-------------|
| `nested_loop` (n=1000) | 12.18 ms  | 7.57 ms   | +61%        |
| `fib` (n=25)           | 8.87 ms   | 6.64 ms   | +34%        |
| `bst` (5k ops)         | 4.07 ms   | 3.06 ms   | +33%        |
| `merge_sort` (n=1000)  | 1.35 ms   | 1.04 ms   | +29%        |
| `match_sum` (n=1M)     | 27.23 ms  | 21.77 ms  | +25%        |
| `int_arith_loop` / i64 | 638.4 µs  | 576.2 µs  | +11%        |
| `int_arith_loop` / u64 | 396.6 µs  | 363.1 µs  | +9%         |

The cleanest controlled measurement is `int_arith_loop/i64` (native baseline
rock-stable at ~76 µs across every stage), which traces the whole arc:
638 µs baseline → 700 µs after step 1 (fp spilled → regression) → 639 µs after
step 2 → 576 µs after step 3 (fp in a register).

## Verification

- Asm re-dumped after each step; `fp` confirmed in a callee-saved register in
  the final form, with no per-op stack reload.
- `cargo test -p mono-move-runtime` (436 tests) and the differential suite
  (`mono-move-testsuite`, 191 tests, incl. small-`--heap-size` cases that force
  GC at every allocation — the GC-root-coherence check) both pass.

## Status

Draft. No behavior change; pure codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</content>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large hot-path VM refactor touching calls, natives, GC roots, and register sync; semantics should be unchanged but regressions would affect all bytecode execution.
> 
> **Overview**
> Refactors the MonoMove interpreter so **pc**, **frame pointer**, and **current function** live in a `VMRegisters` bundle (stored on `InterpreterContext` but copied into a **local** in `run()` for the hot loop). The per-instruction **`step()`** API and **`StepResult`** enum are removed; **`run()`** now contains the full micro-op **`match`** with **`continue`** / **`break`** for success, return, and abort.
> 
> Heap allocation/GC **macros** (`alloc_obj!`, `alloc_vec!`, `gc_collect!`, etc.) no longer read `current_func`/`pc` from context—they take **`$fp`**, **`$pc`**, and **`$func`** at each call site. Call, return, native dispatch, deep copy, and closure helpers are updated to mutate or pass **`VMRegisters`** (or `&mut VMRegisters`) so GC safe points and frame metadata stay coherent without reloading from `self` every instruction.
> 
> Several large opcode helpers (`exec_vec_pack`, `exec_pack_closure`, `exec_store_imm_vec`, `exec_call_closure`) are marked **`#[inline(never)]`** to shrink the dispatch loop. **`VEC_PUSHBACK_INIT_CAPACITY`** replaces a hardcoded `4` for lazy vector allocation on first push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2784a17bee68e13a14c89f358def74f56d989e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->