### PR TITLE
[mono-move] CI benchmark

### DIFF
--- a/.github/workflows/mono-move-bench.yaml
+++ b/.github/workflows/mono-move-bench.yaml
@@ -1,0 +1,84 @@
+name: "mono-move-bench"
+on:
+  workflow_dispatch:
+  # Untrusted PR code runs on a self-hosted runner. Restricted to same-repo PRs
+  # with the `mono-move` label (forks excluded below); re-runs on each push so a
+  # fix shows new numbers.
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+concurrency:
+  group: mono-move-bench-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write # Post the sticky benchmark comment.
+
+jobs:
+  mono-move-bench:
+    # Dispatch, or a same-repo (non-fork) PR carrying the `mono-move` label.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'mono-move') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    runs-on: benchmark-c3d-60
+    timeout-minutes: 120
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0 # Full history so the base ref is reachable.
+
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      # Copy the bench tooling out of the worktree, since the A/B driver checks
+      # out other refs and would otherwise replace the running scripts.
+      - name: Stage bench tooling
+        run: |
+          mkdir -p "$RUNNER_TEMP/perf"
+          cp third_party/move/mono-move/testsuite/benches/perf/compare.py \
+             third_party/move/mono-move/testsuite/benches/perf/run.sh \
+             third_party/move/mono-move/testsuite/benches/perf/config.json \
+             "$RUNNER_TEMP/perf/"
+
+      - name: Run A/B benchmark gate
+        id: gate
+        run: |
+          set +e
+          # run.sh resolves the merge-base of HEAD_SHA and origin/main itself.
+          bash "$RUNNER_TEMP/perf/run.sh" ab \
+            origin/main "$HEAD_SHA" \
+            --out "$RUNNER_TEMP/mono-move-bench.md"
+          code=$?
+          if [ ! -f "$RUNNER_TEMP/mono-move-bench.md" ]; then
+            printf '### mono-move benchmark gate\n\nBenches failed to run (build or runtime error). See job logs.\n' \
+              > "$RUNNER_TEMP/mono-move-bench.md"
+          fi
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+
+      - name: Write step summary
+        if: always()
+        run: cat "$RUNNER_TEMP/mono-move-bench.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post sticky PR comment
+        # A read-only token (e.g. fork PRs) cannot comment; don't fail the gate.
+        continue-on-error: true
+        if: ${{ always() && github.event.number != null }}
+        uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@39c5b5dc7717447d0cba270cd115037d32d2844
+        with:
+          header: mono-move-bench
+          recreate: true
+          path: ${{ runner.temp }}/mono-move-bench.md
+
+      - name: Fail on regression
+        if: ${{ steps.gate.outputs.exit_code != '0' }}
+        run: |
+          echo "mono-move benchmark gate failed: regression beyond the noise band." >&2
+          exit 1

--- a/.github/workflows/mono-move-micro-bench.yaml
+++ b/.github/workflows/mono-move-micro-bench.yaml
@@ -1,4 +1,4 @@
-name: "mono-move-bench"
+name: "mono-move-micro-bench"
 on:
   workflow_dispatch:
   # Untrusted PR code runs on a self-hosted runner. Restricted to same-repo PRs
@@ -8,7 +8,7 @@ on:
     types: [labeled, opened, synchronize, reopened]
 
 concurrency:
-  group: mono-move-bench-${{ github.event.pull_request.number || github.ref }}
+  group: mono-move-micro-bench-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write # Post the sticky benchmark comment.
 
 jobs:
-  mono-move-bench:
+  mono-move-micro-bench:
     # Dispatch, or a same-repo (non-fork) PR carrying the `mono-move` label.
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -25,7 +25,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
       )
     runs-on: benchmark-c3d-60
-    timeout-minutes: 120
+    timeout-minutes: 30
     env:
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
@@ -73,7 +73,7 @@ jobs:
         if: ${{ always() && github.event.number != null }}
         uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@39c5b5dc7717447d0cba270cd115037d32d2844
         with:
-          header: mono-move-bench
+          header: mono-move-micro-bench
           recreate: true
           path: ${{ runner.temp }}/mono-move-bench.md
 

--- a/third_party/move/mono-move/testsuite/benches/int_arith_loop.rs
+++ b/third_party/move/mono-move/testsuite/benches/int_arith_loop.rs
@@ -30,10 +30,10 @@ fn bench_int_arith_loop(c: &mut Criterion) {
             .warm_up_time(std::time::Duration::from_secs(1))
             .measurement_time(std::time::Duration::from_secs(3));
 
-        group.bench_function("native/u64", |b| {
+        group.bench_function("native_u64", |b| {
             b.iter(|| black_box(native_u64_loop(ITERS)));
         });
-        group.bench_function("native/i64", |b| {
+        group.bench_function("native_i64", |b| {
             b.iter(|| black_box(native_i64_loop(ITERS)));
         });
 
@@ -44,7 +44,7 @@ fn bench_int_arith_loop(c: &mut Criterion) {
             IdentStr::new("int_arith_loop").unwrap(),
             IdentStr::new("u64_loop").unwrap(),
             |runner| {
-                group.bench_function("mono/u64", |b| {
+                group.bench_function("mono_u64", |b| {
                     b.iter(|| black_box(runner.call_words(&[ITERS]).unwrap()));
                 });
             },
@@ -57,7 +57,7 @@ fn bench_int_arith_loop(c: &mut Criterion) {
             IdentStr::new("int_arith_loop").unwrap(),
             IdentStr::new("i64_loop").unwrap(),
             |runner| {
-                group.bench_function("mono/i64", |b| {
+                group.bench_function("mono_i64", |b| {
                     // Same 8 bytes; reinterpret as i64.
                     b.iter(|| black_box(runner.call_words(&[ITERS]).unwrap() as i64));
                 });
@@ -78,7 +78,7 @@ fn bench_int_arith_loop(c: &mut Criterion) {
 
         let module = move_bytecode_int_arith_loop();
         testing::with_loaded_move_function(&module, "u64_loop", |env| {
-            group.bench_function("move_vm/u64", |b| {
+            group.bench_function("move_vm_u64", |b| {
                 b.iter(|| {
                     let result = env.run(vec![testing::arg_u64(ITERS)]);
                     black_box(testing::return_u64(&result))
@@ -86,7 +86,7 @@ fn bench_int_arith_loop(c: &mut Criterion) {
             });
         });
         testing::with_loaded_move_function(&module, "i64_loop", |env| {
-            group.bench_function("move_vm/i64", |b| {
+            group.bench_function("move_vm_i64", |b| {
                 b.iter(|| {
                     let result = env.run(vec![testing::arg_u64(ITERS)]);
                     black_box(testing::return_i64(&result))

--- a/third_party/move/mono-move/testsuite/benches/perf/README.md
+++ b/third_party/move/mono-move/testsuite/benches/perf/README.md
@@ -1,0 +1,38 @@
+# mono-move bench regression gate
+
+Catches wall-time regressions in the new VM (the `mono` criterion benches under
+`../`). Runs on each PR labeled `mono-move` via
+`.github/workflows/mono-move-bench.yaml`.
+
+## How it works
+
+Same-job A/B on a dedicated runner: the benches run on the PR's merge-base with
+`main`, then on the PR head compared against it. A bench fails the gate only when
+the whole 95% CI of its slowdown clears the noise band `T` (`threshold_pct` in
+`config.json`, default 3%). Improvements and within-noise changes pass.
+
+There is no committed baseline. `main` is the live baseline, so merging a PR
+automatically becomes the baseline the next PR compares against.
+
+## Files
+
+- `compare.py` — reads `target/criterion/<id>/change/estimates.json`, classifies
+  each mono bench, writes the markdown report, exits 1 on a regression.
+- `run.sh` — the A/B driver (`ab`) and the noise-floor helper (`calibrate-noise`).
+- `config.json` — `threshold_pct` and the gated criterion ids.
+
+When you add or rename a mono bench, update `mono_benches` in `config.json`.
+
+## Local use
+
+```bash
+# Compare your branch against its merge-base with main (heavy: builds + runs
+# both sides; leaves the repo on a detached HEAD).
+third_party/move/mono-move/testsuite/benches/perf/run.sh ab origin/main HEAD --out /tmp/report.md
+
+# Measure the machine's noise floor to pick threshold_pct (runs main vs main).
+third_party/move/mono-move/testsuite/benches/perf/run.sh calibrate-noise
+```
+
+Run from inside the repo. The CI workflow copies these scripts out of the
+worktree first, because `ab` checks out other refs.

--- a/third_party/move/mono-move/testsuite/benches/perf/README.md
+++ b/third_party/move/mono-move/testsuite/benches/perf/README.md
@@ -2,14 +2,16 @@
 
 Catches wall-time regressions in the new VM (the `mono` criterion benches under
 `../`). Runs on each PR labeled `mono-move` via
-`.github/workflows/mono-move-bench.yaml`.
+`.github/workflows/mono-move-micro-bench.yaml`.
 
 ## How it works
 
 Same-job A/B on a dedicated runner: the benches run on the PR's merge-base with
-`main`, then on the PR head compared against it. A bench fails the gate only when
-the whole 95% CI of its slowdown clears the noise band `T` (`threshold_pct` in
-`config.json`, default 3%). Improvements and within-noise changes pass.
+`main`, then on the PR head compared against it. criterion reports each bench's
+slowdown as a 95% confidence interval -- a range that accounts for run-to-run
+noise, not a single number. A bench fails the gate only when that whole interval
+exceeds `threshold_percent` (in `config.json`, default 3%); if the interval
+straddles the threshold the change counts as noise and passes.
 
 There is no committed baseline. `main` is the live baseline, so merging a PR
 automatically becomes the baseline the next PR compares against.
@@ -19,7 +21,7 @@ automatically becomes the baseline the next PR compares against.
 - `compare.py` — reads `target/criterion/<id>/change/estimates.json`, classifies
   each mono bench, writes the markdown report, exits 1 on a regression.
 - `run.sh` — the A/B driver (`ab`) and the noise-floor helper (`calibrate-noise`).
-- `config.json` — `threshold_pct` and the gated criterion ids.
+- `config.json` — `threshold_percent` and the gated criterion ids.
 
 When you add or rename a mono bench, update `mono_benches` in `config.json`.
 
@@ -30,7 +32,7 @@ When you add or rename a mono bench, update `mono_benches` in `config.json`.
 # both sides; leaves the repo on a detached HEAD).
 third_party/move/mono-move/testsuite/benches/perf/run.sh ab origin/main HEAD --out /tmp/report.md
 
-# Measure the machine's noise floor to pick threshold_pct (runs main vs main).
+# Measure the machine's noise floor to pick threshold_percent (runs main vs main).
 third_party/move/mono-move/testsuite/benches/perf/run.sh calibrate-noise
 ```
 

--- a/third_party/move/mono-move/testsuite/benches/perf/compare.py
+++ b/third_party/move/mono-move/testsuite/benches/perf/compare.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# Copyright (c) Aptos Foundation
+# Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+"""Compare mono-move criterion benches against a baseline and gate on regressions.
+
+This reads the JSON criterion writes under `target/criterion/<id>/`:
+  - `change/estimates.json` exists after a `--baseline <name>` run and holds the
+    relative change of this run vs the baseline. Its `mean`/`median` values are
+    ratios (`new/old - 1`), so `+0.05` means 5% slower.
+  - `new/estimates.json` holds the current run's absolute estimates, in
+    nanoseconds per iteration.
+
+The verdict uses the `mean` estimate's confidence interval: a regression needs the
+whole CI above the noise threshold `T`, an improvement needs it below `-T`,
+otherwise the change is within noise.
+"""
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+
+# Verdicts. Only REGRESSION fails the gate.
+REGRESSION = "regression"
+IMPROVEMENT = "improvement"
+NOISE = "noise"
+NEW = "new"
+ABSENT = "absent"
+
+
+def load_config(path):
+    with open(path) as f:
+        cfg = json.load(f)
+    # `threshold_pct` is a percentage (3.0 == 3%); the CI bounds are ratios.
+    cfg["threshold"] = cfg["threshold_pct"] / 100.0
+    return cfg
+
+
+def read_estimates(path):
+    if not path.exists():
+        return None
+    with open(path) as f:
+        return json.load(f)
+
+
+def fmt_pct(ratio):
+    return f"{ratio * 100:+.1f}%"
+
+
+def fmt_ns(ns):
+    if ns is None:
+        return "n/a"
+    if ns < 1_000.0:
+        return f"{ns:.1f}ns"
+    if ns < 1_000_000.0:
+        return f"{ns / 1_000.0:.2f}µs"
+    if ns < 1_000_000_000.0:
+        return f"{ns / 1_000_000.0:.2f}ms"
+    return f"{ns / 1_000_000_000.0:.2f}s"
+
+
+def classify(change, threshold):
+    """Verdict for a change `mean` estimate: regression if the whole CI is above
+    `threshold`, improvement if below `-threshold`, else noise.
+    """
+    ci = change["mean"]["confidence_interval"]
+    lo = ci["lower_bound"]
+    hi = ci["upper_bound"]
+    if lo > threshold:
+        return REGRESSION
+    if hi < -threshold:
+        return IMPROVEMENT
+    return NOISE
+
+
+def evaluate(cfg, criterion_dir):
+    """Evaluate every configured mono bench id; return a list of result dicts."""
+    threshold = cfg["threshold"]
+    results = []
+    for entry in cfg["mono_benches"]:
+        bench_id = entry["id"]
+        id_dir = criterion_dir / bench_id
+        change = read_estimates(id_dir / "change" / "estimates.json")
+        new = read_estimates(id_dir / "new" / "estimates.json")
+        base = read_estimates(id_dir / "main" / "estimates.json")
+
+        new_median = new["median"]["point_estimate"] if new else None
+        base_median = base["median"]["point_estimate"] if base else None
+
+        if change is not None:
+            verdict = classify(change, threshold)
+            mean_pct = change["mean"]["point_estimate"]
+            ci = change["mean"]["confidence_interval"]
+            ci_lo, ci_hi = ci["lower_bound"], ci["upper_bound"]
+        elif new is not None:
+            # Ran but no baseline to compare against -- a bench new to this PR.
+            verdict = NEW
+            mean_pct = ci_lo = ci_hi = None
+        else:
+            # Configured bench produced no results (removed, renamed, or not run).
+            verdict = ABSENT
+            mean_pct = ci_lo = ci_hi = None
+
+        results.append({
+            "id": bench_id,
+            "verdict": verdict,
+            "mean_pct": mean_pct,
+            "ci_lo": ci_lo,
+            "ci_hi": ci_hi,
+            "base_median_ns": base_median,
+            "new_median_ns": new_median,
+        })
+    return results
+
+
+VERDICT_CELL = {
+    REGRESSION: "regression",
+    IMPROVEMENT: "improved",
+    NOISE: "ok",
+    NEW: "new",
+    ABSENT: "absent",
+}
+
+
+def render_markdown(results, cfg):
+    threshold_pct = cfg["threshold_pct"]
+    n_reg = sum(1 for r in results if r["verdict"] == REGRESSION)
+    n_imp = sum(1 for r in results if r["verdict"] == IMPROVEMENT)
+    n_ok = sum(1 for r in results if r["verdict"] == NOISE)
+    n_new = sum(1 for r in results if r["verdict"] == NEW)
+    n_absent = sum(1 for r in results if r["verdict"] == ABSENT)
+
+    if n_reg:
+        headline = f"{n_reg} regression(s) beyond ±{threshold_pct:g}% noise band"
+    else:
+        headline = f"No regressions beyond ±{threshold_pct:g}% noise band"
+
+    lines = [
+        "### mono-move benchmark gate",
+        "",
+        headline,
+        "",
+        f"`{n_ok} ok · {n_imp} improved · {n_new} new · {n_absent} absent` "
+        f"(threshold T = ±{threshold_pct:g}%, criterion mean CI vs `main`)",
+        "",
+        "| Benchmark | mean Δ | 95% CI | median (main → PR) | Verdict |",
+        "| --- | ---: | :---: | :---: | :--- |",
+    ]
+    for r in results:
+        if r["mean_pct"] is None:
+            mean_cell = "n/a"
+            ci_cell = "n/a"
+        else:
+            mean_cell = fmt_pct(r["mean_pct"])
+            ci_cell = f"[{fmt_pct(r['ci_lo'])}, {fmt_pct(r['ci_hi'])}]"
+        median_cell = f"{fmt_ns(r['base_median_ns'])} → {fmt_ns(r['new_median_ns'])}"
+        lines.append(
+            f"| `{r['id']}` | {mean_cell} | {ci_cell} | {median_cell} | "
+            f"{VERDICT_CELL[r['verdict']]} |"
+        )
+    lines.append("")
+    if n_imp:
+        lines.append(
+            "> Improvements are not failures. `main` rebaselines on merge, so the "
+            "next PR compares against the faster code automatically."
+        )
+        lines.append("")
+    if n_absent:
+        lines.append(
+            "> `absent` means a configured bench produced no results (removed, or "
+            "not run). Update `benches/perf/config.json` if a bench was renamed."
+        )
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def emit_json_lines(results, cfg):
+    for r in results:
+        line = {
+            "grep": "grep_json_mono_move_bench",
+            "id": r["id"],
+            "verdict": r["verdict"],
+            "mean_pct": None if r["mean_pct"] is None else r["mean_pct"] * 100.0,
+            "ci_lo_pct": None if r["ci_lo"] is None else r["ci_lo"] * 100.0,
+            "ci_hi_pct": None if r["ci_hi"] is None else r["ci_hi"] * 100.0,
+            "base_median_ns": r["base_median_ns"],
+            "new_median_ns": r["new_median_ns"],
+            "threshold_pct": cfg["threshold_pct"],
+        }
+        print(json.dumps(line))
+
+
+def cmd_ab(args, cfg):
+    criterion_dir = Path(args.criterion_dir)
+    results = evaluate(cfg, criterion_dir)
+    markdown = render_markdown(results, cfg)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(markdown)
+    emit_json_lines(results, cfg)
+    # Human-readable copy to stderr so it shows in CI logs regardless of `--out`.
+    print(markdown, file=sys.stderr)
+
+    regressions = [r for r in results if r["verdict"] == REGRESSION]
+    return 1 if regressions else 0
+
+
+def cmd_calibrate_noise(args, cfg):
+    """Report the runner's observed noise floor from a `main`-vs-`main` A/B.
+
+    With identical code on both sides every change should be ~0; the largest CI
+    bound magnitude across benches is the floor `T` must sit above.
+    """
+    criterion_dir = Path(args.criterion_dir)
+    floor = 0.0
+    print(f"{'benchmark':<28} {'mean Δ':>9} {'|CI| max':>9}")
+    for entry in cfg["mono_benches"]:
+        bench_id = entry["id"]
+        change = read_estimates(criterion_dir / bench_id / "change" / "estimates.json")
+        if change is None:
+            print(f"{bench_id:<28} {'n/a':>9} {'n/a':>9}")
+            continue
+        ci = change["mean"]["confidence_interval"]
+        ci_max = max(abs(ci["lower_bound"]), abs(ci["upper_bound"]))
+        floor = max(floor, ci_max)
+        print(f"{bench_id:<28} {fmt_pct(change['mean']['point_estimate']):>9} "
+              f"{fmt_pct(ci_max):>9}")
+    # Suggest T as the floor rounded up to the next 0.5%, plus a 0.5% margin.
+    floor_pct = floor * 100.0
+    suggested = math.ceil(floor_pct / 0.5) * 0.5 + 0.5
+    print()
+    print(f"observed noise floor: {floor_pct:.2f}%")
+    print(f"suggested threshold_pct: {suggested:.1f}  (set in config.json)")
+    return 0
+
+
+def main():
+    # Parent parser so these options are accepted after the subcommand.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--criterion-dir", default="target/criterion",
+        help="criterion output directory (default: target/criterion)",
+    )
+    common.add_argument(
+        "--config", default=str(Path(__file__).parent / "config.json"),
+        help="path to config.json",
+    )
+
+    parser = argparse.ArgumentParser(description="mono-move bench comparator")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    ab = sub.add_parser("ab", parents=[common],
+                        help="gate a PR A/B run; exit 1 on regression")
+    ab.add_argument("--out", default=None, help="write the markdown report here")
+
+    sub.add_parser("calibrate-noise", parents=[common],
+                   help="report the runner noise floor")
+
+    args = parser.parse_args()
+    cfg = load_config(args.config)
+
+    if args.cmd == "ab":
+        sys.exit(cmd_ab(args, cfg))
+    if args.cmd == "calibrate-noise":
+        sys.exit(cmd_calibrate_noise(args, cfg))
+    parser.error(f"unknown command {args.cmd}")
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/move/mono-move/testsuite/benches/perf/compare.py
+++ b/third_party/move/mono-move/testsuite/benches/perf/compare.py
@@ -34,8 +34,8 @@ ABSENT = "absent"
 def load_config(path):
     with open(path) as f:
         cfg = json.load(f)
-    # `threshold_pct` is a percentage (3.0 == 3%); the CI bounds are ratios.
-    cfg["threshold"] = cfg["threshold_pct"] / 100.0
+    # `threshold_percent` is a percentage (3.0 == 3%); the CI bounds are ratios.
+    cfg["threshold"] = cfg["threshold_percent"] / 100.0
     return cfg
 
 
@@ -126,7 +126,7 @@ VERDICT_CELL = {
 
 
 def render_markdown(results, cfg):
-    threshold_pct = cfg["threshold_pct"]
+    threshold_percent = cfg["threshold_percent"]
     n_reg = sum(1 for r in results if r["verdict"] == REGRESSION)
     n_imp = sum(1 for r in results if r["verdict"] == IMPROVEMENT)
     n_ok = sum(1 for r in results if r["verdict"] == NOISE)
@@ -134,9 +134,9 @@ def render_markdown(results, cfg):
     n_absent = sum(1 for r in results if r["verdict"] == ABSENT)
 
     if n_reg:
-        headline = f"{n_reg} regression(s) beyond ±{threshold_pct:g}% noise band"
+        headline = f"{n_reg} regression(s) beyond ±{threshold_percent:g}% noise band"
     else:
-        headline = f"No regressions beyond ±{threshold_pct:g}% noise band"
+        headline = f"No regressions beyond ±{threshold_percent:g}% noise band"
 
     lines = [
         "### mono-move benchmark gate",
@@ -144,7 +144,7 @@ def render_markdown(results, cfg):
         headline,
         "",
         f"`{n_ok} ok · {n_imp} improved · {n_new} new · {n_absent} absent` "
-        f"(threshold T = ±{threshold_pct:g}%, criterion mean CI vs `main`)",
+        f"(threshold T = ±{threshold_percent:g}%, criterion mean CI vs `main`)",
         "",
         "| Benchmark | mean Δ | 95% CI | median (main → PR) | Verdict |",
         "| --- | ---: | :---: | :---: | :--- |",
@@ -188,7 +188,7 @@ def emit_json_lines(results, cfg):
             "ci_hi_pct": None if r["ci_hi"] is None else r["ci_hi"] * 100.0,
             "base_median_ns": r["base_median_ns"],
             "new_median_ns": r["new_median_ns"],
-            "threshold_pct": cfg["threshold_pct"],
+            "threshold_percent": cfg["threshold_percent"],
         }
         print(json.dumps(line))
 
@@ -234,7 +234,7 @@ def cmd_calibrate_noise(args, cfg):
     suggested = math.ceil(floor_pct / 0.5) * 0.5 + 0.5
     print()
     print(f"observed noise floor: {floor_pct:.2f}%")
-    print(f"suggested threshold_pct: {suggested:.1f}  (set in config.json)")
+    print(f"suggested threshold_percent: {suggested:.1f}  (set in config.json)")
     return 0
 
 

--- a/third_party/move/mono-move/testsuite/benches/perf/config.json
+++ b/third_party/move/mono-move/testsuite/benches/perf/config.json
@@ -1,0 +1,12 @@
+{
+  "threshold_pct": 3.0,
+  "mono_benches": [
+    { "id": "fib/mono" },
+    { "id": "nested_loop/mono" },
+    { "id": "merge_sort/mono" },
+    { "id": "bst/mono" },
+    { "id": "match_sum/mono" },
+    { "id": "int_arith_loop/mono_u64" },
+    { "id": "int_arith_loop/mono_i64" }
+  ]
+}

--- a/third_party/move/mono-move/testsuite/benches/perf/config.json
+++ b/third_party/move/mono-move/testsuite/benches/perf/config.json
@@ -1,5 +1,5 @@
 {
-  "threshold_pct": 3.0,
+  "threshold_percent": 3.0,
   "mono_benches": [
     { "id": "fib/mono" },
     { "id": "nested_loop/mono" },

--- a/third_party/move/mono-move/testsuite/benches/perf/run.sh
+++ b/third_party/move/mono-move/testsuite/benches/perf/run.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Copyright (c) Aptos Foundation
+# Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+#
+# Same-job A/B driver for the mono-move bench regression gate.
+#
+#   run.sh ab <base_ref> <head> [--out <file>]
+#       Run the mono benches on the merge-base of <head> and <base_ref> (typically
+#       origin/main), saved as criterion baseline "main", then on <head> compared
+#       against it, then gate via compare.py. Exits non-zero on a regression.
+#
+#   run.sh calibrate-noise [--out <file>]
+#       Run the benches twice on the current checkout (identical code both times)
+#       and report the runner's noise floor, to pick threshold_pct in config.json.
+#
+# Because `ab` checks out other refs in the repo, run this script from a COPY
+# placed OUTSIDE the working tree (e.g. $RUNNER_TEMP/perf), or the checkout will
+# replace the script while it executes. CWD must be inside the target git repo.
+#
+# Limitation: if a PR changes a bench's parameters (e.g. a `const N`), the base
+# and head runs measure different work and that bench's comparison is not
+# meaningful -- criterion has no knowledge of those constants. Review such PRs by
+# hand. The gate still protects every unchanged bench.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BENCH_DIR="$REPO_ROOT/third_party/move/mono-move/testsuite/benches"
+CRIT_DIR="$REPO_ROOT/target/criterion"
+PKG="mono-move-testsuite"
+
+# List the [[bench]] names defined at the current checkout (file stems under
+# benches/, excluding the perf/ tooling dir which holds no .rs files).
+list_benches() {
+    find "$BENCH_DIR" -maxdepth 1 -name '*.rs' -exec basename {} .rs \; | sort
+}
+
+run_bench() {
+    # run_bench <name> <criterion-arg...>; returns cargo's exit code.
+    local name="$1"; shift
+    echo "::group::cargo bench $name $*" >&2
+    local rc=0
+    (cd "$REPO_ROOT" && cargo bench -p "$PKG" --bench "$name" -- "$@") || rc=$?
+    echo "::endgroup::" >&2
+    return $rc
+}
+
+contains() {
+    # contains <needle> <haystack-words...>
+    local needle="$1"; shift
+    local w
+    for w in "$@"; do [[ "$w" == "$needle" ]] && return 0; done
+    return 1
+}
+
+clean_criterion() {
+    # target/criterion persists on the self-hosted runner; wipe it so a stale
+    # change/ dir from a renamed or removed bench can't produce a false verdict.
+    # Guarded so a bad REPO_ROOT can't become an unbounded delete.
+    if [[ -n "$REPO_ROOT" && "$CRIT_DIR" == "$REPO_ROOT/target/criterion" ]]; then
+        rm -rf "$CRIT_DIR"
+    fi
+}
+
+cmd_ab() {
+    local base_ref="$1" head_arg="$2" out="$3"
+
+    clean_criterion
+
+    # Make `origin/main` resolvable; the merge-base below fails loudly if not.
+    git -C "$REPO_ROOT" fetch --quiet origin main:refs/remotes/origin/main || true
+
+    # Resolve head up front: after the base checkout, "HEAD" points at the base.
+    local head_sha
+    head_sha=$(git -C "$REPO_ROOT" rev-parse --verify "$head_arg^{commit}") || {
+        echo "error: cannot resolve head '$head_arg'" >&2; exit 2; }
+
+    local base_sha
+    base_sha=$(git -C "$REPO_ROOT" merge-base "$head_sha" "$base_ref") || {
+        echo "error: cannot compute merge-base of $head_sha and $base_ref" >&2
+        exit 2; }
+
+    echo ">> base (merge-base of head and $base_ref): $base_sha" >&2
+    git -C "$REPO_ROOT" checkout --quiet --detach "$base_sha"
+    local base_benches; base_benches=$(list_benches)
+    local b
+    for b in $base_benches; do run_bench "$b" --save-baseline main; done
+
+    echo ">> head: $head_sha" >&2
+    git -C "$REPO_ROOT" checkout --quiet --detach "$head_sha"
+    local head_benches; head_benches=$(list_benches)
+    for b in $head_benches; do
+        if ! contains "$b" $base_benches; then
+            # New bench file on this PR: no baseline exists, so just record it.
+            run_bench "$b" --save-baseline new
+        elif ! run_bench "$b" --baseline main; then
+            # --baseline panics if a baseline is missing (a new bench function in
+            # an existing file); re-record without comparison instead of failing.
+            echo ">> '$b': missing baseline (new bench function?); recording without comparison" >&2
+            run_bench "$b" --save-baseline new
+        fi
+    done
+
+    local args=(ab --criterion-dir "$CRIT_DIR")
+    [[ -n "$out" ]] && args+=(--out "$out")
+    python3 "$SCRIPT_DIR/compare.py" "${args[@]}"
+}
+
+cmd_calibrate_noise() {
+    clean_criterion
+    local benches; benches=${MONO_MOVE_BENCHES:-$(list_benches)}
+    local b
+    for b in $benches; do run_bench "$b" --save-baseline main; done
+    for b in $benches; do run_bench "$b" --baseline main; done
+    python3 "$SCRIPT_DIR/compare.py" calibrate-noise --criterion-dir "$CRIT_DIR"
+}
+
+main() {
+    local cmd="${1:-}"; shift || true
+    local out=""
+    local positional=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --out) out="$2"; shift 2 ;;
+            *) positional+=("$1"); shift ;;
+        esac
+    done
+
+    case "$cmd" in
+        ab)
+            [[ ${#positional[@]} -ge 2 ]] || { echo "usage: run.sh ab <base_ref> <head_sha> [--out <file>]" >&2; exit 2; }
+            cmd_ab "${positional[0]}" "${positional[1]}" "$out"
+            ;;
+        calibrate-noise)
+            cmd_calibrate_noise
+            ;;
+        *)
+            echo "usage: run.sh {ab|calibrate-noise} ..." >&2
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/third_party/move/mono-move/testsuite/benches/perf/run.sh
+++ b/third_party/move/mono-move/testsuite/benches/perf/run.sh
@@ -11,7 +11,7 @@
 #
 #   run.sh calibrate-noise [--out <file>]
 #       Run the benches twice on the current checkout (identical code both times)
-#       and report the runner's noise floor, to pick threshold_pct in config.json.
+#       and report the runner's noise floor, to pick threshold_percent in config.json.
 #
 # Because `ab` checks out other refs in the repo, run this script from a COPY
 # placed OUTSIDE the working tree (e.g. $RUNNER_TEMP/perf), or the checkout will


### PR DESCRIPTION
## What

Adds a wall-time regression gate for the mono-move benchmarks
(`third_party/move/mono-move/testsuite/benches/`), gated on the `mono-move` label.

## How it works

Same-job A/B on the dedicated `benchmark-c3d-60` runner:

- The `mono` benches run on the PR's merge-base with `main` (saved as criterion
  baseline `main`), then on the PR head compared against it. Running both halves
  back-to-back on the same machine cancels machine-to-machine variance.
- A bench fails the gate only when the whole 95% criterion confidence interval of
  its slowdown clears the noise band `T` (`threshold_pct` in `config.json`,
  default 3%). Improvements and within-noise changes pass.
- Results post to the job step summary and a sticky PR comment.

There is no committed baseline. `main` is the live baseline, so merging a PR
becomes the baseline the next PR compares against.

## Files

- `perf/compare.py` reads criterion's `change/estimates.json`, classifies each
  mono bench, writes the report, and exits 1 on a regression.
- `perf/run.sh` is the A/B driver (`ab`) plus a noise-floor helper (`calibrate-noise`).
- `perf/config.json` holds the threshold and the gated criterion ids.
- `.github/workflows/mono-move-bench.yaml` is the label-gated workflow.

## Before relying on it

Calibrate `T` on `benchmark-c3d-60`: run `run.sh calibrate-noise` via
`workflow_dispatch` and set `threshold_pct`. The sub-millisecond `int_arith_loop`
benches are the noise-sensitive ones.

## Known follow-up

A configured bench id that produces no comparison is reported `absent` but does
not yet fail the gate. Making `absent` fail, so a mistyped or renamed id cannot
silently drop a bench, is a planned follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and benchmark tooling only; no production VM or auth paths. Gate is label-scoped and runs untrusted PR code only on same-repo runners with restricted permissions.
> 
> **Overview**
> Adds a **mono-move micro-benchmark regression gate** for PRs labeled `mono-move`, running on the dedicated `benchmark-c3d-60` self-hosted runner (same-repo only; forks excluded).
> 
> The new workflow **`.github/workflows/mono-move-micro-bench.yaml`** stages `perf/` scripts outside the worktree, runs merge-base vs PR-head A/B via `run.sh ab`, writes a markdown report to the job summary and a sticky PR comment, and **fails the job** when `compare.py` detects a regression beyond the configured noise band.
> 
> New **`testsuite/benches/perf/`** tooling: `run.sh` checks out merge-base and head, runs criterion benches twice on one machine; `compare.py` reads criterion `change/estimates.json`, classifies each gated `mono` bench (regression only if the full 95% CI clears ±`threshold_percent`, default 3%), and exits 1 on regression; `config.json` lists gated criterion ids; README documents local use and `calibrate-noise`.
> 
> **`int_arith_loop.rs`** renames criterion bench ids from slash form (e.g. `mono/u64`) to underscores (`mono_u64`, `mono_i64`) so they match the ids in `config.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec4b66b30af85071e52d39c3005ab41453e3fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->