### PR TITLE
[mono-move] Keep type as identity, use layouts for size/alignment

### DIFF
--- a/third_party/move/mono-move/core/src/native/context.rs
+++ b/third_party/move/mono-move/core/src/native/context.rs
@@ -88,6 +88,10 @@ pub trait NativeContext {
     /// The `i`-th type argument.
     fn ty_arg(&self, i: usize) -> Result<InternedType, VMInternalError>;
 
+    /// In-memory byte size of a value of type `ty`. Errors if the type has no
+    /// published layout (e.g. an unresolved generic or an unloaded module).
+    fn value_size(&self, ty: InternedType) -> Result<u32, VMInternalError>;
+
     /// Returns a copy of the `i`-th argument's raw in-frame bytes -- a low-level
     /// API for natives that need to operate on generic opaque values.
     fn arg_raw(&self, i: usize) -> Result<Vec<u8>, VMInternalError>;

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -37,13 +37,8 @@
 //!
 //! ## Fully-instantiated structs and enums
 //!
-//! Struct and enum types are arena-allocated, and store module ID, name
-//! and type arguments that uniquely identify the type. Both can carry an
-//! optional layout slot. The slot stores size and alignment of this type. For
-//! structs, per-field offsets in flat memory are also recorded. Note that enum
-//! field offsets are not cached in the type graph because enum definitions
-//! can change on module upgrade (new variants added); per-variant field
-//! layouts are stored per-module and resolved at runtime.
+//! Struct and enum types are arena-allocated, and store module ID, name and
+//! type arguments that uniquely identify the type.
 //!
 //! ## Generic structs
 
@@ -53,7 +48,7 @@ use crate::{
 };
 use mono_move_alloc::GlobalArenaPtr;
 use move_core_types::ability::AbilitySet;
-use std::{cmp::PartialEq, fmt, sync::OnceLock};
+use std::{cmp::PartialEq, fmt};
 
 // ================================================================================================
 // Layout types
@@ -212,77 +207,6 @@ pub fn is_closed_type(ty: InternedType) -> bool {
     }
 }
 
-/// Layout for struct fields:
-///   - Offset of the field in flat memory representation.
-///   - Pointer to the field's type for traversals (e.g., serialization).
-#[derive(Copy, Clone)]
-pub struct FieldLayout {
-    pub offset: FieldOffset,
-    ty: InternedType,
-}
-
-impl FieldLayout {
-    /// Creates a new field layout entry.
-    pub fn new(offset: FieldOffset, ty: InternedType) -> Self {
-        Self { offset, ty }
-    }
-
-    /// Returns the interned type of this field.
-    pub fn ty(&self) -> InternedType {
-        self.ty
-    }
-}
-
-/// Layout information for a [`Type::Nominal`]: total size, alignment, and an
-/// optional pointer to per-field offsets.
-///
-/// `fields` is `Some(_)` when per-field offsets are cached (today: structs)
-/// and `None` when they are not (today: enums, whose layout can change on
-/// module upgrade). `Some(_)` is therefore not a "this is a struct" marker —
-/// once `#[frozen]` enums land, frozen enums will also carry `Some(_)` since
-/// their variants cannot change. TODO(cleanup): replace this side-channel with a
-/// more explicit shape (e.g., a dedicated enum) once frozen enums are wired
-/// in.
-pub struct NominalLayout {
-    /// Total size of the type. Includes necessary padding based on the
-    /// alignment requirements.
-    pub size: Size,
-    pub align: Alignment,
-    fields: Option<GlobalArenaPtr<[FieldLayout]>>,
-}
-
-impl NominalLayout {
-    /// Creates a struct layout entry with per-field offsets.
-    pub fn new_struct(size: Size, align: Alignment, fields: GlobalArenaPtr<[FieldLayout]>) -> Self {
-        Self {
-            size,
-            align,
-            fields: Some(fields),
-        }
-    }
-
-    /// Creates an enum layout entry. Enums do not store per-field offsets
-    /// at the type level.
-    pub fn new_enum(size: Size, align: Alignment) -> Self {
-        Self {
-            size,
-            align,
-            fields: None,
-        }
-    }
-
-    // TODO(testing): This API is test-only for now, will change, so ignore safety.
-    pub fn field_layouts(&self) -> Option<&[FieldLayout]> {
-        self.fields.map(|p| unsafe { p.as_ref_unchecked() })
-    }
-}
-
-// Arena reset bulk-rewinds without running `Drop`. Layout is allowed to skip
-// drop only as long as it owns no non-arena memory. If a future field
-// introduces a heap owner (`Vec`, `String`, `Box`, etc.), this assertion turns
-// the silent leak / double-free into a compile error.
-const _: () = assert!(!std::mem::needs_drop::<NominalLayout>());
-
 // ================================================================================================
 // Type enum
 // ================================================================================================
@@ -320,29 +244,13 @@ pub enum Type {
     Vector {
         elem: InternedType,
     },
-    /// Nominal type — a struct or enum identified by name. The layout slot is
-    /// empty for generic instances and for cross-module references whose
-    /// layout has not yet been populated by the loader; it is filled once via
-    /// [`OnceLock::set`] when all constituent layouts become available. For
-    /// structs, layout stores field offsets as well. This is not the case for
-    /// enums. Enums are always pointer-sized today, because new variants may
-    /// be added on module upgrade.
-    ///
-    /// TODO(completeness): `#[frozen]` enums (e.g., `Option`) cannot gain new variants on
-    /// upgrade, so they should cache per-variant field offsets in the layout
-    /// slot rather than indirecting through a pointer. This will need to be
-    /// wired in once the frozen-enum attribute is supported end-to-end.
-    ///
-    /// The slot is `OnceLock`-gated so layout can be filled after interning.
-    /// Drop on arena reset is skipped (bumpalo bulk-rewinds without calling
-    /// `Drop`), which is harmless only as long as layout owns no non-arena
-    /// memory - keep it that way.
+    /// Nominal type — a struct or enum identified by module, name, and type
+    /// arguments.
     Nominal {
         // TODO(cleanup): Make this a pointer to a named-type struct holding these pointers.
         module_id: InternedModuleId,
         name: InternedIdentifier,
         ty_args: InternedTypeList,
-        layout: OnceLock<NominalLayout>,
     },
     /// Function type with argument types, result types and abilities.
     Function {
@@ -367,49 +275,37 @@ pub enum Type {
     },
 }
 
+/// In-memory slot width and alignment for the shapes whose size is intrinsic:
+/// primitives, references (16-byte fat pointers), and vectors and function
+/// values (8-byte heap-pointer slots). Returns [`None`] for nominal types and
+/// for type parameters.
+pub fn intrinsic_slot_size_and_align(ty: &Type) -> Option<(Size, Alignment)> {
+    Some(match ty {
+        // Primitives.
+        Type::Bool | Type::U8 | Type::I8 => (1, 1),
+        Type::U16 | Type::I16 => (2, 2),
+        Type::U32 | Type::I32 => (4, 4),
+        Type::U64 | Type::I64 => (8, 8),
+        Type::U128 | Type::I128 => (16, 8),
+        Type::U256 | Type::I256 | Type::Address | Type::Signer => (32, 8),
+
+        // Vectors: pointer to the heap which stores vector metadata such as
+        // length, capacity.
+        Type::Vector { .. } => (8, 8),
+
+        // References are 16-byte fat pointers, 8-byte aligned.
+        Type::ImmutRef { .. } | Type::MutRef { .. } => (16, 8),
+
+        // Function values - TODO(completeness): for now use heap pointer values.
+        Type::Function { .. } => (8, 8),
+
+        // Nominal size is the sum of its fields (resolved through the layout
+        // table); type parameters need substitution first.
+        Type::Nominal { .. } | Type::TypeParam { .. } => return None,
+    })
+}
+
 impl Type {
-    /// Returns the size and alignment of this type. Returns [`None`] if the
-    /// size or alignment cannot be computed:
-    ///   - If the type is a generic struct.
-    ///   - If the type is a struct or enum whose layout has not yet been
-    ///     populated (e.g., a cross-module reference awaiting its loader
-    ///     pass).
-    ///   - If the type is an unresolved type parameter.
-    pub fn size_and_align(&self) -> Option<(Size, Alignment)> {
-        Some(match self {
-            // Primitives.
-            Type::Bool | Type::U8 | Type::I8 => (1, 1),
-            Type::U16 | Type::I16 => (2, 2),
-            Type::U32 | Type::I32 => (4, 4),
-            Type::U64 | Type::I64 => (8, 8),
-            Type::U128 | Type::I128 => (16, 8),
-            Type::U256 | Type::I256 | Type::Address | Type::Signer => (32, 8),
-
-            // Vectors: pointer to the heap which stores vector metadata such
-            // as length, capacity.
-            Type::Vector { .. } => (8, 8),
-
-            // References are 16-byte fat pointers, 8-byte aligned.
-            Type::ImmutRef { .. } | Type::MutRef { .. } => (16, 8),
-
-            // Function values - TODO(completeness): for now use heap pointer values.
-            Type::Function { .. } => (8, 8),
-
-            // Nominal types (struct/enum): the layout slot may be empty for
-            // generic instances or for cross-module references awaiting
-            // layout population.
-            Type::Nominal { layout, .. } => match layout.get() {
-                Some(layout) => (layout.size, layout.align),
-                None => return None,
-            },
-
-            // Need type substitution to calculate the size and alignment.
-            Type::TypeParam { .. } => {
-                return None;
-            },
-        })
-    }
-
     /// The short kind word for this type (`"u64"`, `"vector"`, `"struct"`, ...).
     /// Mirrors the legacy VM's `TypeTag::to_short_string`.
     pub fn short_name(&self) -> &'static str {
@@ -442,35 +338,6 @@ impl Type {
     #[inline(always)]
     pub fn is_u64(&self) -> bool {
         matches!(self, Type::U64)
-    }
-
-    /// Returns layout for a nominal (struct or enum) type, or [`None`] for
-    /// other types or for nominal types whose layout slot has not yet been
-    /// populated.
-    pub fn layout(&self) -> Option<&NominalLayout> {
-        match self {
-            Type::Nominal { layout, .. } => layout.get(),
-            Type::Bool
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::U128
-            | Type::U256
-            | Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::I128
-            | Type::I256
-            | Type::Address
-            | Type::Signer
-            | Type::ImmutRef { .. }
-            | Type::MutRef { .. }
-            | Type::Vector { .. }
-            | Type::Function { .. }
-            | Type::TypeParam { .. } => None,
-        }
     }
 }
 

--- a/third_party/move/mono-move/core/src/value_layout.rs
+++ b/third_party/move/mono-move/core/src/value_layout.rs
@@ -17,7 +17,7 @@
 //! header.
 
 use crate::{
-    types::{view_type, InternedType, Type},
+    types::{intrinsic_slot_size_and_align, view_type, Alignment, InternedType, Size, Type},
     DescriptorId, MAX_ALIGN,
 };
 use bitflags::bitflags;
@@ -475,6 +475,16 @@ pub trait LayoutProvider {
     fn layout_by_ty(&self, ty: InternedType) -> Option<&ValueLayout> {
         let id = self.layout_id(ty)?;
         self.layout(id)
+    }
+
+    /// In-memory size and alignment of a value of type `ty`. Intrinsic shapes
+    /// (primitives, references, vectors, functions) resolve without the table;
+    /// nominal types resolve through their published [`ValueLayout`]. Returns
+    /// [`None`] for unresolved type parameters and for nominals whose layout
+    /// has not been published yet.
+    fn size_and_align(&self, ty: InternedType) -> Option<(Size, Alignment)> {
+        intrinsic_slot_size_and_align(view_type(ty))
+            .or_else(|| self.layout_by_ty(ty).map(|l| (l.size, l.align)))
     }
 }
 

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -50,19 +50,18 @@
 //!   - Trade-off: minor memory waste for lower lock contention.
 
 use crate::maintenance_config::MaintenanceConfig;
-use anyhow::{bail, Result};
+use anyhow::Result;
 use dashmap::DashMap;
 use mono_move_alloc::{GlobalArenaPool, GlobalArenaPtr, GlobalArenaShard};
 use mono_move_core::{
-    reserved_layout_id, reserved_layouts, types::NominalLayout, DescriptorId, DescriptorProvider,
-    FrameOffset, FunctionRef, Interner, LayoutId, LayoutProvider, ModuleId, ObjectDescriptor,
-    ValueLayout, TRIVIAL_DESCRIPTOR_ID,
+    reserved_layout_id, reserved_layouts, DescriptorId, DescriptorProvider, FrameOffset,
+    FunctionRef, Interner, LayoutId, LayoutProvider, ModuleId, ObjectDescriptor, ValueLayout,
+    TRIVIAL_DESCRIPTOR_ID,
 };
 use move_binary_format::{file_format::SignatureToken, CompiledModule};
 use std::{
     hash::{Hash, Hasher},
     marker::PhantomData,
-    sync::OnceLock,
 };
 
 // Submodules: to split implementation into smaller pieces.
@@ -81,8 +80,8 @@ use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
 mod types;
 pub use types::{
-    struct_info_at, try_as_primitive_type, view_name, view_type, view_type_list, FieldLayout,
-    InternedType, InternedTypeList, Type,
+    struct_info_at, try_as_primitive_type, view_name, view_type, view_type_list, InternedType,
+    InternedTypeList, Type,
 };
 use types::{TypeInternerKey, TypeListInternerKey};
 
@@ -515,12 +514,8 @@ impl<'ctx> ExecutionGuard<'ctx> {
         unsafe { ptr.as_ref_unchecked() }
     }
 
-    /// Interns a nominal (struct or enum) identity without populating its
-    /// layout. The returned pointer can be used immediately in IR, but
-    /// [`Type::size_and_align`] and [`Type::layout`] will return [`None`]
-    /// until [`Self::set_nominal_layout`] is called for this type. Callers
-    /// using this in cross-module contexts must tolerate the missing layout
-    /// until a layout-population pass runs.
+    /// Interns a nominal (struct or enum) identity. The returned pointer can be
+    /// used immediately in IR.
     pub fn intern_nominal(
         &self,
         module_id: InternedModuleId,
@@ -531,87 +526,8 @@ impl<'ctx> ExecutionGuard<'ctx> {
             module_id,
             name,
             ty_args,
-            layout: OnceLock::new(),
         });
         self.insert_allocated_type_pointer_internal(ty)
-    }
-
-    /// Allocates the field-layout slice in the arena (when `fields` is
-    /// `Some`), builds a [`NominalLayout`] and installs it into the type's
-    /// layout slot. Pass `Some(&fields)` for structs and `None` for enums.
-    /// Returns an error if `ty` is not a nominal type.
-    ///
-    /// Setting layouts concurrently is safe: the layout stores canonical
-    /// field type pointers and so is structurally identical across threads.
-    pub fn set_nominal_layout(
-        &self,
-        ty: InternedType,
-        size: u32,
-        align: u32,
-        fields: Option<&[FieldLayout]>,
-    ) -> Result<()> {
-        let slot = match view_type(ty) {
-            Type::Nominal { layout: slot, .. } => slot,
-            Type::Bool
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::U128
-            | Type::U256
-            | Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::I128
-            | Type::I256
-            | Type::Address
-            | Type::Signer
-            | Type::ImmutRef { .. }
-            | Type::MutRef { .. }
-            | Type::Vector { .. }
-            | Type::Function { .. }
-            | Type::TypeParam { .. } => {
-                bail!("set_nominal_layout called on a non-nominal type")
-            },
-        };
-
-        // Fast path: if the layout is already installed, skip the field-slice
-        // allocation entirely. A race can still leak one allocation between
-        // this check and `slot.set` below, but that is bounded and consistent
-        // with the documented arena race trade-off.
-        if slot.get().is_some() {
-            return Ok(());
-        }
-
-        let layout = match fields {
-            Some(fields) => {
-                let fields_ptr = self.global_arena.alloc_slice_copy(fields);
-                NominalLayout::new_struct(size, align, fields_ptr)
-            },
-            None => NominalLayout::new_enum(size, align),
-        };
-        if let Err(other_layout) = slot.set(layout) {
-            let installed_layout = slot.get().expect("Layout was just installed");
-            debug_assert_eq!(installed_layout.size, other_layout.size);
-            debug_assert_eq!(installed_layout.align, other_layout.align);
-            debug_assert_eq!(
-                installed_layout.field_layouts().is_some(),
-                other_layout.field_layouts().is_some()
-            );
-            // Layout computation is deterministic given the type identity,
-            // so per-field offsets must match too.
-            if let (Some(installed), Some(other)) = (
-                installed_layout.field_layouts(),
-                other_layout.field_layouts(),
-            ) {
-                debug_assert_eq!(installed.len(), other.len());
-                for (installed, other) in installed.iter().zip(other.iter()) {
-                    debug_assert_eq!(installed.offset, other.offset);
-                }
-            }
-        }
-        Ok(())
     }
 
     /// Returns the already-published vector-descriptor id for `elem_ty`,
@@ -816,13 +732,6 @@ impl<'ctx> ExecutionGuard<'ctx> {
     /// Looks up a type previously interned from a signature token of `module`.
     /// Returns `None` if the token has not yet been interned in this module's
     /// context.
-    ///
-    /// For nominal types, the returned pointer carries identity but its
-    /// layout slot may still be empty — `set_nominal_layout` runs in a
-    /// separate pass after all field types are interned. Callers consuming
-    /// this in cross-module contexts must tolerate `None` from
-    /// [`Type::size_and_align`] and [`Type::layout`] until the layout-
-    /// population pass completes.
     pub fn try_intern_for_module(
         &self,
         token: &SignatureToken,
@@ -901,7 +810,6 @@ impl<'ctx> Interner for ExecutionGuard<'ctx> {
             module_id,
             name,
             ty_args,
-            layout: OnceLock::new(),
         });
         self.insert_allocated_type_pointer_internal(ty)
     }
@@ -993,13 +901,11 @@ impl<'ctx> Interner for ExecutionGuard<'ctx> {
                 module_id,
                 name,
                 ty_args: inner_args,
-                layout,
             } => {
                 let new_inner_args = self.subst_type_list(*inner_args, ty_args)?;
                 if new_inner_args == *inner_args {
                     ty
                 } else {
-                    debug_assert!(layout.get().is_none(), "Layout cannot be set for generics");
                     self.nominal_of(*module_id, *name, new_inner_args)
                 }
             },

--- a/third_party/move/mono-move/global-context/src/context/types.rs
+++ b/third_party/move/mono-move/global-context/src/context/types.rs
@@ -3,7 +3,7 @@
 
 //! Type interning infrastructure.
 //!
-//! The pure type model ([`Type`], [`FieldLayout`], [`NominalLayout`], etc.)
+//! The pure type model ([`Type`], etc.)
 //! lives in `mono_move_core::types`. This module provides the interning
 //! machinery that deduplicates types in the global arena, plus cross-format
 //! hashing/equality between [`SignatureToken`]s and interned [`Type`]s.
@@ -218,7 +218,6 @@ impl Hash for TypeInternerKey {
                 module_id,
                 name,
                 ty_args,
-                layout: _,
             } => {
                 // SAFETY: It is safe to dereference pointers because the
                 // caller ensures they remain valid during the lifetime of

--- a/third_party/move/mono-move/global-context/src/lib.rs
+++ b/third_party/move/mono-move/global-context/src/lib.rs
@@ -5,8 +5,7 @@ mod context;
 
 pub use context::{
     struct_info_at, try_as_primitive_type, view_name, view_type, view_type_list, ArenaRef,
-    ExecutionGuard, FieldLayout, FunctionSlot, GlobalContext, InternedType, InternedTypeList,
-    LoadedModule, LoadedModuleSlot, MaintenanceGuard, ModuleMandatoryDependencies, ModuleSlot,
-    Type,
+    ExecutionGuard, FunctionSlot, GlobalContext, InternedType, InternedTypeList, LoadedModule,
+    LoadedModuleSlot, MaintenanceGuard, ModuleMandatoryDependencies, ModuleSlot, Type,
 };
 pub mod maintenance_config;

--- a/third_party/move/mono-move/loader/src/loader.rs
+++ b/third_party/move/mono-move/loader/src/loader.rs
@@ -30,7 +30,7 @@ use mono_move_core::{
     LayoutProvider, ModuleId, ModuleProvider, ValueLayout,
 };
 use mono_move_global_context::{
-    ArenaRef, ExecutionGuard, FieldLayout, FunctionSlot, LoadedModule, LoadedModuleSlot,
+    ArenaRef, ExecutionGuard, FunctionSlot, LoadedModule, LoadedModuleSlot,
     ModuleMandatoryDependencies, ModuleSlot,
 };
 use shared_dsa::UnorderedSet;
@@ -295,6 +295,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
             module.ir(),
             func_ir,
             ty_args,
+            self.guard,
             self.guard,
             descriptors,
             self.natives,
@@ -709,6 +710,16 @@ impl<'a, 'guard, 'ctx> LoweringContext<'a, 'guard, 'ctx> {
     }
 }
 
+impl LayoutProvider for LoweringContext<'_, '_, '_> {
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
+        self.loader.guard.layout(id)
+    }
+
+    fn layout_id(&self, ty: InternedType) -> Option<LayoutId> {
+        self.loader.guard.layout_id(ty)
+    }
+}
+
 impl SpecializerContext for LoweringContext<'_, '_, '_> {
     fn get_fields(
         &mut self,
@@ -752,18 +763,6 @@ impl SpecializerContext for LoweringContext<'_, '_, '_> {
             .module
             .interned_field_types(*nominal_name)
             .cloned())
-    }
-
-    fn set_nominal_layout(
-        &self,
-        ty: InternedType,
-        size: u32,
-        align: u32,
-        fields: Option<&[FieldLayout]>,
-    ) -> anyhow::Result<()> {
-        self.loader
-            .guard
-            .set_nominal_layout(ty, size, align, fields)
     }
 
     fn subst_type(
@@ -811,14 +810,6 @@ impl SpecializerContext for LoweringContext<'_, '_, '_> {
             .loader
             .guard
             .publish_captured_data_descriptor(values_size, pointer_offsets))
-    }
-
-    fn layout_id_for(&self, ty: InternedType) -> Option<LayoutId> {
-        self.loader.guard.layout_id_for(ty)
-    }
-
-    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
-        self.loader.guard.layout(id)
     }
 
     fn publish_layout(&self, ty: InternedType, layout: ValueLayout) -> LayoutId {

--- a/third_party/move/mono-move/natives/src/mem.rs
+++ b/third_party/move/mono-move/natives/src/mem.rs
@@ -4,19 +4,15 @@
 //! Native for the `mem` module.
 
 use crate::{polymorphic_natives, NativeEntry};
-use mono_move_core::{
-    native::{NativeContext, NativeContextFamily, NativeStatus, Opaque, Ref, VMInternalError},
-    types::view_type,
+use mono_move_core::native::{
+    NativeContext, NativeContextFamily, NativeStatus, Opaque, Ref, VMInternalError,
 };
 
 /// `0x1::mem::swap<T>(left: &mut T, right: &mut T)`
 ///
 /// Exchanges the values behind the two references.
 pub fn native_swap<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
-    let (size, _) = view_type(ctx.ty_arg(0)?).size_and_align().ok_or_else(|| {
-        VMInternalError::invariant_violation("mem::swap: type argument has no concrete size".into())
-    })?;
-    let size = size as usize;
+    let size = ctx.value_size(ctx.ty_arg(0)?)? as usize;
     // SAFETY: arg 0 / arg 1 are `&mut T`, each holding `size` valid bytes.
     unsafe {
         let left: Ref<Opaque> = ctx.arg(0)?;

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -250,6 +250,15 @@ impl NativeContext for ProductionNativeContext<'_> {
         })
     }
 
+    fn value_size(&self, ty: InternedType) -> Result<u32, VMInternalError> {
+        self.layouts
+            .size_and_align(ty)
+            .map(|(size, _)| size)
+            .ok_or_else(|| {
+                VMInternalError::invariant_violation("value_size: type has no known layout".into())
+            })
+    }
+
     fn arg_raw(&self, i: usize) -> Result<Vec<u8>, VMInternalError> {
         if self.returns_started.get() {
             return Err(VMInternalError::invariant_violation(format!(

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -18,11 +18,9 @@
 //! 4. For instructions with more than 1 destination, they must be disjoint.
 
 use mono_move_core::{
-    captured_values_size,
-    native::NativeABI,
-    types::{view_type, InternedType},
-    CallClosureOp, ClosureFuncRef, CodeOffset, DescriptorId, DescriptorProvider, FrameOffset,
-    Function, IntBinaryOp, MicroOp, ObjectDescriptorInner, PackClosureOp, ShiftOperand,
+    captured_values_size, native::NativeABI, types::InternedType, CallClosureOp, ClosureFuncRef,
+    CodeOffset, DescriptorId, DescriptorProvider, FrameOffset, Function, IntBinaryOp,
+    LayoutProvider, MicroOp, ObjectDescriptorInner, PackClosureOp, ShiftOperand,
     CLOSURE_DESCRIPTOR_ID, FRAME_METADATA_SIZE,
 };
 use std::fmt;
@@ -53,7 +51,7 @@ impl fmt::Display for VerificationError {
 
 /// Validate a single function and its pointer slots against the descriptor
 /// provider. Returns an empty `Vec` on success.
-pub fn verify_function<P: DescriptorProvider + ?Sized>(
+pub fn verify_function<P: DescriptorProvider + LayoutProvider + ?Sized>(
     func: &Function,
     provider: &P,
 ) -> Vec<VerificationError> {
@@ -69,7 +67,7 @@ pub fn verify_function<P: DescriptorProvider + ?Sized>(
 
 /// Validate every function in a program against a shared descriptor
 /// provider. Errors from each function are concatenated.
-pub fn verify_program<P: DescriptorProvider + ?Sized>(
+pub fn verify_program<P: DescriptorProvider + LayoutProvider + ?Sized>(
     funcs: &[&Function],
     provider: &P,
 ) -> Vec<VerificationError> {
@@ -84,13 +82,13 @@ pub fn verify_program<P: DescriptorProvider + ?Sized>(
 // Per-function verifier — holds shared state so helpers don't need many args
 // ---------------------------------------------------------------------------
 
-struct FunctionVerifier<'a, P: DescriptorProvider + ?Sized> {
+struct FunctionVerifier<'a, P: DescriptorProvider + LayoutProvider + ?Sized> {
     func: &'a Function,
     provider: &'a P,
     errors: &'a mut Vec<VerificationError>,
 }
 
-impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
+impl<P: DescriptorProvider + LayoutProvider + ?Sized> FunctionVerifier<'_, P> {
     fn verify(&mut self) {
         let code = self.func.code.get();
 
@@ -1077,7 +1075,7 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
     /// bounds check still fails the function (via the recorded error) rather
     /// than passing on an unknown size.
     fn type_size(&mut self, pc: usize, ty: InternedType) -> u32 {
-        match view_type(ty).size_and_align() {
+        match self.provider.size_and_align(ty) {
             Some((size, _align)) => size,
             None => {
                 self.err(

--- a/third_party/move/mono-move/runtime/tests/verifier_test.rs
+++ b/third_party/move/mono-move/runtime/tests/verifier_test.rs
@@ -7,15 +7,37 @@ mod common;
 
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
-    Code, CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp,
-    SortedSafePointEntries,
+    types::InternedType, Code, CodeOffset as CO, DescriptorId, DescriptorProvider, FrameLayoutInfo,
+    FrameOffset as FO, Function, LayoutId, LayoutProvider, MicroOp, SortedSafePointEntries,
+    ValueLayout,
 };
 use mono_move_runtime::{verify_function, ObjectDescriptor, ObjectDescriptorTable};
 
-fn trivial_descriptors() -> ObjectDescriptorTable {
+/// A descriptor table paired with an empty layout provider, to satisfy the
+/// verifier's `DescriptorProvider + LayoutProvider` bound. These tests do not
+/// exercise value-comparison operands, the only ops that read a layout.
+struct VerifierProvider(ObjectDescriptorTable);
+
+impl DescriptorProvider for VerifierProvider {
+    fn descriptor(&self, id: DescriptorId) -> Option<&ObjectDescriptor> {
+        self.0.descriptor(id)
+    }
+}
+
+impl LayoutProvider for VerifierProvider {
+    fn layout(&self, _id: LayoutId) -> Option<&ValueLayout> {
+        None
+    }
+
+    fn layout_id(&self, _ty: InternedType) -> Option<LayoutId> {
+        None
+    }
+}
+
+fn trivial_descriptors() -> VerifierProvider {
     let mut t = ObjectDescriptorTable::new();
     t.push(ObjectDescriptor::new_vector(8, vec![0]).unwrap());
-    t
+    VerifierProvider(t)
 }
 
 /// A minimal well-formed function: one `Return`, param_and_local_sizes_sum 8.
@@ -742,7 +764,7 @@ fn vec_pushback_rejects_non_vector_descriptor() {
     let mut descriptors = ObjectDescriptorTable::new();
     let struct_desc = descriptors.push(ObjectDescriptor::new_struct(8, vec![]).unwrap());
     let func = vec_pushback_func(struct_desc);
-    let errors = verify_function(&func, &descriptors);
+    let errors = verify_function(&func, &VerifierProvider(descriptors));
     assert!(errors.iter().any(|e| e.message.contains("VecPushBack")
         && e.message.contains("not a non-empty Vector or Trivial")));
 }

--- a/third_party/move/mono-move/specializer/src/gas.rs
+++ b/third_party/move/mono-move/specializer/src/gas.rs
@@ -27,7 +27,7 @@ use crate::{
     stackless_exec_ir::{Instr, Slot},
 };
 use anyhow::{bail, Result};
-use mono_move_core::types::InternedType;
+use mono_move_core::{types::InternedType, LayoutProvider};
 use move_binary_format::file_format::FieldHandleIndex;
 
 // --- Loads ---
@@ -98,6 +98,9 @@ pub(crate) trait CostContext {
     /// substitutes types here only to read monomorphized sizes,
     /// duplicating the substitution lowering already performs.
     fn concrete_ty(&self, ty: InternedType) -> Result<InternedType>;
+
+    /// Published value layouts, used to resolve concrete type sizes.
+    fn layouts(&self) -> &dyn LayoutProvider;
 }
 
 /// Total move cost over a list of source slots.
@@ -137,7 +140,7 @@ pub(crate) fn instr_cost(instr: &Instr, cx: &impl CostContext) -> Result<u64> {
 
         // --- Structs ---
         Instr::Pack(_, struct_ty, _) | Instr::Unpack(_, struct_ty, _) => move_bytes(
-            concrete_type_size(cx.concrete_ty(*struct_ty)?, "struct type")?,
+            concrete_type_size(cx.layouts(), cx.concrete_ty(*struct_ty)?, "struct type")?,
         ),
 
         // --- Enums ---
@@ -151,8 +154,12 @@ pub(crate) fn instr_cost(instr: &Instr, cx: &impl CostContext) -> Result<u64> {
         | Instr::MutBorrowField(..)
         | Instr::ImmBorrowVariantField(..)
         | Instr::MutBorrowVariantField(..) => BORROW,
-        Instr::ReadRef(_, ref_src) => read_write_ref(ref_pointee_size(cx.slot_ty(*ref_src)?)?),
-        Instr::WriteRef(ref_dst, _) => read_write_ref(ref_pointee_size(cx.slot_ty(*ref_dst)?)?),
+        Instr::ReadRef(_, ref_src) => {
+            read_write_ref(ref_pointee_size(cx.layouts(), cx.slot_ty(*ref_src)?)?)
+        },
+        Instr::WriteRef(ref_dst, _) => {
+            read_write_ref(ref_pointee_size(cx.layouts(), cx.slot_ty(*ref_dst)?)?)
+        },
 
         // --- Fused field access (borrow + read/write) ---
         Instr::ReadField(_, owner, fh, _) => {
@@ -188,18 +195,20 @@ pub(crate) fn instr_cost(instr: &Instr, cx: &impl CostContext) -> Result<u64> {
         Instr::VecLen(..) => VEC_LEN,
         Instr::VecImmBorrow(..) | Instr::VecMutBorrow(..) => VEC_BORROW,
         Instr::VecPushBack(elem_ty, _, _) | Instr::VecPopBack(_, elem_ty, _) => vec_elem(
-            concrete_type_size(cx.concrete_ty(*elem_ty)?, "vector elem type")?,
+            concrete_type_size(cx.layouts(), cx.concrete_ty(*elem_ty)?, "vector elem type")?,
         ),
         Instr::VecUnpack(dsts, elem_ty, _) => {
             VEC_NEW
                 + dsts.len() as u64
                     * move_bytes(concrete_type_size(
+                        cx.layouts(),
                         cx.concrete_ty(*elem_ty)?,
                         "vector elem type",
                     )?)
         },
         Instr::VecSwap(elem_ty, _, _, _) => {
             2 * vec_elem(concrete_type_size(
+                cx.layouts(),
                 cx.concrete_ty(*elem_ty)?,
                 "vector elem type",
             )?)

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -26,13 +26,13 @@ use mono_move_core::{
     native::{NativeIdx, NativeResolver},
     next_captured_value_offset,
     types::{
-        is_closed_type, strip_ref, view_type, view_type_list, Alignment, FieldLayout, InternedType,
-        InternedTypeList, Size, Type, EMPTY_TYPE_LIST,
+        is_closed_type, strip_ref, view_type, view_type_list, InternedType, InternedTypeList, Type,
+        EMPTY_TYPE_LIST,
     },
     value_layout::REF_LAYOUT_ID,
     Code, DescriptorId, FieldTypes, FieldValueLayout, FrameLayoutInfo, FrameOffset, Function,
-    Interner, LayoutFlags, LayoutId, PreparedModule, SizedSlot, SortedSafePointEntries,
-    ValueLayout, FRAME_METADATA_SIZE, MAX_ALIGN,
+    Interner, LayoutFlags, LayoutId, LayoutProvider, PreparedModule, SizedSlot,
+    SortedSafePointEntries, ValueLayout, FRAME_METADATA_SIZE, MAX_ALIGN,
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -53,24 +53,23 @@ fn reserve_slot(frame_data_size: &mut u32, size: u32) -> FrameOffset {
     FrameOffset(offset)
 }
 
-/// Returns the (size, alignment) of a concrete interned type, or None if the
-/// type is not concrete (e.g., contains type parameters or unresolved structs).
-pub fn type_size_and_align(ty: InternedType) -> Option<(Size, Alignment)> {
-    view_type(ty).size_and_align()
-}
-
 /// Size in bytes of `ty`. Errors when the type isn't concrete; `label`
 /// identifies the value in the error message.
-pub fn concrete_type_size(ty: InternedType, label: &str) -> Result<u32> {
-    let (size, _) =
-        type_size_and_align(ty).ok_or_else(|| anyhow::anyhow!("{} has no concrete size", label))?;
+pub fn concrete_type_size(
+    layouts: &dyn LayoutProvider,
+    ty: InternedType,
+    label: &str,
+) -> Result<u32> {
+    let (size, _) = layouts
+        .size_and_align(ty)
+        .ok_or_else(|| anyhow::anyhow!("{} has no concrete size", label))?;
     Ok(size)
 }
 
 /// Byte width of the pointee of reference type `ref_ty`. Errors when `ref_ty`
 /// is not a reference, or when its pointee isn't concrete.
-pub fn ref_pointee_size(ref_ty: InternedType) -> Result<u32> {
-    concrete_type_size(strip_ref(ref_ty)?, "ref pointee type")
+pub fn ref_pointee_size(layouts: &dyn LayoutProvider, ref_ty: InternedType) -> Result<u32> {
+    concrete_type_size(layouts, strip_ref(ref_ty)?, "ref pointee type")
 }
 
 /// A frame slot paired with the type of its value.
@@ -147,8 +146,8 @@ fn publish_struct_descriptor_for(
     ty: InternedType,
     descriptors: &mut UnorderedMap<InternedType, DescriptorId>,
 ) -> Result<()> {
-    if let Some((size, _)) = type_size_and_align(ty)
-        && let Ok(ptr_offsets) = type_pointer_offsets(ty)
+    if let Some((size, _)) = ctx.size_and_align(ty)
+        && let Ok(ptr_offsets) = type_pointer_offsets(ctx, ty)
     {
         let ptr_offsets = ptr_offsets.into_iter().map(FrameOffset).collect::<Vec<_>>();
         let id = ctx.publish_struct_descriptor(ty, size, &ptr_offsets)?;
@@ -301,6 +300,9 @@ pub struct LoweringContext<'a> {
     pub home_types: InternedTypeList,
     /// Interner used to substitute `ty_args` into instruction-embedded types.
     pub interner: &'a dyn Interner,
+    /// Published value layouts. Lowering reads struct field offsets/sizes and
+    /// GC pointer offsets from here.
+    pub layouts: &'a dyn LayoutProvider,
     pub home_slots: Vec<SizedSlot>,
     /// End offset of the home-slot region; feeds `callee_base`.
     pub frame_data_size: u32,
@@ -452,6 +454,7 @@ pub fn try_build_context<'a>(
     func_ir: &FunctionIR,
     ty_args: InternedTypeList,
     interner: &'a impl Interner,
+    layouts: &'a dyn LayoutProvider,
     descriptors: LoweringDescriptors,
     natives: &dyn NativeResolver,
 ) -> Result<BuildContextOutcome<'a>> {
@@ -489,11 +492,14 @@ pub fn try_build_context<'a>(
     let home_list = interner.type_list_of(&func_ir.home_slot_types);
     let home_list = interner.subst_type_list(home_list, ty_args)?;
     let home_types = view_type_list(home_list);
-    let Some(home_slots) = layout_slots(0, home_types) else {
+    let Some(home_slots) = layout_slots(layouts, 0, home_types) else {
         return Ok(BuildContextOutcome::Skipped("not all types are concrete"));
     };
     // Catches sized nominals (e.g. enums) whose GC layout isn't walkable.
-    if home_types.iter().any(|&ty| !gc_layout_supports(ty)) {
+    if home_types
+        .iter()
+        .any(|&ty| !gc_layout_supports(layouts, ty))
+    {
         return Ok(BuildContextOutcome::Skipped(
             "nominal type not yet supported by gc_layout",
         ));
@@ -513,10 +519,13 @@ pub fn try_build_context<'a>(
         interner.type_list_of(module_ir.module.interned_types_at(own_handle.return_));
     let own_ret_list = interner.subst_type_list(own_ret_list, ty_args)?;
     let own_ret_types = view_type_list(own_ret_list);
-    let Some(return_slots) = layout_slots(0, own_ret_types) else {
+    let Some(return_slots) = layout_slots(layouts, 0, own_ret_types) else {
         return Ok(BuildContextOutcome::Skipped("not all types are concrete"));
     };
-    if own_ret_types.iter().any(|&ty| !gc_layout_supports(ty)) {
+    if own_ret_types
+        .iter()
+        .any(|&ty| !gc_layout_supports(layouts, ty))
+    {
         return Ok(BuildContextOutcome::Skipped(
             "nominal type not yet supported by gc_layout",
         ));
@@ -690,21 +699,25 @@ pub fn try_build_context<'a>(
                     anyhow::bail!("CallClosure signature must start with a Function type");
                 };
                 let ret_list = interner.subst_type_list(*results, ty_args)?;
-                let ret_slots = match layout_callee_region(callee_base, view_type_list(ret_list)) {
-                    CalleeRegion::Ready(slots) => slots,
-                    CalleeRegion::Skip(reason) => return Ok(BuildContextOutcome::Skipped(reason)),
-                };
+                let ret_slots =
+                    match layout_callee_region(layouts, callee_base, view_type_list(ret_list)) {
+                        CalleeRegion::Ready(slots) => slots,
+                        CalleeRegion::Skip(reason) => {
+                            return Ok(BuildContextOutcome::Skipped(reason))
+                        },
+                    };
                 closure_call_sites.push(ret_slots);
                 continue;
             },
             _ => continue,
         };
 
-        let arg_slots = match layout_callee_region(callee_base, view_type_list(param_list)) {
+        let arg_slots = match layout_callee_region(layouts, callee_base, view_type_list(param_list))
+        {
             CalleeRegion::Ready(slots) => slots,
             CalleeRegion::Skip(reason) => return Ok(BuildContextOutcome::Skipped(reason)),
         };
-        let ret_slots = match layout_callee_region(callee_base, view_type_list(ret_list)) {
+        let ret_slots = match layout_callee_region(layouts, callee_base, view_type_list(ret_list)) {
             CalleeRegion::Ready(slots) => slots,
             CalleeRegion::Skip(reason) => return Ok(BuildContextOutcome::Skipped(reason)),
         };
@@ -752,6 +765,7 @@ pub fn try_build_context<'a>(
         ty_args,
         home_types: home_list,
         interner,
+        layouts,
         home_slots,
         frame_data_size,
         call_sites,
@@ -772,11 +786,15 @@ pub fn try_build_context<'a>(
 /// padding each to its natural alignment.
 ///
 /// Returns `None` if any type is not concrete.
-fn layout_typed_slots_contiguously(base: u32, types: &[InternedType]) -> Option<Vec<TypedSlot>> {
+fn layout_typed_slots_contiguously(
+    layouts: &dyn LayoutProvider,
+    base: u32,
+    types: &[InternedType],
+) -> Option<Vec<TypedSlot>> {
     let mut slots = Vec::with_capacity(types.len());
     let mut offset = base;
     for &ty in types {
-        let (size, align) = type_size_and_align(ty)?;
+        let (size, align) = layouts.size_and_align(ty)?;
         offset = align_up_u32(offset, align);
         slots.push(TypedSlot {
             slot: SizedSlot {
@@ -796,9 +814,13 @@ fn layout_typed_slots_contiguously(base: u32, types: &[InternedType]) -> Option<
 /// doesn't depend on contiguous layout (e.g., home slots, where a
 /// future bin-packer could shrink the frame) could be migrated to a
 /// non-contiguous strategy without affecting arg/ret callers.
-fn layout_slots(base: u32, types: &[InternedType]) -> Option<Vec<SizedSlot>> {
+fn layout_slots(
+    layouts: &dyn LayoutProvider,
+    base: u32,
+    types: &[InternedType],
+) -> Option<Vec<SizedSlot>> {
     Some(
-        layout_typed_slots_contiguously(base, types)?
+        layout_typed_slots_contiguously(layouts, base, types)?
             .into_iter()
             .map(|ts| ts.slot)
             .collect(),
@@ -814,11 +836,15 @@ enum CalleeRegion {
 
 /// Lays out a callee-frame region (args or returns) at `base` and checks it is
 /// lowerable: every type must be concrete and GC-walkable.
-fn layout_callee_region(base: u32, types: &[InternedType]) -> CalleeRegion {
-    let Some(slots) = layout_typed_slots_contiguously(base, types) else {
+fn layout_callee_region(
+    layouts: &dyn LayoutProvider,
+    base: u32,
+    types: &[InternedType],
+) -> CalleeRegion {
+    let Some(slots) = layout_typed_slots_contiguously(layouts, base, types) else {
         return CalleeRegion::Skip("not all types are concrete");
     };
-    if types.iter().any(|&ty| !gc_layout_supports(ty)) {
+    if types.iter().any(|&ty| !gc_layout_supports(layouts, ty)) {
         return CalleeRegion::Skip("nominal type not yet supported by gc_layout");
     }
     CalleeRegion::Ready(slots)
@@ -827,7 +853,7 @@ fn layout_callee_region(base: u32, types: &[InternedType]) -> CalleeRegion {
 /// Provides context to specializer so it can obtain external information
 /// about types (e.g., their sizes, fields of structs if available) as well
 /// as publish new information about types discovered to the context.
-pub trait SpecializerContext {
+pub trait SpecializerContext: LayoutProvider {
     /// Returns fields of a struct or variants with fields of an enum. If
     /// this information is not available in context, returns [`None`].
     fn get_fields(
@@ -835,15 +861,6 @@ pub trait SpecializerContext {
         module_id: &InternedModuleId,
         nominal_name: &InternedIdentifier,
     ) -> Result<Option<FieldTypes>>;
-
-    /// Publishes a computed layout for the nominal type.
-    fn set_nominal_layout(
-        &self,
-        ty: InternedType,
-        size: u32,
-        align: u32,
-        fields: Option<&[FieldLayout]>,
-    ) -> Result<()>;
 
     /// Substitutes type parameters in the given type using type arguments as
     /// the substitution (indexed by indices in type param nodes). Returns an
@@ -894,13 +911,6 @@ pub trait SpecializerContext {
         values_size: u32,
         pointer_offsets: &[FrameOffset],
     ) -> Result<DescriptorId>;
-
-    /// Returns the layout id for `ty`, or `None` if no layout has been
-    /// published yet. Primitives/references/functions resolve to a reserved id.
-    fn layout_id_for(&self, ty: InternedType) -> Option<LayoutId>;
-
-    /// Returns the published layout for `id`, or `None` if unknown.
-    fn layout(&self, id: LayoutId) -> Option<&ValueLayout>;
 
     /// Publishes `layout` for `ty` and returns its assigned id. Idempotent.
     fn publish_layout(&self, ty: InternedType, layout: ValueLayout) -> LayoutId;
@@ -976,11 +986,19 @@ pub fn try_lower_function(
     func_ir: &FunctionIR,
     ty_args: InternedTypeList,
     interner: &impl Interner,
+    layouts: &dyn LayoutProvider,
     descriptors: LoweringDescriptors,
     natives: &dyn NativeResolver,
 ) -> Result<LoweringOutcome> {
-    let ctx = match try_build_context(module_ir, func_ir, ty_args, interner, descriptors, natives)?
-    {
+    let ctx = match try_build_context(
+        module_ir,
+        func_ir,
+        ty_args,
+        interner,
+        layouts,
+        descriptors,
+        natives,
+    )? {
         BuildContextOutcome::Built(c) => c,
         BuildContextOutcome::Skipped(reason) => return Ok(LoweringOutcome::Skipped(reason)),
     };
@@ -1225,14 +1243,14 @@ fn discover_captured_data_descriptor(
     let mut cursor = 0usize;
     let mut pointer_offsets = Vec::new();
     for &ty in view_type_list(captured_list) {
-        let Some((size, align)) = type_size_and_align(ty) else {
+        let Some((size, align)) = ctx.size_and_align(ty) else {
             return Ok(CapturedDataLayout::NotDerivable);
         };
-        if !gc_layout_supports(ty) {
+        if !gc_layout_supports(ctx, ty) {
             return Ok(CapturedDataLayout::NotDerivable);
         }
         let (offset, next) = next_captured_value_offset(cursor, size as usize, align as usize);
-        for rel in type_pointer_offsets(ty)? {
+        for rel in type_pointer_offsets(ctx, ty)? {
             pointer_offsets.push(FrameOffset(offset as u32 + rel));
         }
         cursor = next;
@@ -1251,13 +1269,14 @@ fn discover_captured_data_descriptor(
 /// Returns `None` if any field type lacks a concrete size or the running
 /// offset/total overflows `u32`.
 fn layout_inline_fields(
+    layouts: &dyn LayoutProvider,
     field_types: &[InternedType],
 ) -> Option<(Vec<VariantFieldLayout>, u32, u32)> {
     let mut offset = 0u32;
     let mut max_align = 1u32;
     let mut fields = Vec::with_capacity(field_types.len());
     for &ty in field_types {
-        let (size, align) = view_type(ty).size_and_align()?;
+        let (size, align) = layouts.size_and_align(ty)?;
         offset = checked_align_up_u32(offset, align)?;
         max_align = max_align.max(align);
         fields.push(VariantFieldLayout { offset, size, ty });
@@ -1332,9 +1351,9 @@ fn try_build_inline_value_layout(
 }
 
 /// Recursive post-order DFS that visits every nominal reachable from the given
-/// type and, as a side effect, publishes its GC vector descriptors,
-/// `NominalLayout`s, and `ValueLayout`s. Returns the type's [`LayoutId`] when one
-/// could be built, or `None` when it is deferred.
+/// type and, as a side effect, publishes its GC vector descriptors and
+/// `ValueLayout`s. Returns the type's [`LayoutId`] when one could be built, or
+/// `None` when it is deferred.
 ///
 /// Additionally, for each `Type::Vector` reached, recurses into the element
 /// type, then publishes a vector descriptor and records the assigned
@@ -1352,7 +1371,7 @@ fn discover_type_metadata(
 ) -> Result<Option<LayoutId>> {
     let ty = ctx.subst_type(ty, ty_args)?;
     if !visited.insert(ty) {
-        return Ok(ctx.layout_id_for(ty));
+        return Ok(ctx.layout_id(ty));
     }
 
     match view_type(ty) {
@@ -1376,7 +1395,7 @@ fn discover_type_metadata(
             // Primitives have known layouts; function value layout depends
             // on actual data, and type parameters have no layout. Nothing to
             // discover.
-            Ok(ctx.layout_id_for(ty))
+            Ok(ctx.layout_id(ty))
         },
         Type::ImmutRef { inner } | Type::MutRef { inner } => {
             // Refs are fixed-size and have known layout, but the referent's
@@ -1392,8 +1411,8 @@ fn discover_type_metadata(
             // Get or publish the GC descriptor for the element.
             let descriptor_id = if let Some(id) = ctx.vec_descriptor_for(*elem) {
                 Some(id)
-            } else if let Some((elem_size, _)) = type_size_and_align(*elem)
-                && let Ok(ptr_offsets) = type_pointer_offsets(*elem)
+            } else if let Some((elem_size, _)) = ctx.size_and_align(*elem)
+                && let Ok(ptr_offsets) = type_pointer_offsets(&*ctx, *elem)
             {
                 let ptr_offsets = ptr_offsets.into_iter().map(FrameOffset).collect::<Vec<_>>();
                 Some(ctx.publish_vec_descriptor(*elem, elem_size, &ptr_offsets)?)
@@ -1457,7 +1476,8 @@ fn discover_type_metadata(
                     // Best-effort layout computation. If any field is still
                     // not sized (or has no published layout), so is the
                     // nominal type: defer. `None` means a field is not sized.
-                    let Some((field_layouts, total, max_align)) = layout_inline_fields(&fields)
+                    let Some((field_layouts, total, max_align)) =
+                        layout_inline_fields(&*ctx, &fields)
                     else {
                         return Ok(None);
                     };
@@ -1474,24 +1494,14 @@ fn discover_type_metadata(
                     else {
                         return Ok(None);
                     };
-                    // TODO(cleanup): remove legacy size/layout.
-                    let nominal_fields = field_layouts
-                        .iter()
-                        .map(|field| FieldLayout::new(field.offset, field.ty))
-                        .collect::<Vec<_>>();
-                    ctx.set_nominal_layout(ty, total, max_align, Some(&nominal_fields))?;
                     Ok(Some(ctx.publish_layout(ty, value_layout)))
                 },
                 Some(FieldTypes::Enum(variants)) => {
                     // An enum is an 8-byte heap pointer at the type level.
                     //
-                    // TODO(correctness): this records only the 8-byte nominal
-                    // pointer — no per-variant nominal field layout and no fixed
-                    // BCS size — so the loading and gas-metering paths that rely
-                    // on nominal layout / serialized size do not yet account for
-                    // enums.
-                    ctx.set_nominal_layout(ty, 8, 8, None)?;
-
+                    // TODO(correctness): the enum value layout carries no fixed
+                    // BCS size, so the gas-metering / serialized-size paths do
+                    // not yet account for enums.
                     let mut variant_layouts: Vec<Vec<VariantFieldLayout>> =
                         Vec::with_capacity(variants.len());
                     let mut variant_ptr_offsets: Vec<Vec<u32>> = Vec::with_capacity(variants.len());
@@ -1528,7 +1538,7 @@ fn discover_type_metadata(
                         // Per-variant layout: offsets are data-region-relative
                         // (0-based after the tag).
                         let Some((variant_layout, variant_size, variant_align)) =
-                            layout_inline_fields(&fields)
+                            layout_inline_fields(&*ctx, &fields)
                         else {
                             all_sized = false;
                             all_value_layouts = false;
@@ -1537,6 +1547,7 @@ fn discover_type_metadata(
                         // GC pointer offsets: each field's inner pointer offsets
                         // shifted by the field's offset within the data region.
                         let Ok(ptr_offsets) = shifted_field_pointer_offsets(
+                            &*ctx,
                             variant_layout.iter().map(|field| (field.offset, field.ty)),
                         ) else {
                             all_sized = false;

--- a/third_party/move/mono-move/specializer/src/lower/gc_layout.rs
+++ b/third_party/move/mono-move/specializer/src/lower/gc_layout.rs
@@ -8,7 +8,7 @@ use crate::stackless_exec_ir::FunctionIR;
 use anyhow::{bail, Result};
 use mono_move_core::{
     types::{view_type, InternedType, Type},
-    FrameOffset,
+    FrameOffset, LayoutId, LayoutKind, LayoutProvider,
 };
 
 /// GC-relevant frame metadata derived for a single function.
@@ -33,7 +33,7 @@ pub fn derive_frame_layout(
     // each slot's type directly, so we wouldn't need to zip with a
     // separate `home_slot_types` slice here.
     for (slot, &ty) in ctx.home_slots.iter().zip(home_slot_types.iter()) {
-        for rel in type_pointer_offsets(ty)? {
+        for rel in type_pointer_offsets(ctx.layouts, ty)? {
             heap_ptr_offsets.push(FrameOffset(slot.offset.0 + rel));
         }
     }
@@ -65,7 +65,7 @@ pub fn derive_frame_layout(
 /// Returns `true` iff `type_pointer_offsets` would accept `ty` without
 /// erroring. Keep in sync with `type_pointer_offsets`: every case that
 /// `bail!`s there must return `false` here.
-pub fn gc_layout_supports(ty: InternedType) -> bool {
+pub fn gc_layout_supports(layouts: &dyn LayoutProvider, ty: InternedType) -> bool {
     match view_type(ty) {
         Type::Bool
         | Type::U8
@@ -86,19 +86,8 @@ pub fn gc_layout_supports(ty: InternedType) -> bool {
         | Type::MutRef { .. }
         | Type::Vector { .. }
         | Type::Function { .. } => true,
-        Type::Nominal { .. } => {
-            // Mirror `type_pointer_offsets`'s Nominal arm: an unpopulated
-            // layout is unsupported (an `Err` there); an enum (populated
-            // layout, no `field_layouts`) is an 8-byte heap pointer
-            // (`Ok(vec![0])` there); otherwise every field must be supported.
-            let Some(layout) = view_type(ty).layout() else {
-                return false;
-            };
-            let Some(fields) = layout.field_layouts() else {
-                return true;
-            };
-            fields.iter().all(|f| gc_layout_supports(f.ty()))
-        },
+        // A nominal is walkable once its value layout is published.
+        Type::Nominal { .. } => layouts.layout_by_ty(ty).is_some(),
         Type::TypeParam { .. } => false,
     }
 }
@@ -110,7 +99,7 @@ pub fn gc_layout_supports(ty: InternedType) -> bool {
 /// contains non-instantiated type parameters. Callers that want to
 /// decide *whether* to lower a function should use `gc_layout_supports`
 /// for a graceful `Skipped` outcome rather than reaching this `Err`.
-pub fn type_pointer_offsets(ty: InternedType) -> Result<Vec<u32>> {
+pub fn type_pointer_offsets(layouts: &dyn LayoutProvider, ty: InternedType) -> Result<Vec<u32>> {
     let offsets = match view_type(ty) {
         // Scalars: no pointer offsets.
         Type::Bool
@@ -136,27 +125,59 @@ pub fn type_pointer_offsets(ty: InternedType) -> Result<Vec<u32>> {
         // 8-byte heap pointers.
         Type::Vector { .. } | Type::Function { .. } => vec![0],
 
-        // Inline structs: walk each field's pointer offsets and shift
-        // by the field's byte offset within the struct. Enums are
-        // 8-byte heap pointers (variant fields live on the heap object,
-        // traced via the enum descriptor, not the frame).
+        // Structs/enums: walk the published value layout. A struct recurses
+        // through its fields' child layouts; an enum is an 8-byte heap pointer.
         //
-        // TODO(metering): rewrite without recursion or add a depth/visited bound;
-        // a malformed or racing `NominalLayout` publisher could otherwise
-        // produce a cyclic layout that blows the stack here.
+        // TODO(metering): rewrite without recursion or add a depth/visited bound.
         Type::Nominal { .. } => {
-            let layout = view_type(ty)
-                .layout()
+            let id = layouts
+                .layout_id(ty)
                 .ok_or_else(|| anyhow::anyhow!("nominal type has no layout populated"))?;
-            let Some(fields) = layout.field_layouts() else {
-                // Enum: an 8-byte heap pointer.
-                return Ok(vec![0]);
-            };
-            shifted_field_pointer_offsets(fields.iter().map(|field| (field.offset, field.ty())))?
+            layout_pointer_offsets(layouts, id)?
         },
 
         Type::TypeParam { .. } => {
             bail!("type parameter reached gc_layout — try_build_context should have skipped");
+        },
+    };
+    Ok(offsets)
+}
+
+/// Heap-pointer byte offsets within a value of the given published layout,
+/// relative to the value's start. Pointer positions are a property of the
+/// layout: a reference, vector, function, or (frozen) enum slot holds a pointer
+/// at relative offset 0; a struct recurses through its fields' child layouts;
+/// scalars hold none.
+///
+/// TODO(metering): rewrite without recursion or add a depth/visited bound.
+fn layout_pointer_offsets(layouts: &dyn LayoutProvider, id: LayoutId) -> Result<Vec<u32>> {
+    let layout = layouts
+        .layout(id)
+        .ok_or_else(|| anyhow::anyhow!("layout id does not resolve to a layout"))?;
+    let offsets = match &layout.kind {
+        LayoutKind::Bool
+        | LayoutKind::UnsignedInt
+        | LayoutKind::SignedInt
+        | LayoutKind::Address => vec![],
+        LayoutKind::Ref
+        | LayoutKind::Vector { .. }
+        | LayoutKind::FrozenEnum { .. }
+        | LayoutKind::Function => vec![0],
+        LayoutKind::Struct { fields } => {
+            let mut out = vec![];
+            for field in fields.iter() {
+                for rel in layout_pointer_offsets(layouts, field.id)? {
+                    let abs = field.offset.checked_add(rel).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "gc_layout: field offset {} + inner offset {} overflows u32",
+                            field.offset,
+                            rel,
+                        )
+                    })?;
+                    out.push(abs);
+                }
+            }
+            out
         },
     };
     Ok(offsets)
@@ -167,11 +188,12 @@ pub fn type_pointer_offsets(ty: InternedType) -> Result<Vec<u32>> {
 /// the enclosing region.
 /// Errors on a non-GC-walkable field type or a `u32` offset overflow.
 pub fn shifted_field_pointer_offsets(
+    layouts: &dyn LayoutProvider,
     fields: impl IntoIterator<Item = (u32, InternedType)>,
 ) -> Result<Vec<u32>> {
     let mut out = vec![];
     for (field_offset, field_ty) in fields {
-        for rel in type_pointer_offsets(field_ty)? {
+        for rel in type_pointer_offsets(layouts, field_ty)? {
             let abs = field_offset.checked_add(rel).ok_or_else(|| {
                 anyhow::anyhow!(
                     "gc_layout: field offset {} + inner offset {} overflows u32",

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -25,8 +25,9 @@ use mono_move_core::{
     types::{is_closed_type, strip_ref, view_type, view_type_list, InternedType, Type},
     CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, DescriptorId, FrameLayoutInfo, FrameOffset,
     IntBinaryOp, IntCastOp, IntCmpOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, JumpIntCmpOp,
-    JumpValueCmpOp, JumpValueRefCmpOp, MicroOp, PackClosureOp, SafePointEntry, ShiftOperand,
-    SizedSlot, ValueCmpOp, ValueRefCmpOp, VecPackOp, VecUnpackOp, FRAME_METADATA_SIZE,
+    JumpValueCmpOp, JumpValueRefCmpOp, LayoutKind, LayoutProvider, MicroOp, PackClosureOp,
+    SafePointEntry, ShiftOperand, SizedSlot, ValueCmpOp, ValueRefCmpOp, VecPackOp, VecUnpackOp,
+    FRAME_METADATA_SIZE,
 };
 use move_binary_format::file_format::{
     ConstantPoolIndex, FieldHandleIndex, VariantFieldHandleIndex,
@@ -185,6 +186,10 @@ impl gas::CostContext for LoweringState<'_> {
     fn concrete_ty(&self, ty: InternedType) -> Result<InternedType> {
         LoweringState::concrete_ty(self, ty)
     }
+
+    fn layouts(&self) -> &dyn LayoutProvider {
+        self.ctx.layouts
+    }
 }
 
 impl<'a> LoweringState<'a> {
@@ -217,23 +222,44 @@ impl<'a> LoweringState<'a> {
         Ok(ty)
     }
 
+    /// Per-field `(offset, size, align)` of a concrete struct type, read from
+    /// its published value layout: byte offsets from the struct layout, and each
+    /// field's size and alignment from its child layout. Errors if `struct_ty`
+    /// has no published layout or is not a struct. `op` labels the caller.
+    fn struct_field_layouts(
+        &self,
+        struct_ty: InternedType,
+        op: &str,
+    ) -> Result<Vec<(u32, u32, u32)>> {
+        let layout = self
+            .ctx
+            .layouts
+            .layout_by_ty(struct_ty)
+            .ok_or_else(|| anyhow::anyhow!("{}: struct type has no populated layout", op))?;
+        let LayoutKind::Struct { fields } = &layout.kind else {
+            bail!("{}: nominal type is not a struct (no field layouts)", op);
+        };
+        fields
+            .iter()
+            .map(|f| {
+                let child =
+                    self.ctx.layouts.layout(f.id).ok_or_else(|| {
+                        anyhow::anyhow!("{}: field layout id does not resolve", op)
+                    })?;
+                Ok((f.offset, child.size, child.align))
+            })
+            .collect()
+    }
+
     /// Resolve a `FieldHandleIndex` against the struct type `struct_ty`
     /// and return `(field_byte_offset, field_byte_size)`.
     fn resolve_field(&self, struct_ty: InternedType, fh: FieldHandleIndex) -> Result<(u32, u32)> {
-        let layout = view_type(struct_ty)
-            .layout()
-            .ok_or_else(|| anyhow::anyhow!("struct type has no layout populated"))?;
-        let fields = layout
-            .field_layouts()
-            .ok_or_else(|| anyhow::anyhow!("nominal type is not a struct (no field layouts)"))?;
+        let fields = self.struct_field_layouts(struct_ty, "field access")?;
         let pos = self.ctx.module.field_position_at(fh) as usize;
-        let field = fields
+        let (offset, size, _align) = *fields
             .get(pos)
             .ok_or_else(|| anyhow::anyhow!("field index {} out of range for struct", pos))?;
-        let (size, _) = view_type(field.ty())
-            .size_and_align()
-            .ok_or_else(|| anyhow::anyhow!("field type has no concrete size"))?;
-        Ok((field.offset, size))
+        Ok((offset, size))
     }
 
     /// Resolve a `VariantFieldHandleIndex` against `enum_ty`'s derived
@@ -339,7 +365,7 @@ impl<'a> LoweringState<'a> {
             let code_offset = CodeOffset(self.out_buf.len() as u32);
             let mut heap_ptr_offsets = Vec::with_capacity(self.xfer_bindings.len());
             for ts in self.xfer_bindings.iter().flatten() {
-                let rels = type_pointer_offsets(ts.ty).with_context(|| {
+                let rels = type_pointer_offsets(self.ctx.layouts, ts.ty).with_context(|| {
                     format!(
                         "deriving safe-point heap pointer offsets at code_offset {}",
                         code_offset.0
@@ -462,7 +488,7 @@ impl<'a> LoweringState<'a> {
         ) {
             return Ok(());
         }
-        let offsets = type_pointer_offsets(dst_ty)?;
+        let offsets = type_pointer_offsets(self.ctx.layouts, dst_ty)?;
         if !offsets.is_empty() {
             self.emit(MicroOp::deep_copy_heap_ptrs(
                 dst_off,
@@ -489,7 +515,7 @@ impl<'a> LoweringState<'a> {
 
     /// Size in bytes of `ref_slot`'s pointee.
     fn ref_pointee_size(&self, ref_slot: Slot) -> Result<u32> {
-        super::context::ref_pointee_size(self.slot_interned_type(ref_slot)?)
+        super::context::ref_pointee_size(self.ctx.layouts, self.slot_interned_type(ref_slot)?)
     }
 
     /// Emit one byte-copy from `src` to `dst_offset`. Caller is
@@ -1323,8 +1349,11 @@ impl<'a> LoweringState<'a> {
             },
             Instr::VecImmBorrow(dst, elem_ty, vec_ref, idx)
             | Instr::VecMutBorrow(dst, elem_ty, vec_ref, idx) => {
-                let elem_size =
-                    concrete_type_size(self.concrete_ty(*elem_ty)?, "vector elem type")?;
+                let elem_size = concrete_type_size(
+                    self.ctx.layouts,
+                    self.concrete_ty(*elem_ty)?,
+                    "vector elem type",
+                )?;
                 let vec_ref_info = self.slot(*vec_ref)?;
                 let idx_info = self.slot(*idx)?;
                 let dst_info = self.def_slot(*dst)?;
@@ -1337,8 +1366,11 @@ impl<'a> LoweringState<'a> {
                 })?;
             },
             Instr::VecPopBack(dst, elem_ty, vec_ref) => {
-                let elem_size =
-                    concrete_type_size(self.concrete_ty(*elem_ty)?, "vector elem type")?;
+                let elem_size = concrete_type_size(
+                    self.ctx.layouts,
+                    self.concrete_ty(*elem_ty)?,
+                    "vector elem type",
+                )?;
                 let vec_ref_info = self.slot(*vec_ref)?;
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::VecPopBack {
@@ -1356,8 +1388,11 @@ impl<'a> LoweringState<'a> {
                         dst: dst_typed.slot.offset,
                     })?;
                 } else {
-                    let elem_size =
-                        concrete_type_size(self.concrete_ty(*elem_ty)?, "vector elem type")?;
+                    let elem_size = concrete_type_size(
+                        self.ctx.layouts,
+                        self.concrete_ty(*elem_ty)?,
+                        "vector elem type",
+                    )?;
                     let descriptor_id = self.vector_descriptor_id("VecPack", dst_typed.ty)?;
                     let srcs = elems
                         .iter()
@@ -1375,8 +1410,11 @@ impl<'a> LoweringState<'a> {
                 // TODO(completeness): the Move compiler only emits `VecUnpack` with count 0,
                 // but handwritten bytecode may use it with any count. If we
                 // restrict to count 0, we can apply simplifications.
-                let elem_size =
-                    concrete_type_size(self.concrete_ty(*elem_ty)?, "vector elem type")?;
+                let elem_size = concrete_type_size(
+                    self.ctx.layouts,
+                    self.concrete_ty(*elem_ty)?,
+                    "vector elem type",
+                )?;
                 let src_info = self.slot(*src)?;
                 let dst_offsets = dsts
                     .iter()
@@ -1389,8 +1427,11 @@ impl<'a> LoweringState<'a> {
                 })))?;
             },
             Instr::VecSwap(elem_ty, vec_ref, idx_a, idx_b) => {
-                let elem_size =
-                    concrete_type_size(self.concrete_ty(*elem_ty)?, "vector elem type")?;
+                let elem_size = concrete_type_size(
+                    self.ctx.layouts,
+                    self.concrete_ty(*elem_ty)?,
+                    "vector elem type",
+                )?;
                 let vec_ref_info = self.slot(*vec_ref)?;
                 let idx_a_info = self.slot(*idx_a)?;
                 let idx_b_info = self.slot(*idx_b)?;
@@ -1402,8 +1443,11 @@ impl<'a> LoweringState<'a> {
                 })?;
             },
             Instr::VecPushBack(elem_ty, vec_ref, val) => {
-                let elem_size =
-                    concrete_type_size(self.concrete_ty(*elem_ty)?, "vector elem type")?;
+                let elem_size = concrete_type_size(
+                    self.ctx.layouts,
+                    self.concrete_ty(*elem_ty)?,
+                    "vector elem type",
+                )?;
                 let vec_ty = strip_ref(self.slot_interned_type(*vec_ref)?)?;
                 let descriptor_id = self.vector_descriptor_id("VecPushBack", vec_ty)?;
                 let vec_ref_info = self.slot(*vec_ref)?;
@@ -1511,17 +1555,13 @@ impl<'a> LoweringState<'a> {
                 // After substitution, `struct_ty` must be a concrete nominal
                 // with a populated layout.
                 let struct_ty = self.concrete_ty(*struct_ty)?;
-                let layout = view_type(struct_ty)
-                    .layout()
-                    .ok_or_else(|| anyhow::anyhow!("Pack: struct_ty has no populated layout"))?;
-                let fields = layout.field_layouts().ok_or_else(|| {
-                    anyhow::anyhow!("Pack: nominal type is not a struct (no field layouts)")
-                })?;
-                if fields.len() != args.len() {
+                // (offset, size, align) per field.
+                let field_layouts = self.struct_field_layouts(struct_ty, "Pack")?;
+                if field_layouts.len() != args.len() {
                     bail!(
                         "Pack: arg count {} does not match struct field count {}",
                         args.len(),
-                        fields.len()
+                        field_layouts.len()
                     );
                 }
                 let dst_info = self.def_slot(*dst)?;
@@ -1529,26 +1569,16 @@ impl<'a> LoweringState<'a> {
                     .iter()
                     .map(|s| self.slot(*s))
                     .collect::<Result<Vec<_>>>()?;
-                // Pre-compute (size, align) per field once.
-                let field_widths: Vec<(u32, u32)> = fields
-                    .iter()
-                    .map(|field| {
-                        view_type(field.ty())
-                            .size_and_align()
-                            .ok_or_else(|| anyhow::anyhow!("Pack: field type has no concrete size"))
-                    })
-                    .collect::<Result<_>>()?;
-                let copies: Vec<_> = fields
+                let copies: Vec<_> = field_layouts
                     .iter()
                     .zip(arg_infos.iter())
-                    .zip(field_widths.iter())
-                    .map(|((field, arg_info), &(size, _))| parallel_copy::Copy {
+                    .map(|(&(offset, size, _align), arg_info)| parallel_copy::Copy {
                         src: arg_info.offset,
-                        dst: FrameOffset(dst_info.offset.0 + field.offset),
+                        dst: FrameOffset(dst_info.offset.0 + offset),
                         width: size,
                     })
                     .collect();
-                let mut indices: Vec<usize> = (0..fields.len()).collect();
+                let mut indices: Vec<usize> = (0..field_layouts.len()).collect();
                 // TODO(perf): check if we can have cheaper checks for reverse/forward emit safety
                 // in the presence of alignments.
                 if parallel_copy::reverse_emit_is_safe(&copies) {
@@ -1557,69 +1587,51 @@ impl<'a> LoweringState<'a> {
                     bail!("Pack: neither reverse nor forward emit is overlap-safe");
                 }
                 for i in indices {
-                    let (size, align) = field_widths[i];
-                    self.emit_single_move(
-                        FrameOffset(dst_info.offset.0 + fields[i].offset),
-                        SizedSlot {
-                            offset: arg_infos[i].offset,
-                            size,
-                            align,
-                        },
-                    )?;
+                    let (offset, size, align) = field_layouts[i];
+                    self.emit_single_move(FrameOffset(dst_info.offset.0 + offset), SizedSlot {
+                        offset: arg_infos[i].offset,
+                        size,
+                        align,
+                    })?;
                 }
             },
             Instr::Unpack(dsts, struct_ty, src) => {
                 // See the `Instr::Pack` arm above for the `struct_ty` contract.
                 let struct_ty = self.concrete_ty(*struct_ty)?;
-                let layout = view_type(struct_ty)
-                    .layout()
-                    .ok_or_else(|| anyhow::anyhow!("Unpack: struct_ty has no populated layout"))?;
-                let fields = layout.field_layouts().ok_or_else(|| {
-                    anyhow::anyhow!("Unpack: nominal type is not a struct (no field layouts)")
-                })?;
-                if fields.len() != dsts.len() {
+                let field_layouts = self.struct_field_layouts(struct_ty, "Unpack")?;
+                if field_layouts.len() != dsts.len() {
                     bail!(
                         "Unpack: dst count {} does not match struct field count {}",
                         dsts.len(),
-                        fields.len()
+                        field_layouts.len()
                     );
                 }
                 let src_info = self.slot(*src)?;
-                // Pre-compute (size, align) per field and resolve each dst's
-                // SizedSlot. We do this in a separate pass so we can build the
-                // per-copy view the debug assert needs without interleaving
-                // it with the actual emit.
-                let mut field_widths = Vec::with_capacity(fields.len());
+                // Resolve all dst offsets first so the overlap-safety check can
+                // run before any load is emitted.
                 let mut dst_offsets = Vec::with_capacity(dsts.len());
-                for (field, dst) in fields.iter().zip(dsts.iter()) {
-                    let (size, align) =
-                        view_type(field.ty()).size_and_align().ok_or_else(|| {
-                            anyhow::anyhow!("Unpack: field type has no concrete size")
-                        })?;
-                    field_widths.push((size, align));
-                    let dst_info = self.def_slot(*dst)?;
-                    dst_offsets.push(dst_info.offset);
+                for &dst in dsts.iter() {
+                    dst_offsets.push(self.def_slot(dst)?.offset);
                 }
-                let copies: Vec<_> = fields
+                let copies: Vec<_> = field_layouts
                     .iter()
                     .zip(dst_offsets.iter())
-                    .zip(field_widths.iter())
-                    .map(|((field, dst_off), &(size, _))| parallel_copy::Copy {
-                        src: FrameOffset(src_info.offset.0 + field.offset),
+                    .map(|(&(offset, size, _align), dst_off)| parallel_copy::Copy {
+                        src: FrameOffset(src_info.offset.0 + offset),
                         dst: *dst_off,
                         width: size,
                     })
                     .collect();
-                let mut indices: Vec<usize> = (0..fields.len()).collect();
+                let mut indices: Vec<usize> = (0..field_layouts.len()).collect();
                 if parallel_copy::reverse_emit_is_safe(&copies) {
                     indices.reverse();
                 } else if !parallel_copy::forward_emit_is_safe(&copies) {
                     bail!("Unpack: neither reverse nor forward emit is overlap-safe");
                 }
                 for i in indices {
-                    let (size, align) = field_widths[i];
+                    let (offset, size, align) = field_layouts[i];
                     self.emit_single_move(dst_offsets[i], SizedSlot {
-                        offset: FrameOffset(src_info.offset.0 + fields[i].offset),
+                        offset: FrameOffset(src_info.offset.0 + offset),
                         size,
                         align,
                     })?;
@@ -1713,7 +1725,7 @@ impl<'a> LoweringState<'a> {
                 })?;
                 debug_assert_eq!(
                     dst_info.size,
-                    concrete_type_size(concrete_ty, "move_from resource")?,
+                    concrete_type_size(self.ctx.layouts, concrete_ty, "move_from resource")?,
                     "move_from: dst slot width must equal the resource's heap-object payload size",
                 );
                 self.emit_heap_move_from(dst_info.offset, box_ptr, dst_info.size)?;
@@ -1752,7 +1764,7 @@ impl<'a> LoweringState<'a> {
                 })?;
                 debug_assert_eq!(
                     val_info.size,
-                    concrete_type_size(concrete_ty, "move_to resource")?,
+                    concrete_type_size(self.ctx.layouts, concrete_ty, "move_to resource")?,
                     "move_to: val slot width must equal the descriptor payload size HeapNew allocated",
                 );
                 self.emit_heap_move_to(box_ptr, val_info.offset, val_info.size)?;
@@ -2068,7 +2080,7 @@ impl<'a> LoweringState<'a> {
         let mut heap_ptr_offsets = Vec::new();
         for s in &cs.arg_slots {
             let base = s.slot.offset.0 - callee_base;
-            for rel in type_pointer_offsets(s.ty)? {
+            for rel in type_pointer_offsets(self.ctx.layouts, s.ty)? {
                 heap_ptr_offsets.push(FrameOffset(base + rel));
             }
         }

--- a/third_party/move/mono-move/testsuite/src/print_sections.rs
+++ b/third_party/move/mono-move/testsuite/src/print_sections.rs
@@ -19,7 +19,7 @@ use anyhow::{anyhow, Result};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::NoNatives,
-    types::{FieldLayout, InternedType, InternedTypeList, EMPTY_TYPE_LIST},
+    types::{InternedType, InternedTypeList, EMPTY_TYPE_LIST},
     DescriptorId, FieldTypes, FrameOffset, Interner, LayoutId, LayoutProvider, ValueLayout,
 };
 use mono_move_global_context::ExecutionGuard;
@@ -127,6 +127,7 @@ fn lower_functions(
                     func_ir,
                     EMPTY_TYPE_LIST,
                     guard,
+                    guard,
                     descriptors,
                     &NoNatives,
                 )
@@ -197,6 +198,16 @@ struct SnapshotLoaderContext<'a, 'guard, 'ctx> {
     module_ir: &'a ModuleIR,
 }
 
+impl LayoutProvider for SnapshotLoaderContext<'_, '_, '_> {
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
+        self.guard.layout(id)
+    }
+
+    fn layout_id(&self, ty: InternedType) -> Option<LayoutId> {
+        self.guard.layout_id(ty)
+    }
+}
+
 impl SpecializerContext for SnapshotLoaderContext<'_, '_, '_> {
     fn get_fields(
         &mut self,
@@ -211,16 +222,6 @@ impl SpecializerContext for SnapshotLoaderContext<'_, '_, '_> {
             .module
             .interned_field_types(*nominal_name)
             .cloned())
-    }
-
-    fn set_nominal_layout(
-        &self,
-        ty: InternedType,
-        size: u32,
-        align: u32,
-        fields: Option<&[FieldLayout]>,
-    ) -> Result<()> {
-        self.guard.set_nominal_layout(ty, size, align, fields)
     }
 
     fn subst_type(&self, ty: InternedType, ty_args: InternedTypeList) -> Result<InternedType> {
@@ -261,14 +262,6 @@ impl SpecializerContext for SnapshotLoaderContext<'_, '_, '_> {
         Ok(self
             .guard
             .publish_captured_data_descriptor(values_size, pointer_offsets))
-    }
-
-    fn layout_id_for(&self, ty: InternedType) -> Option<LayoutId> {
-        self.guard.layout_id_for(ty)
-    }
-
-    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
-        self.guard.layout(id)
     }
 
     fn publish_layout(&self, ty: InternedType, layout: ValueLayout) -> LayoutId {

--- a/third_party/move/mono-move/testsuite/tests/types_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/types_tests.rs
@@ -3,8 +3,8 @@
 
 //! Integration tests for type interning and metadata resolution.
 
-use mono_move_core::{native::NoNatives, GasMeter, Interner};
-use mono_move_global_context::{view_type, GlobalContext};
+use mono_move_core::{native::NoNatives, GasMeter, Interner, LayoutKind, LayoutProvider};
+use mono_move_global_context::GlobalContext;
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
 use mono_move_testsuite::InMemoryModuleProvider;
 use move_core_types::{account_address::AccountAddress, ident_str};
@@ -59,15 +59,13 @@ module 0x1::a {
         .interned_nominal_type_def_idx(guard.identifier_of(ident_str!("B")))
         .unwrap();
     let ty = ir.module.interned_nominal_def_type_at(idx);
-    let layout = view_type(ty).layout().unwrap();
+    let layout = guard.layout_by_ty(ty).unwrap();
     assert_eq!(layout.size, 72);
     assert_eq!(layout.align, 8);
-    let offsets = layout
-        .field_layouts()
-        .expect("Struct layout carries per-field offsets")
-        .iter()
-        .map(|f| f.offset)
-        .collect::<Vec<_>>();
+    let LayoutKind::Struct { fields } = &layout.kind else {
+        panic!("B: expected a struct layout");
+    };
+    let offsets = fields.iter().map(|f| f.offset).collect::<Vec<_>>();
     assert_eq!(offsets, vec![0, 32, 40]);
 
     let idx = ir
@@ -75,15 +73,13 @@ module 0x1::a {
         .interned_nominal_type_def_idx(guard.identifier_of(ident_str!("D")))
         .unwrap();
     let ty = ir.module.interned_nominal_def_type_at(idx);
-    let layout = view_type(ty).layout().unwrap();
+    let layout = guard.layout_by_ty(ty).unwrap();
     assert_eq!(layout.size, 128);
     assert_eq!(layout.align, 8);
-    let offsets = layout
-        .field_layouts()
-        .expect("Struct layout carries per-field offsets")
-        .iter()
-        .map(|f| f.offset)
-        .collect::<Vec<_>>();
+    let LayoutKind::Struct { fields } = &layout.kind else {
+        panic!("D: expected a struct layout");
+    };
+    let offsets = fields.iter().map(|f| f.offset).collect::<Vec<_>>();
     assert_eq!(offsets, vec![0, 1, 8, 16, 24, 40, 48, 120]);
 
     let idx = ir
@@ -91,8 +87,8 @@ module 0x1::a {
         .interned_nominal_type_def_idx(guard.identifier_of(ident_str!("C")))
         .unwrap();
     let ty = ir.module.interned_nominal_def_type_at(idx);
-    let layout = view_type(ty).layout().unwrap();
+    let layout = guard.layout_by_ty(ty).unwrap();
     assert_eq!(layout.size, 8);
     assert_eq!(layout.align, 8);
-    assert!(layout.field_layouts().is_none());
+    assert!(matches!(layout.kind, LayoutKind::FrozenEnum { .. }));
 }


### PR DESCRIPTION
`Type::Nominal` now carries only identity (module, name, type arguments). Size, alignment, and field offsets live solely in the `ValueLayout` table, read through `LayoutProvider`.

## Why

Layout was stored twice and built in one pass: a `NominalLayout` slot on the interned `Type` node, and the `ValueLayout` side table. `NominalLayout` is a strict subset of `ValueLayout`, and the duplication was already marked for removal.

The slot also put mutable, per-deployment state inside the interned, shared identity graph. That forced the `OnceLock`, a race-tolerant double-check on publish, a `needs_drop` assertion, and an "owns no non-arena memory" constraint. Pointer equality on the type graph means structural equality. Layout is neither, and it changes on module upgrade, so it does not belong on the identity node.

## What changed

- Add `slot_size_and_align` for intrinsic widths (primitives, references, vectors, functions) and `LayoutProvider::size_and_align` (intrinsic first, then the table for nominals). One entry point for sizes.
- Make `SpecializerContext` require `LayoutProvider` and drop its duplicated `layout` / `layout_id_for`. Thread a `&dyn LayoutProvider` into the build/lowering pass, the verifier, and the `mem::swap` native.
- Derive GC heap-pointer offsets from `ValueLayout` / `LayoutKind` rather than the type slot.
- Delete `NominalLayout`, `FieldLayout`, `Type::size_and_align`, `Type::layout`, and `set_nominal_layout`. `Type::Nominal` becomes `{ module_id, name, ty_args }`.

## Testing

- `cargo test` across the mono-move crates (core, specializer, runtime, global-context, loader, natives).
- `cargo test -p mono-move-testsuite --test differential`: 190 cases pass. The `--print micro-ops` golden baselines are unchanged — offsets and sizes are identical, only their source moved to the table.
- `types_tests` updated to assert through `LayoutProvider` / `LayoutKind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor across lowering, GC layout walks, verifier, and natives on layout-critical paths; behavior is meant to be equivalent but any lookup mismatch could affect frame sizes or pointer scanning.
> 
> **Overview**
> **Nominal types are identity-only on the type graph; memory layout lives in the `ValueLayout` table.**
> 
> `Type::Nominal` no longer carries a `OnceLock<NominalLayout>` or per-field offsets. **`NominalLayout`**, **`FieldLayout`**, **`set_nominal_layout`**, and **`Type::size_and_align` / `Type::layout`** are removed. Sizes and alignments go through **`intrinsic_slot_size_and_align`** (primitives, refs, vectors, functions) and **`LayoutProvider::size_and_align`** (nominals via published layouts).
> 
> **Lowering, verification, gas metering, and GC layout derivation** now thread a **`&dyn LayoutProvider`** (loader/specializer/runtime). **`SpecializerContext`** subtraits **`LayoutProvider`** instead of duplicating layout APIs; type discovery publishes **`ValueLayout`** only—no parallel nominal layout install. **Pack/Unpack** and struct field access read offsets from **`LayoutKind::Struct`**; **GC heap-pointer walks** recurse **`ValueLayout`** instead of nominal field caches. **`NativeContext::value_size`** (e.g. **`mem::swap`**) uses the layout provider at runtime.
> 
> Tests and differential goldens are updated to assert through **`layout_by_ty`** / **`LayoutKind`**; reported offsets/sizes are intended to stay the same with a single source of truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 007dccaf84cd24b8207d930d39722769510c7d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->