### PR TITLE
[state-sync] Serve hot state chunks from the storage service

### DIFF
--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -22,8 +22,9 @@ use aptos_network::protocols::wire::handshake::v1::ProtocolId;
 use aptos_storage_service_types::{
     requests::{
         DataRequest, EpochEndingLedgerInfoRequest, GetTransactionDataWithProofRequest,
-        StateValuesWithProofRequest, StorageServiceRequest, TransactionOutputsWithProofRequest,
-        TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
+        HotStateValuesWithProofRequest, StateValuesWithProofRequest, StorageServiceRequest,
+        TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
+        TransactionsWithProofRequest,
     },
     responses::{
         DataResponse, ServerProtocolVersion, StorageServerSummary, StorageServiceResponse,
@@ -427,6 +428,12 @@ impl<T: StorageReaderInterface> Handler<T> {
             DataRequest::GetTransactionDataWithProof(request) => {
                 self.get_transaction_data_with_proof(request)
             },
+            DataRequest::GetHotStateValuesWithProof(request) => {
+                self.get_hot_state_value_chunk_with_proof(request)
+            },
+            DataRequest::GetNumberOfHotStatesAtVersion(version) => {
+                self.get_number_of_hot_states_at_version(*version)
+            },
             _ => Err(Error::UnexpectedErrorEncountered(format!(
                 "Received an unexpected request: {:?}",
                 request
@@ -473,6 +480,32 @@ impl<T: StorageReaderInterface> Handler<T> {
 
         Ok(DataResponse::StateValueChunkWithProof(
             state_value_chunk_with_proof,
+        ))
+    }
+
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        request: &HotStateValuesWithProofRequest,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let hot_state_value_chunk_with_proof = self.storage.get_hot_state_value_chunk_with_proof(
+            request.version,
+            request.start_index,
+            request.end_index,
+        )?;
+
+        Ok(DataResponse::HotStateValueChunkWithProof(
+            hot_state_value_chunk_with_proof,
+        ))
+    }
+
+    fn get_number_of_hot_states_at_version(
+        &self,
+        version: Version,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let number_of_hot_states = self.storage.get_number_of_hot_states(version)?;
+
+        Ok(DataResponse::NumberOfHotStatesAtVersion(
+            number_of_hot_states,
         ))
     }
 

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -21,6 +21,7 @@ use aptos_types::{
         AccumulatorRangeProof, TransactionAccumulatorRangeProof, TransactionInfoListWithProof,
     },
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -113,6 +114,24 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
         start_index: u64,
         end_index: u64,
     ) -> aptos_storage_service_types::Result<StateValueChunkWithProof, Error>;
+
+    /// Returns the number of hot state items (hot state Merkle tree leaves) at
+    /// the specified version.
+    fn get_number_of_hot_states(
+        &self,
+        version: u64,
+    ) -> aptos_storage_service_types::Result<u64, Error>;
+
+    /// Returns a chunk holding a list of hot state values starting at the
+    /// specified `start_index` and ending at `end_index` (inclusive). In some
+    /// cases, fewer hot state values may be returned (e.g., due to network or
+    /// chunk limits).
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> aptos_storage_service_types::Result<HotStateValueChunkWithProof, Error>;
 }
 
 /// The underlying implementation of the StorageReaderInterface, used by the
@@ -896,6 +915,114 @@ impl StorageReader {
         )
     }
 
+    /// Drains `value_iterator` into a list of values that respects the response size and time
+    /// limits, updating the truncation metrics. Shared by the cold and hot state value chunking
+    /// paths, which then build the chunk proof from the returned values.
+    fn collect_chunk_values_by_size<Value: Serialize>(
+        &self,
+        mut value_iterator: impl Iterator<Item = StorageResult<(StateKey, Value)>>,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        num_values_to_fetch: u64,
+        max_response_size: u64,
+        chunk_label: &str,
+    ) -> Result<Vec<(StateKey, Value)>, Error> {
+        // Create a response progress tracker
+        let mut response_progress_tracker = ResponseDataProgressTracker::new(
+            num_values_to_fetch,
+            max_response_size,
+            self.config.max_storage_read_wait_time_ms,
+            self.time_service.clone(),
+        );
+
+        // Fetch as many values as possible
+        let mut values = vec![];
+        while !response_progress_tracker.is_response_complete() {
+            match value_iterator.next() {
+                Some(Ok(value)) => {
+                    // Calculate the number of serialized bytes for the value
+                    let num_serialized_bytes = get_num_serialized_bytes(&value)
+                        .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?;
+
+                    // Add the value to the list
+                    if response_progress_tracker
+                        .data_items_fits_in_response(true, num_serialized_bytes)
+                    {
+                        values.push(value);
+                        response_progress_tracker.add_data_item(num_serialized_bytes);
+                    } else {
+                        break; // Cannot add any more data items
+                    }
+                },
+                Some(Err(error)) => {
+                    return Err(Error::StorageErrorEncountered(error.to_string()));
+                },
+                None => {
+                    // Log a warning that the iterator did not contain all the expected data
+                    warn!(
+                        "The iterator for {} is missing data! Version: {:?}, start index: {:?}, \
+                        end index: {:?}, num values to fetch: {:?}",
+                        chunk_label, version, start_index, end_index, num_values_to_fetch
+                    );
+                    break;
+                },
+            }
+        }
+
+        // Update the data truncation metrics
+        response_progress_tracker.update_data_truncation_metrics(chunk_label);
+
+        Ok(values)
+    }
+
+    /// Repeatedly fetches a chunk with proof using `fetch_chunk`, halving the requested count
+    /// until the response fits within a single network frame. Shared by the cold and hot legacy
+    /// chunking paths (which do not use size and time-aware chunking).
+    fn serve_chunk_with_proof_by_size_legacy<Chunk: Serialize>(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        mut num_values_to_fetch: u64,
+        max_response_size: u64,
+        chunk_label: &str,
+        fetch_chunk: impl Fn(u64) -> Result<Chunk, Error>,
+    ) -> Result<Chunk, Error> {
+        while num_values_to_fetch >= 1 {
+            let chunk_with_proof = fetch_chunk(num_values_to_fetch)?;
+            if num_values_to_fetch == 1 {
+                return Ok(chunk_with_proof); // We cannot return less than a single item
+            }
+
+            // Attempt to divide up the request if it overflows the message size
+            let (overflow_frame, num_bytes) =
+                check_overflow_network_frame(&chunk_with_proof, max_response_size)?;
+            if !overflow_frame {
+                return Ok(chunk_with_proof);
+            }
+
+            metrics::increment_chunk_truncation_counter(metrics::TRUNCATION_FOR_SIZE, chunk_label);
+            let new_num_values_to_fetch = num_values_to_fetch / 2;
+            debug!(
+                "The request for {:?} values ({}) was too large (num bytes: {:?}, limit: {:?}). \
+                Retrying with {:?}.",
+                num_values_to_fetch,
+                chunk_label,
+                num_bytes,
+                max_response_size,
+                new_num_values_to_fetch
+            );
+            num_values_to_fetch = new_num_values_to_fetch; // Try again with half the amount of data
+        }
+
+        Err(Error::UnexpectedErrorEncountered(format!(
+            "Unable to serve the {} request! Version: {:?}, start index: {:?}, end index: {:?}. \
+            The data cannot fit into a single network frame!",
+            chunk_label, version, start_index, end_index
+        )))
+    }
+
     /// Returns a state value chunk with proof response (bound by the max response size in bytes)
     fn get_state_value_chunk_with_proof_by_size(
         &self,
@@ -907,8 +1034,8 @@ impl StorageReader {
     ) -> Result<StateValueChunkWithProof, Error> {
         // Calculate the number of state values to fetch
         let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
-        let max_num_state_values = self.config.max_state_chunk_size;
-        let num_state_values_to_fetch = min(expected_num_state_values, max_num_state_values);
+        let num_state_values_to_fetch =
+            min(expected_num_state_values, self.config.max_state_chunk_size);
 
         // If size and time-aware chunking are disabled, use the legacy implementation
         if !use_size_and_time_aware_chunking {
@@ -921,68 +1048,26 @@ impl StorageReader {
             );
         }
 
-        // Get the state value chunk iterator
-        let mut state_value_iterator = self.storage.get_state_value_chunk_iter(
+        // Fetch the state values (bound by the response size) and build the chunk with proof
+        let state_value_iterator = self.storage.get_state_value_chunk_iter(
             version,
             start_index as usize,
             num_state_values_to_fetch as usize,
         )?;
-
-        // Initialize the fetched state values
-        let mut state_values = vec![];
-
-        // Create a response progress tracker
-        let mut response_progress_tracker = ResponseDataProgressTracker::new(
+        let state_values = self.collect_chunk_values_by_size(
+            state_value_iterator,
+            version,
+            start_index,
+            end_index,
             num_state_values_to_fetch,
             max_response_size,
-            self.config.max_storage_read_wait_time_ms,
-            self.time_service.clone(),
-        );
-
-        // Fetch as many state values as possible
-        while !response_progress_tracker.is_response_complete() {
-            match state_value_iterator.next() {
-                Some(Ok(state_value)) => {
-                    // Calculate the number of serialized bytes for the state value
-                    let num_serialized_bytes = get_num_serialized_bytes(&state_value)
-                        .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?;
-
-                    // Add the state value to the list
-                    if response_progress_tracker
-                        .data_items_fits_in_response(true, num_serialized_bytes)
-                    {
-                        state_values.push(state_value);
-                        response_progress_tracker.add_data_item(num_serialized_bytes);
-                    } else {
-                        break; // Cannot add any more data items
-                    }
-                },
-                Some(Err(error)) => {
-                    return Err(Error::StorageErrorEncountered(error.to_string()));
-                },
-                None => {
-                    // Log a warning that the iterator did not contain all the expected data
-                    warn!(
-                        "The state value iterator is missing data! Version: {:?}, \
-                        start index: {:?}, end index: {:?}, num state values to fetch: {:?}",
-                        version, start_index, end_index, num_state_values_to_fetch
-                    );
-                    break;
-                },
-            }
-        }
-
-        // Create the state value chunk with proof
+            DataResponse::get_state_value_chunk_with_proof_label(),
+        )?;
         let state_value_chunk_with_proof = self.storage.get_state_value_chunk_proof(
             version,
             start_index as usize,
             state_values,
         )?;
-
-        // Update the data truncation metrics
-        response_progress_tracker
-            .update_data_truncation_metrics(DataResponse::get_state_value_chunk_with_proof_label());
-
         Ok(state_value_chunk_with_proof)
     }
 
@@ -993,42 +1078,114 @@ impl StorageReader {
         version: u64,
         start_index: u64,
         end_index: u64,
-        mut num_state_values_to_fetch: u64,
+        num_state_values_to_fetch: u64,
         max_response_size: u64,
     ) -> Result<StateValueChunkWithProof, Error> {
-        while num_state_values_to_fetch >= 1 {
-            let state_value_chunk_with_proof = self.storage.get_state_value_chunk_with_proof(
-                version,
-                start_index as usize,
-                num_state_values_to_fetch as usize,
-            )?;
-            if num_state_values_to_fetch == 1 {
-                return Ok(state_value_chunk_with_proof); // We cannot return less than a single item
-            }
+        self.serve_chunk_with_proof_by_size_legacy(
+            version,
+            start_index,
+            end_index,
+            num_state_values_to_fetch,
+            max_response_size,
+            DataResponse::get_state_value_chunk_with_proof_label(),
+            |num_to_fetch| {
+                self.storage
+                    .get_state_value_chunk_with_proof(
+                        version,
+                        start_index as usize,
+                        num_to_fetch as usize,
+                    )
+                    .map_err(Error::from)
+            },
+        )
+    }
 
-            // Attempt to divide up the request if it overflows the message size
-            let (overflow_frame, num_bytes) =
-                check_overflow_network_frame(&state_value_chunk_with_proof, max_response_size)?;
-            if !overflow_frame {
-                return Ok(state_value_chunk_with_proof);
-            } else {
-                metrics::increment_chunk_truncation_counter(
-                    metrics::TRUNCATION_FOR_SIZE,
-                    DataResponse::StateValueChunkWithProof(state_value_chunk_with_proof)
-                        .get_label(),
-                );
-                let new_num_state_values_to_fetch = num_state_values_to_fetch / 2;
-                debug!("The request for {:?} state values was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
-                    num_state_values_to_fetch, num_bytes, max_response_size, new_num_state_values_to_fetch);
-                num_state_values_to_fetch = new_num_state_values_to_fetch; // Try again with half the amount of data
-            }
+    /// Returns a hot state value chunk with proof response (bound by the max response size in bytes)
+    fn get_hot_state_value_chunk_with_proof_by_size(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        max_response_size: u64,
+        use_size_and_time_aware_chunking: bool,
+    ) -> Result<HotStateValueChunkWithProof, Error> {
+        // Calculate the number of hot state values to fetch
+        let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
+        let num_state_values_to_fetch =
+            min(expected_num_state_values, self.config.max_state_chunk_size);
+
+        // If size and time-aware chunking are disabled, use the legacy implementation
+        if !use_size_and_time_aware_chunking {
+            return self.get_hot_state_value_chunk_with_proof_by_size_legacy(
+                version,
+                start_index,
+                end_index,
+                num_state_values_to_fetch,
+                max_response_size,
+            );
         }
 
-        Err(Error::UnexpectedErrorEncountered(format!(
-            "Unable to serve the get_state_value_chunk_with_proof request! Version: {:?}, \
-            start index: {:?}, end index: {:?}. The data cannot fit into a single network frame!",
-            version, start_index, end_index
-        )))
+        // Fetch the hot state values (bound by the response size) and build the chunk with proof
+        let hot_state_value_iterator = self.storage.get_hot_state_value_chunk_iter(
+            version,
+            start_index as usize,
+            num_state_values_to_fetch as usize,
+        )?;
+        let hot_state_values = self.collect_chunk_values_by_size(
+            hot_state_value_iterator,
+            version,
+            start_index,
+            end_index,
+            num_state_values_to_fetch,
+            max_response_size,
+            DataResponse::get_hot_state_value_chunk_with_proof_label(),
+        )?;
+        let hot_state_value_chunk_with_proof = self.storage.get_hot_state_value_chunk_proof(
+            version,
+            start_index as usize,
+            hot_state_values,
+        )?;
+        Ok(hot_state_value_chunk_with_proof)
+    }
+
+    /// Returns a hot state value chunk with proof response (bound by the max response size in
+    /// bytes). This is the legacy implementation (that does not use size and time-aware chunking).
+    /// Unlike the cold state path, the DB exposes only a split iterator/proof API for hot state,
+    /// so each attempt assembles the chunk by collecting the iterator and then building the proof.
+    fn get_hot_state_value_chunk_with_proof_by_size_legacy(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        num_state_values_to_fetch: u64,
+        max_response_size: u64,
+    ) -> Result<HotStateValueChunkWithProof, Error> {
+        self.serve_chunk_with_proof_by_size_legacy(
+            version,
+            start_index,
+            end_index,
+            num_state_values_to_fetch,
+            max_response_size,
+            DataResponse::get_hot_state_value_chunk_with_proof_label(),
+            |num_to_fetch| {
+                let hot_state_values = self
+                    .storage
+                    .get_hot_state_value_chunk_iter(
+                        version,
+                        start_index as usize,
+                        num_to_fetch as usize,
+                    )?
+                    .collect::<StorageResult<Vec<_>>>()
+                    .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+                self.storage
+                    .get_hot_state_value_chunk_proof(
+                        version,
+                        start_index as usize,
+                        hot_state_values,
+                    )
+                    .map_err(Error::from)
+            },
+        )
     }
 }
 
@@ -1213,6 +1370,29 @@ impl StorageReaderInterface for StorageReader {
             self.config.enable_size_and_time_aware_chunking,
         )
     }
+
+    fn get_number_of_hot_states(
+        &self,
+        version: u64,
+    ) -> aptos_storage_service_types::Result<u64, Error> {
+        let number_of_hot_states = self.storage.get_hot_state_item_count(version)?;
+        Ok(number_of_hot_states as u64)
+    }
+
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> aptos_storage_service_types::Result<HotStateValueChunkWithProof, Error> {
+        self.get_hot_state_value_chunk_with_proof_by_size(
+            version,
+            start_index,
+            end_index,
+            self.config.max_network_chunk_bytes,
+            self.config.enable_size_and_time_aware_chunking,
+        )
+    }
 }
 
 // A simple macro that wraps each storage read call with a timer
@@ -1344,6 +1524,22 @@ impl DbReader for TimedStorageReader {
             first_index: usize,
             state_key_values: Vec<(StateKey, StateValue)>,
         ) -> StorageResult<StateValueChunkWithProof>;
+
+        fn get_hot_state_item_count(&self, version: Version) -> StorageResult<usize>;
+
+        fn get_hot_state_value_chunk_iter(
+            &self,
+            version: Version,
+            first_index: usize,
+            chunk_size: usize,
+        ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(StateKey, HotStateValue)>> + '_>>;
+
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> StorageResult<HotStateValueChunkWithProof>;
 
         fn get_persisted_auxiliary_info_iterator(
             &self,

--- a/state-sync/storage-service/server/src/tests/hot_state_values.rs
+++ b/state-sync/storage-service/server/src/tests/hot_state_values.rs
@@ -1,0 +1,197 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::tests::{
+    mock,
+    mock::{MockClient, MockDatabaseReader},
+    utils,
+};
+use aptos_config::config::StorageServiceConfig;
+use aptos_crypto::hash::HashValue;
+use aptos_storage_service_types::{
+    requests::{DataRequest, HotStateValuesWithProofRequest},
+    responses::{DataResponse, StorageServiceResponse},
+    StorageServiceError,
+};
+use aptos_types::{
+    proof::definition::SparseMerkleRangeProof, state_store::hot_state::HotStateValueChunkWithProof,
+};
+use claims::assert_matches;
+use mockall::{
+    predicate::{always, eq},
+    Sequence,
+};
+
+#[tokio::test]
+async fn test_get_hot_state_values_with_proof() {
+    // Test size and time-aware chunking
+    for use_size_and_time_aware_chunking in [false, true] {
+        // Test small and large chunk requests
+        let max_state_chunk_size = StorageServiceConfig::default().max_state_chunk_size;
+        for chunk_size in [1, 100, max_state_chunk_size] {
+            // Create test data
+            let version = 101;
+            let start_index = 100;
+            let end_index = start_index + chunk_size - 1;
+            let hot_state_value_chunk_with_proof = HotStateValueChunkWithProof {
+                first_index: start_index,
+                last_index: end_index,
+                first_key: HashValue::random(),
+                last_key: HashValue::random(),
+                raw_values: vec![],
+                proof: SparseMerkleRangeProof::new(vec![]),
+                root_hash: HashValue::random(),
+            };
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_reader();
+            expect_get_hot_state_values_with_proof(
+                &mut db_reader,
+                version,
+                start_index,
+                chunk_size,
+                hot_state_value_chunk_with_proof.clone(),
+            );
+
+            // Create a storage service config
+            let storage_config =
+                utils::create_storage_config(false, use_size_and_time_aware_chunking);
+
+            // Create the storage client and server
+            let (mut mock_client, mut service, _, _, _) =
+                MockClient::new(Some(db_reader), Some(storage_config));
+            utils::update_storage_server_summary(&mut service, version, 10);
+            tokio::spawn(service.start());
+
+            // Process a request to fetch a hot states chunk with a proof
+            let response = get_hot_state_values_with_proof(
+                &mut mock_client,
+                version,
+                start_index,
+                end_index,
+                false,
+            )
+            .await
+            .unwrap();
+
+            // Verify the response is correct
+            assert_matches!(response, StorageServiceResponse::RawResponse(_));
+            assert_eq!(
+                response.get_data_response().unwrap(),
+                DataResponse::HotStateValueChunkWithProof(hot_state_value_chunk_with_proof)
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_hot_state_values_with_proof_not_serviceable() {
+    // The hot state is currently advertised over the same range as cold state, so a
+    // request for a version the server has not synced to is rejected.
+    let version = 101;
+    let start_index = 100;
+    let end_index = start_index + 99;
+
+    // Create the storage client and server (that cannot service the request)
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
+    utils::update_storage_server_summary(&mut service, version - 1, 10);
+    tokio::spawn(service.start());
+
+    // Process a request to fetch a hot states chunk with a proof
+    let response =
+        get_hot_state_values_with_proof(&mut mock_client, version, start_index, end_index, false)
+            .await
+            .unwrap_err();
+
+    // Verify the request is not serviceable
+    assert_matches!(response, StorageServiceError::InvalidRequest(_));
+}
+
+#[tokio::test]
+async fn test_get_number_of_hot_states() {
+    // Create test data
+    let version = 101;
+    let number_of_hot_states: u64 = 560;
+
+    // Create the mock db reader
+    let mut db_reader = mock::create_mock_db_reader();
+    db_reader
+        .expect_get_hot_state_item_count()
+        .times(1)
+        .with(eq(version))
+        .returning(move |_| Ok(number_of_hot_states as usize));
+
+    // Create the storage client and server
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
+    utils::update_storage_server_summary(&mut service, version, 10);
+    tokio::spawn(service.start());
+
+    // Process a request to fetch the number of hot states at a version
+    let data_request = DataRequest::GetNumberOfHotStatesAtVersion(version);
+    let response = utils::send_storage_request(&mut mock_client, false, data_request)
+        .await
+        .unwrap();
+
+    // Verify the response is correct
+    assert_matches!(response, StorageServiceResponse::RawResponse(_));
+    assert_eq!(
+        response.get_data_response().unwrap(),
+        DataResponse::NumberOfHotStatesAtVersion(number_of_hot_states)
+    );
+}
+
+/// Sets an expectation on the given mock db for a call to fetch hot state values with proof.
+/// Unlike cold state, the hot state path always composes an iterator with a proof (the DB
+/// exposes no combined fetch-and-prove call), regardless of the chunking mode.
+fn expect_get_hot_state_values_with_proof(
+    mock_db: &mut MockDatabaseReader,
+    version: u64,
+    start_index: u64,
+    chunk_size: u64,
+    mut hot_state_value_chunk_with_proof: HotStateValueChunkWithProof,
+) {
+    // Expect a call to get a hot state value iterator
+    let mut expectation_sequence = Sequence::new();
+    let hot_state_value_iterator = hot_state_value_chunk_with_proof
+        .clone()
+        .raw_values
+        .into_iter()
+        .map(Ok);
+    mock_db
+        .expect_get_hot_state_value_chunk_iter()
+        .times(1)
+        .with(
+            eq(version),
+            eq(start_index as usize),
+            eq(chunk_size as usize),
+        )
+        .returning(move |_, _, _| Ok(Box::new(hot_state_value_iterator.clone())))
+        .in_sequence(&mut expectation_sequence);
+
+    // Expect a call to get the hot state value chunk proof
+    mock_db
+        .expect_get_hot_state_value_chunk_proof()
+        .times(1)
+        .with(eq(version), eq(start_index as usize), always())
+        .return_once(move |_, _, given_values| {
+            hot_state_value_chunk_with_proof.raw_values = given_values;
+            Ok(hot_state_value_chunk_with_proof)
+        })
+        .in_sequence(&mut expectation_sequence);
+}
+
+/// Sends a hot state values with proof request and processes the response
+async fn get_hot_state_values_with_proof(
+    mock_client: &mut MockClient,
+    version: u64,
+    start_index: u64,
+    end_index: u64,
+    use_compression: bool,
+) -> Result<StorageServiceResponse, StorageServiceError> {
+    let data_request = DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
+        version,
+        start_index,
+        end_index,
+    });
+    utils::send_storage_request(mock_client, use_compression, data_request).await
+}

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -40,6 +40,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -389,6 +390,22 @@ mock! {
             first_index: usize,
             state_key_values: Vec<(StateKey, StateValue)>,
         ) -> aptos_storage_interface::Result<StateValueChunkWithProof>;
+
+        fn get_hot_state_item_count(&self, version: Version) -> aptos_storage_interface::Result<usize>;
+
+        fn get_hot_state_value_chunk_iter(
+            &self,
+            version: Version,
+            first_index: usize,
+            chunk_size: usize,
+        ) -> aptos_storage_interface::Result<Box<dyn Iterator<Item = aptos_storage_interface::Result<(StateKey, HotStateValue)>>>>;
+
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> aptos_storage_interface::Result<HotStateValueChunkWithProof>;
     }
 }
 

--- a/state-sync/storage-service/server/src/tests/mod.rs
+++ b/state-sync/storage-service/server/src/tests/mod.rs
@@ -5,6 +5,7 @@
 
 mod cache;
 mod epoch_ending;
+mod hot_state_values;
 mod mock;
 mod new_transaction_outputs;
 mod new_transactions;

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -53,6 +53,11 @@ pub enum DataRequest {
     GetTransactionDataWithProof(GetTransactionDataWithProofRequest), // Fetches transaction data with a proof
     GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest), // Optimistically fetches new transaction data with a proof
     SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest), // Subscribes to transaction data with a proof
+
+    // Hot state requests (used by fast sync to bootstrap the hot state).
+    // Note: new variants must be appended (BCS serializes enums by declaration order).
+    GetHotStateValuesWithProof(HotStateValuesWithProofRequest), // Fetches a list of hot states with a proof
+    GetNumberOfHotStatesAtVersion(Version), // Fetches the number of hot states at the specified version
 }
 
 impl DataRequest {
@@ -65,6 +70,8 @@ impl DataRequest {
             Self::GetNumberOfStatesAtVersion(_) => "get_number_of_states_at_version",
             Self::GetServerProtocolVersion => "get_server_protocol_version",
             Self::GetStateValuesWithProof(_) => "get_state_values_with_proof",
+            Self::GetHotStateValuesWithProof(_) => "get_hot_state_values_with_proof",
+            Self::GetNumberOfHotStatesAtVersion(_) => "get_number_of_hot_states_at_version",
             Self::GetStorageServerSummary => "get_storage_server_summary",
             Self::GetTransactionOutputsWithProof(_) => "get_transaction_outputs_with_proof",
             Self::GetTransactionsWithProof(_) => "get_transactions_with_proof",
@@ -345,6 +352,15 @@ pub struct StateValuesWithProofRequest {
     pub version: u64,     // The version to fetch the state values at
     pub start_index: u64, // The index to start fetching state values (inclusive)
     pub end_index: u64,   // The index to stop fetching state values (inclusive)
+}
+
+/// A storage service request for fetching a list of hot state
+/// values at a specified version.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct HotStateValuesWithProofRequest {
+    pub version: u64,     // The version to fetch the hot state values at
+    pub start_index: u64, // The index to start fetching hot state values (inclusive)
+    pub end_index: u64,   // The index to stop fetching hot state values (inclusive)
 }
 
 /// A storage service request for fetching a transaction output list with a

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -4,14 +4,14 @@
 use crate::{
     requests::{
         DataRequest::{
-            GetEpochEndingLedgerInfos, GetNewTransactionDataWithProof,
+            GetEpochEndingLedgerInfos, GetHotStateValuesWithProof, GetNewTransactionDataWithProof,
             GetNewTransactionOutputsWithProof, GetNewTransactionsOrOutputsWithProof,
-            GetNewTransactionsWithProof, GetNumberOfStatesAtVersion, GetServerProtocolVersion,
-            GetStateValuesWithProof, GetStorageServerSummary, GetTransactionDataWithProof,
-            GetTransactionOutputsWithProof, GetTransactionsOrOutputsWithProof,
-            GetTransactionsWithProof, SubscribeTransactionDataWithProof,
-            SubscribeTransactionOutputsWithProof, SubscribeTransactionsOrOutputsWithProof,
-            SubscribeTransactionsWithProof,
+            GetNewTransactionsWithProof, GetNumberOfHotStatesAtVersion, GetNumberOfStatesAtVersion,
+            GetServerProtocolVersion, GetStateValuesWithProof, GetStorageServerSummary,
+            GetTransactionDataWithProof, GetTransactionOutputsWithProof,
+            GetTransactionsOrOutputsWithProof, GetTransactionsWithProof,
+            SubscribeTransactionDataWithProof, SubscribeTransactionOutputsWithProof,
+            SubscribeTransactionsOrOutputsWithProof, SubscribeTransactionsWithProof,
         },
         TransactionDataRequestType,
     },
@@ -26,7 +26,7 @@ use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{
         TransactionListWithProof, TransactionListWithProofV2, TransactionOutputListWithProof,
         TransactionOutputListWithProofV2, Version,
@@ -158,6 +158,11 @@ pub enum DataResponse {
     // TODO: eventually we should deprecate all the old response types.
     TransactionDataWithProof(TransactionDataWithProofResponse),
     NewTransactionDataWithProof(NewTransactionDataWithProofResponse),
+
+    // Hot state responses (used by fast sync to bootstrap the hot state).
+    // Note: new variants must be appended (BCS serializes enums by declaration order).
+    HotStateValueChunkWithProof(HotStateValueChunkWithProof),
+    NumberOfHotStatesAtVersion(u64),
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -193,6 +198,12 @@ impl DataResponse {
             Self::NumberOfStatesAtVersion(_) => Self::get_number_of_states_at_version_label(),
             Self::ServerProtocolVersion(_) => Self::get_server_protocol_version_label(),
             Self::StateValueChunkWithProof(_) => Self::get_state_value_chunk_with_proof_label(),
+            Self::HotStateValueChunkWithProof(_) => {
+                Self::get_hot_state_value_chunk_with_proof_label()
+            },
+            Self::NumberOfHotStatesAtVersion(_) => {
+                Self::get_number_of_hot_states_at_version_label()
+            },
             Self::StorageServerSummary(_) => Self::get_storage_server_summary_label(),
             Self::TransactionOutputsWithProof(_) => {
                 Self::get_transaction_outputs_with_proof_label()
@@ -257,6 +268,16 @@ impl DataResponse {
     /// Returns a label for the state value chunk with proof response
     pub fn get_state_value_chunk_with_proof_label() -> &'static str {
         "state_value_chunk_with_proof"
+    }
+
+    /// Returns a label for the hot state value chunk with proof response
+    pub fn get_hot_state_value_chunk_with_proof_label() -> &'static str {
+        "hot_state_value_chunk_with_proof"
+    }
+
+    /// Returns a label for the number of hot states at version response
+    pub fn get_number_of_hot_states_at_version_label() -> &'static str {
+        "number_of_hot_states_at_version"
     }
 
     /// Returns a label for the storage server summary response
@@ -725,6 +746,28 @@ impl DataSummary {
                 .map(|range| range.contains(*version))
                 .unwrap_or(false),
             GetStateValuesWithProof(request) => {
+                let proof_version = request.version;
+
+                let can_serve_states = self
+                    .states
+                    .map(|range| range.contains(request.version))
+                    .unwrap_or(false);
+
+                let can_create_proof = self
+                    .synced_ledger_info
+                    .as_ref()
+                    .map(|li| li.ledger_info().version() >= proof_version)
+                    .unwrap_or(false);
+
+                can_serve_states && can_create_proof
+            },
+            // Hot state is gated on the same advertised range as cold state for now.
+            // TODO(HotState): advertise and gate on a dedicated, pruner-aware hot state range.
+            GetNumberOfHotStatesAtVersion(version) => self
+                .states
+                .map(|range| range.contains(*version))
+                .unwrap_or(false),
+            GetHotStateValuesWithProof(request) => {
                 let proof_version = request.version;
 
                 let can_serve_states = self


### PR DESCRIPTION

Add the storage service request/response types and server-side handling
that let fast sync fetch hot state, mirroring the existing cold state
value path:

- `GetHotStateValuesWithProof`/`HotStateValueChunkWithProof` and
  `GetNumberOfHotStatesAtVersion`/`NumberOfHotStatesAtVersion`, appended to
  the data request/response enums so BCS discriminants stay stable.
- A server handler plus `StorageReaderInterface` chunking that drives the
  hot state read APIs (`get_hot_state_value_chunk_iter` +
  `get_hot_state_value_chunk_proof`) under the existing size/time-aware and
  network byte limits. The DB exposes only a split iterator/proof API for
  hot state (no combined call), so the legacy path composes the two.

Hot state requests are gated on the same advertised range as cold state for
now; advertising a dedicated, pruner-aware hot state range in the data
summary is a follow-up. The client-side request path and the restore path
that rebuilds the hot state are also out of scope here.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches state-sync serving and wire protocol enums; behavior mirrors proven cold-state chunking but hot-state gating may be wrong until a dedicated range is advertised.
> 
> **Overview**
> Adds **hot state** to the storage service so fast sync can bootstrap hot state over the network, parallel to the existing cold `GetStateValuesWithProof` flow.
> 
> New BCS-appended wire types: `GetHotStateValuesWithProof` / `HotStateValueChunkWithProof` and `GetNumberOfHotStatesAtVersion` / `NumberOfHotStatesAtVersion`, plus handler and `StorageReaderInterface` methods that read via `get_hot_state_value_chunk_iter` + `get_hot_state_value_chunk_proof` (no combined DB call). Chunking reuses the same size/time-aware and legacy network-frame halving as cold state after extracting shared helpers `collect_chunk_values_by_size` and `serve_chunk_with_proof_by_size_legacy`.
> 
> **Serviceability** for hot state currently uses the same advertised state version range as cold state; a dedicated pruner-aware hot range in the data summary is left as follow-up. Integration tests cover chunk fetch, count, and unserviceable versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb7881e1af0fbaa4e67d42d12d4f7ebb11fe6b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->