### PR TITLE
[vm] Skip keyless PVK preparation for view functions

### DIFF
--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -49,7 +49,12 @@ pub fn bootstrap(
     port_tx: Option<oneshot::Sender<u16>>,
 ) -> anyhow::Result<Runtime> {
     let max_runtime_workers = get_max_runtime_workers(&config.api);
-    let runtime = aptos_runtimes::spawn_named_runtime("api".into(), Some(max_runtime_workers));
+    let max_blocking_threads = get_max_blocking_threads(&config.api);
+    let runtime = aptos_runtimes::spawn_named_runtime_with_blocking_threads(
+        "api".into(),
+        Some(max_runtime_workers),
+        Some(max_blocking_threads),
+    );
 
     let context = Context::new(chain_id, db, mp_sender, config.clone(), indexer_reader);
 
@@ -299,10 +304,16 @@ fn get_max_runtime_workers(api_config: &ApiConfig) -> usize {
         .unwrap_or_else(|| num_cpus::get() * api_config.runtime_worker_multiplier)
 }
 
+fn get_max_blocking_threads(api_config: &ApiConfig) -> usize {
+    api_config
+        .max_blocking_threads
+        .unwrap_or(aptos_runtimes::DEFAULT_MAX_BLOCKING_THREADS)
+}
+
 #[cfg(test)]
 mod tests {
     use super::bootstrap;
-    use crate::runtime::get_max_runtime_workers;
+    use crate::runtime::{get_max_blocking_threads, get_max_runtime_workers};
     use aptos_api_test_context::{new_test_context, TestContext};
     use aptos_config::config::{ApiConfig, NodeConfig};
     use aptos_types::chain_id::ChainId;
@@ -353,6 +364,27 @@ mod tests {
         assert_eq!(
             get_max_runtime_workers(&api_config),
             num_cpus::get() * api_config.runtime_worker_multiplier
+        );
+    }
+
+    #[test]
+    fn test_max_blocking_threads() {
+        let max_blocking_threads = 256;
+        let api_config = ApiConfig {
+            max_blocking_threads: Some(max_blocking_threads),
+            ..Default::default()
+        };
+
+        assert_eq!(get_max_blocking_threads(&api_config), max_blocking_threads);
+
+        let api_config = ApiConfig {
+            max_blocking_threads: None,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            get_max_blocking_threads(&api_config),
+            aptos_runtimes::DEFAULT_MAX_BLOCKING_THREADS
         );
     }
 

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -24,9 +24,16 @@ use aptos_vm_types::storage::StorageGasParameters;
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
 use move_vm_runtime::{config::VMConfig, RuntimeEnvironment, WithRuntimeEnvironment};
+use once_cell::sync::Lazy;
 use sha3::{Digest, Sha3_256};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 use triomphe::Arc as TriompheArc;
+
+static KEYLESS_PVK_CACHE: Lazy<Mutex<HashMap<[u8; 32], Arc<PreparedVerifyingKey<Bn254>>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// A runtime environment which can be used for VM initialization and more. Contains features
 /// used by execution, gas parameters, VM configs and global caches. Note that it is the user's
@@ -88,7 +95,7 @@ impl AptosEnvironment {
     /// Returns the prepared verifying key for keyless validation.
     #[inline]
     pub fn keyless_pvk(&self) -> Option<&PreparedVerifyingKey<Bn254>> {
-        self.0.keyless_pvk.as_ref()
+        self.0.keyless_pvk.as_deref()
     }
 
     /// Returns keyless configurations.
@@ -174,7 +181,7 @@ struct Environment {
 
     /// The prepared verification key for keyless accounts. Optional because it might not be set
     /// on-chain or might fail to parse.
-    keyless_pvk: Option<PreparedVerifyingKey<Bn254>>,
+    keyless_pvk: Option<Arc<PreparedVerifyingKey<Bn254>>>,
     /// Some keyless configurations which are not frequently updated.
     keyless_configuration: Option<Configuration>,
 
@@ -283,7 +290,7 @@ impl Environment {
         let keyless_pvk =
             Groth16VerificationKey::fetch_keyless_config(state_view).and_then(|(vk, vk_bytes)| {
                 sha3_256.update(&vk_bytes);
-                vk.try_into().ok()
+                cached_keyless_pvk(vk, &vk_bytes)
             });
         let keyless_configuration =
             Configuration::fetch_keyless_config(state_view).map(|(config, config_bytes)| {
@@ -316,6 +323,27 @@ impl Environment {
         }
         self
     }
+}
+
+fn cached_keyless_pvk(
+    vk: Groth16VerificationKey,
+    vk_bytes: &[u8],
+) -> Option<Arc<PreparedVerifyingKey<Bn254>>> {
+    let key = Sha3_256::digest(vk_bytes).into();
+    let mut cache = KEYLESS_PVK_CACHE
+        .lock()
+        .expect("keyless prepared verifying key cache mutex poisoned");
+
+    if let Some(pvk) = cache.get(&key) {
+        return Some(pvk.clone());
+    }
+
+    let pvk: Arc<PreparedVerifyingKey<Bn254>> = Arc::new(vk.try_into().ok()?);
+    if cache.len() >= 16 {
+        cache.clear();
+    }
+    cache.insert(key, pvk.clone());
+    Some(pvk)
 }
 
 /// Fetches config from storage and updates the hash if it exists. Returns the fetched config.

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -37,7 +37,16 @@ pub struct AptosEnvironment(TriompheArc<Environment>);
 impl AptosEnvironment {
     /// Returns new execution environment based on the current state.
     pub fn new(state_view: &impl StateView) -> Self {
-        Self(TriompheArc::new(Environment::new(state_view, false, None)))
+        Self(TriompheArc::new(Environment::new(
+            state_view, false, None, true,
+        )))
+    }
+
+    /// Returns new execution environment for view function execution.
+    pub fn new_for_view_function(state_view: &impl StateView) -> Self {
+        Self(TriompheArc::new(Environment::new(
+            state_view, false, None, false,
+        )))
     }
 
     /// Returns new execution environment based on the current state, also using the provided gas
@@ -50,20 +59,24 @@ impl AptosEnvironment {
             state_view,
             false,
             Some(gas_hook),
+            true,
         )))
     }
 
     /// Returns new execution environment based on the current state, also injecting create signer
     /// native for government proposal simulation. Should not be used for regular execution.
     pub fn new_with_injected_create_signer_for_gov_sim(state_view: &impl StateView) -> Self {
-        Self(TriompheArc::new(Environment::new(state_view, true, None)))
+        Self(TriompheArc::new(Environment::new(
+            state_view, true, None, true,
+        )))
     }
 
     /// Returns new environment but with delayed field optimization enabled. Should only be used by
     /// block executor where this optimization is needed. Note: whether the optimization will be
     /// enabled or not depends on the feature flag.
     pub fn new_with_delayed_field_optimization_enabled(state_view: &impl StateView) -> Self {
-        let env = Environment::new(state_view, false, None).try_enable_delayed_field_optimization();
+        let env =
+            Environment::new(state_view, false, None, true).try_enable_delayed_field_optimization();
         Self(TriompheArc::new(env))
     }
 
@@ -209,6 +222,7 @@ impl Environment {
         state_view: &impl StateView,
         inject_create_signer_for_gov_sim: bool,
         gas_hook: Option<Arc<dyn Fn(DynamicExpression) + Send + Sync>>,
+        prepare_keyless_pvk: bool,
     ) -> Self {
         // We compute and store a hash of configs in order to distinguish different environments.
         let mut sha3_256 = Sha3_256::new();
@@ -283,7 +297,7 @@ impl Environment {
         let keyless_pvk =
             Groth16VerificationKey::fetch_keyless_config(state_view).and_then(|(vk, vk_bytes)| {
                 sha3_256.update(&vk_bytes);
-                vk.try_into().ok()
+                prepare_keyless_pvk.then(|| vk.try_into().ok()).flatten()
             });
         let keyless_configuration =
             Configuration::fetch_keyless_config(state_view).map(|(config, config_bytes)| {
@@ -332,17 +346,19 @@ fn fetch_config_and_update_hash<T: OnChainConfig>(
 pub mod tests {
     use super::*;
     use aptos_types::{
+        keyless::{Groth16VerificationKey, KeylessGroupResource, VERIFICATION_KEY_FOR_TESTING},
         on_chain_config::{FeatureFlag, GasScheduleV2},
         state_store::{state_key::StateKey, state_value::StateValue, MockStateView},
     };
+    use move_core_types::move_resource::MoveStructType;
     use serde::Serialize;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     #[test]
     fn test_new_environment() {
         // This creates an empty state.
         let state_view = MockStateView::empty();
-        let env = Environment::new(&state_view, false, None);
+        let env = Environment::new(&state_view, false, None, true);
 
         // Check default values.
         assert_eq!(&env.features, &Features::default());
@@ -370,12 +386,41 @@ pub mod tests {
         )]))
     }
 
+    fn state_view_with_keyless_vk() -> MockStateView<StateKey> {
+        let vk = Groth16VerificationKey::from(VERIFICATION_KEY_FOR_TESTING.clone());
+        let keyless_group = KeylessGroupResource {
+            group: BTreeMap::from([(
+                Groth16VerificationKey::struct_tag(),
+                bcs::to_bytes(&vk).unwrap().into(),
+            )]),
+        };
+        MockStateView::new(HashMap::from([(
+            StateKey::resource_group(
+                &aptos_types::account_config::CORE_CODE_ADDRESS,
+                &KeylessGroupResource::struct_tag(),
+            ),
+            StateValue::new_legacy(bcs::to_bytes(&keyless_group).unwrap().into()),
+        )]))
+    }
+
     #[test]
     fn test_environment_eq() {
         let state_view = MockStateView::empty();
         let environment_1 = AptosEnvironment::new(&state_view);
         let environment_2 = AptosEnvironment::new(&state_view);
         assert!(environment_1 == environment_2);
+    }
+
+    #[test]
+    fn test_view_environment_skips_keyless_pvk_preparation() {
+        let state_view = state_view_with_keyless_vk();
+
+        let environment = AptosEnvironment::new(&state_view);
+        let view_environment = AptosEnvironment::new_for_view_function(&state_view);
+
+        assert!(environment.keyless_pvk().is_some());
+        assert!(view_environment.keyless_pvk().is_none());
+        assert!(environment == view_environment);
     }
 
     #[test]

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -24,16 +24,9 @@ use aptos_vm_types::storage::StorageGasParameters;
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
 use move_vm_runtime::{config::VMConfig, RuntimeEnvironment, WithRuntimeEnvironment};
-use once_cell::sync::Lazy;
 use sha3::{Digest, Sha3_256};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::sync::Arc;
 use triomphe::Arc as TriompheArc;
-
-static KEYLESS_PVK_CACHE: Lazy<Mutex<HashMap<[u8; 32], Arc<PreparedVerifyingKey<Bn254>>>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// A runtime environment which can be used for VM initialization and more. Contains features
 /// used by execution, gas parameters, VM configs and global caches. Note that it is the user's
@@ -95,7 +88,7 @@ impl AptosEnvironment {
     /// Returns the prepared verifying key for keyless validation.
     #[inline]
     pub fn keyless_pvk(&self) -> Option<&PreparedVerifyingKey<Bn254>> {
-        self.0.keyless_pvk.as_deref()
+        self.0.keyless_pvk.as_ref()
     }
 
     /// Returns keyless configurations.
@@ -181,7 +174,7 @@ struct Environment {
 
     /// The prepared verification key for keyless accounts. Optional because it might not be set
     /// on-chain or might fail to parse.
-    keyless_pvk: Option<Arc<PreparedVerifyingKey<Bn254>>>,
+    keyless_pvk: Option<PreparedVerifyingKey<Bn254>>,
     /// Some keyless configurations which are not frequently updated.
     keyless_configuration: Option<Configuration>,
 
@@ -290,7 +283,7 @@ impl Environment {
         let keyless_pvk =
             Groth16VerificationKey::fetch_keyless_config(state_view).and_then(|(vk, vk_bytes)| {
                 sha3_256.update(&vk_bytes);
-                cached_keyless_pvk(vk, &vk_bytes)
+                vk.try_into().ok()
             });
         let keyless_configuration =
             Configuration::fetch_keyless_config(state_view).map(|(config, config_bytes)| {
@@ -323,27 +316,6 @@ impl Environment {
         }
         self
     }
-}
-
-fn cached_keyless_pvk(
-    vk: Groth16VerificationKey,
-    vk_bytes: &[u8],
-) -> Option<Arc<PreparedVerifyingKey<Bn254>>> {
-    let key = Sha3_256::digest(vk_bytes).into();
-    let mut cache = KEYLESS_PVK_CACHE
-        .lock()
-        .expect("keyless prepared verifying key cache mutex poisoned");
-
-    if let Some(pvk) = cache.get(&key) {
-        return Some(pvk.clone());
-    }
-
-    let pvk: Arc<PreparedVerifyingKey<Bn254>> = Arc::new(vk.try_into().ok()?);
-    if cache.len() >= 16 {
-        cache.clear();
-    }
-    cache.insert(key, pvk.clone());
-    Some(pvk)
 }
 
 /// Fetches config from storage and updates the hash if it exists. Returns the fetched config.

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2926,7 +2926,7 @@ impl AptosVM {
         max_gas_amount: u64,
         make_gas_meter: impl FnOnce(u64, VMGasParameters, StorageGasParameters) -> G,
     ) -> (ViewFunctionOutput, Option<G>) {
-        let env = AptosEnvironment::new(state_view);
+        let env = AptosEnvironment::new_for_view_function(state_view);
         let vm = AptosVM::new(&env);
 
         let log_context = AdapterLogSchema::new(state_view.id(), 0);

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -70,6 +70,11 @@ pub struct ApiConfig {
     ///
     /// If not set, `runtime_worker_multiplier` will multiply times the number of CPU cores on the machine
     pub max_runtime_workers: Option<usize>,
+    /// Optional: Maximum number of blocking threads for synchronous REST API work.
+    ///
+    /// If not set, this defaults to the runtime default. Dedicated high-throughput
+    /// API nodes may increase this to allow more concurrent blocking API requests.
+    pub max_blocking_threads: Option<usize>,
     /// Multiplier for number of worker threads with number of CPU cores
     ///
     /// If `max_runtime_workers` is set, this is ignored
@@ -134,6 +139,7 @@ impl Default for ApiConfig {
             max_account_modules_page_size: DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE,
             max_gas_view_function: DEFAULT_MAX_VIEW_GAS,
             max_runtime_workers: None,
+            max_blocking_threads: None,
             runtime_worker_multiplier: 2,
             gas_estimation: GasEstimationConfig::default(),
             periodic_gas_estimation_ms: Some(30_000),
@@ -189,6 +195,12 @@ impl ConfigSanitizer for ApiConfig {
             return Err(Error::ConfigSanitizerFailed(
                 sanitizer_name,
                 "runtime_worker_multiplier must be greater than 0!".into(),
+            ));
+        }
+        if api_config.max_blocking_threads == Some(0) {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "max_blocking_threads must be greater than 0!".into(),
             ));
         }
 
@@ -302,6 +314,23 @@ mod tests {
 
         // Sanitize the config and verify that it fails because
         // the runtime worker multiplier is invalid.
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_invalid_blocking_threads() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                max_blocking_threads: Some(0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
         let error =
             ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
                 .unwrap_err();

--- a/crates/aptos-runtimes/src/lib.rs
+++ b/crates/aptos-runtimes/src/lib.rs
@@ -10,10 +10,25 @@ use tokio::runtime::{Builder, Runtime};
 /// we need to leave space for the thread IDs.
 const MAX_THREAD_NAME_LENGTH: usize = 12;
 
+pub const DEFAULT_MAX_BLOCKING_THREADS: usize = 64;
+
 /// Returns a tokio runtime with named threads.
 /// This is useful for tracking threads when debugging.
 pub fn spawn_named_runtime(thread_name: String, num_worker_threads: Option<usize>) -> Runtime {
     spawn_named_runtime_with_start_hook(thread_name, num_worker_threads, || {})
+}
+
+pub fn spawn_named_runtime_with_blocking_threads(
+    thread_name: String,
+    num_worker_threads: Option<usize>,
+    max_blocking_threads: Option<usize>,
+) -> Runtime {
+    spawn_named_runtime_with_start_hook_and_blocking_threads(
+        thread_name,
+        num_worker_threads,
+        max_blocking_threads,
+        || {},
+    )
 }
 
 pub fn spawn_named_runtime_with_start_hook<F>(
@@ -24,8 +39,23 @@ pub fn spawn_named_runtime_with_start_hook<F>(
 where
     F: Fn() + Send + Sync + 'static,
 {
-    const MAX_BLOCKING_THREADS: usize = 64;
+    spawn_named_runtime_with_start_hook_and_blocking_threads(
+        thread_name,
+        num_worker_threads,
+        None,
+        on_thread_start,
+    )
+}
 
+pub fn spawn_named_runtime_with_start_hook_and_blocking_threads<F>(
+    thread_name: String,
+    num_worker_threads: Option<usize>,
+    max_blocking_threads: Option<usize>,
+    on_thread_start: F,
+) -> Runtime
+where
+    F: Fn() + Send + Sync + 'static,
+{
     // Verify the given name has an appropriate length
     if thread_name.len() > MAX_THREAD_NAME_LENGTH {
         panic!(
@@ -47,7 +77,7 @@ where
         .disable_lifo_slot()
         // Limit concurrent blocking tasks from spawn_blocking(), in case, for example, too many
         // Rest API calls overwhelm the node.
-        .max_blocking_threads(MAX_BLOCKING_THREADS)
+        .max_blocking_threads(max_blocking_threads.unwrap_or(DEFAULT_MAX_BLOCKING_THREADS))
         .enable_all();
     if let Some(num_worker_threads) = num_worker_threads {
         builder.worker_threads(num_worker_threads);


### PR DESCRIPTION
## Summary
- add `AptosEnvironment::new_for_view_function` that preserves keyless VK bytes in the environment hash but skips preparing the Groth16 PVK
- use the view-specific environment from `AptosVM::run_view_function`
- add a unit test that confirms normal environments still prepare the PVK while view environments do not

## Test Plan
- `cargo +nightly fmt --check -p aptos-vm-environment -p aptos-vm`
- `cargo check -p aptos-vm-environment`
- `cargo test -p aptos-vm-environment test_view_environment_skips_keyless_pvk_preparation`
- `cargo check -p aptos-vm`

Stacked on #20133.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to view-function environment construction; transaction validation still uses environments that prepare the PVK. Behavior change is omitting unused crypto setup, with equality/hash preserved by design.
> 
> **Overview**
> View function execution no longer pays the cost of converting the on-chain keyless verification key into a **Groth16 prepared verifying key (PVK)**.
> 
> `Environment::new` gains a `prepare_keyless_pvk` flag. When it is false, keyless VK bytes are still folded into the environment hash, but `vk.try_into()` for `PreparedVerifyingKey` is skipped so `keyless_pvk()` stays unset. **`AptosEnvironment::new_for_view_function`** sets that flag to false; all existing constructors keep preparing the PVK. **`AptosVM::run_view_function`** builds the environment via the new constructor instead of `AptosEnvironment::new`.
> 
> A unit test checks that with keyless VK on state, normal env has a PVK, view env does not, and **`PartialEq` still holds** (hash unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec29462f973a3b696cb1be19dbd702fe050e9129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->