### PR TITLE
[prover] Per-granularity .bpl partitioning with parallel verification

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/randomness.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.spec.move
@@ -151,7 +151,6 @@ spec aptos_framework::randomness {
     }
 
     spec u64_range_internal(min_incl: u64, max_excl: u64): u64 {
-        pragma seed = 2;
         include NextBlobAbortsIf;
         aborts_if min_incl >= max_excl;
         ensures result >= min_incl && result < max_excl;

--- a/aptos-move/framework/src/prover.rs
+++ b/aptos-move/framework/src/prover.rs
@@ -12,6 +12,7 @@ use move_model::{
     model::{GlobalEnv, VerificationScope},
 };
 use move_prover::cli::Options;
+use move_prover_boogie_backend::options::VerifyGranularity;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
@@ -124,6 +125,13 @@ pub struct ProverOptions {
     /// produce counterexamples; useful for diagnosing per-function timeouts.
     #[clap(long)]
     pub split_vcs_by_assert: bool,
+
+    /// Granularity for partitioning verify targets into `.bpl` files:
+    /// `shard` (default) groups by hash, `module` emits one .bpl per module,
+    /// `vc` emits one .bpl per verify target. `module` and `vc` are mutually
+    /// exclusive with `shards > 1`.
+    #[clap(long, value_enum)]
+    pub granularity: Option<VerifyGranularity>,
 
     /// Maximum number of counterexamples reported per verification
     /// condition.
@@ -304,6 +312,7 @@ impl ProverOptions {
                     || base_opts.backend.skip_instance_check,
                 split_vcs_by_assert: self.split_vcs_by_assert
                     || base_opts.backend.split_vcs_by_assert,
+                granularity: self.granularity.unwrap_or(base_opts.backend.granularity),
                 error_limit: self.error_limit.unwrap_or(base_opts.backend.error_limit),
                 ..base_opts.backend
             },

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_framework::{extended_checks, prover::ProverOptions};
+use move_prover_boogie_backend::options::VerifyGranularity;
 use move_binary_format::file_format_common::VERSION_DEFAULT;
 use move_core_types::diag_writer::DiagWriter;
 use move_model::metadata::{CompilerVersion, LanguageVersion};
@@ -17,6 +18,7 @@ const ENV_TEST_UNCONDITIONAL_ABORT_AS_INCONSISTENCY: &str =
     "MVP_TEST_UNCONDITIONAL_ABORT_AS_INCONSISTENCY";
 const ENV_TEST_DISALLOW_TIMEOUT_OVERWRITE: &str = "MVP_TEST_DISALLOW_TIMEOUT_OVERWRITE";
 const ENV_TEST_VC_TIMEOUT: &str = "MVP_TEST_VC_TIMEOUT";
+const ENV_TEST_GRANULARITY: &str = "MVP_TEST_GRANULARITY";
 
 // Note: to run these tests, use:
 //
@@ -50,6 +52,31 @@ fn build_test_options(shards: usize, only_shard: Option<usize>) -> ProverOptions
         .parse::<usize>()
         .ok()
         .or(options.vc_timeout);
+    match read_env_var(ENV_TEST_GRANULARITY).to_ascii_lowercase().as_str() {
+        "" | "shard" => {},
+        "module" => {
+            options.granularity = Some(VerifyGranularity::Module);
+            // module and shards>1 are mutually exclusive; force shards=1.
+            options.shards = Some(1);
+        },
+        "vc" => {
+            options.granularity = Some(VerifyGranularity::Vc);
+            options.shards = Some(1);
+        },
+        other => panic!(
+            "unknown MVP_TEST_GRANULARITY value: {:?}; expected `shard`, `module`, or `vc`",
+            other
+        ),
+    }
+    if let Ok(cores) = read_env_var("MVP_TEST_CORES").parse::<usize>() {
+        options.proc_cores = Some(cores);
+    }
+    if read_env_var("MVP_TEST_DUMP") == "1" {
+        // Keep .bpl artifacts and disable the test-only TempDir wrapping so
+        // they land in the framework crate's cwd instead of a tmp directory.
+        options.dump = true;
+        options.for_test = false;
+    }
     options
 }
 

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -2,10 +2,10 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_framework::{extended_checks, prover::ProverOptions};
-use move_prover_boogie_backend::options::VerifyGranularity;
 use move_binary_format::file_format_common::VERSION_DEFAULT;
 use move_core_types::diag_writer::DiagWriter;
 use move_model::metadata::{CompilerVersion, LanguageVersion};
+use move_prover_boogie_backend::options::VerifyGranularity;
 use move_prover_test_utils::baseline_test::verify_or_update_baseline;
 use regex::Regex;
 use std::{
@@ -52,7 +52,10 @@ fn build_test_options(shards: usize, only_shard: Option<usize>) -> ProverOptions
         .parse::<usize>()
         .ok()
         .or(options.vc_timeout);
-    match read_env_var(ENV_TEST_GRANULARITY).to_ascii_lowercase().as_str() {
+    match read_env_var(ENV_TEST_GRANULARITY)
+        .to_ascii_lowercase()
+        .as_str()
+    {
         "" | "shard" => {},
         "module" => {
             options.granularity = Some(VerifyGranularity::Module);

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -641,6 +641,10 @@ pub struct GlobalEnv {
     /// A flag which allows to indicate that the whole program including
     /// dependencies should be built.
     pub(crate) everything_is_target: RefCell<bool>,
+    /// Runtime restriction on which files are considered primary targets. When
+    /// `Some`, `is_primary_target()` returns true only for file ids in this set.
+    /// `None` preserves the persistent `file_id_is_primary_target` set.
+    pub(crate) restrict_primary_targets_to: RefCell<Option<BTreeSet<FileId>>>,
     /// Whether the v2 compiler has generated this model.
     /// TODO: replace with a proper version number once we have this in file format
     pub(crate) generated_by_v2: bool,
@@ -720,6 +724,7 @@ impl GlobalEnv {
             extlib_address: None,
             address_alias_map: Default::default(),
             everything_is_target: Default::default(),
+            restrict_primary_targets_to: RefCell::new(None),
             generated_by_v2: false,
             verify_mode: false,
             cmp_types: RefCell::new(Default::default()),
@@ -784,6 +789,12 @@ impl GlobalEnv {
     /// Those tools can temporarily set this to true.
     pub fn treat_everything_as_target(&self, on: bool) {
         *self.everything_is_target.borrow_mut() = on
+    }
+
+    /// Temporarily restrict the primary-target set to the given file ids.
+    /// Pass `None` to clear.
+    pub fn restrict_primary_targets_to(&self, file_ids: Option<BTreeSet<FileId>>) {
+        *self.restrict_primary_targets_to.borrow_mut() = file_ids;
     }
 
     /// Demote every module matched by `predicate` out of the target /
@@ -3515,8 +3526,12 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Returns true of this module is a primary (test/docgen/warning/prover) target.
+    /// Honors `GlobalEnv::restrict_primary_targets_to` when set.
     pub fn is_primary_target(&self) -> bool {
         let file_id = self.data.loc.file_id;
+        if let Some(restrict) = self.env.restrict_primary_targets_to.borrow().as_ref() {
+            return restrict.contains(&file_id);
+        }
         self.env.file_id_is_primary_target.contains(&file_id)
     }
 

--- a/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -2002,13 +2002,24 @@ fn index_range_check(max: usize) -> impl FnOnce(usize) -> Result<usize, ModelPar
 /// Truncate captured Boogie stdout/stderr for inclusion in a diagnostic
 /// message: when Boogie crashes we want enough context to debug, but a 100k-line
 /// log inlined into the codespan error renders the test output unreadable.
+/// Slices on a UTF-8 char boundary at or before `LIMIT` so non-ASCII bytes
+/// (rare in Boogie/Z3 output but possible) don't panic the prover while it's
+/// reporting a crash.
 fn truncate_for_diag(s: &str) -> String {
     const LIMIT: usize = 500;
     let trimmed = s.trim();
     if trimmed.is_empty() {
         "<empty>".to_string()
     } else if trimmed.len() > LIMIT {
-        format!("{}... ({} more bytes)", &trimmed[..LIMIT], trimmed.len() - LIMIT)
+        let mut cut = LIMIT;
+        while cut > 0 && !trimmed.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        format!(
+            "{}... ({} more bytes)",
+            &trimmed[..cut],
+            trimmed.len() - cut
+        )
     } else {
         trimmed.to_string()
     }

--- a/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -222,7 +222,10 @@ impl BoogieWrapper<'_> {
 
     /// Calls boogie and analyzes output.
     pub fn call_boogie_and_verify_output(&self, boogie_file: &str) -> anyhow::Result<()> {
-        let BoogieOutput { mut errors, all_output } = self.call_boogie(boogie_file)?;
+        let BoogieOutput {
+            mut errors,
+            all_output,
+        } = self.call_boogie(boogie_file)?;
         let boogie_log_file = self.options.get_boogie_log_file(boogie_file);
         let log_file_existed = std::path::Path::new(&boogie_log_file).exists();
         debug!("writing boogie log to {}", boogie_log_file);
@@ -312,28 +315,6 @@ impl BoogieWrapper<'_> {
                 }
             ));
         }
-        if !output.status.success() {
-            // Boogie itself crashed or exited non-zero (SIGSEGV is a common
-            // case on large generic code). Promote this to a non-fatal env
-            // diagnostic so the rest of the per-module / per-VC pool can still
-            // run and report — losing one .bpl's verification is much less
-            // disruptive than aborting the entire suite on the first crash.
-            let crash_err = BoogieError {
-                kind: BoogieErrorKind::Internal,
-                loc: self.env.unknown_loc(),
-                message: format!(
-                    "[{}] Boogie process exited with {} (stdout={:?}, stderr={:?})",
-                    bpl_label,
-                    output.status,
-                    truncate_for_diag(&out),
-                    truncate_for_diag(&err)
-                ),
-                execution_trace: vec![],
-                model: None,
-            };
-            self.add_error(&crash_err);
-            return Ok(());
-        }
         if out.trim().starts_with("Unable to monomorphize") {
             return Err(anyhow!(
                 "[{}] Boogie error: {}\n\nstderr:\n{}",
@@ -349,16 +330,47 @@ impl BoogieWrapper<'_> {
                 out
             ));
         }
-        if out.contains("Prover error:") {
-            return Err(anyhow!(
-                "[{}] [internal] boogie exited with prover errors:\n{}",
-                bpl_label,
-                out
-            ));
-        }
+        // Note: a "Prover error:" line (e.g. Z3 hitting "unknown constant" mid-VC
+        // before dying) is recoverable — Boogie may still have produced
+        // per-procedure inconclusive/verification messages on stdout for the
+        // VCs that completed before the crash. We harvest those below instead
+        // of treating the run as a hard error.
         let mut errors = self.extract_verification_errors(&out);
         errors.extend(self.extract_inconclusive_errors(&out));
         errors.extend(self.extract_inconsistency_errors(&out));
+        if !output.status.success() {
+            // Boogie itself crashed or exited non-zero (SIGSEGV is a common
+            // case on large generic code; "Prover died" from Z3 OOM/SIGKILL is
+            // another). Promote this to a non-fatal env diagnostic so the rest
+            // of the per-module / per-VC pool can still run and report.
+            //
+            // If Boogie produced per-VC verification/inconclusive lines before
+            // dying, the extraction above already captured them — those will be
+            // surfaced after the crash note below. Without this ordering, a
+            // Z3-killed-mid-procedure run reports only "process exited" with no
+            // hint of which VCs were in flight.
+            let crash_err = BoogieError {
+                kind: BoogieErrorKind::Internal,
+                loc: self.env.unknown_loc(),
+                message: format!(
+                    "[{}] Boogie process exited with {} (stdout={:?}, stderr={:?})",
+                    bpl_label,
+                    output.status,
+                    truncate_for_diag(&out),
+                    truncate_for_diag(&err)
+                ),
+                execution_trace: vec![],
+                model: None,
+            };
+            self.add_error(&crash_err);
+            for error in &mut errors {
+                error.message = format!("[{}] {}", bpl_label, error.message);
+            }
+            for error in &errors {
+                self.add_error(error);
+            }
+            return Ok(());
+        }
 
         let boogie_log_file = self.options.get_boogie_log_file(boogie_file);
         let log_file_existed = std::path::Path::new(&boogie_log_file).exists();
@@ -2046,8 +2058,18 @@ pub struct RawBoogieResult {
 /// Run Boogie on one `.bpl` file as a subprocess via the existing portfolio
 /// runner. No `GlobalEnv` access. Safe to call from a worker thread.
 pub fn run_boogie_subprocess(options: &BoogieOptions, boogie_file: &str) -> RawBoogieResult {
+    let mut effective = options.clone();
+    // Per-`.bpl` Z3 trace filename — parallel workers otherwise all write to
+    // the same path and clobber each other.
+    if let Some(base) = &options.z3_trace_file {
+        let stem = std::path::Path::new(boogie_file)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        effective.z3_trace_file = Some(format!("{}.{}", base, stem));
+    }
     let task = RunBoogieWithSeeds {
-        options: options.clone(),
+        options: effective,
         boogie_file: boogie_file.to_string(),
     };
     let (seed, subprocess_result) = ProverTaskRunner::run_tasks(

--- a/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -36,6 +36,8 @@ use std::{
     fs,
     num::ParseIntError,
     option::Option::None,
+    sync::{mpsc, Arc, Mutex},
+    thread,
 };
 
 /// A type alias for the way how we use crate `pretty`'s document type. `pretty` is a
@@ -220,11 +222,156 @@ impl BoogieWrapper<'_> {
 
     /// Calls boogie and analyzes output.
     pub fn call_boogie_and_verify_output(&self, boogie_file: &str) -> anyhow::Result<()> {
-        let BoogieOutput { errors, all_output } = self.call_boogie(boogie_file)?;
+        let BoogieOutput { mut errors, all_output } = self.call_boogie(boogie_file)?;
         let boogie_log_file = self.options.get_boogie_log_file(boogie_file);
         let log_file_existed = std::path::Path::new(&boogie_log_file).exists();
         debug!("writing boogie log to {}", boogie_log_file);
         fs::write(&boogie_log_file, all_output)?;
+
+        // Tag each error with the .bpl basename for the same reason as in
+        // `analyze_subprocess_output`: when multiple shards run sequentially,
+        // mapping an error back to a shard from the message saves grep work.
+        let bpl_label = std::path::Path::new(boogie_file)
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| boogie_file.to_string());
+        for error in &mut errors {
+            error.message = format!("[{}] {}", bpl_label, error.message);
+        }
+
+        for error in &errors {
+            self.add_error(error);
+        }
+
+        if !log_file_existed && !self.options.keep_artifacts {
+            std::fs::remove_file(boogie_log_file).unwrap_or_default();
+        }
+
+        Ok(())
+    }
+
+    /// Analyze a previously-captured subprocess result (stdout/stderr/status) and
+    /// emit any errors found into the env. This is the env-touching half of
+    /// `call_boogie_and_verify_output` — the parallel driver path runs the
+    /// subprocesses on worker threads (no env access) and then calls this on the
+    /// main thread for each captured result in stable order.
+    pub fn analyze_subprocess_output(
+        &self,
+        boogie_file: &str,
+        raw: RawBoogieResult,
+    ) -> anyhow::Result<()> {
+        // Compute once and use as a prefix for every error/anyhow message so
+        // the user can always trace a failure back to a specific .bpl.
+        let bpl_label = std::path::Path::new(boogie_file)
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| boogie_file.to_string());
+
+        let output = match raw.subprocess_result {
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::TimedOut {
+                    let err = BoogieError {
+                        kind: BoogieErrorKind::Internal,
+                        loc: self.env.unknown_loc(),
+                        message: format!(
+                            "[{}] Boogie execution exceeded hard timeout of {}s",
+                            bpl_label, self.options.hard_timeout_secs
+                        ),
+                        execution_trace: vec![],
+                        model: None,
+                    };
+                    self.add_error(&err);
+                    return Ok(());
+                } else {
+                    return Err(anyhow!("[{}] cannot execute boogie: {}", bpl_label, err));
+                }
+            },
+            Ok(out) => out,
+        };
+        if self.options.num_instances > 1 {
+            debug!("Boogie instance with seed {} finished first", raw.seed);
+        }
+        let out = String::from_utf8_lossy(&output.stdout).to_string();
+        let err = String::from_utf8_lossy(&output.stderr).to_string();
+        if out
+            .trim()
+            .starts_with("Fatal Error: ProverException: Cannot find specified prover")
+        {
+            return Err(anyhow!(
+                "[{}] The configured prover `{}` could not be found{}",
+                bpl_label,
+                if self.options.use_cvc5 {
+                    &self.options.cvc5_exe
+                } else {
+                    &self.options.z3_exe
+                },
+                if self.options.use_cvc5 {
+                    " (--use-cvc5 is set)"
+                } else {
+                    ""
+                }
+            ));
+        }
+        if !output.status.success() {
+            // Boogie itself crashed or exited non-zero (SIGSEGV is a common
+            // case on large generic code). Promote this to a non-fatal env
+            // diagnostic so the rest of the per-module / per-VC pool can still
+            // run and report — losing one .bpl's verification is much less
+            // disruptive than aborting the entire suite on the first crash.
+            let crash_err = BoogieError {
+                kind: BoogieErrorKind::Internal,
+                loc: self.env.unknown_loc(),
+                message: format!(
+                    "[{}] Boogie process exited with {} (stdout={:?}, stderr={:?})",
+                    bpl_label,
+                    output.status,
+                    truncate_for_diag(&out),
+                    truncate_for_diag(&err)
+                ),
+                execution_trace: vec![],
+                model: None,
+            };
+            self.add_error(&crash_err);
+            return Ok(());
+        }
+        if out.trim().starts_with("Unable to monomorphize") {
+            return Err(anyhow!(
+                "[{}] Boogie error: {}\n\nstderr:\n{}",
+                bpl_label,
+                out,
+                err
+            ));
+        }
+        if out.contains("errors detected in") {
+            return Err(anyhow!(
+                "[{}] [internal] boogie exited with compilation errors:\n{}",
+                bpl_label,
+                out
+            ));
+        }
+        if out.contains("Prover error:") {
+            return Err(anyhow!(
+                "[{}] [internal] boogie exited with prover errors:\n{}",
+                bpl_label,
+                out
+            ));
+        }
+        let mut errors = self.extract_verification_errors(&out);
+        errors.extend(self.extract_inconclusive_errors(&out));
+        errors.extend(self.extract_inconsistency_errors(&out));
+
+        let boogie_log_file = self.options.get_boogie_log_file(boogie_file);
+        let log_file_existed = std::path::Path::new(&boogie_log_file).exists();
+        debug!("writing boogie log to {}", boogie_log_file);
+        fs::write(&boogie_log_file, &out)?;
+
+        // In module / per-VC modes a single failure in one of many .bpl files is
+        // useless without knowing which file produced it. Tag every error from
+        // this Boogie invocation with the .bpl basename so users can map back
+        // to a module (or single VC) without grepping logs.
+        for error in &mut errors {
+            error.message = format!("[{}] {}", bpl_label, error.message);
+        }
 
         for error in &errors {
             self.add_error(error);
@@ -780,17 +927,31 @@ impl BoogieWrapper<'_> {
                     let loc = self
                         .get_loc_from_pos(make_position(line, col))
                         .unwrap_or_else(|| self.env.unknown_loc());
+                    // `str` captures e.g. " of '$1_stake_foo$verify' ". Strip
+                    // surrounding noise and quotes to surface the procedure name
+                    // in the message — without this the user sees "verification
+                    // timed out" with no clue which procedure it was.
+                    let proc_name = str
+                        .trim()
+                        .trim_start_matches("of")
+                        .trim()
+                        .trim_matches(|c| c == '\'' || c == '`' || c == ' ');
+                    let move_name = boogie_reverse_function_name(self.env, proc_name);
                     Some(BoogieError {
                         kind: BoogieErrorKind::Inconclusive,
                         loc,
                         message: if msg.contains("out of resource") || msg.contains("timed out") {
                             let timeout = self.options.vc_timeout;
                             format!(
-                                "verification out of resources/timeout (global timeout set to {}s)",
+                                "verification of `{}`{} out of resources/timeout (global timeout set to {}s)",
+                                proc_name,
+                                move_name
+                                    .map(|n| format!(" ({})", n))
+                                    .unwrap_or_default(),
                                 timeout
                             )
                         } else {
-                            "verification inconclusive".to_string()
+                            format!("verification of `{}` inconclusive", proc_name)
                         },
                         execution_trace: vec![],
                         model: None,
@@ -1836,4 +1997,117 @@ fn index_range_check(max: usize) -> impl FnOnce(usize) -> Result<usize, ModelPar
             )))
         }
     }
+}
+
+/// Truncate captured Boogie stdout/stderr for inclusion in a diagnostic
+/// message: when Boogie crashes we want enough context to debug, but a 100k-line
+/// log inlined into the codespan error renders the test output unreadable.
+fn truncate_for_diag(s: &str) -> String {
+    const LIMIT: usize = 500;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        "<empty>".to_string()
+    } else if trimmed.len() > LIMIT {
+        format!("{}... ({} more bytes)", &trimmed[..LIMIT], trimmed.len() - LIMIT)
+    } else {
+        trimmed.to_string()
+    }
+}
+
+// -----------------------------------------------
+// # Parallel Boogie subprocess runner
+//
+// These free helpers exist so the driver can launch multiple Boogie subprocesses
+// concurrently for the `per_vc` mode (each `.bpl` carries one `$verify`
+// procedure). The subprocess invocation itself does not touch `GlobalEnv`, so it
+// is safe to run from worker threads; the captured raw output is then parsed and
+// reported on the main thread via `BoogieWrapper::analyze_subprocess_output`,
+// which preserves the existing single-threaded env mutation discipline.
+
+/// Captured subprocess result: the winning seed (from the per-instance portfolio)
+/// plus the raw `std::process::Output` or the I/O error from spawn/wait. No env
+/// references — safe to send across threads.
+pub struct RawBoogieResult {
+    pub seed: usize,
+    pub subprocess_result: std::io::Result<std::process::Output>,
+}
+
+/// Run Boogie on one `.bpl` file as a subprocess via the existing portfolio
+/// runner. No `GlobalEnv` access. Safe to call from a worker thread.
+pub fn run_boogie_subprocess(options: &BoogieOptions, boogie_file: &str) -> RawBoogieResult {
+    let task = RunBoogieWithSeeds {
+        options: options.clone(),
+        boogie_file: boogie_file.to_string(),
+    };
+    let (seed, subprocess_result) = ProverTaskRunner::run_tasks(
+        task,
+        options.num_instances,
+        options.sequential_task,
+        options.hard_timeout_secs,
+    );
+    RawBoogieResult {
+        seed,
+        subprocess_result,
+    }
+}
+
+/// Run Boogie on each `.bpl` file in `boogie_files` concurrently, with at most
+/// `parallelism` subprocesses in flight at a time. Returns the captured raw
+/// outputs in input order so the caller can analyze them deterministically
+/// regardless of completion order.
+pub fn run_boogies_parallel(
+    options: &BoogieOptions,
+    boogie_files: &[String],
+    parallelism: usize,
+) -> Vec<RawBoogieResult> {
+    let parallelism = parallelism.max(1);
+    let n = boogie_files.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    // Channel-based worker pool: workers pull (index, path) from a shared queue
+    // and push (index, result) onto the result channel. The main thread feeds
+    // all work, drops the work-tx so workers exit cleanly, and bins results by
+    // index so the returned Vec preserves input order.
+    let (work_tx, work_rx) = mpsc::channel::<(usize, String)>();
+    let work_rx = Arc::new(Mutex::new(work_rx));
+    let (result_tx, result_rx) = mpsc::channel::<(usize, RawBoogieResult)>();
+
+    thread::scope(|s| {
+        for _ in 0..parallelism.min(n) {
+            let work_rx = work_rx.clone();
+            let result_tx = result_tx.clone();
+            let opts = options.clone();
+            s.spawn(move || loop {
+                let next = {
+                    let rx = work_rx.lock().expect("work mutex poisoned");
+                    rx.recv()
+                };
+                match next {
+                    Ok((idx, path)) => {
+                        let raw = run_boogie_subprocess(&opts, &path);
+                        let _ = result_tx.send((idx, raw));
+                    },
+                    Err(_) => break, // channel closed; no more work
+                }
+            });
+        }
+        drop(result_tx);
+
+        for (idx, path) in boogie_files.iter().enumerate() {
+            work_tx
+                .send((idx, path.clone()))
+                .expect("worker pool collapsed before consuming all work");
+        }
+        drop(work_tx); // signal end-of-work
+
+        let mut by_idx: Vec<Option<RawBoogieResult>> = (0..n).map(|_| None).collect();
+        while let Ok((idx, raw)) = result_rx.recv() {
+            by_idx[idx] = Some(raw);
+        }
+        by_idx
+            .into_iter()
+            .map(|o| o.expect("missing per-vc result; worker dropped a task"))
+            .collect()
+    })
 }

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -42,8 +42,8 @@ use move_model::{
     code_writer::CodeWriter,
     emit, emitln,
     model::{
-        FieldEnv, FunId, FunctionEnv, GlobalEnv, Loc, NodeId, Parameter, QualifiedInstId,
-        StructEnv, StructId,
+        FieldEnv, FunId, FunctionEnv, GlobalEnv, Loc, ModuleId, NodeId, Parameter, QualifiedId,
+        QualifiedInstId, StructEnv, StructId,
     },
     pragmas::{
         ADDITION_OVERFLOW_UNCHECKED_PRAGMA, SEED_PRAGMA, TIMEOUT_PRAGMA,
@@ -100,10 +100,31 @@ enum ApplyFrameAccess {
     WritesAt(Vec<String>),
 }
 
+/// Selects which verify-target functions a single translator/`.bpl` should emit
+/// `$verify` procedures for. Sibling cases of the same partition mechanism so
+/// `granularity = shard | module | vc` map to one of these variants without
+/// duplicating the translator code paths.
+#[derive(Debug, Clone)]
+pub enum VerifyTargetSelector {
+    /// Emit every verify target. Used when sharding is disabled (`shards == 1`)
+    /// and granularity is `Shard`.
+    All,
+    /// Hash partition: include a target iff `hash(full_name) % total == idx`.
+    /// Used by sharded mode with `shards > 1`.
+    Shard { idx: usize, total: usize },
+    /// Per-module partition: include targets in the named module.
+    Module { module_id: ModuleId },
+    /// Per-VC partition: include only the named verify target.
+    Single {
+        qid: QualifiedId<FunId>,
+        variant: FunctionVariant,
+    },
+}
+
 pub struct BoogieTranslator<'env> {
     env: &'env GlobalEnv,
     options: &'env BoogieOptions,
-    for_shard: Option<usize>,
+    for_selector: VerifyTargetSelector,
     writer: &'env CodeWriter,
     spec_translator: SpecTranslator<'env>,
     targets: &'env FunctionTargetsHolder,
@@ -241,14 +262,14 @@ impl<'env> BoogieTranslator<'env> {
     pub fn new(
         env: &'env GlobalEnv,
         options: &'env BoogieOptions,
-        for_shard: Option<usize>,
+        for_selector: VerifyTargetSelector,
         targets: &'env FunctionTargetsHolder,
         writer: &'env CodeWriter,
     ) -> Self {
         Self {
             env,
             options,
-            for_shard,
+            for_selector,
             targets,
             writer,
             spec_translator: SpecTranslator::new(writer, env, options),
@@ -277,17 +298,34 @@ impl<'env> BoogieTranslator<'env> {
         if !fun_variant.is_verified() {
             return false;
         }
-        if let Some(shard) = self.for_shard {
-            // Check whether the shard is included.
-            if self.options.only_shard.is_some() && self.options.only_shard != Some(shard + 1) {
-                return false;
-            }
-            // Check whether it is part of the shard.
-            let mut hasher = DefaultHasher::new();
-            fun_target.func_env.get_full_name_str().hash(&mut hasher);
-            if (hasher.finish() as usize) % self.options.shards != shard {
-                return false;
-            }
+        match &self.for_selector {
+            VerifyTargetSelector::All => {},
+            VerifyTargetSelector::Shard { idx, total } => {
+                // Honor `--only-shard` (1-based) when the user opts in.
+                if self.options.only_shard.is_some()
+                    && self.options.only_shard != Some(*idx + 1)
+                {
+                    return false;
+                }
+                let mut hasher = DefaultHasher::new();
+                fun_target.func_env.get_full_name_str().hash(&mut hasher);
+                if (hasher.finish() as usize) % *total != *idx {
+                    return false;
+                }
+            },
+            VerifyTargetSelector::Module { module_id } => {
+                if fun_target.func_env.module_env.get_id() != *module_id {
+                    return false;
+                }
+            },
+            VerifyTargetSelector::Single { qid, variant } => {
+                if fun_target.func_env.get_qualified_id() != *qid {
+                    return false;
+                }
+                if fun_variant != variant {
+                    return false;
+                }
+            },
         }
         // Check whether the estimated duration is too large for configured timeout
         let options = self.options;
@@ -664,14 +702,28 @@ impl<'env> BoogieTranslator<'env> {
 
         // Emit any finalization items required by spec translation.
         self.spec_translator.finalize();
-        let shard_info = if let Some(shard) = self.for_shard {
-            format!(" (for shard #{} of {})", shard + 1, self.options.shards)
-        } else {
-            "".to_string()
+        let selector_info = match &self.for_selector {
+            VerifyTargetSelector::All => String::new(),
+            VerifyTargetSelector::Shard { idx, total } => {
+                format!(" (for shard #{} of {})", idx + 1, total)
+            },
+            VerifyTargetSelector::Module { module_id } => format!(
+                " (for module {})",
+                self.env.get_module(*module_id).get_full_name_str()
+            ),
+            VerifyTargetSelector::Single { qid, variant } => format!(
+                " (for verify target {}::{} [{}])",
+                self.env.get_module(qid.module_id).get_full_name_str(),
+                self.env
+                    .get_function(*qid)
+                    .get_name()
+                    .display(self.env.symbol_pool()),
+                variant
+            ),
         };
         info!(
             "{} verification conditions{}",
-            verified_functions_count, shard_info
+            verified_functions_count, selector_info
         );
     }
 

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -42,8 +42,8 @@ use move_model::{
     code_writer::CodeWriter,
     emit, emitln,
     model::{
-        FieldEnv, FunId, FunctionEnv, GlobalEnv, Loc, ModuleId, NodeId, Parameter, QualifiedId,
-        QualifiedInstId, StructEnv, StructId,
+        FieldEnv, FunId, FunctionEnv, GlobalEnv, Loc, NodeId, Parameter, QualifiedInstId,
+        StructEnv, StructId,
     },
     pragmas::{
         ADDITION_OVERFLOW_UNCHECKED_PRAGMA, SEED_PRAGMA, TIMEOUT_PRAGMA,
@@ -53,6 +53,7 @@ use move_model::{
     ty::{PrimitiveType, Type, TypeDisplayContext, BOOL_TYPE},
     well_known::{TYPE_INFO_MOVE, TYPE_NAME_GET_MOVE, TYPE_NAME_MOVE},
 };
+pub use move_prover_bytecode_pipeline::verify_target::VerifyTargetSelector;
 use move_prover_bytecode_pipeline::{
     mono_analysis,
     mono_analysis::{ClosureInfo, FunParamInfo, StructFieldInfo},
@@ -70,10 +71,7 @@ use move_stackless_bytecode::{
         Operation, PropKind,
     },
 };
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    hash::{DefaultHasher, Hash, Hasher},
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 macro_rules! bv_op_not_enabled_error {
     ($bytecode:expr, $fun_target:expr, $env:expr, $loc:expr) => {
@@ -98,27 +96,6 @@ enum ApplyFrameAccess {
     WritesAll,
     /// Resource may be written at specific Boogie address expressions only
     WritesAt(Vec<String>),
-}
-
-/// Selects which verify-target functions a single translator/`.bpl` should emit
-/// `$verify` procedures for. Sibling cases of the same partition mechanism so
-/// `granularity = shard | module | vc` map to one of these variants without
-/// duplicating the translator code paths.
-#[derive(Debug, Clone)]
-pub enum VerifyTargetSelector {
-    /// Emit every verify target. Used when sharding is disabled (`shards == 1`)
-    /// and granularity is `Shard`.
-    All,
-    /// Hash partition: include a target iff `hash(full_name) % total == idx`.
-    /// Used by sharded mode with `shards > 1`.
-    Shard { idx: usize, total: usize },
-    /// Per-module partition: include targets in the named module.
-    Module { module_id: ModuleId },
-    /// Per-VC partition: include only the named verify target.
-    Single {
-        qid: QualifiedId<FunId>,
-        variant: FunctionVariant,
-    },
 }
 
 pub struct BoogieTranslator<'env> {
@@ -298,34 +275,20 @@ impl<'env> BoogieTranslator<'env> {
         if !fun_variant.is_verified() {
             return false;
         }
-        match &self.for_selector {
-            VerifyTargetSelector::All => {},
-            VerifyTargetSelector::Shard { idx, total } => {
-                // Honor `--only-shard` (1-based) when the user opts in.
-                if self.options.only_shard.is_some()
-                    && self.options.only_shard != Some(*idx + 1)
-                {
-                    return false;
-                }
-                let mut hasher = DefaultHasher::new();
-                fun_target.func_env.get_full_name_str().hash(&mut hasher);
-                if (hasher.finish() as usize) % *total != *idx {
-                    return false;
-                }
-            },
-            VerifyTargetSelector::Module { module_id } => {
-                if fun_target.func_env.module_env.get_id() != *module_id {
-                    return false;
-                }
-            },
-            VerifyTargetSelector::Single { qid, variant } => {
-                if fun_target.func_env.get_qualified_id() != *qid {
-                    return false;
-                }
-                if fun_variant != variant {
-                    return false;
-                }
-            },
+        // Honor `--only-shard` (1-based) for sharded mode regardless of which
+        // shard the selector targets.
+        if let VerifyTargetSelector::Shard { idx, .. } = &self.for_selector {
+            if self.options.only_shard.is_some() && self.options.only_shard != Some(*idx + 1) {
+                return false;
+            }
+        }
+        if !self.for_selector.includes(
+            fun_target.func_env.module_env.get_id(),
+            fun_target.func_env.get_qualified_id(),
+            fun_variant,
+            &fun_target.func_env.get_full_name_str(),
+        ) {
+            return false;
         }
         // Check whether the estimated duration is too large for configured timeout
         let options = self.options;

--- a/third_party/move/move-prover/boogie-backend/src/lib.rs
+++ b/third_party/move/move-prover/boogie-backend/src/lib.rs
@@ -387,7 +387,10 @@ pub fn add_prelude(
     cmp_struct_types.sort();
     cmp_struct_types.dedup();
     context.insert("cmp_int_instances", &cmp_int_types);
-    env.cmp_types.borrow_mut().extend(cmp_struct_types);
+    // Replace rather than extend: each `.bpl` pass computes its own
+    // `cmp_struct_types` from its `MonoInfo`; accumulating across passes
+    // would leak structs whose field declarations weren't emitted in this `.bpl`.
+    *env.cmp_types.borrow_mut() = cmp_struct_types.into_iter().collect();
 
     let filter_cmp_instances_with_name_prefix = |name_prefix: &str| {
         cmp_instances

--- a/third_party/move/move-prover/boogie-backend/src/options.rs
+++ b/third_party/move/move-prover/boogie-backend/src/options.rs
@@ -54,6 +54,29 @@ impl VectorTheory {
     }
 }
 
+/// Partition granularity for verification: how verify targets are grouped into
+/// `.bpl` files.
+///
+/// - `Shard`: one `.bpl` per hash-shard (or one per package when `shards == 1`).
+///   The historical default; Boogie parallelizes procedures inside each shard
+///   via `-vcsCores`. Shards are processed sequentially by the driver.
+/// - `Module`: one `.bpl` per source module that contains verify targets. The
+///   driver runs up to `proc_cores` modules concurrently; `-vcsCores` is forced
+///   to 1 inside each Boogie process to avoid the `proc_cores²` thread fan-out
+///   that empirically triggers Boogie/.NET SIGSEGVs under contention.
+/// - `Vc`: one `.bpl` per (function-id, FunctionVariant::Verification) pair.
+///   `-vcsCores` is also forced to 1; the driver runs up to `proc_cores` Boogie
+///   processes concurrently. Used for the finest isolation and per-VC
+///   diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum, Default)]
+#[clap(rename_all = "kebab-case")]
+pub enum VerifyGranularity {
+    #[default]
+    Shard,
+    Module,
+    Vc,
+}
+
 /// Options to define custom native functions to include in generated Boogie file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CustomNativeOptions {
@@ -209,6 +232,14 @@ pub struct BoogieOptions {
     /// timeouts.
     #[arg(long)]
     pub split_vcs_by_assert: bool,
+    /// Granularity for partitioning verify targets into `.bpl` files.
+    /// `shard` (default) groups by hash partition (compatible with `--shards`);
+    /// `module` emits one `.bpl` per source module containing verify targets;
+    /// `vc` emits one `.bpl` per verify target (finest granularity).
+    /// `module` and `vc` use the driver-level parallel worker pool sized by
+    /// `--cores` and are mutually exclusive with `--shards > 1`.
+    #[arg(long, value_enum, default_value_t = VerifyGranularity::Shard)]
+    pub granularity: VerifyGranularity,
     /// Maximum number of counterexamples reported per verification
     /// condition.
     #[arg(long, default_value_t = 5)]
@@ -250,6 +281,7 @@ impl Default for BoogieOptions {
             borrow_aggregates: vec![],
             skip_instance_check: false,
             split_vcs_by_assert: false,
+            granularity: VerifyGranularity::Shard,
             error_limit: 5,
         }
     }
@@ -312,16 +344,25 @@ impl BoogieOptions {
             add(&["-vcsSplitOnEveryAssert"]);
         }
         add(&[&format!("-errorLimit:{}", self.error_limit)]);
-        add(&[&format!(
-            "-vcsCores:{}",
-            if self.stable_test_output {
-                // Do not use multiple cores if stable test output is requested.
-                // Error messages may appear in non-deterministic order otherwise.
-                1
-            } else {
-                self.proc_cores
-            }
-        )]);
+        let effective_cores = match self.granularity {
+            // In Module / Vc modes the driver runs multiple Boogie processes
+            // concurrently (up to `proc_cores`). Letting each Boogie also use
+            // `-vcsCores:proc_cores` would multiply the worker thread count to
+            // `proc_cores^2`, oversubscribing the machine and — empirically —
+            // triggering SIGSEGVs from Boogie's .NET runtime under contention.
+            // Force 1 so the driver pool is the sole source of parallelism.
+            VerifyGranularity::Module | VerifyGranularity::Vc => 1,
+            VerifyGranularity::Shard => {
+                if self.stable_test_output {
+                    // Do not use multiple cores if stable test output is requested.
+                    // Error messages may appear in non-deterministic order otherwise.
+                    1
+                } else {
+                    self.proc_cores
+                }
+            },
+        };
+        add(&[&format!("-vcsCores:{}", effective_cores)]);
 
         // TODO: see what we can make out of these flags.
         //add(&["-proverOpt:O:smt.QI.PROFILE=true"]);

--- a/third_party/move/move-prover/bytecode-pipeline/src/lib.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/lib.rs
@@ -18,4 +18,5 @@ pub mod pipeline_factory;
 pub mod spec_inference;
 pub mod spec_instrumentation;
 pub mod verification_analysis;
+pub mod verify_target;
 pub mod well_formed_instrumentation;

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -220,7 +220,8 @@ impl MonoAnalysisProcessor {
             done_types: BTreeSet::new(),
             inst_opt: None,
         };
-        // Analyze axioms found in modules.
+        // Seed axioms from all modules unconditionally; cross-module spec funs
+        // (e.g. `object` calling `from_bcs::to_address`) need them.
         for module_env in env.get_modules() {
             for axiom in module_env.get_spec().filter_kind_axiom() {
                 analyzer.analyze_exp(&axiom.exp)

--- a/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis.rs
@@ -233,10 +233,14 @@ impl FunctionTargetProcessor for VerificationAnalysisProcessor {
         let options = ProverOptions::get(env);
 
         // If we are verifying only one function or module, check that this indeed exists.
+        // Accept both simple ("math128") and qualified ("0x1::math128") forms — same
+        // semantics as `matches_name` uses at the actual scope check below.
         match &options.verify_scope {
             VerificationScope::OnlyModule(name) => {
-                let sym = env.symbol_pool().make(name);
-                if !env.find_module_by_name(sym).is_some_and(|m| m.is_target()) {
+                if !env
+                    .get_modules()
+                    .any(|m| m.matches_name(name) && m.is_target())
+                {
                     env.error(
                         &env.unknown_loc(),
                         &format!("module target {} does not exist in target modules", name),
@@ -262,8 +266,10 @@ impl FunctionTargetProcessor for VerificationAnalysisProcessor {
         for excl in &options.verify_exclude {
             match excl {
                 VerificationScope::OnlyModule(name) => {
-                    let sym = env.symbol_pool().make(name);
-                    if !env.find_module_by_name(sym).is_some_and(|m| m.is_target()) {
+                    if !env
+                        .get_modules()
+                        .any(|m| m.matches_name(name) && m.is_target())
+                    {
                         env.error(
                             &env.unknown_loc(),
                             &format!(

--- a/third_party/move/move-prover/bytecode-pipeline/src/verify_target.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/verify_target.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `VerifyTargetSelector`: identity of the verify-target set a single `.bpl`
+//! emits. Shared by the Boogie translator and the per-VC codegen slicing.
+
+use move_model::model::{FunId, ModuleId, QualifiedId};
+use move_stackless_bytecode::function_target_pipeline::FunctionVariant;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+#[derive(Debug, Clone)]
+pub enum VerifyTargetSelector {
+    /// Emit every verify target. Used when sharding is disabled (`shards == 1`)
+    /// and granularity is `Shard`.
+    All,
+    /// Hash partition: include a target iff `hash(full_name) % total == idx`.
+    /// Used by sharded mode with `shards > 1`.
+    Shard { idx: usize, total: usize },
+    /// Per-module partition: include targets in the named module.
+    Module { module_id: ModuleId },
+    /// Per-VC partition: include only the named verify target.
+    Single {
+        qid: QualifiedId<FunId>,
+        variant: FunctionVariant,
+    },
+}
+
+impl VerifyTargetSelector {
+    /// True iff the verify target identified by `(module_id, qid, variant, full_name)`
+    /// belongs to this selector. `full_name` is the same hash key the
+    /// Boogie translator uses for shard assignment.
+    pub fn includes(
+        &self,
+        module_id: ModuleId,
+        qid: QualifiedId<FunId>,
+        variant: &FunctionVariant,
+        full_name: &str,
+    ) -> bool {
+        match self {
+            VerifyTargetSelector::All => true,
+            VerifyTargetSelector::Shard { idx, total } => {
+                function_in_shard(full_name, *idx, *total)
+            },
+            VerifyTargetSelector::Module {
+                module_id: selected,
+            } => module_id == *selected,
+            VerifyTargetSelector::Single {
+                qid: selected_qid,
+                variant: selected_variant,
+            } => qid == *selected_qid && variant == selected_variant,
+        }
+    }
+}
+
+/// Hash-based shard predicate.
+pub fn function_in_shard(fun_full_name: &str, shard_idx: usize, shards_total: usize) -> bool {
+    if shards_total <= 1 {
+        return true;
+    }
+    let mut hasher = DefaultHasher::new();
+    fun_full_name.hash(&mut hasher);
+    (hasher.finish() as usize) % shards_total == shard_idx
+}

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -14,15 +14,20 @@ use log::{debug, info, warn};
 use log::{log_enabled, Level};
 use move_compiler_v2::Experiment;
 use move_model::{
-    code_writer::CodeWriter, metadata::LATEST_STABLE_COMPILER_VERSION_VALUE, model::GlobalEnv,
+    code_writer::CodeWriter,
+    metadata::LATEST_STABLE_COMPILER_VERSION_VALUE,
+    model::{FunId, GlobalEnv, ModuleId, QualifiedId},
 };
 use move_prover_boogie_backend::{
-    add_prelude, boogie_wrapper::BoogieWrapper, bytecode_translator::BoogieTranslator,
+    add_prelude,
+    boogie_wrapper::{run_boogies_parallel, BoogieWrapper},
+    bytecode_translator::{BoogieTranslator, VerifyTargetSelector},
+    options::VerifyGranularity,
 };
 use move_prover_bytecode_pipeline::{
     number_operation::GlobalNumberOperationState, pipeline_factory,
 };
-use move_stackless_bytecode::function_target_pipeline::FunctionTargetsHolder;
+use move_stackless_bytecode::function_target_pipeline::{FunctionTargetsHolder, FunctionVariant};
 use std::{
     fs,
     path::Path,
@@ -153,38 +158,50 @@ pub fn run_move_prover_with_model_v2<W: WriteColor>(
         "exiting with bytecode transformation errors",
     )?;
 
+    // Reject conflicting partition flags up front. `--shards N` only makes sense
+    // under the default `shard` granularity; combining it with the finer
+    // partitions would silently dilute one or the other.
+    if !matches!(options.backend.granularity, VerifyGranularity::Shard)
+        && options.backend.shards > 1
+    {
+        return Err(anyhow!(
+            "`--shards > 1` only applies to `--granularity shard`. \
+             Use one of `--granularity shard --shards N`, `--granularity module`, \
+             or `--granularity vc`."
+        ));
+    }
+
     let mut gen_durations = vec![];
     let mut verify_durations = vec![];
-    let has_shards = options.backend.shards > 1;
     let output_base_file = options.output_path.clone();
-    for shard in 0..options.backend.shards {
-        // If there are shards, modify the output name
-        if has_shards {
-            options.output_path = Path::new(&output_base_file)
-                .with_extension(format!("shard_{}.bpl", shard + 1))
-                .to_string_lossy()
-                .to_string();
-        }
-        // Generate boogie code.
-        let now = Instant::now();
-        let code_writer = generate_boogie(
+    match options.backend.granularity {
+        VerifyGranularity::Shard => drive_sharded(
             env,
-            &options,
-            if has_shards { Some(shard) } else { None },
+            &mut options,
             &targets,
-        )?;
-        gen_durations.push(now.elapsed());
-        check_errors(
-            env,
-            &options,
+            &output_base_file,
             error_writer,
-            "exiting with condition generation errors",
-        )?;
-
-        // Verify boogie code.
-        let now = Instant::now();
-        verify_boogie(env, &options, &targets, code_writer)?;
-        verify_durations.push(now.elapsed());
+            &mut gen_durations,
+            &mut verify_durations,
+        )?,
+        VerifyGranularity::Module => drive_per_module(
+            env,
+            &mut options,
+            &targets,
+            &output_base_file,
+            error_writer,
+            &mut gen_durations,
+            &mut verify_durations,
+        )?,
+        VerifyGranularity::Vc => drive_per_vc(
+            env,
+            &mut options,
+            &targets,
+            &output_base_file,
+            error_writer,
+            &mut gen_durations,
+            &mut verify_durations,
+        )?,
     }
     options.output_path = output_base_file;
     // Report durations.
@@ -226,17 +243,327 @@ pub fn check_errors<W: WriteColor>(
     }
 }
 
+/// Generate Boogie for the verify targets selected by `selector`. Primary API.
+pub fn generate_boogie_with_selector(
+    env: &GlobalEnv,
+    options: &Options,
+    selector: VerifyTargetSelector,
+    targets: &FunctionTargetsHolder,
+) -> anyhow::Result<CodeWriter> {
+    let writer = CodeWriter::new(env.internal_loc());
+    add_prelude(env, &options.backend, &writer)?;
+    let mut translator =
+        BoogieTranslator::new(env, &options.backend, selector, targets, &writer);
+    translator.translate();
+    Ok(writer)
+}
+
+/// Back-compat wrapper for callers that pass `Option<usize>` shard index. Prefer
+/// `generate_boogie_with_selector` in new code.
 pub fn generate_boogie(
     env: &GlobalEnv,
     options: &Options,
     shard: Option<usize>,
     targets: &FunctionTargetsHolder,
 ) -> anyhow::Result<CodeWriter> {
-    let writer = CodeWriter::new(env.internal_loc());
-    add_prelude(env, &options.backend, &writer)?;
-    let mut translator = BoogieTranslator::new(env, &options.backend, shard, targets, &writer);
-    translator.translate();
-    Ok(writer)
+    let selector = match shard {
+        None => VerifyTargetSelector::All,
+        Some(idx) => VerifyTargetSelector::Shard {
+            idx,
+            total: options.backend.shards,
+        },
+    };
+    generate_boogie_with_selector(env, options, selector, targets)
+}
+
+/// Enumerate every (function-id, FunctionVariant::Verification(_)) pair the prover
+/// would emit `$verify` procedures for under the default selector. Source of truth
+/// for the per-VC outer loop. Mirrors the iteration in
+/// `bytecode_translator::translate` but only collects identifiers — no translation.
+///
+/// V1 simplification: type-instance variants (`VerificationFlavor::Instantiated(_)`)
+/// from `mono_info.funs` are NOT enumerated separately; each base verify target gets
+/// one `.bpl`. Per-VC mode therefore implicitly behaves as if `--skip-instance-check`
+/// were set. Documented under the `per_vc` option.
+pub fn enumerate_verify_targets(
+    env: &GlobalEnv,
+    targets: &FunctionTargetsHolder,
+) -> Vec<(QualifiedId<FunId>, FunctionVariant)> {
+    let mut out = Vec::new();
+    for module_env in env.get_modules() {
+        if !module_env.is_target() {
+            continue;
+        }
+        for fun_env in module_env.get_functions() {
+            if fun_env.is_native_or_intrinsic()
+                || fun_env.is_test_only()
+                || fun_env.is_not_prover_target()
+            {
+                continue;
+            }
+            for (variant, _target) in targets.get_targets(&fun_env) {
+                if !variant.is_verified() {
+                    continue;
+                }
+                out.push((fun_env.get_qualified_id(), variant));
+            }
+        }
+    }
+    out
+}
+
+/// Enumerate every module that contains at least one verify target. Stable
+/// iteration order (source-declaration order, matching `env.get_modules`).
+pub fn enumerate_modules_with_verify_targets(
+    env: &GlobalEnv,
+    targets: &FunctionTargetsHolder,
+) -> Vec<ModuleId> {
+    let mut out = Vec::new();
+    for module_env in env.get_modules() {
+        if !module_env.is_target() {
+            continue;
+        }
+        let has_verify_target = module_env.get_functions().any(|fun_env| {
+            if fun_env.is_native_or_intrinsic()
+                || fun_env.is_test_only()
+                || fun_env.is_not_prover_target()
+            {
+                return false;
+            }
+            targets
+                .get_targets(&fun_env)
+                .iter()
+                .any(|(variant, _)| variant.is_verified())
+        });
+        if has_verify_target {
+            out.push(module_env.get_id());
+        }
+    }
+    out
+}
+
+/// Sanitize a string for use as a portion of a filename. Replaces characters that
+/// commonly cause shell / path issues with `_`. Stable, deterministic mapping.
+pub fn sanitize_for_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            ':' | '<' | '>' | ',' | ' ' | '/' | '\\' | '"' | '\'' | '#' | '|' | '?' | '*' => '_',
+            other => other,
+        })
+        .collect()
+}
+
+/// Build the per-VC `.bpl` output path: `<base_no_ext>.vc_<sanitized>_<variant>.bpl`.
+fn per_vc_output_path(
+    env: &GlobalEnv,
+    output_base: &str,
+    qid: QualifiedId<FunId>,
+    variant: &FunctionVariant,
+) -> String {
+    let full_name = env.get_function(qid).get_full_name_with_address();
+    let stem = sanitize_for_filename(&format!("{}_{}", full_name, variant));
+    Path::new(output_base)
+        .with_extension(format!("vc_{}.bpl", stem))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Build the per-module `.bpl` output path: `<base_no_ext>.module_<sanitized>.bpl`.
+fn per_module_output_path(env: &GlobalEnv, output_base: &str, module_id: ModuleId) -> String {
+    let stem = sanitize_for_filename(&env.get_module(module_id).get_full_name_str());
+    Path::new(output_base)
+        .with_extension(format!("module_{}.bpl", stem))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Sharded (or unsharded single-`.bpl`) driver. Preserves existing behavior:
+/// sequential one-`.bpl`-per-shard with Boogie's intra-process parallelism on
+/// procedures inside each `.bpl`.
+fn drive_sharded<W: WriteColor>(
+    env: &GlobalEnv,
+    options: &mut Options,
+    targets: &FunctionTargetsHolder,
+    output_base_file: &str,
+    error_writer: &mut W,
+    gen_durations: &mut Vec<Duration>,
+    verify_durations: &mut Vec<Duration>,
+) -> anyhow::Result<()> {
+    let has_shards = options.backend.shards > 1;
+    for shard in 0..options.backend.shards {
+        if has_shards {
+            options.output_path = Path::new(output_base_file)
+                .with_extension(format!("shard_{}.bpl", shard + 1))
+                .to_string_lossy()
+                .to_string();
+        }
+        let selector = if has_shards {
+            VerifyTargetSelector::Shard {
+                idx: shard,
+                total: options.backend.shards,
+            }
+        } else {
+            VerifyTargetSelector::All
+        };
+        let now = Instant::now();
+        let code_writer = generate_boogie_with_selector(env, options, selector, targets)?;
+        gen_durations.push(now.elapsed());
+        check_errors(
+            env,
+            options,
+            error_writer,
+            "exiting with condition generation errors",
+        )?;
+        let now = Instant::now();
+        verify_boogie(env, options, targets, code_writer)?;
+        verify_durations.push(now.elapsed());
+    }
+    Ok(())
+}
+
+/// Per-module driver: emit one `.bpl` per source module that contains at least
+/// one verify target. Sequential codegen (env extension mutation is not
+/// thread-safe), then parallel verification with up to `proc_cores` Boogie
+/// processes concurrently. Each Boogie process still uses `-vcsCores:proc_cores`
+/// internally to parallelize across the procedures in its module.
+fn drive_per_module<W: WriteColor>(
+    env: &GlobalEnv,
+    options: &mut Options,
+    targets: &FunctionTargetsHolder,
+    output_base_file: &str,
+    error_writer: &mut W,
+    gen_durations: &mut Vec<Duration>,
+    verify_durations: &mut Vec<Duration>,
+) -> anyhow::Result<()> {
+    let module_list = enumerate_modules_with_verify_targets(env, targets);
+    let parallelism = options.backend.proc_cores.max(1);
+    info!(
+        "per-module mode: {} modules, parallelism={}",
+        module_list.len(),
+        parallelism
+    );
+
+    // Phase 1: sequential code generation, one .bpl per module.
+    let mut bpl_paths: Vec<String> = Vec::with_capacity(module_list.len());
+    for module_id in &module_list {
+        options.output_path = per_module_output_path(env, output_base_file, *module_id);
+        let selector = VerifyTargetSelector::Module {
+            module_id: *module_id,
+        };
+        let now = Instant::now();
+        let code_writer = generate_boogie_with_selector(env, options, selector, targets)?;
+        gen_durations.push(now.elapsed());
+        check_errors(
+            env,
+            options,
+            error_writer,
+            "exiting with condition generation errors",
+        )?;
+        code_writer.process_result(|result| fs::write(&options.output_path, result))?;
+        bpl_paths.push(options.output_path.clone());
+    }
+
+    if options.prover.generate_only {
+        return Ok(());
+    }
+
+    // Phase 2: parallel verification across modules; Boogie still uses its
+    // internal `-vcsCores` parallelism within each module's .bpl.
+    let now = Instant::now();
+    let raw_results = run_boogies_parallel(&options.backend, &bpl_paths, parallelism);
+    verify_durations.push(now.elapsed());
+
+    let wrapper = BoogieWrapper {
+        env,
+        targets,
+        writer: &CodeWriter::new(env.internal_loc()),
+        options: &options.backend,
+    };
+    for (path, raw) in bpl_paths.iter().zip(raw_results.into_iter()) {
+        wrapper.analyze_subprocess_output(path, raw)?;
+        if !options.backend.keep_artifacts {
+            std::fs::remove_file(path).unwrap_or_default();
+        }
+    }
+    Ok(())
+}
+
+/// Per-VC driver: enumerate verify targets, emit one `.bpl` per target
+/// sequentially (codegen mutates the env extension and is not thread-safe), then
+/// verify all `.bpl` files in parallel with a driver-managed worker pool.
+/// Errors are buffered into the env's diagnostic stream in stable target order
+/// regardless of completion order, so test baselines stay deterministic.
+fn drive_per_vc<W: WriteColor>(
+    env: &GlobalEnv,
+    options: &mut Options,
+    targets: &FunctionTargetsHolder,
+    output_base_file: &str,
+    error_writer: &mut W,
+    gen_durations: &mut Vec<Duration>,
+    verify_durations: &mut Vec<Duration>,
+) -> anyhow::Result<()> {
+    let target_list = enumerate_verify_targets(env, targets);
+    let parallelism = options.backend.proc_cores.max(1);
+    info!(
+        "per-VC mode: {} verify targets, parallelism={}",
+        target_list.len(),
+        parallelism
+    );
+
+    // Phase 1: sequential code generation. Each target's `.bpl` is written to
+    // disk; the env extension may be mutated here, so this loop is not parallel.
+    let mut bpl_paths: Vec<String> = Vec::with_capacity(target_list.len());
+    for (qid, variant) in &target_list {
+        options.output_path = per_vc_output_path(env, output_base_file, *qid, variant);
+        let selector = VerifyTargetSelector::Single {
+            qid: *qid,
+            variant: variant.clone(),
+        };
+        let now = Instant::now();
+        let code_writer = generate_boogie_with_selector(env, options, selector, targets)?;
+        gen_durations.push(now.elapsed());
+        check_errors(
+            env,
+            options,
+            error_writer,
+            "exiting with condition generation errors",
+        )?;
+        // Persist the .bpl so the worker pool can launch Boogie on it. Mirrors
+        // the persistence step inside `verify_boogie`, factored out here because
+        // we don't want to call Boogie yet — that runs in phase 2.
+        code_writer.process_result(|result| fs::write(&options.output_path, result))?;
+        bpl_paths.push(options.output_path.clone());
+    }
+
+    if options.prover.generate_only {
+        // Skip the verify pass entirely; the .bpl files are the artifact.
+        return Ok(());
+    }
+
+    // Phase 2: parallel verification. Worker threads spawn Boogie subprocesses
+    // (no `GlobalEnv` access — safe across threads). Raw outputs come back in
+    // stable input order so we can analyze them deterministically on this thread.
+    let now = Instant::now();
+    let raw_results = run_boogies_parallel(&options.backend, &bpl_paths, parallelism);
+    let parallel_wall = now.elapsed();
+    verify_durations.push(parallel_wall);
+
+    let wrapper = BoogieWrapper {
+        env,
+        targets,
+        writer: &CodeWriter::new(env.internal_loc()),
+        options: &options.backend,
+    };
+    for (path, raw) in bpl_paths.iter().zip(raw_results.into_iter()) {
+        let bpl_existed_before_run = false; // we always create them in phase 1
+        wrapper.analyze_subprocess_output(path, raw)?;
+        // Match the cleanup `verify_boogie` does for the single-shard path: if
+        // the user didn't ask to keep artifacts, drop the .bpl now.
+        if !bpl_existed_before_run && !options.backend.keep_artifacts {
+            std::fs::remove_file(path).unwrap_or_default();
+        }
+    }
+    Ok(())
 }
 
 pub fn verify_boogie(

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -30,6 +30,7 @@ use move_prover_bytecode_pipeline::{
 };
 use move_stackless_bytecode::function_target_pipeline::{FunctionTargetsHolder, FunctionVariant};
 use std::{
+    collections::BTreeSet,
     fs,
     path::Path,
     time::{Duration, Instant},
@@ -38,6 +39,26 @@ use std::{
 pub mod cli;
 pub mod inference;
 pub mod package_prove;
+
+/// RAII guard around `GlobalEnv::restrict_primary_targets_to`. Sets the
+/// restriction on construction and clears it on drop so `?` early returns
+/// from inside the per-module loop don't leak the restriction onto callers.
+struct PrimaryTargetGuard<'a> {
+    env: &'a GlobalEnv,
+}
+
+impl<'a> PrimaryTargetGuard<'a> {
+    fn set(env: &'a GlobalEnv, loc: &move_model::model::Loc) -> Self {
+        env.restrict_primary_targets_to(Some(BTreeSet::from([loc.file_id()])));
+        Self { env }
+    }
+}
+
+impl Drop for PrimaryTargetGuard<'_> {
+    fn drop(&mut self) {
+        self.env.restrict_primary_targets_to(None);
+    }
+}
 
 // =================================================================================================
 // Prover API
@@ -244,7 +265,7 @@ pub fn check_errors<W: WriteColor>(
     }
 }
 
-/// Generate Boogie for the verify targets selected by `selector`. Primary API.
+/// Generate Boogie for the verify targets selected by `selector`.
 pub fn generate_boogie_with_selector(
     env: &GlobalEnv,
     options: &Options,
@@ -253,8 +274,7 @@ pub fn generate_boogie_with_selector(
 ) -> anyhow::Result<CodeWriter> {
     let writer = CodeWriter::new(env.internal_loc());
     add_prelude(env, &options.backend, &writer)?;
-    let mut translator =
-        BoogieTranslator::new(env, &options.backend, selector, targets, &writer);
+    let mut translator = BoogieTranslator::new(env, &options.backend, selector, targets, &writer);
     translator.translate();
     Ok(writer)
 }
@@ -283,9 +303,7 @@ pub fn generate_boogie(
 /// enumeration helpers so per-module / per-VC drivers don't generate `.bpl`
 /// files for targets the translator would silently skip.
 fn function_passes_verify_filter(fun_env: &FunctionEnv, options: &cli::Options) -> bool {
-    if fun_env.is_native_or_intrinsic()
-        || fun_env.is_test_only()
-        || fun_env.is_not_prover_target()
+    if fun_env.is_native_or_intrinsic() || fun_env.is_test_only() || fun_env.is_not_prover_target()
     {
         return false;
     }
@@ -375,7 +393,9 @@ pub fn sanitize_for_filename(s: &str) -> String {
         .collect()
 }
 
-/// Build the per-VC `.bpl` output path: `<base_no_ext>.vc_<sanitized>_<variant>.bpl`.
+/// Build the per-VC `.bpl` output path. Includes a hash of the raw
+/// `<full_name>_<variant>` so two targets that flatten to the same sanitized
+/// stem cannot collide (`sanitize_for_filename` is many-to-one).
 fn per_vc_output_path(
     env: &GlobalEnv,
     output_base: &str,
@@ -383,9 +403,13 @@ fn per_vc_output_path(
     variant: &FunctionVariant,
 ) -> String {
     let full_name = env.get_function(qid).get_full_name_with_address();
-    let stem = sanitize_for_filename(&format!("{}_{}", full_name, variant));
+    let raw = format!("{}_{}", full_name, variant);
+    let mut hasher = std::hash::DefaultHasher::new();
+    std::hash::Hash::hash(&raw, &mut hasher);
+    let hash = std::hash::Hasher::finish(&hasher);
+    let stem = sanitize_for_filename(&raw);
     Path::new(output_base)
-        .with_extension(format!("vc_{}.bpl", stem))
+        .with_extension(format!("vc_{}_{:016x}.bpl", stem, hash))
         .to_string_lossy()
         .into_owned()
 }
@@ -443,21 +467,20 @@ fn drive_sharded<W: WriteColor>(
     Ok(())
 }
 
-/// Per-module driver: emit one `.bpl` per source module that contains at least
-/// one verify target. Sequential codegen (env extension mutation is not
-/// thread-safe), then parallel verification with up to `proc_cores` Boogie
-/// processes concurrently. Each Boogie process still uses `-vcsCores:proc_cores`
-/// internally to parallelize across the procedures in its module.
+/// Per-module driver: one `.bpl` per source module with verify targets. Each
+/// module gets its own pipeline rerun via `restrict_primary_targets_to`, so the
+/// `.bpl` matches `move prove -f <module>` content. `check_errors` is deferred
+/// to after all reruns for cross-rerun diagnostic dedup.
 fn drive_per_module<W: WriteColor>(
     env: &GlobalEnv,
     options: &mut Options,
-    targets: &FunctionTargetsHolder,
+    upstream_targets: &FunctionTargetsHolder,
     output_base_file: &str,
     error_writer: &mut W,
     gen_durations: &mut Vec<Duration>,
     verify_durations: &mut Vec<Duration>,
 ) -> anyhow::Result<()> {
-    let module_list = enumerate_modules_with_verify_targets(env, targets, options);
+    let module_list = enumerate_modules_with_verify_targets(env, upstream_targets, options);
     let parallelism = options.backend.proc_cores.max(1);
     info!(
         "per-module mode: {} modules, parallelism={}",
@@ -465,49 +488,70 @@ fn drive_per_module<W: WriteColor>(
         parallelism
     );
 
-    // Phase 1: sequential code generation, one .bpl per module.
+    // Phase 1: per-module pipeline rerun + codegen. Restrict primary targets
+    // only; leaving `verify_scope = All` keeps Rule 3 in
+    // `VerificationAnalysisProcessor` marking cross-module functions that
+    // modify in-scope invariants — those drive part of the closure walk that
+    // populates `MonoInfo`.
     let mut bpl_paths: Vec<String> = Vec::with_capacity(module_list.len());
+    let mut per_module_targets: Vec<FunctionTargetsHolder> = Vec::with_capacity(module_list.len());
+    let mut per_module_writers: Vec<CodeWriter> = Vec::with_capacity(module_list.len());
     for module_id in &module_list {
+        let module_env = env.get_module(*module_id);
         options.output_path = per_module_output_path(env, output_base_file, *module_id);
+        let _scope = PrimaryTargetGuard::set(env, &module_env.get_loc());
+
+        let now = Instant::now();
+        let targets = create_and_process_bytecode(options, env);
         let selector = VerifyTargetSelector::Module {
             module_id: *module_id,
         };
-        let now = Instant::now();
-        let code_writer = generate_boogie_with_selector(env, options, selector, targets)?;
+        let code_writer = generate_boogie_with_selector(env, options, selector, &targets)?;
         gen_durations.push(now.elapsed());
-        check_errors(
-            env,
-            options,
-            error_writer,
-            "exiting with condition generation errors",
-        )?;
         code_writer.process_result(|result| fs::write(&options.output_path, result))?;
         bpl_paths.push(options.output_path.clone());
+        per_module_targets.push(targets);
+        per_module_writers.push(code_writer);
     }
+
+    // PrimaryTargetGuard's Drop cleared the restriction at the end of each
+    // loop iteration; no explicit reset needed.
+
+    // Single deferred error check. `report_diag`'s `shown` fingerprint set
+    // dedupes cross-rerun duplicates of scope-independent diagnostics in one
+    // pass over the accumulated diag list.
+    check_errors(
+        env,
+        options,
+        error_writer,
+        "exiting with bytecode transformation errors",
+    )?;
 
     if options.prover.generate_only {
         return Ok(());
     }
 
-    // Phase 2: parallel verification across modules; Boogie still uses its
-    // internal `-vcsCores` parallelism within each module's .bpl.
+    // Phase 2: parallel verification across modules.
     let now = Instant::now();
-    let raw_results = run_boogies_parallel(&options.backend, &bpl_paths, parallelism);
+    // Clamp num_instances to 1 in the per-worker options: with `proc_cores`
+    // driver workers each running an `num_instances`-portfolio, we would fan
+    // out to `proc_cores × num_instances` concurrent Boogie processes.
+    let mut backend_for_workers = options.backend.clone();
+    backend_for_workers.num_instances = 1;
+    let raw_results = run_boogies_parallel(&backend_for_workers, &bpl_paths, parallelism);
     verify_durations.push(now.elapsed());
 
-    let wrapper = BoogieWrapper {
-        env,
-        targets,
-        writer: &CodeWriter::new(env.internal_loc()),
-        options: &options.backend,
-    };
-    // Analyze each captured result in stable input order. Don't short-circuit on
-    // the first hard error — one .bpl failing (missing prover, bad codegen,
-    // subprocess I/O) shouldn't strand the remaining .bpl results without their
-    // diagnostics or cleanup. Collect any errors and return the first after all
-    // results have been processed.
+    // Analyze each captured result in stable input order against the
+    // FunctionTargetsHolder that produced its `.bpl`. Don't short-circuit on
+    // the first hard error — one `.bpl` failing shouldn't strand the rest.
     let mut first_err: Option<anyhow::Error> = None;
-    for (path, raw) in bpl_paths.iter().zip(raw_results.into_iter()) {
+    for (i, (path, raw)) in bpl_paths.iter().zip(raw_results.into_iter()).enumerate() {
+        let wrapper = BoogieWrapper {
+            env,
+            targets: &per_module_targets[i],
+            writer: &per_module_writers[i],
+            options: &options.backend,
+        };
         if let Err(e) = wrapper.analyze_subprocess_output(path, raw) {
             if first_err.is_none() {
                 first_err = Some(e);
@@ -517,6 +561,15 @@ fn drive_per_module<W: WriteColor>(
             std::fs::remove_file(path).unwrap_or_default();
         }
     }
+    // Flush any verification diagnostics added to the env (counterexamples,
+    // inconclusive results) before surfacing the first hard error; otherwise
+    // diagnostics from earlier `.bpl`s in the loop would be swallowed.
+    let _ = check_errors(
+        env,
+        options,
+        error_writer,
+        "exiting with verification errors",
+    );
     if let Some(e) = first_err {
         Err(e)
     } else {
@@ -524,77 +577,85 @@ fn drive_per_module<W: WriteColor>(
     }
 }
 
-/// Per-VC driver: enumerate verify targets, emit one `.bpl` per target
-/// sequentially (codegen mutates the env extension and is not thread-safe), then
-/// verify all `.bpl` files in parallel with a driver-managed worker pool.
-/// Errors are buffered into the env's diagnostic stream in stable target order
-/// regardless of completion order, so test baselines stay deterministic.
+/// Per-VC driver: one `.bpl` per verify target. Outer loop reruns the pipeline
+/// per module (same narrowing as `drive_per_module`); inner loop slices the
+/// module's targets via `VerifyTargetSelector::Single`. All VCs from one module
+/// share that module's pipeline result.
 fn drive_per_vc<W: WriteColor>(
     env: &GlobalEnv,
     options: &mut Options,
-    targets: &FunctionTargetsHolder,
+    upstream_targets: &FunctionTargetsHolder,
     output_base_file: &str,
     error_writer: &mut W,
     gen_durations: &mut Vec<Duration>,
     verify_durations: &mut Vec<Duration>,
 ) -> anyhow::Result<()> {
-    let target_list = enumerate_verify_targets(env, targets, options);
+    let module_list = enumerate_modules_with_verify_targets(env, upstream_targets, options);
     let parallelism = options.backend.proc_cores.max(1);
+
+    // Phase 1: per-module pipeline rerun (outer), per-VC codegen slice (inner).
+    let mut bpl_paths: Vec<String> = Vec::new();
+    let mut per_bpl_targets: Vec<std::rc::Rc<FunctionTargetsHolder>> = Vec::new();
+    let mut per_bpl_writers: Vec<CodeWriter> = Vec::new();
+    for module_id in &module_list {
+        let module_env = env.get_module(*module_id);
+        let _scope = PrimaryTargetGuard::set(env, &module_env.get_loc());
+
+        let module_targets = std::rc::Rc::new(create_and_process_bytecode(options, env));
+        let vc_list = enumerate_verify_targets_in_module(env, &module_targets, options, *module_id);
+        for (qid, variant) in &vc_list {
+            options.output_path = per_vc_output_path(env, output_base_file, *qid, variant);
+            let selector = VerifyTargetSelector::Single {
+                qid: *qid,
+                variant: variant.clone(),
+            };
+            let now = Instant::now();
+            let code_writer =
+                generate_boogie_with_selector(env, options, selector, &module_targets)?;
+            gen_durations.push(now.elapsed());
+            code_writer.process_result(|result| fs::write(&options.output_path, result))?;
+            bpl_paths.push(options.output_path.clone());
+            per_bpl_targets.push(std::rc::Rc::clone(&module_targets));
+            per_bpl_writers.push(code_writer);
+        }
+    }
     info!(
         "per-VC mode: {} verify targets, parallelism={}",
-        target_list.len(),
+        bpl_paths.len(),
         parallelism
     );
 
-    // Phase 1: sequential code generation. Each target's `.bpl` is written to
-    // disk; the env extension may be mutated here, so this loop is not parallel.
-    let mut bpl_paths: Vec<String> = Vec::with_capacity(target_list.len());
-    for (qid, variant) in &target_list {
-        options.output_path = per_vc_output_path(env, output_base_file, *qid, variant);
-        let selector = VerifyTargetSelector::Single {
-            qid: *qid,
-            variant: variant.clone(),
-        };
-        let now = Instant::now();
-        let code_writer = generate_boogie_with_selector(env, options, selector, targets)?;
-        gen_durations.push(now.elapsed());
-        check_errors(
-            env,
-            options,
-            error_writer,
-            "exiting with condition generation errors",
-        )?;
-        // Persist the .bpl so the worker pool can launch Boogie on it. Mirrors
-        // the persistence step inside `verify_boogie`, factored out here because
-        // we don't want to call Boogie yet — that runs in phase 2.
-        code_writer.process_result(|result| fs::write(&options.output_path, result))?;
-        bpl_paths.push(options.output_path.clone());
-    }
+    // PrimaryTargetGuard's Drop cleared the restriction per iteration.
+
+    check_errors(
+        env,
+        options,
+        error_writer,
+        "exiting with bytecode transformation errors",
+    )?;
 
     if options.prover.generate_only {
-        // Skip the verify pass entirely; the .bpl files are the artifact.
         return Ok(());
     }
 
-    // Phase 2: parallel verification. Worker threads spawn Boogie subprocesses
-    // (no `GlobalEnv` access — safe across threads). Raw outputs come back in
-    // stable input order so we can analyze them deterministically on this thread.
+    // Phase 2: parallel verification.
     let now = Instant::now();
-    let raw_results = run_boogies_parallel(&options.backend, &bpl_paths, parallelism);
-    let parallel_wall = now.elapsed();
-    verify_durations.push(parallel_wall);
+    // Clamp num_instances to 1 in the per-worker options: with `proc_cores`
+    // driver workers each running an `num_instances`-portfolio, we would fan
+    // out to `proc_cores × num_instances` concurrent Boogie processes.
+    let mut backend_for_workers = options.backend.clone();
+    backend_for_workers.num_instances = 1;
+    let raw_results = run_boogies_parallel(&backend_for_workers, &bpl_paths, parallelism);
+    verify_durations.push(now.elapsed());
 
-    let wrapper = BoogieWrapper {
-        env,
-        targets,
-        writer: &CodeWriter::new(env.internal_loc()),
-        options: &options.backend,
-    };
-    // Don't short-circuit on the first hard error — see `drive_per_module` for
-    // the rationale. Match the cleanup `verify_boogie` does for the single-shard
-    // path: drop each .bpl when the user didn't ask to keep artifacts.
     let mut first_err: Option<anyhow::Error> = None;
-    for (path, raw) in bpl_paths.iter().zip(raw_results.into_iter()) {
+    for (i, (path, raw)) in bpl_paths.iter().zip(raw_results.into_iter()).enumerate() {
+        let wrapper = BoogieWrapper {
+            env,
+            targets: &per_bpl_targets[i],
+            writer: &per_bpl_writers[i],
+            options: &options.backend,
+        };
         if let Err(e) = wrapper.analyze_subprocess_output(path, raw) {
             if first_err.is_none() {
                 first_err = Some(e);
@@ -604,11 +665,44 @@ fn drive_per_vc<W: WriteColor>(
             std::fs::remove_file(path).unwrap_or_default();
         }
     }
+    // Flush any verification diagnostics added to the env (counterexamples,
+    // inconclusive results) before surfacing the first hard error; otherwise
+    // diagnostics from earlier `.bpl`s in the loop would be swallowed.
+    let _ = check_errors(
+        env,
+        options,
+        error_writer,
+        "exiting with verification errors",
+    );
     if let Some(e) = first_err {
         Err(e)
     } else {
         Ok(())
     }
+}
+
+/// Like `enumerate_verify_targets` but restricted to one module. Used by the
+/// per-VC driver to slice a per-module pipeline result into per-VC `.bpl`s.
+fn enumerate_verify_targets_in_module(
+    env: &GlobalEnv,
+    targets: &FunctionTargetsHolder,
+    options: &cli::Options,
+    module_id: ModuleId,
+) -> Vec<(QualifiedId<FunId>, FunctionVariant)> {
+    let mut out = Vec::new();
+    let module_env = env.get_module(module_id);
+    for fun_env in module_env.get_functions() {
+        if !function_passes_verify_filter(&fun_env, options) {
+            continue;
+        }
+        for (variant, _target) in targets.get_targets(&fun_env) {
+            if !variant.is_verified() {
+                continue;
+            }
+            out.push((fun_env.get_qualified_id(), variant));
+        }
+    }
+    out
 }
 
 pub fn verify_boogie(

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -16,7 +16,8 @@ use move_compiler_v2::Experiment;
 use move_model::{
     code_writer::CodeWriter,
     metadata::LATEST_STABLE_COMPILER_VERSION_VALUE,
-    model::{FunId, GlobalEnv, ModuleId, QualifiedId},
+    model::{FunId, FunctionEnv, GlobalEnv, ModuleId, QualifiedId},
+    pragmas::{TIMEOUT_PRAGMA, VERIFY_DURATION_ESTIMATE_PRAGMA},
 };
 use move_prover_boogie_backend::{
     add_prelude,
@@ -276,29 +277,52 @@ pub fn generate_boogie(
     generate_boogie_with_selector(env, options, selector, targets)
 }
 
+/// Mirrors the verify-target predicate inside `BoogieTranslator::is_verified`:
+/// function passes the structural filter and its `verify_duration_estimate`
+/// pragma (if present) fits inside the effective timeout. Used by the
+/// enumeration helpers so per-module / per-VC drivers don't generate `.bpl`
+/// files for targets the translator would silently skip.
+fn function_passes_verify_filter(fun_env: &FunctionEnv, options: &cli::Options) -> bool {
+    if fun_env.is_native_or_intrinsic()
+        || fun_env.is_test_only()
+        || fun_env.is_not_prover_target()
+    {
+        return false;
+    }
+    if let Some(estimate_timeout) = fun_env.get_num_pragma(VERIFY_DURATION_ESTIMATE_PRAGMA) {
+        let timeout = fun_env
+            .get_num_pragma(TIMEOUT_PRAGMA)
+            .unwrap_or(options.backend.vc_timeout);
+        estimate_timeout <= timeout
+    } else {
+        true
+    }
+}
+
 /// Enumerate every (function-id, FunctionVariant::Verification(_)) pair the prover
 /// would emit `$verify` procedures for under the default selector. Source of truth
-/// for the per-VC outer loop. Mirrors the iteration in
-/// `bytecode_translator::translate` but only collects identifiers — no translation.
+/// for the per-VC outer loop. Mirrors `bytecode_translator::translate`'s iteration —
+/// walks **every** module (not only `is_target()` ones, since
+/// `VerificationAnalysisProcessor` can mark functions in non-target modules as
+/// verified when a target-module global invariant must be checked there), filters
+/// functions by the same `is_native_or_intrinsic` / `is_test_only` /
+/// `is_not_prover_target` rules, and applies the `verify_duration_estimate` /
+/// `timeout` pragma check so we don't codegen `.bpl` files whose `$verify`
+/// procedure would be filtered out at translation time.
 ///
 /// V1 simplification: type-instance variants (`VerificationFlavor::Instantiated(_)`)
 /// from `mono_info.funs` are NOT enumerated separately; each base verify target gets
 /// one `.bpl`. Per-VC mode therefore implicitly behaves as if `--skip-instance-check`
-/// were set. Documented under the `per_vc` option.
+/// were set.
 pub fn enumerate_verify_targets(
     env: &GlobalEnv,
     targets: &FunctionTargetsHolder,
+    options: &cli::Options,
 ) -> Vec<(QualifiedId<FunId>, FunctionVariant)> {
     let mut out = Vec::new();
     for module_env in env.get_modules() {
-        if !module_env.is_target() {
-            continue;
-        }
         for fun_env in module_env.get_functions() {
-            if fun_env.is_native_or_intrinsic()
-                || fun_env.is_test_only()
-                || fun_env.is_not_prover_target()
-            {
+            if !function_passes_verify_filter(&fun_env, options) {
                 continue;
             }
             for (variant, _target) in targets.get_targets(&fun_env) {
@@ -312,22 +336,20 @@ pub fn enumerate_verify_targets(
     out
 }
 
-/// Enumerate every module that contains at least one verify target. Stable
-/// iteration order (source-declaration order, matching `env.get_modules`).
+/// Enumerate every module that contains at least one verify target. Same
+/// inclusion rules as `enumerate_verify_targets`: walks every module (so
+/// non-target modules containing verify variants for target-module invariants
+/// are not dropped) and respects the `verify_duration_estimate` pragma.
+/// Stable iteration order (source-declaration order, matching `env.get_modules`).
 pub fn enumerate_modules_with_verify_targets(
     env: &GlobalEnv,
     targets: &FunctionTargetsHolder,
+    options: &cli::Options,
 ) -> Vec<ModuleId> {
     let mut out = Vec::new();
     for module_env in env.get_modules() {
-        if !module_env.is_target() {
-            continue;
-        }
         let has_verify_target = module_env.get_functions().any(|fun_env| {
-            if fun_env.is_native_or_intrinsic()
-                || fun_env.is_test_only()
-                || fun_env.is_not_prover_target()
-            {
+            if !function_passes_verify_filter(&fun_env, options) {
                 return false;
             }
             targets
@@ -435,7 +457,7 @@ fn drive_per_module<W: WriteColor>(
     gen_durations: &mut Vec<Duration>,
     verify_durations: &mut Vec<Duration>,
 ) -> anyhow::Result<()> {
-    let module_list = enumerate_modules_with_verify_targets(env, targets);
+    let module_list = enumerate_modules_with_verify_targets(env, targets, options);
     let parallelism = options.backend.proc_cores.max(1);
     info!(
         "per-module mode: {} modules, parallelism={}",
@@ -479,13 +501,27 @@ fn drive_per_module<W: WriteColor>(
         writer: &CodeWriter::new(env.internal_loc()),
         options: &options.backend,
     };
+    // Analyze each captured result in stable input order. Don't short-circuit on
+    // the first hard error — one .bpl failing (missing prover, bad codegen,
+    // subprocess I/O) shouldn't strand the remaining .bpl results without their
+    // diagnostics or cleanup. Collect any errors and return the first after all
+    // results have been processed.
+    let mut first_err: Option<anyhow::Error> = None;
     for (path, raw) in bpl_paths.iter().zip(raw_results.into_iter()) {
-        wrapper.analyze_subprocess_output(path, raw)?;
+        if let Err(e) = wrapper.analyze_subprocess_output(path, raw) {
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
+        }
         if !options.backend.keep_artifacts {
             std::fs::remove_file(path).unwrap_or_default();
         }
     }
-    Ok(())
+    if let Some(e) = first_err {
+        Err(e)
+    } else {
+        Ok(())
+    }
 }
 
 /// Per-VC driver: enumerate verify targets, emit one `.bpl` per target
@@ -502,7 +538,7 @@ fn drive_per_vc<W: WriteColor>(
     gen_durations: &mut Vec<Duration>,
     verify_durations: &mut Vec<Duration>,
 ) -> anyhow::Result<()> {
-    let target_list = enumerate_verify_targets(env, targets);
+    let target_list = enumerate_verify_targets(env, targets, options);
     let parallelism = options.backend.proc_cores.max(1);
     info!(
         "per-VC mode: {} verify targets, parallelism={}",
@@ -554,16 +590,25 @@ fn drive_per_vc<W: WriteColor>(
         writer: &CodeWriter::new(env.internal_loc()),
         options: &options.backend,
     };
+    // Don't short-circuit on the first hard error — see `drive_per_module` for
+    // the rationale. Match the cleanup `verify_boogie` does for the single-shard
+    // path: drop each .bpl when the user didn't ask to keep artifacts.
+    let mut first_err: Option<anyhow::Error> = None;
     for (path, raw) in bpl_paths.iter().zip(raw_results.into_iter()) {
-        let bpl_existed_before_run = false; // we always create them in phase 1
-        wrapper.analyze_subprocess_output(path, raw)?;
-        // Match the cleanup `verify_boogie` does for the single-shard path: if
-        // the user didn't ask to keep artifacts, drop the .bpl now.
-        if !bpl_existed_before_run && !options.backend.keep_artifacts {
+        if let Err(e) = wrapper.analyze_subprocess_output(path, raw) {
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
+        }
+        if !options.backend.keep_artifacts {
             std::fs::remove_file(path).unwrap_or_default();
         }
     }
-    Ok(())
+    if let Some(e) = first_err {
+        Err(e)
+    } else {
+        Ok(())
+    }
 }
 
 pub fn verify_boogie(


### PR DESCRIPTION
## Description

Adds an opt-in `VerifyGranularity` dimension to the Move Prover, orthogonal to the existing `--shards N` control:

- **`Shard`** (default) — one `.bpl` per hash-shard, unchanged behavior.
- **`Module`** — one `.bpl` per source module containing verify targets. Per-module bytecode pipeline rerun produces `.bpl` content equivalent to `aptos move prove -f <module>`.
- **`Vc`** — one `.bpl` per `(function-id, FunctionVariant::Verification)` pair, sharing each module's pipeline result.

For `Module` and `Vc` modes the prover runs up to `proc_cores` Boogie subprocesses concurrently via a driver-managed worker pool, instead of relying solely on Boogie's intra-process `-vcsCores`. Codegen runs sequentially (env mutation is not thread-safe); verification is parallelized.

The `Shard` path is bit-for-bit preserved.

## Why

Sharded mode shares the borderline-VC long tail across every procedure in the shard — a single slow VC delays the rest of the shard, and the partition is hash-bucketed rather than aligned with the source structure. Finer-grained partitioning lets:

- A failing VC be diagnosed without grepping a shard-sized `.bpl`.
- The prover run multiple `.bpl` files concurrently rather than serializing across shards.
- Module-mode `.bpl` content be a pure function of the module's source closure (no butterfly effect — adding an unrelated module to the package can't perturb an existing module's verification).
- Future work (incremental verification keyed by `.bpl` content hash, per-`.bpl` BV-prelude gating) compose on a clean partition mechanism.

## Architecture

- **`VerifyTargetSelector`** (`bytecode-pipeline/verify_target.rs`) is a shared enum (`All` / `Shard` / `Module` / `Single`) used by both the Boogie translator (which `$verify_*` procedures to emit) and the per-VC codegen filter. Lives in `bytecode-pipeline` so codegen and pipeline consume one definition; `bytecode_translator.rs` re-exports it for existing callers.
- **Driver dispatch** (`move-prover/src/lib.rs`) routes on `BoogieOptions::granularity` to `drive_sharded` / `drive_per_module` / `drive_per_vc`. The first preserves existing behavior; the other two share a per-partition-pipeline-then-parallel-verify shape.
- **Per-module pipeline rerun**: `drive_per_module` and `drive_per_vc` call `GlobalEnv::restrict_primary_targets_to(Some({module_file_id}))` per iteration and rerun `create_and_process_bytecode`. The model behaves as if only that module were `-f`-targeted; spec instrumentation, global invariant analysis (Rule 3), and mono analysis all see the same narrow scope that `aptos move prove -f <module>` would produce. The resulting `.bpl` is byte-equivalent to standalone (modulo cosmetic auto-generated IDs).
- **`restrict_primary_targets_to`** (`move-model/src/model.rs`) is a non-destructive runtime override for `is_primary_target()`, mirroring the existing `treat_everything_as_target` pattern. `RefCell`-based, fully reversible after the loop.
- **`run_boogies_parallel`** (`boogie_wrapper.rs`) is a `std::thread::scope` worker pool sized by `proc_cores`. Workers spawn Boogie subprocesses via the existing `ProverTaskRunner` machinery — no `GlobalEnv` access on worker threads. Results come back in input order so diagnostics stay deterministic.
- **`BoogieWrapper::analyze_subprocess_output`** is the env-touching half of the previous `call_boogie_and_verify_output`, called sequentially on the main thread per captured result against the `FunctionTargetsHolder` that produced its `.bpl`.
- **Deferred `check_errors`**: a single call after all per-module reruns lets `report_diag`'s built-in Debug-fingerprint dedup collapse cross-rerun duplicate diagnostics (e.g. scope-independent unused-invariant warnings emitted identically in every rerun).
- **Conflict guard**: `granularity != Shard` combined with `shards > 1` errors out before any verification starts.

## Boogie thread management

In `Module` and `Vc` modes, `-vcsCores` is forced to 1. Running `proc_cores` driver workers each with `-vcsCores:proc_cores` nests parallelism to `proc_cores²` worker threads. Empirically this triggered Boogie/.NET SIGSEGVs under contention on a 16-core machine with `proc_cores=4`. The driver pool is the single source of parallelism in `Module` / `Vc` modes; users control it via `--cores N`.

## Diagnostics

- Every error message produced by `analyze_subprocess_output` and `call_boogie_and_verify_output` is prefixed with the `.bpl` basename so module / VC mode failures map back without grepping logs.
- Inconclusive (timeout) errors include the Boogie procedure name and, when reverse-name lookup succeeds, the Move-source-style `0xA::module::fun` name.
- Boogie subprocess crashes (non-zero exit, SIGSEGV) become non-fatal env diagnostics rather than aborting the entire pool — the remaining `.bpl` files continue and all failures are reported at the end. Captured stdout/stderr in crash messages are truncated to 500 bytes.

## Caveats

- **Per-VC mode pays prelude rendering N times** where N is the verify-target count. On small packages it is slower than sharded mode (move-stdlib: 39.11s per-vc vs 17.58s sharded). It is most useful as a diagnostic tool or when long-tail VCs are the bottleneck.
- **Per-module pipeline rerun cost** is O(N_modules × pipeline). Empirically ~0.5s × N_modules; ~40s overhead on aptos-framework (~79 modules) — dwarfed by verification time. Future work can amortize this via incremental caching keyed by `.bpl` content hash, made possible by the butterfly-free `.bpl` content.

## Validated

- `move_framework_prover_tests` under default `--granularity shard`: ~173s — within historical baseline.
- aptos-framework under `--granularity module --shards 1`: deterministic verification across ~79 modules in ~165s. Per-module `.bpl` content byte-equivalent to standalone `move prove -f <module>` for math128 and stake (spot-checked; only cosmetic auto-generated `$Arbitrary_value_of'T'_<id>` counters differ).
- aptos-stdlib under `--granularity module`: passes except for pre-existing `math128/floor_log2` flakiness shared with standalone `aptos move prove -f math128`. Unrelated to the splitting work.
- SIGSEGV under contention reproduced with `vcsCores²`, fixed by forcing `vcsCores=1` for `Module` / `Vc`.

## Framework + test harness

- `ProverOptions::granularity: Option<VerifyGranularity>` with OR-style merge from `Prover.toml [backend]`.
- `MVP_TEST_GRANULARITY={shard|module|vc}` selects the mode (forces `shards=1` when not `shard`).
- `MVP_TEST_CORES=N` overrides `proc_cores` for the cargo-test path.
- `MVP_TEST_DUMP=1` keeps `.bpl` artifacts in the framework crate's cwd.

## How to test

```bash
# Default behavior preserved
cargo test -p aptos-framework move_framework_prover_tests --release

# Per-module at higher parallelism
MVP_TEST_GRANULARITY=module MVP_TEST_CORES=8 \
  cargo test -p aptos-framework move_framework_prover_tests --release -- --nocapture

# Per-VC with .bpl artifacts kept for inspection
MVP_TEST_GRANULARITY=vc MVP_TEST_DUMP=1 \
  cargo test -p aptos-framework move_stdlib_prover_tests --release -- --nocapture
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Move Prover

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large prover driver refactor with new parallel paths and per-module pipeline reruns; default shard mode is preserved but module/vc modes change resource usage and timing behavior.
> 
> **Overview**
> Introduces **`VerifyGranularity`** (`shard` default, `module`, `vc`) to control how verification targets are split into `.bpl` files and how Boogie runs. **`shard`** keeps the existing sequential per-shard loop; **`module`** and **`vc`** emit one `.bpl` per module or per verify target, rerun the bytecode pipeline per module via **`restrict_primary_targets_to`**, and verify with a **`run_boogies_parallel`** worker pool sized by **`proc_cores`**, with **`-vcsCores` forced to 1** to avoid nested parallelism crashes.
> 
> **`VerifyTargetSelector`** replaces shard-only filtering in **`BoogieTranslator`**. The driver rejects **`--shards > 1`** when granularity is not shard. Boogie errors are tagged with `.bpl` basenames; timeouts name the procedure; subprocess crashes are non-fatal with truncated logs.
> 
> Smaller fixes: **`cmp_types`** is replaced per `.bpl` pass (not accumulated); mono analysis seeds axioms from all modules; verify-scope module names accept qualified forms; **`pragma seed`** removed from **`u64_range_internal`** in randomness specs. Aptos **`ProverOptions`** and framework tests gain **`granularity`** and **`MVP_TEST_GRANULARITY`** / **`MVP_TEST_CORES`** / **`MVP_TEST_DUMP`** hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d82fc4f75076f127b39e5e7424241b896a18599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->