### PR TITLE
[vm] Refactor function type creation

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,6 +8,8 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
+/// - V49:
+///   - Count the closure function-type node towards type size and depth limits
 /// - V48:
 ///   - TBA
 /// - V47:

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -251,7 +251,7 @@ impl Environment {
                 )
             },
             Err(_) => {
-                let ty_builder = aptos_default_ty_builder(true);
+                let ty_builder = aptos_default_ty_builder(true, true);
                 (
                     NativeGasParameters::zeros(),
                     MiscGasParameters::zeros(),

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -5,7 +5,7 @@ pub use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
 use aptos_gas_schedule::{
     gas_feature_versions::{
         RELEASE_V1_15, RELEASE_V1_30, RELEASE_V1_34, RELEASE_V1_38, RELEASE_V1_41, RELEASE_V1_42,
-        RELEASE_V1_45,
+        RELEASE_V1_45, RELEASE_V1_49,
     },
     AptosGasParameters,
 };
@@ -120,26 +120,36 @@ pub fn aptos_prod_ty_builder(
     gas_feature_version: u64,
     gas_params: &AptosGasParameters,
 ) -> TypeBuilder {
-    let check_depth_on_type_counts_v2 = gas_feature_version >= RELEASE_V1_42;
     if gas_feature_version >= RELEASE_V1_15 {
         let max_ty_size = gas_params.vm.txn.max_ty_size;
         let max_ty_depth = gas_params.vm.txn.max_ty_depth;
 
+        let check_depth_on_type_counts_v2 = gas_feature_version >= RELEASE_V1_42;
+        let count_function_type_node = gas_feature_version >= RELEASE_V1_49;
         TypeBuilder::with_limits(
             max_ty_size.into(),
             max_ty_depth.into(),
             check_depth_on_type_counts_v2,
+            count_function_type_node,
         )
     } else {
-        aptos_default_ty_builder(false)
+        aptos_default_ty_builder(false, false)
     }
 }
 
 /// Returns default [TypeBuilder], used only when:
 ///  1. Type size gas parameters are not yet in gas schedule (before 1.15).
 ///   2. No gas parameters are found on-chain.
-pub fn aptos_default_ty_builder(check_depth_on_type_counts_v2: bool) -> TypeBuilder {
-    TypeBuilder::with_limits(128, 20, check_depth_on_type_counts_v2)
+pub fn aptos_default_ty_builder(
+    check_depth_on_type_counts_v2: bool,
+    count_function_type_node: bool,
+) -> TypeBuilder {
+    TypeBuilder::with_limits(
+        128,
+        20,
+        check_depth_on_type_counts_v2,
+        count_function_type_node,
+    )
 }
 
 /// Returns [DeserializerConfig] used by the Aptos blockchain in production.

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -35,7 +35,7 @@ impl GenesisRuntimeBuilder {
             LATEST_GAS_FEATURE_VERSION,
             &features,
             &timed_features,
-            aptos_default_ty_builder(true),
+            aptos_default_ty_builder(true, true),
         );
 
         // All genesis sessions run with unmetered gas meter, and here we set

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -96,7 +96,7 @@ impl Default for VMConfig {
             type_base_cost: 0,
             type_byte_cost: 0,
             delayed_field_optimization_enabled: false,
-            ty_builder: TypeBuilder::with_limits(128, 20, true),
+            ty_builder: TypeBuilder::with_limits(128, 20, true, true),
             enable_function_caches: true,
             enable_lazy_loading: true,
             enable_depth_checks: true,

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -158,6 +158,17 @@ pub(crate) fn create_function_type(
     mask: ClosureMask,
     abilities: AbilitySet,
 ) -> PartialVMResult<Type> {
+    if ty_builder.count_function_type_node {
+        return ty_builder.create_function_ty(
+            func.param_tys(),
+            mask,
+            func.return_tys(),
+            abilities,
+            func.ty_args(),
+        );
+    }
+
+    // Legacy behavior.
     let args = mask
         .extract(func.param_tys(), false)
         .into_iter()

--- a/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
@@ -480,7 +480,7 @@ mod tests {
 
     #[test]
     fn test_ty_to_ty_tag() {
-        let ty_builder = TypeBuilder::with_limits(10, 10, true);
+        let ty_builder = TypeBuilder::with_limits(10, 10, true, true);
 
         let runtime_environment = RuntimeEnvironment::new(vec![]);
         let ty_tag_converter = TypeTagConverter::new(&runtime_environment);
@@ -577,7 +577,7 @@ mod tests {
 
     #[test]
     fn test_ty_to_ty_tag_too_complex() {
-        let ty_builder = TypeBuilder::with_limits(10, 10, true);
+        let ty_builder = TypeBuilder::with_limits(10, 10, true, true);
 
         let vm_config = VMConfig {
             type_base_cost: 1,

--- a/third_party/move/move-vm/transactional-tests/tests/limits/pack_closure_ret_type_too_deep.async-paranoid.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/limits/pack_closure_ret_type_too_deep.async-paranoid.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-15:  publish [module 0x77::test]
+task 1 lines 17-17:  run --verbose 0x77::test::entry
+Error: Function execution failed with VMError: {
+    message: Type depth is larger than maximum 20,
+    major_status: VM_MAX_TYPE_DEPTH_REACHED,
+    sub_status: None,
+    location: 0x77::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 0)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000077, name: Identifier("test") }), FunctionDefinitionIndex(2), 0)] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/limits/pack_closure_ret_type_too_deep.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/limits/pack_closure_ret_type_too_deep.baseline.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-15:  publish [module 0x77::test]
+task 1 lines 17-17:  run --verbose 0x77::test::entry
+Error: Function execution failed with VMError: {
+    message: Type depth is larger than maximum 20,
+    major_status: VM_MAX_TYPE_DEPTH_REACHED,
+    sub_status: None,
+    location: 0x77::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 0)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000077, name: Identifier("test") }), FunctionDefinitionIndex(2), 0)] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/limits/pack_closure_ret_type_too_deep.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/limits/pack_closure_ret_type_too_deep.masm
@@ -1,0 +1,17 @@
+//# publish
+module 0x77::test
+
+#[persistent] public fun h<T>(): vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<T>>>>>>>>>>>>>>>>>>
+    ld_u64 0
+    abort
+
+fun make<T>(): ||vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<T>>>>>>>>>>>>>>>>>> has drop
+    pack_closure h<T>, 0
+    ret
+
+public fun entry()
+    call make<vector<u8>>
+    pop
+    ret
+
+//# run --verbose 0x77::test::entry

--- a/third_party/move/move-vm/transactional-tests/tests/limits/pack_closure_ret_type_too_deep.paranoid.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/limits/pack_closure_ret_type_too_deep.paranoid.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-15:  publish [module 0x77::test]
+task 1 lines 17-17:  run --verbose 0x77::test::entry
+Error: Function execution failed with VMError: {
+    message: Type depth is larger than maximum 20,
+    major_status: VM_MAX_TYPE_DEPTH_REACHED,
+    sub_status: None,
+    location: 0x77::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 0)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000077, name: Identifier("test") }), FunctionDefinitionIndex(2), 0)] }),
+}

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifiers_prop_tests.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifiers_prop_tests.rs
@@ -109,7 +109,7 @@ fn address_specifier_strategy() -> impl Strategy<Value = AddressSpecifier> {
 fn type_args_strategy() -> impl Strategy<Value = Vec<Type>> {
     // Actual type builder limits do not matter because creating primitive
     // integer types is always possible.
-    let ty_builder = TypeBuilder::with_limits(10, 10, true);
+    let ty_builder = TypeBuilder::with_limits(10, 10, true, true);
     prop_oneof![
         Just(vec![]),
         Just(vec![ty_builder.create_u8_ty()]),

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -19,6 +19,7 @@ use move_binary_format::{
 };
 use move_core_types::{
     ability::{Ability, AbilitySet},
+    function::ClosureMask,
     identifier::Identifier,
     language_storage::{FunctionParamOrReturnTag, FunctionTag, ModuleId, StructTag, TypeTag},
     vm_status::{sub_status::unknown_invariant_violation::EPARANOID_FAILURE, StatusCode},
@@ -1026,6 +1027,8 @@ pub struct TypeBuilder {
     // Gates changes to type construction algorithm:
     //   - Reference nodes are not counted towards the final node count and depth.
     pub check_depth_on_type_counts_v2: bool,
+    // When set, the function-type node is counted towards type size and depth limits.
+    pub count_function_type_node: bool,
     ref_ty_count_decrement: u64,
     ref_ty_depth_increment: u64,
 }
@@ -1035,11 +1038,13 @@ impl TypeBuilder {
         max_ty_size: u64,
         max_ty_depth: u64,
         check_depth_on_type_counts_v2: bool,
+        count_function_type_node: bool,
     ) -> Self {
         Self {
             max_ty_size,
             max_ty_depth,
             check_depth_on_type_counts_v2,
+            count_function_type_node,
             // We set count to 0 and depth to 1, which means we do not account for reference node
             // in count/depth calculation. This is fine as we have no nested references, so we only
             // allow 1 extra hop, in the worst case. In return, this guarantees that at runtime
@@ -1249,6 +1254,42 @@ impl TypeBuilder {
         let mut count = 0;
         let check = |c: &mut u64, d: u64| self.check_before_count_increment(c, d);
         self.subst_impl(ty, ty_args, &mut count, 1, check)
+    }
+
+    /// Creates the function type of closure with:
+    ///   - non-masked parameter types,
+    ///   - all return types.
+    /// If type arguments are passed, the type is instantiated.
+    ///
+    /// Returns an error if type creation fails (e.g., type is too large).
+    pub fn create_function_ty(
+        &self,
+        param_tys: &[Type],
+        mask: ClosureMask,
+        return_tys: &[Type],
+        abilities: AbilitySet,
+        ty_args: &[Type],
+    ) -> PartialVMResult<Type> {
+        // Count the function-type node itself; its arguments and results sit
+        // one level below, at depth 2.
+        let mut count = 1;
+        let check = |c: &mut u64, d: u64| self.check_before_count_increment(c, d);
+
+        let args = mask
+            .extract(param_tys, false)
+            .into_iter()
+            .map(|ty| self.subst_impl(ty, ty_args, &mut count, 2, check))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+        let results = return_tys
+            .iter()
+            .map(|ty| self.subst_impl(ty, ty_args, &mut count, 2, check))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+
+        Ok(Type::Function {
+            args,
+            results,
+            abilities,
+        })
     }
 
     /// Given [`Type`]'s node count and depth, returns an error if these values exceed limits.
@@ -1859,7 +1900,7 @@ mod unit_tests {
     fn test_num_nodes_in_subst() {
         use Type::*;
 
-        let ty_builder = TypeBuilder::with_limits(11, 5, true);
+        let ty_builder = TypeBuilder::with_limits(11, 5, true, true);
         let cases: Vec<(Type, Vec<Type>, usize, usize)> = vec![
             (TyParam(0), vec![Bool], 1, 1),
             (TyParam(0), vec![Vector(TriompheArc::new(Bool))], 2, 2),
@@ -1894,7 +1935,7 @@ mod unit_tests {
     fn test_substitution_large_depth() {
         use Type::*;
 
-        let ty_builder = TypeBuilder::with_limits(11, 5, true);
+        let ty_builder = TypeBuilder::with_limits(11, 5, true, true);
 
         let ty = Vector(TriompheArc::new(Vector(TriompheArc::new(TyParam(0)))));
         let ty_arg = Vector(TriompheArc::new(Vector(TriompheArc::new(Bool))));
@@ -1909,7 +1950,7 @@ mod unit_tests {
     fn test_substitution_large_count() {
         use Type::*;
 
-        let ty_builder = TypeBuilder::with_limits(11, 5, true);
+        let ty_builder = TypeBuilder::with_limits(11, 5, true, true);
 
         let ty_params: Vec<Type> = (0..5).map(TyParam).collect();
         let ty = struct_instantiation_ty_for_test(ty_params);
@@ -1938,7 +1979,7 @@ mod unit_tests {
         use Type::*;
 
         // Limits are irrelevant here.
-        let ty_builder = TypeBuilder::with_limits(1, 1, true);
+        let ty_builder = TypeBuilder::with_limits(1, 1, true, true);
 
         assert_eq!(ty_builder.create_u8_ty(), U8);
         assert_eq!(ty_builder.create_u16_ty(), U16);
@@ -1956,7 +1997,7 @@ mod unit_tests {
 
         // Limits are not relevant here.
         let struct_ty =
-            TypeBuilder::with_limits(1, 1, true).create_struct_ty(idx, ability_info.clone());
+            TypeBuilder::with_limits(1, 1, true, true).create_struct_ty(idx, ability_info.clone());
         assert_matches!(struct_ty, Type::Struct { .. });
     }
 
@@ -1968,7 +2009,7 @@ mod unit_tests {
         let ty_params = [TyParam(0), Bool, TyParam(1)];
 
         // Should succeed, type size limit is 5, and we have 5 nodes.
-        let ty_builder = TypeBuilder::with_limits(5, 100, true);
+        let ty_builder = TypeBuilder::with_limits(5, 100, true, true);
         let ty_args = [Bool, Vector(TriompheArc::new(Bool))];
         assert_ok!(ty_builder.create_struct_instantiation_ty(&struct_ty, &ty_params, &ty_args));
 
@@ -1985,7 +2026,7 @@ mod unit_tests {
         // Should succeed, type depth limit is 4, and we have 4 nodes (3 in type parameter + struct).
         let nested_vec = Vector(TriompheArc::new(Vector(TriompheArc::new(Bool))));
         let ty_args = vec![Bool, nested_vec.clone()];
-        let ty_builder = TypeBuilder::with_limits(100, 4, true);
+        let ty_builder = TypeBuilder::with_limits(100, 4, true, true);
         assert_ok!(ty_builder.create_struct_instantiation_ty(&struct_ty, &ty_params, &ty_args));
 
         // Should fail, we have depth of 5 now.
@@ -1999,7 +2040,7 @@ mod unit_tests {
     #[test]
     fn test_create_vec_ty() {
         let max_ty_depth = 5;
-        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth, true);
+        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth, true, true);
 
         let mut depth = 1;
         let mut ty = Type::Bool;
@@ -2018,7 +2059,7 @@ mod unit_tests {
         // a type builder with smaller than depth size limit must return a different
         // error code.
         let max_ty_size = 5;
-        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true);
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true);
         let err = assert_err!(ty_builder.create_vec_ty(&ty));
         assert_eq!(err.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
     }
@@ -2027,7 +2068,7 @@ mod unit_tests {
     fn test_create_ref_ty() {
         let limit = 5;
 
-        let ty_builder = TypeBuilder::with_limits(100, limit, true);
+        let ty_builder = TypeBuilder::with_limits(100, limit, true, true);
 
         let mut depth = 1;
         let mut ty = Type::Bool;
@@ -2039,7 +2080,7 @@ mod unit_tests {
         let ref_ty = assert_ok!(ty_builder.create_ref_ty(&ty, false));
         assert_matches!(ref_ty, Type::Reference(_));
 
-        let ty_builder = TypeBuilder::with_limits(limit, 100, true);
+        let ty_builder = TypeBuilder::with_limits(limit, 100, true, true);
 
         let ref_ty = assert_ok!(ty_builder.create_ref_ty(&ty, false));
         assert_matches!(ref_ty, Type::Reference(_));
@@ -2049,7 +2090,7 @@ mod unit_tests {
     fn test_create_mut_ref_ty() {
         let limit = 5;
 
-        let ty_builder = TypeBuilder::with_limits(100, limit, true);
+        let ty_builder = TypeBuilder::with_limits(100, limit, true, true);
 
         let mut depth = 1;
         let mut ty = Type::Bool;
@@ -2061,7 +2102,7 @@ mod unit_tests {
         let ref_ty = assert_ok!(ty_builder.create_ref_ty(&ty, true));
         assert_matches!(ref_ty, Type::MutableReference(_));
 
-        let ty_builder = TypeBuilder::with_limits(limit, 100, true);
+        let ty_builder = TypeBuilder::with_limits(limit, 100, true, true);
 
         let ref_ty = assert_ok!(ty_builder.create_ref_ty(&ty, true));
         assert_matches!(ref_ty, Type::MutableReference(_));
@@ -2073,7 +2114,7 @@ mod unit_tests {
         use Type::*;
 
         let max_ty_depth = 5;
-        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth, true);
+        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth, true, true);
 
         assert_eq!(assert_ok!(ty_builder.create_constant_ty(&S::U8)), U8);
         assert_eq!(assert_ok!(ty_builder.create_constant_ty(&S::U16)), U16);
@@ -2107,7 +2148,7 @@ mod unit_tests {
         assert_eq!(err.major_status(), StatusCode::VM_MAX_TYPE_DEPTH_REACHED);
 
         let max_ty_size = 5;
-        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true);
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true);
 
         for size in [max_ty_size - 1, max_ty_size] {
             let (expected_ty, vec_tok, _) = nested_vec_for_test(size);
@@ -2146,7 +2187,7 @@ mod unit_tests {
 
         let max_ty_size = 11;
         let max_ty_depth = 5;
-        let ty_builder = TypeBuilder::with_limits(max_ty_size, max_ty_depth, true);
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, max_ty_depth, true, true);
 
         let no_op = |_: &StructTag| unreachable!("Should not be called");
 
@@ -2178,7 +2219,7 @@ mod unit_tests {
         assert_eq!(err.major_status(), StatusCode::VM_MAX_TYPE_DEPTH_REACHED);
 
         let max_ty_size = 5;
-        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true);
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true);
 
         for size in [max_ty_size - 1, max_ty_size] {
             let (expected_ty, _, vec_tag) = nested_vec_for_test(size);


### PR DESCRIPTION
## Description

Refactor function type creation to use builder with limits for proper accounting. Gated by 1.49

## How Has This Been Tested?

Transactional tests.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Move VM type construction for closures behind a gas version gate; transactions that previously packed very deep closure return types may start failing with depth/size errors after activation.
> 
> **Overview**
> Introduces **gas feature V49**, which tightens how closure **function types** are built at runtime: the function-type node itself is included in **type size** and **depth** accounting when packing closures.
> 
> `TypeBuilder` gains a `count_function_type_node` flag and a new `create_function_ty` path that charges one node for the function type and builds masked params/returns under depth 2. `create_function_type` uses this path when the flag is set; older gas versions keep the legacy construction. Production wiring turns the flag on at `RELEASE_V1_49` via `aptos_prod_ty_builder`, with defaults/genesis/VM config updated for the new `with_limits` signature.
> 
> A transactional test (`pack_closure_ret_type_too_deep`) expects **`VM_MAX_TYPE_DEPTH_REACHED`** when a closure’s return type exceeds max depth (e.g. deeply nested `vector`s), including under paranoid/async modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a6d69f7bdbeaa575ec9030fcb2153c44ab28a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->