### PR TITLE
Remove a left-over debug output from the executor-benchmark

### DIFF
--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -100,17 +100,12 @@ fn get_genesis_validator_address(db: &DbReaderWriter) -> AccountAddress {
         if let Ok(validator_set) = bcs::from_bytes::<ValidatorSet>(validator_set_bytes.bytes()) {
             if !validator_set.active_validators.is_empty() {
                 let validator_addr = validator_set.active_validators[0].account_address;
-                eprintln!(
-                    "DEBUG: Using genesis validator address: {:x}",
-                    validator_addr
-                );
                 return validator_addr;
             }
         }
     }
 
     // Fallback to generated address if we can't read the validator set
-    eprintln!("DEBUG: Could not read genesis validator set, falling back to generated address");
     validator_address()
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Logging-only cleanup with no logic or behavior changes.
> 
> **Overview**
> Removes leftover **`eprintln!` DEBUG** lines from **`get_genesis_validator_address`** in the executor benchmark transaction generator.
> 
> When the on-chain **`ValidatorSet`** is read successfully, it no longer prints the chosen genesis validator address. The fallback path also no longer logs that the validator set could not be read. **Validator address selection and fallback behavior are unchanged**—only stderr noise is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e005e2a4c642aea005078fd49de4cccf76171947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->