### PR TITLE
[mono-move] Small benchmark improvements

### DIFF
--- a/third_party/move/mono-move/replay-benchmark/README.md
+++ b/third_party/move/mono-move/replay-benchmark/README.md
@@ -31,6 +31,29 @@ cargo run --release -p mono-move-replay-benchmark -- bench \
 `capture` records each transaction together with the full module dependency closure it needs, so a
 cold replay can resolve every module (not just the ones the original on-chain execution loaded).
 
+There is also an option to benchmark a single transaction at a time.
+
+```bash
+cargo run -p mono-move-replay-benchmark -- bench \
+      --transactions-file data/5663916074_txns \
+      --inputs-file data/5663916074_inputs \
+      --warmup 50 --samples 2000
+```
+
+For profiling, it is usually convenient to record measurements per VM.
+For that, use `--vm (both | v1 | v2)` flag when running the benchmark.
+For example, collecting the profile with samply for V1 VM is simply:
+
+```bash
+cargo build --release -p mono-move-replay-benchmar
+
+samply record \
+      ./target/release/mono-move-replay-benchmark bench \
+      --transactions-file data/5663916074_txns \
+      --inputs-file data/5663916074_inputs \
+      --vm v1 --warmup 50 --samples 2000
+```
+
 ## What is measured
 
 All setup is done once up front; the timer wraps only "deserialize/place the entry arguments +

--- a/third_party/move/mono-move/replay-benchmark/src/main.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/main.rs
@@ -10,7 +10,7 @@
 
 use anyhow::Result;
 use aptos_rest_client::AptosBaseUrl;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use mono_move_replay_benchmark::{
     capture, data, report::TransactionReport, timing::TimingConfig, v1, v2, BenchmarkRun,
 };
@@ -51,6 +51,24 @@ impl From<Network> for AptosBaseUrl {
             Network::Devnet => AptosBaseUrl::Devnet,
             Network::Custom(url) => AptosBaseUrl::Custom(url),
         }
+    }
+}
+
+/// Which VM(s) to run. A single VM lets you profile it without the other in the same process.
+#[derive(Clone, Copy, ValueEnum)]
+enum VMSelection {
+    V1,
+    V2,
+    Both,
+}
+
+impl VMSelection {
+    fn runs_v1(self) -> bool {
+        matches!(self, VMSelection::V1 | VMSelection::Both)
+    }
+
+    fn runs_v2(self) -> bool {
+        matches!(self, VMSelection::V2 | VMSelection::Both)
     }
 }
 
@@ -96,6 +114,14 @@ struct BenchArgs {
         help = "Enable V1 (legacy Move VM) paranoid type checks (default: off)"
     )]
     v1_paranoid: bool,
+    #[clap(
+        long,
+        value_enum,
+        default_value = "both",
+        help = "Which VM(s) to run: v1, v2, or both (default). Use a single VM to profile it \
+                in isolation."
+    )]
+    vm: VMSelection,
 }
 
 #[derive(Parser)]
@@ -163,8 +189,14 @@ fn bench(args: BenchArgs) -> Result<()> {
         let function = format!("{}::{}", input.entry.module(), input.entry.function());
         // Isolate each VM run: a panic (e.g. a MonoMove feature not yet implemented) becomes that
         // VM's failure reason and never aborts the whole benchmark.
-        let v1 = run_vm(|| v1::run(input, &timing));
-        let v2 = run_vm(|| v2::run(input, &timing));
+        let v1 = args
+            .vm
+            .runs_v1()
+            .then(|| run_vm(|| v1::run(input, &timing)));
+        let v2 = args
+            .vm
+            .runs_v2()
+            .then(|| run_vm(|| v2::run(input, &timing)));
         TransactionReport::new(input.version, function, v1, v2).print();
     }
     Ok(())

--- a/third_party/move/mono-move/replay-benchmark/src/report.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/report.rs
@@ -14,33 +14,38 @@ use std::time::Duration;
 pub struct TransactionReport {
     pub version: Version,
     pub function: String,
-    pub v1: Result<BenchmarkRun, String>,
-    pub v2: Result<BenchmarkRun, String>,
-    pub correctness: Correctness,
+    pub v1: Option<Result<BenchmarkRun, String>>,
+    pub v2: Option<Result<BenchmarkRun, String>>,
+    pub correctness: Option<Correctness>,
 }
 
 impl TransactionReport {
     pub fn new(
         version: Version,
         function: String,
-        v1: Result<BenchmarkRun, String>,
-        v2: Result<BenchmarkRun, String>,
+        v1: Option<Result<BenchmarkRun, String>>,
+        v2: Option<Result<BenchmarkRun, String>>,
     ) -> Self {
-        // V1 is the reference. If it could not run, there is nothing to compare against.
-        let correctness = match &v1 {
-            Ok(v1run) => {
-                let v2_outcome = match &v2 {
-                    Ok(v2run) => Ok(&v2run.outcome),
-                    Err(reason) => Err(reason.as_str()),
-                };
-                compare_outcomes(&v1run.outcome, v2_outcome)
-            },
-            Err(reason) => Correctness::Mismatch {
-                detail: format!(
-                    "V1 (reference) could not execute the transaction: {}",
-                    reason
-                ),
-            },
+        // Correctness is only meaningful when both VMs ran. With a single VM selected (profiling
+        // mode) there is nothing to compare against.
+        let correctness = match (&v1, &v2) {
+            (Some(v1), Some(v2)) => Some(match v1 {
+                // V1 is the reference. If it could not run, there is nothing to compare against.
+                Ok(v1run) => {
+                    let v2_outcome = match v2 {
+                        Ok(v2run) => Ok(&v2run.outcome),
+                        Err(reason) => Err(reason.as_str()),
+                    };
+                    compare_outcomes(&v1run.outcome, v2_outcome)
+                },
+                Err(reason) => Correctness::Mismatch {
+                    detail: format!(
+                        "V1 (reference) could not execute the transaction: {}",
+                        reason
+                    ),
+                },
+            }),
+            _ => None,
         };
         Self {
             version,
@@ -53,11 +58,11 @@ impl TransactionReport {
 
     /// The speedup of V2 over V1 (V1_median / V2_median) for matching outcomes. `>1` means V2 is faster.
     pub fn speedup(&self) -> Option<f64> {
-        if !matches!(self.correctness, Correctness::Match) {
+        if !matches!(self.correctness, Some(Correctness::Match)) {
             return None;
         }
-        let v1 = self.v1.as_ref().ok()?;
-        let v2 = self.v2.as_ref().ok()?;
+        let v1 = self.v1.as_ref()?.as_ref().ok()?;
+        let v2 = self.v2.as_ref()?.as_ref().ok()?;
         let v2_nanos = v2.samples.median().as_nanos();
         if v2_nanos == 0 {
             return None;
@@ -69,30 +74,35 @@ impl TransactionReport {
         println!("Transaction {} — {}", self.version, self.function);
         print_vm("  V1 (legacy MoveVM)", &self.v1);
         print_vm("  V2 (MonoMove)     ", &self.v2);
-        match self.speedup() {
-            Some(s) => println!("  speedup (V1/V2)    : {:.2}x  ({})", s, speedup_phrase(s)),
-            None => {
-                let reason = if self.v1.is_err() || self.v2.is_err() {
-                    "one VM did not run to completion"
-                } else {
-                    "outcomes differ — execution times are not comparable"
-                };
-                println!("  speedup (V1/V2)    : n/a ({})", reason);
-            },
+        // Speedup and correctness only apply when both VMs ran.
+        if self.v1.is_some() && self.v2.is_some() {
+            match self.speedup() {
+                Some(s) => println!("  speedup (V1/V2)    : {:.2}x  ({})", s, speedup_phrase(s)),
+                None => {
+                    let both_ran = matches!(self.v1, Some(Ok(_))) && matches!(self.v2, Some(Ok(_)));
+                    let reason = if !both_ran {
+                        "one VM did not run to completion"
+                    } else {
+                        "outcomes differ — execution times are not comparable"
+                    };
+                    println!("  speedup (V1/V2)    : n/a ({})", reason);
+                },
+            }
         }
         match &self.correctness {
-            Correctness::Match => println!("  correctness        : MATCH"),
-            Correctness::Mismatch { detail } => {
+            Some(Correctness::Match) => println!("  correctness        : MATCH"),
+            Some(Correctness::Mismatch { detail }) => {
                 println!("  correctness        : MISMATCH — {}", detail)
             },
+            None => {},
         }
         println!();
     }
 }
 
-fn print_vm(label: &str, run: &Result<BenchmarkRun, String>) {
+fn print_vm(label: &str, run: &Option<Result<BenchmarkRun, String>>) {
     match run {
-        Ok(run) => {
+        Some(Ok(run)) => {
             let t = &run.samples;
             println!(
                 "{}: {} (median over {} samples; spread ±{}, min {}, max {})  →  outcome: {}",
@@ -105,7 +115,8 @@ fn print_vm(label: &str, run: &Result<BenchmarkRun, String>) {
                 describe_outcome(&run.outcome),
             );
         },
-        Err(reason) => println!("{}: did not run — {}", label, reason),
+        Some(Err(reason)) => println!("{}: did not run — {}", label, reason),
+        None => println!("{}: skipped", label),
     }
 }
 

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -151,6 +151,7 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
     let mut interp = InterpreterContext::new(&mut txn_ctx, func);
 
     // Trial run: determine the outcome.
+    // TODO(cleanup): need to reset events / extensions?
     interp.reset(func, GAS_BUDGET);
     place_args(
         &mut interp,
@@ -172,6 +173,7 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
 
     // Timing: per-run reset is outside the timer; only argument placement + execution are timed.
     let samples = collect_samples(timing, || {
+        // TODO(cleanup): need to reset events / extensions?
         interp.reset(func, GAS_BUDGET);
         let start = Instant::now();
         let _ = place_args(


### PR DESCRIPTION
## Description

Ability to benchmark 1 VM at a time via `--vm (both } v1 | v2)` flags.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark CLI and reporting only; default behavior remains both VMs with no production VM path changes.
> 
> **Overview**
> Adds a **`bench --vm`** option (`v1`, `v2`, or `both`, default `both`) so you can run only one VM in the process—useful for profilers like samply without the other VM’s work in the same binary.
> 
> **Reporting** now treats each VM result as optional: skipped VMs print as “skipped”, and speedup/correctness lines are omitted unless both VMs actually ran.
> 
> The **README** documents single-file replay (`--transactions-file` / `--inputs-file`) and an example profiling workflow with `--vm v1`. **V2** gains TODO notes questioning whether events/extensions need reset between trial and timed runs (no behavior change in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8b8a78b25f2f6ffac2b0375cd3798979f06721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->