### PR TITLE
[mono-move] Storage slot natives

### DIFF
--- a/third_party/move/mono-move/core/src/native/context.rs
+++ b/third_party/move/mono-move/core/src/native/context.rs
@@ -188,6 +188,17 @@ pub trait NativeContext {
         ty: InternedType,
     ) -> Result<bool, VMInternalError>;
 
+    /// Borrows the resource of type `ty` at `address`, returning a reference to
+    /// it, or `None` if the resource does not exist. A mutable borrow first
+    /// deep-copies an external or stale value into the local heap
+    /// (copy-on-write).
+    fn borrow_resource(
+        &self,
+        address: AccountAddress,
+        mutable: bool,
+        ty: InternedType,
+    ) -> Result<Option<Ref<'_, Opaque>>, VMInternalError>;
+
     /// BCS-serializes the by-value argument `i` of type `ty` (e.g. a table key).
     fn bcs_serialize_arg(&self, i: usize, ty: InternedType) -> Result<Vec<u8>, VMInternalError>;
 

--- a/third_party/move/mono-move/core/src/native/value.rs
+++ b/third_party/move/mono-move/core/src/native/value.rs
@@ -184,6 +184,15 @@ impl Ref<'_, TableHandle> {
     }
 }
 
+impl Ref<'_, AccountAddress> {
+    /// Borrows the referenced address.
+    pub fn get(&self) -> &AccountAddress {
+        // SAFETY: `AccountAddress` is `[u8; N]` (align 1), so the bytes the
+        // reference points at reinterpret as `&AccountAddress`.
+        unsafe { &*(self.ptr() as *const AccountAddress) }
+    }
+}
+
 /// Marker for a type that is not statically known.
 ///
 /// This can be used to build composite types in generic native functions — e.g. the

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -26,6 +26,7 @@ pub mod object;
 pub mod secp256k1;
 pub mod signer;
 pub mod state_storage;
+pub mod storage_slot;
 pub mod string;
 pub mod table;
 pub mod test_natives;
@@ -45,6 +46,7 @@ pub use object::{make_all_object_natives, ObjectContextExtension};
 pub use secp256k1::make_all_secp256k1_natives;
 pub use signer::make_all_signer_natives;
 pub use state_storage::{make_all_state_storage_natives, StorageUsageAtEpochBoundary};
+pub use storage_slot::make_all_storage_slot_natives;
 pub use string::make_all_string_natives;
 pub use table::make_all_table_natives;
 pub use test_natives::{make_all_test_natives, native_u64_add, native_u64_identity};
@@ -96,6 +98,7 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
     natives.extend(make_all_from_bytes_natives::<F>());
     natives.extend(make_all_table_natives::<F>());
     natives.extend(make_all_secp256k1_natives::<F>());
+    natives.extend(make_all_storage_slot_natives::<F>());
     natives
 }
 

--- a/third_party/move/mono-move/natives/src/storage_slot.rs
+++ b/third_party/move/mono-move/natives/src/storage_slot.rs
@@ -1,0 +1,71 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `storage_slot` module.
+//!
+//! These borrow a `StorageSlotResource<T>` from global storage at the address
+//! held in the `StorageSlot<T>` argument. The resource flows through the same
+//! read-write set as any other resource, so no storage-slot-specific extension
+//! is needed.
+
+use crate::{polymorphic_natives, NativeEntry};
+use mono_move_core::native::{
+    NativeContext, NativeContextFamily, NativeStatus, Ref, VMInternalError,
+};
+use move_core_types::account_address::AccountAddress;
+
+/// `StorageSlotResource<T>` not found at the slot's address.
+const ESTORAGE_SLOT_NOT_FOUND: u64 = 2;
+
+/// Borrows `StorageSlotResource<T>` from global storage at the address held in
+/// the `StorageSlot<T>` argument, writing the reference into return slot 0, or
+/// aborts if the resource is missing.
+//
+// TODO(metering): charge gas.
+fn borrow_storage_slot_resource<C: NativeContext>(
+    ctx: &C,
+    mutable: bool,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `&[mut] StorageSlot<T>`, whose single `addr: address`
+    // field gives it the same representation as `&address`.
+    let slot: Ref<AccountAddress> = unsafe { ctx.arg(0)? };
+    let addr = *slot.get();
+    // ty_arg 1 is `StorageSlotResource<T>` -- the resource to borrow.
+    let resource_ty = ctx.ty_arg(1)?;
+    match ctx.borrow_resource(addr, mutable, resource_ty)? {
+        // SAFETY: return 0 is the `&[mut] StorageSlotResource<T>` reference.
+        Some(r) => unsafe { ctx.set_return(0, r) }.map(|()| NativeStatus::Success),
+        None => Ok(NativeStatus::Abort {
+            code: ESTORAGE_SLOT_NOT_FOUND,
+            message: Some(format!("StorageSlotResource at address {} not found", addr)),
+        }),
+    }
+}
+
+/// `0x1::storage_slot::borrow_storage_slot_resource<T, BR>(self: &StorageSlot<T>): &BR`
+pub fn native_borrow_storage_slot_resource<C: NativeContext>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    borrow_storage_slot_resource(ctx, false)
+}
+
+/// `0x1::storage_slot::borrow_storage_slot_resource_mut<T, BR>(self: &mut StorageSlot<T>): &mut BR`
+pub fn native_borrow_storage_slot_resource_mut<C: NativeContext>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    borrow_storage_slot_resource(ctx, true)
+}
+
+/// Natives for the `storage_slot` module.
+pub fn make_all_storage_slot_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    polymorphic_natives![
+        (
+            "0x1::storage_slot::borrow_storage_slot_resource",
+            native_borrow_storage_slot_resource
+        ),
+        (
+            "0x1::storage_slot::borrow_storage_slot_resource_mut",
+            native_borrow_storage_slot_resource_mut
+        ),
+    ]
+}

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -119,6 +119,57 @@ impl<'a> ProductionNativeContext<'a> {
             returns_started: Cell::new(false),
         }
     }
+
+    /// Borrows the global-storage value at `storage_key`, rooting a reference to
+    /// it for the rest of the call, or `None` if the value does not exist. A
+    /// mutable borrow of an external or stale value first deep-copies it into
+    /// the local heap (copy-on-write).
+    fn borrow_storage_value(
+        &self,
+        storage_key: InMemoryStorageKey,
+        mutable: bool,
+    ) -> Result<Option<Ref<'_, Opaque>>, VMInternalError> {
+        // SAFETY: heap and rws are distinct fields (see the aliasing rule).
+        let rws = unsafe { &mut **self.rws.get() };
+        let ptr = if mutable {
+            match rws.try_borrow_global_mut(self.resource_provider, &storage_key) {
+                Ok(EntryPtr::Writable(ptr)) => ptr,
+                Ok(EntryPtr::NonWritable(ptr)) => {
+                    // Copy-on-write: an external or stale value must be copied
+                    // into the local heap before it can be mutated.
+                    let heap = unsafe { &mut **self.heap.get() };
+                    // SAFETY: `ptr` is a live object (provider- or older-epoch-owned).
+                    let copied = unsafe {
+                        deep_copy_or_gc(
+                            heap,
+                            self.desc_provider,
+                            rws,
+                            &self.pool,
+                            self.extensions,
+                            self.frame_ptr,
+                            TopFrame::Native(self.abi),
+                            ptr,
+                        )
+                    }
+                    .map_err(VMInternalError::from)?;
+                    rws.commit_borrow_global_mut(&storage_key, copied);
+                    copied
+                },
+                Err(RuntimeError::ResourceDoesNotExist { .. }) => return Ok(None),
+                Err(e) => return Err(e.into()),
+            }
+        } else {
+            match rws.borrow_global(self.resource_provider, &storage_key) {
+                Ok(ptr) => ptr,
+                Err(RuntimeError::ResourceDoesNotExist { .. }) => return Ok(None),
+                Err(e) => return Err(e.into()),
+            }
+        };
+        // SAFETY: `ptr` is the live value; the reference points at its start, so
+        // the offset is 0. The pool roots it for the rest of the call.
+        let handle = unsafe { self.pool.root_reference(ptr.as_ptr(), 0) };
+        Ok(Some(Ref::from_handle(handle)))
+    }
 }
 
 impl NativeContext for ProductionNativeContext<'_> {
@@ -434,6 +485,16 @@ impl NativeContext for ProductionNativeContext<'_> {
         Ok(rws.exists(self.resource_provider, &key)?)
     }
 
+    fn borrow_resource(
+        &self,
+        address: AccountAddress,
+        mutable: bool,
+        ty: InternedType,
+    ) -> Result<Option<Ref<'_, Opaque>>, VMInternalError> {
+        let storage_key = InMemoryStorageKey::resource(address, ty);
+        self.borrow_storage_value(storage_key, mutable)
+    }
+
     fn bcs_serialize_arg(&self, i: usize, ty: InternedType) -> Result<Vec<u8>, VMInternalError> {
         let slot = self.abi.args().get(i).copied().ok_or_else(|| {
             VMInternalError::invariant_violation(format!("arg index {i} out of bounds"))
@@ -514,46 +575,7 @@ impl NativeContext for ProductionNativeContext<'_> {
         value_ty: InternedType,
     ) -> Result<Option<Ref<'_, Opaque>>, VMInternalError> {
         let storage_key = InMemoryStorageKey::table_item(*handle, key.into(), value_ty);
-        // SAFETY: heap and rws are distinct fields (see the aliasing rule).
-        let rws = unsafe { &mut **self.rws.get() };
-        let ptr = if mutable {
-            match rws.try_borrow_global_mut(self.resource_provider, &storage_key) {
-                Ok(EntryPtr::Writable(ptr)) => ptr,
-                Ok(EntryPtr::NonWritable(ptr)) => {
-                    // Copy-on-write: an external or stale value must be copied
-                    // into the local heap before it can be mutated.
-                    let heap = unsafe { &mut **self.heap.get() };
-                    // SAFETY: `ptr` is a live object (provider- or older-epoch-owned).
-                    let copied = unsafe {
-                        deep_copy_or_gc(
-                            heap,
-                            self.desc_provider,
-                            rws,
-                            &self.pool,
-                            self.extensions,
-                            self.frame_ptr,
-                            TopFrame::Native(self.abi),
-                            ptr,
-                        )
-                    }
-                    .map_err(VMInternalError::from)?;
-                    rws.commit_borrow_global_mut(&storage_key, copied);
-                    copied
-                },
-                Err(RuntimeError::ResourceDoesNotExist { .. }) => return Ok(None),
-                Err(e) => return Err(e.into()),
-            }
-        } else {
-            match rws.borrow_global(self.resource_provider, &storage_key) {
-                Ok(ptr) => ptr,
-                Err(RuntimeError::ResourceDoesNotExist { .. }) => return Ok(None),
-                Err(e) => return Err(e.into()),
-            }
-        };
-        // SAFETY: `ptr` is the live entry value; the reference points at its
-        // start, so the offset is 0. The pool roots it for the rest of the call.
-        let handle = unsafe { self.pool.root_reference(ptr.as_ptr(), 0) };
-        Ok(Some(Ref::from_handle(handle)))
+        self.borrow_storage_value(storage_key, mutable)
     }
 
     // TODO(cleanup): See if there's a way to separate out argument-reading from boxing.

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/storage_slot.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/storage_slot.move
@@ -1,0 +1,101 @@
+// RUN: publish
+module 0x1::storage_slot {
+    struct StorageSlotResource<T> has key {
+        val: T,
+    }
+
+    struct StorageSlot<phantom T> has store {
+        addr: address,
+    }
+
+    native fun borrow_storage_slot_resource<T: store, BR>(self: &StorageSlot<T>): &BR;
+    native fun borrow_storage_slot_resource_mut<T: store, BR>(self: &mut StorageSlot<T>): &mut BR;
+
+    // Publishes the backing resource under `account` and returns a slot at
+    // `addr`; the caller passes an `addr` that matches `account`.
+    public fun new_at<T: store>(account: &signer, addr: address, value: T): StorageSlot<T> {
+        move_to(account, StorageSlotResource<T> { val: value });
+        StorageSlot { addr }
+    }
+
+    // A slot pointing at `addr` with no backing resource, to exercise the
+    // missing-resource abort.
+    public fun unbacked<T: store>(addr: address): StorageSlot<T> {
+        StorageSlot { addr }
+    }
+
+    public fun borrow<T: store>(self: &StorageSlot<T>): &T {
+        &borrow_storage_slot_resource<T, StorageSlotResource<T>>(self).val
+    }
+
+    public fun borrow_mut<T: store>(self: &mut StorageSlot<T>): &mut T {
+        &mut borrow_storage_slot_resource_mut<T, StorageSlotResource<T>>(self).val
+    }
+
+    public fun destroy<T: store>(self: StorageSlot<T>): T {
+        let StorageSlot { addr } = self;
+        let StorageSlotResource { val } = move_from<StorageSlotResource<T>>(addr);
+        val
+    }
+}
+
+module 0x42::main {
+    use 0x1::storage_slot;
+
+    // borrow reads back the published value.
+    public fun borrow_reads(s: signer, a: address): u64 {
+        let slot = storage_slot::new_at<u64>(&s, a, 42);
+        let v = *storage_slot::borrow(&slot);
+        storage_slot::destroy(slot);
+        v
+    }
+
+    // borrow_mut writes through the reference; a later borrow sees the update.
+    public fun borrow_mut_updates(s: signer, a: address): u64 {
+        let slot = storage_slot::new_at<u64>(&s, a, 10);
+        let before = *storage_slot::borrow(&slot);
+        *storage_slot::borrow_mut(&mut slot) = before + 5;
+        let after = *storage_slot::borrow(&slot);
+        storage_slot::destroy(slot);
+        after
+    }
+
+    // A heap-boxed value type (vector<u8>) round-trips through the borrow.
+    public fun borrow_vector(s: signer, a: address): vector<u8> {
+        let slot = storage_slot::new_at<vector<u8>>(&s, a, b"hello");
+        let v = *storage_slot::borrow(&slot);
+        storage_slot::destroy(slot);
+        v
+    }
+
+    // borrow on a slot with no backing resource aborts.
+    public fun borrow_missing_aborts(a: address): u64 {
+        let slot = storage_slot::unbacked<u64>(a);
+        let v = *storage_slot::borrow(&slot);
+        storage_slot::destroy(slot);
+        v
+    }
+
+    // borrow_mut on a slot with no backing resource aborts.
+    public fun borrow_mut_missing_aborts(a: address): u64 {
+        let slot = storage_slot::unbacked<u64>(a);
+        *storage_slot::borrow_mut(&mut slot) = 0;
+        storage_slot::destroy(slot);
+        0
+    }
+}
+
+// RUN: execute 0x42::main::borrow_reads --args 0x42, 0x42
+// CHECK: results: 42
+
+// RUN: execute 0x42::main::borrow_mut_updates --args 0x7, 0x7
+// CHECK: results: 15
+
+// RUN: execute 0x42::main::borrow_vector --args 0x9, 0x9
+// CHECK: results: 0x68656c6c6f
+
+// RUN: execute 0x42::main::borrow_missing_aborts --args 0x12
+// CHECK-SUBSTR: aborted: code 2
+
+// RUN: execute 0x42::main::borrow_mut_missing_aborts --args 0x13
+// CHECK-SUBSTR: aborted: code 2


### PR DESCRIPTION
## Description

Implements the `storage_slot` natives for mono-move: `borrow_storage_slot_resource` and `borrow_storage_slot_resource_mut`. Each reads the address from the `StorageSlot<T>` argument and borrows `StorageSlotResource<T>` from global storage, returning a reference to it. This matches the legacy-VM natives in `aptos-move/framework/natives/src/storage_slot.rs`, so `aptos_framework::storage_slot::borrow` / `borrow_mut` behave the same on mono-move.

Supporting changes:
- Add `NativeContext::borrow_resource(address, mutable, ty)` and implement it in `ProductionNativeContext`.
- Factor the shared copy-on-write borrow path out of `table_borrow` into a `borrow_storage_value` helper; both table items and resources now go through it. This is behavior-preserving.
- Add a `Ref<AccountAddress>::get()` accessor, mirroring the existing `Ref<TableHandle>::get()`, to read the slot's address.

## How Has This Been Tested?

- New differential test `third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/storage_slot.move`. It runs on both the legacy VM and mono-move via shared `CHECK:` lines, covering an immutable borrow, a mutable borrow with read-back, a heap-boxed `vector<u8>` value, and the missing-resource abort.
- Full differential suite passes (193 tests).
- The `unit_tests` scoreboard (real framework `#[test]`s run on mono-move) reports 0 failures across the token, token-objects, experimental, and trading packages, confirming the `table_borrow` refactor changed no behavior.

Run tests with `RUST_MIN_STACK=1073741824` (the VM recurses deeply; the default test-thread stack overflows).

## Key Areas to Review

- `borrow_storage_value` in `runtime/src/native_context.rs`: confirm the extraction preserves `table_borrow`'s copy-on-write semantics exactly.
- `borrow_resource` on the `NativeContext` trait (`core/src/native/context.rs`) and the native in `natives/src/storage_slot.rs`.
- The abort code `2` matches the Move module's `ESTORAGE_SLOT_NOT_FOUND`.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
