### PR TITLE
[vm] Intern module read records once per distinct module

### DIFF
--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/mod.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod code_storage;
 pub mod module_storage;
+pub mod read_recording;
 
 mod state_view_adapter;
 pub use state_view_adapter::{AptosCodeStorageAdapter, AsAptosCodeStorage};

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/read_recording.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/read_recording.rs
@@ -1,0 +1,184 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+#![allow(clippy::duplicated_attributes)]
+
+use crate::{
+    module_and_script_storage::module_storage::AptosModuleStorage,
+    resolver::{ambassador_impl_BlockSynchronizationKillSwitch, BlockSynchronizationKillSwitch},
+};
+use ambassador::delegate_to_methods;
+use aptos_types::state_store::{state_key::StateKey, state_value::StateValueMetadata};
+use bytes::Bytes;
+use move_binary_format::{
+    errors::{PartialVMResult, VMResult},
+    file_format::CompiledScript,
+    CompiledModule,
+};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+};
+use move_vm_runtime::{
+    ambassador_impl_LayoutCache, ambassador_impl_WithRuntimeEnvironment, LayoutCache,
+    LayoutCacheEntry, Module, ModuleStorage, RuntimeEnvironment, Script, StructKey,
+    WithRuntimeEnvironment,
+};
+use move_vm_types::code::{ambassador_impl_ScriptCache, Code, ScriptCache};
+use std::{cell::RefCell, collections::HashSet, sync::Arc};
+
+/// Wraps a code storage and records the state key of every module the VM fetches through it,
+/// so that module accesses become part of the transaction's observed read set (the basis for
+/// hot state promotion).
+///
+/// Scripts are not state items, so script cache accesses are not recorded.
+pub struct ReadRecordingCodeStorage<'a, C> {
+    code_storage: &'a C,
+    module_reads: RefCell<HashSet<StateKey>>,
+}
+
+impl<'a, C> ReadRecordingCodeStorage<'a, C> {
+    pub fn new(code_storage: &'a C) -> Self {
+        Self {
+            code_storage,
+            module_reads: RefCell::new(HashSet::new()),
+        }
+    }
+
+    /// Returns the state keys of modules fetched so far.
+    pub fn into_recorded_reads(self) -> HashSet<StateKey> {
+        self.module_reads.take()
+    }
+
+    fn record(&self, address: &AccountAddress, module_name: &IdentStr) {
+        self.module_reads
+            .borrow_mut()
+            .insert(StateKey::module(address, module_name));
+    }
+}
+
+#[delegate_to_methods]
+#[delegate(
+    WithRuntimeEnvironment,
+    target_ref = "inner",
+    where = "C: WithRuntimeEnvironment"
+)]
+#[delegate(LayoutCache, target_ref = "inner", where = "C: LayoutCache")]
+#[delegate(
+    BlockSynchronizationKillSwitch,
+    target_ref = "inner",
+    where = "C: BlockSynchronizationKillSwitch"
+)]
+impl<C> ReadRecordingCodeStorage<'_, C> {
+    /// Returns the wrapped code storage.
+    fn inner(&self) -> &C {
+        self.code_storage
+    }
+}
+
+impl<C: ModuleStorage> ModuleStorage for ReadRecordingCodeStorage<'_, C> {
+    fn unmetered_check_module_exists(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> VMResult<bool> {
+        self.record(address, module_name);
+        self.code_storage
+            .unmetered_check_module_exists(address, module_name)
+    }
+
+    fn unmetered_get_module_bytes(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> VMResult<Option<Bytes>> {
+        self.record(address, module_name);
+        self.code_storage
+            .unmetered_get_module_bytes(address, module_name)
+    }
+
+    fn unmetered_get_module_hash_and_size(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> VMResult<Option<([u8; 32], usize)>> {
+        self.record(address, module_name);
+        self.code_storage
+            .unmetered_get_module_hash_and_size(address, module_name)
+    }
+
+    fn unmetered_get_module_size(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> VMResult<Option<usize>> {
+        self.record(address, module_name);
+        self.code_storage
+            .unmetered_get_module_size(address, module_name)
+    }
+
+    fn unmetered_get_deserialized_module(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> VMResult<Option<Arc<CompiledModule>>> {
+        self.record(address, module_name);
+        self.code_storage
+            .unmetered_get_deserialized_module(address, module_name)
+    }
+
+    fn unmetered_get_eagerly_verified_module(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> VMResult<Option<Arc<Module>>> {
+        self.record(address, module_name);
+        self.code_storage
+            .unmetered_get_eagerly_verified_module(address, module_name)
+    }
+
+    fn unmetered_get_lazily_verified_module(
+        &self,
+        module_id: &ModuleId,
+    ) -> VMResult<Option<Arc<Module>>> {
+        self.record(module_id.address(), module_id.name());
+        self.code_storage
+            .unmetered_get_lazily_verified_module(module_id)
+    }
+
+    #[cfg(fuzzing)]
+    fn unmetered_get_module_skip_verification(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> VMResult<Option<Arc<Module>>> {
+        self.record(address, module_name);
+        self.code_storage
+            .unmetered_get_module_skip_verification(address, module_name)
+    }
+}
+
+impl<C: AptosModuleStorage> AptosModuleStorage for ReadRecordingCodeStorage<'_, C> {
+    fn unmetered_get_module_state_value_metadata(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> PartialVMResult<Option<StateValueMetadata>> {
+        self.record(address, module_name);
+        self.code_storage
+            .unmetered_get_module_state_value_metadata(address, module_name)
+    }
+}
+
+#[delegate_to_methods]
+#[delegate(ScriptCache, target_ref = "as_script_cache")]
+impl<C> ReadRecordingCodeStorage<'_, C>
+where
+    C: ScriptCache<Key = [u8; 32], Deserialized = CompiledScript, Verified = Script>,
+{
+    /// Returns the wrapped script cache.
+    fn as_script_cache(
+        &self,
+    ) -> &dyn ScriptCache<Key = [u8; 32], Deserialized = CompiledScript, Verified = Script> {
+        self.code_storage
+    }
+}

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/read_recording.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/read_recording.rs
@@ -16,7 +16,9 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
+    language_storage::ModuleId,
 };
 use move_vm_runtime::{
     ambassador_impl_LayoutCache, ambassador_impl_WithRuntimeEnvironment, LayoutCache,
@@ -24,35 +26,56 @@ use move_vm_runtime::{
     WithRuntimeEnvironment,
 };
 use move_vm_types::code::{ambassador_impl_ScriptCache, Code, ScriptCache};
-use std::{cell::RefCell, collections::HashSet, sync::Arc};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
-/// Wraps a code storage and records the state key of every module the VM fetches through it,
-/// so that module accesses become part of the transaction's observed read set (the basis for
-/// hot state promotion).
+/// Wraps a code storage and records every module the VM fetches through it, so that module
+/// accesses become part of the transaction's observed read set (the basis for hot state
+/// promotion).
+///
+/// The VM fetches the same module repeatedly within a transaction, and interning a module
+/// `StateKey` goes through a global, lock-guarded registry. To keep that off the per-access
+/// hot path, reads are accumulated as deduplicated module ids and interned into `StateKey`s
+/// once, when the set is extracted.
 ///
 /// Scripts are not state items, so script cache accesses are not recorded.
 pub struct ReadRecordingCodeStorage<'a, C> {
     code_storage: &'a C,
-    module_reads: RefCell<HashSet<StateKey>>,
+    module_reads: RefCell<HashMap<AccountAddress, HashSet<Identifier>>>,
 }
 
 impl<'a, C> ReadRecordingCodeStorage<'a, C> {
     pub fn new(code_storage: &'a C) -> Self {
         Self {
             code_storage,
-            module_reads: RefCell::new(HashSet::new()),
+            module_reads: RefCell::new(HashMap::new()),
         }
     }
 
-    /// Returns the state keys of modules fetched so far.
+    /// Interns the recorded module reads into state keys, once per distinct module.
     pub fn into_recorded_reads(self) -> HashSet<StateKey> {
-        self.module_reads.take()
+        self.module_reads
+            .into_inner()
+            .into_iter()
+            .flat_map(|(address, names)| {
+                names
+                    .into_iter()
+                    .map(move |name| StateKey::module(&address, &name))
+            })
+            .collect()
     }
 
     fn record(&self, address: &AccountAddress, module_name: &IdentStr) {
-        self.module_reads
-            .borrow_mut()
-            .insert(StateKey::module(address, module_name));
+        let mut module_reads = self.module_reads.borrow_mut();
+        let names = module_reads.entry(*address).or_default();
+        // `contains` borrows the name, so repeated fetches of an already-seen module touch
+        // no allocation and never reach the StateKey registry; clone only on first sighting.
+        if !names.contains(module_name) {
+            names.insert(module_name.to_owned());
+        }
     }
 }
 

--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -24,7 +24,10 @@ use move_core_types::{
 };
 use move_vm_runtime::execution_tracing::Trace;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
-use std::{collections::BTreeMap, mem};
+use std::{
+    collections::{BTreeMap, HashSet},
+    mem,
+};
 
 /// Output produced by the VM after executing a transaction.
 ///
@@ -259,5 +262,22 @@ impl VMOutput {
         self.change_set.set_events(patched_events.into_iter());
 
         self.into_transaction_output()
+    }
+}
+
+/// A transaction's read set, used for hot-state promotion. Unordered at the
+/// per-transaction level; ordering is imposed later when aggregating per-block.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct UnorderedReadSet {
+    keys: HashSet<StateKey>,
+}
+
+impl UnorderedReadSet {
+    pub fn new(keys: HashSet<StateKey>) -> Self {
+        Self { keys }
+    }
+
+    pub fn as_inner(&self) -> &HashSet<StateKey> {
+        &self.keys
     }
 }

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use ambassador::delegatable_trait;
 use aptos_aggregator::resolver::{TAggregatorV1View, TDelayedFieldView};
 use aptos_types::{
     serde_helper::bcs_utils::size_u32_as_uleb128,
@@ -22,6 +23,7 @@ use std::collections::{BTreeMap, HashMap};
 /// Allows requesting an immediate interrupt to ongoing transaction execution. For example, this
 /// allows an early return from a useless speculative execution when block execution has already
 /// halted (e.g. due to gas limit, committing only a block prefix).
+#[delegatable_trait]
 pub trait BlockSynchronizationKillSwitch {
     fn interrupt_requested(&self) -> bool;
 }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -35,7 +35,9 @@ use aptos_types::{
 };
 use aptos_vm_logging::{flush_speculative_logs, init_speculative_logs};
 use aptos_vm_types::{
-    abstract_write_op::AbstractResourceWriteOp, module_write_set::ModuleWrite, output::VMOutput,
+    abstract_write_op::AbstractResourceWriteOp,
+    module_write_set::ModuleWrite,
+    output::{UnorderedReadSet, VMOutput},
     resolver::ResourceGroupSize,
 };
 use move_core_types::{
@@ -59,13 +61,23 @@ use vm_wrapper::AptosExecutorTask;
 pub struct AptosTransactionOutput {
     vm_output: Option<VMOutput>,
     committed_output: OnceCell<TransactionOutput>,
+    /// State keys read by the VM during the execution (incarnation) that produced this output.
+    ///
+    /// TODO(HotState): also consider recording the read kind (exists/metadata/value) and the
+    /// observed slot hotness, so the promotion policy can filter on them.
+    read_set: UnorderedReadSet,
 }
 
 impl AptosTransactionOutput {
     pub fn new(output: VMOutput) -> Self {
+        Self::new_with_read_set(output, UnorderedReadSet::default())
+    }
+
+    pub fn new_with_read_set(output: VMOutput, read_set: UnorderedReadSet) -> Self {
         Self {
             vm_output: Some(output),
             committed_output: OnceCell::new(),
+            read_set,
         }
     }
 
@@ -107,6 +119,7 @@ impl<'a> AfterMaterializationOutput<SignatureVerifiedTransaction>
 /// Before materialization guard wrapper that holds a read lock.
 pub struct BeforeMaterializationGuard<'a> {
     guard: &'a VMOutput,
+    read_set: &'a UnorderedReadSet,
 }
 
 impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMaterializationGuard<'_> {
@@ -154,6 +167,24 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
         }
 
         writes
+    }
+
+    fn storage_keys_read(&self) -> impl Iterator<Item = &StateKey> {
+        self.read_set.as_inner().iter()
+    }
+
+    fn storage_keys_written(&self) -> impl Iterator<Item = &StateKey> {
+        // Every key receiving a value write becomes hot via the write itself, so the hot
+        // state accumulator must treat it as written and not promote it separately. Unlike
+        // get_write_summary (conflict detection), this includes in-place delayed field
+        // rewrites, aggregator v1 writes/deltas and module writes. The accumulator dedups,
+        // so the chained keys need not be unique.
+        self.guard
+            .resource_write_set()
+            .keys()
+            .chain(self.guard.module_write_set().keys())
+            .chain(self.guard.aggregator_v1_write_set().keys())
+            .chain(self.guard.aggregator_v1_delta_set().keys())
     }
 
     // TODO: get rid of the cloning data-structures in the following APIs.
@@ -381,6 +412,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
                 .vm_output
                 .as_ref()
                 .ok_or_else(|| code_invariant_error("Output must be set but not materialized"))?,
+            read_set: &self.read_set,
         })
     }
 

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -15,7 +15,10 @@ use aptos_types::{
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
 use aptos_vm_types::{
-    module_and_script_storage::code_storage::AptosCodeStorage,
+    module_and_script_storage::{
+        code_storage::AptosCodeStorage, read_recording::ReadRecordingCodeStorage,
+    },
+    output::UnorderedReadSet,
     resolver::{BlockSynchronizationKillSwitch, ExecutorView, ResourceGroupView},
 };
 use fail::fail_point;
@@ -61,17 +64,28 @@ impl ExecutorTask for AptosExecutorTask {
 
         let log_context = AdapterLogSchema::new(self.id, txn_idx as usize);
         let resolver = self.vm.as_move_resolver_with_group_view(view);
-        match self
-            .vm
-            .execute_single_transaction(txn, &resolver, view, &log_context, auxiliary_info)
-        {
+        let code_storage = ReadRecordingCodeStorage::new(view);
+        match self.vm.execute_single_transaction(
+            txn,
+            &resolver,
+            &code_storage,
+            &log_context,
+            auxiliary_info,
+        ) {
             Ok((vm_status, vm_output)) => {
-                if vm_output.status().is_discarded() {
+                // Discarded transactions commit no state changes, so their reads must not feed
+                // hot-state promotion. Only carry the read set for outputs that can commit.
+                let read_set = if vm_output.status().is_discarded() {
                     speculative_trace!(
                         &log_context,
                         format!("Transaction discarded, status: {:?}", vm_status),
                     );
-                }
+                    UnorderedReadSet::default()
+                } else {
+                    let mut keys = resolver.recorded_reads();
+                    keys.extend(code_storage.into_recorded_reads());
+                    UnorderedReadSet::new(keys)
+                };
                 if vm_status.status_code() == StatusCode::SPECULATIVE_EXECUTION_ABORT_ERROR {
                     ExecutionStatus::SpeculativeExecutionAbortError(
                         vm_status.message().cloned().unwrap_or_default(),
@@ -87,13 +101,17 @@ impl ExecutorTask for AptosExecutorTask {
                         &log_context,
                         "Reconfiguration occurred: restart required".into()
                     );
-                    ExecutionStatus::SkipRest(AptosTransactionOutput::new(vm_output))
+                    ExecutionStatus::SkipRest(AptosTransactionOutput::new_with_read_set(
+                        vm_output, read_set,
+                    ))
                 } else {
                     assert!(
                         Self::is_transaction_dynamic_change_set_capable(txn),
                         "DirectWriteSet should always create SkipRest transaction, validate_waypoint_change_set provides this guarantee"
                     );
-                    ExecutionStatus::Success(AptosTransactionOutput::new(vm_output))
+                    ExecutionStatus::Success(AptosTransactionOutput::new_with_read_set(
+                        vm_output, read_set,
+                    ))
                 }
             },
             // execute_single_transaction only returns an error when transactions that should never fail

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -3,7 +3,7 @@
 //! Scratchpad for on chain values during the execution.
 
 use crate::move_vm_ext::{
-    resource_state_key, AptosMoveResolver, AsExecutorView, AsResourceGroupView,
+    resource_state_key, AptosMoveResolver, AsExecutorView, AsResourceGroupView, ReadRecorder,
     ResourceGroupResolver,
 };
 use aptos_aggregator::{
@@ -44,6 +44,7 @@ use move_vm_types::{
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet},
+    rc::Rc,
 };
 use triomphe::Arc as TriompheArc;
 
@@ -68,6 +69,11 @@ pub struct StorageAdapter<'e, E> {
     executor_view: &'e E,
     resource_group_view: ResourceGroupAdapter<'e>,
     accessed_groups: RefCell<HashSet<StateKey>>,
+    /// State keys of all data reads (resources, resource groups, table items, aggregator v1)
+    /// that the VM performed through this resolver, used for hot state promotion. Shared with
+    /// the resolvers of the respawned sessions spawned on top of this resolver, so that the
+    /// reads of all of a transaction's sessions land in one set.
+    recorded_reads: ReadRecorder,
 }
 
 impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
@@ -92,7 +98,18 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
             executor_view,
             resource_group_view,
             accessed_groups: RefCell::new(HashSet::new()),
+            recorded_reads: ReadRecorder::default(),
         }
+    }
+
+    pub(crate) fn with_read_recorder(mut self, recorded_reads: ReadRecorder) -> Self {
+        self.recorded_reads = recorded_reads;
+        self
+    }
+
+    /// Returns the state keys read through this resolver.
+    pub fn recorded_reads(&self) -> HashSet<StateKey> {
+        (*self.recorded_reads.borrow()).clone()
     }
 
     fn get_any_resource_with_layout(
@@ -105,6 +122,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
         let resource_group = get_resource_group_member_from_metadata(struct_tag, metadata);
         if let Some(resource_group) = resource_group {
             let key = StateKey::resource_group(address, &resource_group);
+            self.recorded_reads.borrow_mut().insert(key.clone());
             let buf =
                 self.resource_group_view
                     .get_resource_from_group(&key, struct_tag, maybe_layout)?;
@@ -120,6 +138,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
             Ok((buf, buf_size + group_size as usize))
         } else {
             let state_key = resource_state_key(address, struct_tag)?;
+            self.recorded_reads.borrow_mut().insert(state_key.clone());
             let buf = self
                 .executor_view
                 .get_resource_bytes(&state_key, maybe_layout)?;
@@ -159,7 +178,11 @@ impl<E: ExecutorView> ResourceGroupResolver for StorageAdapter<'_, E> {
     }
 }
 
-impl<E: ExecutorView> AptosMoveResolver for StorageAdapter<'_, E> {}
+impl<E: ExecutorView> AptosMoveResolver for StorageAdapter<'_, E> {
+    fn read_recorder(&self) -> ReadRecorder {
+        Rc::clone(&self.recorded_reads)
+    }
+}
 
 impl<E: ExecutorView> ResourceResolver for StorageAdapter<'_, E> {
     fn get_resource_bytes_with_metadata_and_layout(
@@ -181,6 +204,7 @@ impl<E: ExecutorView> TableResolver for StorageAdapter<'_, E> {
         maybe_layout: Option<&MoveTypeLayout>,
     ) -> Result<Option<Bytes>, PartialVMError> {
         let state_key = StateKey::table_item(&(*handle).into(), key);
+        self.recorded_reads.borrow_mut().insert(state_key.clone());
         self.executor_view
             .get_resource_bytes(&state_key, maybe_layout)
     }
@@ -193,6 +217,7 @@ impl<E: ExecutorView> TAggregatorV1View for StorageAdapter<'_, E> {
         &self,
         id: &Self::Identifier,
     ) -> PartialVMResult<Option<StateValue>> {
+        self.recorded_reads.borrow_mut().insert(id.clone());
         self.executor_view.get_aggregator_v1_state_value(id)
     }
 }
@@ -252,6 +277,7 @@ impl<E: ExecutorView> TDelayedFieldView for StorageAdapter<'_, E> {
 
 impl<E: ExecutorView> ConfigStorage for StorageAdapter<'_, E> {
     fn fetch_config_bytes(&self, state_key: &StateKey) -> anyhow::Result<Option<Bytes>> {
+        self.recorded_reads.borrow_mut().insert(state_key.clone());
         Ok(self.executor_view.get_resource_bytes(state_key, None)?)
     }
 }
@@ -336,5 +362,94 @@ pub(crate) mod tests {
         );
 
         StorageAdapter::new(state_view, group_adapter)
+    }
+
+    #[test]
+    fn test_recorded_reads() {
+        use aptos_types::state_store::MockStateView;
+        use move_core_types::identifier::Identifier;
+
+        let state_view = MockStateView::<StateKey>::empty();
+        let resolver = state_view.as_move_resolver();
+
+        let addr = AccountAddress::ONE;
+        let struct_tag = StructTag {
+            address: addr,
+            module: Identifier::new("m").unwrap(),
+            name: Identifier::new("R").unwrap(),
+            type_args: vec![],
+        };
+        let resource_key = resource_state_key(&addr, &struct_tag).unwrap();
+        let table_handle = TableHandle(addr);
+        let table_key = StateKey::table_item(&table_handle.into(), &[7]);
+        let aggregator_key = StateKey::raw(b"aggregator");
+        let config_key = StateKey::raw(b"config");
+
+        // Reads of non-existent values still count: the slot was consulted.
+        assert!(resolver
+            .get_resource_bytes_with_metadata_and_layout(&addr, &struct_tag, &[], None)
+            .unwrap()
+            .0
+            .is_none());
+        assert!(resolver
+            .resolve_table_entry_bytes_with_layout(&table_handle, &[7], None)
+            .unwrap()
+            .is_none());
+        assert!(resolver
+            .get_aggregator_v1_state_value(&aggregator_key)
+            .unwrap()
+            .is_none());
+        assert!(resolver.fetch_config_bytes(&config_key).unwrap().is_none());
+
+        let expected = [resource_key, table_key, aggregator_key, config_key]
+            .into_iter()
+            .collect::<HashSet<_>>();
+        assert_eq!(resolver.recorded_reads(), expected);
+    }
+
+    /// A respawned session builds a fresh resolver over a change-set-wrapped view but must inherit
+    /// its parent's recorder, so a transaction's sessions accumulate reads into one set.
+    /// `RespawnedSession::spawn` wires this via `read_recorder()` + `with_read_recorder`; this pins
+    /// the contract those two methods must satisfy.
+    #[test]
+    fn test_read_recorder_shared_across_resolvers() {
+        use aptos_types::state_store::MockStateView;
+        use move_core_types::identifier::Identifier;
+
+        let state_view = MockStateView::<StateKey>::empty();
+        let addr = AccountAddress::ONE;
+        let tag = |name: &str| StructTag {
+            address: addr,
+            module: Identifier::new("m").unwrap(),
+            name: Identifier::new(name).unwrap(),
+            type_args: vec![],
+        };
+
+        let parent = state_view.as_move_resolver();
+        let parent_tag = tag("Parent");
+        let parent_key = resource_state_key(&addr, &parent_tag).unwrap();
+        assert!(parent
+            .get_resource_bytes_with_metadata_and_layout(&addr, &parent_tag, &[], None)
+            .unwrap()
+            .0
+            .is_none());
+
+        // Spawn a second resolver inheriting the parent's recorder, exactly as the respawned
+        // session does.
+        let child = state_view
+            .as_move_resolver()
+            .with_read_recorder(parent.read_recorder());
+        let child_tag = tag("Child");
+        let child_key = resource_state_key(&addr, &child_tag).unwrap();
+        assert!(child
+            .get_resource_bytes_with_metadata_and_layout(&addr, &child_tag, &[], None)
+            .unwrap()
+            .0
+            .is_none());
+
+        // Both reads land in the single shared set, observable through either resolver.
+        let expected = [parent_key, child_key].into_iter().collect::<HashSet<_>>();
+        assert_eq!(parent.recorded_reads(), expected);
+        assert_eq!(child.recorded_reads(), expected);
     }
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/mod.rs
@@ -9,7 +9,9 @@ mod vm;
 pub(crate) mod write_op_converter;
 
 pub use crate::move_vm_ext::{
-    resolver::{AptosMoveResolver, AsExecutorView, AsResourceGroupView, ResourceGroupResolver},
+    resolver::{
+        AptosMoveResolver, AsExecutorView, AsResourceGroupView, ReadRecorder, ResourceGroupResolver,
+    },
     session::{convert_modules_into_write_ops, SessionExt},
     vm::{GenesisMoveVm, GenesisRuntimeBuilder},
 };

--- a/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
@@ -11,7 +11,15 @@ use bytes::Bytes;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::language_storage::StructTag;
 use move_vm_types::resolver::ResourceResolver;
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap, HashSet},
+    rc::Rc,
+};
+
+/// Accumulates the state keys of the data reads a transaction performs through its
+/// resolvers, used for hot state promotion.
+pub type ReadRecorder = Rc<RefCell<HashSet<StateKey>>>;
 
 /// A general resolver used by AptosVM. Allows to implement custom hooks on
 /// top of storage, e.g. get resources from resource groups, etc.
@@ -27,6 +35,10 @@ pub trait AptosMoveResolver:
     + AsExecutorView
     + AsResourceGroupView
 {
+    /// The recorder this resolver records data reads into. A respawned session's resolver
+    /// must share the recorder of the resolver it is spawned from, so that the reads of all
+    /// of a transaction's sessions accumulate in one set.
+    fn read_recorder(&self) -> ReadRecorder;
 }
 
 pub trait ResourceGroupResolver {

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/respawned_session.rs
@@ -47,10 +47,16 @@ impl<'r> RespawnedSession<'r> {
             base.as_resource_group_view(),
             previous_session_change_set,
         );
+        // The executor view above wraps the raw view underneath `base`, bypassing `base`'s
+        // read recording, so the new resolver must inherit the recorder explicitly.
+        let read_recorder = base.read_recorder();
 
         RespawnedSessionBuilder {
             executor_view,
-            resolver_builder: |executor_view| vm.as_move_resolver_with_group_view(executor_view),
+            resolver_builder: |executor_view| {
+                vm.as_move_resolver_with_group_view(executor_view)
+                    .with_read_recorder(read_recorder)
+            },
             session_builder: |resolver| {
                 Some(vm.new_session(resolver, session_id, user_transaction_context_opt))
             },

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -906,6 +906,14 @@ where
         HashSet::new()
     }
 
+    fn storage_keys_read(&self) -> impl Iterator<Item = &K> {
+        std::iter::empty()
+    }
+
+    fn storage_keys_written(&self) -> impl Iterator<Item = &K> {
+        std::iter::empty()
+    }
+
     fn get_events(&self) -> Vec<(E, Option<MoveTypeLayout>)> {
         self.events.iter().map(|e| (e.clone(), None)).collect()
     }

--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -450,6 +450,17 @@ pub static HOT_STATE_OP_ACCUMULATOR_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| 
     .unwrap()
 });
 
+pub static HOT_STATE_PROMOTIONS_PER_BLOCK: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "aptos_execution_hot_state_promotions_per_block",
+        // metric description
+        "Number of keys the block end info designates for hot state promotion",
+        exponential_buckets(/*start=*/ 1.0, /*factor=*/ 2.0, /*count=*/ 16).unwrap(),
+    )
+    .unwrap()
+});
+
 pub static NUM_INTERNED_TYPES: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "num_interned_types",

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -2437,10 +2437,11 @@ where
                         read_write_summary,
                         approx_output_size,
                     );
+
                     if idx < num_txns {
                         // Exclude the block-epilogue (idx == num_txns) so num_committed_user_txns
-                        // tracks only user txns. Includes bcs-fallback discards (which accumulate
-                        // a fee statement before being discarded), consistent with the accumulator.
+                        // tracks only user txns. Includes bcs-fallback discards, which still
+                        // accumulate a fee statement before being discarded.
                         num_committed_user_txns += 1;
                     }
 
@@ -2544,6 +2545,16 @@ where
                             continue;
                         }
                     };
+
+                    // Feed only committed transactions to the hot-state accumulator, in commit
+                    // order: bcs-fallback discards have continued above, and genuine discards
+                    // carry empty read/write sets.
+                    if block_limit_processor.is_hot_state_accumulation_enabled() {
+                        block_limit_processor.accumulate_hot_state_rw(
+                            output_before_guard.storage_keys_written(),
+                            output_before_guard.storage_keys_read(),
+                        );
+                    }
 
                     // Apply the writes.
                     let resource_write_set = output_before_guard.resource_write_set();

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -91,9 +91,6 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
             } else {
                 txn_read_write_summary.collapse_resource_group_conflicts()
             };
-            if let Some(x) = &mut self.hot_state_op_accumulator {
-                x.add_transaction(rw_summary.keys_written(), rw_summary.keys_read());
-            }
             self.txn_read_write_summaries.push(rw_summary);
             self.compute_conflict_multiplier(conflict_overlap_length as usize)
         } else {
@@ -117,6 +114,27 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
                 .expect("approx_output_size needs to be computed if block_output_limit is set");
         } else {
             assert_none!(approx_output_size);
+        }
+    }
+
+    /// Returns whether hot state promotions are being accumulated for this block. Callers
+    /// use this to skip extracting the per-transaction key sets when they would be unused.
+    pub(crate) fn is_hot_state_accumulation_enabled(&self) -> bool {
+        self.hot_state_op_accumulator.is_some()
+    }
+
+    /// Feeds the hot state accumulator with the keys the transaction read (the VM-observed
+    /// read set carried by the output) and the keys it writes. Called per transaction in
+    /// commit order.
+    pub(crate) fn accumulate_hot_state_rw<'a>(
+        &mut self,
+        writes: impl Iterator<Item = &'a T::Key>,
+        reads: impl Iterator<Item = &'a T::Key>,
+    ) where
+        T::Key: 'a,
+    {
+        if let Some(accumulator) = &mut self.hot_state_op_accumulator {
+            accumulator.add_transaction(writes, reads);
         }
     }
 
@@ -300,6 +318,9 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
         };
 
         let to_make_hot = self.get_keys_to_make_hot();
+        if self.hot_state_op_accumulator.is_some() {
+            counters::HOT_STATE_PROMOTIONS_PER_BLOCK.observe(to_make_hot.len() as f64);
+        }
         TBlockEndInfoExt::new(inner, to_make_hot)
     }
 

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -186,6 +186,12 @@ pub trait BeforeMaterializationOutput<Txn: Transaction> {
     fn output_approx_size(&self) -> u64;
 
     fn get_write_summary(&self) -> HashSet<InputOutputKey<Txn::Key, Txn::Tag>>;
+
+    /// State keys read by the VM during the execution that produced this output.
+    fn storage_keys_read(&self) -> impl Iterator<Item = &Txn::Key>;
+
+    /// Keys that receive a value write when this output commits.
+    fn storage_keys_written(&self) -> impl Iterator<Item = &Txn::Key>;
 }
 
 pub trait AfterMaterializationOutput<Txn: Transaction> {

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -351,6 +351,12 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
             maybe_read_write_summary,
             output_wrapper.maybe_approx_output_size,
         );
+        if block_limit_processor.is_hot_state_accumulation_enabled() {
+            block_limit_processor.accumulate_hot_state_rw(
+                output_before_guard.storage_keys_written(),
+                output_before_guard.storage_keys_read(),
+            );
+        }
 
         if txn_idx < num_txns - 1
             && block_limit_processor.should_end_block_parallel()

--- a/aptos-move/e2e-move-tests/src/tests/hot_state.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/hot_state.data/pack/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "hot_state_test"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/hot_state.data/pack/sources/read_helper.move
+++ b/aptos-move/e2e-move-tests/src/tests/hot_state.data/pack/sources/read_helper.move
@@ -1,0 +1,93 @@
+module 0xcafe::read_helper {
+    use std::signer;
+    use aptos_std::table::{Self, Table};
+    use aptos_framework::account;
+    use aptos_framework::aggregator_v2::{Self, Aggregator};
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin;
+
+    #[resource_group(scope = global)]
+    struct Group {}
+
+    #[resource_group_member(group = 0xcafe::read_helper::Group)]
+    struct InGroup has key { value: u64 }
+
+    struct Plain has key { value: u64 }
+
+    struct TableHolder has key { entries: Table<u64, u64> }
+
+    /// Holds an aggregator-v2 value; mutating it is recorded as an in-place delayed-field write to
+    /// this resource's own slot.
+    struct Counter has key { value: Aggregator<u64> }
+
+    /// Publishes the read targets under `account`: a plain resource, a resource-group member, and a
+    /// one-entry table. Run as its own applied transaction so that a later block only reads them.
+    public entry fun init(account: &signer) {
+        move_to(account, Plain { value: 1 });
+        move_to(account, InGroup { value: 2 });
+        let entries = table::new<u64, u64>();
+        table::add(&mut entries, 7, 70);
+        move_to(account, TableHolder { entries });
+    }
+
+    /// Reads a plain (non-group) resource without writing it.
+    public entry fun read_plain(target: address) acquires Plain {
+        let _ = borrow_global<Plain>(target).value;
+    }
+
+    /// Reads a resource-group member. The recorded read key is the enclosing *group* key, not the
+    /// member's own struct tag.
+    public entry fun read_group_member(target: address) acquires InGroup {
+        let _ = borrow_global<InGroup>(target).value;
+    }
+
+    /// `exists<T>` loads the slot to answer, so even an absent resource is recorded as a read.
+    public entry fun check_exists(target: address) {
+        let _ = exists<Plain>(target);
+    }
+
+    /// Reads a single table item without writing it.
+    public entry fun read_table_item(target: address) acquires TableHolder {
+        let holder = borrow_global<TableHolder>(target);
+        let _ = *table::borrow(&holder.entries, 7);
+    }
+
+    /// Reads framework state without writing it: the account resource of `target`, plus
+    /// `CoinInfo<AptosCoin>` and the table-backed coin-to-fungible-asset conversion map behind
+    /// `coin::supply`.
+    public entry fun read_only(target: address) {
+        let _ = account::get_sequence_number(target);
+        let _ = coin::supply<AptosCoin>();
+    }
+
+    /// Reads (via `exists`) and then mutates the caller's own `Plain`, so its slot is written.
+    public entry fun write_plain(account: &signer) acquires Plain {
+        let addr = signer::address_of(account);
+        if (exists<Plain>(addr)) {
+            let plain = borrow_global_mut<Plain>(addr);
+            plain.value = plain.value + 1;
+        } else {
+            move_to(account, Plain { value: 1 });
+        };
+    }
+
+    /// Reads (loads the enclosing group) and then mutates the caller's own `InGroup`, so the
+    /// enclosing *group* slot is written.
+    public entry fun write_group_member(account: &signer) acquires InGroup {
+        let member = borrow_global_mut<InGroup>(signer::address_of(account));
+        member.value = member.value + 1;
+    }
+
+    /// Publishes a `Counter` under `account`, in its own applied transaction so a later block only
+    /// mutates it.
+    public entry fun init_counter(account: &signer) {
+        move_to(account, Counter { value: aggregator_v2::create_unbounded_aggregator<u64>() });
+    }
+
+    /// Reads (`borrow_global_mut` loads the slot) and then mutates `target`'s aggregator-v2 field,
+    /// recording an in-place delayed-field write to the `Counter` slot.
+    public entry fun bump_counter(target: address) acquires Counter {
+        let counter = borrow_global_mut<Counter>(target);
+        aggregator_v2::add(&mut counter.value, 1);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/hot_state.rs
+++ b/aptos-move/e2e-move-tests/src/tests/hot_state.rs
@@ -1,0 +1,655 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! End-to-end coverage for the transaction read sets recorded for hot-state promotion.
+//!
+//! Each test drives a small block through real Move execution and inspects the block epilogue's
+//! `to_make_hot` set. The invariants under test are: a slot only *read* in the block is promoted, a
+//! slot the block *writes* (by any transaction) is not, and the promotion set is identical under
+//! sequential and parallel execution. Targeted tests cover each kind of read the VM records (plain
+//! resources, resource-group members, table items, modules, on-chain configs) plus the `exists`
+//! behavior and discard handling, and — for each write kind enumerated by `storage_keys_written`
+//! (plain resources, resource groups, aggregator v1 materializations/deltas, in-place delayed
+//! fields, and modules) — that a written slot is excluded from promotion.
+
+use crate::{aggregator, assert_success, tests::common, MoveHarness};
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
+use aptos_cached_packages::aptos_stdlib;
+use aptos_crypto::HashValue;
+use aptos_language_e2e_tests::account::Account;
+use aptos_types::{
+    account_config::{AccountResource, AggregatorV1Resource, CoinInfoResource},
+    block_executor::{
+        config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
+        transaction_slice_metadata::TransactionSliceMetadata,
+    },
+    chain_id::ChainId,
+    move_utils::MemberId,
+    on_chain_config::{CurrentTimeMicroseconds, Features},
+    state_store::{
+        state_key::{inner::StateKeyInner, StateKey},
+        table::TableHandle,
+    },
+    transaction::{
+        signature_verified_transaction::into_signature_verified_block, ExecutionStatus,
+        Transaction, TransactionStatus,
+    },
+    utility_coin::AptosCoinType,
+};
+use aptos_vm::{aptos_vm::AptosVMBlockExecutor, VMBlockExecutor};
+use move_core_types::{
+    account_address::AccountAddress, ident_str, language_storage::StructTag,
+    parser::parse_struct_tag,
+};
+use std::collections::BTreeSet;
+
+const HELPER_ADDR: &str = "0xcafe";
+
+/// Executes the block against the harness state (without applying it) and returns the per-txn
+/// statuses, the epilogue's `to_make_hot` set, and all keys the block's outputs value-write.
+fn execute_and_get_hot_state_promotions(
+    h: &MoveHarness,
+    txns: Vec<Transaction>,
+    concurrency_level: usize,
+) -> (
+    Vec<TransactionStatus>,
+    BTreeSet<StateKey>,
+    BTreeSet<StateKey>,
+) {
+    let config = BlockExecutorConfig {
+        local: BlockExecutorLocalConfig::default_with_concurrency_level(concurrency_level),
+        // The hot state accumulator requires `add_block_limit_outcome_onchain`;
+        // `with_features` turns on `hotness_in_epilogue` (in default features), which
+        // selects the V2 epilogue payload carrying `to_make_hot`.
+        onchain: BlockExecutorConfigFromOnchain::on_but_large_for_test()
+            .with_features(&Features::default()),
+    };
+    let txn_provider = DefaultTxnProvider::new_without_info(into_signature_verified_block(txns));
+    let block_output = AptosVMBlockExecutor::new()
+        .execute_block_with_config(
+            &txn_provider,
+            h.executor.get_state_view(),
+            config,
+            TransactionSliceMetadata::block(HashValue::zero(), HashValue::new([1; 32])),
+        )
+        .expect("Block execution should succeed");
+    let (outputs, epilogue_txn) = block_output.into_inner();
+
+    let statuses = outputs
+        .iter()
+        .map(|output| output.status().clone())
+        .collect();
+
+    let written_keys = outputs
+        .iter()
+        .flat_map(|output| {
+            output
+                .write_set()
+                .write_op_iter()
+                .map(|(key, _)| key.clone())
+        })
+        .collect();
+
+    let to_make_hot = match epilogue_txn
+        .expect("Block epilogue must be created")
+        .into_inner()
+    {
+        Transaction::BlockEpilogue(payload) => payload
+            .try_get_keys_to_make_hot()
+            .expect("Hotness must be enabled")
+            .clone(),
+        txn => panic!("Expected block epilogue, got: {:?}", txn),
+    };
+    (statuses, to_make_hot, written_keys)
+}
+
+/// Executes `txns` as a block at sequential (concurrency 1) and parallel (concurrency 4) settings,
+/// asserts both promote exactly the same keys, and returns the sequential run's statuses, the
+/// shared promotion set, and the keys the block wrote. Routing every test through here gives
+/// sequential/parallel parity coverage for free.
+fn promotions(
+    h: &MoveHarness,
+    txns: Vec<Transaction>,
+) -> (
+    Vec<TransactionStatus>,
+    BTreeSet<StateKey>,
+    BTreeSet<StateKey>,
+) {
+    let (statuses, sequential, written) = execute_and_get_hot_state_promotions(h, txns.clone(), 1);
+    let (_, parallel, _) = execute_and_get_hot_state_promotions(h, txns, 4);
+    assert_eq!(
+        sequential, parallel,
+        "sequential and parallel execution must promote the same keys",
+    );
+    (statuses, sequential, written)
+}
+
+fn assert_all_success(statuses: &[TransactionStatus]) {
+    for status in statuses {
+        assert!(
+            matches!(status, TransactionStatus::Keep(ExecutionStatus::Success)),
+            "expected all transactions to succeed, got {:?}",
+            statuses,
+        );
+    }
+}
+
+fn helper_address() -> AccountAddress {
+    AccountAddress::from_hex_literal(HELPER_ADDR).unwrap()
+}
+
+/// A `MemberId` for the entry function `0xcafe::read_helper::<name>`.
+fn helper_fn(name: &str) -> MemberId {
+    str::parse(&format!("{HELPER_ADDR}::read_helper::{name}")).unwrap()
+}
+
+/// The `StructTag` for `0xcafe::read_helper::<name>`.
+fn helper_struct(name: &str) -> StructTag {
+    parse_struct_tag(&format!("{HELPER_ADDR}::read_helper::{name}")).unwrap()
+}
+
+/// A user transaction calling `0xcafe::read_helper::<name>(target)`.
+fn read_txn(
+    h: &mut MoveHarness,
+    signer: &Account,
+    name: &str,
+    target: &AccountAddress,
+) -> Transaction {
+    Transaction::UserTransaction(
+        h.create_entry_function(signer, helper_fn(name), vec![], vec![
+            bcs::to_bytes(target).unwrap()
+        ]),
+    )
+}
+
+/// Creates a harness with the `read_helper` package published at `0xcafe`, returning the harness
+/// and the publisher account (needed to republish the package within a block).
+fn new_harness_with_package() -> (MoveHarness, Account) {
+    let mut h = MoveHarness::new();
+    let publisher = h.new_account_at(helper_address());
+    assert_success!(h.publish_package(&publisher, &common::test_dir_path("hot_state.data/pack")));
+    (h, publisher)
+}
+
+/// As [`new_harness_with_package`], plus an `owner` account that already holds the read targets
+/// (`Plain`, `InGroup`, `TableHolder`), created in a prior applied transaction so a later block
+/// only reads them.
+fn setup() -> (MoveHarness, Account) {
+    let (mut h, _publisher) = new_harness_with_package();
+    let owner = h.new_account_with_key_pair();
+    assert_success!(h.run_entry_function(&owner, helper_fn("init"), vec![], vec![]));
+    (h, owner)
+}
+
+/// A plain (non-group) resource that is only read is promoted at its own state key.
+#[test]
+fn test_plain_resource_read_is_promoted() {
+    let (mut h, owner) = setup();
+    let reader = h.new_account_with_key_pair();
+    let txns = vec![read_txn(&mut h, &reader, "read_plain", owner.address())];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    let plain = StateKey::resource(owner.address(), &helper_struct("Plain")).unwrap();
+    assert!(
+        promoted.contains(&plain),
+        "a read-only resource must be promoted"
+    );
+    assert!(!written.contains(&plain));
+}
+
+/// Reading a resource-group member records the enclosing *group* key, not the member's own key.
+#[test]
+fn test_resource_group_member_read_promotes_group_key() {
+    let (mut h, owner) = setup();
+    let reader = h.new_account_with_key_pair();
+    let txns = vec![read_txn(
+        &mut h,
+        &reader,
+        "read_group_member",
+        owner.address(),
+    )];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    let group = StateKey::resource_group(owner.address(), &helper_struct("Group"));
+    let member = StateKey::resource(owner.address(), &helper_struct("InGroup")).unwrap();
+    assert!(promoted.contains(&group), "the group key must be promoted");
+    assert!(
+        !promoted.contains(&member),
+        "the per-member key is never used for group resources",
+    );
+    assert!(!written.contains(&group));
+}
+
+/// Writing a resource-group member writes the enclosing *group* slot (the same key a group read
+/// records), so that slot must be excluded from promotion.
+#[test]
+fn test_written_group_member_excludes_group_key() {
+    let (mut h, owner) = setup();
+    // `write_group_member` reads (loads the group) and then mutates the owner's own `InGroup`.
+    let txns = vec![Transaction::UserTransaction(h.create_entry_function(
+        &owner,
+        helper_fn("write_group_member"),
+        vec![],
+        vec![],
+    ))];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    let group = StateKey::resource_group(owner.address(), &helper_struct("Group"));
+    assert!(
+        written.contains(&group),
+        "writing a group member must write the enclosing group slot",
+    );
+    assert!(
+        !promoted.contains(&group),
+        "a group slot written in the block must not be promoted, even though it was also read",
+    );
+}
+
+/// `exists<T>` loads the slot to answer, so a read of an absent resource is still recorded and the
+/// slot is promoted. This is the intended behavior change from the old summary-based derivation.
+#[test]
+fn test_exists_on_absent_resource_is_recorded() {
+    let (mut h, _owner) = setup();
+    let reader = h.new_account_with_key_pair();
+    // A fresh account that never received a `Plain`.
+    let absent_owner = h.new_account_with_key_pair();
+    let txns = vec![read_txn(
+        &mut h,
+        &reader,
+        "check_exists",
+        absent_owner.address(),
+    )];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    let absent = StateKey::resource(absent_owner.address(), &helper_struct("Plain")).unwrap();
+    assert!(
+        promoted.contains(&absent),
+        "exists<T> consults the slot, so even an absent resource counts as a read",
+    );
+    assert!(!written.contains(&absent));
+}
+
+/// A table item that is only read is promoted at its exact `TableItem` key.
+#[test]
+fn test_table_item_read_is_promoted() {
+    let (mut h, owner) = setup();
+    let reader = h.new_account_with_key_pair();
+
+    // `TableHolder { entries: Table<u64, u64> }` serializes to just the table handle; recover it to
+    // construct the exact item key for the entry `init` wrote (key 7).
+    #[derive(serde::Deserialize)]
+    struct TableHolderRepr {
+        entries: TableHandle,
+    }
+    let handle = h
+        .read_resource::<TableHolderRepr>(owner.address(), helper_struct("TableHolder"))
+        .expect("TableHolder must exist after init")
+        .entries;
+    let item = StateKey::table_item(&handle, &bcs::to_bytes(&7u64).unwrap());
+
+    let txns = vec![read_txn(
+        &mut h,
+        &reader,
+        "read_table_item",
+        owner.address(),
+    )];
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    assert!(
+        promoted.contains(&item),
+        "a read-only table item must be promoted"
+    );
+    assert!(!written.contains(&item));
+}
+
+fn setup_aggregator_v1() -> (MoveHarness, Account, StateKey) {
+    let (mut h, framework) = aggregator::initialize(common::test_dir_path("aggregator.data/pack"));
+    let txn = aggregator::new(&mut h, &framework, 0);
+    assert_success!(h.run(txn));
+
+    #[derive(serde::Deserialize)]
+    struct AggregatorStoreRepr {
+        aggregators: TableHandle,
+    }
+
+    let handle = h
+        .read_resource::<AggregatorStoreRepr>(
+            framework.address(),
+            parse_struct_tag("0x1::aggregator_test::AggregatorStore").unwrap(),
+        )
+        .expect("AggregatorStore must exist after initialize")
+        .aggregators;
+    let aggregator_item = StateKey::table_item(&handle, &bcs::to_bytes(&0u64).unwrap());
+    let aggregator_key = bcs::from_bytes::<AggregatorV1Resource>(
+        &h.read_state_value_bytes(&aggregator_item)
+            .expect("aggregator table item must exist"),
+    )
+    .expect("aggregator table item must deserialize")
+    .state_key();
+
+    (h, framework, aggregator_key)
+}
+
+/// Aggregator v1 reads materialize the value and therefore write the underlying aggregator key;
+/// the key must not be promoted separately by the block epilogue.
+#[test]
+fn test_aggregator_v1_materialized_read_excludes_promotion() {
+    let (mut h, framework, aggregator_key) = setup_aggregator_v1();
+    let txns = vec![Transaction::UserTransaction(aggregator::materialize(
+        &mut h, &framework, 0,
+    ))];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    assert!(
+        written.contains(&aggregator_key),
+        "materializing an aggregator v1 read must write the aggregator key",
+    );
+    assert!(
+        !promoted.contains(&aggregator_key),
+        "a materialized aggregator v1 read must not also promote the written key",
+    );
+}
+
+/// Aggregator v1 deltas count as writes, so delta-written aggregator keys are excluded from
+/// promotion.
+#[test]
+fn test_aggregator_v1_delta_write_excludes_promotion() {
+    let (mut h, framework, aggregator_key) = setup_aggregator_v1();
+    let txns = vec![Transaction::UserTransaction(aggregator::add(
+        &mut h, &framework, 0, 1,
+    ))];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    assert!(
+        written.contains(&aggregator_key),
+        "aggregator v1 add must write the aggregator key",
+    );
+    assert!(
+        !promoted.contains(&aggregator_key),
+        "an aggregator v1 key written by a delta in the block must not be promoted",
+    );
+}
+
+/// Mutating an aggregator-v2 field records an in-place delayed-field write to the enclosing
+/// resource slot. `storage_keys_written` enumerates those writes (unlike the old summary-based
+/// derivation), so the slot — though read to load the resource — must not be promoted.
+#[test]
+fn test_delayed_field_write_excludes_promotion() {
+    let (mut h, owner) = setup();
+    // Give the owner a `Counter` (aggregator-v2 field) in its own applied transaction.
+    assert_success!(h.run_entry_function(&owner, helper_fn("init_counter"), vec![], vec![]));
+    let bumper = h.new_account_with_key_pair();
+    let txns = vec![read_txn(&mut h, &bumper, "bump_counter", owner.address())];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    let counter = StateKey::resource(owner.address(), &helper_struct("Counter")).unwrap();
+    assert!(
+        written.contains(&counter),
+        "mutating the aggregator must write the Counter slot",
+    );
+    assert!(
+        !promoted.contains(&counter),
+        "a slot written via an in-place delayed-field change must not be promoted",
+    );
+}
+
+/// Modules executed by a transaction are reads; ones not (re)published in the block are promoted.
+/// Covers both the user module served from the state view and a framework module served from the
+/// global module cache (recorded via `ReadRecordingCodeStorage`).
+#[test]
+fn test_module_reads_are_promoted() {
+    let (mut h, owner) = setup();
+    let reader = h.new_account_with_key_pair();
+    let txns = vec![read_txn(&mut h, &reader, "read_only", owner.address())];
+
+    let (statuses, promoted, _written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    // User module, served from the state view.
+    assert!(promoted.contains(&StateKey::module(
+        &helper_address(),
+        ident_str!("read_helper")
+    )));
+    // Framework module, served from the global module cache.
+    assert!(promoted.contains(&StateKey::module(&AccountAddress::ONE, ident_str!("coin"))));
+}
+
+/// A module (re)published in the block is written, so it must be excluded from promotion even when
+/// another transaction in the same block executes (reads) it. Mirrors `test_module_reads_are_promoted`,
+/// where the same module — only read — is promoted.
+#[test]
+fn test_republished_module_not_promoted() {
+    let (mut h, publisher) = new_harness_with_package();
+    let owner = h.new_account_with_key_pair();
+    assert_success!(h.run_entry_function(&owner, helper_fn("init"), vec![], vec![]));
+    let reader = h.new_account_with_key_pair();
+
+    // One txn executes `read_helper` (recording its module as a read); a later txn republishes the
+    // package (a compatible upgrade, writing every module slot). The module is read and written in
+    // the same block.
+    let republish = h.create_publish_package(
+        &publisher,
+        &common::test_dir_path("hot_state.data/pack"),
+        None,
+        |_| {},
+    );
+    let txns = vec![
+        read_txn(&mut h, &reader, "read_plain", owner.address()),
+        Transaction::UserTransaction(republish),
+    ];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    let module = StateKey::module(&helper_address(), ident_str!("read_helper"));
+    assert!(
+        written.contains(&module),
+        "republishing must write the module slot",
+    );
+    assert!(
+        !promoted.contains(&module),
+        "a module written in the block must not be promoted, even though another txn read it",
+    );
+}
+
+/// On-chain configs read during the prologue/execution are promoted when the block does not write
+/// them.
+#[test]
+fn test_config_reads_are_promoted() {
+    let (mut h, owner) = setup();
+    let reader = h.new_account_with_key_pair();
+    let txns = vec![read_txn(&mut h, &reader, "read_only", owner.address())];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    for key in [
+        StateKey::on_chain_config::<ChainId>().unwrap(),
+        StateKey::on_chain_config::<CurrentTimeMicroseconds>().unwrap(),
+    ] {
+        assert!(promoted.contains(&key), "config {:?} must be promoted", key);
+        assert!(!written.contains(&key));
+    }
+}
+
+/// A key both read and written by the same transaction is excluded from promotion.
+#[test]
+fn test_written_key_in_same_txn_not_promoted() {
+    let (mut h, owner) = setup();
+    // `write_plain` reads (via `exists`) and then mutates the caller's own `Plain`.
+    let txns = vec![Transaction::UserTransaction(h.create_entry_function(
+        &owner,
+        helper_fn("write_plain"),
+        vec![],
+        vec![],
+    ))];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    let plain = StateKey::resource(owner.address(), &helper_struct("Plain")).unwrap();
+    assert!(
+        written.contains(&plain),
+        "the test must actually write the key"
+    );
+    assert!(
+        !promoted.contains(&plain),
+        "a key written in the block must not be promoted",
+    );
+}
+
+/// Block-level exclusion: a key read by one transaction but written by another in the same block is
+/// excluded from promotion.
+#[test]
+fn test_key_written_by_another_txn_not_promoted() {
+    let (mut h, owner) = setup();
+    let reader = h.new_account_with_key_pair();
+    let txns = vec![
+        read_txn(&mut h, &reader, "read_plain", owner.address()),
+        Transaction::UserTransaction(h.create_entry_function(
+            &owner,
+            helper_fn("write_plain"),
+            vec![],
+            vec![],
+        )),
+    ];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    let plain = StateKey::resource(owner.address(), &helper_struct("Plain")).unwrap();
+    assert!(written.contains(&plain));
+    assert!(
+        !promoted.contains(&plain),
+        "a key written by any txn in the block must not be promoted, even if another txn read it",
+    );
+}
+
+/// A discarded transaction commits no state changes, so the keys it read during its aborted
+/// prologue must not be promoted to hot state. Exercises both the parallel commit path (read set
+/// dropped in the VM wrapper) and the sequential one (the accumulator is fed only past the
+/// bcs-fallback discard point).
+#[test]
+fn test_discarded_txn_reads_not_promoted() {
+    let mut h = MoveHarness::new();
+    let alice = h.new_account_with_key_pair();
+    let bob = h.new_account_with_key_pair();
+    // Dave appears only in the transaction we force to discard, so his account resource is read by
+    // the aborted prologue but written by nothing in the block.
+    let dave = h.new_account_with_key_pair();
+
+    // A committed transfer, so the block has a real promotion set.
+    let good = Transaction::UserTransaction(h.create_transaction_payload(
+        &alice,
+        aptos_stdlib::aptos_account_transfer(*bob.address(), 100),
+    ));
+    // Sequence number one ahead of the account's: the prologue reads Dave's account resource, then
+    // aborts with SEQUENCE_NUMBER_TOO_NEW, discarding the transaction.
+    let discarded = Transaction::UserTransaction(
+        h.create_transaction_without_sign(
+            &dave,
+            aptos_stdlib::aptos_account_transfer(*bob.address(), 1),
+        )
+        .sequence_number(1)
+        .sign(),
+    );
+    let dave_account = StateKey::resource_typed::<AccountResource>(dave.address()).unwrap();
+
+    let (statuses, promoted, written) = promotions(&h, vec![good, discarded]);
+    // Guard against a vacuous test: the block must actually contain a discard.
+    assert!(
+        statuses
+            .iter()
+            .any(|status| matches!(status, TransactionStatus::Discard(_))),
+        "expected a discarded transaction, got {:?}",
+        statuses,
+    );
+    assert!(
+        !promoted.contains(&dave_account),
+        "a discarded transaction's reads must not be promoted",
+    );
+    // A discard writes nothing, so the key is absent on its own merits, not because it was written.
+    assert!(!written.contains(&dave_account));
+}
+
+/// Whole-block smoke test: mixed conflicting transfers plus a read-only call, asserting the broad
+/// invariant that every promoted key was read but not written, that reads of each kind surface, and
+/// that sequential and parallel execution agree.
+#[test]
+fn test_block_promotions_cover_reads_and_exclude_writes() {
+    let (mut h, _publisher) = new_harness_with_package();
+    let alice = h.new_account_with_key_pair();
+    let bob = h.new_account_with_key_pair();
+    // Charlie signs nothing in the block below, so nothing writes his account resource and the
+    // helper's read of it must surface as a promotion.
+    let charlie = h.new_account_with_key_pair();
+
+    let txns = vec![
+        Transaction::UserTransaction(h.create_transaction_payload(
+            &alice,
+            aptos_stdlib::aptos_account_transfer(*bob.address(), 100),
+        )),
+        Transaction::UserTransaction(h.create_transaction_payload(
+            &bob,
+            aptos_stdlib::aptos_account_transfer(*alice.address(), 50),
+        )),
+        read_txn(&mut h, &alice, "read_only", charlie.address()),
+    ];
+
+    let (statuses, promoted, written) = promotions(&h, txns);
+    assert_all_success(&statuses);
+
+    // Modules executed by the transactions are read but not written in this block, so they must be
+    // promoted (a framework module and the user-published one).
+    assert!(promoted.contains(&StateKey::module(
+        &AccountAddress::ONE,
+        ident_str!("aptos_account")
+    )));
+    assert!(promoted.contains(&StateKey::module(
+        &helper_address(),
+        ident_str!("read_helper")
+    )));
+
+    // The following are read but never written in this block, so they must be promoted.
+    for key in [
+        StateKey::on_chain_config::<ChainId>().unwrap(),
+        StateKey::on_chain_config::<CurrentTimeMicroseconds>().unwrap(),
+        StateKey::resource_typed::<AccountResource>(charlie.address()).unwrap(),
+        StateKey::resource_typed::<CoinInfoResource<AptosCoinType>>(&AccountAddress::ONE).unwrap(),
+    ] {
+        assert!(promoted.contains(&key), "Expected promotion for {:?}", key);
+    }
+
+    // The coin-to-fungible-asset conversion map is a table keyed by coin type, read for paired
+    // metadata lookups but never written in this block, so a table item must be promoted.
+    assert!(
+        promoted
+            .iter()
+            .any(|key| matches!(key.inner(), StateKeyInner::TableItem { .. })),
+        "Expected the coin conversion map table item to be promoted",
+    );
+
+    // Keys written in the block become hot at the version they are written, so promoting them again
+    // is redundant and they must not show up.
+    let promoted_and_written: Vec<_> = promoted.intersection(&written).collect();
+    assert!(
+        promoted_and_written.is_empty(),
+        "Promoted keys also written in the block: {:?}",
+        promoted_and_written,
+    );
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -39,6 +39,7 @@ mod gas_profiling;
 mod generate_upgrade_script;
 mod generic_cmp;
 mod governance_updates;
+mod hot_state;
 mod infinite_loop;
 mod init_module;
 mod init_module_closure_store;

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -300,6 +300,14 @@ impl BeforeMaterializationOutput<TestTransaction> for &TestOutput {
     fn get_write_summary(&self) -> HashSet<InputOutputKey<StateKey, StructTag>> {
         HashSet::new()
     }
+
+    fn storage_keys_read(&self) -> impl Iterator<Item = &StateKey> {
+        std::iter::empty()
+    }
+
+    fn storage_keys_written(&self) -> impl Iterator<Item = &StateKey> {
+        std::iter::empty()
+    }
 }
 
 impl AfterMaterializationOutput<TestTransaction> for &TestOutput {

--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -12,7 +12,7 @@ use aptos_forge::{
     EmitJobMode, EmitJobRequest, ForgeConfig, NodeResourceOverride,
 };
 use aptos_sdk::types::on_chain_config::{
-    BlockGasLimitType, OnChainConsensusConfig, OnChainExecutionConfig,
+    BlockGasLimitType, FeatureFlag, Features, OnChainConsensusConfig, OnChainExecutionConfig,
 };
 use aptos_testcases::{
     compatibility_test::SimpleValidatorUpgrade, framework_upgrade::FrameworkUpgrade,
@@ -41,6 +41,20 @@ pub(crate) fn get_land_blocking_test(
     Some(test)
 }
 
+fn compatibility_test_features() -> Features {
+    let mut features = Features::default();
+    // Keep mixed-version forge tests aligned with mainnet/testnet, where this
+    // feature is not enabled yet. When enabled, old and new binaries can
+    // disagree on the hotness portion of transaction outputs.
+    features.disable(FeatureFlag::HOTNESS_IN_EPILOGUE);
+    features
+}
+
+fn set_compatibility_test_features(helm_values: &mut serde_yaml::Value) {
+    helm_values["chain"]["initial_features_override"] =
+        serde_yaml::to_value(compatibility_test_features()).expect("must serialize");
+}
+
 pub(crate) fn compat() -> ForgeConfig {
     ForgeConfig::default()
         .with_suite_name("compat".into())
@@ -50,6 +64,7 @@ pub(crate) fn compat() -> ForgeConfig {
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             helm_values["chain"]["epoch_duration_secs"] =
                 SimpleValidatorUpgrade::EPOCH_DURATION_SECS.into();
+            set_compatibility_test_features(helm_values);
         }))
 }
 
@@ -61,6 +76,7 @@ pub(crate) fn framework_upgrade() -> ForgeConfig {
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             helm_values["chain"]["epoch_duration_secs"] =
                 FrameworkUpgrade::EPOCH_DURATION_SECS.into();
+            set_compatibility_test_features(helm_values);
         }))
         .with_emit_job(mixed_compatible_emit_job())
 }

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -47,7 +47,9 @@ pub use storage::{
         unsync_code_storage::{AsUnsyncCodeStorage, UnsyncCodeStorage},
         unsync_module_storage::{AsUnsyncModuleStorage, BorrowedOrOwned, UnsyncModuleStorage},
     },
-    layout_cache::{LayoutCache, LayoutCacheEntry, NoOpLayoutCache, StructKey},
+    layout_cache::{
+        ambassador_impl_LayoutCache, LayoutCache, LayoutCacheEntry, NoOpLayoutCache, StructKey,
+    },
     loader::{
         eager::EagerLoader,
         lazy::LazyLoader,

--- a/third_party/move/move-vm/runtime/src/storage/layout_cache.rs
+++ b/third_party/move/move-vm/runtime/src/storage/layout_cache.rs
@@ -18,6 +18,7 @@
 //!   2. Arguably, we need layouts for root-like values only (e.g., those with `key` ability).
 
 use crate::LayoutWithDelayedFields;
+use ambassador::delegatable_trait;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::language_storage::ModuleId;
 use move_vm_types::{loaded_data::struct_name_indexing::StructNameIndex, ty_interner::TypeVecId};
@@ -94,6 +95,7 @@ pub struct StructKey {
 }
 
 /// Interface for fetching and storing layouts into the cache.
+#[delegatable_trait]
 pub trait LayoutCache {
     /// If layout root is cached, returns the cached entry (with the modules that were used to
     /// construct it). The reader must ensure to read the module-set for gas charging of validation


### PR DESCRIPTION

The module read recorder called StateKey::module() on every module
fetch, and the VM fetches the same modules many times per transaction.
Each call hits the global StateKey registry's per-shard RwLock, whose
read acquire/release atomics dominate the recording cost under parallel
execution (per profiling).

Accumulate module reads as deduplicated (address, name) ids and intern
them into StateKeys once, when the read set is extracted. Repeated
fetches of an already-seen module then do only a borrowed HashSet lookup
and never reach the registry. The recorded read set is unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
