### PR TITLE
[types] Derive state-key shard index from array length

### DIFF
--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -238,8 +238,8 @@ impl StateKeyRegistry {
         struct_tag: &StructTag,
         address: &AccountAddress,
     ) -> &TwoKeyRegistry<StructTag, AccountAddress> {
-        &self.resource_shards
-            [Self::hash_address_and_name(address, struct_tag.name.as_bytes()) % NUM_RESOURCE_SHARDS]
+        &self.resource_shards[Self::hash_address_and_name(address, struct_tag.name.as_bytes())
+            % self.resource_shards.len()]
     }
 
     pub(crate) fn resource_group(
@@ -250,7 +250,7 @@ impl StateKeyRegistry {
         &self.resource_group_shards[Self::hash_address_and_name(
             address,
             struct_tag.name.as_bytes(),
-        ) % NUM_RESOURCE_GROUP_SHARDS]
+        ) % self.resource_group_shards.len()]
     }
 
     pub(crate) fn module(
@@ -259,7 +259,7 @@ impl StateKeyRegistry {
         name: &IdentStr,
     ) -> &TwoKeyRegistry<AccountAddress, Identifier> {
         &self.module_shards
-            [Self::hash_address_and_name(address, name.as_bytes()) % NUM_MODULE_SHARDS]
+            [Self::hash_address_and_name(address, name.as_bytes()) % self.module_shards.len()]
     }
 
     pub(crate) fn table_item(
@@ -267,11 +267,13 @@ impl StateKeyRegistry {
         handle: &TableHandle,
         key: &[u8],
     ) -> &TwoKeyRegistry<TableHandle, Vec<u8>> {
-        &self.table_item_shards[Self::hash_address_and_name(&handle.0, key) % NUM_MODULE_SHARDS]
+        &self.table_item_shards
+            [Self::hash_address_and_name(&handle.0, key) % self.table_item_shards.len()]
     }
 
     pub(crate) fn raw(&self, bytes: &[u8]) -> &TwoKeyRegistry<Vec<u8>, ()> {
-        &self.raw_shards[Self::hash_address_and_name(&AccountAddress::ONE, bytes) % NUM_RAW_SHARDS]
+        &self.raw_shards
+            [Self::hash_address_and_name(&AccountAddress::ONE, bytes) % self.raw_shards.len()]
     }
 
     pub(crate) fn position(
@@ -284,6 +286,6 @@ impl StateKeyRegistry {
         hasher.write_u8(exchange.as_ref()[AccountAddress::LENGTH - 1]);
         hasher.write_u8(account.as_ref()[AccountAddress::LENGTH - 1]);
         hasher.write_u8(market.as_ref()[AccountAddress::LENGTH - 1]);
-        &self.position_shards[hasher.finish() as usize % NUM_POSITION_SHARDS]
+        &self.position_shards[hasher.finish() as usize % self.position_shards.len()]
     }
 }


### PR DESCRIPTION

`table_item()` indexes into `table_item_shards` but took the modulo
with `NUM_MODULE_SHARDS` instead of `NUM_TABLE_ITEM_SHARDS`. This is
benign today because both constants are 8, but it's a latent bug:
tuning one shard count on its own could push the index out of bounds
(panic) or leave shards unused.

The underlying problem is that every accessor hand-pairs a shard array
with a separately-named modulo constant, and nothing forces the two to
agree. Instead of just correcting the one mismatch, take the modulo
against the array's own `.len()` in all accessors, so the divisor is
always correct by construction and this class of mismatch cannot recur.

`len()` on a fixed-size array is a compile-time constant, so codegen is
unchanged. The `NUM_*_SHARDS` constants stay as the single source of
each shard count, through the array types.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged while shard counts stay equal; only indexing logic is made self-consistent with no API or persistence changes.
> 
> **Overview**
> **State key registry** shard routing now takes the modulo against each shard array’s own `.len()` instead of separately named `NUM_*_SHARDS` constants.
> 
> That fixes a latent bug in `table_item()`, which indexed `table_item_shards` with `NUM_MODULE_SHARDS` (same value today, but wrong if counts diverge). The same pattern is applied to `resource`, `resource_group`, `module`, `raw`, and `position` so the divisor always matches the array by construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5cc7beba4c2101e884117829feb7f3bfba7cd31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->