### PR TITLE
Block-STM V2 Fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10036,6 +10036,7 @@ dependencies = [
  "move-core-types",
  "move-transactional-test-runner",
  "move-vm-runtime",
+ "move-vm-test-utils",
  "move-vm-types",
  "once_cell",
  "primitive-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10019,6 +10019,7 @@ dependencies = [
  "aptos-consensus",
  "aptos-crypto",
  "aptos-framework",
+ "aptos-keygen",
  "aptos-language-e2e-tests",
  "aptos-transaction-simulation",
  "aptos-types",

--- a/aptos-move/aptos-vm-environment/Cargo.toml
+++ b/aptos-move/aptos-vm-environment/Cargo.toml
@@ -42,3 +42,6 @@ triomphe = { workspace = true }
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["testing", "fuzzing"] }
 serde = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -24,9 +24,22 @@ use aptos_vm_types::storage::StorageGasParameters;
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
 use move_vm_runtime::{config::VMConfig, RuntimeEnvironment, WithRuntimeEnvironment};
+#[cfg(fuzzing)]
+use once_cell::sync::OnceCell;
 use sha3::{Digest, Sha3_256};
 use std::sync::Arc;
 use triomphe::Arc as TriompheArc;
+
+#[cfg(fuzzing)]
+type FuzzVmConfigOverride = Box<dyn Fn(&mut VMConfig) + Send + Sync>;
+
+#[cfg(fuzzing)]
+static FUZZ_VM_CONFIG_OVERRIDE: OnceCell<FuzzVmConfigOverride> = OnceCell::new();
+
+#[cfg(fuzzing)]
+pub fn set_vm_config_override_for_fuzzing(override_config: FuzzVmConfigOverride) {
+    FUZZ_VM_CONFIG_OVERRIDE.set(override_config).ok();
+}
 
 /// A runtime environment which can be used for VM initialization and more. Contains features
 /// used by execution, gas parameters, VM configs and global caches. Note that it is the user's
@@ -276,6 +289,14 @@ impl Environment {
             &timed_features,
             ty_builder,
         );
+        #[cfg(fuzzing)]
+        let vm_config = {
+            let mut vm_config = vm_config;
+            if let Some(override_config) = FUZZ_VM_CONFIG_OVERRIDE.get() {
+                override_config(&mut vm_config);
+            }
+            vm_config
+        };
         let runtime_environment = RuntimeEnvironment::new_with_config(natives, vm_config);
 
         // We use an `Option` to handle the VK not being set on-chain, or an incorrect VK being set

--- a/aptos-move/block-executor/src/code_cache_global_manager.rs
+++ b/aptos-move/block-executor/src/code_cache_global_manager.rs
@@ -29,6 +29,8 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress, ident_str, language_storage::ModuleId, vm_status::VMStatus,
 };
+#[cfg(fuzzing)]
+use move_vm_runtime::RuntimeEnvironmentSnapshot;
 use move_vm_runtime::{Module, ModuleStorage, RuntimeEnvironment, WithRuntimeEnvironment};
 use move_vm_types::code::WithSize;
 use parking_lot::{Mutex, MutexGuard};
@@ -49,12 +51,14 @@ macro_rules! alert_or_println {
     };
 }
 
-#[cfg(fuzzing)]
 /// This snapshot of the global module cache for fuzzing allows comparison of parallel and sequential
 /// executions of the same block. It captures the cache state before the block is executed for the first
 /// time and rolls it back afterwards.
-pub type ModuleHotCacheSnapshot =
-    GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension>;
+#[cfg(fuzzing)]
+pub struct ModuleHotCacheSnapshot {
+    module_cache: GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension>,
+    runtime_environment: RuntimeEnvironmentSnapshot,
+}
 
 /// Manages module caches and the execution environment, possibly across multiple blocks.
 pub struct ModuleCacheManager<K, D, V, E> {
@@ -327,17 +331,27 @@ impl AptosModuleCacheManagerGuard<'_> {
     }
 
     /// Takes a shallow snapshot of the current global module cache (hot cache).
-    /// Only available under fuzzing. The snapshot shares underlying Arc module code.
+    /// Only available under fuzzing. The snapshot shares underlying Arc module code and restores the
+    /// runtime interner/tag caches that cached modules/layouts index into.
     #[cfg(fuzzing)]
     pub fn snapshot_hot_cache(&self) -> ModuleHotCacheSnapshot {
-        self.module_cache().clone_for_fuzzing()
+        ModuleHotCacheSnapshot {
+            module_cache: self.module_cache().clone_for_fuzzing(),
+            runtime_environment: self
+                .environment()
+                .runtime_environment()
+                .snapshot_caches_for_fuzzing(),
+        }
     }
 
-    /// Rolls back the global module cache to a previously captured snapshot.
+    /// Rolls back the global module cache and runtime cache state to a previously captured snapshot.
     /// Only available under fuzzing.
     #[cfg(fuzzing)]
     pub fn rollback_hot_cache(&mut self, snapshot: ModuleHotCacheSnapshot) {
-        *self.module_cache_mut() = snapshot;
+        self.environment()
+            .runtime_environment()
+            .restore_caches_for_fuzzing(snapshot.runtime_environment);
+        *self.module_cache_mut() = snapshot.module_cache;
     }
 }
 

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -82,6 +82,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "move_aptosvm_blockstm_v2_compare"
+path = "fuzz_targets/move/aptosvm_blockstm_v2_compare.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "u256_diff_fuzz"
 path = "fuzz_targets/u256_diff_fuzz.rs"
 test = false
@@ -96,6 +102,7 @@ aptos-cached-packages = { workspace = true }
 aptos-consensus = { workspace = true, features = ["fuzzing"], optional = true }
 aptos-crypto = { workspace = true }
 aptos-framework = { workspace = true }
+aptos-keygen = { workspace = true }
 aptos-language-e2e-tests = { workspace = true, features = ["fuzzing"] }
 aptos-transaction-simulation = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -88,6 +88,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "move_movevm_blockv2_direct"
+path = "fuzz_targets/move/movevm_blockv2_direct.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "u256_diff_fuzz"
 path = "fuzz_targets/u256_diff_fuzz.rs"
 test = false
@@ -119,6 +125,7 @@ move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true, features = ["fuzzing"] }
 move-transactional-test-runner = { workspace = true, features = ["fuzzing"] }
 move-vm-runtime = { workspace = true }
+move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true, features = ["fuzzing"] }
 once_cell = { workspace = true }
 primitive-types = { workspace = true }

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_blockstm_v2_compare.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_blockstm_v2_compare.rs
@@ -1,0 +1,1158 @@
+#![no_main]
+#![allow(unexpected_cfgs)]
+
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+#[cfg(fuzzing)]
+use aptos_block_executor::code_cache_global_manager::ModuleHotCacheSnapshot;
+use aptos_block_executor::{
+    code_cache_global_manager::{AptosModuleCacheManager, AptosModuleCacheManagerGuard},
+    txn_commit_hook::NoOpTransactionCommitHook,
+    txn_provider::default::DefaultTxnProvider,
+};
+use aptos_crypto::HashValue;
+use aptos_transaction_simulation::{
+    Account, SimulationStateStore, TransactionBuilder, GENESIS_CHANGE_SET_HEAD,
+};
+use aptos_types::{
+    account_address::AccountAddress,
+    block_executor::{
+        config::{
+            BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig,
+            BlockExecutorModuleCacheLocalConfig,
+        },
+        transaction_slice_metadata::TransactionSliceMetadata,
+    },
+    chain_id::ChainId,
+    on_chain_config::{BlockGasLimitType, FeatureFlag, Features, TimedFeaturesBuilder},
+    transaction::{
+        signature_verified_transaction::into_signature_verified_block, AuxiliaryInfo,
+        EntryFunction, ExecutionStatus, PersistedAuxiliaryInfo, ReplayProtector, Script,
+        SignedTransaction, Transaction, TransactionArgument, TransactionOutput, TransactionPayload,
+        TransactionStatus,
+    },
+    vm_status::{StatusCode, StatusType, VMStatus},
+    write_set::WriteSet,
+};
+use aptos_vm::block_executor::AptosVMBlockExecutorWrapper;
+#[cfg(fuzzing)]
+use aptos_vm_environment::environment::set_vm_config_override_for_fuzzing;
+use aptos_vm_environment::{prod_configs, prod_configs::LATEST_GAS_FEATURE_VERSION};
+use blockstm_executor::{assert_outputs_equal, BlockFuzzExecutor};
+use blockv2_fuzz_config::{
+    apply_verifier_config_overrides, env_optional_bool, env_optional_u32, env_optional_u64,
+    env_optional_usize, env_u64, module_cache_config_from_env,
+};
+use fuzzer::{BlockExecVariantV2, RunnableBlockStateV2, RunnableBlockTransactionV2, UserAccount};
+use libfuzzer_sys::{fuzz_target, Corpus};
+use move_binary_format::{
+    access::ModuleAccess,
+    deserializer::DeserializerConfig,
+    file_format::{CompiledModule, ModuleHandle, Signature, SignatureToken},
+    file_format_common::VERSION_MAX,
+    internals::ModuleIndex,
+};
+use move_core_types::language_storage::ModuleId;
+use once_cell::sync::Lazy;
+use std::{
+    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap},
+    env,
+    hash::Hash,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+mod blockstm_executor;
+mod blockv2_fuzz_config;
+mod utils;
+use utils::vm::{
+    group_modules_by_address_topo, publish_transaction_payload_with_package_names,
+    resolve_function_name, script_bytecode_version, verify_module_fast, verify_script_fast,
+};
+
+#[cfg(fuzzing)]
+type HotCacheSnapshot = ModuleHotCacheSnapshot;
+#[cfg(not(fuzzing))]
+struct HotCacheSnapshot;
+
+static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
+// A single module cache manager and version counter are shared by both the sequential and the
+// Block-STM v2 executions of each fuzz case. Using one manager (rather than one per mode) keeps the
+// Aptos framework hot-loaded in the global module cache while guaranteeing that both executions see
+// an identical execution environment. The framework's verified modules are bound to the environment
+// they were verified under (interned struct names, type pool, verifier cache), so the framework can
+// only stay warm if its environment is kept; the snapshot/rollback below resets everything else (the
+// fuzz case's own published modules) to a clean framework-only baseline before each execution.
+//
+// Two independent managers would each accumulate their own interned/verified state across fuzz
+// iterations and drift apart, making the sequential-vs-v2 comparison non-hermetic (e.g. spurious
+// divergences that only reproduce deep into a fuzzing session, never on the input in isolation).
+static MODULE_CACHE_MANAGER: Lazy<AptosModuleCacheManager> =
+    Lazy::new(AptosModuleCacheManager::new);
+static NEXT_VERSION: AtomicU64 = AtomicU64::new(1);
+
+const MIN_CONCURRENCY_LEVEL: usize = 2;
+const MAX_CONCURRENCY_LEVEL: usize = 8;
+const MAX_BLOCK_ACCOUNTS: usize = 256;
+const MAX_BLOCK_MODULES: usize = 32;
+const MAX_BLOCK_MODULE_REFS: usize = 32;
+const MAX_BLOCK_TXNS: usize = 24;
+const MAX_SECONDARY_SIGNERS: usize = 10;
+const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16;
+const DEFAULT_GAS_UNIT_PRICE: u64 = 100;
+const DEFAULT_MAX_GAS_AMOUNT: u64 = 2_000_000;
+
+static FUZZ_GAS_UNIT_PRICE: Lazy<u64> =
+    Lazy::new(|| env_u64("APTOS_FUZZ_GAS_UNIT_PRICE", DEFAULT_GAS_UNIT_PRICE));
+static FUZZ_MAX_GAS_AMOUNT: Lazy<u64> =
+    Lazy::new(|| env_u64("APTOS_FUZZ_MAX_GAS_AMOUNT", DEFAULT_MAX_GAS_AMOUNT));
+static FUZZ_EFFECTIVE_BLOCK_GAS_LIMIT: Lazy<Option<u64>> =
+    Lazy::new(|| env_optional_u64("APTOS_FUZZ_EFFECTIVE_BLOCK_GAS_LIMIT"));
+static FUZZ_BLOCK_OUTPUT_LIMIT: Lazy<Option<u64>> =
+    Lazy::new(|| env_optional_u64("APTOS_FUZZ_BLOCK_OUTPUT_LIMIT"));
+static FUZZ_CONFLICT_PENALTY_WINDOW: Lazy<Option<u32>> =
+    Lazy::new(|| env_optional_u32("APTOS_FUZZ_CONFLICT_PENALTY_WINDOW"));
+static FUZZ_EXECUTION_GAS_EFFECTIVE_MULTIPLIER: Lazy<Option<u64>> =
+    Lazy::new(|| env_optional_u64("APTOS_FUZZ_EXECUTION_GAS_EFFECTIVE_MULTIPLIER"));
+static FUZZ_IO_GAS_EFFECTIVE_MULTIPLIER: Lazy<Option<u64>> =
+    Lazy::new(|| env_optional_u64("APTOS_FUZZ_IO_GAS_EFFECTIVE_MULTIPLIER"));
+static FUZZ_USE_GRANULAR_RESOURCE_GROUP_CONFLICTS: Lazy<Option<bool>> =
+    Lazy::new(|| env_optional_bool("APTOS_FUZZ_USE_GRANULAR_RESOURCE_GROUP_CONFLICTS"));
+static FUZZ_MAX_IDENTIFIER_SIZE: Lazy<Option<u64>> =
+    Lazy::new(|| env_optional_u64("APTOS_FUZZ_MAX_IDENTIFIER_SIZE"));
+static FUZZ_MAX_CONCURRENCY_LEVEL: Lazy<usize> = Lazy::new(|| {
+    let max_concurrency =
+        env_optional_usize("APTOS_FUZZ_MAX_CONCURRENCY_LEVEL").unwrap_or(MAX_CONCURRENCY_LEVEL);
+    assert!(
+        max_concurrency >= MIN_CONCURRENCY_LEVEL,
+        "APTOS_FUZZ_MAX_CONCURRENCY_LEVEL must be at least {MIN_CONCURRENCY_LEVEL}"
+    );
+    max_concurrency
+});
+static FUZZ_ALLOW_FALLBACK: Lazy<bool> =
+    Lazy::new(|| env_optional_bool("APTOS_FUZZ_ALLOW_FALLBACK").unwrap_or(false));
+static FUZZ_ASYNC_RUNTIME_CHECKS: Lazy<bool> =
+    Lazy::new(|| env_optional_bool("APTOS_FUZZ_ASYNC_RUNTIME_CHECKS").unwrap_or(true));
+static FUZZ_PARANOID_REF_CHECKS: Lazy<bool> =
+    Lazy::new(|| env_optional_bool("APTOS_FUZZ_PARANOID_REF_CHECKS").unwrap_or(true));
+#[cfg(fuzzing)]
+static CONFIGURE_FUZZ_VM_CONFIG: Lazy<()> = Lazy::new(|| {
+    set_vm_config_override_for_fuzzing(Box::new(blockv2_fuzz_config::apply_vm_config_overrides));
+});
+#[cfg(not(fuzzing))]
+static CONFIGURE_FUZZ_VM_CONFIG: Lazy<()> = Lazy::new(|| {});
+static FUZZ_ENABLE_LAYOUT_CACHES: Lazy<bool> = Lazy::new(|| {
+    env_optional_bool("APTOS_FUZZ_ENABLE_LAYOUT_CACHES")
+        .unwrap_or_else(|| env::var_os("APTOS_FUZZ_MAX_LAYOUT_CACHE_SIZE").is_some())
+});
+static FUZZ_MODULE_CACHE_CONFIG: Lazy<BlockExecutorModuleCacheLocalConfig> =
+    Lazy::new(module_cache_config_from_env);
+
+/// Which executor lane(s) each fuzz case exercises, chosen via the `FUZZER_EXEC_MODE` environment
+/// variable (default `v2+seq`):
+///   - `v2+seq`: run Block-STM v2 (parallel) and sequential, assert their outputs match.
+///   - `seq`:    run sequential only (no comparison; just status/invariant checks).
+///   - `v2`:     run Block-STM v2 (parallel) only.
+#[derive(Clone, Copy)]
+enum ExecMode {
+    V2AndSeq,
+    Seq,
+    V2,
+}
+
+static EXEC_MODE: Lazy<ExecMode> = Lazy::new(|| {
+    let raw = env::var("FUZZER_EXEC_MODE").unwrap_or_else(|_| "v2+seq".to_string());
+    match raw.as_str() {
+        "v2+seq" => ExecMode::V2AndSeq,
+        "seq" => ExecMode::Seq,
+        "v2" => ExecMode::V2,
+        other => panic!("unknown FUZZER_EXEC_MODE={other:?}; expected one of: v2+seq, seq, v2"),
+    }
+});
+
+fn require_fuzzing_cfg() {
+    #[cfg(not(fuzzing))]
+    {
+        eprintln!(
+            "move_aptosvm_blockstm_v2_compare must be built with cfg(fuzzing); \
+             refusing to run a non-fuzzing build"
+        );
+        std::process::abort();
+    }
+}
+
+fn next_metadata(counter: &AtomicU64) -> TransactionSliceMetadata {
+    let end = counter.fetch_add(1, Ordering::Relaxed);
+    TransactionSliceMetadata::chunk(end - 1, end)
+}
+
+fn module_self_handle(module: &CompiledModule) -> Option<&ModuleHandle> {
+    module
+        .module_handles
+        .get(module.self_module_handle_idx.into_index())
+}
+
+fn module_self_id(module: &CompiledModule) -> Option<ModuleId> {
+    let handle = module_self_handle(module)?;
+    let address = module
+        .address_identifiers
+        .get(handle.address.into_index())
+        .copied()?;
+    let name = module.identifiers.get(handle.name.into_index())?.to_owned();
+    Some(ModuleId::new(address, name))
+}
+
+fn checked_module_self_id(module: &CompiledModule) -> ModuleId {
+    module_self_id(module).expect("module self id checked at fuzz case boundary")
+}
+
+fn signature_token_is_too_large(token: &SignatureToken) -> bool {
+    match token {
+        SignatureToken::TypeParameter(idx) => *idx > MAX_TYPE_PARAMETER_VALUE,
+        SignatureToken::Vector(inner)
+        | SignatureToken::Reference(inner)
+        | SignatureToken::MutableReference(inner) => signature_token_is_too_large(inner),
+        SignatureToken::StructInstantiation(_, tys) => tys.iter().any(signature_token_is_too_large),
+        SignatureToken::Function(args, results, _) => {
+            args.iter().any(signature_token_is_too_large)
+                || results.iter().any(signature_token_is_too_large)
+        },
+        _ => false,
+    }
+}
+
+fn has_oversized_signatures(signatures: &[Signature]) -> bool {
+    signatures
+        .iter()
+        .any(|signature| signature.0.iter().any(signature_token_is_too_large))
+}
+
+fn filter_bad_tx(exec_variant: &BlockExecVariantV2) -> Result<(), Corpus> {
+    match exec_variant {
+        BlockExecVariantV2::Script { _script, .. } => {
+            if has_oversized_signatures(&_script.signatures) {
+                return Err(Corpus::Keep);
+            }
+            Ok(())
+        },
+        BlockExecVariantV2::Publish { _module_idxs } => {
+            if _module_idxs.is_empty() {
+                return Err(Corpus::Keep);
+            }
+            Ok(())
+        },
+        BlockExecVariantV2::CallFunction { .. } => Ok(()),
+        BlockExecVariantV2::SplitBlock => Ok(()),
+    }
+}
+
+fn create_user_account(vm: &mut BlockFuzzExecutor, account: UserAccount) -> Account {
+    if account.is_inited_and_funded {
+        vm.create_accounts(1, account.fund_amount(), 0).remove(0)
+    } else {
+        vm.new_unfunded_account()
+    }
+}
+
+fn slot_account(accounts: &[Account], slot: u8) -> &Account {
+    assert!(
+        !accounts.is_empty(),
+        "account slots checked at fuzz case boundary"
+    );
+    &accounts[slot as usize % accounts.len()]
+}
+
+fn publish_modules_sender(modules: &[CompiledModule]) -> Result<AccountAddress, Corpus> {
+    let sender = *modules.first().ok_or(Corpus::Keep)?.address();
+    if modules.iter().any(|module| module.address() != &sender) {
+        return Err(Corpus::Keep);
+    }
+    Ok(sender)
+}
+
+fn ensure_account_at<'a>(
+    vm: &mut BlockFuzzExecutor,
+    accounts_by_address: &'a mut HashMap<AccountAddress, Account>,
+    address: AccountAddress,
+) -> &'a Account {
+    accounts_by_address
+        .entry(address)
+        .or_insert_with(|| vm.new_account_at(address))
+}
+
+fn next_sequence_number<K: Copy + Eq + Hash>(sequences: &mut HashMap<K, u64>, key: K) -> u64 {
+    let next = sequences.entry(key).or_insert(0);
+    *next += 1;
+    *next - 1
+}
+
+fn transaction_builder(sender: &Account, replay_protector: ReplayProtector) -> TransactionBuilder {
+    let builder = sender
+        .transaction()
+        .gas_unit_price(*FUZZ_GAS_UNIT_PRICE)
+        .max_gas_amount(*FUZZ_MAX_GAS_AMOUNT);
+    match replay_protector {
+        ReplayProtector::SequenceNumber(sequence_number) => {
+            builder.sequence_number(sequence_number)
+        },
+        ReplayProtector::Nonce(_) => builder,
+    }
+}
+
+fn apply_replay_protector(
+    payload: TransactionPayload,
+    replay_protector: ReplayProtector,
+) -> TransactionPayload {
+    match replay_protector {
+        ReplayProtector::SequenceNumber(_) => payload,
+        ReplayProtector::Nonce(nonce) => payload.set_replay_protection_nonce(nonce),
+    }
+}
+
+fn next_replay_protector(
+    orderless: bool,
+    sequence_by_address: &mut HashMap<AccountAddress, u64>,
+    nonce_by_address: &mut HashMap<AccountAddress, u64>,
+    sender: AccountAddress,
+) -> ReplayProtector {
+    if orderless {
+        ReplayProtector::Nonce(next_sequence_number(nonce_by_address, sender))
+    } else {
+        ReplayProtector::SequenceNumber(next_sequence_number(sequence_by_address, sender))
+    }
+}
+
+fn secondary_signer_accounts(
+    slot_accounts: &[Account],
+    secondary_slots: &[u8],
+) -> Result<Vec<Account>, Corpus> {
+    if secondary_slots.len() > MAX_SECONDARY_SIGNERS {
+        return Err(Corpus::Keep);
+    }
+    Ok(secondary_slots
+        .iter()
+        .map(|slot| slot_account(slot_accounts, *slot).clone())
+        .collect())
+}
+
+fn build_signed_transaction(
+    vm: &mut BlockFuzzExecutor,
+    modules: &[CompiledModule],
+    slot_accounts: &[Account],
+    accounts_by_address: &mut HashMap<AccountAddress, Account>,
+    sequence_by_address: &mut HashMap<AccountAddress, u64>,
+    nonce_by_address: &mut HashMap<AccountAddress, u64>,
+    package_names_by_module: &BTreeMap<ModuleId, String>,
+    input: &RunnableBlockTransactionV2,
+) -> Result<SignedTransaction, Corpus> {
+    // Sequence numbers are bumped eagerly: any error below rejects the entire fuzz case, so the
+    // sequence maps are never observed in a half-updated state.
+    let (sender_acc, payload) = match &input.exec_variant {
+        BlockExecVariantV2::Script {
+            _script,
+            _type_args,
+            _args,
+        } => {
+            let mut script_bytes = vec![];
+            _script
+                .serialize_for_version(Some(script_bytecode_version(_script)), &mut script_bytes)
+                .map_err(|_| Corpus::Keep)?;
+            let args = _args
+                .iter()
+                .cloned()
+                .map(TransactionArgument::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Corpus::Keep)?;
+            let sender_acc = slot_account(slot_accounts, input.sender_slot).clone();
+            (
+                sender_acc,
+                TransactionPayload::Script(Script::new(script_bytes, _type_args.clone(), args)),
+            )
+        },
+        BlockExecVariantV2::CallFunction {
+            _module_idx,
+            _function,
+            _type_args,
+            _args,
+        } => {
+            let module = resolve_module_ref(modules, *_module_idx)?;
+            let module_id = checked_module_self_id(module);
+            let function_name = resolve_function_name(module, *_function)?;
+            let sender_acc = slot_account(slot_accounts, input.sender_slot).clone();
+            (
+                sender_acc,
+                TransactionPayload::EntryFunction(EntryFunction::new(
+                    module_id,
+                    function_name,
+                    _type_args.clone(),
+                    _args.clone(),
+                )),
+            )
+        },
+        BlockExecVariantV2::Publish { _module_idxs } => {
+            let _modules = resolve_module_refs(modules, _module_idxs)?;
+            let sender = publish_modules_sender(&_modules)?;
+            let package_name = package_name_for_modules(&_modules, package_names_by_module);
+            let sender_acc = ensure_account_at(vm, accounts_by_address, sender).clone();
+            (
+                sender_acc,
+                publish_transaction_payload_with_package_names(
+                    &_modules,
+                    package_name,
+                    package_names_by_module,
+                ),
+            )
+        },
+        BlockExecVariantV2::SplitBlock => {
+            unreachable!("split transactions have alredy been removed")
+        },
+    };
+
+    let replay_protector = next_replay_protector(
+        input.orderless,
+        sequence_by_address,
+        nonce_by_address,
+        *sender_acc.address(),
+    );
+    let payload = apply_replay_protector(payload, replay_protector);
+    let raw_tx = transaction_builder(&sender_acc, replay_protector)
+        .payload(payload)
+        .raw();
+    let signed = if let Some(fee_payer_slot) = input.fee_payer_slot {
+        let secondary = secondary_signer_accounts(slot_accounts, &input.secondary_slots)?;
+        let fee_payer = slot_account(slot_accounts, fee_payer_slot).clone();
+        raw_tx
+            .sign_fee_payer(
+                &sender_acc.privkey,
+                secondary.iter().map(|acc| *acc.address()).collect(),
+                secondary.iter().map(|acc| &acc.privkey).collect(),
+                *fee_payer.address(),
+                &fee_payer.privkey,
+            )
+            .map_err(|_| Corpus::Keep)?
+            .into_inner()
+    } else if input.secondary_slots.is_empty() {
+        raw_tx
+            .sign(
+                &sender_acc.privkey,
+                sender_acc.pubkey.as_ed25519().expect("ed25519 public key"),
+            )
+            .map_err(|_| Corpus::Keep)?
+            .into_inner()
+    } else {
+        let secondary = secondary_signer_accounts(slot_accounts, &input.secondary_slots)?;
+        raw_tx
+            .sign_multi_agent(
+                &sender_acc.privkey,
+                secondary.iter().map(|acc| *acc.address()).collect(),
+                secondary.iter().map(|acc| &acc.privkey).collect(),
+            )
+            .map_err(|_| Corpus::Keep)?
+            .into_inner()
+    };
+    Ok(signed)
+}
+
+fn build_publish_transaction(
+    vm: &mut BlockFuzzExecutor,
+    accounts_by_address: &mut HashMap<AccountAddress, Account>,
+    sequence_by_address: &mut HashMap<AccountAddress, u64>,
+    package_names_by_module: &BTreeMap<ModuleId, String>,
+    modules: &[CompiledModule],
+) -> Result<SignedTransaction, Corpus> {
+    let sender = publish_modules_sender(modules)?;
+    let package_name = package_name_for_modules(modules, package_names_by_module);
+    let sequence = next_sequence_number(sequence_by_address, sender);
+    let publisher = ensure_account_at(vm, accounts_by_address, sender);
+    Ok(
+        transaction_builder(publisher, ReplayProtector::SequenceNumber(sequence))
+            .payload(publish_transaction_payload_with_package_names(
+                modules,
+                package_name,
+                package_names_by_module,
+            ))
+            .sign(),
+    )
+}
+
+fn apply_fuzz_feature_overrides(features: &mut Features) {
+    // known false positives with this feature:
+    features.disable(FeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL);
+}
+
+fn configure_fuzz_features(vm: &BlockFuzzExecutor) {
+    let mut features = vm.state_store().get_features().unwrap_or_default();
+    apply_fuzz_feature_overrides(&mut features);
+    vm.state_store().set_features(features).unwrap();
+}
+
+fn onchain_config() -> BlockExecutorConfigFromOnchain {
+    let mut config = BlockExecutorConfigFromOnchain::on_but_large_for_test();
+
+    match &mut config.block_gas_limit_type {
+        BlockGasLimitType::ComplexLimitV1 {
+            effective_block_gas_limit,
+            execution_gas_effective_multiplier,
+            io_gas_effective_multiplier,
+            conflict_penalty_window,
+            use_granular_resource_group_conflicts,
+            block_output_limit,
+            ..
+        } => {
+            if let Some(limit) = *FUZZ_EFFECTIVE_BLOCK_GAS_LIMIT {
+                *effective_block_gas_limit = limit;
+            }
+            if let Some(limit) = *FUZZ_BLOCK_OUTPUT_LIMIT {
+                *block_output_limit = Some(limit);
+            }
+            if let Some(window) = *FUZZ_CONFLICT_PENALTY_WINDOW {
+                *conflict_penalty_window = window;
+            }
+            if let Some(multiplier) = *FUZZ_EXECUTION_GAS_EFFECTIVE_MULTIPLIER {
+                *execution_gas_effective_multiplier = multiplier;
+            }
+            if let Some(multiplier) = *FUZZ_IO_GAS_EFFECTIVE_MULTIPLIER {
+                *io_gas_effective_multiplier = multiplier;
+            }
+            if let Some(use_granular) = *FUZZ_USE_GRANULAR_RESOURCE_GROUP_CONFLICTS {
+                *use_granular_resource_group_conflicts = use_granular;
+            }
+        },
+        BlockGasLimitType::Limit(existing) => {
+            if let Some(limit) = *FUZZ_EFFECTIVE_BLOCK_GAS_LIMIT {
+                *existing = limit;
+            }
+        },
+        BlockGasLimitType::NoLimit => {
+            if let Some(limit) = *FUZZ_EFFECTIVE_BLOCK_GAS_LIMIT {
+                config.block_gas_limit_type = BlockGasLimitType::Limit(limit);
+            }
+        },
+    }
+
+    config
+}
+
+fn block_executor_config(
+    blockstm_v2: bool,
+    parallel: bool,
+    block_size: usize,
+) -> BlockExecutorConfig {
+    BlockExecutorConfig {
+        local: BlockExecutorLocalConfig {
+            // Selects the Block-STM v2 scheduler for parallel execution.
+            blockstm_v2,
+            // Scale the parallel run's workers to the block size, clamped to
+            // [MIN_CONCURRENCY_LEVEL, APTOS_FUZZ_MAX_CONCURRENCY_LEVEL]: at least the minimum so it always
+            // runs multi-threaded (a single worker wouldn't exercise the parallel scheduler or the
+            // races we compare against sequential), and at most the maximum so surplus workers
+            // don't busy-wait on the fuzzer's small blocks. Sequential execution always uses one
+            // worker.
+            concurrency_level: if parallel {
+                block_size.clamp(MIN_CONCURRENCY_LEVEL, *FUZZ_MAX_CONCURRENCY_LEVEL)
+            } else {
+                1
+            },
+            allow_fallback: *FUZZ_ALLOW_FALLBACK,
+            discard_failed_blocks: false,
+            module_cache_config: FUZZ_MODULE_CACHE_CONFIG.clone(),
+            enable_pre_write: true,
+        },
+        onchain: onchain_config(),
+    }
+}
+
+fn lock_hot_cache_manager<'a>(
+    vm: &BlockFuzzExecutor,
+    manager: &'a AptosModuleCacheManager,
+    config: &BlockExecutorConfig,
+    metadata: TransactionSliceMetadata,
+    phase: &str,
+) -> AptosModuleCacheManagerGuard<'a> {
+    let guard = manager
+        .try_lock(
+            vm.get_state_view(),
+            &config.local.module_cache_config,
+            metadata,
+        )
+        .unwrap_or_else(|error| {
+            panic!(
+                "module cache manager try_lock failed {phase}; \
+             check whether RuntimeEnvironment::struct_name_index_map_size() failed, \
+             otherwise this is a fuzzer harness/cache problem: {error:?}"
+            );
+        });
+    if let AptosModuleCacheManagerGuard::None { .. } = &guard {
+        panic!(
+            "module cache manager returned None guard {phase}; \
+             the fuzzer requires the shared hot cache lock and this indicates unexpected \
+             concurrent access or a harness bug"
+        );
+    }
+    guard
+}
+
+fn snapshot_hot_cache(
+    vm: &BlockFuzzExecutor,
+    manager: &AptosModuleCacheManager,
+    config: &BlockExecutorConfig,
+    metadata: TransactionSliceMetadata,
+) -> HotCacheSnapshot {
+    let guard = lock_hot_cache_manager(vm, manager, config, metadata, "before hot-cache snapshot");
+    #[cfg(fuzzing)]
+    {
+        return guard.snapshot_hot_cache();
+    }
+    #[cfg(not(fuzzing))]
+    {
+        drop(guard);
+        HotCacheSnapshot
+    }
+}
+
+fn rollback_hot_cache(
+    vm: &BlockFuzzExecutor,
+    manager: &AptosModuleCacheManager,
+    config: &BlockExecutorConfig,
+    metadata: TransactionSliceMetadata,
+    snapshot: HotCacheSnapshot,
+) {
+    let guard = lock_hot_cache_manager(vm, manager, config, metadata, "before hot-cache rollback");
+    #[cfg(fuzzing)]
+    {
+        let mut guard = guard;
+        guard.rollback_hot_cache(snapshot);
+    }
+    #[cfg(not(fuzzing))]
+    {
+        let _ = snapshot;
+        drop(guard);
+    }
+}
+
+struct BlockExecutionArtifacts {
+    outputs: Vec<TransactionOutput>,
+    state_hash: HashValue,
+}
+
+fn state_store_hash(vm: &BlockFuzzExecutor) -> HashValue {
+    let state = vm.state_store().to_btree_map();
+    let bytes = bcs::to_bytes(&state).expect("state store must serialize");
+    HashValue::sha3_256_of(&bytes)
+}
+
+fn execute_block(
+    vm: &BlockFuzzExecutor,
+    block: Vec<SignedTransaction>,
+    manager: &AptosModuleCacheManager,
+    metadata: TransactionSliceMetadata,
+    config: BlockExecutorConfig,
+) -> Vec<TransactionOutput> {
+    let txn_block: Vec<Transaction> = block
+        .into_iter()
+        .map(Transaction::UserTransaction)
+        .collect();
+    let signature_verified_block = into_signature_verified_block(txn_block);
+    let auxiliary_info = (0..signature_verified_block.len() as u32)
+        .map(|i| {
+            AuxiliaryInfo::new(
+                PersistedAuxiliaryInfo::V1 {
+                    transaction_index: i,
+                },
+                None,
+            )
+        })
+        .collect::<Vec<_>>();
+    let txn_provider = DefaultTxnProvider::new(signature_verified_block, auxiliary_info);
+    let output =
+        AptosVMBlockExecutorWrapper::execute_block::<_, NoOpTransactionCommitHook<VMStatus>, _>(
+            &txn_provider,
+            vm.get_state_view(),
+            manager,
+            config,
+            metadata,
+            None,
+        )
+        .unwrap_or_else(|error| {
+            panic!("block execution failed: {error:?}");
+        });
+    output.into_transaction_outputs_forced()
+}
+
+fn execute_blocks_with_cache_rollback(
+    vm: &BlockFuzzExecutor,
+    blocks: Vec<Vec<SignedTransaction>>,
+    manager: &AptosModuleCacheManager,
+    next_version: &AtomicU64,
+    blockstm_v2: bool,
+    parallel: bool,
+) -> BlockExecutionArtifacts {
+    if blocks.is_empty() {
+        return BlockExecutionArtifacts {
+            outputs: vec![],
+            state_hash: state_store_hash(vm),
+        };
+    }
+
+    let max_block_size = blocks.iter().map(Vec::len).max().unwrap_or(1);
+    tdbg!(
+        "exec start",
+        blockstm_v2,
+        parallel,
+        blocks.len(),
+        max_block_size
+    );
+    let snapshot_config = block_executor_config(blockstm_v2, parallel, max_block_size);
+    // Each fuzz case starts from a fresh genesis state, so writes produced by these blocks must not
+    // stay in the hot module cache. The snapshot keeps prefetched framework modules warm while the
+    // rollback removes modules published by the current fuzz case.
+    tdbg!("snapshot hot cache", blockstm_v2, parallel);
+    let snapshot = snapshot_hot_cache(vm, manager, &snapshot_config, next_metadata(next_version));
+
+    let mut all_outputs = Vec::new();
+    for block in blocks {
+        tdbg!("execute block", blockstm_v2, parallel, block.len(), &block);
+        let config = block_executor_config(blockstm_v2, parallel, block.len());
+        let outputs = execute_block(vm, block, manager, next_metadata(next_version), config);
+        tdbg!("block outputs", outputs.len());
+        vm.apply_transaction_outputs(&outputs);
+        all_outputs.extend(outputs);
+    }
+
+    tdbg!("rollback hot cache", blockstm_v2, parallel);
+    rollback_hot_cache(
+        vm,
+        manager,
+        &snapshot_config,
+        next_metadata(next_version),
+        snapshot,
+    );
+    tdbg!("exec end", blockstm_v2, parallel, all_outputs.len());
+    BlockExecutionArtifacts {
+        outputs: all_outputs,
+        state_hash: state_store_hash(vm),
+    }
+}
+
+/// Compares two executor lanes that must agree and returns the second lane's outputs for status
+/// checking. Panics on a divergence — the differential bug this fuzzer hunts for.
+fn compare_runs(
+    first: BlockExecutionArtifacts,
+    first_name: &str,
+    second: BlockExecutionArtifacts,
+    second_name: &str,
+) -> Result<Vec<TransactionOutput>, Corpus> {
+    tdbg!(
+        "comparing runs",
+        first_name,
+        first.outputs.len(),
+        second_name,
+        second.outputs.len()
+    );
+    assert_outputs_equal(&first.outputs, first_name, &second.outputs, second_name);
+    assert_eq!(
+        first.state_hash, second.state_hash,
+        "{first_name} and {second_name} produced different final state hashes",
+    );
+    Ok(second.outputs)
+}
+
+fn is_invariant_or_unknown(status_code: StatusCode) -> bool {
+    matches!(
+        status_code.status_type(),
+        StatusType::InvariantViolation | StatusType::Unknown
+    )
+}
+
+fn check_status_code_for_invariant_violation(
+    status_code: &StatusCode,
+    source: &str,
+    output: &TransactionOutput,
+) {
+    if is_invariant_or_unknown(*status_code)
+        // TODO: DOUBLE CHECK THESE AND FIX
+        && *status_code != StatusCode::TYPE_RESOLUTION_FAILURE
+        && *status_code != StatusCode::STORAGE_ERROR
+        && *status_code != StatusCode::VERIFICATION_ERROR
+    {
+        panic!(
+            "invariant violation via {source}: {:?}, {:?}",
+            status_code,
+            output.auxiliary_data()
+        );
+    }
+}
+
+fn check_output_status(output: &TransactionOutput) -> Result<(), Corpus> {
+    match tdbg!(output.status()) {
+        TransactionStatus::Keep(ExecutionStatus::Success) => Ok(()),
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(status_code))) => {
+            check_status_code_for_invariant_violation(status_code, "ExecutionStatus", output);
+            Ok(())
+        },
+        TransactionStatus::Keep(_) => Ok(()),
+        TransactionStatus::Discard(status_code) => {
+            check_status_code_for_invariant_violation(status_code, "TransactionStatus", output);
+            Ok(())
+        },
+        TransactionStatus::Retry => Ok(()),
+    }
+}
+
+fn resolve_module_ref(
+    modules: &[CompiledModule],
+    module_idx: u8,
+) -> Result<&CompiledModule, Corpus> {
+    if modules.is_empty() {
+        return Err(Corpus::Keep);
+    }
+    Ok(&modules[module_idx as usize % modules.len()])
+}
+
+fn resolve_module_refs(
+    modules: &[CompiledModule],
+    module_idxs: &[u8],
+) -> Result<Vec<CompiledModule>, Corpus> {
+    if module_idxs.len() > MAX_BLOCK_MODULE_REFS {
+        return Err(Corpus::Keep);
+    }
+    if module_idxs.is_empty() {
+        return Ok(vec![]);
+    }
+    if modules.is_empty() {
+        return Err(Corpus::Keep);
+    }
+
+    let mut seen = BTreeSet::new();
+    Ok(module_idxs
+        .iter()
+        .map(|module_idx| *module_idx as usize % modules.len())
+        .filter(|idx| seen.insert(*idx))
+        .map(|idx| modules[idx].clone())
+        .collect())
+}
+
+/// Records a dependency module under its id, rejecting ambiguous preloads. Different versions of
+/// the same module id are allowed in the block itself as publish transactions, but genesis preload
+/// can contain only one version for a given id.
+fn register_preload_module(
+    modules_by_id: &mut BTreeMap<ModuleId, CompiledModule>,
+    module: &CompiledModule,
+) -> Result<(), Corpus> {
+    let module_id = checked_module_self_id(module);
+    match modules_by_id.entry(module_id) {
+        Entry::Occupied(entry) if entry.get() != module => Err(Corpus::Keep),
+        Entry::Occupied(_) => Ok(()),
+        Entry::Vacant(entry) => {
+            entry.insert(module.clone());
+            Ok(())
+        },
+    }
+}
+
+fn package_name_for_modules<'a>(
+    modules: &[CompiledModule],
+    package_names_by_module: &'a BTreeMap<ModuleId, String>,
+) -> &'a str {
+    for module in modules {
+        let module_id = checked_module_self_id(module);
+        if let Some(package_name) = package_names_by_module.get(&module_id) {
+            return package_name.as_str();
+        }
+    }
+
+    panic!("package name must exist for published module group")
+}
+
+fn build_package_names_by_module(packages: &[Vec<CompiledModule>]) -> BTreeMap<ModuleId, String> {
+    let mut package_names_by_module = BTreeMap::new();
+    for (package_idx, modules) in packages.iter().enumerate() {
+        let module_ids = modules
+            .iter()
+            .map(checked_module_self_id)
+            .collect::<Vec<_>>();
+        let package_name = module_ids
+            .iter()
+            .find_map(|module_id| package_names_by_module.get(module_id))
+            .cloned()
+            .unwrap_or_else(|| format!("package_{package_idx}"));
+
+        for module_id in module_ids {
+            package_names_by_module
+                .entry(module_id)
+                .or_insert_with(|| package_name.clone());
+        }
+    }
+
+    package_names_by_module
+}
+
+fn is_split_block(transaction: &RunnableBlockTransactionV2) -> bool {
+    matches!(&transaction.exec_variant, BlockExecVariantV2::SplitBlock)
+}
+
+fn has_invalid_split_blocks(transactions: &[RunnableBlockTransactionV2]) -> bool {
+    transactions.first().is_some_and(is_split_block)
+        || transactions.last().is_some_and(is_split_block)
+        || transactions
+            .windows(2)
+            .any(|window| window.iter().all(is_split_block))
+}
+
+fn build_signed_transaction_blocks(
+    vm: &mut BlockFuzzExecutor,
+    modules: &[CompiledModule],
+    account_inputs: &[UserAccount],
+    dependency_publish_packages: &[Vec<CompiledModule>],
+    package_names_by_module: &BTreeMap<ModuleId, String>,
+    transaction_blocks: &[Vec<RunnableBlockTransactionV2>],
+) -> Result<Vec<Vec<SignedTransaction>>, Corpus> {
+    if transaction_blocks.is_empty() {
+        return Err(Corpus::Keep);
+    }
+
+    let slot_accounts = account_inputs
+        .iter()
+        .copied()
+        .map(|account| create_user_account(vm, account))
+        .collect::<Vec<_>>();
+    let mut accounts_by_address = slot_accounts
+        .iter()
+        .cloned()
+        .map(|account| (*account.address(), account))
+        .collect::<HashMap<_, _>>();
+    let mut sequence_by_address = HashMap::new();
+    let mut nonce_by_address = HashMap::new();
+    let mut signed_blocks = Vec::with_capacity(transaction_blocks.len());
+
+    if !dependency_publish_packages.is_empty() {
+        let mut block = Vec::with_capacity(dependency_publish_packages.len());
+        for group in dependency_publish_packages {
+            block.push(build_publish_transaction(
+                vm,
+                &mut accounts_by_address,
+                &mut sequence_by_address,
+                package_names_by_module,
+                group,
+            )?);
+        }
+        signed_blocks.push(block);
+    }
+
+    for transaction_block in transaction_blocks {
+        let mut block = Vec::with_capacity(transaction_block.len());
+
+        for tx in transaction_block {
+            block.push(build_signed_transaction(
+                vm,
+                modules,
+                &slot_accounts,
+                &mut accounts_by_address,
+                &mut sequence_by_address,
+                &mut nonce_by_address,
+                package_names_by_module,
+                tx,
+            )?);
+        }
+
+        if block.is_empty() || block.len() > MAX_BLOCK_TXNS {
+            return Err(Corpus::Keep);
+        }
+        signed_blocks.push(block);
+    }
+
+    Ok(signed_blocks)
+}
+
+fn run_case(mut input: RunnableBlockStateV2) -> Result<(), Corpus> {
+    tdbg!(&input);
+
+    tdbg!("filtering fuzz case");
+    if input.accounts.is_empty()
+        || input.accounts.len() > MAX_BLOCK_ACCOUNTS
+        || input.modules.len() > MAX_BLOCK_MODULES
+        || input.transactions.is_empty()
+        || input.transactions.len() > MAX_BLOCK_TXNS
+    {
+        return Err(Corpus::Keep);
+    }
+
+    if has_invalid_split_blocks(&input.transactions) {
+        return Err(Corpus::Keep);
+    }
+
+    // fail fast
+    tdbg!("checking module ids and transaction shape");
+    for module in &mut input.modules {
+        if module_self_id(module).is_none_or(|id| *id.address() == AccountAddress::ONE) {
+            return Err(Corpus::Keep);
+        }
+        for ele in &mut module.function_defs {
+            ele.is_entry = true;
+        }
+    }
+    for tx in &input.transactions {
+        filter_bad_tx(&tx.exec_variant)?;
+    }
+
+    tdbg!("collecting in-block published modules");
+    let mut in_block_published_modules = Vec::new();
+    for tx in &input.transactions {
+        match &tx.exec_variant {
+            BlockExecVariantV2::Script { .. } => {},
+            BlockExecVariantV2::Publish { _module_idxs } => {
+                let _modules = resolve_module_refs(&input.modules, _module_idxs)?;
+                for module in _modules {
+                    if !in_block_published_modules.contains(&module) {
+                        in_block_published_modules.push(module);
+                    }
+                }
+            },
+            BlockExecVariantV2::CallFunction { .. } => (),
+            BlockExecVariantV2::SplitBlock => (),
+        }
+    }
+
+    tdbg!("building preload module set");
+    let mut preload_modules_by_id = BTreeMap::new();
+    for module in &input.modules {
+        if !in_block_published_modules.contains(module) {
+            register_preload_module(&mut preload_modules_by_id, module)?;
+        }
+    }
+
+    let timed_features = TimedFeaturesBuilder::enable_all().build();
+    let mut features = Features::default();
+    apply_fuzz_feature_overrides(&mut features);
+    let mut verifier_config = prod_configs::aptos_prod_verifier_config(
+        LATEST_GAS_FEATURE_VERSION,
+        &features,
+        &timed_features,
+    );
+    apply_verifier_config_overrides(&mut verifier_config);
+    let deserializer_config =
+        DeserializerConfig::new(VERSION_MAX, FUZZ_MAX_IDENTIFIER_SIZE.unwrap_or(255));
+
+    // consider maybe allowing verifier failures??
+
+    tdbg!("verifying scripts");
+    for tx in &input.transactions {
+        match &tx.exec_variant {
+            BlockExecVariantV2::Script { _script, .. } => {
+                verify_script_fast(_script, &verifier_config, &deserializer_config)?;
+            },
+            BlockExecVariantV2::Publish { _module_idxs } => {},
+            BlockExecVariantV2::CallFunction { .. } => (),
+            BlockExecVariantV2::SplitBlock => (),
+        }
+    }
+
+    tdbg!("verifying modules");
+    for module in &input.modules {
+        verify_module_fast(module, &verifier_config, &deserializer_config)?;
+    }
+
+    tdbg!("configuring VM checks");
+    prod_configs::set_async_runtime_checks(*FUZZ_ASYNC_RUNTIME_CHECKS);
+    prod_configs::set_paranoid_ref_checks(*FUZZ_PARANOID_REF_CHECKS);
+    Lazy::force(&CONFIGURE_FUZZ_VM_CONFIG);
+    prod_configs::set_layout_caches(*FUZZ_ENABLE_LAYOUT_CACHES);
+
+    tdbg!("topologically ordering and grouping preload modules");
+    let dependency_publish_packages =
+        group_modules_by_address_topo(preload_modules_by_id.values().cloned().collect())?;
+
+    tdbg!("building package names");
+    let mut publish_packages = dependency_publish_packages.clone();
+    for tx in &input.transactions {
+        if let BlockExecVariantV2::Publish { _module_idxs } = &tx.exec_variant {
+            publish_packages.push(resolve_module_refs(&input.modules, _module_idxs)?);
+        }
+    }
+    let package_names_by_module = build_package_names_by_module(&publish_packages);
+    tdbg!("building transaction blocks");
+    let transaction_blocks = input
+        .transactions
+        .as_slice()
+        .split(is_split_block)
+        .map(<[RunnableBlockTransactionV2]>::to_vec)
+        .collect::<Vec<_>>();
+    let transaction_block_sizes = transaction_blocks.iter().map(Vec::len).collect::<Vec<_>>();
+    tdbg!("transaction block sizes", &transaction_block_sizes);
+    tdbg!("transaction blocks", &transaction_blocks);
+
+    // Every lane shares the same warm manager/version counter. Each call snapshots the
+    // framework-only hot cache, executes all split blocks in that lane, and rolls back the fuzz
+    // case's published modules. Each lane signs transactions from a fresh genesis state, so
+    // sequential/v1/v2 comparisons do not share account or committed transaction state.
+    let run = |blockstm_v2: bool, parallel: bool| -> Result<BlockExecutionArtifacts, Corpus> {
+        tdbg!("building signed tx blocks", blockstm_v2, parallel);
+        let mut vm = BlockFuzzExecutor::from_genesis(&VM_WRITE_SET, ChainId::mainnet());
+        configure_fuzz_features(&vm);
+        let blocks = build_signed_transaction_blocks(
+            &mut vm,
+            &input.modules,
+            &input.accounts,
+            &dependency_publish_packages,
+            &package_names_by_module,
+            &transaction_blocks,
+        )?;
+        let block_sizes = blocks.iter().map(Vec::len).collect::<Vec<_>>();
+        tdbg!("signed block sizes", blockstm_v2, parallel, &block_sizes);
+        tdbg!("signed blocks", blockstm_v2, parallel, &blocks);
+        tdbg!("executing signed tx blocks", blockstm_v2, parallel);
+        Ok(execute_blocks_with_cache_rollback(
+            &vm,
+            blocks,
+            &MODULE_CACHE_MANAGER,
+            &NEXT_VERSION,
+            blockstm_v2,
+            parallel,
+        ))
+    };
+
+    let checked_outputs = match *EXEC_MODE {
+        ExecMode::V2AndSeq => compare_runs(
+            run(false, false)?,
+            "sequential",
+            run(true, true)?,
+            "blockstm_v2",
+        )?,
+        ExecMode::Seq => run(false, false)?.outputs,
+        ExecMode::V2 => run(true, true)?.outputs,
+    };
+
+    tdbg!("checking output statuses", checked_outputs.len());
+    for output in checked_outputs {
+        check_output_status(&output)?;
+    }
+
+    Ok(())
+}
+
+fuzz_target!(
+    init: {
+        require_fuzzing_cfg();
+        Lazy::force(&VM_WRITE_SET);
+        Lazy::force(&MODULE_CACHE_MANAGER);
+        Lazy::force(&EXEC_MODE);
+        Lazy::force(&FUZZ_GAS_UNIT_PRICE);
+        Lazy::force(&FUZZ_MAX_GAS_AMOUNT);
+        Lazy::force(&FUZZ_EFFECTIVE_BLOCK_GAS_LIMIT);
+        Lazy::force(&FUZZ_BLOCK_OUTPUT_LIMIT);
+        Lazy::force(&FUZZ_CONFLICT_PENALTY_WINDOW);
+        Lazy::force(&FUZZ_EXECUTION_GAS_EFFECTIVE_MULTIPLIER);
+        Lazy::force(&FUZZ_IO_GAS_EFFECTIVE_MULTIPLIER);
+        Lazy::force(&FUZZ_USE_GRANULAR_RESOURCE_GROUP_CONFLICTS);
+        Lazy::force(&FUZZ_MAX_IDENTIFIER_SIZE);
+        Lazy::force(&FUZZ_MAX_CONCURRENCY_LEVEL);
+        Lazy::force(&FUZZ_ALLOW_FALLBACK);
+        Lazy::force(&FUZZ_ASYNC_RUNTIME_CHECKS);
+        Lazy::force(&FUZZ_PARANOID_REF_CHECKS);
+        Lazy::force(&FUZZ_ENABLE_LAYOUT_CACHES);
+        Lazy::force(&FUZZ_MODULE_CACHE_CONFIG);
+    },
+    |fuzz_data: RunnableBlockStateV2| -> Corpus {
+        run_case(fuzz_data).err().unwrap_or(Corpus::Keep)
+    }
+);

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_blockstm_v2_compare.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_blockstm_v2_compare.rs
@@ -47,16 +47,13 @@ use blockv2_fuzz_config::{
 use fuzzer::{BlockExecVariantV2, RunnableBlockStateV2, RunnableBlockTransactionV2, UserAccount};
 use libfuzzer_sys::{fuzz_target, Corpus};
 use move_binary_format::{
-    access::ModuleAccess,
-    deserializer::DeserializerConfig,
-    file_format::{CompiledModule, ModuleHandle, Signature, SignatureToken},
+    access::ModuleAccess, deserializer::DeserializerConfig, file_format::CompiledModule,
     file_format_common::VERSION_MAX,
-    internals::ModuleIndex,
 };
 use move_core_types::language_storage::ModuleId;
 use once_cell::sync::Lazy;
 use std::{
-    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap},
+    collections::{btree_map::Entry, BTreeMap, HashMap},
     env,
     hash::Hash,
     sync::atomic::{AtomicU64, Ordering},
@@ -66,8 +63,10 @@ mod blockstm_executor;
 mod blockv2_fuzz_config;
 mod utils;
 use utils::vm::{
-    group_modules_by_address_topo, publish_transaction_payload_with_package_names,
-    resolve_function_name, script_bytecode_version, verify_module_fast, verify_script_fast,
+    checked_module_self_id, filter_bad_modules, filter_bad_tx, group_modules_by_address_topo,
+    has_invalid_split_blocks, is_split_block, publish_transaction_payload_with_package_names,
+    resolve_function_name, resolve_module_ref, resolve_module_refs, script_bytecode_version,
+    verify_module_fast, verify_script_fast,
 };
 
 #[cfg(fuzzing)]
@@ -95,10 +94,8 @@ const MIN_CONCURRENCY_LEVEL: usize = 2;
 const MAX_CONCURRENCY_LEVEL: usize = 8;
 const MAX_BLOCK_ACCOUNTS: usize = 256;
 const MAX_BLOCK_MODULES: usize = 32;
-const MAX_BLOCK_MODULE_REFS: usize = 32;
 const MAX_BLOCK_TXNS: usize = 24;
 const MAX_SECONDARY_SIGNERS: usize = 10;
-const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16;
 const DEFAULT_GAS_UNIT_PRICE: u64 = 100;
 const DEFAULT_MAX_GAS_AMOUNT: u64 = 2_000_000;
 
@@ -184,66 +181,6 @@ fn require_fuzzing_cfg() {
 fn next_metadata(counter: &AtomicU64) -> TransactionSliceMetadata {
     let end = counter.fetch_add(1, Ordering::Relaxed);
     TransactionSliceMetadata::chunk(end - 1, end)
-}
-
-fn module_self_handle(module: &CompiledModule) -> Option<&ModuleHandle> {
-    module
-        .module_handles
-        .get(module.self_module_handle_idx.into_index())
-}
-
-fn module_self_id(module: &CompiledModule) -> Option<ModuleId> {
-    let handle = module_self_handle(module)?;
-    let address = module
-        .address_identifiers
-        .get(handle.address.into_index())
-        .copied()?;
-    let name = module.identifiers.get(handle.name.into_index())?.to_owned();
-    Some(ModuleId::new(address, name))
-}
-
-fn checked_module_self_id(module: &CompiledModule) -> ModuleId {
-    module_self_id(module).expect("module self id checked at fuzz case boundary")
-}
-
-fn signature_token_is_too_large(token: &SignatureToken) -> bool {
-    match token {
-        SignatureToken::TypeParameter(idx) => *idx > MAX_TYPE_PARAMETER_VALUE,
-        SignatureToken::Vector(inner)
-        | SignatureToken::Reference(inner)
-        | SignatureToken::MutableReference(inner) => signature_token_is_too_large(inner),
-        SignatureToken::StructInstantiation(_, tys) => tys.iter().any(signature_token_is_too_large),
-        SignatureToken::Function(args, results, _) => {
-            args.iter().any(signature_token_is_too_large)
-                || results.iter().any(signature_token_is_too_large)
-        },
-        _ => false,
-    }
-}
-
-fn has_oversized_signatures(signatures: &[Signature]) -> bool {
-    signatures
-        .iter()
-        .any(|signature| signature.0.iter().any(signature_token_is_too_large))
-}
-
-fn filter_bad_tx(exec_variant: &BlockExecVariantV2) -> Result<(), Corpus> {
-    match exec_variant {
-        BlockExecVariantV2::Script { _script, .. } => {
-            if has_oversized_signatures(&_script.signatures) {
-                return Err(Corpus::Keep);
-            }
-            Ok(())
-        },
-        BlockExecVariantV2::Publish { _module_idxs } => {
-            if _module_idxs.is_empty() {
-                return Err(Corpus::Keep);
-            }
-            Ok(())
-        },
-        BlockExecVariantV2::CallFunction { .. } => Ok(()),
-        BlockExecVariantV2::SplitBlock => Ok(()),
-    }
 }
 
 fn create_user_account(vm: &mut BlockFuzzExecutor, account: UserAccount) -> Account {
@@ -799,39 +736,6 @@ fn check_output_status(output: &TransactionOutput) -> Result<(), Corpus> {
     }
 }
 
-fn resolve_module_ref(
-    modules: &[CompiledModule],
-    module_idx: u8,
-) -> Result<&CompiledModule, Corpus> {
-    if modules.is_empty() {
-        return Err(Corpus::Keep);
-    }
-    Ok(&modules[module_idx as usize % modules.len()])
-}
-
-fn resolve_module_refs(
-    modules: &[CompiledModule],
-    module_idxs: &[u8],
-) -> Result<Vec<CompiledModule>, Corpus> {
-    if module_idxs.len() > MAX_BLOCK_MODULE_REFS {
-        return Err(Corpus::Keep);
-    }
-    if module_idxs.is_empty() {
-        return Ok(vec![]);
-    }
-    if modules.is_empty() {
-        return Err(Corpus::Keep);
-    }
-
-    let mut seen = BTreeSet::new();
-    Ok(module_idxs
-        .iter()
-        .map(|module_idx| *module_idx as usize % modules.len())
-        .filter(|idx| seen.insert(*idx))
-        .map(|idx| modules[idx].clone())
-        .collect())
-}
-
 /// Records a dependency module under its id, rejecting ambiguous preloads. Different versions of
 /// the same module id are allowed in the block itself as publish transactions, but genesis preload
 /// can contain only one version for a given id.
@@ -885,18 +789,6 @@ fn build_package_names_by_module(packages: &[Vec<CompiledModule>]) -> BTreeMap<M
     }
 
     package_names_by_module
-}
-
-fn is_split_block(transaction: &RunnableBlockTransactionV2) -> bool {
-    matches!(&transaction.exec_variant, BlockExecVariantV2::SplitBlock)
-}
-
-fn has_invalid_split_blocks(transactions: &[RunnableBlockTransactionV2]) -> bool {
-    transactions.first().is_some_and(is_split_block)
-        || transactions.last().is_some_and(is_split_block)
-        || transactions
-            .windows(2)
-            .any(|window| window.iter().all(is_split_block))
 }
 
 fn build_signed_transaction_blocks(
@@ -983,14 +875,7 @@ fn run_case(mut input: RunnableBlockStateV2) -> Result<(), Corpus> {
 
     // fail fast
     tdbg!("checking module ids and transaction shape");
-    for module in &mut input.modules {
-        if module_self_id(module).is_none_or(|id| *id.address() == AccountAddress::ONE) {
-            return Err(Corpus::Keep);
-        }
-        for ele in &mut module.function_defs {
-            ele.is_entry = true;
-        }
-    }
+    filter_bad_modules(&mut input.modules)?;
     for tx in &input.transactions {
         filter_bad_tx(&tx.exec_variant)?;
     }

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/blockstm_executor.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/blockstm_executor.rs
@@ -1,0 +1,243 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_keygen::KeyGen;
+use aptos_transaction_simulation::{
+    Account, AccountData, InMemoryStateStore, SimulationStateStore,
+};
+use aptos_types::{
+    account_address::AccountAddress,
+    account_config::{CoinInfoResource, ConcurrentSupplyResource, ObjectGroupResource},
+    chain_id::ChainId,
+    on_chain_config::FeatureFlag,
+    state_store::{state_key::StateKey, TStateView},
+    transaction::{TransactionOutput, TransactionStatus},
+    write_set::{WriteOp, WriteSet, WriteSetMut},
+    AptosCoinType, CoinType,
+};
+use move_core_types::move_resource::MoveStructType;
+use std::collections::BTreeSet;
+
+const RNG_SEED: [u8; 32] = [9u8; 32];
+const DEFAULT_ACCOUNT_FUND_AMOUNT: u64 = 1_000_000_000_000_000;
+
+pub(crate) struct BlockFuzzExecutor {
+    state_store: InMemoryStateStore,
+    rng: KeyGen,
+}
+
+impl BlockFuzzExecutor {
+    pub(crate) fn from_genesis(write_set: &WriteSet, chain_id: ChainId) -> Self {
+        let state_store = InMemoryStateStore::new();
+        state_store.set_chain_id(chain_id).unwrap();
+        state_store.apply_write_set(write_set).unwrap();
+        Self {
+            state_store,
+            rng: KeyGen::from_seed(RNG_SEED),
+        }
+    }
+
+    pub(crate) fn state_store(&self) -> &InMemoryStateStore {
+        &self.state_store
+    }
+
+    pub(crate) fn get_state_view(&self) -> &InMemoryStateStore {
+        &self.state_store
+    }
+
+    pub(crate) fn apply_transaction_outputs(&self, outputs: &[TransactionOutput]) {
+        for output in outputs {
+            if matches!(output.status(), TransactionStatus::Keep(_)) {
+                self.state_store
+                    .apply_write_set(output.write_set())
+                    .unwrap();
+            }
+        }
+    }
+
+    pub(crate) fn create_accounts(
+        &mut self,
+        size: usize,
+        balance: u64,
+        sequence_number: u64,
+    ) -> Vec<Account> {
+        (0..size)
+            .map(|_| {
+                let account_data =
+                    AccountData::new_from_seed(&mut self.rng, balance, sequence_number);
+                self.add_account_data(&account_data);
+                account_data.into_account()
+            })
+            .collect()
+    }
+
+    pub(crate) fn new_unfunded_account(&mut self) -> Account {
+        Account::new_from_seed(&mut self.rng)
+    }
+
+    pub(crate) fn new_account_at(&mut self, address: AccountAddress) -> Account {
+        let account = Account::new_genesis_account(address);
+        let features = self.state_store.get_features().unwrap_or_default();
+        let account_data = AccountData::with_account(
+            account,
+            DEFAULT_ACCOUNT_FUND_AMOUNT,
+            0,
+            features.is_enabled(FeatureFlag::NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE),
+            features.is_enabled(FeatureFlag::DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE),
+        );
+        self.add_account_data(&account_data);
+        account_data.into_account()
+    }
+
+    fn add_account_data(&self, account_data: &AccountData) {
+        self.state_store.add_account_data(account_data).unwrap();
+
+        if let Some(new_supply) = account_data.coin_balance()
+            && new_supply != 0
+        {
+            let coin_info = self.read_apt_coin_info_resource();
+            let old_supply = self.read_coin_supply(&coin_info);
+            self.state_store
+                .apply_write_set(
+                    &coin_info
+                        .to_writeset(old_supply + new_supply as u128)
+                        .unwrap(),
+                )
+                .unwrap();
+        }
+
+        if let Some(new_supply) = account_data.fungible_balance()
+            && new_supply != 0
+        {
+            let mut group = self.read_fa_supply_resource_group();
+            let mut supply = bcs::from_bytes::<ConcurrentSupplyResource>(
+                group
+                    .group
+                    .get(&ConcurrentSupplyResource::struct_tag())
+                    .unwrap(),
+            )
+            .unwrap();
+            supply
+                .current
+                .set(supply.current.get() + new_supply as u128);
+            group
+                .group
+                .insert(
+                    ConcurrentSupplyResource::struct_tag(),
+                    bcs::to_bytes(&supply).unwrap(),
+                )
+                .unwrap();
+            self.state_store
+                .apply_write_set(
+                    &WriteSetMut::new(vec![(
+                        StateKey::resource_group(
+                            &AccountAddress::TEN,
+                            &ObjectGroupResource::struct_tag(),
+                        ),
+                        WriteOp::legacy_modification(bcs::to_bytes(&group).unwrap().into()),
+                    )])
+                    .freeze()
+                    .unwrap(),
+                )
+                .unwrap();
+        }
+    }
+
+    fn read_apt_coin_info_resource(&self) -> CoinInfoResource<AptosCoinType> {
+        self.state_store
+            .get_resource(AptosCoinType::coin_info_address())
+            .unwrap()
+            .expect("APT coin info must exist in genesis")
+    }
+
+    fn read_coin_supply(&self, coin_info: &CoinInfoResource<AptosCoinType>) -> u128 {
+        self.state_store
+            .get_state_value_bytes(&coin_info.supply_aggregator_state_key())
+            .unwrap()
+            .map(|bytes| bcs::from_bytes::<u128>(&bytes).unwrap())
+            .unwrap_or_default()
+    }
+
+    fn read_fa_supply_resource_group(&self) -> ObjectGroupResource {
+        let bytes = self
+            .state_store
+            .get_state_value_bytes(&StateKey::resource_group(
+                &AccountAddress::TEN,
+                &ObjectGroupResource::struct_tag(),
+            ))
+            .unwrap()
+            .expect("FA supply resource group must exist in genesis");
+        bcs::from_bytes(&bytes).unwrap()
+    }
+}
+
+pub(crate) fn assert_outputs_equal(
+    first: &[TransactionOutput],
+    first_name: &str,
+    second: &[TransactionOutput],
+    second_name: &str,
+) {
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "Transaction outputs size mismatch: in {:?} and in {:?}",
+        first_name,
+        second_name,
+    );
+
+    for (idx, (first_output, second_output)) in first.iter().zip(second.iter()).enumerate() {
+        assert_eq!(
+            first_output.status(),
+            second_output.status(),
+            "Different statuses for {:?} and {:?} for transaction outputs at index {}",
+            first_name,
+            second_name,
+            idx,
+        );
+
+        assert_eq!(
+            first_output.try_extract_fee_statement().unwrap_or_default(),
+            second_output
+                .try_extract_fee_statement()
+                .unwrap_or_default(),
+            "Different gas used for {:?} and {:?} for transaction outputs at index {}",
+            first_name,
+            second_name,
+            idx,
+        );
+
+        let keys = first_output
+            .write_set()
+            .write_op_iter()
+            .chain(second_output.write_set().write_op_iter())
+            .map(|(key, _)| key)
+            .collect::<BTreeSet<_>>();
+        let mut differences = vec![];
+        for key in keys {
+            let write1 = first_output.write_set().get_write_op(key);
+            let write2 = second_output.write_set().get_write_op(key);
+            if write1 != write2 {
+                differences.push(format!(
+                    "Write for {:?} differs: {:?} vs {:?}",
+                    key, write1, write2
+                ));
+            }
+        }
+        if !differences.is_empty() {
+            println!("Differences:\n{}", differences.join("\n"));
+        }
+        assert!(
+            differences.is_empty(),
+            "First write op mismatch for transaction output at index {}, between {} and {}",
+            idx,
+            first_name,
+            second_name,
+        );
+
+        assert_eq!(
+            first_output, second_output,
+            "first transaction output mismatch at index {}, for {} and {}",
+            idx, first_name, second_name,
+        );
+    }
+}

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/blockv2_fuzz_config.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/blockv2_fuzz_config.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+#![allow(dead_code)]
+
+use aptos_types::block_executor::config::BlockExecutorModuleCacheLocalConfig;
+use move_bytecode_verifier::VerifierConfig;
+use move_vm_runtime::config::VMConfig;
+use move_vm_types::loaded_data::runtime_types::TypeBuilder;
+use std::env;
+
+pub(crate) fn env_u64(name: &str, default: u64) -> u64 {
+    match env::var(name) {
+        Ok(raw) => raw
+            .parse()
+            .unwrap_or_else(|err| panic!("{name} must be a u64, got {raw:?}: {err}")),
+        Err(env::VarError::NotPresent) => default,
+        Err(err) => panic!("failed to read {name}: {err}"),
+    }
+}
+
+pub(crate) fn env_optional_u64(name: &str) -> Option<u64> {
+    match env::var(name) {
+        Ok(raw) => Some(
+            raw.parse()
+                .unwrap_or_else(|err| panic!("{name} must be a u64, got {raw:?}: {err}")),
+        ),
+        Err(env::VarError::NotPresent) => None,
+        Err(err) => panic!("failed to read {name}: {err}"),
+    }
+}
+
+pub(crate) fn env_optional_u32(name: &str) -> Option<u32> {
+    match env::var(name) {
+        Ok(raw) => Some(
+            raw.parse()
+                .unwrap_or_else(|err| panic!("{name} must be a u32, got {raw:?}: {err}")),
+        ),
+        Err(env::VarError::NotPresent) => None,
+        Err(err) => panic!("failed to read {name}: {err}"),
+    }
+}
+
+pub(crate) fn env_optional_usize(name: &str) -> Option<usize> {
+    match env::var(name) {
+        Ok(raw) => Some(
+            raw.parse()
+                .unwrap_or_else(|err| panic!("{name} must be a usize, got {raw:?}: {err}")),
+        ),
+        Err(env::VarError::NotPresent) => None,
+        Err(err) => panic!("failed to read {name}: {err}"),
+    }
+}
+
+pub(crate) fn env_optional_bool(name: &str) -> Option<bool> {
+    match env::var(name) {
+        Ok(raw) => match raw.as_str() {
+            "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON" => Some(true),
+            "0" | "false" | "FALSE" | "no" | "NO" | "off" | "OFF" => Some(false),
+            _ => panic!("{name} must be a bool, got {raw:?}"),
+        },
+        Err(env::VarError::NotPresent) => None,
+        Err(err) => panic!("failed to read {name}: {err}"),
+    }
+}
+
+pub(crate) fn apply_verifier_config_overrides(config: &mut VerifierConfig) {
+    if let Some(value) = env_optional_usize("APTOS_FUZZ_MAX_TYPE_NODES") {
+        config.max_type_nodes = Some(value);
+    }
+    if let Some(value) = env_optional_usize("APTOS_FUZZ_MAX_TYPE_DEPTH") {
+        config.max_type_depth = Some(value);
+    }
+}
+
+pub(crate) fn apply_vm_config_overrides(config: &mut VMConfig) {
+    apply_verifier_config_overrides(&mut config.verifier_config);
+
+    if let Some(value) = env_optional_u64("APTOS_FUZZ_LAYOUT_MAX_SIZE") {
+        config.layout_max_size = value;
+    }
+    if let Some(value) = env_optional_u64("APTOS_FUZZ_LAYOUT_MAX_DEPTH") {
+        config.layout_max_depth = value;
+    }
+    if let Some(value) = env_optional_u64("APTOS_FUZZ_MAX_VALUE_NEST_DEPTH") {
+        config.max_value_nest_depth = Some(value);
+    }
+    if let Some(value) = env_optional_u64("APTOS_FUZZ_TYPE_MAX_COST") {
+        config.type_max_cost = value;
+    }
+
+    let max_ty_size = env_optional_u64("APTOS_FUZZ_TYPE_BUILDER_MAX_SIZE");
+    let max_ty_depth = env_optional_u64("APTOS_FUZZ_TYPE_BUILDER_MAX_DEPTH");
+    if max_ty_size.is_some() || max_ty_depth.is_some() {
+        config.ty_builder = TypeBuilder::with_limits(
+            max_ty_size.unwrap_or(128),
+            max_ty_depth.unwrap_or(20),
+            config.check_depth_on_type_counts,
+        );
+    }
+}
+
+pub(crate) fn module_cache_config_from_env() -> BlockExecutorModuleCacheLocalConfig {
+    let mut config = BlockExecutorModuleCacheLocalConfig::default();
+    if let Some(value) = env_optional_usize("APTOS_FUZZ_MAX_MODULE_CACHE_SIZE_BYTES") {
+        config.max_module_cache_size_in_bytes = value;
+    }
+    if let Some(value) = env_optional_usize("APTOS_FUZZ_MAX_STRUCT_NAME_INDEX_MAP_ENTRIES") {
+        config.max_struct_name_index_map_num_entries = value;
+    }
+    if let Some(value) = env_optional_usize("APTOS_FUZZ_MAX_INTERNED_TYS") {
+        config.max_interned_tys = value;
+    }
+    if let Some(value) = env_optional_usize("APTOS_FUZZ_MAX_INTERNED_TY_VECS") {
+        config.max_interned_ty_vecs = value;
+    }
+    if let Some(value) = env_optional_usize("APTOS_FUZZ_MAX_LAYOUT_CACHE_SIZE") {
+        config.max_layout_cache_size = value;
+    }
+    if let Some(value) = env_optional_usize("APTOS_FUZZ_MAX_INTERNED_MODULE_IDS") {
+        config.max_interned_module_ids = value;
+    }
+    config
+}

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/movevm_blockv2_direct.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/movevm_blockv2_direct.rs
@@ -1,0 +1,467 @@
+#![no_main]
+
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use libfuzzer_sys::{fuzz_target, Corpus};
+use move_binary_format::{
+    compatibility::Compatibility,
+    deserializer::DeserializerConfig,
+    errors::{PartialVMError, VMError},
+    file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex},
+    file_format_common::{IDENTIFIER_SIZE_MAX, VERSION_MAX},
+};
+use move_bytecode_verifier::VerifierConfig;
+use move_core_types::{
+    account_address::AccountAddress,
+    gas_algebra::GasQuantity,
+    identifier::Identifier,
+    language_storage::TypeTag,
+    transaction_argument::{convert_txn_args, TransactionArgument},
+    value::MoveValue,
+    vm_status::{StatusCode, StatusType},
+};
+use move_vm_runtime::{
+    config::VMConfig,
+    data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
+    module_traversal::{TraversalContext, TraversalStorage},
+    move_vm::MoveVM,
+    native_extensions::NativeContextExtensions,
+    AsUnsyncCodeStorage, InstantiatedFunctionLoader, LegacyLoaderConfig, RuntimeEnvironment,
+    ScriptLoader, StagingModuleStorage,
+};
+use move_vm_test_utils::{
+    gas_schedule::{CostTable, GasCost, GasStatus},
+    InMemoryStorage,
+};
+use move_vm_types::loaded_data::runtime_types::Type;
+use once_cell::sync::Lazy;
+use std::env;
+
+mod blockv2_fuzz_config;
+mod utils;
+
+use blockv2_fuzz_config::{apply_verifier_config_overrides, apply_vm_config_overrides, env_u64};
+use fuzzer::{BlockExecVariantV2, RunnableBlockStateV2, RunnableBlockTransactionV2};
+use utils::vm::{
+    filter_bad_modules, filter_bad_tx, group_modules_by_address_topo, has_invalid_split_blocks,
+    module_self_id, module_self_id_or_keep, normalize_module_for_fuzz, resolve_function_name,
+    resolve_module_ref, resolve_module_refs, serialize_module_for_version, verify_module_fast,
+    verify_script_fast,
+};
+
+const BYTECODE_VERSION: u32 = VERSION_MAX;
+const MAX_BLOCK_MODULES: usize = 32;
+const MAX_BLOCK_TXNS: usize = 24;
+const MAX_TYPE_ARGS: usize = 8;
+const MAX_ARGS: usize = 16;
+const MAX_SIGNER_ARGS: usize = 16;
+const DEFAULT_EXECUTION_GAS: u64 = 2_000;
+
+static VERIFIER_CONFIG: Lazy<VerifierConfig> = Lazy::new(|| {
+    let mut config = VerifierConfig::production();
+    config.enable_resource_access_control = false;
+    apply_verifier_config_overrides(&mut config);
+    config
+});
+static DESERIALIZER_CONFIG: Lazy<DeserializerConfig> =
+    Lazy::new(|| DeserializerConfig::new(BYTECODE_VERSION, IDENTIFIER_SIZE_MAX));
+static EXECUTION_GAS: Lazy<u64> =
+    Lazy::new(|| env_u64("APTOS_MOVEVM_DIRECT_FUZZ_GAS", DEFAULT_EXECUTION_GAS));
+
+fn direct_vm_config() -> VMConfig {
+    let mut config = VMConfig {
+        verifier_config: VERIFIER_CONFIG.clone(),
+        ..VMConfig::default_for_test()
+    };
+    apply_vm_config_overrides(&mut config);
+    config
+}
+
+fn new_storage() -> InMemoryStorage {
+    InMemoryStorage::new_with_runtime_environment(RuntimeEnvironment::new_with_config(
+        vec![],
+        direct_vm_config(),
+    ))
+}
+
+fn log_interesting_status(source: &str, status_code: StatusCode) {
+    let status_name = format!("{status_code:?}");
+    let kind = match status_code.status_type() {
+        StatusType::InvariantViolation => Some("invariant violation"),
+        _ if status_name.contains("TYPE") => Some("type-named error"),
+        _ => None,
+    };
+
+    if let Some(kind) = kind {
+        eprintln!("movevm_blockv2_direct: {kind} via {source}: status_code = {status_code:?}",);
+    }
+}
+
+fn should_debug_status(status_code: StatusCode) -> bool {
+    env::var("APTOS_MOVEVM_DIRECT_DEBUG_STATUS")
+        .ok()
+        .is_some_and(|statuses| {
+            statuses
+                .split(',')
+                .any(|status| status.trim() == format!("{status_code:?}"))
+        })
+}
+
+fn keep_vm_error(source: &'static str, error: VMError) -> Corpus {
+    tdbg!("vm error", source, &error);
+    log_interesting_status(source, error.major_status());
+    if should_debug_status(error.major_status()) {
+        eprintln!(
+            "movevm_blockv2_direct debug via {source}: {}",
+            error.format_test_output(true)
+        );
+        if env::var_os("APTOS_MOVEVM_DIRECT_DEBUG_NO_PANIC").is_none() {
+            panic!(
+                "movevm_blockv2_direct debug status {:?}",
+                error.major_status()
+            );
+        }
+    }
+    Corpus::Keep
+}
+
+fn keep_partial_vm_error(source: &'static str, error: PartialVMError) -> Corpus {
+    tdbg!("partial vm error", source, &error);
+    log_interesting_status(source, error.major_status());
+    if should_debug_status(error.major_status()) {
+        eprintln!("movevm_blockv2_direct debug via {source}: {error}");
+        if env::var_os("APTOS_MOVEVM_DIRECT_DEBUG_NO_PANIC").is_none() {
+            panic!(
+                "movevm_blockv2_direct debug status {:?}",
+                error.major_status()
+            );
+        }
+    }
+    Corpus::Keep
+}
+
+fn metered_gas_status() -> GasStatus {
+    GasStatus::new(
+        CostTable {
+            instruction_table: vec![GasCost::new(1, 1); 255],
+        },
+        GasQuantity::new(*EXECUTION_GAS),
+    )
+}
+
+fn verify_module(module: CompiledModule) -> Result<CompiledModule, Corpus> {
+    tdbg!("verify module", module_self_id(&module));
+    let module = normalize_module_for_fuzz(module)?;
+    verify_module_fast(&module, &VERIFIER_CONFIG, &DESERIALIZER_CONFIG)?;
+    Ok(module)
+}
+
+fn publish_package(
+    storage: &mut InMemoryStorage,
+    modules: Vec<CompiledModule>,
+) -> Result<(), Corpus> {
+    tdbg!("publish package", modules.len());
+    if modules.is_empty() {
+        return Err(Corpus::Reject);
+    }
+
+    let modules = modules
+        .into_iter()
+        .map(verify_module)
+        .collect::<Result<Vec<_>, _>>()?;
+    let sender = *module_self_id_or_keep(modules.first().ok_or(Corpus::Reject)?)?.address();
+    tdbg!("publish package sender", sender);
+    for module in &modules {
+        if module_self_id_or_keep(module)?.address() != &sender {
+            return Err(Corpus::Reject);
+        }
+    }
+
+    let module_bytes = modules
+        .iter()
+        .map(|module| serialize_module_for_version(module, VERSION_MAX))
+        .collect::<Result<Vec<_>, _>>()?;
+    let verified_bundle = {
+        let module_storage = storage.as_unsync_code_storage();
+        StagingModuleStorage::create_with_compat_config(
+            &sender,
+            Compatibility::no_check(),
+            &module_storage,
+            module_bytes.into_iter().map(Into::into).collect(),
+        )
+        .map_err(|error| keep_vm_error("publish_package_create_staging_storage", error))?
+        .release_verified_module_bundle()
+    };
+
+    for (module_id, bytes) in verified_bundle {
+        storage.add_module_bytes(module_id.address(), module_id.name(), bytes);
+    }
+    Ok(())
+}
+
+fn publish_dependency_modules(
+    storage: &mut InMemoryStorage,
+    dep_modules: &[CompiledModule],
+) -> Result<(), Corpus> {
+    tdbg!("publish dependency modules", dep_modules.len());
+    let dep_modules = dep_modules
+        .iter()
+        .cloned()
+        .map(verify_module)
+        .collect::<Result<Vec<_>, _>>()?;
+    let packages = group_modules_by_address_topo(dep_modules)?;
+    tdbg!("dependency package count", packages.len());
+    for package in packages {
+        publish_package(storage, package)?;
+    }
+    Ok(())
+}
+
+fn serialize_move_args(args: Vec<MoveValue>) -> Result<Vec<Vec<u8>>, Corpus> {
+    let args = args
+        .into_iter()
+        .take(MAX_ARGS)
+        .map(TransactionArgument::try_from)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| Corpus::Keep)?;
+    Ok(convert_txn_args(&args))
+}
+
+fn signer_args(function_param_tys: &[Type]) -> Result<Vec<Vec<u8>>, Corpus> {
+    let signer_count = function_param_tys
+        .iter()
+        .filter(|ty| matches!(ty, Type::Signer) || ty.paranoid_check_is_signer_ref_ty().is_ok())
+        .count();
+    if signer_count > MAX_SIGNER_ARGS {
+        return Err(Corpus::Keep);
+    }
+
+    Ok(vec![
+        MoveValue::Signer(AccountAddress::TWO)
+            .simple_serialize()
+            .ok_or(Corpus::Keep)?;
+        signer_count
+    ])
+}
+
+fn apply_effects(
+    storage: &mut InMemoryStorage,
+    data_cache: TransactionDataCache,
+) -> Result<(), Corpus> {
+    tdbg!("apply effects");
+    let code_storage = storage.as_unsync_code_storage();
+    let change_set = data_cache
+        .into_effects(&code_storage)
+        .map_err(|error| keep_partial_vm_error("data_cache_into_effects", error))?;
+    drop(code_storage);
+    storage
+        .apply(change_set)
+        .map_err(|error| keep_partial_vm_error("storage_apply_effects", error))
+}
+
+fn execute_script(
+    storage: &mut InMemoryStorage,
+    mut script: CompiledScript,
+    mut type_args: Vec<TypeTag>,
+    args: Vec<MoveValue>,
+) -> Result<(), Corpus> {
+    tdbg!("execute script");
+    script.version = VERSION_MAX;
+    type_args.truncate(MAX_TYPE_ARGS);
+    let mut serialized_args = serialize_move_args(args)?;
+
+    tdbg!("verify script");
+    verify_script_fast(&script, &VERIFIER_CONFIG, &DESERIALIZER_CONFIG)?;
+    let mut script_bytes = vec![];
+    script
+        .serialize_for_version(Some(VERSION_MAX), &mut script_bytes)
+        .map_err(|_| Corpus::Keep)?;
+
+    let code_storage = storage.as_unsync_code_storage();
+    let traversal_storage = TraversalStorage::new();
+    let mut traversal_context = TraversalContext::new(&traversal_storage);
+    let mut gas_meter = metered_gas_status();
+    let mut data_cache = TransactionDataCache::empty();
+
+    move_vm_runtime::dispatch_loader!(&code_storage, loader, {
+        let function = loader
+            .load_script(
+                &LegacyLoaderConfig::unmetered(),
+                &mut gas_meter,
+                &mut traversal_context,
+                &script_bytes,
+                &type_args,
+            )
+            .map_err(|error| keep_vm_error("load_script", error))?;
+        let mut all_args = signer_args(function.param_tys())?;
+        all_args.append(&mut serialized_args);
+
+        MoveVM::execute_loaded_function(
+            function,
+            all_args,
+            &mut MoveVmDataCacheAdapter::new(&mut data_cache, storage, &loader),
+            &mut gas_meter,
+            &mut traversal_context,
+            &mut NativeContextExtensions::default(),
+            &loader,
+        )
+        .map_err(|error| keep_vm_error("execute_script_function", error))
+    })?;
+
+    drop(code_storage);
+    apply_effects(storage, data_cache)
+}
+
+fn function_name(
+    module: &CompiledModule,
+    function: FunctionDefinitionIndex,
+) -> Result<Identifier, Corpus> {
+    resolve_function_name(module, function).map_err(|_| Corpus::Keep)
+}
+
+fn execute_function(
+    storage: &mut InMemoryStorage,
+    module: CompiledModule,
+    function: FunctionDefinitionIndex,
+    mut type_args: Vec<TypeTag>,
+    mut args: Vec<Vec<u8>>,
+) -> Result<(), Corpus> {
+    tdbg!("execute function");
+    type_args.truncate(MAX_TYPE_ARGS);
+    args.truncate(MAX_ARGS);
+
+    let module = verify_module(module)?;
+    let module_id = module_self_id_or_keep(&module)?;
+    let function_name = function_name(&module, function)?;
+
+    let code_storage = storage.as_unsync_code_storage();
+    let traversal_storage = TraversalStorage::new();
+    let mut traversal_context = TraversalContext::new(&traversal_storage);
+    let mut gas_meter = metered_gas_status();
+    let mut data_cache = TransactionDataCache::empty();
+
+    move_vm_runtime::dispatch_loader!(&code_storage, loader, {
+        let function = loader
+            .load_instantiated_function(
+                &LegacyLoaderConfig::unmetered(),
+                &mut gas_meter,
+                &mut traversal_context,
+                &module_id,
+                &function_name,
+                &type_args,
+            )
+            .map_err(|error| keep_vm_error("load_instantiated_function", error))?;
+        let mut all_args = signer_args(function.param_tys())?;
+        all_args.append(&mut args);
+
+        MoveVM::execute_loaded_function(
+            function,
+            all_args,
+            &mut MoveVmDataCacheAdapter::new(&mut data_cache, storage, &loader),
+            &mut gas_meter,
+            &mut traversal_context,
+            &mut NativeContextExtensions::default(),
+            &loader,
+        )
+        .map_err(|error| keep_vm_error("execute_entry_function", error))
+    })?;
+
+    drop(code_storage);
+    apply_effects(storage, data_cache)
+}
+
+fn execute_transaction(
+    storage: &mut InMemoryStorage,
+    modules: &[CompiledModule],
+    tx: &RunnableBlockTransactionV2,
+) -> Result<(), Corpus> {
+    tdbg!("execute transaction", &tx.exec_variant);
+    match &tx.exec_variant {
+        BlockExecVariantV2::Script {
+            _script,
+            _type_args,
+            _args,
+        } => execute_script(storage, _script.clone(), _type_args.clone(), _args.clone()),
+        BlockExecVariantV2::CallFunction {
+            _module_idx,
+            _function,
+            _type_args,
+            _args,
+        } => {
+            let module = resolve_module_ref(modules, *_module_idx)?.clone();
+            execute_function(
+                storage,
+                module,
+                *_function,
+                _type_args.clone(),
+                _args.clone(),
+            )
+        },
+        BlockExecVariantV2::Publish { _module_idxs } => {
+            let modules = resolve_module_refs(modules, _module_idxs)?;
+            publish_package(storage, modules)
+        },
+        BlockExecVariantV2::SplitBlock => Ok(()),
+    }
+}
+
+fn run_case(mut input: RunnableBlockStateV2) -> Result<(), Corpus> {
+    tdbg!(&input);
+    tdbg!("filtering fuzz case");
+    if input.modules.len() > MAX_BLOCK_MODULES
+        || input.transactions.is_empty()
+        || input.transactions.len() > MAX_BLOCK_TXNS
+    {
+        return Err(Corpus::Reject);
+    }
+
+    if has_invalid_split_blocks(&input.transactions) {
+        return Err(Corpus::Keep);
+    }
+
+    // fail fast
+    tdbg!("checking module ids and transaction shape");
+    filter_bad_modules(&mut input.modules)?;
+    for tx in &input.transactions {
+        filter_bad_tx(&tx.exec_variant)?;
+    }
+
+    tdbg!("collecting publish modules");
+    let publish_modules = input
+        .transactions
+        .iter()
+        .filter_map(|tx| match &tx.exec_variant {
+            BlockExecVariantV2::Publish { _module_idxs } => {
+                Some(resolve_module_refs(&input.modules, _module_idxs))
+            },
+            _ => None,
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let preload_modules = input
+        .modules
+        .iter()
+        .filter(|module| !publish_modules.contains(module))
+        .cloned()
+        .collect::<Vec<_>>();
+    tdbg!(
+        "preload and transaction counts",
+        preload_modules.len(),
+        input.transactions.len()
+    );
+    let mut storage = new_storage();
+    publish_dependency_modules(&mut storage, &preload_modules)?;
+    tdbg!("executing transactions");
+    for tx in &input.transactions {
+        execute_transaction(&mut storage, &input.modules, tx)?;
+    }
+
+    Ok(())
+}
+
+fuzz_target!(|fuzz_data: RunnableBlockStateV2| -> Corpus {
+    run_case(fuzz_data).err().unwrap_or(Corpus::Keep)
+});

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/utils/vm.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/utils/vm.rs
@@ -23,6 +23,7 @@ use move_binary_format::{
     deserializer::DeserializerConfig,
     errors::VMError,
     file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex},
+    file_format_common::{VERSION_MAX, VERSION_MIN},
 };
 use move_core_types::{
     identifier::Identifier,
@@ -35,6 +36,22 @@ use std::{
 };
 
 pub const BYTECODE_VERSION: u32 = 8;
+
+fn supported_bytecode_version(version: u32) -> u32 {
+    if (VERSION_MIN..=VERSION_MAX).contains(&version) {
+        version
+    } else {
+        VERSION_MAX
+    }
+}
+
+pub(crate) fn module_bytecode_version(module: &CompiledModule) -> u32 {
+    supported_bytecode_version(module.version)
+}
+
+pub(crate) fn script_bytecode_version(script: &CompiledScript) -> u32 {
+    supported_bytecode_version(script.version)
+}
 
 // Used to fuzz the MoveVM
 #[derive(Debug, Arbitrary, Eq, PartialEq, Clone)]
@@ -77,13 +94,13 @@ pub(crate) fn sort_by_deps(
     id: ModuleId,
     visited: &mut HashSet<ModuleId>,
 ) -> Result<(), Corpus> {
+    if order.contains(&id) {
+        return Ok(());
+    }
     if visited.contains(&id) {
         return Err(Corpus::Keep);
     }
     visited.insert(id.clone());
-    if order.contains(&id) {
-        return Ok(());
-    }
     let compiled = &map.get(&id).unwrap();
     for dep in compiled.immediate_dependencies() {
         // Only consider deps which are actually in this package. Deps for outside
@@ -171,11 +188,19 @@ pub(crate) fn verify_module_fast(
 ) -> Result<(), Corpus> {
     let mut module_code = vec![];
     module
-        .serialize_for_version(Some(BYTECODE_VERSION), &mut module_code)
-        .map_err(|_| Corpus::Reject)?;
-    let m_de = CompiledModule::deserialize_with_config(&module_code, deserializer_config)
-        .map_err(|_| Corpus::Reject)?;
+        .serialize_for_version(Some(module_bytecode_version(module)), &mut module_code)
+        .map_err(|e| {
+            tdbg!("module serialization failed", &e);
+            Corpus::Reject
+        })?;
+    let m_de = CompiledModule::deserialize_with_config(&module_code, deserializer_config).map_err(
+        |e| {
+            tdbg!("module deserialization failed", &e);
+            Corpus::Reject
+        },
+    )?;
     move_bytecode_verifier::verify_module_with_config(verifier_config, &m_de).map_err(|e| {
+        tdbg!("module verification failed", &e);
         check_for_invariant_violation_vmerror(e);
         Corpus::Reject
     })
@@ -188,11 +213,19 @@ pub(crate) fn verify_script_fast(
 ) -> Result<(), Corpus> {
     let mut script_code = vec![];
     script
-        .serialize_for_version(Some(BYTECODE_VERSION), &mut script_code)
-        .map_err(|_| Corpus::Reject)?;
-    let s_de = CompiledScript::deserialize_with_config(&script_code, deserializer_config)
-        .map_err(|_| Corpus::Reject)?;
+        .serialize_for_version(Some(script_bytecode_version(script)), &mut script_code)
+        .map_err(|e| {
+            tdbg!("script serialization failed", &e);
+            Corpus::Reject
+        })?;
+    let s_de = CompiledScript::deserialize_with_config(&script_code, deserializer_config).map_err(
+        |e| {
+            tdbg!("script deserialization failed", &e);
+            Corpus::Reject
+        },
+    )?;
     move_bytecode_verifier::verify_script_with_config(verifier_config, &s_de).map_err(|e| {
+        tdbg!("script verification failed", &e);
         check_for_invariant_violation_vmerror(e);
         Corpus::Reject
     })
@@ -222,10 +255,10 @@ pub(crate) fn group_modules_by_address_topo(
         let package_address = module_id_to_start_package.address();
         let mut current_package_for_address: Vec<CompiledModule> = Vec::new();
         for module_id_in_global_order in &order {
-            if module_id_in_global_order.address() == package_address {
-                if let Some(module) = remaining_modules_map.remove(module_id_in_global_order) {
-                    current_package_for_address.push(module);
-                }
+            if module_id_in_global_order.address() == package_address
+                && let Some(module) = remaining_modules_map.remove(module_id_in_global_order)
+            {
+                current_package_for_address.push(module);
             }
         }
         if !current_package_for_address.is_empty() {
@@ -273,11 +306,65 @@ fn publish_transaction_payload(modules: &[CompiledModule]) -> TransactionPayload
     for module in modules {
         let mut module_code: Vec<u8> = vec![];
         module
-            .serialize_for_version(Some(BYTECODE_VERSION), &mut module_code)
+            .serialize_for_version(Some(module_bytecode_version(module)), &mut module_code)
             .expect("Module must serialize");
         pkg_code.push(module_code);
     }
     code_publish_package_txn(pkg_metadata, pkg_code)
+}
+
+pub(crate) fn publish_transaction_payload_with_package_names(
+    modules: &[CompiledModule],
+    package_name: &str,
+    package_names_by_module: &BTreeMap<ModuleId, String>,
+) -> TransactionPayload {
+    let modules_metadata = modules
+        .iter()
+        .map(|module| ModuleMetadata {
+            name: module.name().to_string(),
+            source: vec![],
+            source_map: vec![],
+            extension: None,
+        })
+        .collect();
+
+    let deps = modules
+        .iter()
+        .flat_map(|module| module.immediate_dependencies())
+        .map(|id| PackageDep {
+            account: id.address,
+            package_name: package_names_by_module
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| id.name.to_string()),
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter(|dep| &dep.account != modules[0].address())
+        .collect();
+
+    let metadata = PackageMetadata {
+        name: package_name.to_string(),
+        upgrade_policy: UpgradePolicy::compat(),
+        upgrade_number: 1,
+        source_digest: "".to_string(),
+        manifest: vec![],
+        modules: modules_metadata,
+        deps,
+        extension: None,
+    };
+    let metadata = bcs::to_bytes(&metadata).expect("PackageMetadata must serialize");
+    let code = modules
+        .iter()
+        .map(|module| {
+            let mut code = vec![];
+            module
+                .serialize_for_version(Some(module_bytecode_version(module)), &mut code)
+                .expect("Module must serialize");
+            code
+        })
+        .collect();
+    code_publish_package_txn(metadata, code)
 }
 
 // List of known false positive messages for invariant violations
@@ -427,16 +514,15 @@ pub(crate) fn publish_group(
     match tdbg!(status) {
         ExecutionStatus::Success => Ok(()),
         ExecutionStatus::MiscellaneousError(e) => {
-            if let Some(e) = e {
-                if e.status_type() == StatusType::InvariantViolation
-                    && *e != StatusCode::VERIFICATION_ERROR
-                {
-                    panic!(
-                        "invariant violation via ExecutionStatus: {:?}, {:?}",
-                        e,
-                        res.auxiliary_data()
-                    );
-                }
+            if let Some(e) = e
+                && e.status_type() == StatusType::InvariantViolation
+                && *e != StatusCode::VERIFICATION_ERROR
+            {
+                panic!(
+                    "invariant violation via ExecutionStatus: {:?}, {:?}",
+                    e,
+                    res.auxiliary_data()
+                );
             }
             Err(Corpus::Keep)
         },

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/utils/vm.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/utils/vm.rs
@@ -16,16 +16,21 @@ use aptos_types::{
     },
 };
 use arbitrary::Arbitrary;
-use fuzzer::UserAccount;
+use fuzzer::{BlockExecVariantV2, RunnableBlockTransactionV2, UserAccount};
 use libfuzzer_sys::Corpus;
 use move_binary_format::{
     access::ModuleAccess,
     deserializer::DeserializerConfig,
     errors::VMError,
-    file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex},
+    file_format::{
+        CompiledModule, CompiledScript, FunctionDefinitionIndex, Signature, SignatureToken,
+        Visibility,
+    },
     file_format_common::{VERSION_MAX, VERSION_MIN},
+    internals::ModuleIndex,
 };
 use move_core_types::{
+    account_address::AccountAddress,
     identifier::Identifier,
     language_storage::ModuleId,
     vm_status::{StatusCode, StatusType, VMStatus},
@@ -36,6 +41,7 @@ use std::{
 };
 
 pub const BYTECODE_VERSION: u32 = 8;
+const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16;
 
 fn supported_bytecode_version(version: u32) -> u32 {
     if (VERSION_MIN..=VERSION_MAX).contains(&version) {
@@ -51,6 +57,167 @@ pub(crate) fn module_bytecode_version(module: &CompiledModule) -> u32 {
 
 pub(crate) fn script_bytecode_version(script: &CompiledScript) -> u32 {
     supported_bytecode_version(script.version)
+}
+
+pub(crate) fn module_self_id(module: &CompiledModule) -> Option<ModuleId> {
+    let handle = module
+        .module_handles
+        .get(module.self_module_handle_idx.into_index())?;
+    let address = module
+        .address_identifiers
+        .get(handle.address.into_index())?;
+    let name = module.identifiers.get(handle.name.into_index())?.to_owned();
+    Some(ModuleId::new(*address, name))
+}
+
+pub(crate) fn module_self_id_or_keep(module: &CompiledModule) -> Result<ModuleId, Corpus> {
+    module_self_id(module).ok_or(Corpus::Keep)
+}
+
+pub(crate) fn checked_module_self_id(module: &CompiledModule) -> ModuleId {
+    module_self_id(module).expect("module self id checked at fuzz case boundary")
+}
+
+pub(crate) fn resolve_module_ref(
+    modules: &[CompiledModule],
+    module_idx: u8,
+) -> Result<&CompiledModule, Corpus> {
+    if modules.is_empty() {
+        return Err(Corpus::Keep);
+    }
+    Ok(&modules[module_idx as usize % modules.len()])
+}
+
+pub(crate) fn resolve_module_refs(
+    modules: &[CompiledModule],
+    module_idxs: &[u8],
+) -> Result<Vec<CompiledModule>, Corpus> {
+    const MAX_MODULE_REFS: usize = 32;
+
+    if module_idxs.len() > MAX_MODULE_REFS {
+        return Err(Corpus::Keep);
+    }
+    if module_idxs.is_empty() {
+        return Ok(vec![]);
+    }
+    if modules.is_empty() {
+        return Err(Corpus::Keep);
+    }
+
+    let mut seen = BTreeSet::new();
+    Ok(module_idxs
+        .iter()
+        .map(|module_idx| *module_idx as usize % modules.len())
+        .filter(|idx| seen.insert(*idx))
+        .map(|idx| modules[idx].clone())
+        .collect())
+}
+
+pub(crate) fn normalize_module_for_fuzz(
+    mut module: CompiledModule,
+) -> Result<CompiledModule, Corpus> {
+    module.version = VERSION_MAX;
+    let is_entry_by_handle = module
+        .function_handles
+        .iter()
+        .map(|handle| {
+            module
+                .signatures
+                .get(handle.return_.into_index())
+                .is_some_and(|signature| signature.0.is_empty())
+        })
+        .collect::<Vec<_>>();
+
+    for definition in &mut module.function_defs {
+        if definition.code.is_none() {
+            return Err(Corpus::Keep);
+        }
+        definition.visibility = Visibility::Public;
+        definition.is_entry = is_entry_by_handle
+            .get(definition.function.into_index())
+            .copied()
+            .unwrap_or(false);
+    }
+
+    Ok(module)
+}
+
+pub(crate) fn serialize_module_for_version(
+    module: &CompiledModule,
+    bytecode_version: u32,
+) -> Result<Vec<u8>, Corpus> {
+    let mut bytes = vec![];
+    module
+        .serialize_for_version(Some(bytecode_version), &mut bytes)
+        .map_err(|e| {
+            tdbg!("module serialization failed", &e);
+            Corpus::Keep
+        })?;
+    Ok(bytes)
+}
+
+fn signature_token_is_too_large(token: &SignatureToken) -> bool {
+    match token {
+        SignatureToken::TypeParameter(idx) => *idx > MAX_TYPE_PARAMETER_VALUE,
+        SignatureToken::Vector(inner)
+        | SignatureToken::Reference(inner)
+        | SignatureToken::MutableReference(inner) => signature_token_is_too_large(inner),
+        SignatureToken::StructInstantiation(_, tys) => tys.iter().any(signature_token_is_too_large),
+        SignatureToken::Function(args, results, _) => {
+            args.iter().any(signature_token_is_too_large)
+                || results.iter().any(signature_token_is_too_large)
+        },
+        _ => false,
+    }
+}
+
+fn has_oversized_signatures(signatures: &[Signature]) -> bool {
+    signatures
+        .iter()
+        .any(|signature| signature.0.iter().any(signature_token_is_too_large))
+}
+
+pub(crate) fn filter_bad_modules(modules: &mut [CompiledModule]) -> Result<(), Corpus> {
+    for module in modules {
+        if module_self_id(module).is_none_or(|id| *id.address() == AccountAddress::ONE) {
+            return Err(Corpus::Keep);
+        }
+        for definition in &mut module.function_defs {
+            definition.is_entry = true;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn filter_bad_tx(exec_variant: &BlockExecVariantV2) -> Result<(), Corpus> {
+    match exec_variant {
+        BlockExecVariantV2::Script { _script, .. } => {
+            if has_oversized_signatures(&_script.signatures) {
+                return Err(Corpus::Keep);
+            }
+            Ok(())
+        },
+        BlockExecVariantV2::Publish { _module_idxs } => {
+            if _module_idxs.is_empty() {
+                return Err(Corpus::Keep);
+            }
+            Ok(())
+        },
+        BlockExecVariantV2::CallFunction { .. } => Ok(()),
+        BlockExecVariantV2::SplitBlock => Ok(()),
+    }
+}
+
+pub(crate) fn is_split_block(transaction: &RunnableBlockTransactionV2) -> bool {
+    matches!(&transaction.exec_variant, BlockExecVariantV2::SplitBlock)
+}
+
+pub(crate) fn has_invalid_split_blocks(transactions: &[RunnableBlockTransactionV2]) -> bool {
+    transactions.first().is_some_and(is_split_block)
+        || transactions.last().is_some_and(is_split_block)
+        || transactions
+            .windows(2)
+            .any(|window| window.iter().all(is_split_block))
 }
 
 // Used to fuzz the MoveVM
@@ -237,8 +404,8 @@ pub(crate) fn group_modules_by_address_topo(
     let all_modules = dep_modules;
     let map = all_modules
         .into_iter()
-        .map(|m| (m.self_id(), m))
-        .collect::<BTreeMap<_, _>>();
+        .map(|m| module_self_id_or_keep(&m).map(|id| (id, m)))
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
     let mut order = vec![];
     for id in map.keys() {
         let mut visited = HashSet::new();

--- a/testsuite/fuzzer/src/lib.rs
+++ b/testsuite/fuzzer/src/lib.rs
@@ -5,5 +5,6 @@ pub mod types;
 pub mod utils;
 
 pub use types::{
-    Authenticator, ExecVariant, FundAmount, RunnableState, RunnableStateWithOperations, UserAccount,
+    Authenticator, BlockExecVariantV2, ExecVariant, FundAmount, RunnableBlockStateV2,
+    RunnableBlockTransactionV2, RunnableState, RunnableStateWithOperations, UserAccount,
 };

--- a/testsuite/fuzzer/src/types.rs
+++ b/testsuite/fuzzer/src/types.rs
@@ -62,6 +62,41 @@ pub enum ExecVariant {
     },
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Arbitrary, Dearbitrary)]
+pub enum BlockExecVariantV2 {
+    Script {
+        _script: CompiledScript,
+        _type_args: Vec<TypeTag>,
+        _args: Vec<MoveValue>,
+    },
+    CallFunction {
+        _module_idx: u8,
+        _function: FunctionDefinitionIndex,
+        _type_args: Vec<TypeTag>,
+        _args: Vec<Vec<u8>>,
+    },
+    Publish {
+        _module_idxs: Vec<u8>,
+    },
+    SplitBlock,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Arbitrary, Dearbitrary)]
+pub struct RunnableBlockTransactionV2 {
+    pub exec_variant: BlockExecVariantV2,
+    pub sender_slot: u8,
+    pub orderless: bool,
+    pub secondary_slots: Vec<u8>,
+    pub fee_payer_slot: Option<u8>,
+}
+
+#[derive(Debug, Default, Eq, PartialEq, Clone, Arbitrary, Dearbitrary)]
+pub struct RunnableBlockStateV2 {
+    pub accounts: Vec<UserAccount>,
+    pub modules: Vec<CompiledModule>,
+    pub transactions: Vec<RunnableBlockTransactionV2>,
+}
+
 // Originally from testsuite/fuzzer/src/utils.rs
 #[derive(Debug, Arbitrary, Dearbitrary, Eq, PartialEq, Clone)]
 pub enum Authenticator {

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -37,6 +37,8 @@ pub use runtime_type_checks_async::TypeChecker;
 mod storage;
 
 pub use loader::{Function, LoadedFunction, LoadedFunctionOwner, Module, Script};
+#[cfg(fuzzing)]
+pub use storage::environment::RuntimeEnvironmentSnapshot;
 pub use storage::{
     code_storage::CodeStorage,
     dependencies_gas_charging::check_dependencies_and_charge_gas,

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -38,6 +38,14 @@ use move_vm_types::{
     ty_interner::InternedTypePool,
 };
 use std::sync::Arc;
+#[cfg(fuzzing)]
+use {
+    crate::storage::ty_tag_converter::TypeTagCacheSnapshot,
+    move_vm_types::{
+        loaded_data::struct_name_indexing::StructNameIndexMapSnapshot,
+        module_id_interner::InternedModuleIdPoolSnapshot, ty_interner::InternedTypePoolSnapshot,
+    },
+};
 
 const OPTION_MODULE_BYTES: &[u8] = include_bytes!("option.mv");
 const MEM_MODULE_BYTES: &[u8] = include_bytes!("mem.mv");
@@ -76,6 +84,14 @@ pub struct RuntimeEnvironment {
 
     /// Pool of interned module ids.
     interned_module_id_pool: Arc<InternedModuleIdPool>,
+}
+
+#[cfg(fuzzing)]
+pub struct RuntimeEnvironmentSnapshot {
+    struct_name_index_map: StructNameIndexMapSnapshot,
+    ty_tag_cache: TypeTagCacheSnapshot,
+    interned_ty_pool: InternedTypePoolSnapshot,
+    interned_module_id_pool: InternedModuleIdPoolSnapshot,
 }
 
 impl RuntimeEnvironment {
@@ -390,6 +406,27 @@ impl RuntimeEnvironment {
         self.struct_name_index_map.flush();
         self.interned_ty_pool.flush();
         self.interned_module_id_pool.flush();
+    }
+
+    #[cfg(fuzzing)]
+    pub fn snapshot_caches_for_fuzzing(&self) -> RuntimeEnvironmentSnapshot {
+        RuntimeEnvironmentSnapshot {
+            struct_name_index_map: self.struct_name_index_map.snapshot_for_fuzzing(),
+            ty_tag_cache: self.ty_tag_cache.snapshot_for_fuzzing(),
+            interned_ty_pool: self.interned_ty_pool.snapshot_for_fuzzing(),
+            interned_module_id_pool: self.interned_module_id_pool.snapshot_for_fuzzing(),
+        }
+    }
+
+    #[cfg(fuzzing)]
+    pub fn restore_caches_for_fuzzing(&self, snapshot: RuntimeEnvironmentSnapshot) {
+        self.interned_module_id_pool
+            .restore_for_fuzzing(snapshot.interned_module_id_pool);
+        self.struct_name_index_map
+            .restore_for_fuzzing(snapshot.struct_name_index_map);
+        self.interned_ty_pool
+            .restore_for_fuzzing(snapshot.interned_ty_pool);
+        self.ty_tag_cache.restore_for_fuzzing(snapshot.ty_tag_cache);
     }
 
     /// Flushes the global verified module cache. Should be used when verifier configuration has

--- a/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
@@ -153,6 +153,9 @@ pub struct TypeTagCache {
     cache: RwLock<HashMap<StructKey, PricedStructTag>>,
 }
 
+#[cfg(fuzzing)]
+pub(crate) struct TypeTagCacheSnapshot(HashMap<StructKey, PricedStructTag>);
+
 impl TypeTagCache {
     /// Creates a new empty cache without any entries.
     pub(crate) fn empty() -> Self {
@@ -164,6 +167,16 @@ impl TypeTagCache {
     /// Removes all entries from the cache.
     pub(crate) fn flush(&self) {
         self.cache.write().clear();
+    }
+
+    #[cfg(fuzzing)]
+    pub(crate) fn snapshot_for_fuzzing(&self) -> TypeTagCacheSnapshot {
+        TypeTagCacheSnapshot(self.cache.read().clone())
+    }
+
+    #[cfg(fuzzing)]
+    pub(crate) fn restore_for_fuzzing(&self, snapshot: TypeTagCacheSnapshot) {
+        *self.cache.write() = snapshot.0;
     }
 
     /// Returns the number of entries in the cache.

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -46,6 +46,9 @@ once_cell = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
 [[bench]]
 name = "drop_bench"
 harness = false

--- a/third_party/move/move-vm/types/src/interner.rs
+++ b/third_party/move/move-vm/types/src/interner.rs
@@ -16,6 +16,9 @@ pub struct ConcurrentBTreeInterner<T: 'static> {
     inner: RwLock<InternerPool<T>>,
 }
 
+#[cfg(fuzzing)]
+pub struct ConcurrentBTreeInternerSnapshot<T: 'static>(Vec<T>);
+
 /// Pool storing the interned values.
 struct InternerPool<T: 'static> {
     /// The size for the next allocation of the active buffer.
@@ -199,6 +202,32 @@ where
     /// indices across flushes.
     pub fn flush(&self) {
         self.inner.write().flush();
+    }
+
+    #[cfg(fuzzing)]
+    pub fn snapshot_for_fuzzing(&self) -> ConcurrentBTreeInternerSnapshot<T>
+    where
+        T: Clone,
+    {
+        ConcurrentBTreeInternerSnapshot(
+            self.inner
+                .read()
+                .vec
+                .iter()
+                .map(|value| (**value).clone())
+                .collect(),
+        )
+    }
+
+    #[cfg(fuzzing)]
+    pub fn restore_for_fuzzing(&self, snapshot: ConcurrentBTreeInternerSnapshot<T>)
+    where
+        T: Clone,
+    {
+        self.flush();
+        for value in snapshot.0 {
+            self.intern(value);
+        }
     }
 }
 

--- a/third_party/move/move-vm/types/src/loaded_data/struct_name_indexing.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/struct_name_indexing.rs
@@ -50,6 +50,9 @@ struct IndexMap<T: Clone + Ord> {
 /// guarantees that the same struct name identifier always corresponds to a unique index.
 pub struct StructNameIndexMap(RwLock<IndexMap<StructIdentifier>>);
 
+#[cfg(fuzzing)]
+pub struct StructNameIndexMapSnapshot(IndexMap<StructIdentifier>);
+
 impl StructNameIndexMap {
     /// Returns an empty map with no entries.
     pub fn empty() -> Self {
@@ -64,6 +67,16 @@ impl StructNameIndexMap {
         let mut index_map = self.0.write();
         index_map.backward_map.clear();
         index_map.forward_map.clear();
+    }
+
+    #[cfg(fuzzing)]
+    pub fn snapshot_for_fuzzing(&self) -> StructNameIndexMapSnapshot {
+        StructNameIndexMapSnapshot(self.0.read().clone())
+    }
+
+    #[cfg(fuzzing)]
+    pub fn restore_for_fuzzing(&self, snapshot: StructNameIndexMapSnapshot) {
+        *self.0.write() = snapshot.0;
     }
 
     /// Maps the struct identifier into an index. If the identifier already exists returns the

--- a/third_party/move/move-vm/types/src/module_id_interner.rs
+++ b/third_party/move/move-vm/types/src/module_id_interner.rs
@@ -2,6 +2,8 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::interner::ConcurrentBTreeInterner;
+#[cfg(fuzzing)]
+use crate::interner::ConcurrentBTreeInternerSnapshot;
 use move_core_types::language_storage::ModuleId;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
@@ -10,6 +12,9 @@ pub struct InternedModuleId(usize);
 pub struct InternedModuleIdPool {
     inner: ConcurrentBTreeInterner<ModuleId>,
 }
+
+#[cfg(fuzzing)]
+pub struct InternedModuleIdPoolSnapshot(ConcurrentBTreeInternerSnapshot<ModuleId>);
 
 impl InternedModuleIdPool {
     pub fn new() -> Self {
@@ -36,6 +41,16 @@ impl InternedModuleIdPool {
 
     pub fn flush(&self) {
         self.inner.flush();
+    }
+
+    #[cfg(fuzzing)]
+    pub fn snapshot_for_fuzzing(&self) -> InternedModuleIdPoolSnapshot {
+        InternedModuleIdPoolSnapshot(self.inner.snapshot_for_fuzzing())
+    }
+
+    #[cfg(fuzzing)]
+    pub fn restore_for_fuzzing(&self, snapshot: InternedModuleIdPoolSnapshot) {
+        self.inner.restore_for_fuzzing(snapshot.0);
     }
 }
 

--- a/third_party/move/move-vm/types/src/ty_interner.rs
+++ b/third_party/move/move-vm/types/src/ty_interner.rs
@@ -56,6 +56,7 @@ enum TypeRepr {
     },
 }
 
+#[derive(Clone)]
 struct InternMap<T, I> {
     interned: HashMap<T, I>,
     data: Vec<T>,
@@ -170,6 +171,12 @@ pub struct InternedTypePool {
     ty_vec_interner: TypeVecInterner,
 }
 
+#[cfg(fuzzing)]
+pub struct InternedTypePoolSnapshot {
+    ty_interner: InternMap<TypeRepr, TypeId>,
+    ty_vec_interner: InternMap<Arc<[TypeId]>, TypeVecId>,
+}
+
 impl InternedTypePool {
     /// Creates a new interning context. Context is warmed-up with common types.
     #[allow(clippy::new_without_default)]
@@ -199,6 +206,20 @@ impl InternedTypePool {
     pub fn flush(&self) {
         self.flush_impl();
         self.warmup();
+    }
+
+    #[cfg(fuzzing)]
+    pub fn snapshot_for_fuzzing(&self) -> InternedTypePoolSnapshot {
+        InternedTypePoolSnapshot {
+            ty_interner: self.ty_interner.inner.read().clone(),
+            ty_vec_interner: self.ty_vec_interner.inner.read().clone(),
+        }
+    }
+
+    #[cfg(fuzzing)]
+    pub fn restore_for_fuzzing(&self, snapshot: InternedTypePoolSnapshot) {
+        *self.ty_interner.inner.write() = snapshot.ty_interner;
+        *self.ty_vec_interner.inner.write() = snapshot.ty_vec_interner;
     }
 
     /// Flushes all cached data without warming up the cache.


### PR DESCRIPTION
## Description
Adds new E2E parallel Block-STM v2 and fast MoveVM direct fuzzers.

The E2E fuzzer supports:

* Parallel execution
* Module upgrades
* Account reuse
* Different authenticator types
* Sequential-vs-parallel execution divergence detection
* Reasonable fuzz cases/sec
* A format that can support generators for existing corpus formats, transactional tests, and E2E tests
* Sequential-only and parallel-only modes
* Safe cache rollback to isolate fuzz cases
* Aptos framework caching, so the framework does not need to be reloaded on each execution

The fast `movevm_direct` fuzzer:

* Is designed for performance and is mainly intended to drive corpus generation
* May have a higher false positive rate, but fuzz cases can be checked for validity with the E2E fuzzer
* Achieves 10-20x more fuzz cases/sec
* Does not include the Aptos framework or AptosVM layers, and uses simple gas-charging logic

It is recommended to run these two fuzzers in parallel with `-reload=1` so that interesting inputs are shared between them.

I also added multiple environment variables that override the default gas, execution, and cache limits. Some of these limits are impossible to reach in a single fuzz case at their default values; lowering them allows the fuzzer to exercise the relevant code.

## How Has This Been Tested?
`./fuzz.sh run`

## Key Areas to Review

`cfg` gating in non-fuzzer code.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches block-executor and Move VM runtime cache snapshot/restore paths, but all gated behind cfg(fuzzing); normal validator execution is unchanged aside from lint metadata.
> 
> **Overview**
> Adds **Block-STM v2** fuzzing infrastructure: an E2E target that runs the same signed blocks through **sequential** and **parallel Block-STM v2** AptosVM execution (default `FUZZER_EXEC_MODE=v2+seq`) and panics on output or final-state hash mismatches, plus a faster **MoveVM-only** target for corpus generation on the same `RunnableBlockStateV2` inputs.
> 
> The E2E harness builds multi-block cases (publish/call/script, multi-agent/fee payer, orderless nonces, split blocks), tunes executor/gas/cache limits via env vars, and uses a **shared** module cache manager with **snapshot/rollback** so framework stays warm but per-case publishes do not leak between lanes or iterations.
> 
> **`cfg(fuzzing)`** production hooks (no behavior change in normal builds): `set_vm_config_override_for_fuzzing` in `aptos-vm-environment`; `ModuleHotCacheSnapshot` now captures/restores **runtime interner/tag caches** alongside the global module cache; snapshot/restore APIs on `RuntimeEnvironment` and related pools; `unexpected_cfgs` lint for `fuzzing` on touched crates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e02bfb32df9bf6ccc11c86283ac203f998b5bbf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->