### PR TITLE
[deps] Bump hashbrown 0.14.3 -> 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
  "dashmap 7.0.0-rc2",
  "derivative",
  "fail",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "move-binary-format",
  "move-core-types",
@@ -1807,7 +1807,7 @@ dependencies = [
  "aptos-vm-environment",
  "aptos-vm-logging",
  "aptos-vm-types",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
  "move-core-types",
  "once_cell",
  "rayon",
@@ -4061,7 +4061,7 @@ dependencies = [
  "aptos-vm",
  "aptos-vm-environment",
  "aptos-vm-logging",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -5005,7 +5005,7 @@ dependencies = [
  "derivative",
  "fixed",
  "fxhash",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
  "hex",
  "itertools 0.13.0",
  "jsonwebtoken 8.3.0",
@@ -10670,11 +10670,6 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
- "equivalent",
-]
 
 [[package]]
 name = "hashbrown"
@@ -12983,7 +12978,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
  "mono-move-alloc",
  "mono-move-core",
  "mono-move-loader",
@@ -13252,7 +13247,7 @@ dependencies = [
  "bytes",
  "dearbitrary",
  "ethnum",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
  "hex",
  "num 0.4.1",
  "once_cell",
@@ -13835,7 +13830,7 @@ dependencies = [
  "claims",
  "fail",
  "fxhash",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "lazy_static",
  "lru",
@@ -13898,7 +13893,7 @@ dependencies = [
  "crossbeam",
  "dashmap 7.0.0-rc2",
  "derivative",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "mockall 0.11.4",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -655,7 +655,7 @@ google-cloud-storage = "0.13.0"
 group = "0.13"
 guppy = "0.17.5"
 handlebars = "4.2.2"
-hashbrown = { version = "0.14.3", features = ["equivalent"] }
+hashbrown = { version = "0.17.1", features = ["equivalent"] }
 heck = "0.4.1"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"

--- a/aptos-move/block-executor/src/hot_state_op_accumulator.rs
+++ b/aptos-move/block-executor/src/hot_state_op_accumulator.rs
@@ -51,7 +51,7 @@ where
             if self.to_make_hot.remove(key) {
                 COUNTER.inc_with(&["promotion_removed_by_write"]);
             }
-            self.writes.get_or_insert_owned(key);
+            self.writes.get_or_insert_with(key, |k| k.clone());
         }
 
         for key in reads {

--- a/experimental/execution/ptx-executor/Cargo.toml
+++ b/experimental/execution/ptx-executor/Cargo.toml
@@ -23,9 +23,7 @@ aptos-vm = { workspace = true }
 aptos-vm-environment = { workspace = true }
 aptos-vm-logging = { workspace = true }
 aptos-vm-types = { workspace = true }
+hashbrown = { workspace = true }
 move-core-types = { workspace = true }
 once_cell = { workspace = true }
 rayon = { workspace = true }
-
-# experimental
-hashbrown = "0.14.0"


### PR DESCRIPTION

Upgrade the workspace `hashbrown` dependency to the latest release.

The 0.14 -> 0.15 transition removed `HashSet::get_or_insert_owned`, so the
one caller in the block executor hot-state op accumulator now uses
`get_or_insert_with(key, |k| k.clone())`, preserving the original behavior
of cloning the key only on a miss.

Two other notes:

- The default hasher changes from `ahash` to `foldhash` (the `default-hasher`
  feature stays enabled). All hashbrown maps/sets here are internal caches
  keyed by already-validated data and do not depend on hash ordering, so the
  switch is safe and generally a bit faster.
- `ptx-executor` carried its own `hashbrown` pin; it now uses the workspace
  dependency like everything else.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
