### PR TITLE
[move-flow] Add update subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-move-flow"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "aptos-cli-common",
@@ -3358,6 +3358,7 @@ dependencies = [
  "pathsearch",
  "regex",
  "rmcp",
+ "self_update",
  "serde",
  "serde_json",
  "tempfile",

--- a/aptos-move/flow/CHANGELOG.md
+++ b/aptos-move/flow/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-30
+
+### Added
+- `move-flow update [--check]` subcommand for self-updating from
+  `aptos-labs/aptos-ai` GitHub releases.
+
 ## [1.0.4] - 2026-06-10
 
 ### Added
@@ -16,5 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `x86_64-apple-darwin`, `aarch64-apple-darwin`, and
   `x86_64-pc-windows-msvc`.
 
-[Unreleased]: https://github.com/aptos-labs/aptos-core/compare/move-flow-v1.0.4...HEAD
+[Unreleased]: https://github.com/aptos-labs/aptos-core/compare/move-flow-v1.1.0...HEAD
+[1.1.0]: https://github.com/aptos-labs/aptos-core/compare/move-flow-v1.0.4...move-flow-v1.1.0
 [1.0.4]: https://github.com/aptos-labs/aptos-core/releases/tag/move-flow-v1.0.4

--- a/aptos-move/flow/Cargo.toml
+++ b/aptos-move/flow/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-move-flow"
 description = "MoveFlow: agent support for Move"
-version = "1.0.4"
+version = "1.1.0"
 
 authors = { workspace = true }
 edition = { workspace = true }
@@ -58,6 +58,10 @@ pathsearch = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+self_update = { git = "https://github.com/banool/self_update.git", rev = "8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b", features = [
+    "archive-zip",
+    "compression-zip-deflate",
+] }
 tempfile = { workspace = true }
 tera = { workspace = true }
 tokio = { workspace = true }

--- a/aptos-move/flow/Cargo.toml
+++ b/aptos-move/flow/Cargo.toml
@@ -56,12 +56,12 @@ move-vm-runtime = { workspace = true }
 notify = { workspace = true }
 pathsearch = { workspace = true }
 rmcp = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
 self_update = { git = "https://github.com/banool/self_update.git", rev = "8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b", features = [
     "archive-zip",
     "compression-zip-deflate",
 ] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 tera = { workspace = true }
 tokio = { workspace = true }

--- a/aptos-move/flow/src/lib.rs
+++ b/aptos-move/flow/src/lib.rs
@@ -4,8 +4,9 @@
 pub mod hooks;
 pub mod mcp;
 pub mod plugin;
+pub mod update;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use mcp::supervisor::{run_supervised, RESTART_ENV_VAR};
 use std::path::PathBuf;
@@ -48,6 +49,8 @@ pub enum FlowCommand {
     /// Hook subcommands (called from AI platform hooks).
     #[command(subcommand)]
     Hook(hooks::HookCommand),
+    /// Update move-flow to the latest release.
+    Update(update::UpdateArgs),
 }
 
 /// Supported AI platform targets.
@@ -76,6 +79,12 @@ impl FlowCli {
                 Some(v) => mcp::run(args, &self.global, v == "1").await,
             },
             FlowCommand::Hook(cmd) => hooks::run(cmd),
+            FlowCommand::Update(args) => {
+                let args = args.clone();
+                tokio::task::spawn_blocking(move || update::run(&args))
+                    .await
+                    .context("update task panicked")?
+            },
         }
     }
 }

--- a/aptos-move/flow/src/tests/mod.rs
+++ b/aptos-move/flow/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod move_package_status;
 mod move_package_test;
 mod move_package_verify;
 mod move_replay_transaction;
+mod update;
 
 use super::*;
 

--- a/aptos-move/flow/src/tests/update/mod.rs
+++ b/aptos-move/flow/src/tests/update/mod.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::update::{run, strip_prerelease, UpdateArgs};
+use clap::Parser;
+use self_update::version::bump_is_greater;
+
+#[derive(Parser)]
+struct Cli {
+    #[command(flatten)]
+    args: UpdateArgs,
+}
+
+#[test]
+fn strip_prerelease_suffixes() {
+    assert_eq!(strip_prerelease("1.0.5.beta"), "1.0.5");
+    assert_eq!(strip_prerelease("1.0.5.rc"), "1.0.5");
+    assert_eq!(strip_prerelease("1.0.5"), "1.0.5");
+    assert_eq!(strip_prerelease("1.0.5.other"), "1.0.5.other");
+}
+
+#[test]
+fn tag_version_extraction() {
+    let tag = "move-flow-v1.0.5";
+    assert_eq!(&tag["move-flow-v".len()..], "1.0.5");
+}
+
+#[test]
+fn version_comparison() {
+    assert!(bump_is_greater("1.0.4", "1.0.5").unwrap());
+    assert!(!bump_is_greater("1.0.5", "1.0.4").unwrap());
+    assert!(!bump_is_greater("1.0.5", "1.0.5").unwrap());
+    assert!(bump_is_greater("1.0.4", strip_prerelease("1.0.5.beta")).unwrap());
+}
+
+#[test]
+fn check_flag_parses() {
+    let cli = Cli::try_parse_from(["cmd", "--check"]).unwrap();
+    assert!(cli.args.check);
+}
+
+#[test]
+fn check_flag_defaults_false() {
+    let cli = Cli::try_parse_from(["cmd"]).unwrap();
+    assert!(!cli.args.check);
+}
+
+#[test]
+#[ignore]
+fn live_github_check() {
+    let args = UpdateArgs {
+        check: true,
+        repo_owner: "aptos-labs".into(),
+        repo_name: "aptos-ai".into(),
+    };
+    let result = run(&args);
+    assert!(result.is_ok(), "live check failed: {result:?}");
+}

--- a/aptos-move/flow/src/update.rs
+++ b/aptos-move/flow/src/update.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::{anyhow, Context, Result};
+use clap::Args;
+use self_update::{
+    backends::github::{ReleaseList, Update},
+    version::bump_is_greater,
+};
+
+#[derive(Args, Debug, Clone)]
+pub struct UpdateArgs {
+    /// Check for updates without downloading.
+    #[arg(long)]
+    pub check: bool,
+
+    #[arg(long, default_value = "aptos-labs", hide = true)]
+    pub repo_owner: String,
+
+    #[arg(long, default_value = "aptos-ai", hide = true)]
+    pub repo_name: String,
+}
+
+/// `bump_is_greater` only handles `x.y.z`; strip suffixes it can't parse.
+pub(crate) fn strip_prerelease(v: &str) -> &str {
+    if let Some(stem) = v.strip_suffix(".beta").or_else(|| v.strip_suffix(".rc")) {
+        stem
+    } else {
+        v
+    }
+}
+
+pub fn run(args: &UpdateArgs) -> Result<()> {
+    let releases = ReleaseList::configure()
+        .repo_owner(&args.repo_owner)
+        .repo_name(&args.repo_name)
+        .build()
+        .context("failed to configure release list")?
+        .fetch()
+        .context("failed to fetch releases from GitHub")?;
+
+    let latest = releases
+        .into_iter()
+        .find(|r| r.version.starts_with("move-flow-v"))
+        .ok_or_else(|| {
+            anyhow!(
+                "no move-flow release found in {}/{}",
+                args.repo_owner,
+                args.repo_name
+            )
+        })?;
+
+    let latest_version = &latest.version["move-flow-v".len()..];
+    let current_version = env!("CARGO_PKG_VERSION");
+    let needs_update = bump_is_greater(current_version, strip_prerelease(latest_version))
+        .context("failed to compare versions")?;
+
+    if args.check {
+        if needs_update {
+            println!("Update available: v{latest_version}");
+        } else {
+            println!("Already up to date (v{current_version})");
+        }
+        return Ok(());
+    }
+
+    if !needs_update {
+        println!("Already up to date (v{current_version})");
+        return Ok(());
+    }
+
+    Update::configure()
+        .repo_owner(&args.repo_owner)
+        .repo_name(&args.repo_name)
+        .bin_name("move-flow")
+        .current_version(current_version)
+        .target_version_tag(&latest.version)
+        .no_confirm(true)
+        .build()
+        .context("failed to configure updater")?
+        .update()
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("permission denied") || msg.contains("Access is denied") {
+                anyhow!("cannot replace binary: permission denied (try sudo)")
+            } else if msg.contains("could not find binary") || msg.contains("no asset") {
+                anyhow!(
+                    "no release asset for the current platform — download manually from \
+                     https://github.com/{}/{}/releases",
+                    args.repo_owner,
+                    args.repo_name
+                )
+            } else {
+                anyhow!("update failed: {e:#}")
+            }
+        })?;
+
+    println!("Updated move-flow v{current_version} → v{latest_version}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Adds `move-flow update [--check]` for in-place self-updating from the `aptos-labs/aptos-ai` GitHub releases.

- `--check` reports availability without downloading.
- Default fetches the latest `move-flow-v*` release, verifies via `bump_is_greater`, and atomically replaces the binary on disk.
- Uses the same `self_update` git pin already used by `crates/aptos`.
- Bumps crate to `1.1.0`

## Test plan
- [x] `cargo test -p aptos-move-flow update` — 5 unit tests pass
- [x] `cargo install --path aptos-move/flow --locked --profile ci` succeeds
- [x] `move-flow update --help` shows the subcommand
- [ ] `cargo test -p aptos-move-flow update::live_github_check -- --ignored` (run once `aptos-ai` is public)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Self-update replaces the running binary on disk and pulls artifacts from GitHub; failures are mostly localized but permission or wrong-release-repo issues could confuse users.
> 
> **Overview**
> Adds **`move-flow update [--check]`** so users can self-update from **`aptos-labs/aptos-ai`** GitHub releases tagged `move-flow-v*`, mirroring the **`self_update`** pattern already used by the **`aptos`** CLI.
> 
> **`--check`** only compares the running binary’s version to the latest release and prints whether an update exists. Without it, the command downloads and replaces the **`move-flow`** binary when a newer version is available, with clearer errors for permission denied or missing platform assets.
> 
> Wires the new **`update`** module into the CLI (runs on a blocking task), adds **`self_update`** as a dependency, bumps **`aptos-move-flow`** to **1.1.0**, and documents the feature in the changelog. Unit tests cover version/tag parsing, **`--check`** flag behavior, and an ignored live GitHub check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5645214032fc59c06240dcccf92237b2affdbcd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->