### PR TITLE
[move-flow] fix attrs,type and returnTypes qualification + add lambda tagging

### DIFF
--- a/aptos-move/flow/src/mcp/session.rs
+++ b/aptos-move/flow/src/mcp/session.rs
@@ -7,7 +7,9 @@ use super::{
 use crate::GlobalOpts;
 use rmcp::{
     handler::server::router::tool::ToolRouter,
-    model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo},
+    model::{
+        CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
+    },
     tool_handler, ServerHandler,
 };
 use serde::Serialize;
@@ -180,7 +182,7 @@ impl FlowSession {
                 .map_err(|e| {
                     let msg = format_error_chain(&e);
                     log::info!("build failed for `{}`: {}", key, msg);
-                    rmcp::ErrorData::internal_error(
+                    rmcp::ErrorData::invalid_params(
                         format!("failed to build package `{}`: {}", key, msg),
                         None,
                     )
@@ -229,7 +231,7 @@ impl ServerHandler for FlowSession {
             );
         }
         ServerInfo {
-            protocol_version: Default::default(),
+            protocol_version: ProtocolVersion::default(),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation {
                 name: "move-flow".into(),

--- a/aptos-move/flow/src/mcp/tools/package_query.rs
+++ b/aptos-move/flow/src/mcp/tools/package_query.rs
@@ -7,13 +7,14 @@ use super::super::{
     common::{mcp_err, resolve_function, tool_error, try_call},
     session::{into_call_tool_result, FlowSession},
 };
+use move_compiler_v2::env_pipeline::lambda_lifter::is_lambda_lifted_fun as is_lambda_lifted;
 use move_model::{
-    ast::{Attribute, ExpData, Operation},
+    ast::{Attribute, AttributeValue, ExpData, Operation},
     model::{
         FunId, FunctionEnv, GlobalEnv, Loc, ModuleEnv, NamedConstantEnv, QualifiedId, StructEnv,
         TypeParameter, Visibility,
     },
-    ty::ReferenceKind,
+    ty::{ReferenceKind, TypeDisplayContext},
 };
 use rmcp::{
     handler::server::wrapper::Parameters, model::CallToolResult, schemars, tool, tool_router,
@@ -55,7 +56,7 @@ enum QueryType {
 impl FlowSession {
     #[tool(
         description = "Query structural information about a Move package.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = true, destructive_hint = false)
     )]
     async fn move_package_query(
         &self,
@@ -108,7 +109,7 @@ impl FlowSession {
                 Ok(into_call_tool_result(&result))
             },
             QueryType::Facts => {
-                let result = build_facts(data.env());
+                let result = try_call("failed to build facts", || build_facts(data.env()))?;
                 log::info!("move_package_query facts: {} module(s)", result.len());
                 Ok(into_call_tool_result(&result))
             },
@@ -163,9 +164,12 @@ struct StructSummary {
 }
 
 #[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct FunctionSummary {
     name: String,
     signature: String,
+    /// True for compiler-synthesized lambda-lifted functions.
+    is_lambda_lifted: bool,
 }
 
 /// Build a summary of each target module's constants, structs, and functions.
@@ -178,14 +182,7 @@ fn build_module_summary(env: &GlobalEnv) -> BTreeMap<String, ModuleSummary> {
 
             let constants: Vec<ConstantSummary> = module
                 .get_named_constants()
-                .map(|c| {
-                    let ctx = c.get_type_display_ctx();
-                    ConstantSummary {
-                        name: c.get_name().display(env.symbol_pool()).to_string(),
-                        type_: c.get_type().display(&ctx).to_string(),
-                        value: env.display(&c.get_value()).to_string(),
-                    }
-                })
+                .map(|c| build_constant_summary(env, &c))
                 .collect();
 
             let structs: Vec<StructSummary> = module
@@ -219,6 +216,7 @@ fn build_module_summary(env: &GlobalEnv) -> BTreeMap<String, ModuleSummary> {
                 .map(|f| FunctionSummary {
                     name: f.get_name_str(),
                     signature: f.get_header_string(),
+                    is_lambda_lifted: is_lambda_lifted(&f),
                 })
                 .collect();
 
@@ -328,6 +326,12 @@ struct FriendFacts {
 #[serde(rename_all = "camelCase")]
 struct AttributeFacts {
     name: String,
+    /// Present for an assignment attribute `#[name = value]`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<String>,
+    /// Present for a nested attribute `#[name(inner, ...)]`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<AttributeFacts>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -387,9 +391,14 @@ struct FunctionFacts {
     attributes: Vec<AttributeFacts>,
     type_params: Vec<TypeParamFacts>,
     params: Vec<ParamFacts>,
-    return_type: Option<String>,
+    return_types: Vec<String>,
     acquires_inferred: Vec<String>,
     resource_access: ResourceAccessFacts,
+    /// True for lambda-lifted functions.
+    is_lambda_lifted: bool,
+    /// For a lambda-lifted function, the user function whose source defines the lambda.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    defined_in: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -434,9 +443,10 @@ fn build_module_facts(env: &GlobalEnv, module: &ModuleEnv<'_>) -> ModuleFacts {
 
     let attributes = attrs_to_facts(env, module.get_attributes());
 
+    let defined_in = defining_functions(env, module);
     let functions: Vec<FunctionFacts> = module
         .get_functions()
-        .map(|f| build_function_facts(env, &f))
+        .map(|f| build_function_facts(env, &f, &defined_in))
         .collect();
 
     let structs: Vec<StructFacts> = module
@@ -468,9 +478,51 @@ fn build_constant_summary(env: &GlobalEnv, c: &NamedConstantEnv<'_>) -> Constant
     }
 }
 
-fn build_function_facts(env: &GlobalEnv, func: &FunctionEnv<'_>) -> FunctionFacts {
+/// Maps each lambda-lifted function to the user function whose source
+/// contains it, chaining through nested closures.
+fn defining_functions(
+    env: &GlobalEnv,
+    module: &ModuleEnv<'_>,
+) -> BTreeMap<QualifiedId<FunId>, String> {
+    let mut result = BTreeMap::new();
+    for f in module.get_functions() {
+        if !is_lambda_lifted(&f) {
+            continue;
+        }
+        let lifted = f.get_qualified_id();
+        let mut current = lifted;
+        let mut visited = BTreeSet::new();
+        let name = loop {
+            let Some(host) = env
+                .get_function(current)
+                .get_using_functions()
+                .and_then(|using| using.into_iter().next())
+            else {
+                break None;
+            };
+            if !visited.insert(host) {
+                break None;
+            }
+            let host_env = env.get_function(host);
+            if !is_lambda_lifted(&host_env) {
+                break Some(host_env.get_name_str());
+            }
+            current = host;
+        };
+        if let Some(name) = name {
+            result.insert(lifted, name);
+        }
+    }
+    result
+}
+
+fn build_function_facts(
+    env: &GlobalEnv,
+    func: &FunctionEnv<'_>,
+    defined_in: &BTreeMap<QualifiedId<FunId>, String>,
+) -> FunctionFacts {
     let location = loc_to_file_span(env, &func.get_loc());
-    let type_ctx = func.get_type_display_ctx();
+    let type_ctx = qualified_type_ctx(func.get_type_display_ctx());
 
     let symbol_pool = env.symbol_pool();
     let params: Vec<ParamFacts> = func
@@ -482,7 +534,7 @@ fn build_function_facts(env: &GlobalEnv, func: &FunctionEnv<'_>) -> FunctionFact
         })
         .collect();
 
-    let return_type = format_return_type(func, &type_ctx);
+    let return_types = format_return_types(func, &type_ctx);
 
     let acquires_inferred: Vec<String> = func
         .get_acquired_structs()
@@ -500,6 +552,7 @@ fn build_function_facts(env: &GlobalEnv, func: &FunctionEnv<'_>) -> FunctionFact
     let resource_access = build_resource_access(env, func, &type_ctx);
 
     let attributes = attrs_to_facts(env, func.get_attributes());
+
     let is_view = func
         .get_attributes()
         .iter()
@@ -516,15 +569,17 @@ fn build_function_facts(env: &GlobalEnv, func: &FunctionEnv<'_>) -> FunctionFact
         attributes,
         type_params: type_params_to_facts(env, &func.get_type_parameters()),
         params,
-        return_type,
+        return_types,
         acquires_inferred,
         resource_access,
+        is_lambda_lifted: is_lambda_lifted(func),
+        defined_in: defined_in.get(&func.get_qualified_id()).cloned(),
     }
 }
 
 fn build_struct_facts(env: &GlobalEnv, s: &StructEnv<'_>) -> StructFacts {
     let location = loc_to_file_span(env, &s.get_loc());
-    let type_ctx = s.get_type_display_ctx();
+    let type_ctx = qualified_type_ctx(s.get_type_display_ctx());
     let symbol_pool = env.symbol_pool();
 
     let abilities: Vec<String> = s
@@ -603,13 +658,40 @@ fn type_params_to_facts(env: &GlobalEnv, params: &[TypeParameter]) -> Vec<TypePa
 }
 
 fn attrs_to_facts(env: &GlobalEnv, attrs: &[Attribute]) -> Vec<AttributeFacts> {
+    attrs.iter().map(|a| attr_to_facts(env, a)).collect()
+}
+
+/// Serialize a single attribute, preserving its arguments. `#[name(a, b = c)]`
+/// becomes `{ name, args: [...] }`; `#[name = value]` becomes `{ name, value }`.
+fn attr_to_facts(env: &GlobalEnv, attr: &Attribute) -> AttributeFacts {
     let symbol_pool = env.symbol_pool();
-    attrs
-        .iter()
-        .map(|a| AttributeFacts {
-            name: symbol_pool.string(a.name()).to_string(),
-        })
-        .collect()
+    match attr {
+        Attribute::Apply(_, name, sub) => AttributeFacts {
+            name: symbol_pool.string(*name).to_string(),
+            value: None,
+            args: sub.iter().map(|a| attr_to_facts(env, a)).collect(),
+        },
+        Attribute::Assign(_, name, val) => AttributeFacts {
+            name: symbol_pool.string(*name).to_string(),
+            value: Some(attr_value_to_string(env, val)),
+            args: vec![],
+        },
+    }
+}
+
+/// Render an attribute value: literals via the model's value display, named
+/// paths as fully-qualified `address::module::name` (or a bare name).
+fn attr_value_to_string(env: &GlobalEnv, val: &AttributeValue) -> String {
+    match val {
+        AttributeValue::Value(_, v) => env.display(v).to_string(),
+        AttributeValue::Name(_, module_opt, sym) => {
+            let name = sym.display(env.symbol_pool()).to_string();
+            match module_opt {
+                Some(module) => format!("{}::{}", module.display_full(env), name),
+                None => name,
+            }
+        },
+    }
 }
 
 fn visibility_str(func: &FunctionEnv<'_>) -> String {
@@ -624,24 +706,29 @@ fn visibility_str(func: &FunctionEnv<'_>) -> String {
     .to_string()
 }
 
-fn format_return_type(
-    func: &FunctionEnv<'_>,
-    type_ctx: &move_model::ty::TypeDisplayContext<'_>,
-) -> Option<String> {
-    use move_model::ty::Type;
-    let result = func.get_result_type();
-    if let Type::Tuple(ts) = &result
-        && ts.is_empty()
-    {
-        return None;
+/// A type-display context that renders every struct fully-qualified as `address::module::Name<...>`
+fn qualified_type_ctx(base: TypeDisplayContext<'_>) -> TypeDisplayContext<'_> {
+    TypeDisplayContext {
+        display_module_addr: true,
+        use_module_qualification: true,
+        ..base
     }
-    Some(result.display(type_ctx).to_string())
+}
+
+/// Render a function's return as a list of types: `[]` for no return, one entry
+/// for a scalar, and one entry per element for a tuple (multiple) return.
+fn format_return_types(func: &FunctionEnv<'_>, type_ctx: &TypeDisplayContext<'_>) -> Vec<String> {
+    func.get_result_type()
+        .flatten()
+        .iter()
+        .map(|t| t.display(type_ctx).to_string())
+        .collect()
 }
 /// Empty when the function has no AST body.
 fn build_resource_access(
     env: &GlobalEnv,
     func: &FunctionEnv<'_>,
-    type_ctx: &move_model::ty::TypeDisplayContext<'_>,
+    type_ctx: &TypeDisplayContext<'_>,
 ) -> ResourceAccessFacts {
     let Some(body) = func.get_def() else {
         return ResourceAccessFacts {
@@ -666,7 +753,7 @@ fn build_resource_access(
             if does_read || does_write {
                 let insts = env.get_node_instantiation(*node_id);
                 if let Some(ty) = insts.first() {
-                    let ty = qualified_resource_name(env, ty, type_ctx);
+                    let ty = ty.display(type_ctx).to_string();
                     if does_read {
                         reads.insert(ty.clone());
                     }
@@ -681,35 +768,6 @@ fn build_resource_access(
     ResourceAccessFacts {
         reads: reads.into_iter().collect(),
         writes: writes.into_iter().collect(),
-    }
-}
-
-/// Render the resource type of a global-storage operation as a fully-qualified
-/// `address::module::Struct<TypeArgs>` name, matching the format used by
-/// `acquiresInferred` so consumers can correlate the two. Falls back to the
-/// plain type display for non-struct types, which should not occur for storage
-/// operations.
-fn qualified_resource_name(
-    env: &GlobalEnv,
-    ty: &move_model::ty::Type,
-    type_ctx: &move_model::ty::TypeDisplayContext<'_>,
-) -> String {
-    use move_model::ty::Type;
-    let Type::Struct(mid, sid, type_args) = ty else {
-        return ty.display(type_ctx).to_string();
-    };
-    let base = env
-        .get_struct(mid.qualified(*sid))
-        .get_full_name_with_address();
-    if type_args.is_empty() {
-        base
-    } else {
-        let args = type_args
-            .iter()
-            .map(|t| t.display(type_ctx).to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("{base}<{args}>")
     }
 }
 

--- a/aptos-move/flow/src/tests/list_tools/success.exp
+++ b/aptos-move/flow/src/tests/list_tools/success.exp
@@ -108,7 +108,7 @@
       }
     },
     "annotations": {
-      "readOnlyHint": false,
+      "readOnlyHint": true,
       "destructiveHint": false
     }
   },

--- a/aptos-move/flow/src/tests/move_package_query/facts.exp
+++ b/aptos-move/flow/src/tests/move_package_query/facts.exp
@@ -3,7 +3,7 @@
     "file": "<TEMPDIR>/coin.move",
     "span": [
       1,
-      45
+      61
     ],
     "friends": [
       {
@@ -16,8 +16,8 @@
         "name": "balance_of",
         "file": "<TEMPDIR>/coin.move",
         "span": [
-          26,
-          28
+          38,
+          40
         ],
         "visibility": "public",
         "isEntry": false,
@@ -42,7 +42,9 @@
             "type": "address"
           }
         ],
-        "returnType": "u64",
+        "returnTypes": [
+          "u64"
+        ],
         "acquiresInferred": [
           "0xcafe::coin::CoinStore"
         ],
@@ -51,14 +53,15 @@
             "0xcafe::coin::CoinStore<CoinType>"
           ],
           "writes": []
-        }
+        },
+        "isLambdaLifted": false
       },
       {
         "name": "deposit",
         "file": "<TEMPDIR>/coin.move",
         "span": [
-          35,
-          39
+          47,
+          51
         ],
         "visibility": "public",
         "isEntry": false,
@@ -83,7 +86,7 @@
             "type": "u64"
           }
         ],
-        "returnType": null,
+        "returnTypes": [],
         "acquiresInferred": [
           "0xcafe::coin::CoinStore"
         ],
@@ -94,14 +97,15 @@
           "writes": [
             "0xcafe::coin::CoinStore<CoinType>"
           ]
-        }
+        },
+        "isLambdaLifted": false
       },
       {
         "name": "is_registered",
         "file": "<TEMPDIR>/coin.move",
         "span": [
-          31,
-          33
+          43,
+          45
         ],
         "visibility": "public",
         "isEntry": false,
@@ -126,21 +130,24 @@
             "type": "address"
           }
         ],
-        "returnType": "bool",
+        "returnTypes": [
+          "bool"
+        ],
         "acquiresInferred": [],
         "resourceAccess": {
           "reads": [
             "0xcafe::coin::CoinStore<CoinType>"
           ],
           "writes": []
-        }
+        },
+        "isLambdaLifted": false
       },
       {
         "name": "register",
         "file": "<TEMPDIR>/coin.move",
         "span": [
-          21,
-          23
+          33,
+          35
         ],
         "visibility": "public",
         "isEntry": true,
@@ -161,21 +168,53 @@
             "type": "&signer"
           }
         ],
-        "returnType": null,
+        "returnTypes": [],
         "acquiresInferred": [],
         "resourceAccess": {
           "reads": [],
           "writes": [
             "0xcafe::coin::CoinStore<CoinType>"
           ]
-        }
+        },
+        "isLambdaLifted": false
+      },
+      {
+        "name": "split",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          58,
+          60
+        ],
+        "visibility": "public",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "returnTypes": [
+          "u64",
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": false
       },
       {
         "name": "unregister",
         "file": "<TEMPDIR>/coin.move",
         "span": [
-          41,
-          44
+          53,
+          56
         ],
         "visibility": "public",
         "isEntry": false,
@@ -196,7 +235,9 @@
             "type": "address"
           }
         ],
-        "returnType": "u64",
+        "returnTypes": [
+          "u64"
+        ],
         "acquiresInferred": [
           "0xcafe::coin::CoinStore"
         ],
@@ -207,7 +248,8 @@
           "writes": [
             "0xcafe::coin::CoinStore<CoinType>"
           ]
-        }
+        },
+        "isLambdaLifted": false
       }
     ],
     "structs": [
@@ -239,12 +281,63 @@
         "attributes": []
       },
       {
+        "kind": "struct",
+        "name": "ObjectGroup",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          20,
+          20
+        ],
+        "abilities": [],
+        "typeParams": [],
+        "fields": [
+          {
+            "name": "dummy_field",
+            "type": "bool",
+            "positional": false
+          }
+        ],
+        "attributes": [
+          {
+            "name": "resource_group",
+            "args": [
+              {
+                "name": "scope",
+                "value": "global"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "struct",
+        "name": "Receipt",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          10,
+          12
+        ],
+        "abilities": [
+          "drop",
+          "store"
+        ],
+        "typeParams": [],
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64",
+            "positional": false
+          }
+        ],
+        "attributes": []
+      },
+      {
         "kind": "enum",
         "name": "Status",
         "file": "<TEMPDIR>/coin.move",
         "span": [
-          15,
-          19
+          27,
+          31
         ],
         "abilities": [
           "drop",
@@ -295,8 +388,8 @@
         "name": "TransferEvent",
         "file": "<TEMPDIR>/coin.move",
         "span": [
-          11,
-          13
+          15,
+          17
         ],
         "abilities": [
           "drop",
@@ -315,6 +408,37 @@
             "name": "event"
           }
         ]
+      },
+      {
+        "kind": "struct",
+        "name": "Wrapped",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          23,
+          25
+        ],
+        "abilities": [
+          "key"
+        ],
+        "typeParams": [],
+        "fields": [
+          {
+            "name": "value",
+            "type": "u64",
+            "positional": false
+          }
+        ],
+        "attributes": [
+          {
+            "name": "resource_group_member",
+            "args": [
+              {
+                "name": "group",
+                "value": "0xcafe::coin::ObjectGroup"
+              }
+            ]
+          }
+        ]
       }
     ],
     "constants": [
@@ -328,18 +452,48 @@
   "0xcafe::coin_admin": {
     "file": "<TEMPDIR>/coin.move",
     "span": [
-      47,
-      49
+      63,
+      75
     ],
     "friends": [],
     "attributes": [],
     "functions": [
       {
+        "name": "forward",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          72,
+          74
+        ],
+        "visibility": "public",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "r",
+            "type": "0xcafe::coin::Receipt"
+          }
+        ],
+        "returnTypes": [
+          "0xcafe::coin::Receipt"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": false
+      },
+      {
         "name": "freeze_account",
         "file": "<TEMPDIR>/coin.move",
         "span": [
-          48,
-          48
+          70,
+          70
         ],
         "visibility": "friend",
         "isEntry": false,
@@ -354,15 +508,39 @@
             "type": "address"
           }
         ],
-        "returnType": null,
+        "returnTypes": [],
         "acquiresInferred": [],
         "resourceAccess": {
           "reads": [],
           "writes": []
-        }
+        },
+        "isLambdaLifted": false
       }
     ],
-    "structs": [],
+    "structs": [
+      {
+        "kind": "struct",
+        "name": "Holder",
+        "file": "<TEMPDIR>/coin.move",
+        "span": [
+          66,
+          68
+        ],
+        "abilities": [
+          "drop",
+          "store"
+        ],
+        "typeParams": [],
+        "fields": [
+          {
+            "name": "r",
+            "type": "0xcafe::coin::Receipt",
+            "positional": false
+          }
+        ],
+        "attributes": []
+      }
+    ],
     "constants": []
   }
 }

--- a/aptos-move/flow/src/tests/move_package_query/facts.rs
+++ b/aptos-move/flow/src/tests/move_package_query/facts.rs
@@ -16,9 +16,21 @@ async fn move_package_query_facts() {
         balance: u64,
     }
 
+    struct Receipt has drop, store {
+        amount: u64,
+    }
+
     #[event]
     struct TransferEvent has drop, store {
         amount: u64,
+    }
+
+    #[resource_group(scope = global)]
+    struct ObjectGroup {}
+
+    #[resource_group_member(group = 0xCAFE::coin::ObjectGroup)]
+    struct Wrapped has key {
+        value: u64,
     }
 
     enum Status has drop, store {
@@ -51,10 +63,24 @@ async fn move_package_query_facts() {
         let CoinStore<CoinType> { balance } = move_from<CoinStore<CoinType>>(addr);
         balance
     }
+
+    public fun split(amount: u64): (u64, u64) {
+        (amount, amount)
+    }
 }
 
 module 0xCAFE::coin_admin {
+    use 0xCAFE::coin::Receipt;
+
+    struct Holder has drop, store {
+        r: Receipt,
+    }
+
     public(friend) fun freeze_account(_addr: address) {}
+
+    public fun forward(r: Receipt): Receipt {
+        r
+    }
 }",
     )]);
     let dir = pkg.path().to_str().unwrap();

--- a/aptos-move/flow/src/tests/move_package_query/facts_closure.exp
+++ b/aptos-move/flow/src/tests/move_package_query/facts_closure.exp
@@ -1,0 +1,221 @@
+{
+  "0xcafe::closures": {
+    "file": "<TEMPDIR>/closures.move",
+    "span": [
+      1,
+      14
+    ],
+    "friends": [],
+    "attributes": [],
+    "functions": [
+      {
+        "name": "apply",
+        "file": "<TEMPDIR>/closures.move",
+        "span": [
+          4,
+          4
+        ],
+        "visibility": "internal",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "f",
+            "type": "|u64|u64"
+          },
+          {
+            "name": "x",
+            "type": "u64"
+          }
+        ],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": false
+      },
+      {
+        "name": "run",
+        "file": "<TEMPDIR>/closures.move",
+        "span": [
+          5,
+          5
+        ],
+        "visibility": "internal",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "f",
+            "type": "||u64"
+          }
+        ],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": false
+      },
+      {
+        "name": "setup",
+        "file": "<TEMPDIR>/closures.move",
+        "span": [
+          11,
+          13
+        ],
+        "visibility": "public",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [
+          "0xcafe::closures::Config"
+        ],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": false
+      },
+      {
+        "name": "with_capture",
+        "file": "<TEMPDIR>/closures.move",
+        "span": [
+          7,
+          9
+        ],
+        "visibility": "public",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "c",
+            "type": "u64"
+          }
+        ],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": false
+      },
+      {
+        "name": "__lambda__1__setup",
+        "file": "<TEMPDIR>/closures.move",
+        "span": [
+          12,
+          12
+        ],
+        "visibility": "internal",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [
+            "0xcafe::closures::Config"
+          ],
+          "writes": []
+        },
+        "isLambdaLifted": true,
+        "definedIn": "setup"
+      },
+      {
+        "name": "__lambda__1__with_capture",
+        "file": "<TEMPDIR>/closures.move",
+        "span": [
+          8,
+          8
+        ],
+        "visibility": "internal",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "c",
+            "type": "u64"
+          },
+          {
+            "name": "y",
+            "type": "u64"
+          }
+        ],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": true,
+        "definedIn": "with_capture"
+      }
+    ],
+    "structs": [
+      {
+        "kind": "struct",
+        "name": "Config",
+        "file": "<TEMPDIR>/closures.move",
+        "span": [
+          2,
+          2
+        ],
+        "abilities": [
+          "key"
+        ],
+        "typeParams": [],
+        "fields": [
+          {
+            "name": "v",
+            "type": "u64",
+            "positional": false
+          }
+        ],
+        "attributes": []
+      }
+    ],
+    "constants": []
+  }
+}

--- a/aptos-move/flow/src/tests/move_package_query/facts_closure.rs
+++ b/aptos-move/flow/src/tests/move_package_query/facts_closure.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::tests::common;
+
+/// Facts for lambda-lifted functions: verifies `isLambdaLifted`/`definedIn` tagging,
+/// and that `acquiresInferred` (host) and `resourceAccess` (lifted body) differ.
+#[tokio::test]
+async fn move_package_query_facts_closure() {
+    let pkg = common::make_package("facts_closure", &[(
+        "closures",
+        "module 0xCAFE::closures {
+    struct Config has key { v: u64 }
+
+    fun apply(f: |u64|u64, x: u64): u64 { f(x) }
+    fun run(f: ||u64): u64 { f() }
+
+    public fun with_capture(c: u64): u64 {
+        apply(|y| y + c, 10)
+    }
+
+    public fun setup(): u64 {
+        run(|| borrow_global<Config>(@0xCAFE).v)
+    }
+}",
+    )]);
+    let dir = pkg.path().to_str().unwrap();
+    let client = common::make_client().await;
+    let result = common::call_tool(
+        &client,
+        "move_package_query",
+        serde_json::json!({ "package_path": dir, "query": "facts" }),
+    )
+    .await;
+    let formatted = common::format_tool_result(&result);
+    common::check_baseline(file!(), &formatted);
+}

--- a/aptos-move/flow/src/tests/move_package_query/facts_nested.exp
+++ b/aptos-move/flow/src/tests/move_package_query/facts_nested.exp
@@ -1,0 +1,153 @@
+{
+  "0xcafe::nested": {
+    "file": "<TEMPDIR>/nested.move",
+    "span": [
+      1,
+      7
+    ],
+    "friends": [],
+    "attributes": [],
+    "functions": [
+      {
+        "name": "apply",
+        "file": "<TEMPDIR>/nested.move",
+        "span": [
+          2,
+          2
+        ],
+        "visibility": "internal",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "f",
+            "type": "|u64|u64"
+          },
+          {
+            "name": "x",
+            "type": "u64"
+          }
+        ],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": false
+      },
+      {
+        "name": "outer",
+        "file": "<TEMPDIR>/nested.move",
+        "span": [
+          4,
+          6
+        ],
+        "visibility": "public",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "c",
+            "type": "u64"
+          }
+        ],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": false
+      },
+      {
+        "name": "__lambda__1__outer",
+        "file": "<TEMPDIR>/nested.move",
+        "span": [
+          5,
+          5
+        ],
+        "visibility": "internal",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "c",
+            "type": "u64"
+          },
+          {
+            "name": "x",
+            "type": "u64"
+          },
+          {
+            "name": "y",
+            "type": "u64"
+          }
+        ],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": true,
+        "definedIn": "outer"
+      },
+      {
+        "name": "__lambda__2__outer",
+        "file": "<TEMPDIR>/nested.move",
+        "span": [
+          5,
+          5
+        ],
+        "visibility": "internal",
+        "isEntry": false,
+        "isInline": false,
+        "isNative": false,
+        "isView": false,
+        "attributes": [],
+        "typeParams": [],
+        "params": [
+          {
+            "name": "c",
+            "type": "u64"
+          },
+          {
+            "name": "x",
+            "type": "u64"
+          }
+        ],
+        "returnTypes": [
+          "u64"
+        ],
+        "acquiresInferred": [],
+        "resourceAccess": {
+          "reads": [],
+          "writes": []
+        },
+        "isLambdaLifted": true,
+        "definedIn": "outer"
+      }
+    ],
+    "structs": [],
+    "constants": []
+  }
+}

--- a/aptos-move/flow/src/tests/move_package_query/facts_nested.rs
+++ b/aptos-move/flow/src/tests/move_package_query/facts_nested.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::tests::common;
+
+/// Facts for nested closures: verifies `definedIn` resolves through a chain of
+/// lambda-lifted functions to the outermost user function, not just one hop.
+#[tokio::test]
+async fn move_package_query_facts_nested() {
+    let pkg = common::make_package("facts_nested", &[(
+        "nested",
+        "module 0xCAFE::nested {
+    fun apply(f: |u64|u64, x: u64): u64 { f(x) }
+
+    public fun outer(c: u64): u64 {
+        apply(|x| apply(|y| x + y + c, x), 10)
+    }
+}",
+    )]);
+    let dir = pkg.path().to_str().unwrap();
+    let client = common::make_client().await;
+    let result = common::call_tool(
+        &client,
+        "move_package_query",
+        serde_json::json!({ "package_path": dir, "query": "facts" }),
+    )
+    .await;
+    let formatted = common::format_tool_result(&result);
+    common::check_baseline(file!(), &formatted);
+}

--- a/aptos-move/flow/src/tests/move_package_query/mod.rs
+++ b/aptos-move/flow/src/tests/move_package_query/mod.rs
@@ -7,6 +7,8 @@ mod call_graph_leaf;
 mod dep_graph;
 mod dep_graph_no_deps;
 mod facts;
+mod facts_closure;
+mod facts_nested;
 mod function_usage;
 mod function_usage_bad_format;
 mod function_usage_bad_function;

--- a/aptos-move/flow/src/tests/move_package_query/module_summary.exp
+++ b/aptos-move/flow/src/tests/move_package_query/module_summary.exp
@@ -23,11 +23,13 @@
     "functions": [
       {
         "name": "burn",
-        "signature": "public entry fun burn(t: Token)"
+        "signature": "public entry fun burn(t: Token)",
+        "isLambdaLifted": false
       },
       {
         "name": "mint",
-        "signature": "public fun mint(amount: u64,owner: address): Token"
+        "signature": "public fun mint(amount: u64,owner: address): Token",
+        "isLambdaLifted": false
       }
     ]
   }


### PR DESCRIPTION
## Description
  - Preserve attribute arguments/values in facts (previously only the attribute name was serialized)
  - Unify struct qualification (address::module::Name) across function signatures and struct fields in facts
  - Tag compiler-synthesized lambda-lifted functions and link each to its defining function
  - Return returnTypes as an array instead of a display string creating ambiguity between a tuple return from a scalar
  - Guard the facts path against panics, matching function_usage
  - Mark move_package_query read-only in its tool annotations
  
  
  ## How Has This Been Tested?


## Key Areas to Review


## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): move-flow

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking JSON for facts/module_summary clients in move-flow MCP tooling; changes are localized to query output and error classification, not on-chain or validator code.
> 
> **Overview**
> **Breaking change for `move_package_query` consumers:** the **facts** (and related summaries) JSON shape is richer and some fields were renamed or retyped.
> 
> The **facts** query now serializes **attributes** with nested `args` and assignment `value`s (not just names), uses **fully qualified** struct types in params, fields, `resourceAccess`, and cross-module references, and reports returns as **`returnTypes`** (an array: empty, one scalar, or one entry per tuple element) instead of optional `returnType`. **Lambda-lifted** compiler functions are tagged with **`isLambdaLifted`** and optional **`definedIn`** (resolved through nested closures); **module_summary** adds the same lift flag on each function.
> 
> **MCP behavior:** `move_package_query` is annotated **read-only**; package **build failures** return **`invalid_params`** rather than internal errors; the facts path is wrapped in **`try_call`** to avoid panics; server info sets **`ProtocolVersion`** explicitly.
> 
> Tests and baselines cover attributes, tuple returns, qualification, and closure/nested-closure tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03cca502fd51dbd1e66a912e7e0f845cc196d062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->