### PR TITLE
[mono-move] Add the MonoMove Aptos transaction executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12899,6 +12899,7 @@ dependencies = [
  "move-core-types",
  "specializer",
  "thiserror 1.0.69",
+ "triomphe",
 ]
 
 [[package]]
@@ -12925,6 +12926,7 @@ dependencies = [
  "move-core-types",
  "serde",
  "thiserror 1.0.69",
+ "triomphe",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12881,6 +12881,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "mono-move-aptos-state-view-providers"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-framework",
+ "aptos-types",
+ "bcs 0.1.4",
+ "bytes",
+ "mono-move-aptos-transaction-executor",
+ "mono-move-core",
+ "mono-move-global-context",
+ "mono-move-runtime",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
+ "specializer",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mono-move-aptos-transaction-executor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-cached-packages",
+ "aptos-crypto",
+ "aptos-language-e2e-tests",
+ "aptos-transaction-simulation",
+ "aptos-types",
+ "aptos-vm-types",
+ "bcs 0.1.4",
+ "bytes",
+ "mono-move-aptos-state-view-providers",
+ "mono-move-core",
+ "mono-move-global-context",
+ "mono-move-loader",
+ "mono-move-natives",
+ "mono-move-output",
+ "mono-move-runtime",
+ "move-binary-format",
+ "move-core-types",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "mono-move-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,7 +5116,6 @@ dependencies = [
  "aptos-block-executor",
  "aptos-block-partitioner",
  "aptos-crypto",
- "aptos-crypto-derive",
  "aptos-experimental-runtimes",
  "aptos-framework-natives",
  "aptos-gas-algebra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12889,6 +12889,7 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4",
  "bytes",
+ "fxhash",
  "mono-move-aptos-transaction-executor",
  "mono-move-core",
  "mono-move-global-context",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12897,7 +12897,6 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-verifier",
  "move-core-types",
- "specializer",
  "thiserror 1.0.69",
  "triomphe",
 ]
@@ -12908,11 +12907,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
- "aptos-crypto",
  "aptos-language-e2e-tests",
  "aptos-transaction-simulation",
  "aptos-types",
- "aptos-vm-types",
  "bcs 0.1.4",
  "bytes",
  "mono-move-aptos-state-view-providers",
@@ -12922,7 +12919,6 @@ dependencies = [
  "mono-move-natives",
  "mono-move-output",
  "mono-move-runtime",
- "move-binary-format",
  "move-core-types",
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,8 @@ members = [
     "third_party/move/documentation/framework-book/builder",
     "third_party/move/extensions/move-table-extension",
     "third_party/move/mono-move/alloc",
+    "third_party/move/mono-move/aptos-state-view-providers",
+    "third_party/move/mono-move/aptos-transaction-executor",
     "third_party/move/mono-move/core",
     "third_party/move/mono-move/global-context",
     "third_party/move/mono-move/loader",
@@ -902,6 +904,8 @@ aptos-position-natives = { path = "aptos-move/framework/position-natives" }
 aptos-table-natives = { path = "aptos-move/framework/table-natives" }
 legacy-move-compiler = { path = "third_party/move/move-compiler-v2/legacy-move-compiler" }
 mono-move-alloc = { path = "third_party/move/mono-move/alloc" }
+mono-move-aptos-state-view-providers = { path = "third_party/move/mono-move/aptos-state-view-providers" }
+mono-move-aptos-transaction-executor = { path = "third_party/move/mono-move/aptos-transaction-executor" }
 mono-move-core = { path = "third_party/move/mono-move/core" }
 mono-move-global-context = { path = "third_party/move/mono-move/global-context" }
 mono-move-loader = { path = "third_party/move/mono-move/loader" }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -35,7 +35,6 @@ anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
 aptos-block-executor = { workspace = true }
 aptos-crypto = { workspace = true }
-aptos-crypto-derive = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
 aptos-framework-natives = { workspace = true }
 aptos-gas-algebra = { workspace = true }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -3092,7 +3092,7 @@ impl AptosVM {
                 arguments,
                 func_name.as_ident_str(),
                 &func,
-                metadata.as_ref().map(Arc::as_ref),
+                metadata.as_deref(),
                 vm.features().is_enabled(FeatureFlag::STRUCT_CONSTRUCTORS),
             )
             .map_err(|e| e.finish(Location::Module(module_id)))?;

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -3535,7 +3535,7 @@ impl VMValidator for AptosVM {
 
         let mut session = self.new_session(
             &resolver,
-            SessionId::prologue_meta(&txn_data),
+            txn_data.prologue_session_id(),
             Some(txn_data.as_user_transaction_context()),
         );
 

--- a/aptos-move/aptos-vm/src/errors.rs
+++ b/aptos-move/aptos-vm/src/errors.rs
@@ -3,43 +3,27 @@
 
 use crate::transaction_validation::APTOS_TRANSACTION_VALIDATION;
 use aptos_logger::{enabled, Level};
-use aptos_types::transaction::TransactionStatus;
+use aptos_types::{
+    error::{
+        split_canonical, INVALID_ARGUMENT, INVALID_STATE, NOT_FOUND, OUT_OF_RANGE,
+        PERMISSION_DENIED,
+    },
+    transaction::{
+        validation::{
+            EACCOUNT_DOES_NOT_EXIST, EBAD_ACCOUNT_AUTHENTICATION_KEY, EBAD_CHAIN_ID,
+            ECANT_PAY_GAS_DEPOSIT, EGAS_PAYER_ACCOUNT_MISSING,
+            EINSUFFICIENT_BALANCE_FOR_REQUIRED_DEPOSIT, ENONCE_ALREADY_USED,
+            ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH, ESEQUENCE_NUMBER_TOO_BIG,
+            ESEQUENCE_NUMBER_TOO_NEW, ESEQUENCE_NUMBER_TOO_OLD,
+            ETRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE, ETRANSACTION_EXPIRED,
+        },
+        TransactionStatus,
+    },
+};
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
 use aptos_vm_types::output::VMOutput;
 use move_binary_format::errors::VMError;
 use move_core_types::vm_status::{StatusCode, VMStatus};
-
-/// Error codes that can be emitted by the prologue. These have special significance to the VM when
-/// they are raised during the prologue.
-/// These errors are only expected from the module that is registered as the account module for the system.
-/// The prologue should not emit any other error codes or fail for any reason, doing so will result
-/// in the VM throwing an invariant violation
-// Auth key in transaction is invalid.
-pub const EBAD_ACCOUNT_AUTHENTICATION_KEY: u64 = 1001;
-// Transaction sequence number is too old.
-pub const ESEQUENCE_NUMBER_TOO_OLD: u64 = 1002;
-// Transaction sequence number is too new.
-pub const ESEQUENCE_NUMBER_TOO_NEW: u64 = 1003;
-// Transaction sender's account does not exist.
-pub const EACCOUNT_DOES_NOT_EXIST: u64 = 1004;
-// Insufficient balance (to pay for gas deposit).
-pub const ECANT_PAY_GAS_DEPOSIT: u64 = 1005;
-// Transaction expiration time exceeds block time.
-pub const ETRANSACTION_EXPIRED: u64 = 1006;
-// chain_id in transaction doesn't match the one on-chain.
-pub const EBAD_CHAIN_ID: u64 = 1007;
-// Transaction sequence number exceeds u64 max.
-pub const ESEQUENCE_NUMBER_TOO_BIG: u64 = 1008;
-// Counts of secondary keys and addresses don't match.
-pub const ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH: u64 = 1009;
-// Gas payer account missing in gas payer tx
-pub const EGAS_PAYER_ACCOUNT_MISSING: u64 = 1010;
-// Insufficient balance to cover the required deposit.
-pub const EINSUFFICIENT_BALANCE_FOR_REQUIRED_DEPOSIT: u64 = 1011;
-// Nonce is already in the nonce history
-pub const ENONCE_ALREADY_USED: u64 = 1012;
-// Transaction expiration time is too far in the future.
-pub const ETRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE: u64 = 1013;
 
 // Specified account is not a multisig account.
 const EACCOUNT_NOT_MULTISIG: u64 = 2002;
@@ -73,18 +57,6 @@ const EMULTIPLIER_NOT_AVAILABLE: u64 = 8;
 // Stake pool is not in the current-epoch validator set.
 const EPOOL_NOT_IN_VALIDATOR_SET: u64 = 9;
 
-const INVALID_ARGUMENT: u8 = 0x1;
-const LIMIT_EXCEEDED: u8 = 0x2;
-const INVALID_STATE: u8 = 0x3;
-const PERMISSION_DENIED: u8 = 0x5;
-const NOT_FOUND: u8 = 0x6;
-
-fn error_split(code: u64) -> (u8, u64) {
-    let reason = code & 0xFFFF;
-    let category = ((code >> 16) & 0xFF) as u8;
-    (category, reason)
-}
-
 /// Converts particular Move abort codes to specific validation error codes for the prologue
 /// Any non-abort non-execution code is considered an invariant violation, specifically
 /// `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`
@@ -100,7 +72,7 @@ pub fn convert_prologue_error(
             code,
             message,
         } if APTOS_TRANSACTION_VALIDATION.is_transaction_limits_module_abort(&location) => {
-            let new_major_status = match error_split(code) {
+            let new_major_status = match split_canonical(code) {
                 (PERMISSION_DENIED, ENOT_STAKE_POOL_OWNER) => StatusCode::NOT_STAKE_POOL_OWNER,
                 (PERMISSION_DENIED, ENOT_DELEGATED_VOTER) => StatusCode::NOT_DELEGATED_VOTER,
                 (PERMISSION_DENIED, EINSUFFICIENT_STAKE) => StatusCode::INSUFFICIENT_STAKE,
@@ -138,7 +110,7 @@ pub fn convert_prologue_error(
             code,
             message,
         } if !APTOS_TRANSACTION_VALIDATION.is_account_module_abort(&location) => {
-            let new_major_status = match error_split(code) {
+            let new_major_status = match split_canonical(code) {
                 // TODO: Update these after adding the appropriate error codes into StatusCode
                 // in the Move repo.
                 (INVALID_STATE, EACCOUNT_NOT_MULTISIG) => StatusCode::ACCOUNT_NOT_MULTISIG,
@@ -178,7 +150,7 @@ pub fn convert_prologue_error(
             code,
             message,
         } => {
-            let new_major_status = match error_split(code) {
+            let new_major_status = match split_canonical(code) {
                 // Invalid authentication key
                 (INVALID_ARGUMENT, EBAD_ACCOUNT_AUTHENTICATION_KEY) => StatusCode::INVALID_AUTH_KEY,
                 // Sequence number too old
@@ -196,7 +168,7 @@ pub fn convert_prologue_error(
                 (INVALID_ARGUMENT, ETRANSACTION_EXPIRED) => StatusCode::TRANSACTION_EXPIRED,
                 (INVALID_ARGUMENT, EBAD_CHAIN_ID) => StatusCode::BAD_CHAIN_ID,
                 // Sequence number will overflow
-                (LIMIT_EXCEEDED, ESEQUENCE_NUMBER_TOO_BIG) => StatusCode::SEQUENCE_NUMBER_TOO_BIG,
+                (OUT_OF_RANGE, ESEQUENCE_NUMBER_TOO_BIG) => StatusCode::SEQUENCE_NUMBER_TOO_BIG,
                 (INVALID_ARGUMENT, ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH) => {
                     StatusCode::SECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH
                 },
@@ -263,7 +235,7 @@ pub fn convert_epilogue_error(
             code,
             message,
         } if !APTOS_TRANSACTION_VALIDATION.is_account_module_abort(&location) => {
-            let (category, reason) = error_split(code);
+            let (category, reason) = split_canonical(code);
             let mut err_msg = format!(
                 "[aptos_vm] Unexpected success epilogue Move abort: {:?}::{:?} (Category: {:?} Reason: {:?})",
                 location, code, category, reason
@@ -283,8 +255,8 @@ pub fn convert_epilogue_error(
             location,
             code,
             message,
-        } => match error_split(code) {
-            (LIMIT_EXCEEDED, ECANT_PAY_GAS_DEPOSIT) => VMStatus::MoveAbort {
+        } => match split_canonical(code) {
+            (OUT_OF_RANGE, ECANT_PAY_GAS_DEPOSIT) => VMStatus::MoveAbort {
                 location,
                 code,
                 message,

--- a/aptos-move/aptos-vm/src/move_vm_ext/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/mod.rs
@@ -16,12 +16,11 @@ pub use crate::move_vm_ext::{
     vm::{GenesisMoveVm, GenesisRuntimeBuilder},
 };
 use aptos_types::state_store::state_key::StateKey;
-pub use aptos_types::transaction::user_transaction_context::UserTransactionContext;
+pub use aptos_types::transaction::{user_transaction_context::UserTransactionContext, SessionId};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress, language_storage::StructTag, vm_status::StatusCode,
 };
-pub use session::session_id::SessionId;
 
 pub(crate) fn resource_state_key(
     address: &AccountAddress,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -65,7 +65,6 @@ use std::{borrow::Borrow, collections::BTreeMap};
 use triomphe::Arc as TriompheArc;
 
 pub mod respawned_session;
-pub mod session_id;
 pub(crate) mod user_transaction_sessions;
 pub mod view_with_change_set;
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/abort_hook.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/abort_hook.rs
@@ -7,7 +7,7 @@ use crate::{
             respawned_session::RespawnedSession,
             user_transaction_sessions::session_change_sets::SystemSessionChangeSet,
         },
-        AptosMoveResolver, SessionId,
+        AptosMoveResolver,
     },
     transaction_metadata::TransactionMetadata,
     AptosVM,
@@ -33,7 +33,7 @@ impl<'r> AbortHookSession<'r> {
         resolver: &'r impl AptosMoveResolver,
         prologue_session_change_set: SystemSessionChangeSet,
     ) -> Self {
-        let session_id = SessionId::run_on_abort(txn_meta);
+        let session_id = txn_meta.run_on_abort_session_id();
 
         let session = RespawnedSession::spawn(
             vm,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/epilogue.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/epilogue.rs
@@ -9,7 +9,7 @@ use crate::{
                 SystemSessionChangeSet, UserSessionChangeSet,
             },
         },
-        AptosMoveResolver, SessionId,
+        AptosMoveResolver,
     },
     transaction_metadata::TransactionMetadata,
     AptosVM,
@@ -79,7 +79,7 @@ impl<'r> EpilogueSession<'r> {
         module_write_set: ModuleWriteSet,
         storage_refund: Fee,
     ) -> Self {
-        let session_id = SessionId::epilogue_meta(txn_meta);
+        let session_id = txn_meta.epilogue_session_id();
         let session = RespawnedSession::spawn(
             vm,
             session_id,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/prologue.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/prologue.rs
@@ -9,7 +9,7 @@ use crate::{
                 session_change_sets::SystemSessionChangeSet, user::UserSession,
             },
         },
-        AptosMoveResolver, SessionId,
+        AptosMoveResolver,
     },
     transaction_metadata::TransactionMetadata,
     AptosVM,
@@ -34,7 +34,7 @@ impl<'r> PrologueSession<'r> {
         txn_meta: &TransactionMetadata,
         resolver: &'r impl AptosMoveResolver,
     ) -> Self {
-        let session_id = SessionId::prologue_meta(txn_meta);
+        let session_id = txn_meta.prologue_session_id();
         let session = RespawnedSession::spawn(
             vm,
             session_id,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/user.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/user.rs
@@ -8,7 +8,7 @@ use crate::{
             respawned_session::RespawnedSession,
             user_transaction_sessions::session_change_sets::UserSessionChangeSet,
         },
-        AptosMoveResolver, SessionId,
+        AptosMoveResolver,
     },
     transaction_metadata::TransactionMetadata,
     verifier, AptosVM,
@@ -45,7 +45,7 @@ impl<'r> UserSession<'r> {
         resolver: &'r impl AptosMoveResolver,
         prologue_change_set: VMChangeSet,
     ) -> Self {
-        let session_id = SessionId::txn_meta(txn_meta);
+        let session_id = txn_meta.user_session_id();
 
         let session = RespawnedSession::spawn(
             vm,

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -2,7 +2,6 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::AptosVM;
-use aptos_crypto::HashValue;
 use aptos_gas_algebra::{FeePerGasUnit, Gas, NumBytes};
 use aptos_types::{
     account_address::AccountAddress,
@@ -12,8 +11,8 @@ use aptos_types::{
         authenticator::AuthenticationProof,
         user_transaction_context::{TransactionIndexKind, UserTransactionContext},
         AuxiliaryInfo, EntryFunction, Multisig, MultisigTransactionPayload, ReplayProtector,
-        SignedTransaction, TransactionExecutable, TransactionExecutableRef, TransactionExtraConfig,
-        TransactionPayload, TransactionPayloadInner, TxnLimitsRequest,
+        SessionId, SignedTransaction, TransactionExecutable, TransactionExecutableRef,
+        TransactionExtraConfig, TransactionPayload, TransactionPayloadInner, TxnLimitsRequest,
     },
 };
 use move_core_types::vm_status::{StatusCode, VMStatus};
@@ -64,22 +63,17 @@ impl TransactionMetadata {
             txn.raw_txn_bytes_len()
         };
 
-        let (script_hash, is_approved_gov_script) =
-            if let Ok(TransactionExecutableRef::Script(s)) = txn.payload().executable_ref() {
-                let script_hash = HashValue::sha3_256_of(s.code()).to_vec();
-                let is_approved_gov_script = ApprovedExecutionHashes::fetch_config(resolver)
-                    .ok()
-                    .flatten()
-                    .is_some_and(|approved| {
-                        approved
-                            .entries
-                            .iter()
-                            .any(|(_, hash)| hash == &script_hash)
-                    });
-                (script_hash, is_approved_gov_script)
-            } else {
-                (vec![], false)
-            };
+        let script_hash = txn.payload().script_hash();
+        let is_approved_gov_script = !script_hash.is_empty()
+            && ApprovedExecutionHashes::fetch_config(resolver)
+                .ok()
+                .flatten()
+                .is_some_and(|approved| {
+                    approved
+                        .entries
+                        .iter()
+                        .any(|(_, hash)| hash == &script_hash)
+                });
 
         let extra_config = txn.extra_config();
         let txn_limits_request = extra_config.txn_limits_request();
@@ -263,6 +257,46 @@ impl TransactionMetadata {
 
     pub fn replay_protector(&self) -> ReplayProtector {
         self.replay_protector
+    }
+
+    /// The session id of the transaction's payload session.
+    pub fn user_session_id(&self) -> SessionId {
+        SessionId::txn(
+            self.sender,
+            self.replay_protector(),
+            self.script_hash.clone(),
+            self.expiration_timestamp_secs,
+        )
+    }
+
+    /// The session id of the transaction's prologue session.
+    pub fn prologue_session_id(&self) -> SessionId {
+        SessionId::prologue(
+            self.sender,
+            self.replay_protector(),
+            self.script_hash.clone(),
+            self.expiration_timestamp_secs,
+        )
+    }
+
+    /// The session id of the transaction's abort-hook session.
+    pub fn run_on_abort_session_id(&self) -> SessionId {
+        SessionId::run_on_abort(
+            self.sender,
+            self.replay_protector(),
+            self.script_hash.clone(),
+            self.expiration_timestamp_secs,
+        )
+    }
+
+    /// The session id of the transaction's epilogue session.
+    pub fn epilogue_session_id(&self) -> SessionId {
+        SessionId::epilogue(
+            self.sender,
+            self.replay_protector(),
+            self.script_hash.clone(),
+            self.expiration_timestamp_secs,
+        )
     }
 
     pub fn is_orderless(&self) -> bool {

--- a/aptos-move/aptos-vm/src/transaction_validation_versioned.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation_versioned.rs
@@ -14,7 +14,9 @@ use crate::{
 use aptos_gas_algebra::Gas;
 use aptos_types::{
     fee_statement::FeeStatement,
-    transaction::{ReplayProtector, TxnLimitsRequest, UserTxnLimitsRequest},
+    transaction::{
+        EpilogueArgs, PrologueArgs, ReplayProtector, TxnLimitsRequest, UserTxnLimitsRequest,
+    },
 };
 use aptos_vm_logging::log_schema::AdapterLogSchema;
 use move_binary_format::errors::VMResult;
@@ -23,27 +25,6 @@ use move_vm_runtime::{
     logging::expect_no_verification_errors, module_traversal::TraversalContext, ModuleStorage,
 };
 use move_vm_types::gas::UnmeteredGasMeter;
-use serde::Serialize;
-
-/// Mirrors Move enum in `transaction_validation.move` and needs to have the
-/// same BCS serialization.
-#[derive(Serialize)]
-enum PrologueArgs {
-    V1 {
-        needs_fee_payer_auth_check: bool,
-        txn_sender_public_key: Option<Vec<u8>>,
-        fee_payer_public_key_hash: Option<Vec<u8>>,
-        replay_protector: ReplayProtector,
-        secondary_signer_addresses: Vec<AccountAddress>,
-        secondary_signer_public_key_hashes: Vec<Option<Vec<u8>>>,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        txn_expiration_time: u64,
-        chain_id: u8,
-        is_simulation: bool,
-        txn_limits_request: Option<UserTxnLimitsRequest>,
-    },
-}
 
 /// Builder that collects prologue arguments and selects the appropriate enum
 /// variant to build.
@@ -143,20 +124,6 @@ pub(crate) fn run_prologue(
         .map(|_return_vals| ())
         .map_err(expect_no_verification_errors)
         .or_else(|err| convert_prologue_error(err, log_context))
-}
-
-/// Mirrors Move enum in `transaction_validation.move` and needs to have the
-/// same BCS serialization.
-#[derive(Serialize)]
-enum EpilogueArgs {
-    V1 {
-        fee_statement: FeeStatement,
-        txn_gas_price: u64,
-        txn_max_gas_units: u64,
-        gas_units_remaining: u64,
-        is_simulation: bool,
-        is_orderless_txn: bool,
-    },
 }
 
 /// Builder that collects epilogue arguments and selects the appropriate enum

--- a/third_party/move/mono-move/AGENTS.md
+++ b/third_party/move/mono-move/AGENTS.md
@@ -10,7 +10,8 @@ Every inline TODO is `// TODO(<group>): message`, where `<group>` is one or more
 
 | group | covers |
 |---|---|
-| correctness | wrong results, unsoundness, aliasing/security, legacy-VM parity |
+| correctness | wrong results, unsoundness, aliasing, legacy-VM parity |
+| security | attacker-reachable abuse: unbounded user-controlled input, cache pollution |
 | completeness | unimplemented functionality, `todo!()` gaps, future-feature constraints |
 | metering | gas charging and recursion/size/cache-DoS bounds |
 | perf | speed-only optimizations |
@@ -23,5 +24,5 @@ verify (prints nothing if clean):
 ```bash
 grep -rn "TODO" --include='*.rs' third_party/move/mono-move \
   | grep -v 'todo!\|unimplemented!\|unreachable!' \
-  | grep -vE 'TODO\(((correctness|completeness|metering|perf|cleanup|testing)(, )?)+\):'
+  | grep -vE 'TODO\(((correctness|security|completeness|metering|perf|cleanup|testing)(, )?)+\):'
 ```

--- a/third_party/move/mono-move/aptos-state-view-providers/AGENTS.md
+++ b/third_party/move/mono-move/aptos-state-view-providers/AGENTS.md
@@ -1,0 +1,8 @@
+# aptos-state-view-providers
+
+`StateView`-backed implementations of the transaction executor's data traits,
+for sequential execution: tests, simulation, and replay-style tools. The
+production data layer comes from the Block-STM integration behind the same
+traits.
+
+See the crate docs in `src/lib.rs`.

--- a/third_party/move/mono-move/aptos-state-view-providers/CLAUDE.md
+++ b/third_party/move/mono-move/aptos-state-view-providers/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](AGENTS.md) for crate documentation.

--- a/third_party/move/mono-move/aptos-state-view-providers/Cargo.toml
+++ b/third_party/move/mono-move/aptos-state-view-providers/Cargo.toml
@@ -19,7 +19,6 @@ aptos-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
 fxhash = { workspace = true }
-triomphe = { workspace = true }
 mono-move-aptos-transaction-executor = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-global-context = { workspace = true }
@@ -27,5 +26,5 @@ mono-move-runtime = { workspace = true }
 move-binary-format = { workspace = true }
 move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true }
-specializer = { workspace = true }
 thiserror = { workspace = true }
+triomphe = { workspace = true }

--- a/third_party/move/mono-move/aptos-state-view-providers/Cargo.toml
+++ b/third_party/move/mono-move/aptos-state-view-providers/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "mono-move-aptos-state-view-providers"
+description = "StateView-backed data providers for the MonoMove Aptos transaction executor."
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-framework = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+bytes = { workspace = true }
+mono-move-aptos-transaction-executor = { workspace = true }
+mono-move-core = { workspace = true }
+mono-move-global-context = { workspace = true }
+mono-move-runtime = { workspace = true }
+move-binary-format = { workspace = true }
+move-bytecode-verifier = { workspace = true }
+move-core-types = { workspace = true }
+specializer = { workspace = true }
+thiserror = { workspace = true }

--- a/third_party/move/mono-move/aptos-state-view-providers/Cargo.toml
+++ b/third_party/move/mono-move/aptos-state-view-providers/Cargo.toml
@@ -19,6 +19,7 @@ aptos-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
 fxhash = { workspace = true }
+triomphe = { workspace = true }
 mono-move-aptos-transaction-executor = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-global-context = { workspace = true }

--- a/third_party/move/mono-move/aptos-state-view-providers/Cargo.toml
+++ b/third_party/move/mono-move/aptos-state-view-providers/Cargo.toml
@@ -18,6 +18,7 @@ aptos-framework = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
+fxhash = { workspace = true }
 mono-move-aptos-transaction-executor = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-global-context = { workspace = true }

--- a/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
+++ b/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
@@ -11,7 +11,7 @@
 //!   materializing each value into a long-lived arena on first access, and
 //!   resolves resource-group placement.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use aptos_framework::natives::code::PackageRegistry;
 use aptos_types::{
     state_store::{state_key::StateKey, StateView},
@@ -24,25 +24,25 @@ use mono_move_aptos_transaction_executor::{
 };
 use mono_move_core::{
     intern_struct_tag,
+    interner::{view_module_id, InternedModuleId},
     storage::{
         module_provider::ModuleProvider,
         resource_provider::{
             InMemoryStorageKey, ResourceProvider, ResourceProviderError, StorageRead,
         },
     },
-    struct_tag_of,
-    types::InternedType,
-    ExecutionErrorKind, FrameOffset, IntoExecutionError, LayoutProvider, VMInternalError, VMResult,
+    types::{view_name, view_type, InternedType, Type},
+    ExecutionErrorKind, IntoExecutionError, LayoutProvider, VMInternalError, VMResult,
     OBJECT_HEADER_SIZE,
 };
 use mono_move_global_context::ExecutionGuard;
 use mono_move_runtime::{deserialize_into, Heap};
 use move_binary_format::CompiledModule;
 use move_core_types::{
-    account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
     move_resource::MoveStructType,
 };
-use specializer::lower::gc_layout::type_pointer_offsets;
 use std::cell::RefCell;
 use thiserror::Error;
 use triomphe::Arc;
@@ -157,12 +157,13 @@ struct ProviderState {
     /// Resource-group membership per resource type, resolved from the defining
     /// module's metadata. `None` = not a group member.
     group_membership: FxHashMap<InternedType, Option<InternedType>>,
-    /// Aptos metadata of each module consulted for group membership so far,
-    /// keyed by the module's state key. `None` = module absent or without
-    /// metadata.
-    module_metadata: FxHashMap<StateKey, Option<Arc<RuntimeModuleMetadataV1>>>,
-    /// Stored members of each resource group read so far, keyed by the
-    /// group's state key.
+    /// Aptos metadata of each module consulted for group membership so far.
+    /// `None` = module absent or without metadata.
+    module_metadata: FxHashMap<InternedModuleId, Option<Arc<RuntimeModuleMetadataV1>>>,
+    /// Members of each resource group read so far, keyed by the group's state key.
+    ///
+    /// Here it is safe to use a non-cryptographic hasher because `StateKey` already
+    /// gets hashed by its crypto digest.
     groups: FxHashMap<StateKey, Option<Arc<GroupMembers>>>,
 }
 
@@ -182,13 +183,18 @@ impl<'a, 'ctx, S: StateView> StateViewResourceProvider<'a, 'ctx, S> {
 
     /// Resolves group membership from the defining module's Aptos metadata.
     fn resolve_group_of(&self, ty: InternedType) -> Result<Option<InternedType>> {
-        let tag = struct_tag_of(ty).ok_or_else(|| anyhow!("resource type is not nominal"))?;
-        let Some(metadata) = self.module_metadata(&tag)? else {
+        let Type::Nominal {
+            module_id, name, ..
+        } = view_type(ty)
+        else {
+            bail!("resource type is not nominal");
+        };
+        let Some(metadata) = self.module_metadata(*module_id)? else {
             return Ok(None);
         };
         let Some(group_tag) = metadata
             .struct_attributes
-            .get(tag.name.as_str())
+            .get(view_name(*name))
             .into_iter()
             .flatten()
             .find_map(|attr| attr.get_resource_group_member())
@@ -198,17 +204,22 @@ impl<'a, 'ctx, S: StateView> StateViewResourceProvider<'a, 'ctx, S> {
         Ok(Some(intern_struct_tag(&group_tag, self.guard)?))
     }
 
-    /// The Aptos metadata of `tag`'s defining module, if any. Cached per
-    /// module.
+    /// The Aptos metadata of a module, if any. Cached per module.
     //
     // TODO(perf): cache the metadata in the global context instead — this
     // deserializes the whole defining module for its metadata, duplicating the
     // loader's own fetch and deserialization of the same bytes.
-    fn module_metadata(&self, tag: &StructTag) -> Result<Option<Arc<RuntimeModuleMetadataV1>>> {
-        let key = StateKey::module(&tag.address, &tag.module);
-        if let Some(metadata) = self.inner.borrow().module_metadata.get(&key) {
+    fn module_metadata(
+        &self,
+        module_id: InternedModuleId,
+    ) -> Result<Option<Arc<RuntimeModuleMetadataV1>>> {
+        if let Some(metadata) = self.inner.borrow().module_metadata.get(&module_id) {
             return Ok(metadata.clone());
         }
+        let view = view_module_id(module_id);
+        let name = IdentStr::new(view_name(view.name()))
+            .map_err(|e| anyhow!("invalid module name: {e}"))?;
+        let key = StateKey::module(view.address(), name);
         let metadata = match self
             .state_view
             .get_state_value(&key)
@@ -224,7 +235,7 @@ impl<'a, 'ctx, S: StateView> StateViewResourceProvider<'a, 'ctx, S> {
         self.inner
             .borrow_mut()
             .module_metadata
-            .insert(key, metadata.clone());
+            .insert(module_id, metadata.clone());
         Ok(metadata)
     }
 
@@ -259,17 +270,12 @@ impl<S: StateView> ResourceProvider for StateViewResourceProvider<'_, '_, S> {
             .guard
             .layout_by_ty(ty)
             .ok_or_else(|| internal(format!("no layout for the value at {:?}", key.address())))?;
-        // Ensure the type's GC descriptor exists (a no-op when lowering
-        // already published it), using the same pointer-offset computation
-        // lowering uses.
-        let offsets: Vec<FrameOffset> = type_pointer_offsets(self.guard, ty)
-            .map_err(|e| internal(format!("pointer offsets unavailable: {e}")))?
-            .into_iter()
-            .map(FrameOffset)
-            .collect();
+        // Lowering publishes a descriptor for every resource a global-storage
+        // instruction reaches, so the read that got here has one already.
         let descriptor = self
             .guard
-            .publish_struct_descriptor(ty, layout.size, &offsets);
+            .struct_descriptor(ty)
+            .ok_or_else(|| internal(format!("no GC descriptor for {:?}", key.address())))?;
 
         let mut inner = self.inner.borrow_mut();
         let obj = inner

--- a/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
+++ b/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
@@ -1,0 +1,319 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Data providers serving MonoMove's module and resource reads from an Aptos
+//! `StateView`, for sequential execution: tests, simulation, and replay-style
+//! tools. Production execution uses the Block-STM integration's providers.
+//!
+//! - `StateViewModuleProvider` serves module bytes and package co-membership
+//!   to the loader.
+//! - `StateViewResourceProvider` serves resource and table-item reads,
+//!   materializing each value into a long-lived arena on first access, and
+//!   resolves resource-group placement.
+
+use anyhow::{anyhow, Result};
+use aptos_framework::natives::code::PackageRegistry;
+use aptos_types::{
+    state_store::{state_key::StateKey, StateView},
+    vm::module_metadata::{get_metadata, RuntimeModuleMetadataV1},
+};
+use bytes::Bytes;
+use mono_move_aptos_transaction_executor::{
+    decode_group_members, AptosDataProvider, GroupMembers, StorageLocation,
+};
+use mono_move_core::{
+    intern_struct_tag,
+    storage::{
+        module_provider::ModuleProvider,
+        resource_provider::{
+            InMemoryStorageKey, ResourceProvider, ResourceProviderError, StorageRead,
+        },
+    },
+    struct_tag_of,
+    types::InternedType,
+    ExecutionErrorKind, FrameOffset, IntoExecutionError, LayoutProvider, VMInternalError, VMResult,
+    OBJECT_HEADER_SIZE,
+};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_runtime::{deserialize_into, Heap};
+use move_binary_format::CompiledModule;
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
+    move_resource::MoveStructType,
+};
+use specializer::lower::gc_layout::type_pointer_offsets;
+use std::{cell::RefCell, collections::HashMap, sync::Arc};
+use thiserror::Error;
+
+/// Size of the provider's value arena.
+pub const DEFAULT_RESOURCE_ARENA_BYTES: usize = 64 * 1024 * 1024;
+
+/// Errors raised by these providers.
+#[derive(Debug, Error)]
+#[error("{0}")]
+struct ProviderError(String);
+
+impl IntoExecutionError for ProviderError {
+    fn kind(&self) -> ExecutionErrorKind {
+        ExecutionErrorKind::Placeholder
+    }
+}
+
+fn provider_error(detail: String) -> VMInternalError {
+    VMInternalError::new(ProviderError(detail))
+}
+
+/// Serves module bytes to the loader from a `StateView`.
+pub struct StateViewModuleProvider<'s, S> {
+    state_view: &'s S,
+}
+
+impl<'s, S: StateView> StateViewModuleProvider<'s, S> {
+    pub fn new(state_view: &'s S) -> Self {
+        Self { state_view }
+    }
+}
+
+impl<S: StateView> ModuleProvider for StateViewModuleProvider<'_, S> {
+    fn get_module_bytes(&self, address: &AccountAddress, name: &str) -> VMResult<Option<Bytes>> {
+        let name = Identifier::new(name)
+            .map_err(|e| provider_error(format!("invalid module name {name:?}: {e}")))?;
+        let key = StateKey::module(address, &name);
+        Ok(self
+            .state_view
+            .get_state_value(&key)
+            .map_err(|e| provider_error(format!("module read failed: {e}")))?
+            .map(|value| value.bytes().clone()))
+    }
+
+    fn deserialize_module(&self, bytes: &[u8]) -> VMResult<CompiledModule> {
+        // TODO(correctness): use the on-chain deserializer config (max version, etc.).
+        CompiledModule::deserialize(bytes)
+            .map_err(|e| provider_error(format!("deserialize failed: {e:?}")))
+    }
+
+    fn verify_module(&self, module: &CompiledModule) -> VMResult<()> {
+        // TODO(correctness): use the on-chain verifier config instead of the default.
+        move_bytecode_verifier::verify_module(module)
+            .map_err(|e| provider_error(format!("verification failed: {e:?}")))
+    }
+
+    // TODO(perf): fetches and BCS-deserializes the address's entire
+    // `PackageRegistry` (for 0x1: every framework package) on each call,
+    // uncached.
+    fn get_same_package_modules(
+        &self,
+        address: &AccountAddress,
+        module_name: &str,
+    ) -> VMResult<Vec<Identifier>> {
+        let identifier = |name: &str| {
+            Identifier::new(name)
+                .map_err(|e| provider_error(format!("invalid module name {name:?}: {e}")))
+        };
+        let key = StateKey::resource(address, &PackageRegistry::struct_tag())
+            .map_err(|e| provider_error(format!("bad state key: {e}")))?;
+        let Some(value) = self
+            .state_view
+            .get_state_value(&key)
+            .map_err(|e| provider_error(format!("package registry read failed: {e}")))?
+        else {
+            return Err(provider_error(format!("no package registry at {address}")));
+        };
+        let registry: PackageRegistry = bcs::from_bytes(value.bytes())
+            .map_err(|e| provider_error(format!("malformed package registry: {e}")))?;
+        for package in &registry.packages {
+            let names = package
+                .modules
+                .iter()
+                .map(|m| identifier(&m.name))
+                .collect::<VMResult<Vec<_>>>()?;
+            if names.iter().any(|n| n.as_str() == module_name) {
+                return Ok(names);
+            }
+        }
+        Err(provider_error(format!(
+            "module {address}::{module_name} not found in any package"
+        )))
+    }
+}
+
+/// Serves resource and table-item reads from a `StateView`, materializing each
+/// value into a long-lived arena on first access. Also resolves and remembers
+/// resource-group membership.
+pub struct StateViewResourceProvider<'a, 'ctx, S> {
+    guard: &'a ExecutionGuard<'ctx>,
+    state_view: &'a S,
+    inner: RefCell<ProviderState>,
+}
+
+/// The provider's interior-mutable state: caches and the value arena.
+struct ProviderState {
+    /// Bump arena holding the flat values served to reads, which
+    /// `ExternalHeap` pointers point into. Never collected or reset; must stay
+    /// alive as long as those pointers (through materialization).
+    arena: Heap,
+    /// Resource-group membership per resource type, resolved from the defining
+    /// module's metadata. `None` = not a group member.
+    group_membership: HashMap<InternedType, Option<InternedType>>,
+    /// Aptos metadata of each module consulted for group membership so far,
+    /// keyed by the module's state key. `None` = module absent or without
+    /// metadata.
+    module_metadata: HashMap<StateKey, Option<Arc<RuntimeModuleMetadataV1>>>,
+    /// Stored members of each resource group read so far, keyed by the
+    /// group's state key.
+    groups: HashMap<StateKey, Option<Arc<GroupMembers>>>,
+}
+
+impl<'a, 'ctx, S: StateView> StateViewResourceProvider<'a, 'ctx, S> {
+    pub fn new(guard: &'a ExecutionGuard<'ctx>, state_view: &'a S, arena_size: usize) -> Self {
+        Self {
+            guard,
+            state_view,
+            inner: RefCell::new(ProviderState {
+                arena: Heap::new(arena_size),
+                group_membership: HashMap::new(),
+                module_metadata: HashMap::new(),
+                groups: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Resolves group membership from the defining module's Aptos metadata.
+    fn resolve_group_of(&self, ty: InternedType) -> Result<Option<InternedType>> {
+        let tag = struct_tag_of(ty).ok_or_else(|| anyhow!("resource type is not nominal"))?;
+        let Some(metadata) = self.module_metadata(&tag)? else {
+            return Ok(None);
+        };
+        let Some(group_tag) = metadata
+            .struct_attributes
+            .get(tag.name.as_str())
+            .into_iter()
+            .flatten()
+            .find_map(|attr| attr.get_resource_group_member())
+        else {
+            return Ok(None);
+        };
+        Ok(Some(intern_struct_tag(&group_tag, self.guard)?))
+    }
+
+    /// The Aptos metadata of `tag`'s defining module, if any. Cached per
+    /// module.
+    //
+    // TODO(perf): cache the metadata in the global context instead — this
+    // deserializes the whole defining module for its metadata, duplicating the
+    // loader's own fetch and deserialization of the same bytes.
+    fn module_metadata(&self, tag: &StructTag) -> Result<Option<Arc<RuntimeModuleMetadataV1>>> {
+        let key = StateKey::module(&tag.address, &tag.module);
+        if let Some(metadata) = self.inner.borrow().module_metadata.get(&key) {
+            return Ok(metadata.clone());
+        }
+        let metadata = match self
+            .state_view
+            .get_state_value(&key)
+            .map_err(|e| anyhow!("module read failed: {e}"))?
+        {
+            Some(value) => {
+                let module = CompiledModule::deserialize(value.bytes())
+                    .map_err(|e| anyhow!("deserialize failed: {e:?}"))?;
+                get_metadata(&module.metadata)
+            },
+            None => None,
+        };
+        self.inner
+            .borrow_mut()
+            .module_metadata
+            .insert(key, metadata.clone());
+        Ok(metadata)
+    }
+
+    /// The stored BCS bytes for a key, looked up among the group's members
+    /// for group-member keys. `None` = does not exist.
+    fn fetch_bytes(&self, key: &InMemoryStorageKey) -> Result<Option<Bytes>> {
+        match self.locate_key(key)? {
+            StorageLocation::OwnSlot(state_key) => Ok(self
+                .state_view
+                .get_state_value(&state_key)
+                .map_err(|e| anyhow!("state read failed: {e}"))?
+                .map(|value| value.bytes().clone())),
+            StorageLocation::GroupMember { group, member } => Ok(self
+                .group_members(&group)?
+                .and_then(|members| members.get(&member).cloned())),
+        }
+    }
+}
+
+impl<S: StateView> ResourceProvider for StateViewResourceProvider<'_, '_, S> {
+    // No per-key cache: the read-write set's working map already deduplicates
+    // reads, so each key reaches the provider at most once.
+    fn get_resource(&self, key: &InMemoryStorageKey) -> Result<StorageRead, ResourceProviderError> {
+        let internal = |detail: String| ResourceProviderError::InvariantViolation(detail);
+        let Some(blob) = self.fetch_bytes(key).map_err(|e| internal(e.to_string()))? else {
+            return Ok(StorageRead::DoesNotExist);
+        };
+
+        // Materialize the value (BCS → flat) into the provider's arena.
+        let ty = key.value_ty();
+        let layout = self
+            .guard
+            .layout_by_ty(ty)
+            .ok_or_else(|| internal(format!("no layout for the value at {:?}", key.address())))?;
+        // Ensure the type's GC descriptor exists (a no-op when lowering
+        // already published it), using the same pointer-offset computation
+        // lowering uses.
+        let offsets: Vec<FrameOffset> = type_pointer_offsets(self.guard, ty)
+            .map_err(|e| internal(format!("pointer offsets unavailable: {e}")))?
+            .into_iter()
+            .map(FrameOffset)
+            .collect();
+        let descriptor = self
+            .guard
+            .publish_struct_descriptor(ty, layout.size, &offsets);
+
+        let mut inner = self.inner.borrow_mut();
+        let obj = inner
+            .arena
+            .alloc_object(OBJECT_HEADER_SIZE + layout.size as usize, descriptor)
+            .ok_or_else(|| internal("resource arena is full".to_string()))?;
+        // SAFETY: `obj` is a freshly reserved object sized for the value's
+        // layout; `deserialize_into` writes the flat value there.
+        unsafe { deserialize_into(self.guard, &mut inner.arena, ty, &blob, obj.as_ptr()) }
+            .map_err(|e| internal(format!("stored value failed to deserialize: {e}")))?;
+        Ok(StorageRead::ExternalHeap {
+            ptr: obj,
+            version: 0,
+        })
+    }
+}
+
+impl<S: StateView> AptosDataProvider for StateViewResourceProvider<'_, '_, S> {
+    /// Cached per resource type.
+    fn group_of(&self, ty: InternedType) -> Result<Option<InternedType>> {
+        if let Some(group) = self.inner.borrow().group_membership.get(&ty) {
+            return Ok(*group);
+        }
+        let group = self.resolve_group_of(ty)?;
+        self.inner.borrow_mut().group_membership.insert(ty, group);
+        Ok(group)
+    }
+
+    /// Loaded from the state view on first access, caching absence as well so a
+    /// missing group is read at most once.
+    fn group_members(&self, group_key: &StateKey) -> Result<Option<Arc<GroupMembers>>> {
+        if let Some(members) = self.inner.borrow().groups.get(group_key) {
+            return Ok(members.clone());
+        }
+        let members = match self
+            .state_view
+            .get_state_value(group_key)
+            .map_err(|e| anyhow!("group read failed: {e}"))?
+        {
+            Some(value) => Some(Arc::new(decode_group_members(value.bytes(), self.guard)?)),
+            None => None,
+        };
+        self.inner
+            .borrow_mut()
+            .groups
+            .insert(group_key.clone(), members.clone());
+        Ok(members)
+    }
+}

--- a/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
+++ b/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
@@ -18,6 +18,7 @@ use aptos_types::{
     vm::module_metadata::{get_metadata, RuntimeModuleMetadataV1},
 };
 use bytes::Bytes;
+use fxhash::FxHashMap;
 use mono_move_aptos_transaction_executor::{
     decode_group_members, AptosDataProvider, GroupMembers, StorageLocation,
 };
@@ -42,7 +43,7 @@ use move_core_types::{
     move_resource::MoveStructType,
 };
 use specializer::lower::gc_layout::type_pointer_offsets;
-use std::{cell::RefCell, collections::HashMap, sync::Arc};
+use std::{cell::RefCell, sync::Arc};
 use thiserror::Error;
 
 /// Size of the provider's value arena.
@@ -148,20 +149,20 @@ pub struct StateViewResourceProvider<'a, 'ctx, S> {
 
 /// The provider's interior-mutable state: caches and the value arena.
 struct ProviderState {
-    /// Bump arena holding the flat values served to reads, which
-    /// `ExternalHeap` pointers point into. Never collected or reset; must stay
-    /// alive as long as those pointers (through materialization).
+    /// Bump arena holding the flat values that reads hand out pointers into.
+    /// Never collected or reset; must stay alive as long as those pointers
+    /// (through materialization).
     arena: Heap,
     /// Resource-group membership per resource type, resolved from the defining
     /// module's metadata. `None` = not a group member.
-    group_membership: HashMap<InternedType, Option<InternedType>>,
+    group_membership: FxHashMap<InternedType, Option<InternedType>>,
     /// Aptos metadata of each module consulted for group membership so far,
     /// keyed by the module's state key. `None` = module absent or without
     /// metadata.
-    module_metadata: HashMap<StateKey, Option<Arc<RuntimeModuleMetadataV1>>>,
+    module_metadata: FxHashMap<StateKey, Option<Arc<RuntimeModuleMetadataV1>>>,
     /// Stored members of each resource group read so far, keyed by the
     /// group's state key.
-    groups: HashMap<StateKey, Option<Arc<GroupMembers>>>,
+    groups: FxHashMap<StateKey, Option<Arc<GroupMembers>>>,
 }
 
 impl<'a, 'ctx, S: StateView> StateViewResourceProvider<'a, 'ctx, S> {
@@ -171,9 +172,9 @@ impl<'a, 'ctx, S: StateView> StateViewResourceProvider<'a, 'ctx, S> {
             state_view,
             inner: RefCell::new(ProviderState {
                 arena: Heap::new(arena_size),
-                group_membership: HashMap::new(),
-                module_metadata: HashMap::new(),
-                groups: HashMap::new(),
+                group_membership: FxHashMap::default(),
+                module_metadata: FxHashMap::default(),
+                groups: FxHashMap::default(),
             }),
         }
     }

--- a/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
+++ b/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
@@ -43,8 +43,9 @@ use move_core_types::{
     move_resource::MoveStructType,
 };
 use specializer::lower::gc_layout::type_pointer_offsets;
-use std::{cell::RefCell, sync::Arc};
+use std::cell::RefCell;
 use thiserror::Error;
+use triomphe::Arc;
 
 /// Size of the provider's value arena.
 pub const DEFAULT_RESOURCE_ARENA_BYTES: usize = 64 * 1024 * 1024;

--- a/third_party/move/mono-move/aptos-transaction-executor/AGENTS.md
+++ b/third_party/move/mono-move/aptos-transaction-executor/AGENTS.md
@@ -1,72 +1,53 @@
 # aptos-transaction-executor
 
-Reimplementation of the AptosVM transaction-execution layer on the MonoMove VM.
-Executes one Aptos user transaction — prologue → payload → epilogue —
-producing an unmaterialized `TxnOutcome`. Block-level coordination
-(sequencing, Block-STM, block metadata) lives above this crate.
+The AptosVM transaction-execution layer on the MonoMove VM: one Aptos user
+transaction, prologue → payload → epilogue, producing an unmaterialized
+`TxnOutcome`. Block-level coordination lives above this crate.
 
-Proof-of-concept scope: entry functions only. Scripts, multisig, module
-publishing, keyless/account-abstraction auth, orderless transactions, mempool
-validation, and view functions are `TODO(completeness)` placeholders. Gas is
-incomplete (see Key design decisions).
+## Working assumptions
 
-## Interface
+- Assume the latest feature set. All on-chain features and the latest gas
+  feature version are enabled; supporting only that is sufficient. Do not port
+  legacy validation paths, old gas versions, or feature-flag branches.
+- Entry functions are the only supported payload. Anything else is a
+  `TODO(completeness)`.
+- Gas is deliberately incomplete: MonoMove's units are uncalibrated, IO gas and
+  storage fees are not charged. Do not treat a gas mismatch against the legacy VM
+  as a regression.
+- Past the prologue, a transaction always commits and charges the fee.
+- Materialization is optional. Nothing on the execution path may call into
+  `materialize/` -- it is up to the higher-level coordinator to decide when to
+  call it.
 
-- `AptosTransactionExecutor` is a thin handle borrowing everything from the
-  block coordinator: the execution guard, the native registry, the data layers
-  (`ModuleProvider` for code, the runtime's `ResourceProvider` for resources),
-  and the config snapshot (features, epoch-boundary storage usage). It owns
-  nothing it reads and never touches a `StateView` itself.
-- In: `SignedTransaction` (signature verification is the caller's job).
-- Out: `TxnOutcome` — the transaction's typed conclusion, carrying its side
-  effects in VM representation. `materialize()` renders it into a
-  `TransactionOutput`; only this step needs the wider `AptosDataProvider`,
-  whose answers must agree with the provider that served execution.
-  Block-level consumers will eventually read the effects directly.
-- `StateView`-backed implementations of the data traits live in the sibling
-  `mono-move-aptos-state-view-providers` crate (a dev-dependency here, used by
-  the e2e tests); Block-STM integration provides the production
-  implementations.
+## Before wiring to the block coordinator
+
+There are critical issues we need to address before wiring up the transaction
+executor to the block coordinator:
+
+- Entry-function validation: `entry` visibility, no return values, admissible
+  argument types. Without the visibility check a signed payload naming any
+  loadable function runs it.
+- Argument and signer checks: duplicate signers, signer counts, malformed
+  arguments.
+- `check_gas` pre-flight: transaction size, gas price bounds, intrinsic gas.
+  Without it a zero gas price buys a full `max_gas_amount` budget.
 
 ## Modules
 
-Modules stay private; anything public at the crate level is re-exported from
-`lib.rs`, which holds nothing else.
+Modules stay private; anything public is re-exported from `lib.rs`, which holds
+nothing else.
 
 | Module | Purpose |
 |---|---|
 | `executor.rs` | `AptosTransactionExecutor`: the transaction lifecycle driver |
-| `outcome.rs` | `TxnOutcome`: the unmaterialized transaction conclusion, and `materialize()` |
-| `errors.rs` | The typed outcome taxonomy: `DiscardReason`, `CommitStatus`, and the per-stage failure enums |
-| `materialize/` | Rendering into the storage-facing formats: `txn_output.rs` drains the write set (with resource-group merge-back) into a `TransactionOutput`; `vm_status.rs` projects the taxonomy onto `VMStatus` |
+| `outcome.rs` | `TxnOutcome`: the unmaterialized conclusion, and `materialize()` |
+| `errors.rs` | The typed outcome taxonomy: `DiscardReason`, `ExecutionStatus`, and the per-stage failure enums |
+| `materialize/` | `txn_output.rs` drains the write set (with resource-group merge-back) into a `TransactionOutput`; `vm_status.rs` projects the taxonomy onto `VMStatus` |
 | `providers.rs` | The `AptosDataProvider` trait: what write-set materialization needs from the data layer |
-| `natives.rs` | Native function wiring: the production native registry and the per-transaction native extensions |
+| `natives.rs` | The production native registry and the per-transaction native extensions |
 | `calls.rs` | Making one function call in the shared interpreter context |
 | `metadata.rs` | The slice of transaction metadata the prologue needs |
-| `sys_calls.rs` | Unmetered framework system calls with Rust-built arguments: the transaction prologue and epilogue |
-
-## Key design decisions
-
-- **One session, checkpoints.** No per-stage change sets, no respawned
-  sessions, no view overlays: prologue, payload, and epilogue run in one
-  interpreter context, a failed payload rolls the heap and read-write set back
-  to the post-prologue checkpoint, and writes are drained exactly once at the
-  end.
-- **Only the current feature path.** The versioned prologue/epilogue is the
-  only validation path; legacy variants and old gas versions are intentionally
-  not ported.
-- **Gas is incomplete.** Execution is metered in MonoMove's uncalibrated
-  units against the transaction's gas limit; IO gas, storage fees, and
-  refunds are not charged yet, and the prologue/epilogue run unmetered.
-  Gas amounts therefore diverge from the legacy VM by design; differential
-  tests compare outputs with only the fee-embedding slots masked.
-- **The write-set drain in `materialize/txn_output.rs` is a stopgap**, and where it should
-  ultimately live is an open question. Real publication (modification
-  detection, storage metadata, refunds) belongs inside the runtime, and the
-  runtime already has `SessionEffects::write_set()` — but that path knows
-  nothing about resource groups, which this drain handles via the data
-  provider. Resolving the two (and how much of resource groups the VM layer
-  should see at all) needs a design doc before either side hardens.
+| `sys_calls.rs` | The unmetered prologue and epilogue calls |
 
 ## Testing
 
@@ -74,6 +55,6 @@ Modules stay private; anything public at the crate level is re-exported from
 cargo test -p mono-move-aptos-transaction-executor
 ```
 
-`tests/e2e.rs` builds genesis state with `FakeExecutor` (dev-dependency), runs
-the same transaction on the legacy VM and this crate, and compares status,
-write sets, and events, masking only the gas-fee slots.
+`tests/e2e.rs` builds genesis state with `FakeExecutor`, runs the same
+transaction on the legacy VM and this crate, and compares status, write sets,
+and events, masking only the gas-fee slots.

--- a/third_party/move/mono-move/aptos-transaction-executor/AGENTS.md
+++ b/third_party/move/mono-move/aptos-transaction-executor/AGENTS.md
@@ -1,0 +1,79 @@
+# aptos-transaction-executor
+
+Reimplementation of the AptosVM transaction-execution layer on the MonoMove VM.
+Executes one Aptos user transaction — prologue → payload → epilogue —
+producing an unmaterialized `TxnOutcome`. Block-level coordination
+(sequencing, Block-STM, block metadata) lives above this crate.
+
+Proof-of-concept scope: entry functions only. Scripts, multisig, module
+publishing, keyless/account-abstraction auth, orderless transactions, mempool
+validation, and view functions are `TODO(completeness)` placeholders. Gas is
+incomplete (see Key design decisions).
+
+## Interface
+
+- `AptosTransactionExecutor` is a thin handle borrowing everything from the
+  block coordinator: the execution guard, the native registry, the data layers
+  (`ModuleProvider` for code, the runtime's `ResourceProvider` for resources),
+  and the config snapshot (features, epoch-boundary storage usage). It owns
+  nothing it reads and never touches a `StateView` itself.
+- In: `SignedTransaction` (signature verification is the caller's job).
+- Out: `TxnOutcome` — the transaction's typed conclusion, carrying its side
+  effects in VM representation. `materialize()` renders it into a
+  `TransactionOutput`; only this step needs the wider `AptosDataProvider`,
+  whose answers must agree with the provider that served execution.
+  Block-level consumers will eventually read the effects directly.
+- `StateView`-backed implementations of the data traits live in the sibling
+  `mono-move-aptos-state-view-providers` crate (a dev-dependency here, used by
+  the e2e tests); Block-STM integration provides the production
+  implementations.
+
+## Modules
+
+Modules stay private; anything public at the crate level is re-exported from
+`lib.rs`, which holds nothing else.
+
+| Module | Purpose |
+|---|---|
+| `executor.rs` | `AptosTransactionExecutor`: the transaction lifecycle driver |
+| `outcome.rs` | `TxnOutcome`: the unmaterialized transaction conclusion, and `materialize()` |
+| `errors.rs` | The typed outcome taxonomy: `DiscardReason`, `CommitStatus`, and the per-stage failure enums |
+| `materialize/` | Rendering into the storage-facing formats: `txn_output.rs` drains the write set (with resource-group merge-back) into a `TransactionOutput`; `vm_status.rs` projects the taxonomy onto `VMStatus` |
+| `providers.rs` | The `AptosDataProvider` trait: what write-set materialization needs from the data layer |
+| `natives.rs` | Native function wiring: the production native registry and the per-transaction native extensions |
+| `calls.rs` | Making one function call in the shared interpreter context |
+| `metadata.rs` | The slice of transaction metadata the prologue needs |
+| `sys_calls.rs` | Unmetered framework system calls with Rust-built arguments: the transaction prologue and epilogue |
+
+## Key design decisions
+
+- **One session, checkpoints.** No per-stage change sets, no respawned
+  sessions, no view overlays: prologue, payload, and epilogue run in one
+  interpreter context, a failed payload rolls the heap and read-write set back
+  to the post-prologue checkpoint, and writes are drained exactly once at the
+  end.
+- **Only the current feature path.** The versioned prologue/epilogue is the
+  only validation path; legacy variants and old gas versions are intentionally
+  not ported.
+- **Gas is incomplete.** Execution is metered in MonoMove's uncalibrated
+  units against the transaction's gas limit; IO gas, storage fees, and
+  refunds are not charged yet, and the prologue/epilogue run unmetered.
+  Gas amounts therefore diverge from the legacy VM by design; differential
+  tests compare outputs with only the fee-embedding slots masked.
+- **The write-set drain in `materialize/txn_output.rs` is a stopgap**, and where it should
+  ultimately live is an open question. Real publication (modification
+  detection, storage metadata, refunds) belongs inside the runtime, and the
+  runtime already has `SessionEffects::write_set()` — but that path knows
+  nothing about resource groups, which this drain handles via the data
+  provider. Resolving the two (and how much of resource groups the VM layer
+  should see at all) needs a design doc before either side hardens.
+
+## Testing
+
+```bash
+cargo test -p mono-move-aptos-transaction-executor
+```
+
+`tests/e2e.rs` builds genesis state with `FakeExecutor` (dev-dependency), runs
+the same transaction on the legacy VM and this crate, and compares status,
+write sets, and events, masking only the gas-fee slots.

--- a/third_party/move/mono-move/aptos-transaction-executor/CLAUDE.md
+++ b/third_party/move/mono-move/aptos-transaction-executor/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](AGENTS.md) for crate documentation, architecture, and commands.

--- a/third_party/move/mono-move/aptos-transaction-executor/Cargo.toml
+++ b/third_party/move/mono-move/aptos-transaction-executor/Cargo.toml
@@ -14,22 +14,19 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-aptos-crypto = { workspace = true }
 aptos-types = { workspace = true }
-aptos-vm-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
-triomphe = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-global-context = { workspace = true }
 mono-move-loader = { workspace = true }
 mono-move-natives = { workspace = true }
 mono-move-output = { workspace = true }
 mono-move-runtime = { workspace = true }
-move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+triomphe = { workspace = true }
 
 [dev-dependencies]
 aptos-cached-packages = { workspace = true }

--- a/third_party/move/mono-move/aptos-transaction-executor/Cargo.toml
+++ b/third_party/move/mono-move/aptos-transaction-executor/Cargo.toml
@@ -19,6 +19,7 @@ aptos-types = { workspace = true }
 aptos-vm-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
+triomphe = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-global-context = { workspace = true }
 mono-move-loader = { workspace = true }

--- a/third_party/move/mono-move/aptos-transaction-executor/Cargo.toml
+++ b/third_party/move/mono-move/aptos-transaction-executor/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "mono-move-aptos-transaction-executor"
+description = "The Aptos transaction-execution layer on the MonoMove VM."
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm-types = { workspace = true }
+bcs = { workspace = true }
+bytes = { workspace = true }
+mono-move-core = { workspace = true }
+mono-move-global-context = { workspace = true }
+mono-move-loader = { workspace = true }
+mono-move-natives = { workspace = true }
+mono-move-output = { workspace = true }
+mono-move-runtime = { workspace = true }
+move-binary-format = { workspace = true }
+move-core-types = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+aptos-cached-packages = { workspace = true }
+aptos-language-e2e-tests = { workspace = true }
+aptos-transaction-simulation = { workspace = true }
+mono-move-aptos-state-view-providers = { workspace = true }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
@@ -16,7 +16,9 @@ use mono_move_runtime::{
     error::{RuntimeError, RuntimeInvariantViolation},
     InterpreterContext, RuntimeStatus,
 };
-use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, vm_status::AbortLocation,
+};
 
 /// The parameter types of a loaded module's function, instantiated with
 /// `ty_args`.
@@ -119,7 +121,11 @@ pub(crate) fn place_args(
 /// channel instead.
 pub(crate) enum CallStatus {
     Success,
-    Abort { code: u64, message: Option<String> },
+    Abort {
+        code: u64,
+        message: Option<String>,
+        location: AbortLocation,
+    },
 }
 
 /// Loads `module::function<ty_args>`, places arguments, and runs it in the
@@ -151,13 +157,15 @@ pub(crate) fn call_function(
 
     Ok(match interp.run()? {
         RuntimeStatus::Success => CallStatus::Success,
-        // TODO(correctness): `location` is dropped here, so aborts surface with
-        // a placeholder location. Thread it through the failure taxonomy.
         RuntimeStatus::Aborted {
             code,
             message,
-            location: _,
-        } => CallStatus::Abort { code, message },
+            location,
+        } => CallStatus::Abort {
+            code,
+            message,
+            location,
+        },
     })
 }
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
@@ -16,12 +16,14 @@ use mono_move_runtime::{
     error::{RuntimeError, RuntimeInvariantViolation},
     InterpreterContext, RuntimeStatus,
 };
-use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr, vm_status::AbortLocation,
-};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
 /// The parameter types of a loaded module's function, instantiated with
 /// `ty_args`.
+//
+// TODO(perf, cleanup): `Function` does not carry its signature, so this
+// re-derives the parameters from the module IR on every call -- which is also
+// the only reason callers need the `LoadedModule`.
 fn param_types(
     guard: &ExecutionGuard,
     loaded: &LoadedModule,
@@ -42,6 +44,9 @@ fn param_types(
 /// Fills the root frame of `func` from the signer and BCS-argument lists, in
 /// parameter order: `signer`/`&signer` parameters from the signer list,
 /// everything else deserialized from BCS.
+//
+// TODO(correctness): rework this part as a whole together with proper argument
+// validation.
 pub(crate) fn place_args(
     interp: &mut InterpreterContext<'_>,
     func: &Function,
@@ -59,9 +64,22 @@ pub(crate) fn place_args(
     let mut signers = signer_bufs.iter();
     let mut args = args.iter();
     let missing_signer = || anyhow!("not enough signers for the function");
+    // Signers must lead the parameter list, as the legacy VM requires.
+    let mut seen_argument = false;
     for (slot, ty) in func.param_slots.iter().zip(params) {
         let offset = slot.offset.0;
-        match view_type(*ty) {
+        let view = view_type(*ty);
+        let is_signer_param = matches!(view, Type::Signer)
+            || matches!(view, Type::ImmutRef { inner } | Type::MutRef { inner }
+                if matches!(view_type(*inner), Type::Signer));
+        if is_signer_param {
+            if seen_argument {
+                bail!("a signer parameter follows an argument");
+            }
+        } else {
+            seen_argument = true;
+        }
+        match view {
             Type::Signer => {
                 let signer = signers.next().ok_or_else(missing_signer)?;
                 interp.set_root_arg(offset, signer);
@@ -69,14 +87,21 @@ pub(crate) fn place_args(
             Type::ImmutRef { inner } | Type::MutRef { inner }
                 if matches!(view_type(*inner), Type::Signer) =>
             {
-                // A reference is a 16-byte (base, byte_offset) fat pointer at the
-                // signer buffer. The base is outside the VM heap, so the GC
-                // leaves it alone.
                 let signer = signers.next().ok_or_else(missing_signer)?;
-                let mut fat = [0u8; 16];
-                fat[..8].copy_from_slice(&(signer.as_ptr() as u64).to_le_bytes());
-                interp.set_root_arg(offset, &fat);
+                // SAFETY: the signer buffers outlive the call, and sit outside
+                // the VM heap so the GC leaves the reference alone.
+                unsafe { interp.set_root_ref_arg(offset, signer.as_ptr()) };
             },
+            // A reference to anything else cannot be built from a transaction
+            // argument, and a function value would let a payload pass something
+            // like `minter: || Coin`.
+            Type::ImmutRef { .. } | Type::MutRef { .. } => {
+                bail!("a reference to a non-signer is not a valid argument")
+            },
+            Type::Function { .. } => bail!("a function value is not a valid argument"),
+            // Substitution has already run, so a type parameter here means it
+            // failed.
+            Type::TypeParam { .. } => bail!("parameter type is still uninstantiated"),
             Type::Bool
             | Type::U8
             | Type::U16
@@ -91,12 +116,12 @@ pub(crate) fn place_args(
             | Type::I128
             | Type::I256
             | Type::Address
-            | Type::ImmutRef { .. }
-            | Type::MutRef { .. }
             | Type::Vector { .. }
-            | Type::Nominal { .. }
-            | Type::Function { .. }
-            | Type::TypeParam { .. } => {
+            // TODO(security, completeness): only the framework's constructible
+            // structs (`String`, `Object`, `Option`, ...) are valid arguments;
+            // everything else must be rejected. See the pre-coordinator gates in
+            // AGENTS.md.
+            | Type::Nominal { .. } => {
                 let arg = args
                     .next()
                     .ok_or_else(|| anyhow!("not enough arguments for the function"))?;
@@ -117,17 +142,6 @@ pub(crate) fn place_args(
     Ok(())
 }
 
-/// How a function call concluded. VM errors are reported through the `Err`
-/// channel instead.
-pub(crate) enum CallStatus {
-    Success,
-    Abort {
-        code: u64,
-        message: Option<String>,
-        location: AbortLocation,
-    },
-}
-
 /// Loads `module::function<ty_args>`, places arguments, and runs it in the
 /// transaction's interpreter context, metered against the context's gas
 /// budget.
@@ -140,7 +154,7 @@ pub(crate) fn call_function(
     ty_args: InternedTypeList,
     signer_bufs: &[[u8; AccountAddress::LENGTH]],
     args: &[Vec<u8>],
-) -> Result<CallStatus, VMInternalError> {
+) -> Result<RuntimeStatus, VMInternalError> {
     let module_id = guard.module_id_of(address, module_name);
     let function = guard.identifier_of(function_name);
     let func_ptr = interp.load_function(module_id, function, ty_args)?;
@@ -153,20 +167,12 @@ pub(crate) fn call_function(
     let params = param_types(guard, loaded, function, ty_args).map_err(invariant_violation)?;
 
     interp.prepare_call(func);
+    // TODO(correctness): rejecting an argument is a user error, not an invariant
+    // violation. It needs a real status once argument validation moves into the
+    // pre-execution checks.
     place_args(interp, func, &params, signer_bufs, args).map_err(invariant_violation)?;
 
-    Ok(match interp.run()? {
-        RuntimeStatus::Success => CallStatus::Success,
-        RuntimeStatus::Aborted {
-            code,
-            message,
-            location,
-        } => CallStatus::Abort {
-            code,
-            message,
-            location,
-        },
-    })
+    interp.run()
 }
 
 fn invariant_violation(err: anyhow::Error) -> VMInternalError {

--- a/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
@@ -175,7 +175,8 @@ pub(crate) fn call_function(
     interp.run()
 }
 
-fn invariant_violation(err: anyhow::Error) -> VMInternalError {
+/// An error that should not be reachable, as a VM error.
+pub(crate) fn invariant_violation(err: anyhow::Error) -> VMInternalError {
     VMInternalError::new(RuntimeError::InvariantViolation(
         RuntimeInvariantViolation::Unreachable(err.to_string()),
     ))

--- a/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
@@ -1,0 +1,168 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Helpers for running Move functions inside the transaction's single
+//! interpreter context: parameter typing, argument placement, and the call
+//! entry points.
+
+use anyhow::{anyhow, bail, Result};
+use mono_move_core::{
+    interner::InternedIdentifier,
+    types::{view_type, view_type_list, InternedType, InternedTypeList, Type},
+    Function, Interner, VMInternalError,
+};
+use mono_move_global_context::{ExecutionGuard, LoadedModule};
+use mono_move_runtime::{
+    error::{RuntimeError, RuntimeInvariantViolation},
+    InterpreterContext, RuntimeStatus,
+};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
+
+/// The parameter types of a loaded module's function, instantiated with
+/// `ty_args`.
+fn param_types(
+    guard: &ExecutionGuard,
+    loaded: &LoadedModule,
+    function: InternedIdentifier,
+    ty_args: InternedTypeList,
+) -> Result<Vec<InternedType>> {
+    let Some(Some(ir)) = loaded.get_function_ir(function) else {
+        bail!("function has no IR in its loaded module");
+    };
+    let params = loaded
+        .ir()
+        .module
+        .function_signature_at(ir.handle_idx)
+        .params;
+    Ok(view_type_list(guard.subst_type_list(params, ty_args)?).to_vec())
+}
+
+/// Fills the root frame of `func` from the signer and BCS-argument lists, in
+/// parameter order: `signer`/`&signer` parameters from the signer list,
+/// everything else deserialized from BCS.
+pub(crate) fn place_args(
+    interp: &mut InterpreterContext<'_>,
+    func: &Function,
+    params: &[InternedType],
+    signer_bufs: &[[u8; AccountAddress::LENGTH]],
+    args: &[Vec<u8>],
+) -> Result<()> {
+    if func.param_slots.len() != params.len() {
+        bail!(
+            "lowered function has {} parameter slots but the signature has {} parameters",
+            func.param_slots.len(),
+            params.len()
+        );
+    }
+    let mut signers = signer_bufs.iter();
+    let mut args = args.iter();
+    let missing_signer = || anyhow!("not enough signers for the function");
+    for (slot, ty) in func.param_slots.iter().zip(params) {
+        let offset = slot.offset.0;
+        match view_type(*ty) {
+            Type::Signer => {
+                let signer = signers.next().ok_or_else(missing_signer)?;
+                interp.set_root_arg(offset, signer);
+            },
+            Type::ImmutRef { inner } | Type::MutRef { inner }
+                if matches!(view_type(*inner), Type::Signer) =>
+            {
+                // A reference is a 16-byte (base, byte_offset) fat pointer at the
+                // signer buffer. The base is outside the VM heap, so the GC
+                // leaves it alone.
+                let signer = signers.next().ok_or_else(missing_signer)?;
+                let mut fat = [0u8; 16];
+                fat[..8].copy_from_slice(&(signer.as_ptr() as u64).to_le_bytes());
+                interp.set_root_arg(offset, &fat);
+            },
+            Type::Bool
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::U128
+            | Type::U256
+            | Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::I128
+            | Type::I256
+            | Type::Address
+            | Type::ImmutRef { .. }
+            | Type::MutRef { .. }
+            | Type::Vector { .. }
+            | Type::Nominal { .. }
+            | Type::Function { .. }
+            | Type::TypeParam { .. } => {
+                let arg = args
+                    .next()
+                    .ok_or_else(|| anyhow!("not enough arguments for the function"))?;
+                // SAFETY: `offset`/`ty` come from this function's own signature, so
+                // the slot is valid for the type's in-memory size.
+                unsafe { interp.deserialize_root_arg(offset, *ty, arg) }.map_err(|e| {
+                    anyhow!("failed to place argument at frame offset {}: {}", offset, e)
+                })?;
+            },
+        }
+    }
+    if args.next().is_some() {
+        bail!("too many arguments for the function");
+    }
+    if signers.next().is_some() {
+        bail!("too many signers for the function");
+    }
+    Ok(())
+}
+
+/// How a function call concluded. VM errors are reported through the `Err`
+/// channel instead.
+pub(crate) enum CallStatus {
+    Success,
+    Abort { code: u64, message: Option<String> },
+}
+
+/// Loads `module::function<ty_args>`, places arguments, and runs it in the
+/// transaction's interpreter context, metered against the context's gas
+/// budget.
+pub(crate) fn call_function(
+    guard: &ExecutionGuard<'_>,
+    interp: &mut InterpreterContext<'_>,
+    address: &AccountAddress,
+    module_name: &IdentStr,
+    function_name: &IdentStr,
+    ty_args: InternedTypeList,
+    signer_bufs: &[[u8; AccountAddress::LENGTH]],
+    args: &[Vec<u8>],
+) -> Result<CallStatus, VMInternalError> {
+    let module_id = guard.module_id_of(address, module_name);
+    let function = guard.identifier_of(function_name);
+    let func_ptr = interp.load_function(module_id, function, ty_args)?;
+    // SAFETY: the pointer lives in a LoadedModule arena kept alive by the guard.
+    let func: &Function = unsafe { func_ptr.as_ref_unchecked() };
+
+    let loaded = interp
+        .read_set()
+        .get_loaded(guard.arena_ref_for_module_id(module_id))?;
+    let params = param_types(guard, loaded, function, ty_args).map_err(invariant_violation)?;
+
+    interp.prepare_call(func);
+    place_args(interp, func, &params, signer_bufs, args).map_err(invariant_violation)?;
+
+    Ok(match interp.run()? {
+        RuntimeStatus::Success => CallStatus::Success,
+        // TODO(correctness): `location` is dropped here, so aborts surface with
+        // a placeholder location. Thread it through the failure taxonomy.
+        RuntimeStatus::Aborted {
+            code,
+            message,
+            location: _,
+        } => CallStatus::Abort { code, message },
+    })
+}
+
+fn invariant_violation(err: anyhow::Error) -> VMInternalError {
+    VMInternalError::new(RuntimeError::InvariantViolation(
+        RuntimeInvariantViolation::Unreachable(err.to_string()),
+    ))
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/errors.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/errors.rs
@@ -36,78 +36,52 @@ pub enum DiscardReason {
     Unsupported(&'static str),
     /// A type argument failed to resolve.
     InvalidTypeArgument(String),
-    Prologue(PrologueFailure),
-    /// The epilogue misbehaved. One versioned Move epilogue runs from up to
-    /// three places, and `run` says which one failed.
-    Epilogue {
-        run: &'static str,
-        failure: EpilogueFailure,
+    Failure {
+        stage: ExecutionStage,
+        failure: MoveExecutionFailure,
     },
     /// An executor-internal invariant violation.
     InvariantViolation(String),
 }
 
-/// How an executed transaction concluded. Any conclusion other than success
-/// still charges the fee and bumps the sequence number.
+/// Which Move call the transaction was in when it failed.
+#[derive(Clone, Copy, Debug)]
+pub enum ExecutionStage {
+    Prologue,
+    Payload,
+    /// The epilogue after a payload that succeeded.
+    Epilogue,
+    /// The epilogue after a payload that was rolled back.
+    EpilogueAfterRollback,
+    /// The epilogue rerun after the first one failed.
+    EpilogueRetry,
+}
+
+/// How an executed transaction concluded. Every variant commits on-chain and is
+/// charged the fee.
 #[derive(Debug)]
 pub enum ExecutionStatus {
     Success,
-    /// A Move abort, raised either by the payload or by the epilogue's balance
-    /// check; the payload's effects were dropped.
-    Abort {
-        code: u64,
-        message: Option<String>,
-        location: AbortLocation,
+    /// The payload or the epilogue failed; the payload's effects were dropped.
+    Failure {
+        stage: ExecutionStage,
+        failure: MoveExecutionFailure,
     },
-    /// The payload failed with a VM error; its effects were dropped.
-    Failure(VMInternalError),
-    /// The epilogue failed some way it must not after a successful payload, and
-    /// rerunning it against the state the prologue left succeeded. The payload's
-    /// effects were dropped and the fee still charged. The fee abort is
-    /// legitimate and becomes `Abort` instead.
-    RecoveredEpilogueFailure(EpilogueFailure),
 }
 
-/// A prologue failure; always discards the transaction.
+/// How Move execution failed, whether it was the prologue, the payload, the
+/// epilogue, or the transaction as a whole. What a failure means for the
+/// transaction is the driver's call.
 #[derive(Debug)]
-pub enum PrologueFailure {
-    /// The prologue aborted: the transaction failed validation.
+pub enum MoveExecutionFailure {
+    /// Execution reached a Move abort.
     Abort {
         code: u64,
         message: Option<String>,
         location: AbortLocation,
     },
-    /// The prologue must not fail any other way.
-    Unexpected(String),
-}
-
-/// A payload execution failure. An abort always commits (charging the fee);
-/// whether a VM error commits or discards follows the legacy keep/discard
-/// rules.
-#[derive(Debug)]
-pub(crate) enum PayloadFailure {
-    /// The payload executed a Move abort.
-    Abort {
-        code: u64,
-        message: Option<String>,
-        location: AbortLocation,
-    },
-    /// The payload failed with a VM error.
-    Internal(VMInternalError),
-}
-
-/// An epilogue failure. The fee payer failing to cover the fee is the only
-/// legitimate one, which the driver recognizes by the abort code.
-#[derive(Debug)]
-pub enum EpilogueFailure {
-    /// The epilogue executed a Move abort.
-    Abort {
-        code: u64,
-        message: Option<String>,
-        location: AbortLocation,
-    },
-    /// The epilogue failed with a VM error.
-    Internal(VMInternalError),
+    /// Execution failed with a VM error.
+    RuntimeError(VMInternalError),
 }
 
 /// Whether an epilogue abort is the fee payer failing to cover the fee.

--- a/third_party/move/mono-move/aptos-transaction-executor/src/errors.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/errors.rs
@@ -72,7 +72,11 @@ pub enum ExecutionStatus {
 #[derive(Debug)]
 pub enum PrologueFailure {
     /// The prologue aborted: the transaction failed validation.
-    Abort { code: u64, message: Option<String> },
+    Abort {
+        code: u64,
+        message: Option<String>,
+        location: AbortLocation,
+    },
     /// The prologue must not fail any other way.
     Unexpected(String),
 }
@@ -83,7 +87,11 @@ pub enum PrologueFailure {
 #[derive(Debug)]
 pub(crate) enum PayloadFailure {
     /// The payload executed a Move abort.
-    Abort { code: u64, message: Option<String> },
+    Abort {
+        code: u64,
+        message: Option<String>,
+        location: AbortLocation,
+    },
     /// The payload failed with a VM error.
     Internal(VMInternalError),
 }
@@ -93,7 +101,11 @@ pub(crate) enum PayloadFailure {
 #[derive(Debug)]
 pub enum EpilogueFailure {
     /// The epilogue executed a Move abort.
-    Abort { code: u64, message: Option<String> },
+    Abort {
+        code: u64,
+        message: Option<String>,
+        location: AbortLocation,
+    },
     /// The epilogue failed with a VM error.
     Internal(VMInternalError),
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/errors.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/errors.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_types::{
+    error::{split_canonical, OUT_OF_RANGE},
+    transaction::validation::ECANT_PAY_GAS_DEPOSIT,
+};
+use mono_move_core::VMInternalError;
+use move_core_types::vm_status::AbortLocation;
+use thiserror::Error;
+
+/// Every reason a transaction's effects could not be rendered into a
+/// `TransactionOutput`. Always an executor bug; the reasons are diagnostics.
+#[derive(Debug, Error)]
+#[error("failed to materialize the transaction output: {}", .0.join("; "))]
+pub struct MaterializationError(Vec<String>);
+
+impl MaterializationError {
+    /// Sorts the reasons, so that what is reported does not depend on the order
+    /// the failures were hit in.
+    pub fn new(mut reasons: Vec<String>) -> Self {
+        reasons.sort();
+        Self(reasons)
+    }
+
+    pub fn reasons(&self) -> &[String] {
+        &self.0
+    }
+}
+
+/// Why a transaction was discarded: it produced no side effects, and only its
+/// rejection reason is observable.
+#[derive(Debug)]
+pub enum DiscardReason {
+    /// A transaction shape this executor does not support yet.
+    Unsupported(&'static str),
+    /// A type argument failed to resolve.
+    InvalidTypeArgument(String),
+    Prologue(PrologueFailure),
+    /// The epilogue misbehaved. One versioned Move epilogue runs from up to
+    /// three places, and `run` says which one failed.
+    Epilogue {
+        run: &'static str,
+        failure: EpilogueFailure,
+    },
+    /// An executor-internal invariant violation.
+    InvariantViolation(String),
+}
+
+/// How an executed transaction concluded. Any conclusion other than success
+/// still charges the fee and bumps the sequence number.
+#[derive(Debug)]
+pub enum ExecutionStatus {
+    Success,
+    /// A Move abort, raised either by the payload or by the epilogue's balance
+    /// check; the payload's effects were dropped.
+    Abort {
+        code: u64,
+        message: Option<String>,
+        location: AbortLocation,
+    },
+    /// The payload failed with a VM error; its effects were dropped.
+    Failure(VMInternalError),
+    /// The epilogue failed some way it must not after a successful payload, and
+    /// rerunning it against the state the prologue left succeeded. The payload's
+    /// effects were dropped and the fee still charged. The fee abort is
+    /// legitimate and becomes `Abort` instead.
+    RecoveredEpilogueFailure(EpilogueFailure),
+}
+
+/// A prologue failure; always discards the transaction.
+#[derive(Debug)]
+pub enum PrologueFailure {
+    /// The prologue aborted: the transaction failed validation.
+    Abort { code: u64, message: Option<String> },
+    /// The prologue must not fail any other way.
+    Unexpected(String),
+}
+
+/// A payload execution failure. An abort always commits (charging the fee);
+/// whether a VM error commits or discards follows the legacy keep/discard
+/// rules.
+#[derive(Debug)]
+pub(crate) enum PayloadFailure {
+    /// The payload executed a Move abort.
+    Abort { code: u64, message: Option<String> },
+    /// The payload failed with a VM error.
+    Internal(VMInternalError),
+}
+
+/// An epilogue failure. The fee payer failing to cover the fee is the only
+/// legitimate one, which the driver recognizes by the abort code.
+#[derive(Debug)]
+pub enum EpilogueFailure {
+    /// The epilogue executed a Move abort.
+    Abort { code: u64, message: Option<String> },
+    /// The epilogue failed with a VM error.
+    Internal(VMInternalError),
+}
+
+/// Whether an epilogue abort is the fee payer failing to cover the fee.
+pub(crate) fn is_cant_pay_fee_abort(code: u64) -> bool {
+    split_canonical(code) == (OUT_OF_RANGE, ECANT_PAY_GAS_DEPOSIT)
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -24,10 +24,6 @@ use mono_move_core::{
 use mono_move_global_context::ExecutionGuard;
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
 use mono_move_runtime::{InterpreterContext, ProductionNativeRegistry};
-use move_core_types::{
-    account_address::AccountAddress, ident_str, language_storage::ModuleId,
-    vm_status::AbortLocation,
-};
 
 /// The Aptos transaction executor on MonoMove (the legacy AptosVM's role).
 ///
@@ -162,14 +158,16 @@ impl<'a> AptosTransactionExecutor<'a> {
         let payload_succeeded = payload_result.is_ok();
         let execution_status = match payload_result {
             Ok(()) => ExecutionStatus::Success,
-            Err(PayloadFailure::Abort { code, message }) => {
+            Err(PayloadFailure::Abort {
+                code,
+                message,
+                location,
+            }) => {
                 rollback(&mut interp, 1)?;
                 ExecutionStatus::Abort {
                     code,
                     message,
-                    // TODO(correctness): MonoMove does not carry the aborting
-                    // module yet, so the location is a placeholder for now.
-                    location: AbortLocation::Script,
+                    location,
                 }
             },
             Err(PayloadFailure::Internal(err)) => {
@@ -211,17 +209,14 @@ impl<'a> AptosTransactionExecutor<'a> {
                 match failure {
                     // The fee payer can no longer cover the fee. This is the one
                     // epilogue abort that survives as the transaction's status.
-                    EpilogueFailure::Abort { code, message } if is_cant_pay_fee_abort(code) => {
-                        ExecutionStatus::Abort {
-                            code,
-                            message,
-                            // The abort is raised by
-                            // `transaction_validation.move`'s balance assert.
-                            location: AbortLocation::Module(ModuleId::new(
-                                AccountAddress::ONE,
-                                ident_str!("transaction_validation").to_owned(),
-                            )),
-                        }
+                    EpilogueFailure::Abort {
+                        code,
+                        message,
+                        location,
+                    } if is_cant_pay_fee_abort(code) => ExecutionStatus::Abort {
+                        code,
+                        message,
+                        location,
                     },
                     // Any other epilogue failure is the framework misbehaving.
                     // Treat it as an invariant violation (with gas charged) rather than discarding.
@@ -275,7 +270,15 @@ impl<'a> AptosTransactionExecutor<'a> {
 
         match status {
             CallStatus::Success => Ok(()),
-            CallStatus::Abort { code, message } => Err(PayloadFailure::Abort { code, message }),
+            CallStatus::Abort {
+                code,
+                message,
+                location,
+            } => Err(PayloadFailure::Abort {
+                code,
+                message,
+                location,
+            }),
         }
     }
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -69,6 +69,8 @@ impl<'a> AptosTransactionExecutor<'a> {
     }
 
     /// Executes one user transaction, returning its side effects unmaterialized (see [`TxnOutcome`]).
+    //
+    // TODO(completeness): add logging. Should warn on unexpected errors/discards.
     pub fn execute_user_transaction(&self, txn: &SignedTransaction) -> TxnOutcome {
         match self.execute_user_transaction_impl(txn) {
             Ok(outcome) => outcome,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -3,9 +3,7 @@
 
 use crate::{
     calls::{call_function, CallStatus},
-    errors::{
-        is_cant_pay_fee_abort, DiscardReason, EpilogueFailure, ExecutionStatus, PayloadFailure,
-    },
+    errors::{DiscardReason, ExecutionStage, ExecutionStatus, MoveExecutionFailure},
     metadata::TxnMetadata,
     natives::transaction_extensions,
     outcome::TxnOutcome,
@@ -144,7 +142,12 @@ impl<'a> AptosTransactionExecutor<'a> {
 
         // ============================ Prologue ==============================
         // Validate the transaction (auth key, sequence number or nonce, fee coverage etc.)
-        run_prologue(&mut interp, guard, &signers, &txn_data).map_err(DiscardReason::Prologue)?;
+        run_prologue(&mut interp, guard, &signers, &txn_data).map_err(|failure| {
+            DiscardReason::Failure {
+                stage: ExecutionStage::Prologue,
+                failure,
+            }
+        })?;
         // A failed payload rolls back to here, so prologue effects (e.g. nonce insertion) survive.
         checkpoint(&mut interp)?;
 
@@ -155,24 +158,17 @@ impl<'a> AptosTransactionExecutor<'a> {
 
         // TODO(metering): charge gas for global storage writes and events.
 
+        // A failed payload keeps only the prologue's effects; the epilogue below
+        // still charges the fee.
         let payload_succeeded = payload_result.is_ok();
         let execution_status = match payload_result {
             Ok(()) => ExecutionStatus::Success,
-            Err(PayloadFailure::Abort {
-                code,
-                message,
-                location,
-            }) => {
+            Err(failure) => {
                 rollback(&mut interp, 1)?;
-                ExecutionStatus::Abort {
-                    code,
-                    message,
-                    location,
+                ExecutionStatus::Failure {
+                    stage: ExecutionStage::Payload,
+                    failure,
                 }
-            },
-            Err(PayloadFailure::Internal(err)) => {
-                rollback(&mut interp, 1)?;
-                ExecutionStatus::Failure(err)
             },
         };
 
@@ -194,35 +190,27 @@ impl<'a> AptosTransactionExecutor<'a> {
             // Payload failed + epilogue failed => no choice but to discard.
             // This should not happen unless there is a bug in the executor.
             Err(failure) if !payload_succeeded => {
-                return Err(DiscardReason::Epilogue {
-                    run: "after a rolled-back payload",
+                return Err(DiscardReason::Failure {
+                    stage: ExecutionStage::EpilogueAfterRollback,
                     failure,
                 })
             },
-            // Payload succeeded + epilogue failed => rollback payload effects and retry.
+            // Payload succeeded + epilogue failed => rollback payload effects and
+            // retry. The transaction still commits, charging the fee; which
+            // epilogue failures are legitimate is decided when the status is
+            // converted.
+            //
+            // TODO(correctness): audit this against the legacy VM, which may
+            // discard here instead.
             Err(failure) => {
                 rollback(&mut interp, 1)?;
-                epilogue(&mut interp).map_err(|failure| DiscardReason::Epilogue {
-                    run: "on the retry",
+                epilogue(&mut interp).map_err(|failure| DiscardReason::Failure {
+                    stage: ExecutionStage::EpilogueRetry,
                     failure,
                 })?;
-                match failure {
-                    // The fee payer can no longer cover the fee. This is the one
-                    // epilogue abort that survives as the transaction's status.
-                    EpilogueFailure::Abort {
-                        code,
-                        message,
-                        location,
-                    } if is_cant_pay_fee_abort(code) => ExecutionStatus::Abort {
-                        code,
-                        message,
-                        location,
-                    },
-                    // Any other epilogue failure is the framework misbehaving.
-                    // Treat it as an invariant violation (with gas charged) rather than discarding.
-                    failure @ (EpilogueFailure::Abort { .. } | EpilogueFailure::Internal(_)) => {
-                        ExecutionStatus::RecoveredEpilogueFailure(failure)
-                    },
+                ExecutionStatus::Failure {
+                    stage: ExecutionStage::Epilogue,
+                    failure,
                 }
             },
         };
@@ -243,7 +231,7 @@ impl<'a> AptosTransactionExecutor<'a> {
         txn_data: &TxnMetadata,
         entry: &EntryFunction,
         ty_args: InternedTypeList,
-    ) -> Result<(), PayloadFailure> {
+    ) -> Result<(), MoveExecutionFailure> {
         // TODO(security, completeness): entry-function validation -- `entry`
         // visibility, no return values, allowed argument types, and constructed
         // arguments (`String`, `Object<T>`, `Option<..>`) from
@@ -266,7 +254,7 @@ impl<'a> AptosTransactionExecutor<'a> {
             &signer_bufs,
             entry.args(),
         )
-        .map_err(PayloadFailure::Internal)?;
+        .map_err(MoveExecutionFailure::RuntimeError)?;
 
         match status {
             CallStatus::Success => Ok(()),
@@ -274,7 +262,7 @@ impl<'a> AptosTransactionExecutor<'a> {
                 code,
                 message,
                 location,
-            } => Err(PayloadFailure::Abort {
+            } => Err(MoveExecutionFailure::Abort {
                 code,
                 message,
                 location,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -7,7 +7,7 @@ use crate::{
     metadata::TxnMetadata,
     natives::transaction_extensions,
     outcome::TxnOutcome,
-    sys_calls::{run_epilogue, run_prologue, validation_signers},
+    sys_calls::{run_epilogue, run_prologue, TxnSigners},
 };
 use aptos_types::{
     fee_statement::FeeStatement,
@@ -138,7 +138,7 @@ impl<'a> AptosTransactionExecutor<'a> {
         )
         .with_extensions(extensions);
 
-        let signers = validation_signers(&txn_data);
+        let signers = TxnSigners::for_validation(&txn_data);
 
         // ============================ Prologue ==============================
         // Validate the transaction (auth key, sequence number or nonce, fee coverage etc.)
@@ -237,12 +237,8 @@ impl<'a> AptosTransactionExecutor<'a> {
         // arguments (`String`, `Object<T>`, `Option<..>`) from
         // `transaction_arg_validation`.
 
-        // Signers: the sender plus any secondary signers.
         // TODO(completeness): multi-agent transactions are untested.
-        let mut signer_bufs = vec![txn_data.sender.into_bytes()];
-        for secondary in &txn_data.secondary_signers {
-            signer_bufs.push(secondary.into_bytes());
-        }
+        let signers = TxnSigners::for_payload(txn_data);
 
         let status = call_function(
             self.guard,
@@ -251,7 +247,7 @@ impl<'a> AptosTransactionExecutor<'a> {
             entry.module().name(),
             entry.function(),
             ty_args,
-            &signer_bufs,
+            signers.as_slice(),
             entry.args(),
         )
         .map_err(MoveExecutionFailure::RuntimeError)?;

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -1,0 +1,307 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    calls::{call_function, CallStatus},
+    errors::{
+        is_cant_pay_fee_abort, DiscardReason, EpilogueFailure, ExecutionStatus, PayloadFailure,
+    },
+    metadata::TxnMetadata,
+    natives::transaction_extensions,
+    outcome::TxnOutcome,
+    sys_calls::{run_epilogue, run_prologue, validation_signers},
+};
+use aptos_types::{
+    fee_statement::FeeStatement,
+    on_chain_config::Features,
+    state_store::state_storage_usage::StateStorageUsage,
+    transaction::{EntryFunction, SignedTransaction, TransactionExecutableRef},
+};
+use mono_move_core::{
+    intern_type_tag, storage::module_provider::ModuleProvider, types::InternedTypeList, GasMeter,
+    Interner, ResourceProvider,
+};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
+use mono_move_runtime::{InterpreterContext, ProductionNativeRegistry};
+use move_core_types::{
+    account_address::AccountAddress, ident_str, language_storage::ModuleId,
+    vm_status::AbortLocation,
+};
+
+/// The Aptos transaction executor on MonoMove (the legacy AptosVM's role).
+///
+/// It is designed to be a transient object borrowing various contexts from the block coordinator,
+/// for transaction execution (most likely just a single one).
+pub struct AptosTransactionExecutor<'a> {
+    guard: &'a ExecutionGuard<'a>,
+    // TODO(cleanup): We are considering moving the native registry into the GlobalContext.
+    // This parameter may disappear once it moves there.
+    natives: &'a ProductionNativeRegistry,
+    module_provider: &'a dyn ModuleProvider,
+    data_provider: &'a dyn ResourceProvider,
+    // TODO(completeness): Consider growing these into the full `AptosEnvironment` supplied by
+    // the coordinator.
+    // Should however rethink whether we can simply reuse the existing `AptosEnvironment` struct.
+    //
+    // Nothing reads the features yet -- gas configuration and the pre-execution
+    // checks will -- but the coordinator already supplies them.
+    #[allow(dead_code)]
+    features: &'a Features,
+    /// State storage usage at the current epoch's beginning.
+    usage: StateStorageUsage,
+}
+
+impl<'a> AptosTransactionExecutor<'a> {
+    /// Constructs a new `AptosTransactionExecutor`. The borrowed contexts are
+    /// built and owned by the block coordinator, which reuses them across the
+    /// executors it creates.
+    pub fn new(
+        guard: &'a ExecutionGuard<'a>,
+        natives: &'a ProductionNativeRegistry,
+        module_provider: &'a dyn ModuleProvider,
+        data_provider: &'a dyn ResourceProvider,
+        features: &'a Features,
+        usage: StateStorageUsage,
+    ) -> Self {
+        Self {
+            guard,
+            natives,
+            module_provider,
+            data_provider,
+            features,
+            usage,
+        }
+    }
+
+    /// Executes one user transaction, returning its side effects unmaterialized (see [`TxnOutcome`]).
+    pub fn execute_user_transaction(&self, txn: &SignedTransaction) -> TxnOutcome {
+        match self.execute_user_transaction_impl(txn) {
+            Ok(outcome) => outcome,
+            Err(reason) => TxnOutcome::Discarded(reason),
+        }
+    }
+
+    /// Actual implementation of the transaction execution flow.
+    fn execute_user_transaction_impl(
+        &self,
+        txn: &SignedTransaction,
+    ) -> Result<TxnOutcome, DiscardReason> {
+        let guard = self.guard;
+
+        // ======================== Pre-execution checks ========================
+        // Reject what this executor cannot execute, before touching any state.
+        //
+        // TODO(metering, security): gas checks (`check_gas`): txn size bounds,
+        // gas price bounds, intrinsic gas coverage. Without them a transaction
+        // outside the configured bounds -- including a zero gas price -- buys a
+        // full `max_gas_amount` budget for free.
+        let txn_data = TxnMetadata::new(txn);
+
+        let entry = match txn.payload().executable_ref() {
+            Ok(TransactionExecutableRef::EntryFunction(entry)) => entry,
+            // TODO(completeness): scripts, multisig payloads, encrypted
+            // transactions, module publishing.
+            Ok(TransactionExecutableRef::Script(_))
+            | Ok(TransactionExecutableRef::Encrypted)
+            | Ok(TransactionExecutableRef::Empty)
+            | Err(_) => {
+                return Err(DiscardReason::Unsupported(
+                    "anything but entry-function payloads",
+                ))
+            },
+        };
+        // TODO(security): these type arguments are user supplied, so interning
+        // them can pollute the global caches. Needs a bound.
+        let interned_ty_args = entry
+            .ty_args()
+            .iter()
+            .map(|tag| intern_type_tag(tag, guard))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| DiscardReason::InvalidTypeArgument(format!("{e:#}")))?;
+        let ty_args = guard.type_list_of(&interned_ty_args);
+
+        // ========================== Session setup ===========================
+        // One session hosts the whole transaction: prologue, payload, epilogue.
+        // TODO(completeness): make the loading policy configurable.
+        let loader = Loader::new_with_policy(
+            guard,
+            self.module_provider,
+            LoadingPolicy::Lazy(LoweringPolicy::Lazy),
+            self.natives,
+        );
+
+        let extensions = transaction_extensions(&txn_data, self.usage);
+
+        let max_gas = txn_data.max_gas_amount;
+        let mut interp = InterpreterContext::new_idle(
+            loader,
+            // TODO(metering): MonoMove gas units are uncalibrated; budgeting
+            // 1:1 against the transaction's gas units is a placeholder.
+            GasMeter::new(max_gas),
+            self.data_provider,
+            self.natives,
+        )
+        .with_extensions(extensions);
+
+        let signers = validation_signers(&txn_data);
+
+        // ============================ Prologue ==============================
+        // Validate the transaction (auth key, sequence number or nonce, fee coverage etc.)
+        run_prologue(&mut interp, guard, &signers, &txn_data).map_err(DiscardReason::Prologue)?;
+        // A failed payload rolls back to here, so prologue effects (e.g. nonce insertion) survive.
+        checkpoint(&mut interp)?;
+
+        // ========================== User payload ============================
+        let payload_result = self.execute_entry_function(&mut interp, &txn_data, entry, ty_args);
+        let gas_remaining = interp.gas_balance();
+        let gas_used = max_gas.saturating_sub(gas_remaining);
+
+        // TODO(metering): charge gas for global storage writes and events.
+
+        let payload_succeeded = payload_result.is_ok();
+        let execution_status = match payload_result {
+            Ok(()) => ExecutionStatus::Success,
+            Err(PayloadFailure::Abort { code, message }) => {
+                rollback(&mut interp, 1)?;
+                ExecutionStatus::Abort {
+                    code,
+                    message,
+                    // TODO(correctness): MonoMove does not carry the aborting
+                    // module yet, so the location is a placeholder for now.
+                    location: AbortLocation::Script,
+                }
+            },
+            Err(PayloadFailure::Internal(err)) => {
+                rollback(&mut interp, 1)?;
+                ExecutionStatus::Failure(err)
+            },
+        };
+
+        // ============================ Epilogue ==============================
+        // Transaction cleanup -- charge gas, bump sequence number etc.
+        let fee_statement = placeholder_fee_statement(gas_used);
+        let epilogue = |interp: &mut InterpreterContext<'_>| {
+            run_epilogue(
+                interp,
+                guard,
+                &signers,
+                &txn_data,
+                fee_statement,
+                gas_remaining,
+            )
+        };
+        let execution_status = match epilogue(&mut interp) {
+            Ok(()) => execution_status,
+            // Payload failed + epilogue failed => no choice but to discard.
+            // This should not happen unless there is a bug in the executor.
+            Err(failure) if !payload_succeeded => {
+                return Err(DiscardReason::Epilogue {
+                    run: "after a rolled-back payload",
+                    failure,
+                })
+            },
+            // Payload succeeded + epilogue failed => rollback payload effects and retry.
+            Err(failure) => {
+                rollback(&mut interp, 1)?;
+                epilogue(&mut interp).map_err(|failure| DiscardReason::Epilogue {
+                    run: "on the retry",
+                    failure,
+                })?;
+                match failure {
+                    // The fee payer can no longer cover the fee. This is the one
+                    // epilogue abort that survives as the transaction's status.
+                    EpilogueFailure::Abort { code, message } if is_cant_pay_fee_abort(code) => {
+                        ExecutionStatus::Abort {
+                            code,
+                            message,
+                            // The abort is raised by
+                            // `transaction_validation.move`'s balance assert.
+                            location: AbortLocation::Module(ModuleId::new(
+                                AccountAddress::ONE,
+                                ident_str!("transaction_validation").to_owned(),
+                            )),
+                        }
+                    },
+                    // Any other epilogue failure is the framework misbehaving.
+                    // Treat it as an invariant violation (with gas charged) rather than discarding.
+                    failure @ (EpilogueFailure::Abort { .. } | EpilogueFailure::Internal(_)) => {
+                        ExecutionStatus::RecoveredEpilogueFailure(failure)
+                    },
+                }
+            },
+        };
+
+        // ============================= Output ===============================
+        // Hand the side effects back unmaterialized; the coordinator decides
+        // when (and whether) to render them into storage formats.
+        Ok(TxnOutcome::Executed {
+            status: execution_status,
+            fee_statement,
+            effects: interp.finish(),
+        })
+    }
+
+    fn execute_entry_function(
+        &self,
+        interp: &mut InterpreterContext<'_>,
+        txn_data: &TxnMetadata,
+        entry: &EntryFunction,
+        ty_args: InternedTypeList,
+    ) -> Result<(), PayloadFailure> {
+        // TODO(security, completeness): entry-function validation -- `entry`
+        // visibility, no return values, allowed argument types, and constructed
+        // arguments (`String`, `Object<T>`, `Option<..>`) from
+        // `transaction_arg_validation`.
+
+        // Signers: the sender plus any secondary signers.
+        // TODO(completeness): multi-agent transactions are untested.
+        let mut signer_bufs = vec![txn_data.sender.into_bytes()];
+        for secondary in &txn_data.secondary_signers {
+            signer_bufs.push(secondary.into_bytes());
+        }
+
+        let status = call_function(
+            self.guard,
+            interp,
+            &entry.module().address,
+            entry.module().name(),
+            entry.function(),
+            ty_args,
+            &signer_bufs,
+            entry.args(),
+        )
+        .map_err(PayloadFailure::Internal)?;
+
+        match status {
+            CallStatus::Success => Ok(()),
+            CallStatus::Abort { code, message } => Err(PayloadFailure::Abort { code, message }),
+        }
+    }
+}
+
+/// The fee statement for a transaction that consumed `gas_used` units.
+//
+// TODO(metering): IO gas, storage fees, and refunds are all zero until they
+// are charged; `gas_used` is in uncalibrated MonoMove units.
+fn placeholder_fee_statement(gas_used: u64) -> FeeStatement {
+    FeeStatement::builder()
+        .total_charge_gas_units(gas_used)
+        .execution_gas_units(gas_used)
+        .io_gas_units(0)
+        .storage_fee_octas(0)
+        .storage_fee_refund_octas(0)
+        .build()
+}
+
+fn checkpoint(interp: &mut InterpreterContext<'_>) -> Result<(), DiscardReason> {
+    interp
+        .checkpoint()
+        .map_err(|e| DiscardReason::InvariantViolation(format!("checkpoint failed: {e}")))
+}
+
+fn rollback(interp: &mut InterpreterContext<'_>, n: usize) -> Result<(), DiscardReason> {
+    interp
+        .rollback(n)
+        .map_err(|e| DiscardReason::InvariantViolation(format!("rollback failed: {e}")))
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    calls::{call_function, CallStatus},
+    calls::call_function,
     errors::{DiscardReason, ExecutionStage, ExecutionStatus, MoveExecutionFailure},
     metadata::TxnMetadata,
     natives::transaction_extensions,
@@ -21,7 +21,7 @@ use mono_move_core::{
 };
 use mono_move_global_context::ExecutionGuard;
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
-use mono_move_runtime::{InterpreterContext, ProductionNativeRegistry};
+use mono_move_runtime::{InterpreterContext, ProductionNativeRegistry, RuntimeStatus};
 
 /// The Aptos transaction executor on MonoMove (the legacy AptosVM's role).
 ///
@@ -257,8 +257,8 @@ impl<'a> AptosTransactionExecutor<'a> {
         .map_err(MoveExecutionFailure::RuntimeError)?;
 
         match status {
-            CallStatus::Success => Ok(()),
-            CallStatus::Abort {
+            RuntimeStatus::Success => Ok(()),
+            RuntimeStatus::Aborted {
                 code,
                 message,
                 location,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/lib.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/lib.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! The Aptos transaction-execution layer (the legacy AptosVM's role) on the
+//! MonoMove VM.
+//!
+//! Executes user transactions single-threaded — prologue, payload, epilogue —
+//! producing an unmaterialized [`TxnOutcome`].
+
+// Modules stay private; anything public at the crate level is re-exported
+// here.
+mod calls;
+mod errors;
+mod executor;
+mod materialize;
+mod metadata;
+mod natives;
+mod outcome;
+mod providers;
+mod sys_calls;
+
+pub use errors::{
+    DiscardReason, EpilogueFailure, ExecutionStatus, MaterializationError, PrologueFailure,
+};
+pub use executor::AptosTransactionExecutor;
+pub use natives::production_natives;
+pub use outcome::TxnOutcome;
+pub use providers::{decode_group_members, AptosDataProvider, GroupMembers, StorageLocation};

--- a/third_party/move/mono-move/aptos-transaction-executor/src/lib.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/lib.rs
@@ -20,7 +20,7 @@ mod providers;
 mod sys_calls;
 
 pub use errors::{
-    DiscardReason, EpilogueFailure, ExecutionStatus, MaterializationError, PrologueFailure,
+    DiscardReason, ExecutionStage, ExecutionStatus, MaterializationError, MoveExecutionFailure,
 };
 pub use executor::AptosTransactionExecutor;
 pub use natives::production_natives;

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/mod.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/mod.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Converts the transaction's output into both the storage format (`TransactionOutput`)
+//! and the legacy `VMStatus`.
+
+mod txn_output;
+mod vm_status;
+
+pub(crate) use txn_output::{discarded_output, executed_output};
+pub(crate) use vm_status::{discard_to_vm_status, executed_vm_status};

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
@@ -1,0 +1,209 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Creates a `TransactionOutput` from a transaction's side effects.
+
+use crate::{
+    errors::MaterializationError,
+    providers::{nominal_tag, AptosDataProvider, StorageLocation},
+};
+use aptos_types::{
+    state_store::state_key::StateKey,
+    transaction::{TransactionAuxiliaryData, TransactionOutput, TransactionStatus},
+    write_set::{WriteOp, WriteSet},
+};
+use bytes::Bytes;
+use mono_move_core::{storage::resource_provider::InMemoryStorageKey, types::InternedType};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_output::to_contract_events;
+use mono_move_runtime::{serialize_value, SessionEffects, WriteClass};
+use move_core_types::{language_storage::StructTag, vm_status::StatusCode};
+use std::{
+    collections::{BTreeMap, HashMap},
+    ptr::NonNull,
+};
+
+// TODO(security): audit all error messages and make sure they do not lead to
+// deep recursions or OOMs.
+
+/// Creates the output of an executed transaction from its effects.
+pub(crate) fn executed_output(
+    effects: &SessionEffects,
+    guard: &ExecutionGuard,
+    provider: &dyn AptosDataProvider,
+    gas_used: u64,
+    status: TransactionStatus,
+    auxiliary_data: TransactionAuxiliaryData,
+) -> Result<TransactionOutput, MaterializationError> {
+    let write_set = drain_write_set(effects, guard, provider).map_err(MaterializationError::new)?;
+    // SAFETY: the effects' frozen heap (which event payloads point into) is
+    // live for the duration of output assembly.
+    let events = unsafe { to_contract_events(&effects.extensions, guard) }
+        .map_err(|e| MaterializationError::new(vec![format!("event finalization failed: {e}")]))?;
+    Ok(TransactionOutput::new(
+        write_set,
+        events,
+        gas_used,
+        status,
+        auxiliary_data,
+    ))
+}
+
+/// Creates the output of a discarded transaction: empty, carrying the reason.
+pub(crate) fn discarded_output(
+    status_code: StatusCode,
+    auxiliary_data: TransactionAuxiliaryData,
+) -> TransactionOutput {
+    TransactionOutput::new(
+        WriteSet::default(),
+        vec![],
+        0,
+        TransactionStatus::Discard(status_code),
+        auxiliary_data,
+    )
+}
+
+/// One member's new state within a resource group: new bytes or removal.
+type MemberOp = Option<Bytes>;
+
+/// Drains the read-write set into a write set, serializing written values
+/// straight out of the effects' frozen heap.
+///
+/// SAFETY: this function needs to guarantee that its result (both the write set
+/// and the errors) are deterministic, not depending on the order of iteration of
+/// any data structures.
+//
+// TODO(correctness): every copied-on-write entry is emitted as a write, even
+// when the bytes are unchanged. Eventually we will want to byte-compare against
+// the original bytes.
+//
+// TODO(metering): writes are not charged IO gas or storage fees.
+fn drain_write_set(
+    effects: &SessionEffects,
+    guard: &ExecutionGuard<'_>,
+    provider: &dyn AptosDataProvider,
+) -> Result<WriteSet, Vec<String>> {
+    let mut writes: Vec<(StateKey, WriteOp)> = vec![];
+    let mut group_ops: HashMap<StateKey, HashMap<InternedType, MemberOp>> = HashMap::new();
+    let mut failures: Vec<String> = vec![];
+
+    // SAFETY: written pointers refer to live values in the effects' frozen
+    // heap, and no GC runs during the drain.
+    let written_bytes = |ptr: NonNull<u8>, ty: InternedType| -> Result<Bytes, String> {
+        let blob = unsafe { serialize_value(guard, ptr, ty) }
+            .map_err(|e| format!("failed to serialize written value: {e}"))?;
+        Ok(Bytes::from(blob))
+    };
+    let mut convert = |key: &InMemoryStorageKey, class: WriteClass| -> Result<(), String> {
+        match provider.locate_key(key).map_err(|e| format!("{e:#}"))? {
+            StorageLocation::OwnSlot(state_key) => {
+                let op = match class {
+                    WriteClass::Creation(ptr) => {
+                        WriteOp::legacy_creation(written_bytes(ptr, key.value_ty())?)
+                    },
+                    WriteClass::Modification(ptr) => {
+                        WriteOp::legacy_modification(written_bytes(ptr, key.value_ty())?)
+                    },
+                    WriteClass::Deletion => WriteOp::legacy_deletion(),
+                };
+                writes.push((state_key, op));
+            },
+            StorageLocation::GroupMember { group, member } => {
+                let member_op = match class {
+                    WriteClass::Creation(ptr) | WriteClass::Modification(ptr) => {
+                        Some(written_bytes(ptr, key.value_ty())?)
+                    },
+                    WriteClass::Deletion => None,
+                };
+                group_ops
+                    .entry(group)
+                    .or_default()
+                    .insert(member, member_op);
+            },
+        }
+        Ok(())
+    };
+    // Note on determinism: the read-write set iterates in an unspecified order,
+    // so nothing here may depend on it.
+    for (key, class) in effects.read_write_set.writes() {
+        if let Err(e) = convert(key, class) {
+            failures.push(e);
+        }
+    }
+
+    // Merge each group's member ops into its stored members and emit one write
+    // per group.
+    for (group_key, member_ops) in group_ops {
+        match merge_group(provider, &group_key, member_ops) {
+            Ok(op) => writes.push((group_key, op)),
+            Err(e) => failures.push(e),
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(failures);
+    }
+    // `WriteSet::new` collects into a `BTreeMap`, so we do not need to sort the
+    // `writes` vector here.
+    WriteSet::new(writes).map_err(|e| vec![format!("failed to build the write set: {e:?}")])
+}
+
+/// Merges a group's member ops into a single write for the group's slot.
+///
+/// The stored blob is canonical in struct-tag order.
+///
+/// SAFETY: this function needs to guarantee that its result (both the write set
+/// and the error) are deterministic, not depending on iteration order.
+fn merge_group(
+    provider: &dyn AptosDataProvider,
+    group_key: &StateKey,
+    member_ops: HashMap<InternedType, MemberOp>,
+) -> Result<WriteOp, String> {
+    let old = provider
+        .group_members(group_key)
+        .map_err(|e| format!("failed to read the members of group {group_key:?}: {e:#}"))?;
+    let mut members: BTreeMap<StructTag, Bytes> = BTreeMap::new();
+
+    // Members the transaction did not touch, then the ones it wrote, which take
+    // precedence. Removed members are left out as part of this process.
+    let untouched = old
+        .iter()
+        .flat_map(|stored| stored.iter())
+        .filter(|(ty, _)| !member_ops.contains_key(ty));
+    let written = member_ops
+        .iter()
+        .filter_map(|(ty, op)| Some((ty, op.as_ref()?)));
+    for (ty, bytes) in untouched.chain(written) {
+        // The error must not name the member to avoid non-determinism -- both
+        // iterators are unordered.
+        let tag = nominal_tag(*ty)
+            .map_err(|_| format!("group {group_key:?} has a non-nominal member"))?;
+        members.insert(tag, bytes.clone());
+    }
+    let new_bytes = if members.is_empty() {
+        None
+    } else {
+        let blob = bcs::to_bytes(&members)
+            .map_err(|e| format!("failed to encode the members of group {group_key:?}: {e}"))?;
+        Some(Bytes::from(blob))
+    };
+    group_op(old.is_some(), new_bytes)
+}
+
+/// Builds the write op for a resource-group slot: creation/modification/
+/// deletion by whether the group existed before and has members after.
+//
+// TODO(correctness): ops carry no `StateValueMetadata` (slot deposits, refunds,
+// creation time); the legacy VM's `WriteOpConverter` fills these.
+fn group_op(existed: bool, new_bytes: Option<Bytes>) -> Result<WriteOp, String> {
+    Ok(match (existed, new_bytes) {
+        (false, Some(bytes)) => WriteOp::legacy_creation(bytes),
+        (true, Some(bytes)) => WriteOp::legacy_modification(bytes),
+        (true, None) => WriteOp::legacy_deletion(),
+        (false, None) => {
+            // Unreachable: a member deletion implies the member (and so the
+            // group) existed in storage.
+            return Err("an empty group emitted a write".to_string());
+        },
+    })
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
@@ -125,6 +125,10 @@ fn drain_write_set(
     };
     // Note on determinism: the read-write set iterates in an unspecified order,
     // so nothing here may depend on it.
+    //
+    // TODO(correctness): consider sorting the keys first to ensure determinism. This
+    // cannot currently be done because keys contain `InternedType`, which is
+    // basically a pointer and does not implement `Ord`.
     for (key, class) in effects.read_write_set.writes_unordered() {
         // TODO(perf): currently we collect all errors and sort them to ensure determinism.
         // We should however revisit the design later and see if we want to switch to an alternative approach.

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
@@ -125,7 +125,7 @@ fn drain_write_set(
     };
     // Note on determinism: the read-write set iterates in an unspecified order,
     // so nothing here may depend on it.
-    for (key, class) in effects.read_write_set.writes() {
+    for (key, class) in effects.read_write_set.writes_unordered() {
         if let Err(e) = convert(key, class) {
             failures.push(e);
         }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
@@ -126,6 +126,10 @@ fn drain_write_set(
     // Note on determinism: the read-write set iterates in an unspecified order,
     // so nothing here may depend on it.
     for (key, class) in effects.read_write_set.writes_unordered() {
+        // TODO(perf): currently we collect all errors and sort them to ensure determinism.
+        // We should however revisit the design later and see if we want to switch to an alternative approach.
+        //   - What if you want to fail fast on error?
+        //   - Are we concerned about too many writes here?
         if let Err(e) = convert(key, class) {
             failures.push(e);
         }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
@@ -26,6 +26,15 @@ use move_core_types::{
     language_storage::ModuleId,
     vm_status::{AbortLocation, StatusCode, VMStatus},
 };
+use std::sync::LazyLock;
+
+/// Where the transaction prologue and epilogue live.
+static ABORT_LOC_VALIDATION_MODULE: LazyLock<AbortLocation> = LazyLock::new(|| {
+    AbortLocation::Module(ModuleId::new(
+        AccountAddress::ONE,
+        ident_str!("transaction_validation").to_owned(),
+    ))
+});
 
 /// Converts a type-erased VM error into `VMStatus`: fine-grained for the
 /// error types with known legacy mappings, by public category otherwise.
@@ -132,7 +141,7 @@ fn prologue_failure_to_status(failure: MoveExecutionFailure) -> VMStatus {
             return unexpected_validation_error("prologue", err.to_string())
         },
     };
-    if location != validation_module() {
+    if location != *ABORT_LOC_VALIDATION_MODULE {
         return unexpected_prologue_abort(code, message, location);
     }
     let new_major_status = match split_canonical(code) {
@@ -160,13 +169,6 @@ fn prologue_failure_to_status(failure: MoveExecutionFailure) -> VMStatus {
         _ => return unexpected_prologue_abort(code, message, location),
     };
     VMStatus::error(new_major_status, None)
-}
-
-fn validation_module() -> AbortLocation {
-    AbortLocation::Module(ModuleId::new(
-        AccountAddress::ONE,
-        ident_str!("transaction_validation").to_owned(),
-    ))
 }
 
 fn unexpected_prologue_abort(

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
@@ -18,7 +18,12 @@ use aptos_types::{
 use mono_move_core::{ExecutionErrorKind, VMInternalError};
 use mono_move_loader::LoaderError;
 use mono_move_runtime::RuntimeError;
-use move_core_types::vm_status::{StatusCode, VMStatus};
+use move_core_types::{
+    account_address::AccountAddress,
+    ident_str,
+    language_storage::ModuleId,
+    vm_status::{AbortLocation, StatusCode, VMStatus},
+};
 
 /// Converts a type-erased VM error into `VMStatus`: fine-grained for the
 /// error types with known legacy mappings, by public category otherwise.
@@ -100,17 +105,23 @@ fn unsupported_status(msg: &str) -> VMStatus {
 /// Mirrors the legacy VM's `convert_prologue_error`: recognized validation
 /// aborts map to their discard codes.
 //
-// TODO(correctness): MonoMove aborts carry no location yet, so every prologue
-// abort is treated as coming from the transaction-validation module. The
-// multisig- and transaction-limits-module branches need locations to be
-// distinguishable.
+// TODO(completeness): the legacy VM also recognizes aborts from
+// `transaction_limits` and the multisig account module. Neither is reachable
+// here yet, so they land in the unexpected-abort branch below.
 fn prologue_failure_to_status(failure: PrologueFailure) -> VMStatus {
-    let (code, message) = match failure {
-        PrologueFailure::Abort { code, message } => (code, message),
+    let (code, message, location) = match failure {
+        PrologueFailure::Abort {
+            code,
+            message,
+            location,
+        } => (code, message, location),
         PrologueFailure::Unexpected(detail) => {
             return unexpected_validation_error("prologue", detail)
         },
     };
+    if location != validation_module() {
+        return unexpected_prologue_abort(code, message, location);
+    }
     let new_major_status = match split_canonical(code) {
         (INVALID_ARGUMENT, EBAD_ACCOUNT_AUTHENTICATION_KEY) => StatusCode::INVALID_AUTH_KEY,
         (INVALID_ARGUMENT, ESEQUENCE_NUMBER_TOO_OLD) => StatusCode::SEQUENCE_NUMBER_TOO_OLD,
@@ -133,22 +144,30 @@ fn prologue_failure_to_status(failure: PrologueFailure) -> VMStatus {
             StatusCode::TRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE
         },
         (INVALID_ARGUMENT, ENONCE_ALREADY_USED) => StatusCode::NONCE_ALREADY_USED,
-        (category, reason) => {
-            let mut err_msg = format!(
-                "Unexpected prologue Move abort: {:?} (Category: {:?} Reason: {:?})",
-                code, category, reason
-            );
-            if let Some(abort_msg) = message {
-                err_msg.push_str(" Message: ");
-                err_msg.push_str(&abort_msg);
-            }
-            return VMStatus::error(
-                StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION,
-                Some(err_msg),
-            );
-        },
+        _ => return unexpected_prologue_abort(code, message, location),
     };
     VMStatus::error(new_major_status, None)
+}
+
+fn validation_module() -> AbortLocation {
+    AbortLocation::Module(ModuleId::new(
+        AccountAddress::ONE,
+        ident_str!("transaction_validation").to_owned(),
+    ))
+}
+
+fn unexpected_prologue_abort(
+    code: u64,
+    message: Option<String>,
+    location: AbortLocation,
+) -> VMStatus {
+    let (category, reason) = split_canonical(code);
+    let mut detail = format!("{location:?}::{code} (Category: {category:?} Reason: {reason:?})");
+    if let Some(abort_msg) = message {
+        detail.push_str(" Message: ");
+        detail.push_str(&abort_msg);
+    }
+    unexpected_validation_error("prologue Move abort:", detail)
 }
 
 fn unexpected_validation_error(msg: &str, detail: String) -> VMStatus {
@@ -166,8 +185,9 @@ fn epilogue_failure_status(run: &str, detail: &str) -> VMStatus {
     unexpected_validation_error(&format!("epilogue {run}"), detail.to_string())
 }
 
-// TODO(correctness): the mapping is coarse; several kinds need location info
-// (`ExecutionFailure`) and exact status codes to match the legacy VM.
+// TODO(correctness): the mapping is coarse; several kinds should be
+// `ExecutionFailure`, which needs the location, function and code offset the
+// legacy VM reports. Currently,`RuntimeError` carries none of those.
 fn runtime_error_to_status(err: &RuntimeError) -> VMStatus {
     use RuntimeError as E;
     let code = match err {

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
@@ -3,7 +3,9 @@
 
 //! Converts the typed outcome taxonomy into `VMStatus`.
 
-use crate::errors::{DiscardReason, ExecutionStatus, PrologueFailure};
+use crate::errors::{
+    is_cant_pay_fee_abort, DiscardReason, ExecutionStage, ExecutionStatus, MoveExecutionFailure,
+};
 use aptos_types::{
     error::{split_canonical, INVALID_ARGUMENT, INVALID_STATE, OUT_OF_RANGE},
     transaction::validation::{
@@ -57,9 +59,12 @@ pub(crate) fn discard_to_vm_status(reason: DiscardReason) -> VMStatus {
         DiscardReason::InvalidTypeArgument(detail) => {
             VMStatus::error(StatusCode::TYPE_RESOLUTION_FAILURE, Some(detail))
         },
-        DiscardReason::Prologue(failure) => prologue_failure_to_status(failure),
-        DiscardReason::Epilogue { run, failure } => {
-            epilogue_failure_status(run, &format!("{failure:?}"))
+        DiscardReason::Failure {
+            stage: ExecutionStage::Prologue,
+            failure,
+        } => prologue_failure_to_status(failure),
+        DiscardReason::Failure { stage, failure } => {
+            stage_failure_status(&stage, &format!("{failure:?}"))
         },
         DiscardReason::InvariantViolation(detail) => invariant_status(detail),
     }
@@ -67,21 +72,29 @@ pub(crate) fn discard_to_vm_status(reason: DiscardReason) -> VMStatus {
 
 /// Converts an executed transaction's conclusion into its `VMStatus`.
 pub(crate) fn executed_vm_status(status: &ExecutionStatus) -> VMStatus {
-    match status {
-        ExecutionStatus::Success => VMStatus::Executed,
-        ExecutionStatus::Abort {
+    let (stage, failure) = match status {
+        ExecutionStatus::Success => return VMStatus::Executed,
+        ExecutionStatus::Failure { stage, failure } => (stage, failure),
+    };
+    match failure {
+        // The fee payer failing to cover the fee is the one epilogue abort that
+        // survives as the transaction's own; any other means the framework
+        // misbehaved, which the legacy VM reports as an unexpected error.
+        MoveExecutionFailure::Abort {
             code,
             message,
             location,
-        } => VMStatus::MoveAbort {
-            location: location.clone(),
-            code: *code,
-            message: message.clone(),
+        } if matches!(stage, ExecutionStage::Payload) || is_cant_pay_fee_abort(*code) => {
+            VMStatus::MoveAbort {
+                location: location.clone(),
+                code: *code,
+                message: message.clone(),
+            }
         },
-        ExecutionStatus::Failure(err) => internal_error_to_status(err),
-        ExecutionStatus::RecoveredEpilogueFailure(failure) => {
-            epilogue_failure_status("after a successful payload", &format!("{failure:?}"))
+        MoveExecutionFailure::RuntimeError(err) if matches!(stage, ExecutionStage::Payload) => {
+            internal_error_to_status(err)
         },
+        failure => stage_failure_status(stage, &format!("{failure:?}")),
     }
 }
 
@@ -108,15 +121,15 @@ fn unsupported_status(msg: &str) -> VMStatus {
 // TODO(completeness): the legacy VM also recognizes aborts from
 // `transaction_limits` and the multisig account module. Neither is reachable
 // here yet, so they land in the unexpected-abort branch below.
-fn prologue_failure_to_status(failure: PrologueFailure) -> VMStatus {
+fn prologue_failure_to_status(failure: MoveExecutionFailure) -> VMStatus {
     let (code, message, location) = match failure {
-        PrologueFailure::Abort {
+        MoveExecutionFailure::Abort {
             code,
             message,
             location,
         } => (code, message, location),
-        PrologueFailure::Unexpected(detail) => {
-            return unexpected_validation_error("prologue", detail)
+        MoveExecutionFailure::RuntimeError(err) => {
+            return unexpected_validation_error("prologue", err.to_string())
         },
     };
     if location != validation_module() {
@@ -179,10 +192,17 @@ fn unexpected_validation_error(msg: &str, detail: String) -> VMStatus {
     )
 }
 
-/// The status of an epilogue failure the fee abort does not cover, whether it
-/// ends up kept or discarded. `run` says which epilogue run failed.
-fn epilogue_failure_status(run: &str, detail: &str) -> VMStatus {
-    unexpected_validation_error(&format!("epilogue {run}"), detail.to_string())
+/// The status of a failure the legacy mapping does not recognize: the framework
+/// misbehaved, which the legacy VM reports as an unexpected error.
+fn stage_failure_status(stage: &ExecutionStage, detail: &str) -> VMStatus {
+    let what = match stage {
+        ExecutionStage::Prologue => "prologue",
+        ExecutionStage::Payload => "payload",
+        ExecutionStage::Epilogue => "epilogue",
+        ExecutionStage::EpilogueAfterRollback => "epilogue after a rolled-back payload",
+        ExecutionStage::EpilogueRetry => "epilogue retry",
+    };
+    unexpected_validation_error(what, detail.to_string())
 }
 
 // TODO(correctness): the mapping is coarse; several kinds should be

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
@@ -1,0 +1,223 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Converts the typed outcome taxonomy into `VMStatus`.
+
+use crate::errors::{DiscardReason, ExecutionStatus, PrologueFailure};
+use aptos_types::{
+    error::{split_canonical, INVALID_ARGUMENT, INVALID_STATE, OUT_OF_RANGE},
+    transaction::validation::{
+        EACCOUNT_DOES_NOT_EXIST, EBAD_ACCOUNT_AUTHENTICATION_KEY, EBAD_CHAIN_ID,
+        ECANT_PAY_GAS_DEPOSIT, EGAS_PAYER_ACCOUNT_MISSING,
+        EINSUFFICIENT_BALANCE_FOR_REQUIRED_DEPOSIT, ENONCE_ALREADY_USED,
+        ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH, ESEQUENCE_NUMBER_TOO_BIG,
+        ESEQUENCE_NUMBER_TOO_NEW, ESEQUENCE_NUMBER_TOO_OLD,
+        ETRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE, ETRANSACTION_EXPIRED,
+    },
+};
+use mono_move_core::{ExecutionErrorKind, VMInternalError};
+use mono_move_loader::LoaderError;
+use mono_move_runtime::RuntimeError;
+use move_core_types::vm_status::{StatusCode, VMStatus};
+
+/// Converts a type-erased VM error into `VMStatus`: fine-grained for the
+/// error types with known legacy mappings, by public category otherwise.
+//
+// TODO(correctness): extend the downcast set as more subsystem error types
+// (verifier, deserializer, gas) need exact legacy codes.
+// TODO(cleanup): refactor comparison replay benchmark mapping
+fn internal_error_to_status(err: &VMInternalError) -> VMStatus {
+    if let Some(err) = err.downcast_ref::<RuntimeError>() {
+        return runtime_error_to_status(err);
+    }
+    if let Some(err) = err.downcast_ref::<LoaderError>() {
+        return loader_error_to_status(err);
+    }
+    let code = match err.kind() {
+        ExecutionErrorKind::OutOfGas => StatusCode::OUT_OF_GAS,
+        ExecutionErrorKind::LinkingError => StatusCode::LINKER_ERROR,
+        ExecutionErrorKind::InvariantViolation => StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        ExecutionErrorKind::RuntimeLimitExceeded
+        | ExecutionErrorKind::InvalidOperation
+        | ExecutionErrorKind::Placeholder => StatusCode::UNKNOWN_STATUS,
+    };
+    VMStatus::error(code, Some(err.to_string()))
+}
+
+/// Converts a discard reason into the `VMStatus` the transaction is rejected
+/// with.
+pub(crate) fn discard_to_vm_status(reason: DiscardReason) -> VMStatus {
+    match reason {
+        DiscardReason::Unsupported(msg) => unsupported_status(msg),
+        DiscardReason::InvalidTypeArgument(detail) => {
+            VMStatus::error(StatusCode::TYPE_RESOLUTION_FAILURE, Some(detail))
+        },
+        DiscardReason::Prologue(failure) => prologue_failure_to_status(failure),
+        DiscardReason::Epilogue { run, failure } => {
+            epilogue_failure_status(run, &format!("{failure:?}"))
+        },
+        DiscardReason::InvariantViolation(detail) => invariant_status(detail),
+    }
+}
+
+/// Converts an executed transaction's conclusion into its `VMStatus`.
+pub(crate) fn executed_vm_status(status: &ExecutionStatus) -> VMStatus {
+    match status {
+        ExecutionStatus::Success => VMStatus::Executed,
+        ExecutionStatus::Abort {
+            code,
+            message,
+            location,
+        } => VMStatus::MoveAbort {
+            location: location.clone(),
+            code: *code,
+            message: message.clone(),
+        },
+        ExecutionStatus::Failure(err) => internal_error_to_status(err),
+        ExecutionStatus::RecoveredEpilogueFailure(failure) => {
+            epilogue_failure_status("after a successful payload", &format!("{failure:?}"))
+        },
+    }
+}
+
+/// An executor-internal invariant violation.
+fn invariant_status(detail: String) -> VMStatus {
+    VMStatus::error(
+        StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        Some(format!("[aptos_txn_executor] {detail}")),
+    )
+}
+
+fn unsupported_status(msg: &str) -> VMStatus {
+    VMStatus::error(
+        StatusCode::FEATURE_UNDER_GATING,
+        Some(format!(
+            "the MonoMove transaction executor does not support {msg}"
+        )),
+    )
+}
+
+/// Mirrors the legacy VM's `convert_prologue_error`: recognized validation
+/// aborts map to their discard codes.
+//
+// TODO(correctness): MonoMove aborts carry no location yet, so every prologue
+// abort is treated as coming from the transaction-validation module. The
+// multisig- and transaction-limits-module branches need locations to be
+// distinguishable.
+fn prologue_failure_to_status(failure: PrologueFailure) -> VMStatus {
+    let (code, message) = match failure {
+        PrologueFailure::Abort { code, message } => (code, message),
+        PrologueFailure::Unexpected(detail) => {
+            return unexpected_validation_error("prologue", detail)
+        },
+    };
+    let new_major_status = match split_canonical(code) {
+        (INVALID_ARGUMENT, EBAD_ACCOUNT_AUTHENTICATION_KEY) => StatusCode::INVALID_AUTH_KEY,
+        (INVALID_ARGUMENT, ESEQUENCE_NUMBER_TOO_OLD) => StatusCode::SEQUENCE_NUMBER_TOO_OLD,
+        (INVALID_ARGUMENT, ESEQUENCE_NUMBER_TOO_NEW) => StatusCode::SEQUENCE_NUMBER_TOO_NEW,
+        (INVALID_ARGUMENT, EACCOUNT_DOES_NOT_EXIST) => StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST,
+        (INVALID_ARGUMENT, ECANT_PAY_GAS_DEPOSIT) => {
+            StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE
+        },
+        (INVALID_ARGUMENT, ETRANSACTION_EXPIRED) => StatusCode::TRANSACTION_EXPIRED,
+        (INVALID_ARGUMENT, EBAD_CHAIN_ID) => StatusCode::BAD_CHAIN_ID,
+        (OUT_OF_RANGE, ESEQUENCE_NUMBER_TOO_BIG) => StatusCode::SEQUENCE_NUMBER_TOO_BIG,
+        (INVALID_ARGUMENT, ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH) => {
+            StatusCode::SECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH
+        },
+        (INVALID_ARGUMENT, EGAS_PAYER_ACCOUNT_MISSING) => StatusCode::GAS_PAYER_ACCOUNT_MISSING,
+        (INVALID_STATE, EINSUFFICIENT_BALANCE_FOR_REQUIRED_DEPOSIT) => {
+            StatusCode::INSUFFICIENT_BALANCE_FOR_REQUIRED_DEPOSIT
+        },
+        (INVALID_ARGUMENT, ETRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE) => {
+            StatusCode::TRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE
+        },
+        (INVALID_ARGUMENT, ENONCE_ALREADY_USED) => StatusCode::NONCE_ALREADY_USED,
+        (category, reason) => {
+            let mut err_msg = format!(
+                "Unexpected prologue Move abort: {:?} (Category: {:?} Reason: {:?})",
+                code, category, reason
+            );
+            if let Some(abort_msg) = message {
+                err_msg.push_str(" Message: ");
+                err_msg.push_str(&abort_msg);
+            }
+            return VMStatus::error(
+                StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION,
+                Some(err_msg),
+            );
+        },
+    };
+    VMStatus::error(new_major_status, None)
+}
+
+fn unexpected_validation_error(msg: &str, detail: String) -> VMStatus {
+    VMStatus::error(
+        StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION,
+        Some(format!(
+            "[aptos_txn_executor] Unexpected {msg} error: {detail}"
+        )),
+    )
+}
+
+/// The status of an epilogue failure the fee abort does not cover, whether it
+/// ends up kept or discarded. `run` says which epilogue run failed.
+fn epilogue_failure_status(run: &str, detail: &str) -> VMStatus {
+    unexpected_validation_error(&format!("epilogue {run}"), detail.to_string())
+}
+
+// TODO(correctness): the mapping is coarse; several kinds need location info
+// (`ExecutionFailure`) and exact status codes to match the legacy VM.
+fn runtime_error_to_status(err: &RuntimeError) -> VMStatus {
+    use RuntimeError as E;
+    let code = match err {
+        E::ArithmeticOverflow { .. }
+        | E::ArithmeticUnderflow { .. }
+        | E::DivisionByZero { .. }
+        | E::ShiftAmountOutOfRange { .. }
+        | E::ArithmeticUnderOverflow { .. }
+        | E::DivisionByZeroOrOverflow { .. }
+        | E::NegateMinOverflow { .. }
+        | E::CastOutOfRange { .. } => StatusCode::ARITHMETIC_ERROR,
+        E::PopFromEmptyVector
+        | E::VectorIndexOutOfBounds { .. }
+        | E::VecUnpackLengthMismatch { .. } => StatusCode::VECTOR_OPERATION_ERROR,
+        E::ResourceDoesNotExist { .. } => StatusCode::MISSING_DATA,
+        E::ResourceAlreadyExists { .. } => StatusCode::RESOURCE_ALREADY_EXISTS,
+        E::EnumVariantMismatch { .. } => StatusCode::TYPE_MISMATCH,
+        E::StackOverflow => StatusCode::CALL_STACK_OVERFLOW,
+        // Raised only by the runtime's own write-set builder, which this crate
+        // does not use (its drain goes through the provider).
+        E::StateKeyTypeTooDeep => StatusCode::TOO_MANY_TYPE_NODES,
+        E::OutOfHeapMemory { .. } | E::AllocationTooLarge { .. } | E::VecAllocSizeOverflow => {
+            StatusCode::MEMORY_LIMIT_EXCEEDED
+        },
+        E::InvalidAbortMessage
+        | E::AbortMessageTooLong { .. }
+        | E::BCSEof
+        | E::BCSInvalidUleb
+        | E::BCSSequenceTooLong { .. }
+        | E::BCSRemainingInput { .. }
+        | E::BCSInvalidBool { .. }
+        | E::BCSSignerNotDeserializable => StatusCode::UNKNOWN_STATUS,
+        E::InvariantViolation(_) | E::ResourceProvider(_) => {
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
+        },
+    };
+    VMStatus::error(code, Some(format!("{}", err)))
+}
+
+fn loader_error_to_status(err: &LoaderError) -> VMStatus {
+    use LoaderError as L;
+    let code = match err {
+        // Kept (and charged) under the function-values feature, since a stale
+        // function value makes this reachable at runtime.
+        L::FunctionNotFound { .. } => StatusCode::FUNCTION_RESOLUTION_FAILURE,
+        L::ModuleNotFound { .. } | L::FunctionIrMissing => StatusCode::LINKER_ERROR,
+        L::LoweringSkipped { .. } => StatusCode::UNKNOWN_STATUS,
+        L::GlobalContext(_) | L::InvariantViolation(_) => {
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
+        },
+    };
+    VMStatus::error(code, Some(format!("{}", err)))
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_types::transaction::{ReplayProtector, SessionId, SignedTransaction};
+use move_core_types::account_address::AccountAddress;
+
+/// The slice of transaction metadata need by the executor.
+pub(crate) struct TxnMetadata {
+    pub sender: AccountAddress,
+    pub fee_payer: Option<AccountAddress>,
+    pub secondary_signers: Vec<AccountAddress>,
+    pub sender_auth_key: Option<Vec<u8>>,
+    pub fee_payer_auth_key: Option<Vec<u8>>,
+    pub secondary_auth_keys: Vec<Option<Vec<u8>>>,
+    pub gas_unit_price: u64,
+    pub max_gas_amount: u64,
+    pub expiration_timestamp_secs: u64,
+    pub chain_id: u8,
+    pub replay_protector: ReplayProtector,
+    /// Seeds unique-address generation. Derived like the legacy VM's, from the
+    /// payload session's id, so generated addresses match.
+    pub txn_hash: Vec<u8>,
+}
+
+impl TxnMetadata {
+    pub fn new(txn: &SignedTransaction) -> Self {
+        Self {
+            sender: txn.sender(),
+            fee_payer: txn.authenticator_ref().fee_payer_address(),
+            secondary_signers: txn.authenticator().secondary_signer_addresses(),
+            sender_auth_key: txn
+                .authenticator()
+                .sender()
+                .authentication_proof()
+                .optional_auth_key(),
+            fee_payer_auth_key: txn
+                .authenticator()
+                .fee_payer_signer()
+                .and_then(|signer| signer.authentication_proof().optional_auth_key()),
+            secondary_auth_keys: txn
+                .authenticator()
+                .secondary_signers()
+                .iter()
+                .map(|account_auth| account_auth.authentication_proof().optional_auth_key())
+                .collect(),
+            gas_unit_price: txn.gas_unit_price(),
+            max_gas_amount: txn.max_gas_amount(),
+            expiration_timestamp_secs: txn.expiration_timestamp_secs(),
+            chain_id: txn.chain_id().id(),
+            replay_protector: txn.replay_protector(),
+            txn_hash: SessionId::txn(
+                txn.sender(),
+                txn.replay_protector(),
+                txn.payload().script_hash(),
+                txn.expiration_timestamp_secs(),
+            )
+            .txn_hash()
+            .to_vec(),
+        }
+    }
+
+    pub fn is_orderless(&self) -> bool {
+        matches!(self.replay_protector, ReplayProtector::Nonce(_))
+    }
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::metadata::TxnMetadata;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
+use mono_move_core::{
+    native::{NativeExtensions, NativeName},
+    Interner,
+};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_natives::{
+    make_all_production_natives, Dispatch, EventStore, ObjectContextExtension,
+    StorageUsageAtEpochBoundary, TransactionContextExtension,
+};
+use mono_move_runtime::{ProductionContextFamily, ProductionNativeRegistry};
+
+/// Builds the production native registry.
+pub fn production_natives(guard: &ExecutionGuard<'_>) -> ProductionNativeRegistry {
+    let mut natives = ProductionNativeRegistry::new();
+    natives
+        .register_all(
+            make_all_production_natives::<ProductionContextFamily>()
+                .into_iter()
+                .map(|(addr, module, function, dispatch, func)| {
+                    let module = guard.module_id_of(&addr, &module);
+                    let function = guard.identifier_of(&function);
+                    let name = match dispatch {
+                        Dispatch::Polymorphic => NativeName::Polymorphic { module, function },
+                        Dispatch::Monomorphic(ty_args) => NativeName::Monomorphic {
+                            module,
+                            function,
+                            ty_args: guard.type_list_of(ty_args),
+                        },
+                    };
+                    (name, func)
+                }),
+        )
+        .expect("natives have unique qualified names");
+    natives
+}
+
+/// The native extensions a user transaction runs with.
+pub(crate) fn transaction_extensions(
+    txn_data: &TxnMetadata,
+    usage: StateStorageUsage,
+) -> NativeExtensions {
+    let mut extensions = NativeExtensions::new();
+    // TODO(completeness): the transaction index and the reserved byte
+    // (block execution vs. validation/simulation) come from the auxiliary
+    // info the block coordinator has to pass in; both are hardcoded here.
+    extensions.add(TransactionContextExtension::new(
+        txn_data.txn_hash.clone(),
+        0,
+        0,
+        0,
+    ));
+    extensions.add(ObjectContextExtension::new());
+    extensions.add(StorageUsageAtEpochBoundary::new(
+        usage.items() as u64,
+        usage.bytes() as u64,
+    ));
+    extensions.add(EventStore::new());
+    extensions
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/outcome.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/outcome.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    errors::{DiscardReason, ExecutionStatus, MaterializationError},
+    materialize,
+    providers::AptosDataProvider,
+};
+use aptos_types::{
+    fee_statement::FeeStatement,
+    on_chain_config::Features,
+    transaction::{TransactionAuxiliaryData, TransactionOutput, TransactionStatus},
+};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_runtime::SessionEffects;
+
+/// The outcome of one transaction, not yet materialized into a write set.
+/// Intended to be consumed by the block coordinator for efficient handling.
+pub enum TxnOutcome {
+    /// Rejected without side effects.
+    Discarded(DiscardReason),
+    /// Executed: the fee is charged and the side effects are real, whether or
+    /// not the payload succeeded.
+    Executed {
+        status: ExecutionStatus,
+        fee_statement: FeeStatement,
+        effects: SessionEffects,
+    },
+}
+
+impl TxnOutcome {
+    pub fn is_discarded(&self) -> bool {
+        matches!(self, TxnOutcome::Discarded(_))
+    }
+
+    /// Forces the outcome into a `TransactionOutput`: converts the status,
+    /// serializes writes (merging resource-group members), and finalizes
+    /// events. Fails only if the effects cannot be converted to storage
+    /// formats, e.g. BCS serialized, which is abnormal — unlike a discard,
+    /// which is a normal outcome carried in the output's status.
+    //
+    // TODO(perf): this is only intended for compatibility and testing, and
+    // the block coordinator should eventually handle the effects directly.
+    pub fn materialize(
+        self,
+        guard: &ExecutionGuard,
+        provider: &dyn AptosDataProvider,
+        features: &Features,
+        auxiliary_data: TransactionAuxiliaryData,
+    ) -> Result<TransactionOutput, MaterializationError> {
+        match self {
+            TxnOutcome::Discarded(reason) => Ok(materialize::discarded_output(
+                materialize::discard_to_vm_status(reason).status_code(),
+                auxiliary_data,
+            )),
+            TxnOutcome::Executed {
+                status: execution_status,
+                fee_statement,
+                effects,
+            } => {
+                let vm_status = materialize::executed_vm_status(&execution_status);
+                // The `true` is `memory_limit_exceeded_as_miscellaneous_error`.
+                // We always set this to true to replicate the latest behavior.
+                let txn_status = TransactionStatus::from_vm_status(vm_status, features, true);
+                materialize::executed_output(
+                    &effects,
+                    guard,
+                    provider,
+                    fee_statement.gas_used(),
+                    txn_status,
+                    auxiliary_data,
+                )
+            },
+        }
+    }
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/providers.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/providers.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::{anyhow, Result};
+use aptos_types::state_store::{state_key::StateKey, table::TableHandle};
+use bytes::Bytes;
+use mono_move_core::{
+    intern_struct_tag,
+    storage::resource_provider::{InMemoryStorageKey, ResourceProvider},
+    struct_tag_of,
+    types::InternedType,
+    Interner,
+};
+use move_core_types::language_storage::StructTag;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+
+/// Trait extending the runtime's [`ResourceProvider`] interface with additional capabilities to
+/// handle resource groups and table items.
+pub trait AptosDataProvider: ResourceProvider {
+    /// The resource group a resource type belongs to, if any.
+    fn group_of(&self, ty: InternedType) -> Result<Option<InternedType>>;
+
+    /// The stored members of the group behind `group_key`, as execution read
+    /// them, or `None` if no group is stored there.
+    fn group_members(&self, group_key: &StateKey) -> Result<Option<Arc<GroupMembers>>>;
+
+    /// Resolves where the value at a read-write-set key lives in state
+    /// storage.
+    fn locate_key(&self, key: &InMemoryStorageKey) -> Result<StorageLocation> {
+        Ok(match key {
+            InMemoryStorageKey::Resource { address, ty } => match self.group_of(*ty)? {
+                Some(group_ty) => StorageLocation::GroupMember {
+                    group: StateKey::resource_group(address, &nominal_tag(group_ty)?),
+                    member: *ty,
+                },
+                None => StorageLocation::OwnSlot(
+                    StateKey::resource(address, &nominal_tag(*ty)?)
+                        .map_err(|e| anyhow!("bad state key: {e}"))?,
+                ),
+            },
+            InMemoryStorageKey::TableItem { handle, key, .. } => {
+                StorageLocation::OwnSlot(StateKey::table_item(&TableHandle(handle.address()), key))
+            },
+        })
+    }
+}
+
+/// A resource group's members and their stored bytes. Unordered: the stored
+/// encoding is canonical in struct-tag order.
+pub type GroupMembers = HashMap<InternedType, Bytes>;
+
+/// Where a value lives in state storage.
+pub enum StorageLocation {
+    /// In a slot of its own.
+    OwnSlot(StateKey),
+    /// Inside a resource group's slot, under the member type.
+    GroupMember {
+        group: StateKey,
+        member: InternedType,
+    },
+}
+
+/// Decodes a group's stored blob, interning each member's struct tag.
+pub fn decode_group_members(blob: &[u8], interner: &impl Interner) -> Result<GroupMembers> {
+    let tagged: BTreeMap<StructTag, Bytes> = bcs::from_bytes(blob)?;
+    tagged
+        .into_iter()
+        .map(|(tag, bytes)| Ok((intern_struct_tag(&tag, interner)?, bytes)))
+        .collect()
+}
+
+/// The struct tag of a nominal type, for storage keys.
+pub(crate) fn nominal_tag(ty: InternedType) -> Result<StructTag> {
+    struct_tag_of(ty).ok_or_else(|| anyhow!("resource type is not nominal"))
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/providers.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/providers.rs
@@ -12,10 +12,8 @@ use mono_move_core::{
     Interner,
 };
 use move_core_types::language_storage::StructTag;
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, HashMap};
+use triomphe::Arc;
 
 /// Trait extending the runtime's [`ResourceProvider`] interface with additional capabilities to
 /// handle resource groups and table items.
@@ -50,6 +48,9 @@ pub trait AptosDataProvider: ResourceProvider {
 
 /// A resource group's members and their stored bytes. Unordered: the stored
 /// encoding is canonical in struct-tag order.
+//
+// TODO(cleanup): consider `shared-dsa`'s `UnorderedSet` and make it explicit that
+// the iteration order can be non-deterministic.
 pub type GroupMembers = HashMap<InternedType, Bytes>;
 
 /// Where a value lives in state storage.
@@ -73,6 +74,9 @@ pub fn decode_group_members(blob: &[u8], interner: &impl Interner) -> Result<Gro
 }
 
 /// The struct tag of a nominal type, for storage keys.
+//
+// TODO(perf): should be a cached method on the context, which would also let the
+// state-view providers stop open-coding it.
 pub(crate) fn nominal_tag(ty: InternedType) -> Result<StructTag> {
     struct_tag_of(ty).ok_or_else(|| anyhow!("resource type is not nominal"))
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
@@ -7,18 +7,14 @@
 //! here too. Only the versioned validation path is supported; the many legacy
 //! prologue/epilogue variants are intentionally not ported.
 
-use crate::{
-    calls::{call_function, CallStatus},
-    errors::MoveExecutionFailure,
-    metadata::TxnMetadata,
-};
+use crate::{calls::call_function, errors::MoveExecutionFailure, metadata::TxnMetadata};
 use aptos_types::{
     fee_statement::FeeStatement,
     transaction::{EpilogueArgs, PrologueArgs},
 };
 use mono_move_core::{types::InternedTypeList, Interner, VMInternalError};
 use mono_move_global_context::ExecutionGuard;
-use mono_move_runtime::InterpreterContext;
+use mono_move_runtime::{InterpreterContext, RuntimeStatus};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use serde::Serialize;
 
@@ -43,7 +39,7 @@ fn call_system_function(
     ty_args: InternedTypeList,
     signer_bufs: &[[u8; AccountAddress::LENGTH]],
     args: &[Vec<u8>],
-) -> Result<CallStatus, VMInternalError> {
+) -> Result<RuntimeStatus, VMInternalError> {
     interp.unmetered(|interp| {
         call_function(
             guard,
@@ -66,7 +62,7 @@ fn call_validation_function(
     function: &IdentStr,
     signers: &[[u8; AccountAddress::LENGTH]; 2],
     args: &impl Serialize,
-) -> Result<CallStatus, VMInternalError> {
+) -> Result<RuntimeStatus, VMInternalError> {
     let args_blob = bcs::to_bytes(args).expect("validation args serialize");
     call_system_function(
         guard,
@@ -105,8 +101,8 @@ pub(crate) fn run_prologue(
         .map_err(MoveExecutionFailure::RuntimeError)?;
 
     match status {
-        CallStatus::Success => Ok(()),
-        CallStatus::Abort {
+        RuntimeStatus::Success => Ok(()),
+        RuntimeStatus::Aborted {
             code,
             message,
             location,
@@ -138,8 +134,8 @@ pub(crate) fn run_epilogue(
         .map_err(MoveExecutionFailure::RuntimeError)?;
 
     match status {
-        CallStatus::Success => Ok(()),
-        CallStatus::Abort {
+        RuntimeStatus::Success => Ok(()),
+        RuntimeStatus::Aborted {
             code,
             message,
             location,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
@@ -7,7 +7,12 @@
 //! here too. Only the versioned validation path is supported; the many legacy
 //! prologue/epilogue variants are intentionally not ported.
 
-use crate::{calls::call_function, errors::MoveExecutionFailure, metadata::TxnMetadata};
+use crate::{
+    calls::{call_function, invariant_violation},
+    errors::MoveExecutionFailure,
+    metadata::TxnMetadata,
+};
+use anyhow::anyhow;
 use aptos_types::{
     fee_statement::FeeStatement,
     transaction::{EpilogueArgs, PrologueArgs},
@@ -22,15 +27,31 @@ const TRANSACTION_VALIDATION: &IdentStr = ident_str!("transaction_validation");
 const VERSIONED_PROLOGUE: &IdentStr = ident_str!("versioned_prologue");
 const VERSIONED_EPILOGUE: &IdentStr = ident_str!("versioned_epilogue");
 
-/// The sender and fee-payer signer buffers every validation call takes.
-pub(crate) fn validation_signers(txn_data: &TxnMetadata) -> [[u8; AccountAddress::LENGTH]; 2] {
-    let fee_payer = txn_data.fee_payer.unwrap_or(txn_data.sender);
-    [txn_data.sender.into_bytes(), fee_payer.into_bytes()]
+/// The signer buffers a Move call receives, in parameter order.
+pub(crate) struct TxnSigners(Vec<[u8; AccountAddress::LENGTH]>);
+
+impl TxnSigners {
+    /// Sender and fee payer, as the prologue and epilogue take them.
+    pub(crate) fn for_validation(txn_data: &TxnMetadata) -> Self {
+        let fee_payer = txn_data.fee_payer.unwrap_or(txn_data.sender);
+        Self(vec![txn_data.sender.into_bytes(), fee_payer.into_bytes()])
+    }
+
+    /// Sender and any secondary signers, as an entry function takes them.
+    pub(crate) fn for_payload(txn_data: &TxnMetadata) -> Self {
+        let mut signers = vec![txn_data.sender.into_bytes()];
+        signers.extend(txn_data.secondary_signers.iter().map(|s| s.into_bytes()));
+        Self(signers)
+    }
+
+    pub(crate) fn as_slice(&self) -> &[[u8; AccountAddress::LENGTH]] {
+        &self.0
+    }
 }
 
-/// Like `call_function`, but unmetered: system code never consumes the
-/// transaction's gas budget, including its module loads.
-fn call_system_function(
+/// Like `call_function`, but system code never consumes the transaction's gas
+/// budget, including its module loads.
+fn call_system_function_unmetered(
     guard: &ExecutionGuard<'_>,
     interp: &mut InterpreterContext<'_>,
     address: &AccountAddress,
@@ -54,24 +75,24 @@ fn call_system_function(
     })
 }
 
-/// Calls `0x1::transaction_validation::<function>(signers…, args)`,
-/// unmetered.
-fn call_validation_function(
+/// Calls `0x1::transaction_validation::<function>(signers…, args)`.
+fn call_validation_function_unmetered(
     guard: &ExecutionGuard<'_>,
     interp: &mut InterpreterContext<'_>,
     function: &IdentStr,
-    signers: &[[u8; AccountAddress::LENGTH]; 2],
+    signers: &TxnSigners,
     args: &impl Serialize,
 ) -> Result<RuntimeStatus, VMInternalError> {
-    let args_blob = bcs::to_bytes(args).expect("validation args serialize");
-    call_system_function(
+    let args_blob = bcs::to_bytes(args)
+        .map_err(|e| invariant_violation(anyhow!("validation args do not serialize: {e}")))?;
+    call_system_function_unmetered(
         guard,
         interp,
         &AccountAddress::ONE,
         TRANSACTION_VALIDATION,
         function,
         guard.type_list_of(&[]),
-        signers,
+        signers.as_slice(),
         &[args_blob],
     )
 }
@@ -79,7 +100,7 @@ fn call_validation_function(
 pub(crate) fn run_prologue(
     interp: &mut InterpreterContext<'_>,
     guard: &ExecutionGuard<'_>,
-    signers: &[[u8; AccountAddress::LENGTH]; 2],
+    signers: &TxnSigners,
     txn_data: &TxnMetadata,
 ) -> Result<(), MoveExecutionFailure> {
     let args = PrologueArgs::V1 {
@@ -97,8 +118,9 @@ pub(crate) fn run_prologue(
         // TODO(completeness): transaction limits requests (staking multipliers).
         txn_limits_request: None,
     };
-    let status = call_validation_function(guard, interp, VERSIONED_PROLOGUE, signers, &args)
-        .map_err(MoveExecutionFailure::RuntimeError)?;
+    let status =
+        call_validation_function_unmetered(guard, interp, VERSIONED_PROLOGUE, signers, &args)
+            .map_err(MoveExecutionFailure::RuntimeError)?;
 
     match status {
         RuntimeStatus::Success => Ok(()),
@@ -117,7 +139,7 @@ pub(crate) fn run_prologue(
 pub(crate) fn run_epilogue(
     interp: &mut InterpreterContext<'_>,
     guard: &ExecutionGuard<'_>,
-    signers: &[[u8; AccountAddress::LENGTH]; 2],
+    signers: &TxnSigners,
     txn_data: &TxnMetadata,
     fee_statement: FeeStatement,
     gas_units_remaining: u64,
@@ -130,8 +152,9 @@ pub(crate) fn run_epilogue(
         is_simulation: false,
         is_orderless_txn: txn_data.is_orderless(),
     };
-    let status = call_validation_function(guard, interp, VERSIONED_EPILOGUE, signers, &args)
-        .map_err(MoveExecutionFailure::RuntimeError)?;
+    let status =
+        call_validation_function_unmetered(guard, interp, VERSIONED_EPILOGUE, signers, &args)
+            .map_err(MoveExecutionFailure::RuntimeError)?;
 
     match status {
         RuntimeStatus::Success => Ok(()),

--- a/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
@@ -106,7 +106,15 @@ pub(crate) fn run_prologue(
 
     match status {
         CallStatus::Success => Ok(()),
-        CallStatus::Abort { code, message } => Err(PrologueFailure::Abort { code, message }),
+        CallStatus::Abort {
+            code,
+            message,
+            location,
+        } => Err(PrologueFailure::Abort {
+            code,
+            message,
+            location,
+        }),
     }
 }
 
@@ -131,6 +139,14 @@ pub(crate) fn run_epilogue(
 
     match status {
         CallStatus::Success => Ok(()),
-        CallStatus::Abort { code, message } => Err(EpilogueFailure::Abort { code, message }),
+        CallStatus::Abort {
+            code,
+            message,
+            location,
+        } => Err(EpilogueFailure::Abort {
+            code,
+            message,
+            location,
+        }),
     }
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     calls::{call_function, CallStatus},
-    errors::{EpilogueFailure, PrologueFailure},
+    errors::MoveExecutionFailure,
     metadata::TxnMetadata,
 };
 use aptos_types::{
@@ -85,7 +85,7 @@ pub(crate) fn run_prologue(
     guard: &ExecutionGuard<'_>,
     signers: &[[u8; AccountAddress::LENGTH]; 2],
     txn_data: &TxnMetadata,
-) -> Result<(), PrologueFailure> {
+) -> Result<(), MoveExecutionFailure> {
     let args = PrologueArgs::V1 {
         needs_fee_payer_auth_check: txn_data.fee_payer.is_some(),
         txn_sender_public_key: txn_data.sender_auth_key.clone(),
@@ -102,7 +102,7 @@ pub(crate) fn run_prologue(
         txn_limits_request: None,
     };
     let status = call_validation_function(guard, interp, VERSIONED_PROLOGUE, signers, &args)
-        .map_err(|err| PrologueFailure::Unexpected(err.to_string()))?;
+        .map_err(MoveExecutionFailure::RuntimeError)?;
 
     match status {
         CallStatus::Success => Ok(()),
@@ -110,7 +110,7 @@ pub(crate) fn run_prologue(
             code,
             message,
             location,
-        } => Err(PrologueFailure::Abort {
+        } => Err(MoveExecutionFailure::Abort {
             code,
             message,
             location,
@@ -125,7 +125,7 @@ pub(crate) fn run_epilogue(
     txn_data: &TxnMetadata,
     fee_statement: FeeStatement,
     gas_units_remaining: u64,
-) -> Result<(), EpilogueFailure> {
+) -> Result<(), MoveExecutionFailure> {
     let args = EpilogueArgs::V1 {
         fee_statement,
         txn_gas_price: txn_data.gas_unit_price,
@@ -135,7 +135,7 @@ pub(crate) fn run_epilogue(
         is_orderless_txn: txn_data.is_orderless(),
     };
     let status = call_validation_function(guard, interp, VERSIONED_EPILOGUE, signers, &args)
-        .map_err(EpilogueFailure::Internal)?;
+        .map_err(MoveExecutionFailure::RuntimeError)?;
 
     match status {
         CallStatus::Success => Ok(()),
@@ -143,7 +143,7 @@ pub(crate) fn run_epilogue(
             code,
             message,
             location,
-        } => Err(EpilogueFailure::Abort {
+        } => Err(MoveExecutionFailure::Abort {
             code,
             message,
             location,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/sys_calls.rs
@@ -1,0 +1,136 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Unmetered calls into framework system functions with Rust-built arguments.
+//! Today: the transaction prologue and epilogue
+//! (`0x1::transaction_validation`); the block prologue and epilogue will live
+//! here too. Only the versioned validation path is supported; the many legacy
+//! prologue/epilogue variants are intentionally not ported.
+
+use crate::{
+    calls::{call_function, CallStatus},
+    errors::{EpilogueFailure, PrologueFailure},
+    metadata::TxnMetadata,
+};
+use aptos_types::{
+    fee_statement::FeeStatement,
+    transaction::{EpilogueArgs, PrologueArgs},
+};
+use mono_move_core::{types::InternedTypeList, Interner, VMInternalError};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_runtime::InterpreterContext;
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use serde::Serialize;
+
+const TRANSACTION_VALIDATION: &IdentStr = ident_str!("transaction_validation");
+const VERSIONED_PROLOGUE: &IdentStr = ident_str!("versioned_prologue");
+const VERSIONED_EPILOGUE: &IdentStr = ident_str!("versioned_epilogue");
+
+/// The sender and fee-payer signer buffers every validation call takes.
+pub(crate) fn validation_signers(txn_data: &TxnMetadata) -> [[u8; AccountAddress::LENGTH]; 2] {
+    let fee_payer = txn_data.fee_payer.unwrap_or(txn_data.sender);
+    [txn_data.sender.into_bytes(), fee_payer.into_bytes()]
+}
+
+/// Like `call_function`, but unmetered: system code never consumes the
+/// transaction's gas budget, including its module loads.
+fn call_system_function(
+    guard: &ExecutionGuard<'_>,
+    interp: &mut InterpreterContext<'_>,
+    address: &AccountAddress,
+    module_name: &IdentStr,
+    function_name: &IdentStr,
+    ty_args: InternedTypeList,
+    signer_bufs: &[[u8; AccountAddress::LENGTH]],
+    args: &[Vec<u8>],
+) -> Result<CallStatus, VMInternalError> {
+    interp.unmetered(|interp| {
+        call_function(
+            guard,
+            interp,
+            address,
+            module_name,
+            function_name,
+            ty_args,
+            signer_bufs,
+            args,
+        )
+    })
+}
+
+/// Calls `0x1::transaction_validation::<function>(signers…, args)`,
+/// unmetered.
+fn call_validation_function(
+    guard: &ExecutionGuard<'_>,
+    interp: &mut InterpreterContext<'_>,
+    function: &IdentStr,
+    signers: &[[u8; AccountAddress::LENGTH]; 2],
+    args: &impl Serialize,
+) -> Result<CallStatus, VMInternalError> {
+    let args_blob = bcs::to_bytes(args).expect("validation args serialize");
+    call_system_function(
+        guard,
+        interp,
+        &AccountAddress::ONE,
+        TRANSACTION_VALIDATION,
+        function,
+        guard.type_list_of(&[]),
+        signers,
+        &[args_blob],
+    )
+}
+
+pub(crate) fn run_prologue(
+    interp: &mut InterpreterContext<'_>,
+    guard: &ExecutionGuard<'_>,
+    signers: &[[u8; AccountAddress::LENGTH]; 2],
+    txn_data: &TxnMetadata,
+) -> Result<(), PrologueFailure> {
+    let args = PrologueArgs::V1 {
+        needs_fee_payer_auth_check: txn_data.fee_payer.is_some(),
+        txn_sender_public_key: txn_data.sender_auth_key.clone(),
+        fee_payer_public_key_hash: txn_data.fee_payer_auth_key.clone(),
+        replay_protector: txn_data.replay_protector,
+        secondary_signer_addresses: txn_data.secondary_signers.clone(),
+        secondary_signer_public_key_hashes: txn_data.secondary_auth_keys.clone(),
+        txn_gas_price: txn_data.gas_unit_price,
+        txn_max_gas_units: txn_data.max_gas_amount,
+        txn_expiration_time: txn_data.expiration_timestamp_secs,
+        chain_id: txn_data.chain_id,
+        is_simulation: false,
+        // TODO(completeness): transaction limits requests (staking multipliers).
+        txn_limits_request: None,
+    };
+    let status = call_validation_function(guard, interp, VERSIONED_PROLOGUE, signers, &args)
+        .map_err(|err| PrologueFailure::Unexpected(err.to_string()))?;
+
+    match status {
+        CallStatus::Success => Ok(()),
+        CallStatus::Abort { code, message } => Err(PrologueFailure::Abort { code, message }),
+    }
+}
+
+pub(crate) fn run_epilogue(
+    interp: &mut InterpreterContext<'_>,
+    guard: &ExecutionGuard<'_>,
+    signers: &[[u8; AccountAddress::LENGTH]; 2],
+    txn_data: &TxnMetadata,
+    fee_statement: FeeStatement,
+    gas_units_remaining: u64,
+) -> Result<(), EpilogueFailure> {
+    let args = EpilogueArgs::V1 {
+        fee_statement,
+        txn_gas_price: txn_data.gas_unit_price,
+        txn_max_gas_units: txn_data.max_gas_amount,
+        gas_units_remaining,
+        is_simulation: false,
+        is_orderless_txn: txn_data.is_orderless(),
+    };
+    let status = call_validation_function(guard, interp, VERSIONED_EPILOGUE, signers, &args)
+        .map_err(EpilogueFailure::Internal)?;
+
+    match status {
+        CallStatus::Success => Ok(()),
+        CallStatus::Abort { code, message } => Err(EpilogueFailure::Abort { code, message }),
+    }
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -8,6 +8,11 @@
 //! Gas amounts intentionally differ between the two VMs, so writes that embed
 //! the fee (the fee payer's fungible store, the APT supply) and fee events are
 //! allowed to differ in *content*; everything else must match byte-for-byte.
+//
+// TODO(testing): revisit once the executor is more mature/wired up. See if we
+// want to switch to other payloads that are less gas-dependent, or get this
+// covered by other tests, such as the e2e move tests. Note that the sender's
+// store is masked, so a wrong debit there is not caught.
 
 use aptos_language_e2e_tests::executor::FakeExecutor;
 use aptos_types::{

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -206,21 +206,28 @@ fn p2p_transfer_insufficient_balance_aborts_like_v1() {
         .sign();
 
     let v1_output = fx.execute_transaction(txn.clone());
-    let TransactionStatus::Keep(ExecutionStatus::MoveAbort { code: v1_code, .. }) =
-        v1_output.status()
+    let TransactionStatus::Keep(ExecutionStatus::MoveAbort {
+        code: v1_code,
+        location: v1_location,
+        ..
+    }) = v1_output.status()
     else {
         panic!("v1 did not abort: {:?}", v1_output.status());
     };
 
     let v2_output = execute_v2(fx.get_state_view(), &txn);
-    // TODO(correctness): compare the abort location and info once MonoMove
-    // aborts carry their module.
-    let TransactionStatus::Keep(ExecutionStatus::MoveAbort { code: v2_code, .. }) =
-        v2_output.status()
+    // TODO(correctness): compare the abort info too, once the executor resolves
+    // it from the aborting module's metadata the way the legacy VM does.
+    let TransactionStatus::Keep(ExecutionStatus::MoveAbort {
+        code: v2_code,
+        location: v2_location,
+        ..
+    }) = v2_output.status()
     else {
         panic!("v2 did not abort: {:?}", v2_output.status());
     };
     assert_eq!(v1_code, v2_code, "abort codes differ");
+    assert_eq!(v1_location, v2_location, "abort locations differ");
 
     compare_outputs(&v1_output, &v2_output, *alice.address());
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -1,0 +1,381 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! End-to-end differential test: a p2p transfer executed by the legacy
+//! AptosVM (via `FakeExecutor`) and by the MonoMove-backed transaction
+//! executor against the same starting state.
+//!
+//! Gas amounts intentionally differ between the two VMs, so writes that embed
+//! the fee (the fee payer's fungible store, the APT supply) and fee events are
+//! allowed to differ in *content*; everything else must match byte-for-byte.
+
+use aptos_language_e2e_tests::executor::FakeExecutor;
+use aptos_types::{
+    on_chain_config::{Features, OnChainConfig},
+    state_store::StateView,
+    transaction::{
+        ExecutionStatus, SignedTransaction, TransactionAuxiliaryData, TransactionOutput,
+        TransactionStatus,
+    },
+};
+use mono_move_aptos_state_view_providers::{
+    StateViewModuleProvider, StateViewResourceProvider, DEFAULT_RESOURCE_ARENA_BYTES,
+};
+use mono_move_aptos_transaction_executor::{production_natives, AptosTransactionExecutor};
+use mono_move_global_context::GlobalContext;
+use std::collections::BTreeMap;
+
+/// Event types whose payload embeds gas amounts.
+const GAS_DEPENDENT_EVENTS: &[&str] = &[
+    "0x1::transaction_fee::FeeStatement",
+    "0x1::fungible_asset::Withdraw",
+    "0x1::coin::CoinWithdraw",
+];
+
+/// Runs one transaction through the MonoMove executor against `state`,
+/// materialized into the legacy output formats.
+fn execute_v2<S: StateView>(state: &S, txn: &SignedTransaction) -> TransactionOutput {
+    let global_ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = global_ctx
+        .try_execution_context(0)
+        .expect("execution context is available");
+    let natives = production_natives(&guard);
+    let module_provider = StateViewModuleProvider::new(state);
+    let data_provider = StateViewResourceProvider::new(&guard, state, DEFAULT_RESOURCE_ARENA_BYTES);
+    let features = Features::fetch_config(state)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let usage = state.get_usage().expect("usage is readable");
+    let executor = AptosTransactionExecutor::new(
+        &guard,
+        &natives,
+        &module_provider,
+        &data_provider,
+        &features,
+        usage,
+    );
+    executor
+        .execute_user_transaction(txn)
+        .materialize(
+            &guard,
+            &data_provider,
+            &features,
+            TransactionAuxiliaryData::default(),
+        )
+        .expect("the transaction output materializes")
+}
+
+#[test]
+fn p2p_transfer_matches_v1() {
+    let mut fx = FakeExecutor::from_head_genesis();
+    let alice = fx.create_raw_account_data(1_000_000_000, 10);
+    fx.add_account_data(&alice);
+    let bob = fx.create_raw_account_data(100_000_000, 0);
+    fx.add_account_data(&bob);
+
+    let txn = alice
+        .account()
+        .transaction()
+        .payload(aptos_cached_packages::aptos_stdlib::aptos_account_transfer(
+            *bob.address(),
+            1_000,
+        ))
+        .sequence_number(10)
+        .gas_unit_price(100)
+        .max_gas_amount(1_000_000)
+        .sign();
+
+    // V1 (reference), on the starting state.
+    let v1_output = fx.execute_transaction(txn.clone());
+    assert_eq!(
+        v1_output.status(),
+        &TransactionStatus::Keep(ExecutionStatus::Success),
+        "v1 rejected the transfer: {:?}",
+        v1_output.status()
+    );
+
+    // V2, on the same starting state.
+    let v2_output = execute_v2(fx.get_state_view(), &txn);
+    assert_eq!(
+        v2_output.status(),
+        &TransactionStatus::Keep(ExecutionStatus::Success),
+        "v2 failed the transfer"
+    );
+
+    compare_outputs(&v1_output, &v2_output, *alice.address());
+}
+
+/// Compares the two outputs' write sets and events, masking only what gas
+/// divergence explains.
+fn compare_outputs(
+    v1: &TransactionOutput,
+    v2: &TransactionOutput,
+    fee_payer: move_core_types::account_address::AccountAddress,
+) {
+    let v1_writes: BTreeMap<_, _> = v1.write_set().write_op_iter().collect();
+    let v2_writes: BTreeMap<_, _> = v2.write_set().write_op_iter().collect();
+
+    let v1_keys: Vec<_> = v1_writes.keys().collect();
+    let v2_keys: Vec<_> = v2_writes.keys().collect();
+    assert_eq!(
+        v1_keys, v2_keys,
+        "the two VMs wrote different sets of state keys"
+    );
+
+    // The only slots allowed to differ are the two that embed the fee: the
+    // fee payer's primary store (its object group) and the APT metadata
+    // object at 0xa (supply).
+    let gas_dependent = gas_dependent_keys(fee_payer);
+    let mut unexplained = vec![];
+    let mut num_diffs = 0;
+    for (key, v1_op) in &v1_writes {
+        let v2_op = &v2_writes[*key];
+        if v1_op.bytes() == v2_op.bytes() {
+            continue;
+        }
+        num_diffs += 1;
+        if !gas_dependent.contains(key) {
+            unexplained.push(format!(
+                "{key:?}:\n  v1: {:?}\n  v2: {:?}",
+                v1_op.bytes(),
+                v2_op.bytes()
+            ));
+        }
+    }
+    assert!(
+        unexplained.is_empty(),
+        "writes differ beyond gas-dependent slots:\n{}",
+        unexplained.join("\n")
+    );
+    // Both VMs must actually have charged a fee (otherwise the mask above is
+    // vacuous and something upstream is broken).
+    assert!(
+        num_diffs >= 1,
+        "no write differed; was a fee charged at all?"
+    );
+    assert!(v1.gas_used() > 0, "v1 charged no gas");
+    assert!(v2.gas_used() > 0, "v2 charged no gas");
+
+    // Events: same sequence of types; payloads equal except gas-dependent ones.
+    let v1_events = v1.events();
+    let v2_events = v2.events();
+    let v1_types: Vec<_> = v1_events
+        .iter()
+        .map(|e| format!("{:?}", e.type_tag()))
+        .collect();
+    let v2_types: Vec<_> = v2_events
+        .iter()
+        .map(|e| format!("{:?}", e.type_tag()))
+        .collect();
+    assert_eq!(v1_types, v2_types, "event sequences differ");
+    for (e1, e2) in v1_events.iter().zip(v2_events) {
+        let ty = e1.type_tag().to_canonical_string();
+        if GAS_DEPENDENT_EVENTS.contains(&ty.as_str()) {
+            continue;
+        }
+        assert_eq!(
+            e1.event_data(),
+            e2.event_data(),
+            "event payload differs for {ty}"
+        );
+    }
+}
+
+/// A transfer exceeding the sender's balance: the payload aborts inside
+/// `0x1::fungible_asset`, the payload's effects roll back, and the failure
+/// epilogue still charges the fee and bumps the sequence number.
+#[test]
+fn p2p_transfer_insufficient_balance_aborts_like_v1() {
+    let mut fx = FakeExecutor::from_head_genesis();
+    let alice = fx.create_raw_account_data(1_000_000_000, 10);
+    fx.add_account_data(&alice);
+    let bob = fx.create_raw_account_data(100_000_000, 0);
+    fx.add_account_data(&bob);
+
+    let txn = alice
+        .account()
+        .transaction()
+        .payload(aptos_cached_packages::aptos_stdlib::aptos_account_transfer(
+            *bob.address(),
+            u64::MAX,
+        ))
+        .sequence_number(10)
+        .gas_unit_price(100)
+        .max_gas_amount(1_000_000)
+        .sign();
+
+    let v1_output = fx.execute_transaction(txn.clone());
+    let TransactionStatus::Keep(ExecutionStatus::MoveAbort { code: v1_code, .. }) =
+        v1_output.status()
+    else {
+        panic!("v1 did not abort: {:?}", v1_output.status());
+    };
+
+    let v2_output = execute_v2(fx.get_state_view(), &txn);
+    // TODO(correctness): compare the abort location and info once MonoMove
+    // aborts carry their module.
+    let TransactionStatus::Keep(ExecutionStatus::MoveAbort { code: v2_code, .. }) =
+        v2_output.status()
+    else {
+        panic!("v2 did not abort: {:?}", v2_output.status());
+    };
+    assert_eq!(v1_code, v2_code, "abort codes differ");
+
+    compare_outputs(&v1_output, &v2_output, *alice.address());
+}
+
+/// A transfer that drains the fee payer's entire balance: the payload
+/// succeeds, but the success epilogue cannot collect the fee, so the payload
+/// rolls back and the fee is charged from the restored balance. The
+/// transaction is kept as the can't-pay-fee abort, matching the legacy VM's
+/// failure cleanup — including the abort location.
+#[test]
+fn p2p_transfer_draining_fee_payer_aborts_like_v1() {
+    let mut fx = FakeExecutor::from_head_genesis();
+    let alice = fx.create_raw_account_data(1_000_000_000, 10);
+    fx.add_account_data(&alice);
+    let bob = fx.create_raw_account_data(100_000_000, 0);
+    fx.add_account_data(&bob);
+
+    // Send the entire balance: nothing is left for the fee at epilogue time.
+    let txn = alice
+        .account()
+        .transaction()
+        .payload(aptos_cached_packages::aptos_stdlib::aptos_account_transfer(
+            *bob.address(),
+            1_000_000_000,
+        ))
+        .sequence_number(10)
+        .gas_unit_price(100)
+        .max_gas_amount(1_000_000)
+        .sign();
+
+    let v1_output = fx.execute_transaction(txn.clone());
+    let TransactionStatus::Keep(ExecutionStatus::MoveAbort {
+        code: v1_code,
+        location: v1_location,
+        ..
+    }) = v1_output.status()
+    else {
+        panic!("v1 did not abort: {:?}", v1_output.status());
+    };
+
+    let v2_output = execute_v2(fx.get_state_view(), &txn);
+    let TransactionStatus::Keep(ExecutionStatus::MoveAbort {
+        code: v2_code,
+        location: v2_location,
+        ..
+    }) = v2_output.status()
+    else {
+        panic!("v2 did not abort: {:?}", v2_output.status());
+    };
+    assert_eq!(v1_code, v2_code, "abort codes differ");
+    assert_eq!(v1_location, v2_location, "abort locations differ");
+
+    compare_outputs(&v1_output, &v2_output, *alice.address());
+}
+
+/// A nonexistent entry function: kept (and charged) on both VMs, because the
+/// function-values feature makes a missing function runtime-reachable. This
+/// exercises the kept non-abort payload failure path: rollback plus failure
+/// epilogue.
+#[test]
+fn nonexistent_entry_function_kept_like_v1() {
+    use aptos_types::transaction::{EntryFunction, TransactionPayload};
+    use move_core_types::{ident_str, language_storage::ModuleId};
+
+    let mut fx = FakeExecutor::from_head_genesis();
+    let alice = fx.create_raw_account_data(1_000_000_000, 10);
+    fx.add_account_data(&alice);
+
+    let txn = alice
+        .account()
+        .transaction()
+        .payload(TransactionPayload::EntryFunction(EntryFunction::new(
+            ModuleId::new(
+                move_core_types::account_address::AccountAddress::ONE,
+                ident_str!("coin").to_owned(),
+            ),
+            ident_str!("no_such_function").to_owned(),
+            vec![],
+            vec![],
+        )))
+        .sequence_number(10)
+        .gas_unit_price(100)
+        .max_gas_amount(1_000_000)
+        .sign();
+
+    let v1_output = fx.execute_transaction(txn.clone());
+    assert!(
+        matches!(
+            v1_output.status(),
+            TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(_))
+        ),
+        "v1 did not keep as a miscellaneous error: {:?}",
+        v1_output.status()
+    );
+
+    let v2_output = execute_v2(fx.get_state_view(), &txn);
+    assert_eq!(v1_output.status(), v2_output.status());
+
+    compare_outputs(&v1_output, &v2_output, *alice.address());
+}
+
+/// Two dependent transfers executed sequentially, each transaction's outputs
+/// applied to the state before the next: the second transaction's prologue
+/// only passes if it observes the first one's sequence-number bump.
+#[test]
+fn sequential_execution_applies_outputs() {
+    use aptos_transaction_simulation::{DeltaStateStore, SimulationStateStore};
+
+    let mut fx = FakeExecutor::from_head_genesis();
+    let alice = fx.create_raw_account_data(1_000_000_000, 10);
+    fx.add_account_data(&alice);
+    let bob = fx.create_raw_account_data(100_000_000, 0);
+    fx.add_account_data(&bob);
+
+    let transfer = |seq| {
+        alice
+            .account()
+            .transaction()
+            .payload(aptos_cached_packages::aptos_stdlib::aptos_account_transfer(
+                *bob.address(),
+                1_000,
+            ))
+            .sequence_number(seq)
+            .gas_unit_price(100)
+            .max_gas_amount(1_000_000)
+            .sign()
+    };
+
+    let state = DeltaStateStore::new_with_base(fx.get_state_view());
+    for (i, txn) in [transfer(10), transfer(11)].iter().enumerate() {
+        let output = execute_v2(&state, txn);
+        assert_eq!(
+            output.status(),
+            &TransactionStatus::Keep(ExecutionStatus::Success),
+            "transaction {i} failed"
+        );
+        state
+            .apply_write_set(output.write_set())
+            .expect("write set applies");
+    }
+}
+
+/// The state keys whose content embeds the transaction fee: the fee payer's
+/// primary fungible store group and the APT metadata object group (supply).
+fn gas_dependent_keys(
+    fee_payer: move_core_types::account_address::AccountAddress,
+) -> Vec<aptos_types::state_store::state_key::StateKey> {
+    use aptos_types::state_store::state_key::StateKey;
+    use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
+    use std::str::FromStr;
+
+    let object_group = StructTag::from_str("0x1::object::ObjectGroup").unwrap();
+    let store = aptos_types::account_config::fungible_store::primary_apt_store(fee_payer);
+    vec![
+        StateKey::resource_group(&store, &object_group),
+        StateKey::resource_group(&AccountAddress::TEN, &object_group),
+    ]
+}

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -48,8 +48,8 @@ pub use object_descriptor::{
     CLOSURE_DESCRIPTOR_ID, RESERVED_DESCRIPTOR_COUNT, TRIVIAL_DESCRIPTOR_ID,
 };
 pub use prepared_module::{
-    intern_sig_token, FieldTypes, FunctionInstantiationSignature, FunctionSignature,
-    PreparedModule, PreparedModuleError,
+    intern_sig_token, intern_struct_tag, intern_type_tag, FieldTypes,
+    FunctionInstantiationSignature, FunctionSignature, PreparedModule, PreparedModuleError,
 };
 pub use root_pool::{ObjectHandle, ReferenceHandle, RootPool};
 pub use storage::{

--- a/third_party/move/mono-move/core/src/prepared_module.rs
+++ b/third_party/move/mono-move/core/src/prepared_module.rs
@@ -18,6 +18,7 @@ use move_binary_format::{
     },
     CompiledModule,
 };
+use move_core_types::language_storage::{FunctionParamOrReturnTag, StructTag, TypeTag};
 use shared_dsa::UnorderedMap;
 use std::ops::Deref;
 use thiserror::Error;
@@ -488,6 +489,78 @@ pub fn intern_sig_token(
             interner.nominal_of(module_id, struct_name, interner.type_list_of(&ty_args))
         },
     }
+}
+
+/// Interns a runtime [`TypeTag`] (e.g. a transaction's type argument, or a
+/// resource's struct tag).
+//
+// TODO(metering): decide if this construction requires metering.
+pub fn intern_type_tag(tag: &TypeTag, interner: &impl Interner) -> anyhow::Result<InternedType> {
+    use crate::types as ty;
+    Ok(match tag {
+        TypeTag::Bool => ty::BOOL_TY,
+        TypeTag::U8 => ty::U8_TY,
+        TypeTag::U16 => ty::U16_TY,
+        TypeTag::U32 => ty::U32_TY,
+        TypeTag::U64 => ty::U64_TY,
+        TypeTag::U128 => ty::U128_TY,
+        TypeTag::U256 => ty::U256_TY,
+        TypeTag::I8 => ty::I8_TY,
+        TypeTag::I16 => ty::I16_TY,
+        TypeTag::I32 => ty::I32_TY,
+        TypeTag::I64 => ty::I64_TY,
+        TypeTag::I128 => ty::I128_TY,
+        TypeTag::I256 => ty::I256_TY,
+        TypeTag::Address => ty::ADDRESS_TY,
+        TypeTag::Signer => ty::SIGNER_TY,
+        TypeTag::Vector(elem) => interner.vector_of(intern_type_tag(elem, interner)?),
+        TypeTag::Struct(struct_tag) => intern_struct_tag(struct_tag, interner)?,
+        TypeTag::Function(function_tag) => {
+            let args = intern_function_param_tags(&function_tag.args, interner)?;
+            let results = intern_function_param_tags(&function_tag.results, interner)?;
+            interner.function_of(
+                interner.type_list_of(&args),
+                interner.type_list_of(&results),
+                function_tag.abilities,
+            )
+        },
+    })
+}
+
+/// Interns a function tag's parameter or return tags, applying each one's
+/// reference kind.
+fn intern_function_param_tags(
+    tags: &[FunctionParamOrReturnTag],
+    interner: &impl Interner,
+) -> anyhow::Result<Vec<InternedType>> {
+    tags.iter()
+        .map(|tag| {
+            Ok(match tag {
+                FunctionParamOrReturnTag::Value(tag) => intern_type_tag(tag, interner)?,
+                FunctionParamOrReturnTag::Reference(tag) => {
+                    interner.immut_ref_of(intern_type_tag(tag, interner)?)
+                },
+                FunctionParamOrReturnTag::MutableReference(tag) => {
+                    interner.mut_ref_of(intern_type_tag(tag, interner)?)
+                },
+            })
+        })
+        .collect()
+}
+
+/// Interns a struct tag into its nominal type.
+pub fn intern_struct_tag(
+    struct_tag: &StructTag,
+    interner: &impl Interner,
+) -> anyhow::Result<InternedType> {
+    let module_id = interner.module_id_of(&struct_tag.address, struct_tag.module.as_ident_str());
+    let name = interner.identifier_of(struct_tag.name.as_ident_str());
+    let args = struct_tag
+        .type_args
+        .iter()
+        .map(|arg| intern_type_tag(arg, interner))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(interner.nominal_of(module_id, name, interner.type_list_of(&args)))
 }
 
 fn intern_struct_info(

--- a/third_party/move/mono-move/core/src/storage/resource_provider.rs
+++ b/third_party/move/mono-move/core/src/storage/resource_provider.rs
@@ -74,6 +74,14 @@ impl InMemoryStorageKey {
             InMemoryStorageKey::TableItem { handle, .. } => handle.address(),
         }
     }
+
+    /// The type of the value stored at this key.
+    pub fn value_ty(&self) -> InternedType {
+        match self {
+            InMemoryStorageKey::Resource { ty, .. } => *ty,
+            InMemoryStorageKey::TableItem { value_ty, .. } => *value_ty,
+        }
+    }
 }
 
 impl From<&InMemoryStorageKey> for InMemoryStorageKey {

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -575,6 +575,15 @@ impl<'ctx> ExecutionGuard<'ctx> {
             })
     }
 
+    /// The struct-object descriptor already published for `struct_ty`, if any.
+    pub fn struct_descriptor(&self, struct_ty: InternedType) -> Option<DescriptorId> {
+        self.ctx
+            .descriptors
+            .struct_by_ty
+            .get(&struct_ty)
+            .map(|id| *id)
+    }
+
     /// Materializes a struct-object descriptor for `struct_ty` (the inline
     /// resource laid out as a heap object) into the shared arena and returns
     /// its assigned [`DescriptorId`]. Idempotent: subsequent calls with the

--- a/third_party/move/mono-move/runtime/src/global_storage.rs
+++ b/third_party/move/mono-move/runtime/src/global_storage.rs
@@ -106,7 +106,7 @@ pub struct Entry {
 
 /// The write an [`Entry`] contributes to the write set, by its `(read, write)`
 /// pair.
-pub(crate) enum WriteClass {
+pub enum WriteClass {
     /// Did not exist before, now does. Carries the value pointer to serialize.
     Creation(NonNull<u8>),
     /// Existed before, now (possibly) modified — any mutable borrow counts,
@@ -145,7 +145,7 @@ impl Entry {
 
     /// Classifies this entry's `(read, write)` into a [`WriteClass`], or
     /// [`None`] if it is not a write.
-    pub(crate) fn write_class(&self) -> Option<WriteClass> {
+    pub fn write_class(&self) -> Option<WriteClass> {
         match self.write {
             StorageWrite::NotModified => None,
             StorageWrite::LocalHeap { ptr, .. } => Some(match self.read {
@@ -409,7 +409,7 @@ impl ResourceReadWriteSet {
 
     /// Yields each entry that is a write, with its [`WriteClass`]. Order is
     /// unspecified (backing hash map); callers must sort before emitting.
-    pub(crate) fn writes(&self) -> impl Iterator<Item = (&InMemoryStorageKey, WriteClass)> {
+    pub fn writes(&self) -> impl Iterator<Item = (&InMemoryStorageKey, WriteClass)> {
         self.entries
             .iter()
             .filter_map(|(key, entry)| entry.write_class().map(|class| (key, class)))

--- a/third_party/move/mono-move/runtime/src/global_storage.rs
+++ b/third_party/move/mono-move/runtime/src/global_storage.rs
@@ -407,9 +407,9 @@ impl ResourceReadWriteSet {
         self.journal.len()
     }
 
-    /// Yields each entry that is a write, with its [`WriteClass`]. Order is
-    /// unspecified (backing hash map); callers must sort before emitting.
-    pub fn writes(&self) -> impl Iterator<Item = (&InMemoryStorageKey, WriteClass)> {
+    /// Yields each entry that is a write, with its [`WriteClass`]. Callers must
+    /// sort before emitting.
+    pub fn writes_unordered(&self) -> impl Iterator<Item = (&InMemoryStorageKey, WriteClass)> {
         self.entries
             .iter()
             .filter_map(|(key, entry)| entry.write_class().map(|class| (key, class)))

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -81,12 +81,10 @@ impl VMRegisters {
     const IDLE_PC: usize = usize::MAX;
 
     /// Registers initialized with a fresh root frame, ready to begin execution.
-    fn new(stack_base: *mut u8, func: &Function) -> Self {
+    fn new(stack: &MemoryRegion, func: &Function) -> Self {
         Self {
             pc: 0,
-            // SAFETY: `stack_base` points to a stack allocation far larger than
-            // `FRAME_METADATA_SIZE`, so the offset stays in bounds.
-            fp: unsafe { stack_base.add(FRAME_METADATA_SIZE) },
+            fp: root_frame_base(stack),
             func: NonNull::from(func),
         }
     }
@@ -97,12 +95,10 @@ impl VMRegisters {
     // TODO(cleanup): `func` has no value until the first call, so this hands
     // out a dangling pointer and leans on `is_idle` instead of the `NonNull`
     // invariant. Look for ways to get rid of this workaround in the future.
-    fn idle(stack_base: *mut u8) -> Self {
+    fn idle(stack: &MemoryRegion) -> Self {
         Self {
             pc: Self::IDLE_PC,
-            // SAFETY: `stack_base` points to a stack allocation far larger than
-            // `FRAME_METADATA_SIZE`, so the offset stays in bounds.
-            fp: unsafe { stack_base.add(FRAME_METADATA_SIZE) },
+            fp: root_frame_base(stack),
             func: NonNull::dangling(),
         }
     }
@@ -110,6 +106,17 @@ impl VMRegisters {
     fn is_idle(&self) -> bool {
         self.pc == Self::IDLE_PC
     }
+}
+
+/// Frame pointer of the root call frame, which sits above the stack's sentinel
+/// frame metadata.
+fn root_frame_base(stack: &MemoryRegion) -> *mut u8 {
+    assert!(
+        stack.len() > FRAME_METADATA_SIZE,
+        "stack is too small to hold a root frame"
+    );
+    // SAFETY: the offset is within `stack`, checked above.
+    unsafe { stack.as_ptr().add(FRAME_METADATA_SIZE) }
 }
 
 /// What a finished transaction leaves behind: the frozen heap, the
@@ -252,7 +259,7 @@ impl<'guard> InterpreterContext<'guard> {
             natives,
             extensions: NativeExtensions::new(),
             resource_provider,
-            registers: VMRegisters::new(base, entry),
+            registers: VMRegisters::new(&stack, entry),
             stack,
             heap: Heap::new(heap_size),
             root_pool: RootPool::new(),
@@ -286,7 +293,7 @@ impl<'guard> InterpreterContext<'guard> {
             natives,
             extensions: NativeExtensions::new(),
             resource_provider,
-            registers: VMRegisters::idle(base),
+            registers: VMRegisters::idle(&stack),
             stack,
             heap: Heap::new(DEFAULT_HEAP_SIZE),
             root_pool: RootPool::new(),
@@ -432,7 +439,7 @@ impl<'guard> InterpreterContext<'guard> {
         let base = self.stack.as_ptr();
 
         // Reset execution state to root frame.
-        self.registers = VMRegisters::new(base, func);
+        self.registers = VMRegisters::new(&self.stack, func);
 
         // Re-write sentinel metadata so Return from root triggers Done.
         unsafe {

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -93,6 +93,10 @@ impl VMRegisters {
 
     /// Registers of an idle context; [`Self::new`] via `prepare_call` must run
     /// before execution.
+    //
+    // TODO(cleanup): `func` has no value until the first call, so this hands
+    // out a dangling pointer and leans on `is_idle` instead of the `NonNull`
+    // invariant. Look for ways to get rid of this workaround in the future.
     fn idle(stack_base: *mut u8) -> Self {
         Self {
             pc: Self::IDLE_PC,

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -75,6 +75,11 @@ pub(crate) struct VMRegisters {
 }
 
 impl VMRegisters {
+    /// Sentinel `pc` marking a context with no function installed yet.
+    /// Guarded at every entry point that would touch the registers, so the
+    /// dangling function pointer is never dereferenced.
+    const IDLE_PC: usize = usize::MAX;
+
     /// Registers initialized with a fresh root frame, ready to begin execution.
     fn new(stack_base: *mut u8, func: &Function) -> Self {
         Self {
@@ -84,6 +89,22 @@ impl VMRegisters {
             fp: unsafe { stack_base.add(FRAME_METADATA_SIZE) },
             func: NonNull::from(func),
         }
+    }
+
+    /// Registers of an idle context; [`Self::new`] via `prepare_call` must run
+    /// before execution.
+    fn idle(stack_base: *mut u8) -> Self {
+        Self {
+            pc: Self::IDLE_PC,
+            // SAFETY: `stack_base` points to a stack allocation far larger than
+            // `FRAME_METADATA_SIZE`, so the offset stays in bounds.
+            fp: unsafe { stack_base.add(FRAME_METADATA_SIZE) },
+            func: NonNull::dangling(),
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        self.pc == Self::IDLE_PC
     }
 }
 
@@ -123,7 +144,7 @@ fn abort_location(module_id: InternedModuleId) -> VMResult<AbortLocation> {
 /// Per-transaction interpreter context with a unified call stack and a
 /// GC-managed heap: owns the transaction state (code loader and read-set, gas
 /// meter, native extensions, resource read-write set) and the machine state
-/// (stack, heap, VM registers). Interpreter sessions are [`Self::invoke`] /
+/// (stack, heap, VM registers). Interpreter sessions are [`Self::prepare_call`] /
 /// [`Self::reset`] calls on the same context, so state like the heap and the
 /// read-write set lives across sessions within one transaction.
 ///
@@ -230,6 +251,40 @@ impl<'guard> InterpreterContext<'guard> {
             registers: VMRegisters::new(base, entry),
             stack,
             heap: Heap::new(heap_size),
+            root_pool: RootPool::new(),
+            read_write_set: ResourceReadWriteSet::new(),
+            rng: StdRng::seed_from_u64(0),
+        }
+    }
+
+    /// Creates a context with no function installed and an empty read-set:
+    /// for drivers that resolve their first function through the context
+    /// itself. [`prepare_call`](Self::prepare_call) must run before execution.
+    pub fn new_idle(
+        loader: Loader<'guard, 'guard>,
+        gas_meter: GasMeter,
+        resource_provider: &'guard dyn ResourceProvider,
+        natives: &'guard ProductionNativeRegistry,
+    ) -> Self {
+        let stack = MemoryRegion::new(DEFAULT_STACK_SIZE);
+        let base = stack.as_ptr();
+
+        unsafe {
+            write_u64(base, META_SAVED_PC_OFFSET, 0);
+            write_u64(base, META_SAVED_FP_OFFSET, 0);
+            write_ptr(base, META_SAVED_FUNC_PTR_OFFSET, null());
+        }
+
+        Self {
+            loader,
+            read_set: ModuleReadSet::new(),
+            gas_meter,
+            natives,
+            extensions: NativeExtensions::new(),
+            resource_provider,
+            registers: VMRegisters::idle(base),
+            stack,
+            heap: Heap::new(DEFAULT_HEAP_SIZE),
             root_pool: RootPool::new(),
             read_write_set: ResourceReadWriteSet::new(),
             rng: StdRng::seed_from_u64(0),
@@ -355,10 +410,21 @@ impl<'guard> InterpreterContext<'guard> {
         crate::write_set::build_write_set(&self.read_write_set, self.loader.guard())
     }
 
+    /// Runs `f` with gas metering suspended: the meter is swapped for an
+    /// effectively unbounded one and restored afterwards, so loads and
+    /// execution inside `f` never touch the transaction's budget. Used for
+    /// system code (prologue, epilogue) that runs unmetered by design.
+    pub fn unmetered<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let saved = std::mem::replace(&mut self.gas_meter, GasMeter::with_max_budget());
+        let result = f(self);
+        self.gas_meter = saved;
+        result
+    }
+
     /// Reset the context to call a different function, preserving the heap.
     ///
     /// Use `set_root_arg` to place arguments before calling `run()`.
-    pub fn invoke(&mut self, func: &Function) {
+    pub fn prepare_call(&mut self, func: &Function) {
         let base = self.stack.as_ptr();
 
         // Reset execution state to root frame.
@@ -388,7 +454,7 @@ impl<'guard> InterpreterContext<'guard> {
     /// stack and heap buffers instead of reallocating them. Place arguments with
     /// [`set_root_arg`](Self::set_root_arg) before calling [`run`](Self::run).
     pub fn reset(&mut self, func: &Function, gas_budget: u64) {
-        self.invoke(func);
+        self.prepare_call(func);
         self.heap.reset();
         self.read_write_set = ResourceReadWriteSet::new();
         self.root_pool = RootPool::new();
@@ -495,6 +561,11 @@ impl<'guard> InterpreterContext<'guard> {
     /// as a `u64` suitable for embedding in args. Useful for passing pre-built
     /// data into a program without generating initialization micro-ops.
     pub fn alloc_u64_vec(&mut self, descriptor_id: DescriptorId, values: &[u64]) -> VMResult<u64> {
+        if self.registers.is_idle() {
+            invariant_violation!(Unreachable(
+                "allocation on an idle context: no call was prepared".to_string()
+            ));
+        }
         let n = values.len() as u64;
         let ptr = alloc_vec!(
             self,
@@ -1085,6 +1156,12 @@ impl InterpreterContext<'_> {
     }
 
     pub fn run(&mut self) -> VMResult<RuntimeStatus> {
+        if self.registers.is_idle() {
+            invariant_violation!(Unreachable(
+                "run on an idle context: no call was prepared".to_string()
+            ));
+        }
+
         // Hoist the VM registers into a local so the dispatch loop keeps
         // them in CPU registers rather than reloading from `self.registers`
         // each iteration. Only sync back to `self` on exit.

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -538,6 +538,25 @@ impl<'guard> InterpreterContext<'guard> {
         }
     }
 
+    /// Place a reference to `target` in the root frame at the given byte offset.
+    ///
+    /// # Safety
+    ///
+    /// `target` must stay valid and pinned until the call finishes. Pointing
+    /// outside the VM heap also keeps it away from the GC.
+    pub unsafe fn set_root_ref_arg(&mut self, offset: u32, target: *const u8) {
+        // SAFETY: the offset is a parameter slot of the root frame, so it is
+        // within the stack and wide enough for a reference.
+        unsafe {
+            write_fat_ptr(
+                self.stack.as_ptr(),
+                FRAME_METADATA_SIZE + offset as usize,
+                target,
+                0,
+            )
+        };
+    }
+
     /// Read a raw heap pointer from the root frame at the given byte offset.
     pub fn root_heap_ptr(&self, offset: u32) -> *const u8 {
         unsafe { read_ptr(self.stack.as_ptr(), FRAME_METADATA_SIZE + offset as usize) }

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -15,7 +15,7 @@ mod verifier;
 mod write_set;
 
 pub use error::{RuntimeError, RuntimeStatus};
-pub use global_storage::ResourceReadWriteSet;
+pub use global_storage::{ResourceReadWriteSet, WriteClass};
 pub use heap::Heap;
 pub use interpreter::{InterpreterContext, SessionEffects};
 pub use memory::{
@@ -30,3 +30,4 @@ pub use native_context::{
 pub use types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
 pub use value_utils::{deserialize_into, serialize};
 pub use verifier::{verify_function, verify_program, VerificationError};
+pub use write_set::serialize_value;

--- a/third_party/move/mono-move/runtime/src/write_set.rs
+++ b/third_party/move/mono-move/runtime/src/write_set.rs
@@ -37,7 +37,7 @@ pub(crate) fn build_write_set<L: LayoutProvider + ?Sized>(
     layouts: &L,
 ) -> VMResult<WriteSet> {
     let mut writes = Vec::new();
-    for (key, class) in rws.writes() {
+    for (key, class) in rws.writes_unordered() {
         let state_key = state_key_of(key)?;
         // TODO(correctness): these are metadata-less legacy write ops; we need to set the
         // `StateValueMetadata` (slot deposit / refund) carried over from the pre-state.

--- a/third_party/move/mono-move/runtime/src/write_set.rs
+++ b/third_party/move/mono-move/runtime/src/write_set.rs
@@ -43,10 +43,17 @@ pub(crate) fn build_write_set<L: LayoutProvider + ?Sized>(
         // `StateValueMetadata` (slot deposit / refund) carried over from the pre-state.
         let op = match class {
             WriteClass::Creation(ptr) => {
-                WriteOp::legacy_creation(serialize_value(layouts, ptr, value_type(key))?.into())
+                WriteOp::legacy_creation(
+                    // SAFETY: `ptr` is the current value of a `LocalHeap` entry and no
+                    // GC runs during write-set generation.
+                    unsafe { serialize_value(layouts, ptr, value_type(key)) }?.into(),
+                )
             },
             WriteClass::Modification(ptr) => {
-                WriteOp::legacy_modification(serialize_value(layouts, ptr, value_type(key))?.into())
+                WriteOp::legacy_modification(
+                    // SAFETY: as above.
+                    unsafe { serialize_value(layouts, ptr, value_type(key)) }?.into(),
+                )
             },
             WriteClass::Deletion => WriteOp::legacy_deletion(),
         };
@@ -89,14 +96,16 @@ fn value_type(key: &InMemoryStorageKey) -> InternedType {
 }
 
 /// BCS-serializes the value at `ptr` of type `ty`.
-fn serialize_value<L: LayoutProvider + ?Sized>(
+///
+/// # Safety
+///
+/// `ptr` must be a fully initialized value of type `ty` in a live heap, and no
+/// GC may run for the duration of the call.
+pub unsafe fn serialize_value<L: LayoutProvider + ?Sized>(
     layouts: &L,
     ptr: NonNull<u8>,
     ty: InternedType,
 ) -> VMResult<Vec<u8>> {
-    // SAFETY: `ptr` is the current value of a `LocalHeap` entry — a fully
-    // initialized value of type `ty` living in this transaction's heap. The
-    // heap stays alive for the call and no GC runs during write-set
-    // generation, so the value (and everything it reaches) remains valid.
+    // SAFETY: forwarded from this function's contract.
     unsafe { value_utils::serialize(layouts, ptr.as_ptr(), ty) }
 }

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -156,6 +156,11 @@ pub fn canonical(category: u64, reason: u64) -> u64 {
     (category << 16) + reason
 }
 
+/// Split a canonical error code back into its category and reason.
+pub fn split_canonical(code: u64) -> (u64, u64) {
+    ((code >> 16) & 0xFF, code & 0xFFFF)
+}
+
 /// Functions to construct a canonical error code of the given category.
 pub fn invalid_argument(r: u64) -> u64 {
     canonical(INVALID_ARGUMENT, r)
@@ -192,4 +197,27 @@ pub fn not_implemented(r: u64) -> u64 {
 }
 pub fn unavailable(r: u64) -> u64 {
     canonical(UNAVAILABLE, r)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_canonical_inverts_canonical() {
+        for category in [INVALID_ARGUMENT, OUT_OF_RANGE, INVALID_STATE, UNAVAILABLE] {
+            for reason in [0, 1, 1005, 0xFFFF] {
+                assert_eq!(
+                    split_canonical(canonical(category, reason)),
+                    (category, reason)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn split_canonical_ignores_the_upper_bytes() {
+        // Compiler-generated codes carry a non-zero prefix above the category.
+        assert_eq!(split_canonical(0xFF_0002_03E9), (OUT_OF_RANGE, 1001));
+    }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -51,9 +51,11 @@ pub mod encrypted_payload;
 mod module;
 mod multisig;
 mod script;
+pub mod session_id;
 pub mod signature_verified_transaction;
 pub mod use_case;
 pub mod user_transaction_context;
+pub mod validation;
 pub mod webauthn;
 
 pub use self::block_epilogue::{
@@ -87,12 +89,14 @@ pub use script::{
     TypeArgumentABI,
 };
 use serde::de::DeserializeOwned;
+pub use session_id::SessionId;
 use std::{
     collections::BTreeSet,
     hash::Hash,
     ops::Deref,
     sync::{atomic::AtomicU64, Arc},
 };
+pub use validation::{EpilogueArgs, PrologueArgs};
 
 pub type Version = u64; // Height - also used for MVCC in StateDB
 pub type AtomicVersion = AtomicU64;
@@ -979,6 +983,17 @@ pub enum TransactionExtraConfig {
 }
 
 impl TransactionPayload {
+    /// The SHA3-256 hash of a script payload's code; empty for every other
+    /// payload kind.
+    pub fn script_hash(&self) -> Vec<u8> {
+        match self.executable_ref() {
+            Ok(TransactionExecutableRef::Script(script)) => {
+                HashValue::sha3_256_of(script.code()).to_vec()
+            },
+            _ => vec![],
+        }
+    }
+
     pub fn is_multisig(&self) -> bool {
         match self {
             TransactionPayload::EntryFunction(_) => false,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -990,7 +990,10 @@ impl TransactionPayload {
             Ok(TransactionExecutableRef::Script(script)) => {
                 HashValue::sha3_256_of(script.code()).to_vec()
             },
-            _ => vec![],
+            Ok(TransactionExecutableRef::EntryFunction(_))
+            | Ok(TransactionExecutableRef::Empty)
+            | Ok(TransactionExecutableRef::Encrypted)
+            | Err(_) => vec![],
         }
     }
 

--- a/types/src/transaction/session_id.rs
+++ b/types/src/transaction/session_id.rs
@@ -1,13 +1,18 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::transaction_metadata::TransactionMetadata;
-use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
-use aptos_types::{
+//! Identifies a VM session within a transaction.
+//!
+//! The BCS crypto-hash of a `SessionId` seeds unique-address (AUID) generation,
+//! so it is consensus-visible: neither the variant order nor the field layout
+//! may change.
+
+use crate::{
     block_metadata::BlockMetadata, block_metadata_ext::BlockMetadataExt,
     transaction::ReplayProtector, validator_txn::ValidatorTransaction,
 };
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
 
@@ -88,18 +93,23 @@ impl SessionId {
             .expect("HashValue should convert to [u8; 32]")
     }
 
-    pub fn txn_meta(txn_metadata: &TransactionMetadata) -> Self {
-        match txn_metadata.replay_protector() {
+    pub fn txn(
+        sender: AccountAddress,
+        replay_protector: ReplayProtector,
+        script_hash: Vec<u8>,
+        expiration_time: u64,
+    ) -> Self {
+        match replay_protector {
             ReplayProtector::SequenceNumber(sequence_number) => Self::Txn {
-                sender: txn_metadata.sender,
+                sender,
                 sequence_number,
-                script_hash: txn_metadata.script_hash.clone(),
+                script_hash,
             },
             ReplayProtector::Nonce(nonce) => Self::OrderlessTxn {
-                sender: txn_metadata.sender,
+                sender,
                 nonce,
-                expiration_time: txn_metadata.expiration_timestamp_secs,
-                script_hash: txn_metadata.script_hash.clone(),
+                expiration_time,
+                script_hash,
             },
         }
     }
@@ -124,50 +134,65 @@ impl SessionId {
         Self::BlockEpilogue { id }
     }
 
-    pub fn prologue_meta(txn_metadata: &TransactionMetadata) -> Self {
-        match txn_metadata.replay_protector() {
+    pub fn prologue(
+        sender: AccountAddress,
+        replay_protector: ReplayProtector,
+        script_hash: Vec<u8>,
+        expiration_time: u64,
+    ) -> Self {
+        match replay_protector {
             ReplayProtector::SequenceNumber(sequence_number) => Self::Prologue {
-                sender: txn_metadata.sender,
+                sender,
                 sequence_number,
-                script_hash: txn_metadata.script_hash.clone(),
+                script_hash,
             },
             ReplayProtector::Nonce(nonce) => Self::OrderlessTxnProlouge {
-                sender: txn_metadata.sender,
+                sender,
                 nonce,
-                expiration_time: txn_metadata.expiration_timestamp_secs,
-                script_hash: txn_metadata.script_hash.clone(),
+                expiration_time,
+                script_hash,
             },
         }
     }
 
-    pub fn run_on_abort(txn_metadata: &TransactionMetadata) -> Self {
-        match txn_metadata.replay_protector() {
+    pub fn run_on_abort(
+        sender: AccountAddress,
+        replay_protector: ReplayProtector,
+        script_hash: Vec<u8>,
+        expiration_time: u64,
+    ) -> Self {
+        match replay_protector {
             ReplayProtector::SequenceNumber(sequence_number) => Self::RunOnAbort {
-                sender: txn_metadata.sender,
+                sender,
                 sequence_number,
-                script_hash: txn_metadata.script_hash.clone(),
+                script_hash,
             },
             ReplayProtector::Nonce(nonce) => Self::OrderlessRunOnAbort {
-                sender: txn_metadata.sender,
+                sender,
                 nonce,
-                expiration_time: txn_metadata.expiration_timestamp_secs,
-                script_hash: txn_metadata.script_hash.clone(),
+                expiration_time,
+                script_hash,
             },
         }
     }
 
-    pub fn epilogue_meta(txn_metadata: &TransactionMetadata) -> Self {
-        match txn_metadata.replay_protector() {
+    pub fn epilogue(
+        sender: AccountAddress,
+        replay_protector: ReplayProtector,
+        script_hash: Vec<u8>,
+        expiration_time: u64,
+    ) -> Self {
+        match replay_protector {
             ReplayProtector::SequenceNumber(sequence_number) => Self::Epilogue {
-                sender: txn_metadata.sender,
+                sender,
                 sequence_number,
-                script_hash: txn_metadata.script_hash.clone(),
+                script_hash,
             },
             ReplayProtector::Nonce(nonce) => Self::OrderlessTxnEpilogue {
-                sender: txn_metadata.sender,
+                sender,
                 nonce,
-                expiration_time: txn_metadata.expiration_timestamp_secs,
-                script_hash: txn_metadata.script_hash.clone(),
+                expiration_time,
+                script_hash,
             },
         }
     }
@@ -186,7 +211,7 @@ impl SessionId {
         self.hash()
     }
 
-    pub(crate) fn into_script_hash(self) -> Vec<u8> {
+    pub fn into_script_hash(self) -> Vec<u8> {
         match self {
             Self::Txn { script_hash, .. }
             | Self::Prologue { script_hash, .. }

--- a/types/src/transaction/session_id.rs
+++ b/types/src/transaction/session_id.rs
@@ -2,10 +2,6 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Identifies a VM session within a transaction.
-//!
-//! The BCS crypto-hash of a `SessionId` seeds unique-address (AUID) generation,
-//! so it is consensus-visible: neither the variant order nor the field layout
-//! may change.
 
 use crate::{
     block_metadata::BlockMetadata, block_metadata_ext::BlockMetadataExt,
@@ -16,6 +12,11 @@ use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
 
+/// Identifies a VM session within a transaction.
+///
+/// Its BCS crypto-hash seeds unique-address (AUID) generation, so this enum is
+/// consensus-visible: neither the variant order nor the field layout may
+/// change, and a new session kind must be a new variant.
 #[derive(BCSCryptoHash, Clone, CryptoHasher, Deserialize, Serialize)]
 pub enum SessionId {
     Txn {

--- a/types/src/transaction/validation.rs
+++ b/types/src/transaction/validation.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! The arguments the transaction prologue and epilogue take, and the abort
+//! codes they raise. Both mirror `transaction_validation.move` and are shared
+//! by every VM.
+//!
+//! The argument enums must keep the same BCS serialization: the framework
+//! deserializes them directly, so neither the variant order nor the field
+//! layout may change. If you need to add a new field, add a new variant here --
+//! never edit an existing one.
+
+use crate::{
+    fee_statement::FeeStatement,
+    transaction::{ReplayProtector, UserTxnLimitsRequest},
+};
+use move_core_types::account_address::AccountAddress;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub enum PrologueArgs {
+    V1 {
+        needs_fee_payer_auth_check: bool,
+        txn_sender_public_key: Option<Vec<u8>>,
+        fee_payer_public_key_hash: Option<Vec<u8>>,
+        replay_protector: ReplayProtector,
+        secondary_signer_addresses: Vec<AccountAddress>,
+        secondary_signer_public_key_hashes: Vec<Option<Vec<u8>>>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
+        is_simulation: bool,
+        txn_limits_request: Option<UserTxnLimitsRequest>,
+    },
+}
+
+#[derive(Serialize)]
+pub enum EpilogueArgs {
+    V1 {
+        fee_statement: FeeStatement,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64,
+        is_simulation: bool,
+        is_orderless_txn: bool,
+    },
+}
+
+/// Abort codes the prologue raises, which the VM translates into specific
+/// validation statuses. The prologue must not abort with anything else; doing so
+/// is treated as an invariant violation.
+//
+// TODO(testing): find a way to check these against the Move declarations.
+pub const EBAD_ACCOUNT_AUTHENTICATION_KEY: u64 = 1001;
+// Transaction sequence number is too old.
+pub const ESEQUENCE_NUMBER_TOO_OLD: u64 = 1002;
+// Transaction sequence number is too new.
+pub const ESEQUENCE_NUMBER_TOO_NEW: u64 = 1003;
+// Transaction sender's account does not exist.
+pub const EACCOUNT_DOES_NOT_EXIST: u64 = 1004;
+// Insufficient balance (to pay for gas deposit).
+pub const ECANT_PAY_GAS_DEPOSIT: u64 = 1005;
+// Transaction expiration time exceeds block time.
+pub const ETRANSACTION_EXPIRED: u64 = 1006;
+// chain_id in transaction doesn't match the one on-chain.
+pub const EBAD_CHAIN_ID: u64 = 1007;
+// Transaction sequence number exceeds u64 max.
+pub const ESEQUENCE_NUMBER_TOO_BIG: u64 = 1008;
+// Counts of secondary keys and addresses don't match.
+pub const ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH: u64 = 1009;
+// Gas payer account missing in gas payer tx
+pub const EGAS_PAYER_ACCOUNT_MISSING: u64 = 1010;
+// Insufficient balance to cover the required deposit.
+pub const EINSUFFICIENT_BALANCE_FOR_REQUIRED_DEPOSIT: u64 = 1011;
+// Nonce is already in the nonce history
+pub const ENONCE_ALREADY_USED: u64 = 1012;
+// Transaction expiration time is too far in the future.
+pub const ETRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE: u64 = 1013;

--- a/types/src/vm/module_metadata.rs
+++ b/types/src/vm/module_metadata.rs
@@ -27,8 +27,9 @@ use move_model::{
     model::StructEnv,
 };
 use serde::{Deserialize, Serialize};
-use std::{cell::RefCell, collections::BTreeMap, env, num::NonZeroUsize, str::FromStr, sync::Arc};
+use std::{cell::RefCell, collections::BTreeMap, env, num::NonZeroUsize, str::FromStr};
 use thiserror::Error;
+use triomphe::Arc;
 
 pub mod prelude {
     pub use crate::vm::module_metadata::{


### PR DESCRIPTION
## Description

New crate `mono-move/aptos-transaction-executor`: the AptosVM transaction layer on the MonoMove VM. Executes one user transaction (prologue → entry function → epilogue) single-threaded, returning an unmaterialized `TxnOutcome`. Rebased onto current `main`, so #20242, #20254 and #20289 are all in.

Design choices:

- **One session, one checkpoint.** No respawned sessions or per-stage change sets; failed payloads roll back to the post-prologue checkpoint. Prologue/epilogue run unmetered via a scoped meter swap — no gas resets.
- **Deferred materialization.** The executor returns raw VM effects; rendering them into a `TransactionOutput` is a separate, fallible step (`materialize()`), and the legacy `VMStatus` mapping is quarantined next to it. The read-write set has no defined iteration order, so the drain gathers every failure it hits and `MaterializationError` sorts them on construction — what gets reported cannot depend on that order.
- **Typed outcomes.** The driver uses `DiscardReason`/`ExecutionStatus`, both carrying a `MoveExecutionFailure` and the `ExecutionStage` it happened in — illegal states unrepresentable; `VMStatus` constructed only at the projection edge, which is also where a failure's legitimacy is judged. Aborts carry the `AbortLocation` the runtime reports, so the executor records where an abort came from rather than the status mapper asserting it afterwards; the prologue's validation table is guarded on that location instead of being applied to every abort regardless of module.
- **Past the prologue, the transaction always commits and pays.** Neither a payload VM error nor a misbehaving epilogue discards: the payload's effects are dropped, the epilogue reruns against the state the prologue left, and only a failing rerun discards. This matches `failed_transaction_cleanup`, and it keeps the executor's control flow out of the legacy status projection — nothing on the execution path calls into `materialize/`, so that step is genuinely skippable for Block-STM.
- **The executor owns no data access.** It borrows `ModuleProvider` (code) and the runtime's `ResourceProvider` (reads); materialization needs one extra trait for resource groups. Block-STM later supplies production implementations behind the same traits; the `StateView`-backed ones (for tests, simulation, replay) live in a separate crate.
- **No block executor.** Block semantics belong to the Block-STM workstream (obligations documented in `AGENTS.md`).

Scope: entry functions and the versioned prologue/epilogue only; resource groups work end to end; gas incomplete (uncalibrated, no IO/storage fees). Scripts, multisig, publishing, keyless/AA, orderless, arg validation: inline `TODO`s.

### Shared types (touches `aptos-types` and `aptos-vm`)

`SessionId` and the prologue/epilogue argument enums were private to `aptos-vm`, so this executor initially mirrored them. Both are byte-exact-critical — `SessionId`'s BCS crypto-hash seeds AUID generation, and the framework deserializes the arg enums directly — so the copies were a consensus hazard. They now live in `aptos-types` and both VMs share them.

Two more duplications go the same way. The 13 prologue abort codes were defined per VM, so they now sit next to the argument enums in `aptos_types::transaction::validation` -- both mirror `transaction_validation.move`. And every VM rolled its own decoder for Move's abort-code convention, even though `aptos_types::error` already had `canonical()` to build a code and the correctly-named categories; `split_canonical` is the missing inverse. That retires a misnomer along the way: `aptos-vm` called category `0x2` `LIMIT_EXCEEDED`, which `error.move` does not define -- it is `OUT_OF_RANGE`.

One finding worth flagging: nothing checks the Rust codes still agree with the Move constants they mirror, and they have drifted. The framework calls 1010 `PROLOGUE_EFEE_PAYER_NOT_ENABLED`, and no Move constant carries 1011. Left as a `TODO(testing)` -- it needs a framework owner, since a dead code means a prologue abort nothing translates.

`SessionId`'s hash is unchanged: the derived hasher seeds from the serde name, not the module path, and a new test pins the `Txn`/`OrderlessTxn` hashes to guard that. Its four `TransactionMetadata`-taking constructors became primitive-taking ones, with convenience methods on `TransactionMetadata` itself; `move_vm_ext` still re-exports `SessionId`, so existing imports are untouched. With it shared, this executor seeds AUIDs the way the legacy VM does — from the payload session's id — which is what makes comparison testing possible.

Reading map (start at `executor.rs`, everything else hangs off it):

| File | What's there |
|---|---|
| `executor.rs` | The lifecycle driver: preflight → prologue → payload → epilogue |
| `calls.rs`, `sys_calls.rs` | Running one Move function; the unmetered prologue/epilogue calls |
| `errors.rs`, `outcome.rs` | The typed outcome taxonomy and `TxnOutcome` |
| `materialize/` | `txn_output.rs` renders effects into a `TransactionOutput`; `vm_status.rs` projects onto `VMStatus` |
| `providers.rs` | The `AptosDataProvider` trait (resource groups) |
| `aptos-state-view-providers/` | `StateView`-backed data layers for sequential execution |
| runtime/core diffs | `new_idle()`, `invoke` → `prepare_call`, `unmetered()`, `WriteClass`/`serialize_value` pub, tag interning in core |

### Open questions for reviewers

- **Resource groups and the VM boundary.** Should reads carry their storage location (resolving groups once, on read), and how much of groups should the VM layer see at all? The executor itself never uses the group trait today — only materialization does.
- **Where the write-set drain belongs.** The runtime's `SessionEffects::write_set()` is group-unaware and models a single function run (aborts drop all writes), while a transaction abort still commits the epilogue's fee writes. Unifying the two needs a design doc.

### Known gaps (fixes coming while in draft)

Multisig payloads slip past the preflight as plain entry functions; type args are not resolved/ability-checked; `new_idle` skips `verify_function`; no `check_gas` preflight. Argument placement now rejects what the legacy VM rejects — function values, references to non-signers, uninstantiated type parameters, and signers that do not lead the parameter list — but as a backstop: rejections surface as invariant violations rather than a signature error, and which structs are constructible from an argument is still unchecked. The attacker-reachable gaps — entry visibility, the remaining argument admissibility, `check_gas` — are labelled `TODO(security, ..)` and listed in `AGENTS.md` as gates that must land before a real coordinator drives this executor; today the only caller is the e2e harness.

## How Has This Been Tested?

Differential e2e vs the legacy VM on `FakeExecutor` genesis (statuses including abort codes and locations, write sets, events; only gas-fee slots masked): p2p transfer, insufficient-balance abort, fee-payer drained (epilogue retry), nonexistent entry function, two dependent transfers applied sequentially. Runtime, differential, `aptos-types` and `aptos-vm` unit suites pass; fmt/clippy clean. The `SessionId` move is covered by the hash-stability and constructor tests described above; broader legacy-VM coverage is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches consensus-critical SessionId hashing and shared prologue abort mapping while adding a new execution path; AGENTS.md lists pre-coordinator security gaps (entry visibility, check_gas, argument validation) that are not fully enforced yet.
> 
> **Overview**
> Introduces **`mono-move-aptos-transaction-executor`**, which runs a single user transaction on MonoMove (versioned prologue → entry payload → epilogue) in one interpreter session with checkpoint/rollback, unmetered system calls, and an unmaterialized **`TxnOutcome`** plus optional **`materialize()`** to **`TransactionOutput`** / **`VMStatus`**. **`mono-move-aptos-state-view-providers`** implements module/resource reads (including resource groups) from **`StateView`** for tests and sequential tools.
> 
> **Consensus-visible sharing:** **`SessionId`**, **`PrologueArgs`** / **`EpilogueArgs`**, and prologue abort codes move into **`aptos-types`**; **`split_canonical`** replaces per-VM abort decoding (including **`OUT_OF_RANGE`** for sequence-too-big / can’t-pay-fee cases). **`aptos-vm`** drops its local **`session_id`** module and uses **`TransactionMetadata`** session-id helpers and **`TransactionPayload::script_hash()`**.
> 
> **MonoMove runtime/core:** **`InterpreterContext::new_idle`**, **`prepare_call`**, **`unmetered`**, signer ref args, public write-set draining (**`WriteClass`**, **`serialize_value`**), and **`intern_type_tag`** / struct-tag interning; descriptor lookup for materialization.
> 
> Differential e2e tests compare legacy AptosVM vs the new executor on **`FakeExecutor`** genesis (writes/events; gas-sensitive slots masked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0af70249c38603793643268eb3eecaae47bcab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






