### PR TITLE
[cli] Fix rotate-key profile saving without an existing config

### DIFF
--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -124,17 +124,19 @@ impl CliCommand<RotateSummary> for RotateKey {
                 ));
             };
 
-            // Verify that config exists by attempting to load it.
-            let config = CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?;
-
-            // Verify that the new profile name does not already exist in the config.
-            if let Some(profiles) = config.profiles {
-                if profiles.contains_key(new_profile_name) {
-                    return Err(CliError::CommandArgumentError(format!(
-                        "Profile {} already exists",
-                        new_profile_name
-                    )));
-                };
+            // Verify that the new profile name does not already exist in the config,
+            // if a config exists. A missing config is fine: it will be created when
+            // the new profile is saved.
+            if CliConfig::config_exists(ConfigSearchMode::CurrentDirAndParents) {
+                let config = CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?;
+                if let Some(profiles) = config.profiles {
+                    if profiles.contains_key(new_profile_name) {
+                        return Err(CliError::CommandArgumentError(format!(
+                            "Profile {} already exists",
+                            new_profile_name
+                        )));
+                    };
+                }
             }
         };
 
@@ -292,20 +294,30 @@ impl CliCommand<RotateSummary> for RotateKey {
         // specified, then it will have already been error checked above.
         let new_profile_name = self.new_profile_options.save_to_profile.unwrap();
 
-        // If no config exists, then the error should've been caught earlier during the profile
-        // name verification step.
-        let mut config = CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?;
+        // Load the config if it exists, otherwise start a fresh one. Saving below
+        // creates the config file.
+        let mut config = if CliConfig::config_exists(ConfigSearchMode::CurrentDirAndParents) {
+            CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?
+        } else {
+            CliConfig::default()
+        };
         if config.profiles.is_none() {
             config.profiles = Some(BTreeMap::new());
         }
 
-        // Create new config.
+        // Create new config, inheriting settings from the current profile when one
+        // exists rather than requiring it.
+        let base_profile = match self.txn_options.profile_options.profile() {
+            Ok(profile) => profile,
+            Err(CliError::ConfigNotFoundError(_)) => ProfileConfig::default(),
+            Err(err) => return Err(err),
+        };
         let mut new_profile_config = ProfileConfig {
             public_key: Some(new_public_key),
             account: Some(current_address),
             private_key: new_private_key,
             derivation_path: new_derivation_path,
-            ..self.txn_options.profile_options.profile()?
+            ..base_profile
         };
 
         if let Some(url) = self.txn_options.rest_options.url {


### PR DESCRIPTION
## Description

Fixes #9547. `aptos key rotate-key --save-to-profile <name>` failed with a config error when no config file (or default profile) existed, following the solution sketched in the issue:

1. The profile-name verification now only loads the config when one exists.
2. Saving starts from a fresh `CliConfig` when none exists; `save()` already creates the `.aptos` folder and config file.
3. The new profile no longer requires the current (default) profile; it falls back to an empty base profile when there is none, while still surfacing real config errors.

## How Has This Been Tested?

`cargo check -p aptos` passes. Manually traced all three failure paths against `CliConfig`/`ProfileOptions` in aptos-cli-common.

## Key Areas to Review

The `ConfigNotFoundError` match when building the new profile: other errors still propagate, only the missing-profile case falls back to defaults.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI post-rotation config path; no on-chain or auth logic changes, with explicit propagation of non-missing-config errors.
> 
> **Overview**
> Fixes **`aptos key rotate-key --save-to-profile`** when there is no `.aptos` config or default profile yet.
> 
> **Pre-rotation checks** only load config to reject duplicate profile names when a config file already exists; missing config is allowed.
> 
> **After a successful rotation**, saving uses an existing config or **`CliConfig::default()`**, then **`config.save()`** creates the file. The new profile copies settings from the current profile when **`profile()`** succeeds, and uses **`ProfileConfig::default()`** only when the error is **`ConfigNotFoundError`**; other config errors still fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd904f6d8a01e7a0cfd9162d8ef9a54f84d5f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->