### PR TITLE
[sdk] Fix integer overflow waiting for a transaction with u64::MAX expiration

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -826,7 +826,8 @@ impl Client {
 
             if let Some(max_server_lag_wait_duration) = max_server_lag_wait {
                 if aptos_infallible::duration_since_epoch().as_secs()
-                    > expiration_timestamp_secs + max_server_lag_wait_duration.as_secs()
+                    > expiration_timestamp_secs
+                        .saturating_add(max_server_lag_wait_duration.as_secs())
                 {
                     return Err(anyhow!(
                         "Ledger on endpoint ({}) is more than {}s behind current time, timing out waiting for the transaction. Warning, transaction ({}) might still succeed.",


### PR DESCRIPTION
## Description

Fixes #10440. `Client::wait_for_transaction_by_hash_inner` panicked with `attempt to add with overflow` when a transaction was submitted with `expiration_timestamp_secs = u64::MAX`. The server-lag timeout check now uses `saturating_add`, so a non-expiring transaction simply never trips that timeout.

## How Has This Been Tested?

`cargo check -p aptos-rest-client` passes. The overflow site is the only arithmetic on `expiration_timestamp_secs` in the crate.

## Key Areas to Review

Single-line change in the `max_server_lag_wait` check.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line arithmetic change in SDK polling logic; normal expirations behave the same, with only the edge case of u64::MAX affected.
> 
> **Overview**
> Fixes a panic in **`Client::wait_for_transaction_by_hash_inner`** when **`expiration_timestamp_secs`** is **`u64::MAX`**: the server-lag guard used **`+`**, which overflowed while computing the deadline.
> 
> The timeout comparison now uses **`saturating_add`** on the expiration timestamp plus **`max_server_lag_wait`**, so “never expire” transactions no longer crash the wait loop and simply skip that lag-based timeout path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c248aa4ad96ac002d64e8588775d60cddf19e1e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->