### PR TITLE
check uri blacklist before fetching animation_url in nft parser

### DIFF
--- a/ecosystem/nft-metadata-crawler/src/parser/worker.rs
+++ b/ecosystem/nft-metadata-crawler/src/parser/worker.rs
@@ -304,6 +304,16 @@ impl Worker {
         // If raw_animation_uri_option is None, skip
         if let Some(raw_animation_uri) = raw_animation_uri_option {
             self.log_info("Parsing raw_animation_uri");
+
+            // Check raw_animation_uri against the URI blacklist
+            if self.is_blacklisted_uri(&raw_animation_uri) {
+                self.log_info("Found match in URI blacklist, marking as do_not_parse");
+                self.model.set_do_not_parse(true);
+                self.upsert();
+                SKIP_URI_COUNT.with_label_values(&["blacklist"]).inc();
+                return Ok(());
+            }
+
             let animation_uri = URIParser::parse(
                 &self.parser_config.ipfs_prefix,
                 &raw_animation_uri,


### PR DESCRIPTION
## Description

`raw_image_uri` is checked against `uri_blacklist` before it is fetched, but the `raw_animation_uri` branch parses and optimizes the URI without that check. A token whose JSON metadata sets `animation_url` to a blacklisted entry is still fetched and optimized, so the blacklist is only half enforced. Both `image` and `animation_url` come from the same untrusted on-chain metadata, so an operator that blacklists a host to stop the crawler from reaching it can still be driven to it through the animation field. This adds the same check on the animation path, mirroring the image branch (skip, mark `do_not_parse`, bump the `blacklist` skip counter, return early).

## How Has This Been Tested?

`cargo check -p aptos-nft-metadata-crawler` and `cargo clippy -p aptos-nft-metadata-crawler` are clean. The new branch is identical in shape to the existing `raw_image_uri` blacklist branch, which is exercised by the same `parse` flow. `Worker` requires a live Postgres connection, so there is no unit-test harness for this path to extend.

## Key Areas to Review

The animation branch returns `Ok(())` after setting `do_not_parse`, matching how a blacklisted image URI is handled (both skip the trailing retry/success bookkeeping). Worth confirming that early-return is the intended behavior for a blacklisted animation, same as for a blacklisted image.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, symmetric guard in the NFT metadata crawler parser with no auth or schema changes; behavior aligns with existing image blacklist handling.
> 
> **Overview**
> The NFT metadata crawler already blocked **`raw_image_uri`** against **`uri_blacklist`** before fetch/optimize, but **`animation_url`** could still hit blacklisted hosts. This change runs the same **`is_blacklisted_uri`** check on **`raw_animation_uri`** immediately before **`URIParser::parse`** and animation optimization.
> 
> On a match, the worker sets **`do_not_parse`**, upserts, increments **`SKIP_URI_COUNT`** with label **`blacklist`**, and returns early—matching the image and top-level asset URI blacklist behavior so operators cannot be driven to blocked hosts via metadata **`animation_url`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c066bada02ea9b73b39d4dda1a90a2c9dd5e95c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->