### PR TITLE
add code download mode for comparison testing tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,6 +5067,7 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4",
  "bytes",
+ "futures",
  "lru",
  "move-core-types",
  "tokio",

--- a/aptos-move/aptos-e2e-comparison-testing/src/data_collection.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/data_collection.rs
@@ -35,6 +35,7 @@ pub struct DataCollection {
     current_dir: PathBuf,
     batch_size: u64,
     dump_write_set: bool,
+    skip_txn_execution: bool,
     filter_condition: FilterCondition,
     enable_features: Vec<FeatureFlag>,
     disable_features: Vec<FeatureFlag>,
@@ -48,6 +49,7 @@ impl DataCollection {
         skip_failed_txns: bool,
         skip_publish_txns: bool,
         dump_write_set: bool,
+        skip_txn_execution: bool,
         skip_source_code: bool,
         target_account: Option<AccountAddress>,
         enable_features: Vec<FeatureFlag>,
@@ -58,6 +60,7 @@ impl DataCollection {
             current_dir,
             batch_size,
             dump_write_set,
+            skip_txn_execution,
             filter_condition: FilterCondition {
                 skip_failed_txns,
                 skip_publish_txns,
@@ -76,6 +79,7 @@ impl DataCollection {
         skip_failed_txns: bool,
         skip_publish_txns: bool,
         dump_write_set: bool,
+        skip_txn_execution: bool,
         skip_source_code: bool,
         target_account: Option<AccountAddress>,
         enable_features: Vec<FeatureFlag>,
@@ -88,6 +92,7 @@ impl DataCollection {
             skip_failed_txns,
             skip_publish_txns,
             dump_write_set,
+            skip_txn_execution,
             skip_source_code,
             target_account,
             enable_features,
@@ -128,6 +133,7 @@ impl DataCollection {
         compilation_cache: &mut CompilationCache,
         current_dir: PathBuf,
         base_experiments: &[String],
+        skip_source_compilation: bool,
     ) -> Option<PackageInfo> {
         let upgrade_number = if is_aptos_package(&package_name) {
             None
@@ -160,6 +166,7 @@ impl DataCollection {
                 None,
                 base_experiments,
                 &[],
+                skip_source_compilation,
             );
             if let Err(err) = res {
                 eprintln!("{} at: {}", err, version);
@@ -205,16 +212,24 @@ impl DataCollection {
             return Err(anyhow::Error::msg("aptos packages are missing"));
         }
         let mut compiled_cache = CompilationCache::default();
-        compile_aptos_packages(
-            &aptos_commons_path,
-            &mut compiled_cache.base_compiled_package_cache,
-            &base_experiments,
-            "base",
-        )?;
+        // the compiled framework is only needed for txn execution
+        if !self.skip_txn_execution {
+            compile_aptos_packages(
+                &aptos_commons_path,
+                &mut compiled_cache.base_compiled_package_cache,
+                &base_experiments,
+                "base",
+            )?;
+        }
         let compilation_cache: Arc<Mutex<CompilationCache>> = Arc::new(Mutex::new(compiled_cache));
-        let data_manager = Arc::new(Mutex::new(DataManager::new_with_dir_creation(
-            &self.current_dir,
-        )));
+        // create no replay artifacts in source-only mode, so `execute` rejects such dumps
+        let data_manager_opt = if self.skip_txn_execution {
+            None
+        } else {
+            Some(Arc::new(Mutex::new(DataManager::new_with_dir_creation(
+                &self.current_dir,
+            ))))
+        };
         let index_writer = Arc::new(Mutex::new(IndexWriter::new(&self.current_dir)));
 
         let mut cur_version = begin;
@@ -240,6 +255,9 @@ impl DataCollection {
                     .lock()
                     .unwrap()
                     .write_err(&format!("{}:{}", cur_version, batch));
+                // the skipped range may contain publish txns whose cache
+                // invalidation never ran, so drop all cached package data
+                module_registry_map.clear();
             }
             let txns = res_txns.unwrap_or_default();
             if !txns.is_empty() {
@@ -250,43 +268,56 @@ impl DataCollection {
                     let compilation_cache = compilation_cache.clone();
                     let current_dir = self.current_dir.clone();
                     let dump_write_set = self.dump_write_set;
-                    let data_manager = data_manager.clone();
+                    let data_manager = data_manager_opt.clone();
                     let index = index_writer.clone();
                     let base_experiments = base_experiments.clone();
-                    let data_state = InMemoryStateStore::default();
-                    let features_to_enable = self.enable_features.clone();
-                    let features_to_disable = self.disable_features.clone();
-                    let cache_v1 = compilation_cache
-                        .lock()
-                        .unwrap()
-                        .base_compiled_package_cache
-                        .clone();
-                    add_aptos_packages_to_state_store(&data_state, &cache_v1);
-                    let state_view = DataStateView::new_with_data_reads_and_code(
-                        self.debugger.clone(),
-                        version,
-                        data_state,
-                        features_to_enable,
-                        features_to_disable,
-                    );
+                    let skip_txn_execution = self.skip_txn_execution;
+                    // in source-only mode, compile-validation is skipped too
+                    let skip_source_compilation = self.skip_txn_execution;
+                    // no state view (and no remote state reads) when txns are not executed
+                    let state_view_opt = if self.skip_txn_execution {
+                        None
+                    } else {
+                        let data_state = InMemoryStateStore::default();
+                        let features_to_enable = self.enable_features.clone();
+                        let features_to_disable = self.disable_features.clone();
+                        let cache_v1 = compilation_cache
+                            .lock()
+                            .unwrap()
+                            .base_compiled_package_cache
+                            .clone();
+                        add_aptos_packages_to_state_store(&data_state, &cache_v1);
+                        Some(DataStateView::new_with_data_reads_and_code(
+                            self.debugger.clone(),
+                            version,
+                            data_state,
+                            features_to_enable,
+                            features_to_disable,
+                        ))
+                    };
 
                     let txn_execution_thread = tokio::task::spawn_blocking(move || {
-                        // Use default info to improve performance
-                        let aux_info = PersistedAuxiliaryInfo::None;
+                        let epoch_result_opt = if let Some(state_view) = &state_view_opt {
+                            // Use default info to improve performance
+                            let aux_info = PersistedAuxiliaryInfo::None;
 
-                        let epoch_result_res =
-                            Self::execute_transactions_at_version_with_state_view(
+                            match Self::execute_transactions_at_version_with_state_view(
                                 vec![txn.clone()],
                                 vec![aux_info],
-                                &state_view,
-                            );
-                        if let Err(err) = epoch_result_res {
-                            println!(
-                                "execution error during transaction at version:{} :{}",
-                                version, err
-                            );
-                            return;
-                        }
+                                state_view,
+                            ) {
+                                Ok(outputs) => Some(outputs),
+                                Err(err) => {
+                                    println!(
+                                        "execution error during transaction at version:{} :{}",
+                                        version, err
+                                    );
+                                    return;
+                                },
+                            }
+                        } else {
+                            None
+                        };
 
                         let mut version_idx = TxnIndex {
                             version,
@@ -304,6 +335,7 @@ impl DataCollection {
                                 &mut compilation_cache.lock().unwrap(),
                                 current_dir.clone(),
                                 &base_experiments,
+                                skip_source_compilation,
                             );
                             if package_info_opt.is_none() {
                                 return;
@@ -311,17 +343,23 @@ impl DataCollection {
                             version_idx.package_info = package_info_opt.unwrap();
                         }
 
-                        // dump through data_manager
-                        Self::dump_txn_index(
-                            &mut data_manager.lock().unwrap(),
-                            version_idx,
-                            &state_view.get_state_keys().lock().unwrap(),
-                            epoch_result_res,
-                            dump_write_set,
-                        );
+                        // dump through data_manager (skipped in source-only mode)
+                        if let (Some(state_view), Some(outputs), Some(data_manager)) =
+                            (state_view_opt, epoch_result_opt, data_manager)
+                        {
+                            Self::dump_txn_index(
+                                &mut data_manager.lock().unwrap(),
+                                version_idx,
+                                &state_view.get_state_keys().lock().unwrap(),
+                                Ok(outputs),
+                                dump_write_set,
+                            );
+                        }
 
-                        // Log version
-                        index.lock().unwrap().add_version(version);
+                        // only replayable (executed) txns are indexed
+                        if !skip_txn_execution {
+                            index.lock().unwrap().add_version(version);
+                        }
                     });
                     txn_execution_ths.push(txn_execution_thread);
                 }

--- a/aptos-move/aptos-e2e-comparison-testing/src/execution.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/execution.rs
@@ -131,6 +131,16 @@ impl Execution {
         if !check_aptos_packages_availability(aptos_commons_path.clone()) {
             return Err(anyhow::Error::msg("aptos packages are missing"));
         }
+
+        // prepare data; checked before the slow framework compilation to fail fast
+        let data_manager = DataManager::new(&self.input_path);
+        if !data_manager.check_dir_availability() {
+            return Err(anyhow::Error::msg("data is missing"));
+        }
+        if !IndexReader::check_availability(&self.input_path) {
+            return Err(anyhow::Error::msg("index file is missing"));
+        }
+
         let mut compiled_cache = CompilationCache::default();
         if self.execution_mode.is_v1_or_compare() {
             compile_aptos_packages(
@@ -147,15 +157,6 @@ impl Execution {
                 &compared_experiments,
                 "compared",
             )?;
-        }
-
-        // prepare data
-        let data_manager = DataManager::new(&self.input_path);
-        if !data_manager.check_dir_availability() {
-            return Err(anyhow::Error::msg("data is missing"));
-        }
-        if !IndexReader::check_availability(&self.input_path) {
-            return Err(anyhow::Error::msg("index file is missing"));
         }
         let mut index_reader = IndexReader::new(&self.input_path);
 
@@ -290,33 +291,41 @@ impl Execution {
         base_experiments: &[String],
         compared_experiments: &[String],
     ) -> Result<()> {
-        if let Some(txn_idx) = data_manager.get_txn_index(cur_version) {
-            // compile the code if the source code is available
-            if txn_idx.package_info.is_compilable()
-                && !is_aptos_package(&txn_idx.package_info.package_name)
-            {
-                let compiled_result = self.compile_code(
-                    &txn_idx,
-                    compiled_cache,
-                    base_experiments,
-                    compared_experiments,
-                );
-                if let Err(err) = compiled_result {
-                    self.output_result_str(format!("{} at version:{}", err, cur_version));
-                    return Err(err);
-                }
-            }
-            // read the state data
-            let state = data_manager.get_state(cur_version);
-            self.execute_and_compare(
-                cur_version,
-                state,
-                &txn_idx,
-                &compiled_cache.base_compiled_package_cache,
-                &compiled_cache.compared_compiled_package_cache,
-                None,
+        let Some(txn_idx) = data_manager.get_txn_index(cur_version) else {
+            // skipping silently would make an incomplete or mixed dump look clean
+            let msg = format!(
+                "version {} is in the version index but has no txn index entry; the dump \
+                 directory is incomplete or mixes source-only and replayable artifacts",
+                cur_version
             );
+            self.output_result_str(msg.clone());
+            return Err(anyhow::Error::msg(msg));
+        };
+        // compile the code if the source code is available
+        if txn_idx.package_info.is_compilable()
+            && !is_aptos_package(&txn_idx.package_info.package_name)
+        {
+            let compiled_result = self.compile_code(
+                &txn_idx,
+                compiled_cache,
+                base_experiments,
+                compared_experiments,
+            );
+            if let Err(err) = compiled_result {
+                self.output_result_str(format!("{} at version:{}", err, cur_version));
+                return Err(err);
+            }
         }
+        // read the state data
+        let state = data_manager.get_state(cur_version);
+        self.execute_and_compare(
+            cur_version,
+            state,
+            &txn_idx,
+            &compiled_cache.base_compiled_package_cache,
+            &compiled_cache.compared_compiled_package_cache,
+            None,
+        );
         Ok(())
     }
 

--- a/aptos-move/aptos-e2e-comparison-testing/src/lib.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/lib.rs
@@ -376,6 +376,8 @@ struct CompilationCache {
     failed_packages_compared: HashSet<PackageInfo>,
     base_compiled_package_cache: HashMap<PackageInfo, HashMap<ModuleId, Vec<u8>>>,
     compared_compiled_package_cache: HashMap<PackageInfo, HashMap<ModuleId, Vec<u8>>>,
+    /// Packages already dumped to disk; consulted when compilation is skipped.
+    dumped_packages: HashSet<PackageInfo>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
@@ -501,7 +503,11 @@ fn dump_and_compile_from_package_metadata(
     execution_mode: Option<ExecutionMode>,
     base_experiments: &[String],
     compared_experiments: &[String],
+    skip_source_compilation: bool,
 ) -> anyhow::Result<()> {
+    if skip_source_compilation && compilation_cache.dumped_packages.contains(&package_info) {
+        return Ok(());
+    }
     let root_package_dir = root_dir.join(format!("{}", package_info,));
     if compilation_cache
         .failed_packages_base
@@ -521,12 +527,12 @@ fn dump_and_compile_from_package_metadata(
             package_info.package_name
         )));
     }
-    if !root_package_dir.exists() {
-        std::fs::create_dir_all(root_package_dir.as_path())?;
-    }
     let root_package_metadata = dep_map
         .get(&(package_info.address, package_info.package_name.clone()))
         .unwrap();
+    if !root_package_dir.exists() {
+        std::fs::create_dir_all(root_package_dir.as_path())?;
+    }
     // step 1: unzip and save the source code into src into corresponding folder
     let sources_dir = root_package_dir.join("sources");
     std::fs::create_dir_all(sources_dir.as_path())?;
@@ -603,6 +609,7 @@ fn dump_and_compile_from_package_metadata(
                         execution_mode,
                         base_experiments,
                         compared_experiments,
+                        skip_source_compilation,
                     )?;
                 }
                 break;
@@ -615,6 +622,12 @@ fn dump_and_compile_from_package_metadata(
     std::fs::write(toml_path, manifest.to_string()).unwrap();
 
     // step 5: test whether the code can be compiled
+    if skip_source_compilation {
+        compilation_cache
+            .dumped_packages
+            .insert(package_info.clone());
+        return Ok(());
+    }
     if !compilation_cache
         .compiled_package_map
         .contains_key(&package_info)

--- a/aptos-move/aptos-e2e-comparison-testing/src/main.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/main.rs
@@ -14,8 +14,6 @@ use move_core_types::account_address::AccountAddress;
 use std::{collections::BTreeSet, path::PathBuf};
 use url::Url;
 
-const BATCH_SIZE: u64 = 500;
-
 #[derive(Subcommand)]
 pub enum Cmd {
     /// Collect and dump the data
@@ -38,6 +36,10 @@ pub enum Cmd {
         /// Dump the write set of txns
         #[clap(long, default_value_t = false)]
         dump_write_set: bool,
+        /// Only collect source code: skip txn execution, state/txn-index dumping
+        /// and compile-validation of the dumped sources
+        #[clap(long, default_value_t = false)]
+        skip_txn_execution: bool,
         /// With this set, only dump transactions that are sent to this account
         #[clap(long)]
         target_account: Option<AccountAddress>,
@@ -112,10 +114,17 @@ pub struct Argument {
     /// Number of txns to scan/execute
     #[clap(long)]
     limit: u64,
+
+    /// Number of txns to scan per batch, fetched as concurrent pages of 100
+    #[clap(long, default_value_t = 500)]
+    batch_size: u64,
 }
 
 impl Argument {
     fn validate(&self) -> Result<(), String> {
+        if self.batch_size == 0 {
+            return Err("batch size must be at least 1".to_string());
+        }
         let overlap = Self::overlapping_features(&self.enable_features, &self.disable_features);
         if overlap.is_empty() {
             Ok(())
@@ -161,9 +170,10 @@ async fn main() -> Result<()> {
             skip_publish_txns,
             skip_source_code_check: skip_source_code,
             dump_write_set,
+            skip_txn_execution,
             target_account,
         } => {
-            let batch_size = BATCH_SIZE;
+            let batch_size = args.batch_size;
             let output = if let Some(path) = output_path {
                 path
             } else {
@@ -187,6 +197,7 @@ async fn main() -> Result<()> {
                 skip_failed_txns,
                 skip_publish_txns,
                 dump_write_set,
+                skip_txn_execution,
                 skip_source_code,
                 target_account,
                 args.enable_features,
@@ -206,7 +217,7 @@ async fn main() -> Result<()> {
             base_experiments,
             compared_experiments,
         } => {
-            let batch_size = BATCH_SIZE;
+            let batch_size = args.batch_size;
             let output = if let Some(path) = output_path {
                 path
             } else {

--- a/aptos-move/aptos-e2e-comparison-testing/src/online_execution.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/online_execution.rs
@@ -125,6 +125,7 @@ impl OnlineExecutor {
                 execution_mode,
                 base_experiments,
                 compared_experiments,
+                false,
             );
             if let Err(err) = res {
                 eprintln!("{} at:{}", err, version);
@@ -192,6 +193,7 @@ impl OnlineExecutor {
                     .lock()
                     .unwrap()
                     .write_err(&format!("{}:{}:{:?}", cur_version, batch, err));
+                module_registry_map.clear();
                 cur_version += batch;
                 continue;
             }

--- a/aptos-move/aptos-validator-interface/Cargo.toml
+++ b/aptos-move/aptos-validator-interface/Cargo.toml
@@ -25,6 +25,7 @@ async-recursion = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
+futures = { workspace = true }
 lru = { workspace = true }
 move-core-types = { workspace = true }
 tokio = { workspace = true }

--- a/aptos-move/aptos-validator-interface/src/rest_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/rest_interface.rs
@@ -30,6 +30,61 @@ impl RestDebuggerInterface {
     pub fn new(client: Client) -> Self {
         Self(client)
     }
+
+    /// The txn-fetching part of [`AptosValidatorInterface::get_committed_transactions`],
+    /// without the persisted auxiliary infos.
+    async fn get_committed_transactions_no_aux(
+        &self,
+        start: Version,
+        limit: u64,
+    ) -> Result<(Vec<Transaction>, Vec<TransactionInfo>)> {
+        let mut txns = Vec::with_capacity(limit as usize);
+        let mut txn_infos = Vec::with_capacity(limit as usize);
+
+        while txns.len() < limit as usize {
+            self.0
+                .get_transactions_bcs(
+                    Some(start + txns.len() as u64),
+                    Some(limit as u16 - txns.len() as u16),
+                )
+                .await?
+                .into_inner()
+                .into_iter()
+                .for_each(|txn| {
+                    txns.push(txn.transaction);
+                    txn_infos.push(txn.info);
+                });
+            println!("Got {}/{} txns from RestApi.", txns.len(), limit);
+        }
+
+        Ok((txns, txn_infos))
+    }
+
+    /// Same as [`Self::get_committed_transactions_no_aux`], but fetches the
+    /// API-page-sized chunks concurrently.
+    async fn get_committed_transactions_no_aux_concurrent(
+        &self,
+        start: Version,
+        limit: u64,
+    ) -> Result<(Vec<Transaction>, Vec<TransactionInfo>)> {
+        // the API's default max page size (DEFAULT_MAX_PAGE_SIZE)
+        const PAGE_SIZE: u64 = 100;
+        let mut chunk_futures = vec![];
+        let mut cursor = start;
+        while cursor < start + limit {
+            let count = PAGE_SIZE.min(start + limit - cursor);
+            chunk_futures.push(self.get_committed_transactions_no_aux(cursor, count));
+            cursor += count;
+        }
+        let mut txns = Vec::with_capacity(limit as usize);
+        let mut txn_infos = Vec::with_capacity(limit as usize);
+        for chunk in futures::future::join_all(chunk_futures).await {
+            let (t, i) = chunk?;
+            txns.extend(t);
+            txn_infos.extend(i);
+        }
+        Ok((txns, txn_infos))
+    }
 }
 
 #[async_recursion]
@@ -227,27 +282,8 @@ impl AptosValidatorInterface for RestDebuggerInterface {
         Vec<TransactionInfo>,
         Vec<PersistedAuxiliaryInfo>,
     )> {
-        let mut txns = Vec::with_capacity(limit as usize);
-        let mut txn_infos = Vec::with_capacity(limit as usize);
-
-        while txns.len() < limit as usize {
-            self.0
-                .get_transactions_bcs(
-                    Some(start + txns.len() as u64),
-                    Some(limit as u16 - txns.len() as u16),
-                )
-                .await?
-                .into_inner()
-                .into_iter()
-                .for_each(|txn| {
-                    txns.push(txn.transaction);
-                    txn_infos.push(txn.info);
-                });
-            println!("Got {}/{} txns from RestApi.", txns.len(), limit);
-        }
-
+        let (txns, txn_infos) = self.get_committed_transactions_no_aux(start, limit).await?;
         let auxiliary_infos = self.get_persisted_auxiliary_infos(start, limit).await?;
-
         Ok((txns, txn_infos, auxiliary_infos))
     }
 
@@ -276,7 +312,9 @@ impl AptosValidatorInterface for RestDebuggerInterface {
         )>,
     > {
         let mut txns = Vec::with_capacity(limit as usize);
-        let (tns, infos, _auxiliary_infos) = self.get_committed_transactions(start, limit).await?;
+        let (tns, infos) = self
+            .get_committed_transactions_no_aux_concurrent(start, limit)
+            .await?;
         let temp_txns = tns
             .iter()
             .zip(infos)


### PR DESCRIPTION
## Description

Adds a source-code-only download mode to the comparison-testing tool and speeds up its txn scanning.

- **`dump --skip-txn-execution`**: collects the verified source of every package called by an entry-function txn (plus transitive deps) without executing txns, and without compile-validating the dumped sources (a `dumped_packages` set dedupes re-dumps instead of the compiled-package map). This avoids execution-only failure modes on historical version ranges (e.g. framework bytecode-version mismatches) and the per-txn remote read-set recording.
- **Replay-corpus integrity**: a source-only dump produces no replay artifacts at all — no state/write-set dirs, no txn-index db, and no `version_index.txt` entries — so `execute` rejects it with "data is missing" instead of silently replaying nothing. Additionally, `execute` now checks data availability before the (slow) framework compilation, and treats an indexed version with no txn-index entry as a loud per-version error rather than silent success, so incomplete or mixed dump directories can no longer produce false-clean comparison runs.
- **Faster scanning**: `get_and_filter_committed_transactions` no longer fetches persisted auxiliary infos it immediately discarded, and fetches API pages concurrently via `get_committed_transactions_no_aux_concurrent`. The txn-fetch loop is extracted verbatim into `get_committed_transactions_no_aux`, so the `get_committed_transactions` trait method behaves exactly as before. Net: ~11× faster (2.6s → 0.23s per 500-txn batch; a 1M-version window drops from ~90 min to ~8 min).
- **`--batch-size <N>`** (default 500, the previous hard-coded value): batches are fetched as N/100 concurrent pages, so this also controls request concurrency; e.g. `--batch-size 2500` gives a further ~3× scan speedup.

## How Has This Been Tested?

- Live mainnet dumps with `--skip-txn-execution` (genesis-era and recent ranges): package sources and rewritten Move.toml dumped correctly, no state/write-set/index artifacts, no compilation, dumped packages verified compilable with `aptos move test` against the framework checkout.
- `execute` against a source-only dump fails fast with "data is missing"; `execute` against a synthetic mixed directory (stale index entry without txn data) reports a per-version error instead of succeeding.
- 5000-version scan benchmarks confirming the speedups (default and `--batch-size 2500`); default (execution) mode and `online`/`execute` paths unchanged on well-formed corpora and still build/run.

## Type of Change
- [x] New feature
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the e2e comparison-testing CLI and REST debugger helper; no validator or consensus paths, with stricter errors on incomplete dumps.
> 
> **Overview**
> Adds **`dump --skip-txn-execution`**: collects package sources (and deps) without running the VM, without compile-validating dumps, and without writing replay artifacts (state, txn index, version index). **`execute`** now validates dump data **before** framework compilation and errors if the version index references a version with no txn-index entry, so source-only or mixed corpora cannot look like a clean replay run.
> 
> **Scanning performance**: filtered txn collection skips unused persisted auxiliary infos and fetches REST pages (100 txns) **concurrently** via new helpers on `RestDebuggerInterface`. **`--batch-size`** (default 500, was hard-coded) controls batch size and fetch concurrency. On batch fetch failures, **`module_registry_map`** is cleared so stale package cache cannot survive skipped publish ranges.
> 
> Dump path uses **`join_all`** for per-txn blocking work; **`skip_source_compilation`** + **`dumped_packages`** dedupe disk dumps without compiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf439858ebb71a1b210018369bf7d8a4cf5c639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->