### PR TITLE
[vm] Fix and test zero-copy BCS serialization (supersedes #20179, builds on #18535)

### DIFF
--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -51,6 +51,10 @@ pub fn create_option_u64(enum_option_enabled: bool, value: Option<u64>) -> Value
  *
  **************************************************************************************************/
 /// Rust implementation of Move's `native public fun to_bytes<T>(&T): vector<u8>`
+///
+/// Serializes the value reference `&T` into BCS bytes.
+/// Returns a vector of u8 bytes representing the serialized value.
+/// Aborts if serialization fails.
 fn native_to_bytes(
     context: &mut SafeNativeContext,
     ty_args: &[Type],
@@ -84,16 +88,13 @@ fn native_to_bytes(
         }
     };
 
-    // TODO(#14175): Reading the reference performs a deep copy, and we can
-    //               implement it in a more efficient way.
-    let val = ref_to_val.read_ref()?;
-
+    // Use `serialize_ref` to avoid deep copying the value before serialization.
     let function_value_extension = context.function_value_extension();
     let max_value_nest_depth = context.max_value_nest_depth();
     let serialized_value = match ValueSerDeContext::new(max_value_nest_depth)
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
-        .serialize(&val, &layout)?
+        .serialize_ref(&ref_to_val, &layout)?
     {
         Some(serialized_value) => serialized_value,
         None => {
@@ -116,6 +117,10 @@ fn native_to_bytes(
  *   cost is charged.
  *
  **************************************************************************************************/
+/// Rust implementation of Move's `native public fun serialized_size<T>(&T): u64`
+///
+/// Returns the size of the serialized value in bytes.
+/// Aborts if serialization fails (e.g., due to cycle detection or depth limit).
 fn native_serialized_size(
     context: &mut SafeNativeContext,
     ty_args: &[Type],
@@ -148,9 +153,7 @@ fn serialized_size_impl(
     reference: Reference,
     ty: &Type,
 ) -> PartialVMResult<usize> {
-    // TODO(#14175): Reading the reference performs a deep copy, and we can
-    //               implement it in a more efficient way.
-    let value = reference.read_ref()?;
+    // Use `serialized_size_ref` to avoid deep copying the value.
     let ty_layout = context.type_to_type_layout(ty)?;
 
     let function_value_extension = context.function_value_extension();
@@ -159,7 +162,7 @@ fn serialized_size_impl(
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
         .with_delayed_fields_serde()
-        .serialized_size(&value, &ty_layout)
+        .serialized_size_ref(&reference, &ty_layout)
 }
 
 fn native_constant_serialized_size(

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -6,8 +6,8 @@
 use crate::{
     delayed_values::delayed_field_id::DelayedFieldID,
     values::{
-        AbstractFunction, DeserializationSeed, SerializationReadyValue, SerializedFunctionData,
-        Value,
+        AbstractFunction, DeserializationSeed, Reference, SerializationReadyValue,
+        SerializedFunctionData, Value,
     },
 };
 #[cfg(test)]
@@ -149,10 +149,7 @@ impl<'a> ValueSerDeContext<'a> {
     }
 
     pub(crate) fn check_depth(&self, depth: u64) -> PartialVMResult<()> {
-        if self
-            .max_value_nested_depth
-            .is_some_and(|max_depth| depth > max_depth)
-        {
+        if self.max_value_nested_depth.unwrap_or(2048).lt(&depth) {
             return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
         }
         Ok(())
@@ -219,9 +216,65 @@ impl<'a> ValueSerDeContext<'a> {
         }
     }
 
+    /// Serializes a [Reference] based on the provided layout. For legacy reasons, all serialization
+    /// errors are mapped to [None]. If [DelayedFieldsExtension] is set, and there are too many
+    /// delayed fields, an error may be returned.
+    pub fn serialize_ref(
+        self,
+        value: &Reference,
+        layout: &MoveTypeLayout,
+    ) -> PartialVMResult<Option<Vec<u8>>> {
+        let value = SerializationReadyValue {
+            ctx: &self,
+            layout,
+            value,
+            depth: 1,
+        };
+
+        match bcs::to_bytes(&value).ok() {
+            Some(bytes) => Ok(Some(bytes)),
+            None => {
+                // Check if the error is due to too many delayed fields. If so, to be compatible
+                // with the older implementation return an error.
+                if let Some(delayed_fields_extension) = self.delayed_fields_extension {
+                    if delayed_fields_extension.delayed_fields_count.into_inner()
+                        > DelayedFieldsExtension::MAX_DELAYED_FIELDS_PER_RESOURCE
+                    {
+                        return Err(PartialVMError::new(StatusCode::TOO_MANY_DELAYED_FIELDS)
+                            .with_message(
+                                "Too many Delayed fields in a single resource.".to_string(),
+                            ));
+                    }
+                }
+                Ok(None)
+            },
+        }
+    }
+
     /// Returns the serialized size of a [Value] with the associated layout. All errors are mapped
     /// to [StatusCode::VALUE_SERIALIZATION_ERROR].
     pub fn serialized_size(self, value: &Value, layout: &MoveTypeLayout) -> PartialVMResult<usize> {
+        let value = SerializationReadyValue {
+            ctx: &self,
+            layout,
+            value,
+            depth: 1,
+        };
+        bcs::serialized_size(&value).map_err(|e| {
+            PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
+                "failed to compute serialized size of a value: {:?}",
+                e
+            ))
+        })
+    }
+
+    /// Returns the serialized size of a [Reference] with the associated layout. All errors are mapped
+    /// to [StatusCode::VALUE_SERIALIZATION_ERROR].
+    pub fn serialized_size_ref(
+        self,
+        value: &Reference,
+        layout: &MoveTypeLayout,
+    ) -> PartialVMResult<usize> {
         let value = SerializationReadyValue {
             ctx: &self,
             layout,

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -195,25 +195,7 @@ impl<'a> ValueSerDeContext<'a> {
             value,
             depth: 1,
         };
-
-        match bcs::to_bytes(&value).ok() {
-            Some(bytes) => Ok(Some(bytes)),
-            None => {
-                // Check if the error is due to too many delayed fields. If so, to be compatible
-                // with the older implementation return an error.
-                if let Some(delayed_fields_extension) = self.delayed_fields_extension {
-                    if delayed_fields_extension.delayed_fields_count.into_inner()
-                        > DelayedFieldsExtension::MAX_DELAYED_FIELDS_PER_RESOURCE
-                    {
-                        return Err(PartialVMError::new(StatusCode::TOO_MANY_DELAYED_FIELDS)
-                            .with_message(
-                                "Too many Delayed fields in a single resource.".to_string(),
-                            ));
-                    }
-                }
-                Ok(None)
-            },
-        }
+        self.serialize_internal(&value)
     }
 
     /// Serializes a [Reference] based on the provided layout. For legacy reasons, all serialization
@@ -230,14 +212,20 @@ impl<'a> ValueSerDeContext<'a> {
             value,
             depth: 1,
         };
+        self.serialize_internal(&value)
+    }
 
-        match bcs::to_bytes(&value).ok() {
+    fn serialize_internal<V: serde::Serialize>(
+        &self,
+        value: &V,
+    ) -> PartialVMResult<Option<Vec<u8>>> {
+        match bcs::to_bytes(value).ok() {
             Some(bytes) => Ok(Some(bytes)),
             None => {
                 // Check if the error is due to too many delayed fields. If so, to be compatible
                 // with the older implementation return an error.
-                if let Some(delayed_fields_extension) = self.delayed_fields_extension {
-                    if delayed_fields_extension.delayed_fields_count.into_inner()
+                if let Some(delayed_fields_extension) = &self.delayed_fields_extension {
+                    if *delayed_fields_extension.delayed_fields_count.borrow()
                         > DelayedFieldsExtension::MAX_DELAYED_FIELDS_PER_RESOURCE
                     {
                         return Err(PartialVMError::new(StatusCode::TOO_MANY_DELAYED_FIELDS)
@@ -260,12 +248,7 @@ impl<'a> ValueSerDeContext<'a> {
             value,
             depth: 1,
         };
-        bcs::serialized_size(&value).map_err(|e| {
-            PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
-                "failed to compute serialized size of a value: {:?}",
-                e
-            ))
-        })
+        self.serialized_size_internal(&value)
     }
 
     /// Returns the serialized size of a [Reference] with the associated layout. All errors are mapped
@@ -281,7 +264,11 @@ impl<'a> ValueSerDeContext<'a> {
             value,
             depth: 1,
         };
-        bcs::serialized_size(&value).map_err(|e| {
+        self.serialized_size_internal(&value)
+    }
+
+    fn serialized_size_internal<V: serde::Serialize>(&self, value: &V) -> PartialVMResult<usize> {
+        bcs::serialized_size(value).map_err(|e| {
             PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
                 "failed to compute serialized size of a value: {:?}",
                 e

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -149,7 +149,10 @@ impl<'a> ValueSerDeContext<'a> {
     }
 
     pub(crate) fn check_depth(&self, depth: u64) -> PartialVMResult<()> {
-        if self.max_value_nested_depth.unwrap_or(2048).lt(&depth) {
+        if self
+            .max_value_nested_depth
+            .is_some_and(|max_depth| depth > max_depth)
+        {
             return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
         }
         Ok(())

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -895,4 +895,74 @@ mod tests {
             "generous depth limit must allow nested value"
         );
     }
+
+    #[test]
+    fn serialize_ref_indexed_closure_enforces_depth_one_level_deeper() {
+        use move_core_types::function::ClosureMask;
+
+        let mut ext = MockFunctionValueExtension::new();
+        ext.expect_get_serialization_data().returning(|af| {
+            Ok(af
+                .downcast_ref::<MockAbstractFunction>()
+                .expect("cast")
+                .data
+                .clone())
+        });
+
+        // A closure capturing one argument. Captured arguments add a nesting level. Closures are
+        // stored as primitives, so `borrow_loc` yields an `IndexedRef` -- the path whose depth
+        // accounting must mirror `IndexedRef::read_ref`, which copies the element at `depth + 1`.
+        let make_closure = || {
+            Value::closure(
+                Box::new(MockAbstractFunction::new(
+                    "f",
+                    vec![],
+                    ClosureMask::new(0b1),
+                    vec![MoveTypeLayout::U64],
+                )),
+                vec![Value::u64(7)],
+            )
+        };
+        let layout = MoveTypeLayout::Function;
+
+        let mut locals = Locals::new(1);
+        locals.store_loc(0, make_closure()).unwrap();
+        let get_ref = || {
+            locals
+                .borrow_loc(0)
+                .unwrap()
+                .value_as::<Reference>()
+                .unwrap()
+        };
+
+        let owned = make_closure();
+
+        // Smallest depth limit at which each path succeeds.
+        let owned_min = (1..=8u64)
+            .find(|&m| {
+                ValueSerDeContext::new(Some(m))
+                    .with_func_args_deserialization(&ext)
+                    .serialize(&owned, &layout)
+                    .unwrap()
+                    .is_some()
+            })
+            .expect("owned closure serializes within depth 8");
+        let ref_min = (1..=8u64)
+            .find(|&m| {
+                ValueSerDeContext::new(Some(m))
+                    .with_func_args_deserialization(&ext)
+                    .serialize_ref(&get_ref(), &layout)
+                    .unwrap()
+                    .is_some()
+            })
+            .expect("closure reference serializes within depth 8");
+
+        // Serializing through an indexed reference visits the element one level deeper than
+        // serializing the owned value, matching `IndexedRef::read_ref`'s `copy_value(depth + 1)`.
+        assert_eq!(
+            ref_min,
+            owned_min + 1,
+            "indexed reference must enforce the depth limit one level deeper than the owned value"
+        );
+    }
 }

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -10,7 +10,10 @@ mod tests {
     use crate::{
         delayed_values::delayed_field_id::DelayedFieldID,
         value_serde::{MockFunctionValueExtension, ValueSerDeContext},
-        values::{function_values_impl::mock::MockAbstractFunction, values_impl, Struct, Value},
+        values::{
+            function_values_impl::mock::MockAbstractFunction, values_impl, Locals, Reference,
+            Struct, StructRef, Value, VectorRef,
+        },
     };
     use better_any::TidExt;
     use claims::{assert_err, assert_ok, assert_some};
@@ -595,5 +598,301 @@ mod tests {
 
         // ser(MoveValue) == ser(VMValue)
         assert_eq!(bytes, vm_bytes);
+    }
+
+    // ======================================================================================
+    // Zero-copy reference serialization (serialize_ref / serialized_size_ref)
+    //
+    // These tests guarantee that serializing through a `&Reference` (the zero-copy path used by
+    // the `bcs` natives) produces byte-for-byte identical output and identical sizes to the
+    // copy-based path that serializes an owned `Value`.
+
+    fn nested_struct_layout() -> MoveTypeLayout {
+        use MoveStructLayout::*;
+        use MoveTypeLayout::*;
+        MoveTypeLayout::new_struct(Runtime(vec![
+            Bool,
+            Vector(Box::new(U32)),
+            MoveTypeLayout::new_struct(Runtime(vec![U64, Vector(Box::new(U8)), Address])),
+            Vector(Box::new(MoveTypeLayout::new_struct(Runtime(vec![
+                U16, Bool,
+            ])))),
+        ]))
+    }
+
+    fn nested_struct_value() -> Value {
+        Value::struct_(Struct::pack(vec![
+            Value::bool(true),
+            Value::vector_u32(vec![1, 2, 3]),
+            Value::struct_(Struct::pack(vec![
+                Value::u64(42),
+                Value::vector_u8(vec![7, 8, 9]),
+                Value::address(AccountAddress::TWO),
+            ])),
+            Value::vector_unchecked(vec![
+                Value::struct_(Struct::pack(vec![Value::u16(1), Value::bool(false)])),
+                Value::struct_(Struct::pack(vec![Value::u16(2), Value::bool(true)])),
+            ])
+            .unwrap(),
+        ]))
+    }
+
+    /// Serializes `value` both as an owned value and through a whole-value reference obtained via
+    /// `Locals::borrow_loc`, asserting the encodings and sizes match.
+    fn assert_ref_matches_value(value: Value, layout: &MoveTypeLayout, legacy_signer: bool) {
+        let mk_ctx = || {
+            let ctx = ValueSerDeContext::new(None).with_delayed_fields_serde();
+            if legacy_signer {
+                ctx.with_legacy_signer()
+            } else {
+                ctx
+            }
+        };
+
+        let owned_bytes = mk_ctx()
+            .serialize(&value, layout)
+            .expect("owned serialization must not error");
+        let owned_size = mk_ctx().serialized_size(&value, layout);
+
+        // `borrow_loc` yields a `ContainerRef` for containers and an `IndexedRef` (into the locals
+        // container) for primitives, so this exercises both `Reference` serialization arms.
+        let mut locals = Locals::new(1);
+        locals.store_loc(0, value).unwrap();
+        let get_ref = || {
+            locals
+                .borrow_loc(0)
+                .unwrap()
+                .value_as::<Reference>()
+                .unwrap()
+        };
+
+        let ref_bytes = mk_ctx()
+            .serialize_ref(&get_ref(), layout)
+            .expect("reference serialization must not error");
+        assert_eq!(
+            owned_bytes, ref_bytes,
+            "serialize_ref output differs from serialize for layout {:?}",
+            layout
+        );
+
+        let ref_size = mk_ctx().serialized_size_ref(&get_ref(), layout);
+        match (&owned_size, &ref_size) {
+            (Ok(a), Ok(b)) => assert_eq!(
+                a, b,
+                "serialized_size_ref differs from serialized_size for layout {:?}",
+                layout
+            ),
+            (Err(_), Err(_)) => {},
+            _ => panic!(
+                "serialized_size / serialized_size_ref disagree on success for layout {:?}: {:?} vs {:?}",
+                layout, owned_size, ref_size
+            ),
+        }
+
+        if let (Some(bytes), Ok(size)) = (&owned_bytes, &owned_size) {
+            assert_eq!(*size, bytes.len(), "size must equal serialized length");
+        }
+    }
+
+    #[test]
+    fn serialize_ref_matches_serialize_scalars_and_containers() {
+        use MoveStructLayout::*;
+        use MoveTypeLayout::*;
+
+        let cases: Vec<(Value, MoveTypeLayout)> = vec![
+            (Value::u8(10), U8),
+            (Value::u16(1000), U16),
+            (Value::u32(100000), U32),
+            (Value::u64(10), U64),
+            (Value::u128(10), U128),
+            (Value::u256(int256::U256::ONE), U256),
+            (Value::bool(true), Bool),
+            (Value::address(AccountAddress::ONE), Address),
+            (Value::vector_u8(vec![1, 2, 3, 4]), Vector(Box::new(U8))),
+            (Value::vector_u64(vec![7, 8, 9]), Vector(Box::new(U64))),
+            (
+                Value::vector_address(vec![AccountAddress::ONE, AccountAddress::TWO]),
+                Vector(Box::new(Address)),
+            ),
+            (
+                Value::vector_unchecked(vec![
+                    Value::vector_u8(vec![1, 2]),
+                    Value::vector_u8(vec![3]),
+                ])
+                .unwrap(),
+                Vector(Box::new(Vector(Box::new(U8)))),
+            ),
+            (
+                Value::struct_(values_impl::Struct::pack(vec![
+                    Value::bool(true),
+                    Value::vector_u32(vec![1, 2, 3, 4, 5]),
+                ])),
+                MoveTypeLayout::new_struct(Runtime(vec![Bool, Vector(Box::new(U32))])),
+            ),
+            (nested_struct_value(), nested_struct_layout()),
+        ];
+
+        for (value, layout) in cases {
+            assert_ref_matches_value(value, &layout, false);
+        }
+    }
+
+    #[test]
+    fn serialize_ref_matches_serialize_enum_variants() {
+        let layout = enum_layout();
+        let values = vec![
+            Value::struct_(Struct::pack_variant(0, iter::once(Value::u64(42)))),
+            Value::struct_(Struct::pack_variant(1, iter::empty())),
+            Value::struct_(Struct::pack_variant(
+                2,
+                [Value::bool(true), Value::u32(13)].into_iter(),
+            )),
+        ];
+        for value in values {
+            assert_ref_matches_value(value, &layout, false);
+        }
+    }
+
+    #[test]
+    fn serialize_ref_matches_serialize_signer() {
+        // Non-legacy master and permissioned signers.
+        assert_ref_matches_value(
+            Value::master_signer(AccountAddress::ONE),
+            &MoveTypeLayout::Signer,
+            false,
+        );
+        assert_ref_matches_value(
+            Value::permissioned_signer(AccountAddress::ONE, AccountAddress::TWO),
+            &MoveTypeLayout::Signer,
+            false,
+        );
+        // Legacy master signer.
+        assert_ref_matches_value(
+            Value::master_signer(AccountAddress::ONE),
+            &MoveTypeLayout::Signer,
+            true,
+        );
+    }
+
+    #[test]
+    fn serialize_ref_matches_serialize_delayed_fields() {
+        use IdentifierMappingKind::*;
+        use MoveTypeLayout::*;
+
+        let cases: Vec<(Value, MoveTypeLayout)> = vec![
+            (
+                Value::delayed_value(DelayedFieldID::new_with_width(12, 8)),
+                Native(Aggregator, Box::new(U64)),
+            ),
+            (
+                Value::delayed_value(DelayedFieldID::new_with_width(123, 16)),
+                Native(Snapshot, Box::new(U128)),
+            ),
+        ];
+        for (value, layout) in cases {
+            assert_ref_matches_value(value, &layout, false);
+        }
+    }
+
+    #[test]
+    fn serialize_ref_matches_serialize_indexed_field_refs() {
+        use MoveTypeLayout::*;
+
+        // Borrow a primitive field of a struct: yields an `IndexedRef` into `Container::Struct`.
+        let field_layouts = [U64, Bool, Address];
+        let field_values = [
+            Value::u64(777),
+            Value::bool(true),
+            Value::address(AccountAddress::TWO),
+        ];
+
+        let mut locals = Locals::new(1);
+        locals
+            .store_loc(
+                0,
+                Value::struct_(values_impl::Struct::pack(vec![
+                    Value::u64(777),
+                    Value::bool(true),
+                    Value::address(AccountAddress::TWO),
+                ])),
+            )
+            .unwrap();
+        let struct_ref = locals
+            .borrow_loc(0)
+            .unwrap()
+            .value_as::<StructRef>()
+            .unwrap();
+
+        for (idx, field_layout) in field_layouts.iter().enumerate() {
+            let field_ref = struct_ref
+                .borrow_field(idx)
+                .unwrap()
+                .value_as::<Reference>()
+                .unwrap();
+            let ref_bytes = ValueSerDeContext::new(None)
+                .serialize_ref(&field_ref, field_layout)
+                .unwrap();
+            let expected = ValueSerDeContext::new(None)
+                .serialize(&field_values[idx], field_layout)
+                .unwrap();
+            assert_eq!(ref_bytes, expected, "field {} mismatch", idx);
+        }
+
+        // Borrow an element of a specialized primitive vector: yields an `IndexedRef` into a
+        // specialized container (e.g. `Container::VecU64`).
+        let mut vec_locals = Locals::new(1);
+        vec_locals
+            .store_loc(0, Value::vector_u64(vec![10, 20, 30]))
+            .unwrap();
+        let vector_ref = vec_locals
+            .borrow_loc(0)
+            .unwrap()
+            .value_as::<VectorRef>()
+            .unwrap();
+        let elem_ref = vector_ref
+            .borrow_elem(1)
+            .unwrap()
+            .value_as::<Reference>()
+            .unwrap();
+        let ref_bytes = ValueSerDeContext::new(None)
+            .serialize_ref(&elem_ref, &U64)
+            .unwrap();
+        let expected = ValueSerDeContext::new(None)
+            .serialize(&Value::u64(20), &U64)
+            .unwrap();
+        assert_eq!(ref_bytes, expected, "specialized vec element mismatch");
+    }
+
+    #[test]
+    fn serialize_ref_respects_depth_limit() {
+        // A reference must enforce the same nesting-depth limit as the owned path.
+        let value = nested_struct_value();
+        let layout = nested_struct_layout();
+
+        let mut locals = Locals::new(1);
+        locals.store_loc(0, value).unwrap();
+        let reference = locals
+            .borrow_loc(0)
+            .unwrap()
+            .value_as::<Reference>()
+            .unwrap();
+
+        // A tiny depth limit must cause serialization to fail (return None), matching `serialize`.
+        let shallow = ValueSerDeContext::new(Some(1))
+            .serialize_ref(&reference, &layout)
+            .unwrap();
+        assert!(
+            shallow.is_none(),
+            "shallow depth limit must reject nested value"
+        );
+
+        // A generous limit must succeed.
+        let deep = ValueSerDeContext::new(Some(64))
+            .serialize_ref(&reference, &layout)
+            .unwrap();
+        assert!(
+            deep.is_some(),
+            "generous depth limit must allow nested value"
+        );
     }
 }

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5326,43 +5326,8 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
             },
 
             // Signer.
-            (L::Signer, Value::Container(Container::Struct(r))) => {
-                if self.ctx.legacy_signer {
-                    // Only allow serialization of master signer.
-                    if *r.borrow()[0].as_value_ref::<u16>().map_err(|_| {
-                        invariant_violation::<S>(format!(
-                            "First field of a signer needs to be an enum descriminator, got {:?}",
-                            self.value
-                        ))
-                    })? != MASTER_SIGNER_VARIANT
-                    {
-                        return Err(S::Error::custom(PartialVMError::new(StatusCode::ABORTED)));
-                    }
-                    r.borrow()
-                        .get(MASTER_ADDRESS_FIELD_OFFSET)
-                        .ok_or_else(|| {
-                            invariant_violation::<S>(format!(
-                                "cannot serialize container {:?} as {:?}",
-                                self.value, self.layout
-                            ))
-                        })?
-                        .as_value_ref::<AccountAddress>()
-                        .map_err(|_| {
-                            invariant_violation::<S>(format!(
-                                "cannot serialize container {:?} as {:?}",
-                                self.value, self.layout
-                            ))
-                        })?
-                        .serialize(serializer)
-                } else {
-                    (SerializationReadyValue {
-                        ctx: self.ctx,
-                        layout: &MoveStructLayout::signer_serialization_layout(),
-                        value: &*r.borrow(),
-                        depth: self.depth,
-                    })
-                    .serialize(serializer)
-                }
+            (L::Signer, Value::Container(c)) => {
+                serialize_signer_container(self.ctx, self.depth, c, serializer)
             },
 
             // Delayed values. For their serialization, we must have custom
@@ -5414,6 +5379,60 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                 value, layout
             ))),
         }
+    }
+}
+
+fn serialize_signer_container<S: serde::Serializer>(
+    ctx: &ValueSerDeContext,
+    depth: u64,
+    container: &Container,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+
+    match container {
+        Container::Struct(r) => {
+            if ctx.legacy_signer {
+                // Only allow serialization of master signer.
+                if *r.borrow()[0].as_value_ref::<u16>().map_err(|_| {
+                    invariant_violation::<S>(format!(
+                        "First field of a signer needs to be an enum descriminator, got {:?}",
+                        container
+                    ))
+                })? != MASTER_SIGNER_VARIANT
+                {
+                    return Err(S::Error::custom(PartialVMError::new(StatusCode::ABORTED)));
+                }
+                r.borrow()
+                    .get(MASTER_ADDRESS_FIELD_OFFSET)
+                    .ok_or_else(|| {
+                        invariant_violation::<S>(format!(
+                            "cannot serialize container {:?} as signer",
+                            container
+                        ))
+                    })?
+                    .as_value_ref::<AccountAddress>()
+                    .map_err(|_| {
+                        invariant_violation::<S>(format!(
+                            "cannot serialize container {:?} as signer",
+                            container
+                        ))
+                    })?
+                    .serialize(serializer)
+            } else {
+                (SerializationReadyValue {
+                    ctx,
+                    layout: &MoveStructLayout::signer_serialization_layout(),
+                    value: &*r.borrow(),
+                    depth,
+                })
+                .serialize(serializer)
+            }
+        },
+        _ => Err(invariant_violation::<S>(format!(
+            "cannot serialize container {:?} as signer",
+            container
+        ))),
     }
 }
 
@@ -5621,44 +5640,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
                 serialize_vector_container(self.ctx, self.depth, layout, c, serializer)
             },
             // Signer.
-            (L::Signer, Container::Struct(r)) => {
-                if self.ctx.legacy_signer {
-                    // Only allow serialization of master signer.
-                    if *r.borrow()[0].as_value_ref::<u16>().map_err(|_| {
-                        invariant_violation::<S>(format!(
-                            "First field of a signer needs to be an enum descriminator, got {:?}",
-                            self.value
-                        ))
-                    })? != MASTER_SIGNER_VARIANT
-                    {
-                        return Err(S::Error::custom(PartialVMError::new(StatusCode::ABORTED)));
-                    }
-                    r.borrow()
-                        .get(MASTER_ADDRESS_FIELD_OFFSET)
-                        .ok_or_else(|| {
-                            invariant_violation::<S>(format!(
-                                "cannot serialize container {:?} as {:?}",
-                                self.value, self.layout
-                            ))
-                        })?
-                        .as_value_ref::<AccountAddress>()
-                        .map_err(|_| {
-                            invariant_violation::<S>(format!(
-                                "cannot serialize container {:?} as {:?}",
-                                self.value, self.layout
-                            ))
-                        })?
-                        .serialize(serializer)
-                } else {
-                    (SerializationReadyValue {
-                        ctx: self.ctx,
-                        layout: &MoveStructLayout::signer_serialization_layout(),
-                        value: &*r.borrow(),
-                        depth: self.depth,
-                    })
-                    .serialize(serializer)
-                }
-            },
+            (L::Signer, c) => serialize_signer_container(self.ctx, self.depth, c, serializer),
             (layout, value) => Err(invariant_violation::<S>(format!(
                 "cannot serialize value {:?} as {:?}",
                 value, layout

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5595,7 +5595,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Re
                     ctx: self.ctx,
                     layout: self.layout,
                     value: container,
-                    depth: self.depth + 1,
+                    depth: self.depth,
                 })
                 .serialize(serializer)
             },
@@ -5613,7 +5613,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Re
                             ctx: self.ctx,
                             layout: self.layout,
                             value: val,
-                            depth: self.depth + 1,
+                            depth: self.depth,
                         })
                         .serialize(serializer)
                     },

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5529,24 +5529,78 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
         self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
         match (self.layout, self.value) {
             (L::Struct(struct_layout), Container::Struct(r)) => {
-                let values = r.borrow();
-                let field_layouts = struct_layout.fields(None);
-                if field_layouts.len() != values.len() {
-                    return Err(invariant_violation::<S>(format!(
-                        "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
-                        self.value, self.layout
-                    )));
+                let values_ref = r.borrow();
+                let mut values = values_ref.as_slice();
+
+                if let Some((tag, variant_layouts)) =
+                    try_get_variant_field_layouts(struct_layout, values)
+                {
+                    let tag_idx = tag as usize;
+                    let variant_tag = tag_idx as u32;
+                    let variant_names = value::variant_name_placeholder((tag + 1) as usize)
+                        .map_err(|e| serde::ser::Error::custom(format!("{}", e)))?;
+                    let variant_name = variant_names[tag_idx];
+                    values = &values[1..];
+                    if variant_layouts.len() != values.len() {
+                        return Err(invariant_violation::<S>(format!(
+                            "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
+                            self.value, self.layout
+                        )));
+                    }
+                    match values.len() {
+                        0 => serializer.serialize_unit_variant(
+                            value::MOVE_ENUM_NAME,
+                            variant_tag,
+                            variant_name,
+                        ),
+                        1 => serializer.serialize_newtype_variant(
+                            value::MOVE_ENUM_NAME,
+                            variant_tag,
+                            variant_name,
+                            &SerializationReadyValue {
+                                ctx: self.ctx,
+                                layout: &variant_layouts[0],
+                                value: &values[0],
+                                depth: self.depth + 1,
+                            },
+                        ),
+                        _ => {
+                            let mut t = serializer.serialize_tuple_variant(
+                                value::MOVE_ENUM_NAME,
+                                variant_tag,
+                                variant_name,
+                                values.len(),
+                            )?;
+                            for (layout, value) in variant_layouts.iter().zip(values) {
+                                t.serialize_field(&SerializationReadyValue {
+                                    ctx: self.ctx,
+                                    layout,
+                                    value,
+                                    depth: self.depth + 1,
+                                })?
+                            }
+                            t.end()
+                        },
+                    }
+                } else {
+                    let field_layouts = struct_layout.fields(None);
+                    if field_layouts.len() != values.len() {
+                        return Err(invariant_violation::<S>(format!(
+                            "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
+                            self.value, self.layout
+                        )));
+                    }
+                    let mut t = serializer.serialize_tuple(values.len())?;
+                    for (layout, value) in field_layouts.iter().zip(values.iter()) {
+                        t.serialize_element(&SerializationReadyValue {
+                            ctx: self.ctx,
+                            layout,
+                            value,
+                            depth: self.depth + 1,
+                        })?;
+                    }
+                    t.end()
                 }
-                let mut t = serializer.serialize_tuple(values.len())?;
-                for (layout, value) in field_layouts.iter().zip(values.iter()) {
-                    t.serialize_element(&SerializationReadyValue {
-                        ctx: self.ctx,
-                        layout,
-                        value,
-                        depth: self.depth + 1,
-                    })?;
-                }
-                t.end()
             },
             (L::Vector(layout), c) => {
                 let layout = layout.as_ref();

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5615,11 +5615,16 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Re
                         // ref that the copy-based path would have rejected could be serialized.
                         val.check_valid_for_indexed_ref(r)
                             .map_err(S::Error::custom)?;
+                        // `IndexedRef::read_ref` copies the referenced element at `depth + 1`, so
+                        // the copy-based path enforces the nesting-depth limit one level deeper
+                        // than the reference itself. Mirror that here (relevant for indexed refs to
+                        // closures, whose captured arguments add further nesting) so that the depth
+                        // boundary at which serialization fails matches the copy-based path.
                         (SerializationReadyValue {
                             ctx: self.ctx,
                             layout: self.layout,
                             value: val,
-                            depth: self.depth,
+                            depth: self.depth + 1,
                         })
                         .serialize(serializer)
                     },

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5322,39 +5322,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
             // Vectors.
             (L::Vector(layout), Value::Container(c)) => {
                 let layout = layout.as_ref();
-                match (layout, c) {
-                    (L::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
-                    (L::U16, Container::VecU16(r)) => r.borrow().serialize(serializer),
-                    (L::U32, Container::VecU32(r)) => r.borrow().serialize(serializer),
-                    (L::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
-                    (L::U128, Container::VecU128(r)) => r.borrow().serialize(serializer),
-                    (L::U256, Container::VecU256(r)) => r.borrow().serialize(serializer),
-                    (L::I8, Container::VecI8(r)) => r.borrow().serialize(serializer),
-                    (L::I16, Container::VecI16(r)) => r.borrow().serialize(serializer),
-                    (L::I32, Container::VecI32(r)) => r.borrow().serialize(serializer),
-                    (L::I64, Container::VecI64(r)) => r.borrow().serialize(serializer),
-                    (L::I128, Container::VecI128(r)) => r.borrow().serialize(serializer),
-                    (L::I256, Container::VecI256(r)) => r.borrow().serialize(serializer),
-                    (L::Bool, Container::VecBool(r)) => r.borrow().serialize(serializer),
-                    (L::Address, Container::VecAddress(r)) => r.borrow().serialize(serializer),
-                    (_, Container::Vec(r)) => {
-                        let v = r.borrow();
-                        let mut t = serializer.serialize_seq(Some(v.len()))?;
-                        for value in v.iter() {
-                            t.serialize_element(&SerializationReadyValue {
-                                ctx: self.ctx,
-                                layout,
-                                value,
-                                depth: self.depth + 1,
-                            })?;
-                        }
-                        t.end()
-                    },
-                    (layout, container) => Err(invariant_violation::<S>(format!(
-                        "cannot serialize container {:?} as {:?}",
-                        container, layout
-                    ))),
-                }
+                serialize_vector_container(self.ctx, self.depth, layout, c, serializer)
             },
 
             // Signer.
@@ -5446,6 +5414,52 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                 value, layout
             ))),
         }
+    }
+}
+
+fn serialize_vector_container<S: serde::Serializer>(
+    ctx: &ValueSerDeContext,
+    depth: u64,
+    layout: &MoveTypeLayout,
+    container: &Container,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+    use MoveTypeLayout as L;
+    // layout is already &MoveTypeLayout
+
+    match (layout, container) {
+        (L::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
+        (L::U16, Container::VecU16(r)) => r.borrow().serialize(serializer),
+        (L::U32, Container::VecU32(r)) => r.borrow().serialize(serializer),
+        (L::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
+        (L::U128, Container::VecU128(r)) => r.borrow().serialize(serializer),
+        (L::U256, Container::VecU256(r)) => r.borrow().serialize(serializer),
+        (L::I8, Container::VecI8(r)) => r.borrow().serialize(serializer),
+        (L::I16, Container::VecI16(r)) => r.borrow().serialize(serializer),
+        (L::I32, Container::VecI32(r)) => r.borrow().serialize(serializer),
+        (L::I64, Container::VecI64(r)) => r.borrow().serialize(serializer),
+        (L::I128, Container::VecI128(r)) => r.borrow().serialize(serializer),
+        (L::I256, Container::VecI256(r)) => r.borrow().serialize(serializer),
+        (L::Bool, Container::VecBool(r)) => r.borrow().serialize(serializer),
+        (L::Address, Container::VecAddress(r)) => r.borrow().serialize(serializer),
+        (_, Container::Vec(r)) => {
+            let v = r.borrow();
+            let mut t = serializer.serialize_seq(Some(v.len()))?;
+            for value in v.iter() {
+                t.serialize_element(&SerializationReadyValue {
+                    ctx,
+                    layout,
+                    value,
+                    depth: depth + 1,
+                })?;
+            }
+            t.end()
+        },
+        (layout, container) => Err(invariant_violation::<S>(format!(
+            "cannot serialize container {:?} as {:?}",
+            container, layout
+        ))),
     }
 }
 
@@ -5604,39 +5618,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
             },
             (L::Vector(layout), c) => {
                 let layout = layout.as_ref();
-                match (layout, c) {
-                    (L::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
-                    (L::U16, Container::VecU16(r)) => r.borrow().serialize(serializer),
-                    (L::U32, Container::VecU32(r)) => r.borrow().serialize(serializer),
-                    (L::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
-                    (L::U128, Container::VecU128(r)) => r.borrow().serialize(serializer),
-                    (L::U256, Container::VecU256(r)) => r.borrow().serialize(serializer),
-                    (L::I8, Container::VecI8(r)) => r.borrow().serialize(serializer),
-                    (L::I16, Container::VecI16(r)) => r.borrow().serialize(serializer),
-                    (L::I32, Container::VecI32(r)) => r.borrow().serialize(serializer),
-                    (L::I64, Container::VecI64(r)) => r.borrow().serialize(serializer),
-                    (L::I128, Container::VecI128(r)) => r.borrow().serialize(serializer),
-                    (L::I256, Container::VecI256(r)) => r.borrow().serialize(serializer),
-                    (L::Bool, Container::VecBool(r)) => r.borrow().serialize(serializer),
-                    (L::Address, Container::VecAddress(r)) => r.borrow().serialize(serializer),
-                    (_, Container::Vec(r)) => {
-                        let v = r.borrow();
-                        let mut t = serializer.serialize_seq(Some(v.len()))?;
-                        for value in v.iter() {
-                            t.serialize_element(&SerializationReadyValue {
-                                ctx: self.ctx,
-                                layout,
-                                value,
-                                depth: self.depth + 1,
-                            })?;
-                        }
-                        t.end()
-                    },
-                    (layout, container) => Err(invariant_violation::<S>(format!(
-                        "cannot serialize container {:?} as {:?}",
-                        container, layout
-                    ))),
-                }
+                serialize_vector_container(self.ctx, self.depth, layout, c, serializer)
             },
             // Signer.
             (L::Signer, Container::Struct(r)) => {

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5522,6 +5522,223 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveStructLayout, 
     }
 }
 
+impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Container> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use MoveTypeLayout as L;
+
+        self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
+        match (self.layout, self.value) {
+            (L::Struct(struct_layout), Container::Struct(r)) => {
+                let values = r.borrow();
+                let field_layouts = struct_layout.fields(None);
+                if field_layouts.len() != values.len() {
+                    return Err(invariant_violation::<S>(format!(
+                        "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
+                        self.value, self.layout
+                    )));
+                }
+                let mut t = serializer.serialize_tuple(values.len())?;
+                for (layout, value) in field_layouts.iter().zip(values.iter()) {
+                    t.serialize_element(&SerializationReadyValue {
+                        ctx: self.ctx,
+                        layout,
+                        value,
+                        depth: self.depth + 1,
+                    })?;
+                }
+                t.end()
+            },
+            (L::Vector(layout), c) => {
+                let layout = layout.as_ref();
+                match (layout, c) {
+                    (L::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
+                    (L::U16, Container::VecU16(r)) => r.borrow().serialize(serializer),
+                    (L::U32, Container::VecU32(r)) => r.borrow().serialize(serializer),
+                    (L::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
+                    (L::U128, Container::VecU128(r)) => r.borrow().serialize(serializer),
+                    (L::U256, Container::VecU256(r)) => r.borrow().serialize(serializer),
+                    (L::I8, Container::VecI8(r)) => r.borrow().serialize(serializer),
+                    (L::I16, Container::VecI16(r)) => r.borrow().serialize(serializer),
+                    (L::I32, Container::VecI32(r)) => r.borrow().serialize(serializer),
+                    (L::I64, Container::VecI64(r)) => r.borrow().serialize(serializer),
+                    (L::I128, Container::VecI128(r)) => r.borrow().serialize(serializer),
+                    (L::I256, Container::VecI256(r)) => r.borrow().serialize(serializer),
+                    (L::Bool, Container::VecBool(r)) => r.borrow().serialize(serializer),
+                    (L::Address, Container::VecAddress(r)) => r.borrow().serialize(serializer),
+                    (_, Container::Vec(r)) => {
+                        let v = r.borrow();
+                        let mut t = serializer.serialize_seq(Some(v.len()))?;
+                        for value in v.iter() {
+                            t.serialize_element(&SerializationReadyValue {
+                                ctx: self.ctx,
+                                layout,
+                                value,
+                                depth: self.depth + 1,
+                            })?;
+                        }
+                        t.end()
+                    },
+                    (layout, container) => Err(invariant_violation::<S>(format!(
+                        "cannot serialize container {:?} as {:?}",
+                        container, layout
+                    ))),
+                }
+            },
+            // Signer.
+            (L::Signer, Container::Struct(r)) => {
+                if self.ctx.legacy_signer {
+                    // Only allow serialization of master signer.
+                    if *r.borrow()[0].as_value_ref::<u16>().map_err(|_| {
+                        invariant_violation::<S>(format!(
+                            "First field of a signer needs to be an enum descriminator, got {:?}",
+                            self.value
+                        ))
+                    })? != MASTER_SIGNER_VARIANT
+                    {
+                        return Err(S::Error::custom(PartialVMError::new(StatusCode::ABORTED)));
+                    }
+                    r.borrow()
+                        .get(MASTER_ADDRESS_FIELD_OFFSET)
+                        .ok_or_else(|| {
+                            invariant_violation::<S>(format!(
+                                "cannot serialize container {:?} as {:?}",
+                                self.value, self.layout
+                            ))
+                        })?
+                        .as_value_ref::<AccountAddress>()
+                        .map_err(|_| {
+                            invariant_violation::<S>(format!(
+                                "cannot serialize container {:?} as {:?}",
+                                self.value, self.layout
+                            ))
+                        })?
+                        .serialize(serializer)
+                } else {
+                    (SerializationReadyValue {
+                        ctx: self.ctx,
+                        layout: &MoveStructLayout::signer_serialization_layout(),
+                        value: &*r.borrow(),
+                        depth: self.depth,
+                    })
+                    .serialize(serializer)
+                }
+            },
+            (layout, value) => Err(invariant_violation::<S>(format!(
+                "cannot serialize value {:?} as {:?}",
+                value, layout
+            ))),
+        }
+    }
+}
+
+impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Reference> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
+        match &self.value.0 {
+            ReferenceImpl::ContainerRef(r) => {
+                let container = r.container();
+                (SerializationReadyValue {
+                    ctx: self.ctx,
+                    layout: self.layout,
+                    value: container,
+                    depth: self.depth + 1,
+                })
+                .serialize(serializer)
+            },
+            ReferenceImpl::IndexedRef(r) => {
+                // Check tag first!
+                r.check_tag().map_err(S::Error::custom)?;
+                let container = r.container_ref.container();
+                match container {
+                    Container::Vec(vals) | Container::Locals(vals) | Container::Struct(vals) => {
+                        let vals = vals.borrow();
+                        let val = vals.get(r.idx as usize).ok_or_else(|| {
+                            invariant_violation::<S>("index out of bounds".to_string())
+                        })?;
+                        (SerializationReadyValue {
+                            ctx: self.ctx,
+                            layout: self.layout,
+                            value: val,
+                            depth: self.depth + 1,
+                        })
+                        .serialize(serializer)
+                    },
+                    Container::VecU8(vals) => {
+                        serializer.serialize_u8(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecU64(vals) => {
+                        serializer.serialize_u64(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecU128(vals) => {
+                        serializer.serialize_u128(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecBool(vals) => {
+                        serializer.serialize_bool(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecAddress(vals) => vals
+                        .borrow()
+                        .get(r.idx as usize)
+                        .ok_or_else(|| invariant_violation::<S>("index out of bounds".to_string()))?
+                        .serialize(serializer),
+                    Container::VecU16(vals) => {
+                        serializer.serialize_u16(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecU32(vals) => {
+                        serializer.serialize_u32(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecU256(vals) => vals
+                        .borrow()
+                        .get(r.idx as usize)
+                        .ok_or_else(|| invariant_violation::<S>("index out of bounds".to_string()))?
+                        .serialize(serializer),
+                    Container::VecI8(vals) => {
+                        serializer.serialize_i8(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI16(vals) => {
+                        serializer.serialize_i16(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI32(vals) => {
+                        serializer.serialize_i32(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI64(vals) => {
+                        serializer.serialize_i64(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI128(vals) => {
+                        serializer.serialize_i128(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI256(vals) => vals
+                        .borrow()
+                        .get(r.idx as usize)
+                        .ok_or_else(|| invariant_violation::<S>("index out of bounds".to_string()))?
+                        .serialize(serializer),
+                }
+            },
+        }
+    }
+}
+
 // Seed used by deserializer to ensure there is information about the value
 // being deserialized.
 pub(crate) struct DeserializationSeed<'c, L> {

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5565,7 +5565,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
                 let values = r.borrow();
                 (SerializationReadyValue {
                     ctx: self.ctx,
-                    layout: struct_layout,
+                    layout: struct_layout.as_ref(),
                     value: &*values,
                     depth: self.depth,
                 })

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5609,6 +5609,12 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Re
                         let val = vals.get(r.idx as usize).ok_or_else(|| {
                             invariant_violation::<S>("index out of bounds".to_string())
                         })?;
+                        // Mirror the invariant guard that `IndexedRef::read_ref` enforces: an
+                        // indexed reference must point at a primitive element, never at a nested
+                        // container or another reference. Without this, a malformed/stale indexed
+                        // ref that the copy-based path would have rejected could be serialized.
+                        val.check_valid_for_indexed_ref(r)
+                            .map_err(S::Error::custom)?;
                         (SerializationReadyValue {
                             ctx: self.ctx,
                             layout: self.layout,

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5562,78 +5562,14 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
         self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
         match (self.layout, self.value) {
             (L::Struct(struct_layout), Container::Struct(r)) => {
-                let values_ref = r.borrow();
-                let mut values = values_ref.as_slice();
-
-                if let Some((tag, variant_layouts)) =
-                    try_get_variant_field_layouts(struct_layout, values)
-                {
-                    let tag_idx = tag as usize;
-                    let variant_tag = tag_idx as u32;
-                    let variant_names = value::variant_name_placeholder((tag + 1) as usize)
-                        .map_err(|e| serde::ser::Error::custom(format!("{}", e)))?;
-                    let variant_name = variant_names[tag_idx];
-                    values = &values[1..];
-                    if variant_layouts.len() != values.len() {
-                        return Err(invariant_violation::<S>(format!(
-                            "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
-                            self.value, self.layout
-                        )));
-                    }
-                    match values.len() {
-                        0 => serializer.serialize_unit_variant(
-                            value::MOVE_ENUM_NAME,
-                            variant_tag,
-                            variant_name,
-                        ),
-                        1 => serializer.serialize_newtype_variant(
-                            value::MOVE_ENUM_NAME,
-                            variant_tag,
-                            variant_name,
-                            &SerializationReadyValue {
-                                ctx: self.ctx,
-                                layout: &variant_layouts[0],
-                                value: &values[0],
-                                depth: self.depth + 1,
-                            },
-                        ),
-                        _ => {
-                            let mut t = serializer.serialize_tuple_variant(
-                                value::MOVE_ENUM_NAME,
-                                variant_tag,
-                                variant_name,
-                                values.len(),
-                            )?;
-                            for (layout, value) in variant_layouts.iter().zip(values) {
-                                t.serialize_field(&SerializationReadyValue {
-                                    ctx: self.ctx,
-                                    layout,
-                                    value,
-                                    depth: self.depth + 1,
-                                })?
-                            }
-                            t.end()
-                        },
-                    }
-                } else {
-                    let field_layouts = struct_layout.fields(None);
-                    if field_layouts.len() != values.len() {
-                        return Err(invariant_violation::<S>(format!(
-                            "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
-                            self.value, self.layout
-                        )));
-                    }
-                    let mut t = serializer.serialize_tuple(values.len())?;
-                    for (layout, value) in field_layouts.iter().zip(values.iter()) {
-                        t.serialize_element(&SerializationReadyValue {
-                            ctx: self.ctx,
-                            layout,
-                            value,
-                            depth: self.depth + 1,
-                        })?;
-                    }
-                    t.end()
-                }
+                let values = r.borrow();
+                (SerializationReadyValue {
+                    ctx: self.ctx,
+                    layout: struct_layout,
+                    value: &*values,
+                    depth: self.depth,
+                })
+                .serialize(serializer)
             },
             (L::Vector(layout), c) => {
                 let layout = layout.as_ref();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Recreates the work from #20179 (which was accidentally closed after its branch was overwritten by unrelated commits). This carries #18535's zero-copy BCS serialization commits (`serialize_ref` / `serialized_size_ref`, resolving #14175) plus the fixups below. Because #18535 comes from a fork, its commits cannot be used as a PR base in this repo, so they are included here and this PR targets `main`.

Fixups on top of #18535:

1. **Fix compile error (blocker).** The new `SerializationReadyValue<MoveTypeLayout, Container>` impl passed the `Arc<MoveStructLayout>` from `L::Struct` directly where a `&MoveStructLayout` is expected, so `move-vm-types` did not compile. Added `.as_ref()` to match the existing `Value` serializer. (Not caught on #18535 because CI there is gated behind a failing `permission-check`, so all Rust build/test jobs were skipped.)

2. **Restore the indexed-ref invariant guard.** `IndexedRef::read_ref` enforces `check_valid_for_indexed_ref`, which rejects a stale/malformed indexed reference pointing at a nested container or another reference. The zero-copy path dropped this guard; it is restored so `serialize_ref` has the same safety behavior as the copy-based path.

3. **Match `read_ref` depth accounting for indexed refs.** `IndexedRef::read_ref` copies the referenced element at `depth + 1`, so the copy-based path enforces the nesting-depth limit one level deeper than the reference. The indexed-ref serialization arm now visits the element at `self.depth + 1`, so `bcs::to_bytes` / `serialized_size` reject at the same depth boundary as before (relevant for indexed refs to closures, whose captured arguments add nesting).

4. **Add differential and depth-parity tests.** Since the correctness requirement is that the reference path produces byte-identical output to the copy-based path (BCS output is consensus-sensitive), added tests asserting parity of bytes, size, and depth-limit behavior.

## Disposition of automated review comments (from #20179)

- **Depth-limit parity for indexed refs (closures):** addressed by fixup (3) and pinned by `serialize_ref_indexed_closure_enforces_depth_one_level_deeper`.
- **Failure-class change (`read_ref` errors now map to `None` → `NFE_BCS_SERIALIZATION_FAILURE`):** intentional and consistent with the existing owned `serialize` path in #18535, which already maps every serializer error (including `VM_MAX_VALUE_DEPTH_REACHED` and invariant/tag failures) to `None`. Routing reference-structural failures through the same fail-closed abort keeps the reference and owned paths consistent; these are invariant violations that should not occur under a correct verifier. Left as-is by design.

## How Has This Been Tested?

New tests in `third_party/move/move-vm/types/src/values/serialization_tests.rs` assert `serialize_ref` / `serialized_size_ref` match `serialize` / `serialized_size` across scalars, specialized/nested/general vectors, structs, nested structs, enum variants, signers (master/permissioned, legacy/non-legacy), delayed fields, indexed field/element refs, and depth-limit enforcement (incl. the indexed-ref-to-closure `+1` parity).

`cargo test -p move-vm-types --lib` passes. `cargo +nightly fmt` and `cargo clippy -p move-vm-types --lib --tests` are clean for the changed code. `aptos-move-stdlib` (the natives caller) compiles.

## Type of Change
- [x] Bug fix
- [x] Performance improvement
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15248e7f-82b7-4b20-91a8-bab1159c6520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15248e7f-82b7-4b20-91a8-bab1159c6520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

