### PR TITLE
[consensus] Suppress try_next deprecation from futures backport

### DIFF
--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -150,6 +150,9 @@ proptest! {
                         order_rule.process_new_node(flatten_nodes[idx].metadata());
                     }
                     let mut ordered = vec![];
+                    // `try_next` is deprecated upstream in favor of `try_recv`, unavailable
+                    // in the pinned futures-rs backport fork.
+                    #[allow(deprecated)]
                     while let Ok(Some(mut ordered_nodes)) = receiver.try_next() {
                         ordered.append(&mut ordered_nodes);
                     }
@@ -162,6 +165,9 @@ proptest! {
         let (mut order_rule, mut receiver) = create_order_rule(epoch_state.clone(), dag);
         order_rule.process_all();
         let mut ordered = vec![];
+        // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+        // pinned futures-rs backport fork.
+        #[allow(deprecated)]
         while let Ok(Some(mut ordered_nodes)) = receiver.try_next() {
             ordered.append(&mut ordered_nodes);
         }
@@ -250,6 +256,9 @@ fn test_order_rule_basic() {
         vec![(4, 1), (4, 0), (5, 2)],
     ];
     let mut batch = 0;
+    // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+    // pinned futures-rs backport fork.
+    #[allow(deprecated)]
     while let Ok(Some(ordered_nodes)) = receiver.try_next() {
         assert_eq!(
             ordered_nodes

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -580,6 +580,9 @@ impl BufferManager {
         self.previous_commit_time = Instant::now();
         self.commit_proof_rb_handle.take();
         // purge the incoming blocks queue
+        // `UnboundedReceiver::try_next` is deprecated upstream in favor of `try_recv`,
+        // but the pinned futures-rs backport fork does not yet provide `try_recv`.
+        #[allow(deprecated)]
         while let Ok(Some(blocks)) = self.block_rx.try_next() {
             for b in blocks.ordered_blocks {
                 if let Some(futs) = b.abort_pipeline() {

--- a/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/consensus/src/rand/rand_gen/rand_manager.rs
@@ -213,6 +213,9 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
         // Drain stale decision messages (Success/Skip) from previously spawned
         // aggregation tasks and shared futures to prevent them from affecting
         // new blocks that may arrive at the same rounds after reset.
+        // `try_next` is deprecated upstream in favor of `try_recv`, which the pinned
+        // futures-rs backport fork does not yet provide.
+        #[allow(deprecated)]
         while matches!(self.decision_rx.try_next(), Ok(Some(_))) {}
         self.stop = matches!(signal, ResetSignal::Stop);
         let _ = tx.send(ResetAck::default());
@@ -398,6 +401,9 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                     self.process_incoming_blocks(blocks);
                 }
                 Some(reset) = reset_rx.next() => {
+                    // `try_next` is deprecated upstream in favor of `try_recv`, which the
+                    // pinned futures-rs backport fork does not yet provide.
+                    #[allow(deprecated)]
                     while matches!(incoming_blocks.try_next(), Ok(Some(_))) {}
                     self.process_reset(reset);
                 }

--- a/consensus/src/rand/rand_gen/rand_store.rs
+++ b/consensus/src/rand/rand_gen/rand_store.rs
@@ -614,6 +614,9 @@ mod tests {
         {
             rand_store.add_share(share).unwrap();
         }
+        // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+        // pinned futures-rs backport fork.
+        #[allow(deprecated)]
         assert!(result_rx.try_next().is_err());
         for metadata in blocks_1.all_rand_metadata() {
             rand_store.add_rand_metadata(metadata, Some(resolved_rand_check(true)));
@@ -627,6 +630,9 @@ mod tests {
         for metadata in blocks_2.all_rand_metadata() {
             rand_store.add_rand_metadata(metadata, Some(resolved_rand_check(true)));
         }
+        // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+        // pinned futures-rs backport fork.
+        #[allow(deprecated)]
         assert!(result_rx.try_next().is_err());
 
         for share in ctxt.authors[1..6]
@@ -670,6 +676,9 @@ mod tests {
         }
 
         // No decision yet because the future hasn't resolved
+        // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+        // pinned futures-rs backport fork.
+        #[allow(deprecated)]
         assert!(result_rx.try_next().is_err());
 
         // Resolve the future — the spawned task proceeds to aggregate
@@ -698,6 +707,9 @@ mod tests {
         for m in metadata.iter() {
             rand_store.add_rand_metadata(m.clone(), Some(resolved_rand_check(true)));
         }
+        // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+        // pinned futures-rs backport fork.
+        #[allow(deprecated)]
         assert!(result_rx.try_next().is_err());
 
         // Add shares one by one — aggregation should trigger when threshold is met
@@ -742,6 +754,9 @@ mod tests {
         // The spawned task sees the future resolved to false → skips aggregation silently
         // (Skip sending is handled by the shared future in rand_manager, not by try_aggregate)
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+        // pinned futures-rs backport fork.
+        #[allow(deprecated)]
         assert!(result_rx.try_next().is_err());
     }
 
@@ -767,6 +782,9 @@ mod tests {
             rand_store.add_share(share).unwrap();
         }
         // No decision yet — still waiting for metadata
+        // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+        // pinned futures-rs backport fork.
+        #[allow(deprecated)]
         assert!(result_rx.try_next().is_err());
 
         // Now add metadata with resolved future — threshold already met → aggregation triggered

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -487,6 +487,9 @@ impl SecretShareManager {
                 }
                 Some(reset) = reset_rx.next() => {
                     let mut dropped = 0;
+                    // `try_next` is deprecated upstream in favor of `try_recv`, which the
+                    // pinned futures-rs backport fork does not yet provide.
+                    #[allow(deprecated)]
                     while matches!(incoming_blocks.try_next(), Ok(Some(_))) {
                         dropped += 1;
                     }

--- a/consensus/src/twins/basic_twins_test.rs
+++ b/consensus/src/twins/basic_twins_test.rs
@@ -105,6 +105,9 @@ fn drop_config_test() {
         assert!(node0_commit.is_some());
 
         // Check that the commit log for n2 is empty
+        // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in the
+        // pinned futures-rs backport fork.
+        #[allow(deprecated)]
         let node2_commit = match nodes[2].commit_cb_receiver.try_next() {
             Ok(Some(node_commit)) => Some(node_commit),
             _ => None,
@@ -167,6 +170,9 @@ fn twins_vote_dedup_test() {
         // have been created
         let mut commit_seen = false;
         for node in &mut nodes {
+            // `try_next` is deprecated upstream in favor of `try_recv`, unavailable in
+            // the pinned futures-rs backport fork.
+            #[allow(deprecated)]
             if let Ok(Some(_node_commit)) = node.commit_cb_receiver.try_next() {
                 commit_seen = true;
             }


### PR DESCRIPTION
## Summary

`cargo xclippy` runs with `-D warnings`. The `futures-rs` backport fork resolved in CI marks `UnboundedReceiver::try_next` `#[deprecated]` in favor of `try_recv`, but the pinned fork does not expose `try_recv`. This turns into **15 hard errors across `consensus/`**, blocking `rust-lints` on every branch (the call sites are identical on `main`).

## Change

Annotate each of the 15 call sites with a statement-scoped `#[allow(deprecated)]` plus a rationale comment. **No behavior change** — `try_next` is retained because `try_recv` is unavailable in the fork the workspace currently builds against.

Migrating to `try_recv` is deferred until the fork exposes it (the semantics differ: `try_next` returns `Ok(None)` on close vs `try_recv` returning `Err(Closed)`), so a blanket rename is not a safe drop-in.

## Affected files
- `consensus/src/pipeline/buffer_manager.rs`
- `consensus/src/rand/rand_gen/rand_manager.rs`
- `consensus/src/rand/rand_gen/rand_store.rs`
- `consensus/src/rand/secret_sharing/secret_share_manager.rs`
- `consensus/src/dag/tests/order_rule_tests.rs`
- `consensus/src/twins/basic_twins_test.rs`

## Test
- `cargo check -p aptos-consensus --tests` — compiles clean
- `cargo +nightly fmt -p aptos-consensus -- --check` — clean