### PR TITLE
API memory manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,11 +455,13 @@ dependencies = [
  "aptos-gas-meter",
  "aptos-gas-schedule",
  "aptos-global-constants",
+ "aptos-jemalloc",
  "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-move-stdlib",
  "aptos-proptest-helpers",
+ "aptos-resource-viewer",
  "aptos-runtimes",
  "aptos-sdk",
  "aptos-storage-interface",
@@ -4057,11 +4059,15 @@ name = "aptos-resource-viewer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-config",
+ "aptos-jemalloc",
  "aptos-logger",
  "aptos-types",
  "aptos-vm",
  "aptos-vm-environment",
  "aptos-vm-logging",
+ "bcs 0.1.4",
+ "criterion",
  "hashbrown 0.14.3",
  "move-binary-format",
  "move-bytecode-utils",
@@ -4069,6 +4075,7 @@ dependencies = [
  "move-resource-viewer",
  "move-vm-runtime",
  "move-vm-types",
+ "tikv-jemallocator",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -17,6 +17,7 @@ ignored = ["mime"]
 
 [features]
 failpoints = ["fail/failpoints"]
+metered-allocations = ["aptos-api-types/metered-allocations"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -64,6 +65,7 @@ aptos-gas-meter = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-move-stdlib = { workspace = true }
 aptos-proptest-helpers = { workspace = true }
+aptos-resource-viewer = { workspace = true }
 aptos-transaction-filters = { workspace = true, features = ["fuzzing"] }
 flate2 = { workspace = true }
 move-package = { workspace = true }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -28,6 +28,7 @@ aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-global-constants = { workspace = true }
+aptos-jemalloc = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-mempool = { workspace = true }
 aptos-metrics-core = { workspace = true }

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 use anyhow::Context as AnyhowContext;
 use aptos_api_types::{
-    AccountData, Address, AptosErrorCode, AsConverter, AssetType, LedgerInfo, MoveModuleBytecode,
-    MoveModuleId, MoveResource, MoveStructTag, StateKeyWrapper, U64,
+    AccountData, Address, AptosErrorCode, AssetType, LedgerInfo, MoveModuleBytecode, MoveModuleId,
+    MoveResource, MoveStructTag, StateKeyWrapper, U64,
 };
 use aptos_sdk::types::{get_paired_fa_metadata_address, get_paired_fa_primary_store_address};
 use aptos_types::{
@@ -476,8 +476,7 @@ impl Account {
                 let state_view = self
                     .context
                     .latest_state_view_poem(&self.latest_ledger_info)?;
-                let converter = state_view
-                    .as_converter(self.context.db.clone(), self.context.indexer_reader.clone());
+                let converter = self.context.as_converter(&state_view);
                 let converted_resources = converter
                     .try_into_resources(resources.iter().map(|(k, v)| (k.clone(), v.as_slice())))
                     .context("Failed to build move resource response from data in DB")
@@ -658,8 +657,9 @@ impl Account {
         let (ledger_info, requested_ledger_version, state_view) =
             self.context.state_view(Some(self.ledger_version))?;
 
-        let bytes = state_view
-            .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
+        let bytes = self
+            .context
+            .as_converter(&state_view)
             .find_resource(&state_view, self.address, resource_type)
             .context(format!(
                 "Failed to query DB to check for {} at {}",
@@ -682,8 +682,8 @@ impl Account {
                 )
             })?;
 
-        state_view
-            .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
+        self.context
+            .as_converter(&state_view)
             .move_struct_fields(resource_type, &bytes)
             .context("Failed to convert move structs from storage")
             .map_err(|err| {

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -13,7 +13,7 @@ use crate::{
 use anyhow::{anyhow, ensure, format_err, Context as AnyhowContext, Result};
 use aptos_api_types::{
     transaction::ReplayProtector, AptosErrorCode, AsConverter, BcsBlock, GasEstimation, LedgerInfo,
-    ResourceGroup, TransactionOnChainData, TransactionSummary,
+    MoveConverter, ResourceGroup, TransactionOnChainData, TransactionSummary,
 };
 use aptos_config::config::{GasEstimationConfig, NodeConfig, RoleType};
 use aptos_crypto::HashValue;
@@ -40,7 +40,7 @@ use aptos_types::{
     },
     state_store::{
         state_key::{inner::StateKeyInner, prefix::StateKeyPrefix, StateKey},
-        TStateView,
+        StateView, TStateView,
     },
     transaction::{
         block_epilogue::BlockEndInfo,
@@ -150,6 +150,14 @@ impl Context {
 
     pub fn max_account_modules_page_size(&self) -> u16 {
         self.node_config.api.max_account_modules_page_size
+    }
+
+    pub fn as_converter<'a, S: StateView>(&self, state_view: &'a S) -> MoveConverter<'a, S> {
+        state_view.as_converter_with_resource_annotation_limit(
+            self.db.clone(),
+            self.indexer_reader.clone(),
+            self.node_config.api.max_resource_annotation_bytes,
+        )
     }
 
     pub fn latest_state_view(&self) -> Result<DbStateView> {
@@ -509,7 +517,7 @@ impl Context {
 
         // We should be able to do an unwrap here, otherwise the above db read would fail.
         let state_view = self.state_view_at_version(version)?;
-        let converter = state_view.as_converter(self.db.clone(), self.indexer_reader.clone());
+        let converter = self.as_converter(&state_view);
 
         // Extract resources from resource groups and flatten into all resources
         let kvs = kvs
@@ -713,7 +721,7 @@ impl Context {
         }
 
         let state_view = self.latest_state_view_poem(ledger_info)?;
-        let converter = state_view.as_converter(self.db.clone(), self.indexer_reader.clone());
+        let converter = self.as_converter(&state_view);
         let txns: Vec<aptos_api_types::Transaction> = data
             .into_iter()
             .map(|t| {
@@ -745,7 +753,7 @@ impl Context {
         }
 
         let state_view = self.latest_state_view_poem(ledger_info)?;
-        let converter = state_view.as_converter(self.db.clone(), self.indexer_reader.clone());
+        let converter = self.as_converter(&state_view);
         let txns: Vec<aptos_api_types::Transaction> = data
             .into_iter()
             .map(|t| {

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 use anyhow::Context as AnyhowContext;
 use aptos_api_types::{
-    verify_field_identifier, Address, AptosErrorCode, AsConverter, IdentifierWrapper, LedgerInfo,
-    MoveStructTag, VerifyInputWithRecursion, VersionedEvent, U64,
+    verify_field_identifier, Address, AptosErrorCode, IdentifierWrapper, LedgerInfo, MoveStructTag,
+    VerifyInputWithRecursion, VersionedEvent, U64,
 };
 use aptos_types::event::EventKey;
 use poem_openapi::{
@@ -179,10 +179,10 @@ impl EventsApi {
 
         match accept_type {
             AcceptType::Json => {
+                let state_view = self.context.latest_state_view_poem(&latest_ledger_info)?;
                 let events = self
                     .context
-                    .latest_state_view_poem(&latest_ledger_info)?
-                    .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
+                    .as_converter(&state_view)
                     .try_into_versioned_events(&events)
                     .context("Failed to convert events from storage into response")
                     .map_err(|err| {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -16,6 +16,7 @@ mod failpoint;
 mod headers_sanity_check;
 mod index;
 mod log;
+mod memory_admission;
 pub mod metrics;
 mod page;
 mod response;

--- a/api/src/memory_admission.rs
+++ b/api/src/memory_admission.rs
@@ -1,0 +1,153 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Process-wide memory admission middleware. When process resident memory is at or
+//! above the configured cap, new API requests are shed with HTTP 503 before
+//! dispatch. The health-check endpoint is exempt; a cap of `0` disables the gate.
+
+use crate::metrics::MEMORY_ADMISSION_REJECTED;
+use aptos_api_types::{AptosError, AptosErrorCode};
+use poem::{http::StatusCode, Endpoint, IntoResponse, Middleware, Request, Response, Result};
+use poem_openapi::payload::Json;
+
+/// Path suffix exempt from the gate so liveness probes always succeed.
+const HEALTH_CHECK_PATH_SUFFIX: &str = "/-/healthy";
+
+/// poem `Middleware` wrapping each endpoint with the memory-admission gate.
+/// Constructed with the resident-memory cap in bytes (`0` disables the gate).
+pub struct MemoryAdmission {
+    cap_bytes: usize,
+    resident_fn: fn() -> Option<i64>,
+}
+
+impl MemoryAdmission {
+    pub fn new(cap_bytes: usize) -> Self {
+        Self {
+            cap_bytes,
+            resident_fn: aptos_jemalloc::current_process_resident_bytes,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_resident_fn(cap_bytes: usize, resident_fn: fn() -> Option<i64>) -> Self {
+        Self {
+            cap_bytes,
+            resident_fn,
+        }
+    }
+}
+
+impl<E: Endpoint> Middleware<E> for MemoryAdmission {
+    type Output = MemoryAdmissionEndpoint<E>;
+
+    fn transform(&self, inner: E) -> Self::Output {
+        MemoryAdmissionEndpoint {
+            inner,
+            cap_bytes: self.cap_bytes,
+            resident_fn: self.resident_fn,
+        }
+    }
+}
+
+pub struct MemoryAdmissionEndpoint<E> {
+    inner: E,
+    cap_bytes: usize,
+    resident_fn: fn() -> Option<i64>,
+}
+
+/// Pure admission decision: reject when the gate is enabled (`cap != 0`), the path
+/// is not exempt, and a known resident value is at/above the cap. `None` resident
+/// (unavailable) fails open.
+fn should_reject(resident: Option<i64>, cap: usize, path: &str) -> bool {
+    if cap == 0 || path.ends_with(HEALTH_CHECK_PATH_SUFFIX) {
+        return false;
+    }
+    matches!(resident, Some(r) if r >= cap as i64)
+}
+
+fn overloaded_response() -> Response {
+    Json(AptosError::new_with_error_code(
+        "Server is shedding load; please retry shortly",
+        AptosErrorCode::Overloaded,
+    ))
+    .with_status(StatusCode::SERVICE_UNAVAILABLE)
+    .into_response()
+}
+
+impl<E: Endpoint> Endpoint for MemoryAdmissionEndpoint<E> {
+    type Output = Response;
+
+    async fn call(&self, req: Request) -> Result<Self::Output> {
+        let resident = (self.resident_fn)();
+        if should_reject(resident, self.cap_bytes, req.uri().path()) {
+            MEMORY_ADMISSION_REJECTED.inc();
+            return Ok(overloaded_response());
+        }
+        self.inner.call(req).await.map(IntoResponse::into_response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use poem::{handler, http::StatusCode, test::TestClient, EndpointExt};
+
+    #[handler]
+    fn ok_handler() -> &'static str {
+        "ok"
+    }
+
+    fn high_resident() -> Option<i64> {
+        Some(1_000_000)
+    }
+
+    #[test]
+    fn should_reject_logic() {
+        // cap 0 -> disabled.
+        assert!(!should_reject(Some(100), 0, "/v1/accounts"));
+        // unknown resident -> fail open.
+        assert!(!should_reject(None, 50, "/v1/accounts"));
+        // at/above cap -> reject.
+        assert!(should_reject(Some(50), 50, "/v1/accounts"));
+        // below cap -> admit.
+        assert!(!should_reject(Some(49), 50, "/v1/accounts"));
+        // health check exempt even when over cap.
+        assert!(!should_reject(Some(1_000), 50, "/v1/-/healthy"));
+    }
+
+    #[tokio::test]
+    async fn under_cap_passes() {
+        // cap (2_000_000) is above the injected resident (1_000_000) -> admit.
+        let cli = TestClient::new(
+            ok_handler.with(MemoryAdmission::with_resident_fn(2_000_000, high_resident)),
+        );
+        let resp = cli.get("/v1/accounts").send().await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn cap_zero_disabled_passes() {
+        let cli =
+            TestClient::new(ok_handler.with(MemoryAdmission::with_resident_fn(0, high_resident)));
+        let resp = cli.get("/v1/accounts").send().await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn over_cap_returns_503() {
+        let cli = TestClient::new(
+            ok_handler.with(MemoryAdmission::with_resident_fn(1000, high_resident)),
+        );
+        let resp = cli.get("/v1/accounts").send().await;
+        resp.assert_status(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn over_cap_health_check_exempt_passes() {
+        let cli = TestClient::new(
+            ok_handler.with(MemoryAdmission::with_resident_fn(1000, high_resident)),
+        );
+        let resp = cli.get("/v1/-/healthy").send().await;
+        resp.assert_status_is_ok();
+    }
+}

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -3,10 +3,19 @@
 
 use aptos_global_constants::DEFAULT_BUCKETS;
 use aptos_metrics_core::{
-    exponential_buckets, register_histogram_vec, register_int_counter_vec, register_int_gauge,
-    HistogramVec, IntCounterVec, IntGauge,
+    exponential_buckets, register_histogram_vec, register_int_counter, register_int_counter_vec,
+    register_int_gauge, HistogramVec, IntCounter, IntCounterVec, IntGauge,
 };
 use once_cell::sync::Lazy;
+
+/// Number of API requests rejected by the memory admission middleware.
+pub static MEMORY_ADMISSION_REJECTED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_api_memory_admission_rejected_total",
+        "Number of API requests rejected by the memory admission middleware (over the resident-memory cap)"
+    )
+    .unwrap()
+});
 
 pub const GAS_ESTIMATE_DEPRIORITIZED: &str = "deprioritized";
 pub const GAS_ESTIMATE_CURRENT: &str = "current";

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -12,6 +12,7 @@ use crate::{
     headers_sanity_check::HeadersSanityCheck,
     index::IndexApi,
     log::middleware_log,
+    memory_admission::MemoryAdmission,
     set_failpoints,
     spec::{spec_endpoint_json, spec_endpoint_yaml},
     state::StateApi,
@@ -258,6 +259,8 @@ pub fn attach_poem_to_runtime(
             .with_if(config.api.compression_enabled, Compression::new())
             .with(HeadersSanityCheck::new(size_limit))
             .with(CatchPanic::new().with_handler(panic_handler))
+            // Runs first (LIFO): shed new requests with 503 when over the memory cap.
+            .with(MemoryAdmission::new(config.api.memory_admission_cap_bytes))
             // NOTE: Make sure to keep this after all the `with` middleware.
             .catch_all_error(convert_error)
             .around(middleware_log);

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -14,9 +14,9 @@ use crate::{
 };
 use anyhow::Context as AnyhowContext;
 use aptos_api_types::{
-    verify_module_identifier, Address, AptosErrorCode, AsConverter, IdentifierWrapper,
-    MoveModuleBytecode, MoveResource, MoveStructTag, MoveValue, RawStateValueRequest,
-    RawTableItemRequest, TableItemRequest, VerifyInput, VerifyInputWithRecursion, U64,
+    verify_module_identifier, Address, AptosErrorCode, IdentifierWrapper, MoveModuleBytecode,
+    MoveResource, MoveStructTag, MoveValue, RawStateValueRequest, RawTableItemRequest,
+    TableItemRequest, VerifyInput, VerifyInputWithRecursion, U64,
 };
 use aptos_types::state_store::{state_key::StateKey, table::TableHandle, TStateView};
 use move_core_types::language_storage::StructTag;
@@ -286,8 +286,9 @@ impl StateApi {
             })?;
 
         let (ledger_info, ledger_version, state_view) = self.context.state_view(ledger_version)?;
-        let bytes = state_view
-            .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
+        let bytes = self
+            .context
+            .as_converter(&state_view)
             .find_resource(&state_view, address, &tag)
             .context(format!(
                 "Failed to query DB to check for {} at {}",
@@ -305,8 +306,9 @@ impl StateApi {
 
         match accept_type {
             AcceptType::Json => {
-                let resource = state_view
-                    .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
+                let resource = self
+                    .context
+                    .as_converter(&state_view)
                     .try_into_resource(&tag, &bytes)
                     .context("Failed to deserialize resource data retrieved from DB")
                     .map_err(|err| {
@@ -405,8 +407,7 @@ impl StateApi {
             .context
             .state_view(ledger_version.map(|inner| inner.0))?;
 
-        let converter =
-            state_view.as_converter(self.context.db.clone(), self.context.indexer_reader.clone());
+        let converter = self.context.as_converter(&state_view);
 
         // Convert key to lookup version for DB
         let vm_key = converter

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -23,9 +23,9 @@ use anyhow::Context as AnyhowContext;
 use aptos_api_types::{
     transaction::{PersistedAuxiliaryInfo, TransactionSummary},
     verify_function_identifier, verify_module_identifier, Address, AptosError, AptosErrorCode,
-    AsConverter, EncodeSubmissionRequest, GasEstimation, GasEstimationBcs, HashValue,
-    HexEncodedBytes, LedgerInfo, MoveType, PendingTransaction, SubmitTransactionRequest,
-    Transaction, TransactionData, TransactionOnChainData, TransactionsBatchSingleSubmissionFailure,
+    EncodeSubmissionRequest, GasEstimation, GasEstimationBcs, HashValue, HexEncodedBytes,
+    LedgerInfo, MoveType, PendingTransaction, SubmitTransactionRequest, Transaction,
+    TransactionData, TransactionOnChainData, TransactionsBatchSingleSubmissionFailure,
     TransactionsBatchSubmissionResult, UserTransaction, VerifyInput, VerifyInputWithRecursion, U64,
 };
 use aptos_crypto::signing_message;
@@ -1019,11 +1019,8 @@ impl TransactionsApi {
                     TransactionData::OnChain(txn) => {
                         let timestamp =
                             self.context.get_block_timestamp(ledger_info, txn.version)?;
-                        state_view
-                            .as_converter(
-                                self.context.db.clone(),
-                                self.context.indexer_reader.clone(),
-                            )
+                        self.context
+                            .as_converter(&state_view)
                             .try_into_onchain_transaction(timestamp, txn)
                             .context("Failed to convert on chain transaction to Transaction")
                             .map_err(|err| {
@@ -1034,8 +1031,9 @@ impl TransactionsApi {
                                 )
                             })?
                     },
-                    TransactionData::Pending(txn) => state_view
-                        .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
+                    TransactionData::Pending(txn) => self
+                        .context
+                        .as_converter(&state_view)
                         .try_into_pending_transaction(*txn)
                         .context("Failed to convert on pending transaction to Transaction")
                         .map_err(|err| {
@@ -1236,23 +1234,24 @@ impl TransactionsApi {
 
                 Ok(signed_transaction)
             },
-            SubmitTransactionPost::Json(data) => self
-                .context
-                .latest_state_view_poem(ledger_info)?
-                .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
-                .try_into_signed_transaction_poem(data.0, self.context.chain_id())
-                .context("Failed to create SignedTransaction from SubmitTransactionRequest")
-                .map_err(|err| {
-                    SubmitTransactionError::bad_request_with_code(
-                        err,
-                        AptosErrorCode::InvalidInput,
-                        ledger_info,
-                    )
-                })
-                .and_then(|signed_transaction| {
-                    self.validate_signed_transaction_payload(ledger_info, &signed_transaction)?;
-                    Ok(signed_transaction)
-                }),
+            SubmitTransactionPost::Json(data) => {
+                let state_view = self.context.latest_state_view_poem(ledger_info)?;
+                self.context
+                    .as_converter(&state_view)
+                    .try_into_signed_transaction_poem(data.0, self.context.chain_id())
+                    .context("Failed to create SignedTransaction from SubmitTransactionRequest")
+                    .map_err(|err| {
+                        SubmitTransactionError::bad_request_with_code(
+                            err,
+                            AptosErrorCode::InvalidInput,
+                            ledger_info,
+                        )
+                    })
+                    .and_then(|signed_transaction| {
+                        self.validate_signed_transaction_payload(ledger_info, &signed_transaction)?;
+                        Ok(signed_transaction)
+                    })
+            },
         }
     }
 
@@ -1444,8 +1443,9 @@ impl TransactionsApi {
                 .into_iter()
                 .enumerate()
                 .map(|(index, txn)| {
-                    self.context.latest_state_view_poem(ledger_info)?
-                        .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
+                    let state_view = self.context.latest_state_view_poem(ledger_info)?;
+                    self.context
+                        .as_converter(&state_view)
                         .try_into_signed_transaction_poem(txn, self.context.chain_id())
                         .context(format!("Failed to create SignedTransaction from SubmitTransactionRequest at position {}", index))
                         .map_err(|err| {
@@ -1547,15 +1547,16 @@ impl TransactionsApi {
                         })?;
 
                     // We provide the pending transaction so that users have the hash associated
-                    let pending_txn = state_view
-                            .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
-                            .try_into_pending_transaction_poem(txn)
-                            .context("Failed to build PendingTransaction from mempool response, even though it said the request was accepted")
-                            .map_err(|err| SubmitTransactionError::internal_with_code(
-                                err,
-                                AptosErrorCode::InternalError,
-                                ledger_info,
-                            ))?;
+                    let pending_txn = self
+                        .context
+                        .as_converter(&state_view)
+                        .try_into_pending_transaction_poem(txn)
+                        .context("Failed to build PendingTransaction from mempool response, even though it said the request was accepted")
+                        .map_err(|err| SubmitTransactionError::internal_with_code(
+                            err,
+                            AptosErrorCode::InternalError,
+                            ledger_info,
+                        ))?;
                     SubmitTransactionResponse::try_from_json((
                         pending_txn,
                         ledger_info,
@@ -1831,8 +1832,9 @@ impl TransactionsApi {
 
         let ledger_info = self.context.get_latest_ledger_info()?;
         let state_view = self.context.latest_state_view_poem(&ledger_info)?;
-        let raw_txn: RawTransaction = state_view
-            .as_converter(self.context.db.clone(), self.context.indexer_reader.clone())
+        let raw_txn: RawTransaction = self
+            .context
+            .as_converter(&state_view)
             .try_into_raw_transaction_poem(request.transaction, self.context.chain_id())
             .context("The given transaction is invalid")
             .map_err(|err| {

--- a/api/src/view_function.rs
+++ b/api/src/view_function.rs
@@ -14,8 +14,7 @@ use crate::{
 };
 use anyhow::Context as anyhowContext;
 use aptos_api_types::{
-    AptosErrorCode, AsConverter, MoveValue, ViewFunction, ViewRequest, MAX_RECURSIVE_TYPES_ALLOWED,
-    U64,
+    AptosErrorCode, MoveValue, ViewFunction, ViewRequest, MAX_RECURSIVE_TYPES_ALLOWED, U64,
 };
 use aptos_bcs_utils::serialize_uleb128;
 use aptos_types::{state_store::StateView, transaction::ViewFunctionError, vm_status::StatusCode};
@@ -38,8 +37,8 @@ pub fn convert_view_function_error(
 ) -> (String, Option<StatusCode>) {
     match error {
         ViewFunctionError::MoveAbort(status, vm_error_code) => {
-            let vm_status = state_view
-                .as_converter(context.db.clone(), context.indexer_reader.clone())
+            let vm_status = context
+                .as_converter(state_view)
                 .explain_vm_status(status, None);
             (vm_status, *vm_error_code)
         },
@@ -113,8 +112,8 @@ fn view_request(
         })?;
 
     let view_function: ViewFunction = match request {
-        ViewFunctionRequest::Json(data) => state_view
-            .as_converter(context.db.clone(), context.indexer_reader.clone())
+        ViewFunctionRequest::Json(data) => context
+            .as_converter(&state_view)
             .convert_view_function(data.0)
             .map_err(|err| {
                 BasicErrorWith404::bad_request_with_code(
@@ -193,8 +192,8 @@ fn view_request(
             BasicResponse::try_from_encoded((ret, &ledger_info, BasicResponseStatus::Ok))
         },
         AcceptType::Json => {
-            let return_types = state_view
-                .as_converter(context.db.clone(), context.indexer_reader.clone())
+            let return_types = context
+                .as_converter(&state_view)
                 .function_return_types(&view_function)
                 .and_then(|tys| {
                     tys.iter()
@@ -213,8 +212,8 @@ fn view_request(
                 .into_iter()
                 .zip(return_types.into_iter())
                 .map(|(v, ty)| {
-                    state_view
-                        .as_converter(context.db.clone(), context.indexer_reader.clone())
+                    context
+                        .as_converter(&state_view)
                         .try_into_move_value(&ty, &v)
                 })
                 .collect::<anyhow::Result<Vec<_>>>()

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -15,6 +15,9 @@ rust-version = { workspace = true }
 [package.metadata.cargo-machete]
 ignored = ["async-trait", "poem", "poem-openapi-derive"]
 
+[features]
+metered-allocations = ["aptos-resource-viewer/metered-allocations"]
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-config = { workspace = true }

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -229,8 +229,11 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 match state_view.get_state_value_bytes(&key)? {
                     Some(group_bytes) => {
                         let mut meter = self.resource_annotation_meter();
-                        let group = decode_resource_group_with_limit(&group_bytes, &mut meter)?;
-                        group.get(tag).cloned().map(Bytes::from)
+                        let mut group = decode_resource_group_with_limit(&group_bytes, &mut meter)?;
+                        // Take ownership of the requested member rather than cloning it: `group`
+                        // is dropped immediately after, so removing avoids a full copy of a value
+                        // that can approach the annotation budget.
+                        group.remove(tag).map(Bytes::from)
                     },
                     None => None,
                 }

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -841,7 +841,9 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
         let mut ret = Vec::with_capacity(events.len());
         for event in events {
             let (ty, data_blob) = ty_and_data(event);
-            let data = self.inner.view_value_with_limit(ty, data_blob, &mut meter)?;
+            let data = self
+                .inner
+                .view_value_with_limit(ty, data_blob, &mut meter)?;
             ret.push((event, MoveValue::try_from(data)?.json()?).into());
             meter.check()?;
         }

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -160,36 +160,51 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
     /// `try_into_resources_from_resource_group`), where the returned meter is threaded across an
     /// entire page/group so the whole batch shares one byte budget. `find_resource` also takes a
     /// fresh meter from this method, but uses it to bound a single resource-group decode in
-    /// isolation.
+    /// isolation. `try_into_resource` takes one to bound a single resource, checking it after the
+    /// `AnnotatedMoveStruct` -> `MoveResource` conversion so the API-type materialization counts too.
     ///
-    /// The **per-call-bounded** entry points (`try_into_resource`, `move_struct_fields`,
-    /// `try_into_move_value`) do not use this — they rely on `self.inner`'s own fresh meter, so
-    /// each call gets an independent budget. The annotator owns the budget value; the converter no
-    /// longer stores its own copy.
+    /// The remaining **per-call-bounded** entry points (`move_struct_fields`, `try_into_move_value`)
+    /// do not use this — they rely on `self.inner`'s own fresh meter, so each call gets an
+    /// independent budget. The annotator owns the budget value; the converter no longer stores its
+    /// own copy.
     fn resource_annotation_meter(&self) -> Meter {
         self.inner.fresh_meter()
     }
 
+    /// Annotate one resource and charge its full materialization — annotation plus the
+    /// `AnnotatedMoveStruct` -> `MoveResource` (API-type/JSON) conversion — against `meter`.
+    ///
+    /// Single source of truth for the per-resource metering protocol shared by the batch
+    /// (`annotate_with_limit`) and single (`try_into_resource`) entry points: keeping the
+    /// view + convert + `check()` sequence in one place is what stops the two from drifting.
+    ///
     /// INVARIANT: must stay synchronous. `Meter` reads thread-local live bytes; an `.await`
-    /// between `fresh_meter()` and the `check()`s would measure an unrelated task's thread and
+    /// between `fresh_meter()` and the `check()` would measure an unrelated task's thread and
     /// silently corrupt the budget. Keep the whole annotation tree on one thread, await-free.
+    fn annotate_one(
+        &self,
+        tag: &StructTag,
+        bytes: &[u8],
+        meter: &mut Meter,
+    ) -> Result<MoveResource> {
+        let annotated = self.inner.view_resource_with_limit(tag, bytes, meter)?;
+        let resource: MoveResource = annotated.try_into()?;
+        meter.check()?;
+        Ok(resource)
+    }
+
+    // INVARIANT: threads one `Meter` across every element — see `annotate_one`. The shared batch
+    // budget is measured on one thread, so this call tree must never `.await`.
     fn annotate_with_limit<'b, T: Borrow<StructTag>>(
         &self,
         data: impl Iterator<Item = (T, &'b [u8])>,
         meter: &mut Meter,
     ) -> Result<Vec<MoveResource>> {
-        data.map(|(typ, bytes)| {
-            let annotated = self
-                .inner
-                .view_resource_with_limit(typ.borrow(), bytes, meter)?;
-            let resource: MoveResource = annotated.try_into()?;
-            meter.check()?;
-            Ok(resource)
-        })
-        .collect()
+        data.map(|(typ, bytes)| self.annotate_one(typ.borrow(), bytes, meter))
+            .collect()
     }
 
-    // INVARIANT: must stay synchronous — see `annotate_with_limit`. The shared batch `Meter`
+    // INVARIANT: must stay synchronous — see `annotate_one`. The shared batch `Meter`
     // measures thread-local live bytes, so this call tree must never `.await`.
     pub fn try_into_resources<'b>(
         &self,
@@ -198,8 +213,10 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
         self.annotate_with_limit(data, &mut self.resource_annotation_meter())
     }
 
+    // INVARIANT: must stay synchronous — see `annotate_one`. The `Meter` measures thread-local
+    // live bytes, so this call tree must never `.await`.
     pub fn try_into_resource(&self, tag: &StructTag, bytes: &'_ [u8]) -> Result<MoveResource> {
-        self.inner.view_resource(tag, bytes)?.try_into()
+        self.annotate_one(tag, bytes, &mut self.resource_annotation_meter())
     }
 
     pub fn is_resource_group(&self, tag: &StructTag) -> bool {

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -19,9 +19,10 @@ use crate::{
     TransactionPayload, VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload, U64,
 };
 use anyhow::{bail, ensure, format_err, Context as AnyhowContext, Result};
+use aptos_config::config::DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES;
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_logger::{sample, sample::SampleRate};
-use aptos_resource_viewer::AptosValueAnnotator;
+use aptos_resource_viewer::{AptosValueAnnotator, Meter};
 use aptos_storage_interface::DbReader;
 use aptos_types::{
     access_path::{AccessPath, Path},
@@ -53,7 +54,7 @@ use move_core_types::{
 };
 use serde_json::Value;
 use std::{
-    collections::BTreeMap,
+    borrow::Borrow,
     convert::{TryFrom, TryInto},
     iter::IntoIterator,
     sync::Arc,
@@ -62,6 +63,12 @@ use std::{
 
 const OBJECT_MODULE: &IdentStr = ident_str!("object");
 const OBJECT_STRUCT: &IdentStr = ident_str!("Object");
+
+fn decode_resource_group_with_limit(bytes: &[u8], meter: &mut Meter) -> Result<ResourceGroup> {
+    let group = bcs::from_bytes::<ResourceGroup>(bytes)?;
+    meter.check()?;
+    Ok(group)
+}
 
 /// Recursively substitute generic type parameters in a MoveType with actual type arguments.
 fn substitute_type_in_move_type(
@@ -123,19 +130,72 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
         db: Arc<dyn DbReader>,
         indexer_reader: Option<Arc<dyn IndexerReader>>,
     ) -> Self {
+        Self::new_with_resource_annotation_limit(
+            inner,
+            db,
+            indexer_reader,
+            DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES,
+        )
+    }
+
+    pub fn new_with_resource_annotation_limit(
+        inner: &'a S,
+        db: Arc<dyn DbReader>,
+        indexer_reader: Option<Arc<dyn IndexerReader>>,
+        max_resource_annotation_bytes: usize,
+    ) -> Self {
         Self {
-            inner: AptosValueAnnotator::new(inner),
+            inner: AptosValueAnnotator::new_with_resource_annotation_limit(
+                inner,
+                max_resource_annotation_bytes,
+            ),
             db,
             indexer_reader,
         }
     }
 
+    /// A fresh annotation [`Meter`] seeded with the annotator's configured byte budget.
+    ///
+    /// Used by the **aggregate-bounded** entry points (`try_into_resources`,
+    /// `try_into_resources_from_resource_group`), where the returned meter is threaded across an
+    /// entire page/group so the whole batch shares one byte budget. `find_resource` also takes a
+    /// fresh meter from this method, but uses it to bound a single resource-group decode in
+    /// isolation.
+    ///
+    /// The **per-call-bounded** entry points (`try_into_resource`, `move_struct_fields`,
+    /// `try_into_move_value`) do not use this — they rely on `self.inner`'s own fresh meter, so
+    /// each call gets an independent budget. The annotator owns the budget value; the converter no
+    /// longer stores its own copy.
+    fn resource_annotation_meter(&self) -> Meter {
+        self.inner.fresh_meter()
+    }
+
+    /// INVARIANT: must stay synchronous. `Meter` reads thread-local live bytes; an `.await`
+    /// between `fresh_meter()` and the `check()`s would measure an unrelated task's thread and
+    /// silently corrupt the budget. Keep the whole annotation tree on one thread, await-free.
+    fn annotate_with_limit<'b, T: Borrow<StructTag>>(
+        &self,
+        data: impl Iterator<Item = (T, &'b [u8])>,
+        meter: &mut Meter,
+    ) -> Result<Vec<MoveResource>> {
+        data.map(|(typ, bytes)| {
+            let annotated = self
+                .inner
+                .view_resource_with_limit(typ.borrow(), bytes, meter)?;
+            let resource: MoveResource = annotated.try_into()?;
+            meter.check()?;
+            Ok(resource)
+        })
+        .collect()
+    }
+
+    // INVARIANT: must stay synchronous — see `annotate_with_limit`. The shared batch `Meter`
+    // measures thread-local live bytes, so this call tree must never `.await`.
     pub fn try_into_resources<'b>(
         &self,
         data: impl Iterator<Item = (StructTag, &'b [u8])>,
     ) -> Result<Vec<MoveResource>> {
-        data.map(|(typ, bytes)| self.inner.view_resource(&typ, bytes)?.try_into())
-            .collect()
+        self.annotate_with_limit(data, &mut self.resource_annotation_meter())
     }
 
     pub fn try_into_resource(&self, tag: &StructTag, bytes: &'_ [u8]) -> Result<MoveResource> {
@@ -168,8 +228,9 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 let key = StateKey::resource_group(&address.into(), &group_tag);
                 match state_view.get_state_value_bytes(&key)? {
                     Some(group_bytes) => {
-                        let group: BTreeMap<StructTag, Bytes> = bcs::from_bytes(&group_bytes)?;
-                        group.get(tag).cloned()
+                        let mut meter = self.resource_annotation_meter();
+                        let group = decode_resource_group_with_limit(&group_bytes, &mut meter)?;
+                        group.get(tag).cloned().map(Bytes::from)
                     },
                     None => None,
                 }
@@ -185,13 +246,16 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
         &self,
         bytes: &[u8],
     ) -> Result<Vec<MoveResource>> {
-        let resources_with_tag: Vec<(StructTag, Vec<u8>)> = bcs::from_bytes::<ResourceGroup>(bytes)
-            .map(|map| map.into_iter().collect::<Vec<_>>())?;
-
-        resources_with_tag
-            .iter()
-            .map(|(struct_tag, value_bytes)| self.try_into_resource(struct_tag, value_bytes))
-            .collect::<Result<Vec<_>>>()
+        let mut meter = self.resource_annotation_meter();
+        // Borrow tags straight out of the decoded group: no intermediate Vec, no per-resource
+        // StructTag clone. `group` lives until the end of the function, so the borrows are valid.
+        let group = decode_resource_group_with_limit(bytes, &mut meter)?;
+        self.annotate_with_limit(
+            group
+                .iter()
+                .map(|(tag, value_bytes)| (tag, value_bytes.as_slice())),
+            &mut meter,
+        )
     }
 
     pub fn move_struct_fields(
@@ -1493,6 +1557,13 @@ pub trait AsConverter<R> {
         db: Arc<dyn DbReader>,
         indexer_reader: Option<Arc<dyn IndexerReader>>,
     ) -> MoveConverter<'_, R>;
+
+    fn as_converter_with_resource_annotation_limit(
+        &self,
+        db: Arc<dyn DbReader>,
+        indexer_reader: Option<Arc<dyn IndexerReader>>,
+        max_resource_annotation_bytes: usize,
+    ) -> MoveConverter<'_, R>;
 }
 
 impl<R: StateView> AsConverter<R> for R {
@@ -1502,6 +1573,20 @@ impl<R: StateView> AsConverter<R> for R {
         indexer_reader: Option<Arc<dyn IndexerReader>>,
     ) -> MoveConverter<'_, R> {
         MoveConverter::new(self, db, indexer_reader)
+    }
+
+    fn as_converter_with_resource_annotation_limit(
+        &self,
+        db: Arc<dyn DbReader>,
+        indexer_reader: Option<Arc<dyn IndexerReader>>,
+        max_resource_annotation_bytes: usize,
+    ) -> MoveConverter<'_, R> {
+        MoveConverter::new_with_resource_annotation_limit(
+            self,
+            db,
+            indexer_reader,
+            max_resource_annotation_bytes,
+        )
     }
 }
 

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -819,29 +819,41 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
         }))
     }
 
-    pub fn try_into_events(&self, events: &[ContractEvent]) -> Result<Vec<Event>> {
-        let mut ret = vec![];
+    // INVARIANT: must stay synchronous — see `annotate_with_limit`. The shared `Meter` measures
+    // thread-local live bytes, so the whole page must be annotated on one thread without `.await`.
+    //
+    // One meter is threaded across the whole page so its cumulative live-byte budget bounds the
+    // page *aggregate*, not each event in isolation. `ty_and_data` extracts the annotatable
+    // `(type, blob)` from each event kind; the trailing `check()` also charges the retained JSON
+    // that `view_value_with_limit`'s internal checks run before.
+    fn annotate_events<'e, E, T>(
+        &self,
+        events: &'e [E],
+        ty_and_data: impl Fn(&E) -> (&TypeTag, &[u8]),
+    ) -> Result<Vec<T>>
+    where
+        T: From<(&'e E, serde_json::Value)>,
+    {
+        let mut meter = self.resource_annotation_meter();
+        let mut ret = Vec::with_capacity(events.len());
         for event in events {
-            let data = self
-                .inner
-                .view_value(event.type_tag(), event.event_data())?;
+            let (ty, data_blob) = ty_and_data(event);
+            let data = self.inner.view_value_with_limit(ty, data_blob, &mut meter)?;
             ret.push((event, MoveValue::try_from(data)?.json()?).into());
+            meter.check()?;
         }
         Ok(ret)
+    }
+
+    pub fn try_into_events(&self, events: &[ContractEvent]) -> Result<Vec<Event>> {
+        self.annotate_events(events, |e| (e.type_tag(), e.event_data()))
     }
 
     pub fn try_into_versioned_events(
         &self,
         events: &[EventWithVersion],
     ) -> Result<Vec<VersionedEvent>> {
-        let mut ret = vec![];
-        for event in events {
-            let data = self
-                .inner
-                .view_value(event.event.type_tag(), event.event.event_data())?;
-            ret.push((event, MoveValue::try_from(data)?.json()?).into());
-        }
-        Ok(ret)
+        self.annotate_events(events, |e| (e.event.type_tag(), e.event.event_data()))
     }
 
     pub fn try_into_signed_transaction_poem(

--- a/api/types/src/error.rs
+++ b/api/types/src/error.rs
@@ -104,6 +104,8 @@ pub enum AptosErrorCode {
     MempoolIsFull = 501,
     /// The transaction was dropped because the inbound transaction rate limit was exceeded.
     RateLimited = 502,
+    /// The server is shedding load due to memory pressure; retry later.
+    Overloaded = 503,
 
     /// Internal server error
     InternalError = 600,
@@ -136,4 +138,9 @@ fn test_serialize_deserialize() {
     let _: AptosError = bcs::from_bytes(&bcs::to_bytes(&without_code).unwrap()).unwrap();
     let _: AptosError =
         serde_json::from_str(&serde_json::to_string(&without_code).unwrap()).unwrap();
+}
+
+#[test]
+fn test_overloaded_error_code_discriminant() {
+    assert_eq!(AptosErrorCode::Overloaded as u32, 503);
 }

--- a/aptos-move/aptos-resource-viewer/Cargo.toml
+++ b/aptos-move/aptos-resource-viewer/Cargo.toml
@@ -12,8 +12,13 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+metered-allocations = ["aptos-jemalloc/metered-allocations"]
+
 [dependencies]
 anyhow = { workspace = true }
+aptos-config = { workspace = true }
+aptos-jemalloc = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
@@ -30,3 +35,8 @@ move-vm-types = { workspace = true }
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["testing"] }
 move-vm-types = { workspace = true, features = ["testing"] }
+bcs = { workspace = true }
+
+[target.'cfg(unix)'.dev-dependencies]
+jemallocator = { workspace = true }
+aptos-jemalloc = { workspace = true, features = ["metered-allocations"] }

--- a/aptos-move/aptos-resource-viewer/Cargo.toml
+++ b/aptos-move/aptos-resource-viewer/Cargo.toml
@@ -34,9 +34,14 @@ move-vm-types = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["testing"] }
-move-vm-types = { workspace = true, features = ["testing"] }
 bcs = { workspace = true }
+criterion = { workspace = true }
+move-vm-types = { workspace = true, features = ["testing"] }
 
 [target.'cfg(unix)'.dev-dependencies]
-jemallocator = { workspace = true }
 aptos-jemalloc = { workspace = true, features = ["metered-allocations"] }
+jemallocator = { workspace = true }
+
+[[bench]]
+name = "annotate"
+harness = false

--- a/aptos-move/aptos-resource-viewer/benches/annotate.rs
+++ b/aptos-move/aptos-resource-viewer/benches/annotate.rs
@@ -1,0 +1,945 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Measures the overhead of real-allocation annotation metering.
+//!
+//! The `metered-allocations` feature changes exactly one thing on the hot path:
+//! whether `aptos_jemalloc::current_live_bytes()` performs two jemalloc `mallctl`
+//! reads per `Meter::check()` (metering ON) or returns `0` for free (metering OFF).
+//! `Meter::check()` is called recursively at every node of the value tree, so the
+//! per-node reader cost is the entire cost of the feature.
+//!
+//! Rather than compile the bench twice, we pass the two readers explicitly:
+//!   - `read_metering_off` — a `|| 0` reader, identical to the no-op
+//!     `current_live_bytes()` the node links in a metering-OFF build.
+//!   - `aptos_jemalloc::current_live_bytes` — the real jemalloc reader.
+//! Both run against the same payloads in one `cargo bench`, so the delta between
+//! the two groups is a faithful with/without-checks comparison.
+//!
+//! jemalloc must be the global allocator for the real reader to report live bytes,
+//! so this binary installs it (unix only), mirroring `tests/metering.rs`.
+
+use aptos_config::config::DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES;
+use criterion::{black_box, Criterion};
+use move_binary_format::{
+    file_format::{
+        empty_module, FieldDefinition, IdentifierIndex, SignatureToken, StructDefinition,
+        StructFieldInformation, StructHandle, StructHandleIndex, TypeSignature, VariantDefinition,
+    },
+    CompiledModule,
+};
+use move_core_types::{
+    ability::AbilitySet,
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, StructTag, TypeTag},
+    value::{MoveStruct, MoveValue},
+};
+use move_resource_viewer::{AnnotatedMoveValue, CompiledModuleView, MoveValueAnnotator};
+use std::{collections::HashMap, sync::Arc};
+
+#[cfg(unix)]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+/// Per-query annotation byte budget for the bench. A bench-only ceiling chosen so nothing
+/// aborts mid-measure — we time full annotation, not early exits. Far above the production
+/// budget (`DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES` = 100 MB); the Layer-3b structural-edge
+/// workloads deliberately exceed that production budget, and `edge_value_depth_128` alone
+/// expands a legal 1 MB resource to ~1.5 GB of annotation heap, so the ceiling clears it.
+const BUDGET: usize = 4_000_000_000;
+
+/// The single-resource storage-write cap (`max_bytes_per_write_op` = `1 << 20`): the largest
+/// BCS blob a resource can be and still be writable on-chain, hence the largest a real API
+/// request ever annotates per resource. Every Layer-3b edge workload sizes itself just under
+/// this, so it is a *legal* resource rather than a synthetic over-large blob.
+const MAX_RESOURCE_BYTES: usize = 1 << 20;
+
+/// Resolves the modules a struct payload references. An empty map mirrors the old
+/// `EmptyModuleView`: primitive vectors resolve without any module lookup. The
+/// trait is implemented for `&ModuleMapView` so the annotator borrows the view
+/// (the annotator is generic with no `Clone`/`'static` bound) — each benchmark
+/// iteration constructs a fresh annotator from `&view` with no cloning.
+struct ModuleMapView {
+    modules: HashMap<ModuleId, Arc<CompiledModule>>,
+}
+
+impl ModuleMapView {
+    fn empty() -> Self {
+        Self {
+            modules: HashMap::new(),
+        }
+    }
+
+    fn from_modules(modules: Vec<CompiledModule>) -> Self {
+        Self {
+            modules: modules
+                .into_iter()
+                .map(|m| (m.self_id(), Arc::new(m)))
+                .collect(),
+        }
+    }
+}
+
+impl CompiledModuleView for &ModuleMapView {
+    type Item = Arc<CompiledModule>;
+
+    fn view_compiled_module(&self, id: &ModuleId) -> anyhow::Result<Option<Self::Item>> {
+        Ok(self.modules.get(id).cloned())
+    }
+}
+
+/// Models the reader linked when `metered-allocations` is OFF: a trivial `|| 0`.
+fn read_metering_off() -> i64 {
+    0
+}
+
+// ============================================================
+// Layer 1: module builders — assemble the 0x1::bench module
+// ============================================================
+
+fn intern(m: &mut CompiledModule, s: &str) -> IdentifierIndex {
+    let idx = IdentifierIndex(m.identifiers.len() as u16);
+    m.identifiers.push(Identifier::new(s).unwrap());
+    idx
+}
+
+fn vector(tok: SignatureToken) -> SignatureToken {
+    SignatureToken::Vector(Box::new(tok))
+}
+
+fn struct_tok(idx: StructHandleIndex) -> SignatureToken {
+    SignatureToken::Struct(idx)
+}
+
+/// Resolves the handle index of the already-defined struct named `name`. Lets a
+/// composite shape reference a shared building block by name, so block order does
+/// not have to thread index bindings around.
+fn struct_idx(m: &CompiledModule, name: &str) -> StructHandleIndex {
+    let ident = Identifier::new(name).unwrap();
+    let pos = m
+        .struct_handles
+        .iter()
+        .position(|h| m.identifiers[h.name.0 as usize] == ident)
+        .expect("struct must be defined before it is referenced");
+    StructHandleIndex(pos as u16)
+}
+
+/// Appends a struct named `name` with `fields` to module `m`, returning its handle
+/// index. Centralizes handle/def bookkeeping so each shape is a few readable lines.
+fn define_struct(
+    m: &mut CompiledModule,
+    name: &str,
+    fields: &[(&str, SignatureToken)],
+) -> StructHandleIndex {
+    let module = m.self_module_handle_idx;
+    let name_idx = intern(m, name);
+    let handle_idx = StructHandleIndex(m.struct_handles.len() as u16);
+    m.struct_handles.push(StructHandle {
+        module,
+        name: name_idx,
+        abilities: AbilitySet::EMPTY,
+        type_parameters: vec![],
+    });
+    let field_defs = fields
+        .iter()
+        .map(|(fname, tok)| FieldDefinition {
+            name: intern(m, fname),
+            signature: TypeSignature(tok.clone()),
+        })
+        .collect();
+    m.struct_defs.push(StructDefinition {
+        struct_handle: handle_idx,
+        field_information: StructFieldInformation::Declared(field_defs),
+    });
+    handle_idx
+}
+
+/// Appends an enum named `name` to module `m`, emitting `DeclaredVariants`. Each
+/// `(variant_name, fields)` pair becomes a `VariantDefinition`. Returns the handle
+/// index. The only builder that touches variants.
+fn define_enum(
+    m: &mut CompiledModule,
+    name: &str,
+    variants: Vec<(&str, Vec<(&str, SignatureToken)>)>,
+) -> StructHandleIndex {
+    let module = m.self_module_handle_idx;
+    let name_idx = intern(m, name);
+    let handle_idx = StructHandleIndex(m.struct_handles.len() as u16);
+    m.struct_handles.push(StructHandle {
+        module,
+        name: name_idx,
+        abilities: AbilitySet::EMPTY,
+        type_parameters: vec![],
+    });
+    let variant_defs = variants
+        .into_iter()
+        .map(|(vname, fields)| {
+            let name = intern(m, vname);
+            let fields = fields
+                .into_iter()
+                .map(|(fname, tok)| FieldDefinition {
+                    name: intern(m, fname),
+                    signature: TypeSignature(tok),
+                })
+                .collect();
+            VariantDefinition { name, fields }
+        })
+        .collect();
+    m.struct_defs.push(StructDefinition {
+        struct_handle: handle_idx,
+        field_information: StructFieldInformation::DeclaredVariants(variant_defs),
+    });
+    handle_idx
+}
+
+/// `0x1::bench::<name>` with no type args.
+fn struct_tag(name: &str) -> TypeTag {
+    TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ONE,
+        module: Identifier::new("bench").unwrap(),
+        name: Identifier::new(name).unwrap(),
+        type_args: vec![],
+    }))
+}
+
+/// Hand-builds module `0x1::bench`, the single self-contained module holding every
+/// benchmark shape. Built directly with `file_format` (no node, DB, or compiler).
+/// Layout: the existing vector-of-structs shape, then shared building blocks reused
+/// across resource shapes, then one composite block per resource. Composites resolve
+/// shared blocks via `struct_idx`.
+fn bench_module() -> CompiledModule {
+    let mut m = empty_module();
+    // Re-home the self module from the placeholder `0x0::<SELF>` to `0x1::bench`.
+    m.address_identifiers[0] = AccountAddress::ONE;
+    m.identifiers[0] = Identifier::new("bench").unwrap();
+
+    use SignatureToken::{Address, Bool, U128, U64, U8};
+
+    // --- vector-of-nested-structs shape (existing `vec_of_structs`) ---
+    let inner = define_struct(&mut m, "Inner", &[
+        ("a", U64),
+        ("b", U64),
+        ("c", Address),
+        ("d", Bool),
+    ]);
+    define_struct(&mut m, "Outer", &[
+        ("items", vector(struct_tok(inner))),
+        ("tag", vector(U8)),
+        ("n", U128),
+    ]);
+
+    // --- shared building blocks (composed by the resource shapes below) ---
+    // `Object<T>` annotates as a one-field struct `{ inner: address }` — a struct
+    // node, not a bare address — so the topology must keep it a struct.
+    define_struct(&mut m, "Object", &[("inner", Address)]);
+    define_struct(&mut m, "String", &[("bytes", vector(U8))]);
+    let id = define_struct(&mut m, "ID", &[("creation_num", U64), ("addr", Address)]);
+    let guid = define_struct(&mut m, "GUID", &[("id", struct_tok(id))]);
+    define_struct(&mut m, "EventHandle", &[
+        ("counter", U64),
+        ("guid", struct_tok(guid)),
+    ]);
+
+    // --- FungibleStore (0x1::fungible_asset) — modern default balance store ---
+    let object = struct_idx(&m, "Object");
+    define_struct(&mut m, "FungibleStore", &[
+        ("metadata", struct_tok(object)),
+        ("balance", U64),
+        ("frozen", Bool),
+    ]);
+
+    // --- CoinStore<AptosCoin> (0x1::coin) — legacy, deep EventHandle nesting ---
+    let event_handle = struct_idx(&m, "EventHandle");
+    let coin = define_struct(&mut m, "Coin", &[("value", U64)]);
+    define_struct(&mut m, "CoinStore", &[
+        ("coin", struct_tok(coin)),
+        ("frozen", Bool),
+        ("deposit_events", struct_tok(event_handle)),
+        ("withdraw_events", struct_tok(event_handle)),
+    ]);
+
+    // --- Token (0x4::token, v2 NFT) — String/byte-heavy + Object + EventHandle ---
+    let object = struct_idx(&m, "Object");
+    let string = struct_idx(&m, "String");
+    let event_handle = struct_idx(&m, "EventHandle");
+    define_struct(&mut m, "Token", &[
+        ("collection", struct_tok(object)),
+        ("index", U64),
+        ("description", struct_tok(string)),
+        ("name", struct_tok(string)),
+        ("uri", struct_tok(string)),
+        ("mutation_events", struct_tok(event_handle)),
+    ]);
+
+    // --- PropertyMap (0x4::property_map) — string-keyed SimpleMap, distinct leaf mix ---
+    let string = struct_idx(&m, "String");
+    let property_value = define_struct(&mut m, "PropertyValue", &[
+        ("type", U8),
+        ("value", vector(U8)),
+    ]);
+    let element = define_struct(&mut m, "PropertyElement", &[
+        ("key", struct_tok(string)),
+        ("value", struct_tok(property_value)),
+    ]);
+    let simple_map = define_struct(&mut m, "PropertySimpleMap", &[(
+        "data",
+        vector(struct_tok(element)),
+    )]);
+    define_struct(&mut m, "PropertyMap", &[("inner", struct_tok(simple_map))]);
+
+    // --- VersionedConfig — a Move enum (V1/V2); the only RuntimeVariant workload ---
+    // Models the versioned-resource idiom (e.g. confidential_asset::GlobalConfig).
+    let auditor = define_struct(&mut m, "AuditorShape", &[("ek", vector(U8))]);
+    define_enum(&mut m, "VersionedConfig", vec![
+        ("V1", vec![("flag", Bool), ("inner", struct_tok(auditor))]),
+        ("V2", vec![
+            ("flag", Bool),
+            ("inner", struct_tok(auditor)),
+            ("paused", Bool),
+        ]),
+    ]);
+
+    // --- CoinInfo.supply — Option/OptionalAggregator/Aggregator nesting idiom ---
+    let aggregator = define_struct(&mut m, "Aggregator", &[
+        ("handle", Address),
+        ("key", Address),
+        ("limit", U128),
+    ]);
+    let integer = define_struct(&mut m, "Integer", &[("value", U128), ("limit", U128)]);
+    let opt_aggregator = define_struct(&mut m, "OptionAggregator", &[(
+        "vec",
+        vector(struct_tok(aggregator)),
+    )]);
+    let opt_integer = define_struct(&mut m, "OptionInteger", &[(
+        "vec",
+        vector(struct_tok(integer)),
+    )]);
+    let optional_aggregator = define_struct(&mut m, "OptionalAggregator", &[
+        ("aggregator", struct_tok(opt_aggregator)),
+        ("integer", struct_tok(opt_integer)),
+    ]);
+    let opt_optional = define_struct(&mut m, "OptionOptionalAggregator", &[(
+        "vec",
+        vector(struct_tok(optional_aggregator)),
+    )]);
+    define_struct(&mut m, "CoinInfo", &[("supply", struct_tok(opt_optional))]);
+
+    // --- PackageRegistry (0x1::code) — heaviest realistic API payload ---
+    let string = struct_idx(&m, "String");
+    let any = define_struct(&mut m, "Any", &[
+        ("type_name", struct_tok(string)),
+        ("data", vector(U8)),
+    ]);
+    let opt_any = define_struct(&mut m, "OptionAny", &[("vec", vector(struct_tok(any)))]);
+    let upgrade_policy = define_struct(&mut m, "UpgradePolicy", &[("policy", U8)]);
+    let module_metadata = define_struct(&mut m, "ModuleMetadata", &[
+        ("name", struct_tok(string)),
+        ("source", vector(U8)),
+        ("source_map", vector(U8)),
+        ("extension", struct_tok(opt_any)),
+    ]);
+    let package_dep = define_struct(&mut m, "PackageDep", &[
+        ("account", Address),
+        ("package_name", struct_tok(string)),
+    ]);
+    let package_metadata = define_struct(&mut m, "PackageMetadata", &[
+        ("name", struct_tok(string)),
+        ("upgrade_policy", struct_tok(upgrade_policy)),
+        ("upgrade_number", U64),
+        ("source_digest", struct_tok(string)),
+        ("manifest", vector(U8)),
+        ("modules", vector(struct_tok(module_metadata))),
+        ("deps", vector(struct_tok(package_dep))),
+        ("extension", struct_tok(opt_any)),
+    ]);
+    define_struct(&mut m, "PackageRegistry", &[(
+        "packages",
+        vector(struct_tok(package_metadata)),
+    )]);
+
+    // --- Layer 3b shapes: structural-edge / max-size workloads ---
+
+    // WideStruct — 30 fields, the verifier's `max_fields_in_struct` = 30 wall. Field types come
+    // from `wide_field` (which also produces the matching values), so type and value stay aligned.
+    let wide_names: Vec<String> = (0..30).map(|i| format!("f{i:02}")).collect();
+    let wide_fields: Vec<(&str, SignatureToken)> = wide_names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| (name.as_str(), wide_field(i).0))
+        .collect();
+    define_struct(&mut m, "WideStruct", &wide_fields);
+
+    // BigEnum — 90 variants, the verifier's `max_struct_variants` = 90 wall. Each variant
+    // carries the same two-field body; the value (`big_enum_elem`) selects the highest tag.
+    let enum_vnames: Vec<String> = (0..90).map(|i| format!("V{i:02}")).collect();
+    let big_enum_variants: Vec<(&str, Vec<(&str, SignatureToken)>)> = enum_vnames
+        .iter()
+        .map(|name| (name.as_str(), vec![("a", U64), ("b", Bool)]))
+        .collect();
+    define_enum(&mut m, "BigEnum", big_enum_variants);
+
+    m
+}
+
+// ============================================================
+// Layer 2: value helpers + per-shape element/payload builders
+// ============================================================
+
+/// `Object<T>`-shaped value: a struct `{ inner: address }`.
+fn move_object(addr: AccountAddress) -> MoveValue {
+    MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Address(addr)]))
+}
+
+/// `EventHandle { counter: u64, guid: GUID { id: ID { creation_num: u64, addr } } }`.
+fn move_event_handle() -> MoveValue {
+    MoveValue::Struct(MoveStruct::Runtime(vec![
+        MoveValue::U64(0),
+        MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Struct(
+            MoveStruct::Runtime(vec![
+                MoveValue::U64(0),
+                MoveValue::Address(AccountAddress::ONE),
+            ]),
+        )])),
+    ]))
+}
+
+/// `0x1::string::String`-shaped value: a struct `{ bytes: vector<u8> }`.
+fn move_string(s: &str) -> MoveValue {
+    MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Vector(
+        s.bytes().map(MoveValue::U8).collect(),
+    )]))
+}
+
+/// An empty `Option<Any>` value: `{ vec: vector<Any> }` of length 0.
+fn none_any() -> MoveValue {
+    MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Vector(vec![])]))
+}
+
+/// One `FungibleStore { metadata: Object, balance: u64, frozen: bool }`.
+fn fungible_store_elem() -> MoveValue {
+    MoveValue::Struct(MoveStruct::Runtime(vec![
+        move_object(AccountAddress::ONE),
+        MoveValue::U64(1_000),
+        MoveValue::Bool(false),
+    ]))
+}
+
+/// One `CoinStore { coin: Coin { value }, frozen, deposit_events, withdraw_events }`.
+fn coin_store_elem() -> MoveValue {
+    MoveValue::Struct(MoveStruct::Runtime(vec![
+        MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::U64(500)])),
+        MoveValue::Bool(false),
+        move_event_handle(),
+        move_event_handle(),
+    ]))
+}
+
+/// One v2 `Token`: `Object` collection ref, an index, three `String`s, an `EventHandle`.
+fn token_elem() -> MoveValue {
+    MoveValue::Struct(MoveStruct::Runtime(vec![
+        move_object(AccountAddress::ONE),
+        MoveValue::U64(1_234),
+        move_string("a tokenized digital collectible with a medium-length description"),
+        move_string("Token #1234"),
+        move_string("https://example.com/nft/metadata/1234.json"),
+        move_event_handle(),
+    ]))
+}
+
+/// One `PropertyMap { inner: SimpleMap { data: vector<Element> } }` of `props`
+/// string-keyed entries with `PropertyValue { type: u8, value: vector<u8> }` leaves.
+fn property_map_elem(props: usize) -> MoveValue {
+    let entry = MoveValue::Struct(MoveStruct::Runtime(vec![
+        move_string("property_key_name"),
+        MoveValue::Struct(MoveStruct::Runtime(vec![
+            MoveValue::U8(0x09),
+            MoveValue::Vector((0..16u8).map(MoveValue::U8).collect()),
+        ])),
+    ]));
+    MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Struct(
+        MoveStruct::Runtime(vec![MoveValue::Vector(vec![entry; props])]),
+    )]))
+}
+
+/// One `VersionedConfig` in its `V2` variant (tag 1):
+/// `{ flag: bool, inner: AuditorShape, paused: bool }`.
+fn versioned_v2_elem() -> MoveValue {
+    MoveValue::Struct(MoveStruct::RuntimeVariant(1, vec![
+        MoveValue::Bool(true),
+        MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Vector(
+            (0..32u8).map(MoveValue::U8).collect(),
+        )])),
+        MoveValue::Bool(false),
+    ]))
+}
+
+/// One `CoinInfo { supply: Option<OptionalAggregator> }` with the aggregator side
+/// `Some` and the integer side `None`, exercising both 0- and 1-length wrappers.
+fn coin_info_elem() -> MoveValue {
+    let some_aggregator = MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Vector(vec![
+        MoveValue::Struct(MoveStruct::Runtime(vec![
+            MoveValue::Address(AccountAddress::ONE),
+            MoveValue::Address(AccountAddress::ONE),
+            MoveValue::U128(0),
+        ])),
+    ])]));
+    let none_integer = MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Vector(vec![])]));
+    let optional_aggregator =
+        MoveValue::Struct(MoveStruct::Runtime(vec![some_aggregator, none_integer]));
+    let supply = MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Vector(vec![
+        optional_aggregator,
+    ])]));
+    MoveValue::Struct(MoveStruct::Runtime(vec![supply]))
+}
+
+/// Type and value of field `i` of `WideStruct`, as a single pair so the two projections
+/// cannot drift (BCS is positional — a type/value mismatch would silently mis-decode). The
+/// struct definition takes the `SignatureToken`; the payload takes the `MoveValue`; both come
+/// from this one cycle, so the lockstep is structural, not comment-enforced.
+fn wide_field(i: usize) -> (SignatureToken, MoveValue) {
+    use SignatureToken::{Address, Bool, U128, U64};
+    match i % 4 {
+        0 => (U64, MoveValue::U64(i as u64)),
+        1 => (Bool, MoveValue::Bool(i.is_multiple_of(2))),
+        2 => (Address, MoveValue::Address(AccountAddress::ONE)),
+        _ => (U128, MoveValue::U128(i as u128)),
+    }
+}
+
+/// One `WideStruct`: 30 field values, each from `wide_field` so they match the struct's field
+/// types position-for-position by construction.
+fn wide_struct_elem() -> MoveValue {
+    MoveValue::Struct(MoveStruct::Runtime(
+        (0..30).map(|i| wide_field(i).1).collect(),
+    ))
+}
+
+/// `vector<WideStruct>` filled to ~1 MB — pins the struct-field wall (30 fields) under the
+/// storage-write cap. Reuses the canonical `vec_of` driver, then asserts the legal size.
+///
+/// Peak annotation heap: modest (~tens of MB) — well under the production 100 MB budget.
+fn edge_struct_width_30() -> (ModuleMapView, Vec<u8>, TypeTag) {
+    let elem = wide_struct_elem();
+    let n = fill_count(&elem);
+    let payload = vec_of("WideStruct", elem, n, None, 30);
+    assert_legal_size(&payload.1);
+    payload
+}
+
+/// One `BigEnum` at the highest tag (89): `{ a: u64, b: bool }`. The 90-variant *count* lives
+/// in the type definition; the value is a single variant exercising the deepest tag dispatch.
+fn big_enum_elem() -> MoveValue {
+    MoveValue::Struct(MoveStruct::RuntimeVariant(89, vec![
+        MoveValue::U64(0),
+        MoveValue::Bool(true),
+    ]))
+}
+
+/// `vector<BigEnum>` filled to ~1 MB — pins the enum-variant wall (90 variants), value at tag
+/// 89. The only Layer-3b shape on the `RuntimeVariant` / `FatStructLayout::Variants` path.
+///
+/// Peak annotation heap: modest — well under the production 100 MB budget.
+fn edge_enum_variants_90() -> (ModuleMapView, Vec<u8>, TypeTag) {
+    let elem = big_enum_elem();
+    let n = fill_count(&elem);
+    let payload = vec_of("BigEnum", elem, n, Some(89), 2);
+    assert_legal_size(&payload.1);
+    payload
+}
+
+/// `vector<Chain>` of 128-deep nested vectors over a `u64` leaf, filled to ~1 MB — pins the
+/// value-nesting wall (`DEFAULT_MAX_VM_VALUE_NESTED_DEPTH` = 128). Built directly against the
+/// empty view (nested primitive vectors need no module lookup), like `nested_vec_u64`.
+///
+/// `u64` (not `u8`) leaf: a `vector<u8>` collapses to a `Bytes` node, erasing the innermost
+/// level. Heaviest workload by far — every `Vector` node clones its element `TypeTag`, so this
+/// legal ≤1 MB resource expands to ~1.5 GB of annotation heap and would abort under the
+/// production 100 MB budget.
+fn edge_value_depth_128() -> (ModuleMapView, Vec<u8>, TypeTag) {
+    const DEPTH: usize = 128; // DEFAULT_MAX_VM_VALUE_NESTED_DEPTH
+
+    // One chain: a u64 leaf wrapped in (DEPTH - 1) single-element vectors. The outer vector
+    // added below contributes the final level, for DEPTH nested Vector nodes total.
+    let mut chain = MoveValue::U64(0);
+    for _ in 0..DEPTH - 1 {
+        chain = MoveValue::Vector(vec![chain]);
+    }
+    let chain_bytes = bcs::to_bytes(&chain).expect("chain must serialize").len();
+    let n = (MAX_RESOURCE_BYTES / chain_bytes.max(1)).max(1);
+    let blob = bcs::to_bytes(&MoveValue::Vector(vec![chain; n])).unwrap();
+
+    // Type: DEPTH nested vectors over u64.
+    let mut ty = TypeTag::U64;
+    for _ in 0..DEPTH {
+        ty = TypeTag::Vector(Box::new(ty));
+    }
+
+    assert_legal_size(&blob);
+    let view = ModuleMapView::empty();
+    // Self-check: annotate once (metering OFF, so the budget never trips) and confirm the
+    // realized depth is exactly 128.
+    let annotator = MoveValueAnnotator::new_with_meter_config(&view, BUDGET, read_metering_off);
+    let annotated = annotator
+        .view_value(&ty, &blob)
+        .expect("depth payload must annotate");
+    assert_eq!(
+        container_depth(&annotated),
+        DEPTH,
+        "value must nest to depth {DEPTH}"
+    );
+
+    (view, blob, ty)
+}
+
+/// Bare `vector<bool>` of ~1 M elements (~1 byte each), filled to ~1 MB — pins the node-count
+/// wall: the most annotation nodes (hence `Meter::check()` reader calls) a single legal
+/// resource can force. Built against the empty view, like `flat_vec_u64`.
+///
+/// `bool`, not `u8`: the annotator collapses `vector<u8>` to one `Bytes` node, which would
+/// yield a single node; `bool` is 1 byte/element and is annotated per-element.
+///
+/// Peak annotation heap: ~150–170 MB (each bool expands to a full `AnnotatedMoveValue::Bool`
+/// node) — crosses the production 100 MB budget, so it aborts under production metering.
+fn edge_nodes_1mb() -> (ModuleMapView, Vec<u8>, TypeTag) {
+    // Leave headroom for the vector length prefix so the blob stays under the 1 MB cap.
+    let n = MAX_RESOURCE_BYTES - 16;
+    let blob = bcs::to_bytes(&MoveValue::Vector(vec![MoveValue::Bool(false); n])).unwrap();
+    assert_legal_size(&blob);
+    (
+        ModuleMapView::empty(),
+        blob,
+        TypeTag::Vector(Box::new(TypeTag::Bool)),
+    )
+}
+
+/// A wide, shallow payload: `vector<u64>` with `n` elements. Lots of nodes, each
+/// cheap to allocate — stresses the per-node reader call rather than allocation.
+fn flat_vec_u64(n: usize) -> (ModuleMapView, Vec<u8>, TypeTag) {
+    let blob = bcs::to_bytes(&MoveValue::Vector(vec![MoveValue::U64(0); n])).unwrap();
+    (
+        ModuleMapView::empty(),
+        blob,
+        TypeTag::Vector(Box::new(TypeTag::U64)),
+    )
+}
+
+/// A deep, amplifying payload: `vector<vector<vector<u64>>>` of `dim^3` leaves.
+fn nested_vec_u64(dim: usize) -> (ModuleMapView, Vec<u8>, TypeTag) {
+    let inner = MoveValue::Vector(vec![MoveValue::U64(0); dim]);
+    let mid = MoveValue::Vector(vec![inner; dim]);
+    let outer = MoveValue::Vector(vec![mid; dim]);
+    let blob = bcs::to_bytes(&outer).unwrap();
+    let ty = TypeTag::Vector(Box::new(TypeTag::Vector(Box::new(TypeTag::Vector(
+        Box::new(TypeTag::U64),
+    )))));
+    (ModuleMapView::empty(), blob, ty)
+}
+
+/// `PackageRegistry` (`0x1::code`) — the heaviest realistic API payload: large
+/// `vector<u8>` sources + `String` names, nested two levels. A single top-level
+/// struct (not a vector), parameterized so it does not dominate total bench time.
+fn package_registry(
+    pkgs: usize,
+    modules_per_pkg: usize,
+    src_bytes: usize,
+) -> (ModuleMapView, Vec<u8>, TypeTag) {
+    let view = ModuleMapView::from_modules(vec![bench_module()]);
+
+    let source: Vec<MoveValue> = (0..src_bytes).map(|i| MoveValue::U8(i as u8)).collect();
+    let module_meta = MoveValue::Struct(MoveStruct::Runtime(vec![
+        move_string("module_name"),
+        MoveValue::Vector(source.clone()), // source (~src_bytes)
+        MoveValue::Vector(source),         // source_map (~src_bytes)
+        none_any(),                        // extension: Option<Any>
+    ]));
+    let dep = MoveValue::Struct(MoveStruct::Runtime(vec![
+        MoveValue::Address(AccountAddress::ONE),
+        move_string("AptosFramework"),
+    ]));
+    let package_meta = MoveValue::Struct(MoveStruct::Runtime(vec![
+        move_string("MyPackage"),
+        MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::U8(1)])), // UpgradePolicy
+        MoveValue::U64(1),                                              // upgrade_number
+        move_string("0x0000000000000000000000000000000000000000000000000000000000000000"),
+        MoveValue::Vector((0..256u32).map(|i| MoveValue::U8(i as u8)).collect()), // manifest
+        MoveValue::Vector(vec![module_meta; modules_per_pkg]),
+        MoveValue::Vector(vec![dep; 4]), // 4 framework deps (fixed, not parameterized)
+        none_any(),
+    ]));
+    let registry = MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::Vector(
+        vec![package_meta; pkgs],
+    )]));
+    let blob = bcs::to_bytes(&registry).unwrap();
+    let ty = struct_tag("PackageRegistry");
+
+    check_struct(&view, &blob, &ty, 1);
+
+    (view, blob, ty)
+}
+
+/// `Outer { items: [Inner; n], tag: [u8; 32], n: 0 }` plus the module defining
+/// its types. Eagerly annotates once and asserts the shape, so a broken
+/// module/blob panics at setup instead of silently mis-measuring.
+///
+/// Builds a single top-level `Outer` struct (not a `vector<Shape>`), so it uses
+/// `check_struct` and a bespoke body rather than the `vec_of` driver — the same
+/// deliberate odd-one-out pattern as `package_registry`.
+fn vec_of_structs(n: usize) -> (ModuleMapView, Vec<u8>, TypeTag) {
+    let view = ModuleMapView::from_modules(vec![bench_module()]);
+
+    let inner = MoveValue::Struct(MoveStruct::Runtime(vec![
+        MoveValue::U64(7),
+        MoveValue::U64(8),
+        MoveValue::Address(AccountAddress::ONE),
+        MoveValue::Bool(true),
+    ]));
+    let outer = MoveValue::Struct(MoveStruct::Runtime(vec![
+        MoveValue::Vector(vec![inner; n]),
+        MoveValue::Vector((0..32u8).map(MoveValue::U8).collect()),
+        MoveValue::U128(0),
+    ]));
+    let blob = bcs::to_bytes(&outer).unwrap();
+    let ty = struct_tag("Outer");
+
+    check_struct(&view, &blob, &ty, 3);
+
+    (view, blob, ty)
+}
+
+// ============================================================
+// Layer 3: generic driver, self-checks, and the workload table
+// ============================================================
+
+/// Builds a `vector<Shape>` workload of `n` copies of `elem`, where `Shape` is
+/// `0x1::bench::<name>`, and self-checks it (`variant`/`fields` describe the first
+/// element). Returns the `(view, blob, ty)` triple the bench loop consumes. This is
+/// the single place the from-modules / bcs / tag / self-check ritual lives.
+fn vec_of(
+    name: &str,
+    elem: MoveValue,
+    n: usize,
+    variant: Option<u16>,
+    fields: usize,
+) -> (ModuleMapView, Vec<u8>, TypeTag) {
+    let view = ModuleMapView::from_modules(vec![bench_module()]);
+    let blob = bcs::to_bytes(&MoveValue::Vector(vec![elem; n])).unwrap();
+    let ty = TypeTag::Vector(Box::new(struct_tag(name)));
+    check_vector(&view, &blob, &ty, variant, fields);
+    (view, blob, ty)
+}
+
+/// Setup-time self-check: annotate `blob` as `vector<struct>` and assert its first
+/// element annotates as variant `variant` (`None` for a plain struct) with `fields`
+/// fields. Panics at setup on a malformed shape.
+fn check_vector(
+    view: &ModuleMapView,
+    blob: &[u8],
+    ty: &TypeTag,
+    variant: Option<u16>,
+    fields: usize,
+) {
+    let annotator = MoveValueAnnotator::new_with_meter_config(view, BUDGET, read_metering_off);
+    match annotator
+        .view_value(ty, blob)
+        .expect("bench payload must annotate")
+    {
+        AnnotatedMoveValue::Vector(_, elems) => {
+            let s = match elems.first() {
+                Some(AnnotatedMoveValue::Struct(s)) => s,
+                other => panic!("expected a struct element, got {other:?}"),
+            };
+            assert_eq!(
+                s.variant_info.as_ref().map(|(t, _)| *t),
+                variant,
+                "element variant mismatch",
+            );
+            assert_eq!(
+                s.value.len(),
+                fields,
+                "element must annotate to {fields} fields"
+            );
+        },
+        other => panic!("expected an annotated vector, got {other:?}"),
+    }
+}
+
+/// Setup-time self-check: annotate `blob` as a top-level struct and assert it has
+/// `fields` fields. Panics at setup (not mid-measure) on a malformed shape.
+fn check_struct(view: &ModuleMapView, blob: &[u8], ty: &TypeTag, fields: usize) {
+    let annotator = MoveValueAnnotator::new_with_meter_config(view, BUDGET, read_metering_off);
+    match annotator
+        .view_value(ty, blob)
+        .expect("bench struct payload must annotate")
+    {
+        AnnotatedMoveValue::Struct(s) => {
+            assert_eq!(
+                s.value.len(),
+                fields,
+                "struct must annotate to {fields} fields"
+            );
+        },
+        other => panic!("expected an annotated struct, got {other:?}"),
+    }
+}
+
+/// Realized nesting depth of an annotated value, counting `Vector` containers (the leaf is not
+/// a container). Used by `edge_value_depth_128`'s self-check to confirm the value reaches the
+/// `DEFAULT_MAX_VM_VALUE_NESTED_DEPTH` = 128 ceiling. The `_` arm is intentional: for this
+/// payload every non-`Vector` value is genuinely a depth-0 leaf, not a silenced enum variant.
+fn container_depth(v: &AnnotatedMoveValue) -> usize {
+    match v {
+        AnnotatedMoveValue::Vector(_, elems) => 1 + elems.first().map_or(0, container_depth),
+        _ => 0,
+    }
+}
+
+/// Repeat count so a `vector<elem>` payload lands just under the 1 MB storage-write cap.
+/// `elem` is serialized once for its exact BCS size; the vector length prefix (≤ 9 bytes) is
+/// negligible.
+fn fill_count(elem: &MoveValue) -> usize {
+    let elem_bytes = bcs::to_bytes(elem).expect("element must serialize").len();
+    (MAX_RESOURCE_BYTES / elem_bytes.max(1)).max(1)
+}
+
+/// Setup-time assertion that an edge payload is a *legal, genuinely-maxed* resource: at most
+/// the 1 MB write cap (could exist on-chain) and at least 0.9 MB (actually stresses the
+/// limit, not a toy).
+fn assert_legal_size(blob: &[u8]) {
+    assert!(
+        blob.len() <= MAX_RESOURCE_BYTES,
+        "edge payload is {} bytes, over the {MAX_RESOURCE_BYTES}-byte storage-write cap",
+        blob.len(),
+    );
+    assert!(
+        blob.len() * 10 >= MAX_RESOURCE_BYTES * 9,
+        "edge payload is {} bytes, under 0.9 MB — not genuinely maxed",
+        blob.len(),
+    );
+}
+
+fn annotate_once(view: &ModuleMapView, blob: &[u8], ty: &TypeTag, read_live: fn() -> i64) {
+    let annotator = MoveValueAnnotator::new_with_meter_config(view, BUDGET, read_live);
+    let value = annotator
+        .view_value(ty, blob)
+        .expect("benchmark payload must annotate within budget");
+    black_box(value);
+}
+
+/// The single workload table shared by the timing suite and the amplification report. String
+/// literals give `&'static str` names; each tuple is the `(view, blob, type)` an annotation
+/// consumes.
+fn workloads() -> Vec<(&'static str, (ModuleMapView, Vec<u8>, TypeTag))> {
+    vec![
+        ("flat_vec_u64_80k", flat_vec_u64(80_000)),
+        ("nested_vec_u64_48", nested_vec_u64(48)),
+        ("vec_of_structs_20k", vec_of_structs(20_000)),
+        (
+            "vec_fungible_store_20k",
+            vec_of("FungibleStore", fungible_store_elem(), 20_000, None, 3),
+        ),
+        (
+            "vec_coin_store_10k",
+            vec_of("CoinStore", coin_store_elem(), 10_000, None, 4),
+        ),
+        (
+            "vec_token_10k",
+            vec_of("Token", token_elem(), 10_000, None, 6),
+        ),
+        (
+            "vec_property_map_2k_x16",
+            vec_of("PropertyMap", property_map_elem(16), 2_000, None, 1),
+        ),
+        (
+            "vec_versioned_enum_20k",
+            vec_of("VersionedConfig", versioned_v2_elem(), 20_000, Some(1), 3),
+        ),
+        (
+            "vec_coin_info_10k",
+            vec_of("CoinInfo", coin_info_elem(), 10_000, None, 1),
+        ),
+        ("package_registry_4x8x800", package_registry(4, 8, 800)),
+        // --- Layer 3b: structural-edge / max-size workloads (design spec 2026-06-24) ---
+        ("edge_struct_width_30", edge_struct_width_30()),
+        ("edge_enum_variants_90", edge_enum_variants_90()),
+        ("edge_value_depth_128", edge_value_depth_128()),
+        ("edge_nodes_1mb", edge_nodes_1mb()),
+    ]
+}
+
+fn bench_annotation(c: &mut Criterion, workloads: &[(&str, (ModuleMapView, Vec<u8>, TypeTag))]) {
+    for (name, (view, blob, ty)) in workloads {
+        let mut group = c.benchmark_group(*name);
+        group.bench_function("metering_off", |b| {
+            b.iter(|| annotate_once(view, blob, ty, read_metering_off))
+        });
+        group.bench_function("metering_on", |b| {
+            b.iter(|| annotate_once(view, blob, ty, aptos_jemalloc::current_live_bytes))
+        });
+        group.finish();
+    }
+}
+
+/// Production per-request annotation budget (the real config default).
+const PROD_BUDGET: usize = DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES; // 100 MB
+/// Max concurrent annotations: the API blocking-pool cap (`MAX_BLOCKING_THREADS`,
+/// `crates/aptos-runtimes/src/lib.rs`). Annotation runs on `api_spawn_blocking`.
+const ANNOTATION_CONCURRENCY: usize = 64;
+/// Assumed node-wide memory tolerance, for the implied-budget calculation.
+const MEMORY_TOLERANCE: usize = 20_000_000_000; // 20 GB
+
+/// One-shot heap-amplification characterization, printed before the timing suite. For each
+/// workload it annotates once with the real jemalloc reader, measures peak live heap, and
+/// prints disk size, peak heap, the disk→heap amplification factor, and whether the payload
+/// would abort under the production per-request budget. The realistic shapes stay single-digit
+/// × and never abort; only the pathological `edge_value_depth_128` (~1500×) aborts.
+fn report_amplification(workloads: &[(&str, (ModuleMapView, Vec<u8>, TypeTag))]) {
+    println!("\n=== annotation heap-amplification report ===");
+    println!(
+        "per-request budget {} MB · concurrency {} · aggregate worst {} GB · no global cap",
+        PROD_BUDGET / 1_000_000,
+        ANNOTATION_CONCURRENCY,
+        PROD_BUDGET * ANNOTATION_CONCURRENCY / 1_000_000_000,
+    );
+    println!(
+        "implied safe per-request budget at {} GB tolerance: {} MB",
+        MEMORY_TOLERANCE / 1_000_000_000,
+        MEMORY_TOLERANCE / ANNOTATION_CONCURRENCY / 1_000_000,
+    );
+    println!(
+        "{:<28} {:>10} {:>11} {:>8}  aborts@budget?",
+        "workload", "disk", "peak heap", "amp"
+    );
+    for (name, (view, blob, ty)) in workloads {
+        let before = aptos_jemalloc::current_live_bytes();
+        let annotator = MoveValueAnnotator::new_with_meter_config(
+            view,
+            BUDGET,
+            aptos_jemalloc::current_live_bytes,
+        );
+        let annotated = annotator
+            .view_value(ty, blob)
+            .expect("report payload must annotate within BUDGET");
+        let peak = (aptos_jemalloc::current_live_bytes() - before).max(0) as usize;
+        black_box(&annotated);
+        drop(annotated);
+        let amp = peak as f64 / blob.len().max(1) as f64;
+        println!(
+            "{:<28} {:>9}K {:>10}M {:>7.0}x  {}",
+            name,
+            blob.len() / 1_000,
+            peak / 1_000_000,
+            amp,
+            if peak > PROD_BUDGET { "YES" } else { "no" },
+        );
+    }
+    println!();
+}
+
+fn main() {
+    let workloads = workloads();
+    report_amplification(&workloads);
+    let mut criterion = Criterion::default().configure_from_args();
+    bench_annotation(&mut criterion, &workloads);
+    criterion.final_summary();
+}

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -56,6 +56,15 @@ impl<'a, S: StateView> AptosValueAnnotator<'a, S> {
         self.0.view_value(ty_tag, blob)
     }
 
+    pub fn view_value_with_limit(
+        &self,
+        ty_tag: &TypeTag,
+        blob: &[u8],
+        meter: &mut Meter,
+    ) -> anyhow::Result<AnnotatedMoveValue> {
+        self.0.view_value_with_limit(ty_tag, blob, meter)
+    }
+
     pub fn view_module(&self, module_id: &ModuleId) -> anyhow::Result<Option<Arc<CompiledModule>>> {
         self.0.view_module(module_id)
     }

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod module_view;
 
 use crate::module_view::ModuleView;
+use aptos_config::config::DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES;
 use aptos_types::state_store::StateView;
 use aptos_vm::data_cache::get_resource_group_member_from_metadata;
 use move_binary_format::CompiledModule;
@@ -19,7 +20,7 @@ use move_core_types::{
 };
 use move_resource_viewer::MoveValueAnnotator;
 pub use move_resource_viewer::{
-    AnnotatedMoveClosure, AnnotatedMoveStruct, AnnotatedMoveValue, MoveTableInfo,
+    AnnotatedMoveClosure, AnnotatedMoveStruct, AnnotatedMoveValue, Meter, MoveTableInfo,
 };
 use std::sync::Arc;
 
@@ -27,8 +28,18 @@ pub struct AptosValueAnnotator<'a, S>(MoveValueAnnotator<ModuleView<'a, S>>);
 
 impl<'a, S: StateView> AptosValueAnnotator<'a, S> {
     pub fn new(state_view: &'a S) -> Self {
-        let view = ModuleView::new(state_view);
-        Self(MoveValueAnnotator::new(view))
+        Self::new_with_resource_annotation_limit(state_view, DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES)
+    }
+
+    pub fn new_with_resource_annotation_limit(
+        state_view: &'a S,
+        max_annotation_bytes: usize,
+    ) -> Self {
+        Self(MoveValueAnnotator::new_with_meter_config(
+            ModuleView::new(state_view),
+            max_annotation_bytes,
+            aptos_jemalloc::current_live_bytes,
+        ))
     }
 
     /// Collect information about tables contained in the value represented by the blob.
@@ -71,6 +82,21 @@ impl<'a, S: StateView> AptosValueAnnotator<'a, S> {
         blob: &[u8],
     ) -> anyhow::Result<AnnotatedMoveStruct> {
         self.0.view_resource(tag, blob)
+    }
+
+    pub fn view_resource_with_limit(
+        &self,
+        tag: &StructTag,
+        blob: &[u8],
+        meter: &mut Meter,
+    ) -> anyhow::Result<AnnotatedMoveStruct> {
+        self.0.view_resource_with_limit(tag, blob, meter)
+    }
+
+    /// A fresh [`Meter`] seeded with this annotator's configured annotation byte budget.
+    /// The annotator is the single owner of that budget value.
+    pub fn fresh_meter(&self) -> Meter {
+        self.0.fresh_meter()
     }
 
     pub fn view_struct_fields(

--- a/aptos-move/aptos-resource-viewer/tests/metering.rs
+++ b/aptos-move/aptos-resource-viewer/tests/metering.rs
@@ -72,4 +72,44 @@ mod metered {
             "amplifying input must be rejected, not OOM"
         );
     }
+
+    #[test]
+    fn shared_meter_bounds_aggregate_across_calls() {
+        // A single meter threaded across many *retained* values must abort once their
+        // cumulative live footprint exceeds the budget, even though each value alone is
+        // far under it. This is the contract the events-page converter relies on.
+        //
+        // Contrast (why the fix is needed): looping over `view_value` instead would seed a
+        // *fresh* meter per value, each measured from an ever-higher baseline, so none would
+        // abort and the page aggregate would grow unbounded. That per-call path is intentionally
+        // left unchanged and is exercised by the single-value sanity assertion below.
+        let blob = vec_u64_blob(80_000);
+        let ty = TypeTag::Vector(Box::new(TypeTag::U64));
+        let annotator = MoveValueAnnotator::new_with_meter_config(
+            EmptyModuleView,
+            40_000_000, // 40 MB budget; one annotated value stays well under 10 MB
+            aptos_jemalloc::current_live_bytes,
+        );
+
+        // Sanity: one value annotates comfortably under the budget (per-call baseline).
+        assert!(annotator.view_value(&ty, &blob).is_ok());
+
+        let mut meter = annotator.fresh_meter();
+        let mut retained = Vec::new();
+        let mut aborted = false;
+        for _ in 0..64 {
+            match annotator.view_value_with_limit(&ty, &blob, &mut meter) {
+                Ok(v) => retained.push(v), // keep it live so the shared delta grows
+                Err(_) => {
+                    aborted = true;
+                    break;
+                },
+            }
+        }
+        assert!(
+            aborted,
+            "shared meter must abort once retained values exceed the budget (retained {})",
+            retained.len()
+        );
+    }
 }

--- a/aptos-move/aptos-resource-viewer/tests/metering.rs
+++ b/aptos-move/aptos-resource-viewer/tests/metering.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Dedicated jemalloc-backed test binary for real-allocation annotation metering.
+//! Only meaningful with `--features metered-allocations`; otherwise the reader is a
+//! no-op and the module compiles to nothing (an empty, passing binary).
+
+#[cfg(all(unix, feature = "metered-allocations"))]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(all(unix, feature = "metered-allocations"))]
+mod metered {
+    use move_binary_format::CompiledModule;
+    use move_core_types::{
+        language_storage::{ModuleId, TypeTag},
+        value::MoveValue,
+    };
+    use move_resource_viewer::{CompiledModuleView, MoveValueAnnotator};
+    use std::sync::Arc;
+
+    // No modules needed: primitive vectors resolve without module lookup.
+    struct EmptyModuleView;
+    impl CompiledModuleView for EmptyModuleView {
+        type Item = Arc<CompiledModule>;
+
+        fn view_compiled_module(&self, _id: &ModuleId) -> anyhow::Result<Option<Self::Item>> {
+            Ok(None)
+        }
+    }
+
+    fn annotate(blob: &[u8], ty: &TypeTag, budget: usize) -> anyhow::Result<()> {
+        // The annotator's configured budget seeds the fresh Meter inside view_value,
+        // and the real jemalloc reader makes it measure live bytes.
+        let annotator = MoveValueAnnotator::new_with_meter_config(
+            EmptyModuleView,
+            budget,
+            aptos_jemalloc::current_live_bytes,
+        );
+        annotator.view_value(ty, blob)?;
+        Ok(())
+    }
+
+    fn vec_u64_blob(n: usize) -> Vec<u8> {
+        bcs::to_bytes(&MoveValue::Vector(vec![MoveValue::U64(0); n])).unwrap()
+    }
+
+    #[test]
+    fn node_dense_but_cheap_payload_is_allowed() {
+        // ~80k u64 elements: real footprint < 10 MB. The OLD model charged
+        // ~1024/node on top of the floor (~118 MB) and would have rejected this.
+        let blob = vec_u64_blob(80_000);
+        let ty = TypeTag::Vector(Box::new(TypeTag::U64));
+        assert!(
+            annotate(&blob, &ty, 100_000_000).is_ok(),
+            "node-dense but cheap payload must annotate under a 100MB live-byte budget"
+        );
+    }
+
+    #[test]
+    fn amplifying_input_aborts() {
+        // vector<vector<vector<u64>>> = 64^3 = 262_144 leaves; tiny budget.
+        let inner = MoveValue::Vector(vec![MoveValue::U64(0); 64]);
+        let mid = MoveValue::Vector(vec![inner; 64]);
+        let outer = MoveValue::Vector(vec![mid; 64]);
+        let blob = bcs::to_bytes(&outer).unwrap();
+        let ty = TypeTag::Vector(Box::new(TypeTag::Vector(Box::new(TypeTag::Vector(
+            Box::new(TypeTag::U64),
+        )))));
+        assert!(
+            annotate(&blob, &ty, 1_000_000).is_err(),
+            "amplifying input must be rejected, not OOM"
+        );
+    }
+}

--- a/aptos-move/aptos-resource-viewer/tests/metering.rs
+++ b/aptos-move/aptos-resource-viewer/tests/metering.rs
@@ -75,14 +75,10 @@ mod metered {
 
     #[test]
     fn shared_meter_bounds_aggregate_across_calls() {
-        // A single meter threaded across many *retained* values must abort once their
-        // cumulative live footprint exceeds the budget, even though each value alone is
-        // far under it. This is the contract the events-page converter relies on.
-        //
-        // Contrast (why the fix is needed): looping over `view_value` instead would seed a
-        // *fresh* meter per value, each measured from an ever-higher baseline, so none would
-        // abort and the page aggregate would grow unbounded. That per-call path is intentionally
-        // left unchanged and is exercised by the single-value sanity assertion below.
+        // One meter shared across many *retained* values must abort once their cumulative live
+        // footprint exceeds the budget, though each value alone is far under it — the contract the
+        // events-page converter relies on. (Looping `view_value` would seed a fresh meter per value
+        // and never see the aggregate; that per-call path is left to the sanity assert below.)
         let blob = vec_u64_blob(80_000);
         let ty = TypeTag::Vector(Box::new(TypeTag::U64));
         let annotator = MoveValueAnnotator::new_with_meter_config(

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -23,7 +23,8 @@ consensus-only-perf-test = [
     "aptos-mempool/consensus-only-perf-test",
     "aptos-db/consensus-only-perf-test",
 ]
-default = []
+default = ["metered-allocations"]
+metered-allocations = ["aptos-api/metered-allocations"]
 failpoints = [
     "fail/failpoints",
     "aptos-consensus/failpoints",

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -64,6 +64,9 @@ pub struct ApiConfig {
     /// it is aborted. Measured via jemalloc per-thread counters on production (jemalloc) builds;
     /// a no-op on builds without the `metered-allocations` reader. Must be > 0 (see `sanitize`).
     pub max_resource_annotation_bytes: usize,
+    /// Process resident-memory cap (bytes) above which the API sheds new requests
+    /// with 503. `0` disables the gate.
+    pub memory_admission_cap_bytes: usize,
     /// Maximum page size for module paginated APIs
     pub max_account_modules_page_size: u16,
     /// Maximum gas unit limit for view functions
@@ -103,6 +106,9 @@ pub const DEFAULT_MAX_SUBMIT_TRANSACTION_BATCH_SIZE: usize = 10;
 pub const DEFAULT_MAX_PAGE_SIZE: u16 = 100;
 const DEFAULT_MAX_ACCOUNT_RESOURCES_PAGE_SIZE: u16 = 9999;
 pub const DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES: usize = 100_000_000;
+/// Process resident-memory cap (bytes) above which the API sheds new requests with 503.
+/// `0` disables the gate. Sized relative to machine RAM, not annotation load.
+pub const DEFAULT_MEMORY_ADMISSION_CAP_BYTES: usize = 20_000_000_000;
 const DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE: u16 = 9999;
 const DEFAULT_MAX_VIEW_GAS: u64 = 2_000_000; // We keep this value the same as the max number of gas allowed for one single transaction defined in aptos-gas.
 
@@ -137,6 +143,7 @@ impl Default for ApiConfig {
             max_events_page_size: DEFAULT_MAX_PAGE_SIZE,
             max_account_resources_page_size: DEFAULT_MAX_ACCOUNT_RESOURCES_PAGE_SIZE,
             max_resource_annotation_bytes: DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES,
+            memory_admission_cap_bytes: DEFAULT_MEMORY_ADMISSION_CAP_BYTES,
             max_account_modules_page_size: DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE,
             max_gas_view_function: DEFAULT_MAX_VIEW_GAS,
             max_runtime_workers: None,
@@ -265,6 +272,14 @@ mod tests {
         assert_eq!(
             ApiConfig::default().max_resource_annotation_bytes,
             DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES
+        );
+    }
+
+    #[test]
+    fn test_memory_admission_cap_default() {
+        assert_eq!(
+            ApiConfig::default().memory_admission_cap_bytes,
+            DEFAULT_MEMORY_ADMISSION_CAP_BYTES
         );
     }
 

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -60,6 +60,10 @@ pub struct ApiConfig {
     pub max_events_page_size: u16,
     /// Maximum page size for resource paginated APIs
     pub max_account_resources_page_size: u16,
+    /// Maximum **real live heap bytes** a single resource-annotation request may allocate before
+    /// it is aborted. Measured via jemalloc per-thread counters on production (jemalloc) builds;
+    /// a no-op on builds without the `metered-allocations` reader. Must be > 0 (see `sanitize`).
+    pub max_resource_annotation_bytes: usize,
     /// Maximum page size for module paginated APIs
     pub max_account_modules_page_size: u16,
     /// Maximum gas unit limit for view functions
@@ -98,6 +102,7 @@ const DEFAULT_REQUEST_CONTENT_LENGTH_LIMIT: u64 = 8 * 1024 * 1024; // 8 MB
 pub const DEFAULT_MAX_SUBMIT_TRANSACTION_BATCH_SIZE: usize = 10;
 pub const DEFAULT_MAX_PAGE_SIZE: u16 = 100;
 const DEFAULT_MAX_ACCOUNT_RESOURCES_PAGE_SIZE: u16 = 9999;
+pub const DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES: usize = 100_000_000;
 const DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE: u16 = 9999;
 const DEFAULT_MAX_VIEW_GAS: u64 = 2_000_000; // We keep this value the same as the max number of gas allowed for one single transaction defined in aptos-gas.
 
@@ -131,6 +136,7 @@ impl Default for ApiConfig {
             max_transactions_page_size: DEFAULT_MAX_PAGE_SIZE,
             max_events_page_size: DEFAULT_MAX_PAGE_SIZE,
             max_account_resources_page_size: DEFAULT_MAX_ACCOUNT_RESOURCES_PAGE_SIZE,
+            max_resource_annotation_bytes: DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES,
             max_account_modules_page_size: DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE,
             max_gas_view_function: DEFAULT_MAX_VIEW_GAS,
             max_runtime_workers: None,
@@ -192,6 +198,15 @@ impl ConfigSanitizer for ApiConfig {
             ));
         }
 
+        // A zero annotation budget makes every resource read fail closed with "Query exceeds
+        // size limit" and gives operators no startup signal. Reject it.
+        if api_config.max_resource_annotation_bytes == 0 {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "max_resource_annotation_bytes must be greater than 0!".into(),
+            ));
+        }
+
         // Sanitize the gas estimation config
         GasEstimationConfig::sanitize(node_config, node_type, chain_id)?;
 
@@ -246,6 +261,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_resource_annotation_limit_default() {
+        assert_eq!(
+            ApiConfig::default().max_resource_annotation_bytes,
+            DEFAULT_MAX_RESOURCE_ANNOTATION_BYTES
+        );
+    }
+
+    #[test]
     fn test_sanitize_disabled_api() {
         // Create a node config with the API disabled
         let node_config = NodeConfig {
@@ -285,6 +308,23 @@ mod tests {
 
         // Sanitize the config for an unknown network and verify that it succeeds
         ApiConfig::sanitize(&node_config, NodeType::Validator, None).unwrap();
+    }
+
+    #[test]
+    fn test_sanitize_rejects_zero_resource_annotation_limit() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                max_resource_annotation_bytes: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let result =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()));
+        assert!(
+            result.is_err(),
+            "a zero resource-annotation budget must be rejected by sanitize"
+        );
     }
 
     #[test]

--- a/crates/aptos-jemalloc/Cargo.toml
+++ b/crates/aptos-jemalloc/Cargo.toml
@@ -12,6 +12,11 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+# Enables `current_live_bytes()` to read jemalloc's per-thread allocation
+# counters. Off by default so non-production builds compile a zero-cost no-op.
+metered-allocations = []
+
 [target.'cfg(unix)'.dependencies]
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }

--- a/crates/aptos-jemalloc/src/lib.rs
+++ b/crates/aptos-jemalloc/src/lib.rs
@@ -9,6 +9,38 @@ mod metrics;
 #[cfg(unix)]
 pub use metrics::start_jemalloc_metrics_thread;
 
+/// Current live heap bytes attributable to the calling thread, as
+/// `thread.allocated − thread.deallocated` from jemalloc's per-thread counters.
+///
+/// Signed because a thread may deallocate memory allocated on another thread, so
+/// its `deallocated` can momentarily exceed its `allocated`. Callers snapshot
+/// this at the start of a synchronous, `.await`-free region and re-read it to get
+/// the region's allocation delta. The mallctl MIBs are cached per-thread so each
+/// call is a couple of instructions.
+///
+/// Returns `0` when the `metered-allocations` feature is off (or on non-unix),
+/// which makes any `Meter` built on it a no-op.
+#[cfg(all(unix, feature = "metered-allocations"))]
+pub fn current_live_bytes() -> i64 {
+    use jemalloc_ctl::thread;
+    thread_local! {
+        static MIBS: (thread::allocatedp_mib, thread::deallocatedp_mib) = (
+            thread::allocatedp::mib().expect("jemalloc thread.allocated mib"),
+            thread::deallocatedp::mib().expect("jemalloc thread.deallocated mib"),
+        );
+    }
+    MIBS.with(|(alloc, dealloc)| match (alloc.read(), dealloc.read()) {
+        (Ok(a), Ok(d)) => a.get() as i64 - d.get() as i64,
+        _ => 0,
+    })
+}
+
+/// No-op reader: see the metered variant above.
+#[cfg(not(all(unix, feature = "metered-allocations")))]
+pub fn current_live_bytes() -> i64 {
+    0
+}
+
 /// Sets up jemalloc as the global allocator and configures `malloc_conf`.
 ///
 /// Invoke at the top level of a binary crate (`main.rs`).

--- a/crates/aptos-jemalloc/src/lib.rs
+++ b/crates/aptos-jemalloc/src/lib.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+mod resident;
 #[cfg(unix)]
 pub use jemallocator;
+pub use resident::current_process_resident_bytes;
 
 #[cfg(unix)]
 mod metrics;

--- a/crates/aptos-jemalloc/src/resident.rs
+++ b/crates/aptos-jemalloc/src/resident.rs
@@ -1,0 +1,123 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Throttle-cached reader for process resident bytes, used by the API memory
+//! admission gate. The pure `ResidentCache` takes its clock and raw reader as
+//! parameters so it is unit-testable without jemalloc or a live clock.
+
+#[cfg(any(unix, test))]
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+/// Minimum interval between underlying jemalloc reads. Requests within one window
+/// approximately share a sampled value; at a boundary a few concurrent refreshes
+/// may race, which is harmless for a best-effort gate.
+#[cfg(any(unix, test))]
+const REFRESH_INTERVAL_MILLIS: u64 = 250;
+
+/// Throttled cache of process resident bytes.
+#[cfg(any(unix, test))]
+struct ResidentCache {
+    /// Last sampled resident bytes; negative means "never sampled".
+    bytes: AtomicI64,
+    /// Monotonic-millis timestamp of the last refresh; `u64::MAX` means "never".
+    last_refresh_millis: AtomicU64,
+}
+
+#[cfg(any(unix, test))]
+impl ResidentCache {
+    const fn new() -> Self {
+        Self {
+            bytes: AtomicI64::new(-1),
+            last_refresh_millis: AtomicU64::new(u64::MAX),
+        }
+    }
+
+    /// Returns cached resident bytes, refreshing via `read_raw` only when the cache
+    /// is older than `REFRESH_INTERVAL_MILLIS`. `now_millis` is a monotonic clock
+    /// reading. Returns `None` until a successful read has ever occurred.
+    fn get(&self, now_millis: u64, read_raw: impl FnOnce() -> Option<i64>) -> Option<i64> {
+        // `bytes` and `last_refresh_millis` are updated independently under Relaxed:
+        // brief staleness and a few redundant reads per window are tolerated by design.
+        let last = self.last_refresh_millis.load(Ordering::Relaxed);
+        let stale = last == u64::MAX || now_millis.saturating_sub(last) >= REFRESH_INTERVAL_MILLIS;
+        if stale && let Some(v) = read_raw() {
+            self.bytes.store(v, Ordering::Relaxed);
+            self.last_refresh_millis
+                .store(now_millis, Ordering::Relaxed);
+            return Some(v);
+        }
+        match self.bytes.load(Ordering::Relaxed) {
+            b if b >= 0 => Some(b),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(unix)]
+static CACHE: ResidentCache = ResidentCache::new();
+
+/// Current process resident bytes (jemalloc `stats.resident`), throttle-cached.
+/// `None` when unavailable (non-unix, jemalloc not the global allocator, or read
+/// error). Callers treat `None` as "unknown" and fail open.
+#[cfg(unix)]
+pub fn current_process_resident_bytes() -> Option<i64> {
+    use once_cell::sync::Lazy;
+    use std::time::Instant;
+    static BASE: Lazy<Instant> = Lazy::new(Instant::now);
+    let now_millis = BASE.elapsed().as_millis() as u64;
+    CACHE.get(now_millis, read_resident_raw)
+}
+
+#[cfg(unix)]
+fn read_resident_raw() -> Option<i64> {
+    use jemalloc_ctl::{epoch, stats};
+    // Advance the epoch so the stats read returns a fresh value.
+    epoch::advance().ok()?;
+    stats::resident::read().ok().map(|v| v as i64)
+}
+
+#[cfg(not(unix))]
+pub fn current_process_resident_bytes() -> Option<i64> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn first_call_refreshes_then_caches_within_interval() {
+        let cache = ResidentCache::new();
+        let calls = Cell::new(0);
+        let read = || {
+            calls.set(calls.get() + 1);
+            Some(1000)
+        };
+        assert_eq!(cache.get(0, read), Some(1000));
+        assert_eq!(calls.get(), 1);
+        // Within the interval: cached, no new raw read.
+        assert_eq!(cache.get(100, read), Some(1000));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn refreshes_after_interval() {
+        let cache = ResidentCache::new();
+        let next = Cell::new(1000i64);
+        let read = || Some(next.get());
+        assert_eq!(cache.get(0, read), Some(1000));
+        next.set(2000);
+        assert_eq!(cache.get(REFRESH_INTERVAL_MILLIS - 1, read), Some(1000));
+        assert_eq!(cache.get(REFRESH_INTERVAL_MILLIS, read), Some(2000));
+    }
+
+    #[test]
+    fn none_until_first_successful_read() {
+        let cache = ResidentCache::new();
+        assert_eq!(cache.get(0, || None), None);
+        assert_eq!(cache.get(REFRESH_INTERVAL_MILLIS, || Some(500)), Some(500));
+        // Not yet stale again: cached value returned without calling read_raw.
+        assert_eq!(cache.get(REFRESH_INTERVAL_MILLIS + 1, || None), Some(500));
+    }
+}

--- a/crates/aptos-rosetta/src/error.rs
+++ b/crates/aptos-rosetta/src/error.rs
@@ -317,6 +317,7 @@ impl From<RestError> for ApiError {
                 },
                 AptosErrorCode::MempoolIsFull => ApiError::MempoolIsFull(Some(err.error.message)),
                 AptosErrorCode::RateLimited => ApiError::RateLimited(Some(err.error.message)),
+                AptosErrorCode::Overloaded => ApiError::RateLimited(Some(err.error.message)),
                 AptosErrorCode::WebFrameworkError => {
                     ApiError::InternalError(Some(err.error.message))
                 },

--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -4,7 +4,7 @@
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 //! Loaded representation for runtime types.
 
-use crate::limit::Limiter;
+use crate::limit::Meter;
 use fxhash::FxHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
@@ -146,16 +146,10 @@ impl FatStructType {
     pub fn subst(
         &self,
         ty_args: &[FatType],
-        subst_struct: &impl Fn(
-            &FatStructType,
-            &[FatType],
-            &mut Limiter,
-        ) -> PartialVMResult<FatStructRef>,
-        limiter: &mut Limiter,
+        subst_struct: &impl Fn(&FatStructType, &[FatType], &mut Meter) -> PartialVMResult<FatStructRef>,
+        meter: &mut Meter,
     ) -> PartialVMResult<FatStructType> {
-        limiter.charge(std::mem::size_of::<AccountAddress>())?;
-        limiter.charge(self.module.as_bytes().len())?;
-        limiter.charge(self.name.as_bytes().len())?;
+        meter.check()?;
         // self.contains_tables already reflects tables directly used in field types, we
         // only need to combine it here with tables used in type arguments.
         let contains_tables = self.contains_tables || ty_args.iter().any(|t| t.contains_tables());
@@ -167,13 +161,13 @@ impl FatStructType {
             ty_args: self
                 .ty_args
                 .iter()
-                .map(|ty| ty.subst(ty_args, subst_struct, limiter))
+                .map(|ty| ty.subst(ty_args, subst_struct, meter))
                 .collect::<PartialVMResult<_>>()?,
             layout: match &self.layout {
                 FatStructLayout::Singleton(fields) => FatStructLayout::Singleton(
                     fields
                         .iter()
-                        .map(|ty| ty.subst(ty_args, subst_struct, limiter))
+                        .map(|ty| ty.subst(ty_args, subst_struct, meter))
                         .collect::<PartialVMResult<_>>()?,
                 ),
                 FatStructLayout::Variants(variants) => FatStructLayout::Variants(
@@ -182,7 +176,7 @@ impl FatStructType {
                         .map(|fields| {
                             fields
                                 .iter()
-                                .map(|ty| ty.subst(ty_args, subst_struct, limiter))
+                                .map(|ty| ty.subst(ty_args, subst_struct, meter))
                                 .collect::<PartialVMResult<_>>()
                         })
                         .collect::<PartialVMResult<_>>()?,
@@ -200,16 +194,14 @@ impl FatStructType {
         }
     }
 
-    pub fn struct_tag(&self, limiter: &mut Limiter) -> PartialVMResult<StructTag> {
+    pub fn struct_tag(&self, meter: &mut Meter) -> PartialVMResult<StructTag> {
         let ty_args = self
             .ty_args
             .iter()
-            .map(|ty| ty.type_tag(limiter))
+            .map(|ty| ty.type_tag(meter))
             .collect::<PartialVMResult<Vec<_>>>()?;
 
-        limiter.charge(std::mem::size_of::<AccountAddress>())?;
-        limiter.charge(self.module.as_bytes().len())?;
-        limiter.charge(self.name.as_bytes().len())?;
+        meter.check()?;
 
         Ok(StructTag {
             address: self.address,
@@ -228,15 +220,15 @@ impl FatStructType {
 }
 
 impl FatFunctionType {
-    fn clone_with_limit(&self, limiter: &mut Limiter) -> PartialVMResult<Self> {
-        let clone_slice = |limiter: &mut Limiter, tys: &[FatType]| {
+    fn clone_with_limit(&self, meter: &mut Meter) -> PartialVMResult<Self> {
+        let clone_slice = |meter: &mut Meter, tys: &[FatType]| {
             tys.iter()
-                .map(|ty| ty.clone_with_limit(limiter))
+                .map(|ty| ty.clone_with_limit(meter))
                 .collect::<PartialVMResult<Vec<_>>>()
         };
         Ok(FatFunctionType {
-            args: clone_slice(limiter, &self.args)?,
-            results: clone_slice(limiter, &self.results)?,
+            args: clone_slice(meter, &self.args)?,
+            results: clone_slice(meter, &self.results)?,
             abilities: self.abilities,
         })
     }
@@ -244,51 +236,47 @@ impl FatFunctionType {
     pub fn subst(
         &self,
         ty_args: &[FatType],
-        subst_struct: &impl Fn(
-            &FatStructType,
-            &[FatType],
-            &mut Limiter,
-        ) -> PartialVMResult<FatStructRef>,
-        limiter: &mut Limiter,
+        subst_struct: &impl Fn(&FatStructType, &[FatType], &mut Meter) -> PartialVMResult<FatStructRef>,
+        meter: &mut Meter,
     ) -> PartialVMResult<Self> {
-        let subst_slice = |limiter: &mut Limiter, tys: &[FatType]| {
+        let subst_slice = |meter: &mut Meter, tys: &[FatType]| {
             tys.iter()
-                .map(|ty| ty.subst(ty_args, subst_struct, limiter))
+                .map(|ty| ty.subst(ty_args, subst_struct, meter))
                 .collect::<PartialVMResult<Vec<_>>>()
         };
         Ok(FatFunctionType {
-            args: subst_slice(limiter, &self.args)?,
-            results: subst_slice(limiter, &self.results)?,
+            args: subst_slice(meter, &self.args)?,
+            results: subst_slice(meter, &self.results)?,
             abilities: self.abilities,
         })
     }
 
-    pub fn fun_tag(&self, limiter: &mut Limiter) -> PartialVMResult<FunctionTag> {
-        let tag_slice = |limiter: &mut Limiter, tys: &[FatType]| {
+    pub fn fun_tag(&self, meter: &mut Meter) -> PartialVMResult<FunctionTag> {
+        let tag_slice = |meter: &mut Meter, tys: &[FatType]| {
             tys.iter()
                 .map(|ty| {
                     Ok(match ty {
                         FatType::Reference(ty) => {
-                            FunctionParamOrReturnTag::Reference(ty.type_tag(limiter)?)
+                            FunctionParamOrReturnTag::Reference(ty.type_tag(meter)?)
                         },
                         FatType::MutableReference(ty) => {
-                            FunctionParamOrReturnTag::MutableReference(ty.type_tag(limiter)?)
+                            FunctionParamOrReturnTag::MutableReference(ty.type_tag(meter)?)
                         },
-                        ty => FunctionParamOrReturnTag::Value(ty.type_tag(limiter)?),
+                        ty => FunctionParamOrReturnTag::Value(ty.type_tag(meter)?),
                     })
                 })
                 .collect::<PartialVMResult<Vec<_>>>()
         };
         Ok(FunctionTag {
-            args: tag_slice(limiter, &self.args)?,
-            results: tag_slice(limiter, &self.results)?,
+            args: tag_slice(meter, &self.args)?,
+            results: tag_slice(meter, &self.results)?,
             abilities: self.abilities,
         })
     }
 }
 
 impl FatType {
-    fn clone_with_limit(&self, limit: &mut Limiter) -> PartialVMResult<Self> {
+    fn clone_with_limit(&self, meter: &mut Meter) -> PartialVMResult<Self> {
         use FatType::*;
         Ok(match self {
             TyParam(idx) => TyParam(*idx),
@@ -307,29 +295,25 @@ impl FatType {
             I256 => I256,
             Address => Address,
             Signer => Signer,
-            Vector(ty) => Vector(Box::new(ty.clone_with_limit(limit)?)),
-            Reference(ty) => Reference(Box::new(ty.clone_with_limit(limit)?)),
-            MutableReference(ty) => MutableReference(Box::new(ty.clone_with_limit(limit)?)),
+            Vector(ty) => Vector(Box::new(ty.clone_with_limit(meter)?)),
+            Reference(ty) => Reference(Box::new(ty.clone_with_limit(meter)?)),
+            MutableReference(ty) => MutableReference(Box::new(ty.clone_with_limit(meter)?)),
             Struct(struct_ty) => Struct(struct_ty.clone()),
-            Function(fun_ty) => Function(Box::new(fun_ty.clone_with_limit(limit)?)),
+            Function(fun_ty) => Function(Box::new(fun_ty.clone_with_limit(meter)?)),
         })
     }
 
     pub fn subst(
         &self,
         ty_args: &[FatType],
-        subst_struct: &impl Fn(
-            &FatStructType,
-            &[FatType],
-            &mut Limiter,
-        ) -> PartialVMResult<FatStructRef>,
-        limit: &mut Limiter,
+        subst_struct: &impl Fn(&FatStructType, &[FatType], &mut Meter) -> PartialVMResult<FatStructRef>,
+        meter: &mut Meter,
     ) -> PartialVMResult<FatType> {
         use FatType::*;
 
         let res = match self {
             TyParam(idx) => match ty_args.get(*idx) {
-                Some(ty) => ty.clone_with_limit(limit)?,
+                Some(ty) => ty.clone_with_limit(meter)?,
                 None => {
                     return Err(
                         PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
@@ -357,10 +341,10 @@ impl FatType {
             I256 => I256,
             Address => Address,
             Signer => Signer,
-            Vector(ty) => Vector(Box::new(ty.subst(ty_args, subst_struct, limit)?)),
-            Reference(ty) => Reference(Box::new(ty.subst(ty_args, subst_struct, limit)?)),
+            Vector(ty) => Vector(Box::new(ty.subst(ty_args, subst_struct, meter)?)),
+            Reference(ty) => Reference(Box::new(ty.subst(ty_args, subst_struct, meter)?)),
             MutableReference(ty) => {
-                MutableReference(Box::new(ty.subst(ty_args, subst_struct, limit)?))
+                MutableReference(Box::new(ty.subst(ty_args, subst_struct, meter)?))
             },
 
             Struct(struct_ty) => {
@@ -369,17 +353,17 @@ impl FatType {
                     // by type substitution.
                     Struct(struct_ty.clone())
                 } else {
-                    Struct((*subst_struct)(struct_ty, ty_args, limit)?)
+                    Struct((*subst_struct)(struct_ty, ty_args, meter)?)
                 }
             },
 
-            Function(fun_ty) => Function(Box::new(fun_ty.subst(ty_args, subst_struct, limit)?)),
+            Function(fun_ty) => Function(Box::new(fun_ty.subst(ty_args, subst_struct, meter)?)),
         };
 
         Ok(res)
     }
 
-    pub fn type_tag(&self, limit: &mut Limiter) -> PartialVMResult<TypeTag> {
+    pub fn type_tag(&self, meter: &mut Meter) -> PartialVMResult<TypeTag> {
         use FatType::*;
 
         let res = match self {
@@ -398,9 +382,9 @@ impl FatType {
             I256 => TypeTag::I256,
             Address => TypeTag::Address,
             Signer => TypeTag::Signer,
-            Vector(ty) => TypeTag::Vector(Box::new(ty.type_tag(limit)?)),
-            Struct(struct_ty) => TypeTag::Struct(Box::new(struct_ty.struct_tag(limit)?)),
-            Function(fun_ty) => TypeTag::Function(Box::new(fun_ty.fun_tag(limit)?)),
+            Vector(ty) => TypeTag::Vector(Box::new(ty.type_tag(meter)?)),
+            Struct(struct_ty) => TypeTag::Struct(Box::new(struct_ty.struct_tag(meter)?)),
+            Function(fun_ty) => TypeTag::Function(Box::new(fun_ty.fun_tag(meter)?)),
 
             Reference(_) | MutableReference(_) | TyParam(_) => {
                 return Err(

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -701,9 +701,21 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
     }
 
     pub fn view_value(&self, ty_tag: &TypeTag, blob: &[u8]) -> anyhow::Result<AnnotatedMoveValue> {
-        let mut meter = self.fresh_meter();
-        let ty = self.resolve_type_impl(ty_tag, &mut meter)?;
-        self.view_value_by_fat_type(&ty, blob, &mut meter)
+        self.view_value_with_limit(ty_tag, blob, &mut self.fresh_meter())
+    }
+
+    /// Annotate a single value against a caller-supplied [`Meter`]. Threading one meter across a
+    /// batch (e.g. a page of events) bounds the batch's *aggregate* live heap, mirroring
+    /// [`view_resource_with_limit`] for resources. Callers wanting an isolated per-call budget use
+    /// [`view_value`], which seeds a fresh meter.
+    pub fn view_value_with_limit(
+        &self,
+        ty_tag: &TypeTag,
+        blob: &[u8],
+        meter: &mut Meter,
+    ) -> anyhow::Result<AnnotatedMoveValue> {
+        let ty = self.resolve_type_impl(ty_tag, meter)?;
+        self.view_value_by_fat_type(&ty, blob, meter)
     }
 
     /// Collect information about tables contained in the value represented by the blob.

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -7,7 +7,7 @@ use crate::fat_type::{
     FatFunctionType, FatStructLayout, FatStructRef, FatStructType, FatType, StructName,
 };
 use anyhow::{anyhow, bail};
-pub use limit::Limiter;
+pub use limit::{Meter, DEFAULT_MAX_ANNOTATION_BYTES};
 use move_binary_format::{
     access::{ModuleAccess, ScriptAccess},
     binary_views::BinaryIndexedView,
@@ -19,7 +19,8 @@ use move_binary_format::{
     views::FunctionHandleView,
     CompiledModule,
 };
-use move_bytecode_utils::{compiled_module_viewer::CompiledModuleView, layout::TypeLayoutBuilder};
+pub use move_bytecode_utils::compiled_module_viewer::CompiledModuleView;
+use move_bytecode_utils::layout::TypeLayoutBuilder;
 use move_core_types::{
     ability::{Ability, AbilitySet},
     account_address::AccountAddress,
@@ -102,12 +103,15 @@ pub struct MoveTableInfo {
 
 pub struct MoveValueAnnotator<V> {
     module_viewer: V,
+    max_annotation_bytes: usize,
+    /// Reads the calling thread's current live bytes, so annotation is bounded by real allocation.
+    read_live: fn() -> i64,
     /// A cache for fat type info for structs. For a generic struct, the uninstantiated
     /// FatStructType of the base definition will be stored here as well.
     ///
-    /// Notice that this cache (and the next one) effect the computation `Limit`: no-cached
-    /// annotation may hit limits which cached ones don't. Since limits aren't precise metering,
-    /// this effect is expected and OK.
+    /// Notice that this cache (and the next one) effect the metering: a non-cached
+    /// annotation may hit limits which cached ones don't. Since the meter observes real
+    /// allocation rather than precise per-node cost, this effect is expected and OK.
     fat_struct_def_cache: RefCell<BTreeMap<StructName, FatStructRef>>,
     /// A cache for fat type info for struct instantiations. This cache is build from
     /// substituting parameters for the uninstantiated types in `fat_struct_def_cache`.
@@ -116,7 +120,7 @@ pub struct MoveValueAnnotator<V> {
     contains_tables_cache: RefCell<BTreeMap<TypeTag, bool>>,
     /// Caches resolved captured types per closure signature, so many closures
     /// with the same signature resolve only once. Like the caches above, this
-    /// affects the `Limiter`, which is fine on a read path.
+    /// affects the `Meter`, which is fine on a read path.
     captured_tys_cache: RefCell<BTreeMap<ClosureCapturedTysCacheKey, Rc<Vec<FatType>>>>,
 }
 
@@ -125,14 +129,33 @@ pub struct MoveValueAnnotator<V> {
 type ClosureCapturedTysCacheKey = (ModuleId, Identifier, Vec<TypeTag>, ClosureMask);
 
 impl<V: CompiledModuleView> MoveValueAnnotator<V> {
+    /// No-op metering (reader returns 0). Used where no allocator counters are wired.
     pub fn new(module_viewer: V) -> Self {
+        Self::new_with_meter_config(module_viewer, DEFAULT_MAX_ANNOTATION_BYTES, || 0)
+    }
+
+    /// Inject the live-bytes reader so annotation is bounded by real allocation.
+    pub fn new_with_meter_config(
+        module_viewer: V,
+        max_annotation_bytes: usize,
+        read_live: fn() -> i64,
+    ) -> Self {
         Self {
             module_viewer,
+            max_annotation_bytes,
+            read_live,
             fat_struct_def_cache: RefCell::default(),
             fat_struct_inst_cache: RefCell::default(),
             contains_tables_cache: RefCell::default(),
             captured_tys_cache: RefCell::default(),
         }
+    }
+
+    /// A fresh [`Meter`] seeded with this annotator's configured budget and reader. The annotator
+    /// is the single owner of that budget; callers that need to bound a batch in aggregate take one
+    /// meter and thread it across the batch, while single-value entry points take a fresh one.
+    pub fn fresh_meter(&self) -> Meter {
+        Meter::new(self.max_annotation_bytes, self.read_live)
     }
 
     pub fn get_type_layout_with_types(&self, type_tag: &TypeTag) -> anyhow::Result<MoveTypeLayout> {
@@ -156,7 +179,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         args: &[TransactionArgument],
         ty_args: &[TypeTag],
     ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
-        let mut limit = Limiter::default();
+        let mut meter = self.fresh_meter();
         let compiled_script = CompiledScript::deserialize(script_bytes)
             .map_err(|err| anyhow!("Failed to deserialzie script: {:?}", err))?;
         let param_tys = compiled_script
@@ -164,11 +187,11 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             .0
             .iter()
             .map(|tok| {
-                self.resolve_signature(BinaryIndexedView::Script(&compiled_script), tok, &mut limit)
+                self.resolve_signature(BinaryIndexedView::Script(&compiled_script), tok, &mut meter)
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         let args_bytes = convert_txn_args(args);
-        self.view_arguments_or_returns(&param_tys, ty_args, &args_bytes, &mut limit)
+        self.view_arguments_or_returns(&param_tys, ty_args, &args_bytes, &mut meter)
     }
 
     pub fn view_function_arguments(
@@ -178,9 +201,9 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         ty_args: &[TypeTag],
         args: &[Vec<u8>],
     ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
-        let mut limit = Limiter::default();
-        let param_tys = self.resolve_function_arguments(module, function, &mut limit)?;
-        self.view_arguments_or_returns(&param_tys, ty_args, args, &mut limit)
+        let mut meter = self.fresh_meter();
+        let param_tys = self.resolve_function_arguments(module, function, &mut meter)?;
+        self.view_arguments_or_returns(&param_tys, ty_args, args, &mut meter)
     }
 
     pub fn view_function_returns(
@@ -190,9 +213,9 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         ty_args: &[TypeTag],
         returns: &[Vec<u8>],
     ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
-        let mut limit = Limiter::default();
-        let return_tys = self.resolve_function_returns(module, function, &mut limit)?;
-        self.view_arguments_or_returns(&return_tys, ty_args, returns, &mut limit)
+        let mut meter = self.fresh_meter();
+        let return_tys = self.resolve_function_returns(module, function, &mut meter)?;
+        self.view_arguments_or_returns(&return_tys, ty_args, returns, &mut meter)
     }
 
     fn view_arguments_or_returns(
@@ -200,7 +223,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         param_tys: &[FatType],
         ty_args: &[TypeTag],
         args: &[Vec<u8>],
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
         let types: Vec<&FatType> = param_tys
             .iter()
@@ -237,24 +260,24 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         // Convert type args
         let ty_args: Vec<FatType> = ty_args
             .iter()
-            .map(|ty| self.resolve_type_impl(ty, limit))
+            .map(|ty| self.resolve_type_impl(ty, meter))
             .collect::<anyhow::Result<_>>()?;
 
         if ty_args.is_empty() {
             types
                 .iter()
                 .enumerate()
-                .map(|(i, ty)| self.view_value_by_fat_type(ty, &args[i], limit))
+                .map(|(i, ty)| self.view_value_by_fat_type(ty, &args[i], meter))
                 .collect::<anyhow::Result<Vec<AnnotatedMoveValue>>>()
         } else {
             types
                 .iter()
                 .enumerate()
                 .map(|(i, ty)| {
-                    ty.subst(&ty_args, &self.struct_substitutor(), limit)
+                    ty.subst(&ty_args, &self.struct_substitutor(), meter)
                         .map_err(anyhow::Error::from)
                         .and_then(|fat_type| {
-                            self.view_value_by_fat_type(&fat_type, &args[i], limit)
+                            self.view_value_by_fat_type(&fat_type, &args[i], meter)
                         })
                 })
                 .collect::<anyhow::Result<Vec<AnnotatedMoveValue>>>()
@@ -263,8 +286,8 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
 
     fn struct_substitutor(
         &self,
-    ) -> impl Fn(&FatStructType, &[FatType], &mut Limiter) -> PartialVMResult<FatStructRef> {
-        |st, ty_args, limiter| {
+    ) -> impl Fn(&FatStructType, &[FatType], &mut Meter) -> PartialVMResult<FatStructRef> {
+        |st, ty_args, meter| {
             assert!(
                 !ty_args.is_empty(),
                 "Type arguments cannot be empty for substitution"
@@ -272,9 +295,9 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             let st_ty_args = st
                 .ty_args
                 .iter()
-                .map(|ty| ty.subst(ty_args, &self.struct_substitutor(), limiter))
+                .map(|ty| ty.subst(ty_args, &self.struct_substitutor(), meter))
                 .collect::<PartialVMResult<Vec<_>>>()?;
-            self.resolve_generic_struct(st.struct_name(), st_ty_args, limiter)
+            self.resolve_generic_struct(st.struct_name(), st_ty_args, meter)
                 .map_err(|e| {
                     PartialVMError::new_invariant_violation(format!(
                         "cannot annotate generic value: {}",
@@ -288,7 +311,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         module: &ModuleId,
         function: &IdentStr,
-        limit: &mut Limiter,
+        meter: &mut Meter,
         selector: F,
     ) -> anyhow::Result<Vec<FatType>>
     where
@@ -304,7 +327,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                     .0
                     .iter()
                     .map(|signature| {
-                        self.resolve_signature(BinaryIndexedView::Module(m), signature, limit)
+                        self.resolve_signature(BinaryIndexedView::Module(m), signature, meter)
                     })
                     .collect::<anyhow::Result<_>>();
             }
@@ -316,18 +339,18 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         module: &ModuleId,
         function: &IdentStr,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<Vec<FatType>> {
-        self.resolve_function_types(module, function, limit, |fh| fh.parameters())
+        self.resolve_function_types(module, function, meter, |fh| fh.parameters())
     }
 
     fn resolve_function_returns(
         &self,
         module: &ModuleId,
         function: &IdentStr,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<Vec<FatType>> {
-        self.resolve_function_types(module, function, limit, |fh| fh.return_())
+        self.resolve_function_types(module, function, meter, |fh| fh.return_())
     }
 
     pub fn view_resource(
@@ -335,19 +358,20 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         tag: &StructTag,
         blob: &[u8],
     ) -> anyhow::Result<AnnotatedMoveStruct> {
-        self.view_resource_with_limit(tag, blob, &mut Limiter::default())
+        self.view_resource_with_limit(tag, blob, &mut self.fresh_meter())
     }
 
     pub fn view_resource_with_limit(
         &self,
         tag: &StructTag,
         blob: &[u8],
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<AnnotatedMoveStruct> {
-        let ty = self.resolve_struct_tag(tag, &mut Limiter::default())?;
+        let ty = self.resolve_struct_tag(tag, meter)?;
         let struct_def = (ty.as_ref()).try_into().map_err(into_vm_status)?;
         let move_struct = MoveStruct::simple_deserialize(blob, &struct_def)?;
-        self.annotate_struct(&move_struct, &ty, limit)
+        meter.check()?;
+        self.annotate_struct(&move_struct, &ty, meter)
     }
 
     pub fn move_struct_fields(
@@ -355,9 +379,12 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         tag: &StructTag,
         blob: &[u8],
     ) -> anyhow::Result<(Option<Identifier>, Vec<(Identifier, MoveValue)>)> {
-        let ty = self.resolve_struct_tag(tag, &mut Limiter::default())?;
+        let meter = &mut self.fresh_meter();
+        let ty = self.resolve_struct_tag(tag, meter)?;
         let struct_def = (ty.as_ref()).try_into().map_err(into_vm_status)?;
-        Ok(match MoveStruct::simple_deserialize(blob, &struct_def)? {
+        let decoded = MoveStruct::simple_deserialize(blob, &struct_def)?;
+        meter.check()?;
+        Ok(match decoded {
             MoveStruct::Runtime(values) => {
                 let (tag, field_names) = self.get_field_information(&ty, None)?;
                 debug_assert_eq!(tag, None);
@@ -381,7 +408,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
     fn resolve_struct_tag(
         &self,
         struct_tag: &StructTag,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<FatStructRef> {
         let StructTag {
             address,
@@ -395,29 +422,29 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             name: name.to_owned(),
         };
         if type_args.is_empty() {
-            return self.resolve_basic_struct(&struct_name, limit);
+            return self.resolve_basic_struct(&struct_name, meter);
         }
         let type_args = type_args
             .iter()
-            .map(|ty| self.resolve_type_impl(ty, limit))
+            .map(|ty| self.resolve_type_impl(ty, meter))
             .collect::<anyhow::Result<Vec<_>>>()?;
-        self.resolve_generic_struct(struct_name, type_args, limit)
+        self.resolve_generic_struct(struct_name, type_args, meter)
     }
 
     fn resolve_generic_struct(
         &self,
         struct_name: StructName,
         type_args: Vec<FatType>,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<FatStructRef> {
         let name_and_args = (struct_name, type_args);
         if let Some(fat_ty) = self.fat_struct_inst_cache.borrow().get(&name_and_args) {
             return Ok(fat_ty.clone());
         }
-        let base_type = self.resolve_basic_struct(&name_and_args.0, limit)?;
+        let base_type = self.resolve_basic_struct(&name_and_args.0, meter)?;
         let inst_type = FatStructRef::new(
             base_type
-                .subst(&name_and_args.1, &self.struct_substitutor(), limit)
+                .subst(&name_and_args.1, &self.struct_substitutor(), meter)
                 .map_err(|e: PartialVMError| {
                     anyhow!("type {:?} cannot be resolved: {:?}", name_and_args, e)
                 })?,
@@ -431,7 +458,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
     fn resolve_basic_struct(
         &self,
         struct_name: &StructName,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<FatStructRef> {
         if let Some(fat_ty) = self.fat_struct_def_cache.borrow().get(struct_name) {
             return Ok(fat_ty.clone());
@@ -443,7 +470,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
 
         let struct_def = find_struct_def_in_module(module, struct_name.name.as_ident_str())?;
         let base_type =
-            FatStructRef::new(self.resolve_struct_definition(module, struct_def, limit)?);
+            FatStructRef::new(self.resolve_struct_definition(module, struct_def, meter)?);
         self.fat_struct_def_cache
             .borrow_mut()
             .insert(struct_name.to_owned(), base_type.clone());
@@ -454,7 +481,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         module: &CompiledModule,
         idx: StructDefinitionIndex,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<FatStructType> {
         let struct_def = module.struct_def_at(idx);
         let struct_handle = module.struct_handle_at(struct_def.struct_handle);
@@ -466,23 +493,21 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             .map(FatType::TyParam)
             .collect();
 
-        limit.charge(std::mem::size_of::<AccountAddress>())?;
-        limit.charge(module_name.as_bytes().len())?;
-        limit.charge(name.as_bytes().len())?;
+        meter.check()?;
 
         let table_id = &*TABLE_MODULE_ID;
         let mut contains_tables = address == table_id.address
             && module_name == table_id.name
             && name == *TABLE_STRUCT_NAME;
         let mut make_fields =
-            |fields: &[FieldDefinition], limit: &mut Limiter| -> anyhow::Result<Vec<FatType>> {
+            |fields: &[FieldDefinition], meter: &mut Meter| -> anyhow::Result<Vec<FatType>> {
                 fields
                     .iter()
                     .map(|field_def| {
                         let ty = self.resolve_signature(
                             BinaryIndexedView::Module(module),
                             &field_def.signature.0,
-                            limit,
+                            meter,
                         );
                         if !contains_tables {
                             contains_tables =
@@ -496,7 +521,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         match &struct_def.field_information {
             StructFieldInformation::Native => Err(anyhow!("Unexpected Native Struct")),
             StructFieldInformation::Declared(fields) => {
-                let fat_fields = make_fields(fields, limit)?;
+                let fat_fields = make_fields(fields, meter)?;
                 Ok(FatStructType {
                     address,
                     module: module_name,
@@ -510,7 +535,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             StructFieldInformation::DeclaredVariants(variants) => {
                 let fat_variants = variants
                     .iter()
-                    .map(|variant| make_fields(&variant.fields, limit))
+                    .map(|variant| make_fields(&variant.fields, meter))
                     .collect::<anyhow::Result<_>>()?;
                 Ok(FatStructType {
                     address,
@@ -529,7 +554,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         module: BinaryIndexedView,
         sig: &SignatureToken,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<FatType> {
         Ok(match sig {
             SignatureToken::Bool => FatType::Bool,
@@ -548,20 +573,20 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             SignatureToken::Address => FatType::Address,
             SignatureToken::Signer => FatType::Signer,
             SignatureToken::Vector(ty) => {
-                FatType::Vector(Box::new(self.resolve_signature(module, ty, limit)?))
+                FatType::Vector(Box::new(self.resolve_signature(module, ty, meter)?))
             },
             SignatureToken::Function(args, results, abilities) => {
-                let resolve_slice = |toks: &[SignatureToken], limit: &mut Limiter| {
+                let resolve_slice = |toks: &[SignatureToken], meter: &mut Meter| {
                     toks.iter()
                         .map(|tok| {
                             // Function type can have references as immediate argument or return
                             // types.
                             Ok(match tok {
                                 SignatureToken::Reference(t) => FatType::Reference(Box::new(
-                                    self.resolve_signature(module, t, limit)?,
+                                    self.resolve_signature(module, t, meter)?,
                                 )),
                                 SignatureToken::MutableReference(t) => FatType::MutableReference(
-                                    Box::new(self.resolve_signature(module, t, limit)?),
+                                    Box::new(self.resolve_signature(module, t, meter)?),
                                 ),
                                 SignatureToken::Bool
                                 | SignatureToken::U8
@@ -583,29 +608,29 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                                 | SignatureToken::I64
                                 | SignatureToken::I128
                                 | SignatureToken::I256 => {
-                                    self.resolve_signature(module, tok, limit)?
+                                    self.resolve_signature(module, tok, meter)?
                                 },
                             })
                         })
                         .collect::<anyhow::Result<Vec<_>>>()
                 };
                 FatType::Function(Box::new(FatFunctionType {
-                    args: resolve_slice(args, limit)?,
-                    results: resolve_slice(results, limit)?,
+                    args: resolve_slice(args, meter)?,
+                    results: resolve_slice(results, meter)?,
                     abilities: *abilities,
                 }))
             },
             SignatureToken::Struct(idx) => {
                 let struct_name = self.handle_to_struct_name(module, *idx);
-                FatType::Struct(self.resolve_basic_struct(&struct_name, limit)?)
+                FatType::Struct(self.resolve_basic_struct(&struct_name, meter)?)
             },
             SignatureToken::StructInstantiation(idx, toks) => {
                 let struct_name = self.handle_to_struct_name(module, *idx);
                 let ty_args = toks
                     .iter()
-                    .map(|tok| self.resolve_signature(module, tok, limit))
+                    .map(|tok| self.resolve_signature(module, tok, meter))
                     .collect::<anyhow::Result<Vec<_>>>()?;
-                FatType::Struct(self.resolve_generic_struct(struct_name, ty_args, limit)?)
+                FatType::Struct(self.resolve_generic_struct(struct_name, ty_args, meter)?)
             },
             SignatureToken::TypeParameter(idx) => FatType::TyParam(*idx as usize),
             SignatureToken::MutableReference(_) => return Err(anyhow!("Unexpected Reference")),
@@ -630,16 +655,12 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         }
     }
 
-    fn resolve_type_impl(
-        &self,
-        type_tag: &TypeTag,
-        limit: &mut Limiter,
-    ) -> anyhow::Result<FatType> {
+    fn resolve_type_impl(&self, type_tag: &TypeTag, meter: &mut Meter) -> anyhow::Result<FatType> {
         Ok(match type_tag {
             TypeTag::Address => FatType::Address,
             TypeTag::Signer => FatType::Signer,
             TypeTag::Bool => FatType::Bool,
-            TypeTag::Struct(st) => FatType::Struct(self.resolve_struct_tag(st, limit)?),
+            TypeTag::Struct(st) => FatType::Struct(self.resolve_struct_tag(st, meter)?),
             TypeTag::U8 => FatType::U8,
             TypeTag::U16 => FatType::U16,
             TypeTag::U32 => FatType::U32,
@@ -652,7 +673,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             TypeTag::I64 => FatType::I64,
             TypeTag::I128 => FatType::I128,
             TypeTag::I256 => FatType::I256,
-            TypeTag::Vector(ty) => FatType::Vector(Box::new(self.resolve_type_impl(ty, limit)?)),
+            TypeTag::Vector(ty) => FatType::Vector(Box::new(self.resolve_type_impl(ty, meter)?)),
             TypeTag::Function(function_tag) => {
                 let mut convert_tags = |tags: &[FunctionParamOrReturnTag]| {
                     tags.iter()
@@ -660,12 +681,12 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                             use FunctionParamOrReturnTag::*;
                             Ok(match t {
                                 Reference(t) => {
-                                    FatType::Reference(Box::new(self.resolve_type_impl(t, limit)?))
+                                    FatType::Reference(Box::new(self.resolve_type_impl(t, meter)?))
                                 },
                                 MutableReference(t) => FatType::MutableReference(Box::new(
-                                    self.resolve_type_impl(t, limit)?,
+                                    self.resolve_type_impl(t, meter)?,
                                 )),
-                                Value(t) => self.resolve_type_impl(t, limit)?,
+                                Value(t) => self.resolve_type_impl(t, meter)?,
                             })
                         })
                         .collect::<anyhow::Result<Vec<_>>>()
@@ -680,9 +701,9 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
     }
 
     pub fn view_value(&self, ty_tag: &TypeTag, blob: &[u8]) -> anyhow::Result<AnnotatedMoveValue> {
-        let mut limit = Limiter::default();
-        let ty = self.resolve_type_impl(ty_tag, &mut limit)?;
-        self.view_value_by_fat_type(&ty, blob, &mut limit)
+        let mut meter = self.fresh_meter();
+        let ty = self.resolve_type_impl(ty_tag, &mut meter)?;
+        self.view_value_by_fat_type(&ty, blob, &mut meter)
     }
 
     /// Collect information about tables contained in the value represented by the blob.
@@ -692,21 +713,22 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         blob: &[u8],
         infos: &mut Vec<MoveTableInfo>,
     ) -> anyhow::Result<()> {
-        let mut limit = Limiter::default();
-        if !self.contains_tables(ty_tag, &mut limit)? {
+        let mut meter = self.fresh_meter();
+        if !self.contains_tables(ty_tag, &mut meter)? {
             return Ok(());
         }
-        let fat_ty = self.resolve_type_impl(ty_tag, &mut limit)?;
+        let fat_ty = self.resolve_type_impl(ty_tag, &mut meter)?;
         let layout = (&fat_ty).try_into().map_err(into_vm_status)?;
         let move_value = MoveValue::simple_deserialize(blob, &layout)?;
-        self.collect_table_info_from_value(&fat_ty, move_value, &mut limit, infos)
+        meter.check()?;
+        self.collect_table_info_from_value(&fat_ty, move_value, &mut meter, infos)
     }
 
-    fn contains_tables(&self, ty_tag: &TypeTag, limit: &mut Limiter) -> anyhow::Result<bool> {
+    fn contains_tables(&self, ty_tag: &TypeTag, meter: &mut Meter) -> anyhow::Result<bool> {
         if let Some(contains) = self.contains_tables_cache.borrow().get(ty_tag) {
             return Ok(*contains);
         }
-        let ty = self.resolve_type_impl(ty_tag, limit)?;
+        let ty = self.resolve_type_impl(ty_tag, meter)?;
         let contains = ty.contains_tables();
         self.contains_tables_cache
             .borrow_mut()
@@ -718,32 +740,28 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         ty: &FatType,
         blob: &[u8],
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<AnnotatedMoveValue> {
         let layout = ty.try_into().map_err(into_vm_status)?;
         let move_value = MoveValue::simple_deserialize(blob, &layout)?;
-        self.annotate_value(&move_value, ty, limit)
+        meter.check()?;
+        self.annotate_value(&move_value, ty, meter)
     }
 
     fn annotate_struct(
         &self,
         move_struct: &MoveStruct,
         ty: &FatStructType,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<AnnotatedMoveStruct> {
         let struct_tag = ty
-            .struct_tag(limit)
+            .struct_tag(meter)
             .map_err(|e| e.finish(Location::Undefined).into_vm_status())?;
         let (variant_tag, field_values) = move_struct.optional_variant_and_fields();
         let (variant_info, field_names) = self.get_field_information(ty, variant_tag)?;
-        if let Some((_, name)) = &variant_info {
-            limit.charge(name.as_bytes().len())?;
-        }
-        for name in field_names.iter() {
-            limit.charge(name.as_bytes().len())?;
-        }
+        meter.check()?;
 
-        let annotate_values = |values: &[MoveValue], tys: &[FatType], limit: &mut Limiter| {
+        let annotate_values = |values: &[MoveValue], tys: &[FatType], meter: &mut Meter| {
             anyhow::ensure!(
                 values.len() == tys.len() && tys.len() == field_names.len(),
                 "struct field count mismatch: {} values, {} types, {} names",
@@ -755,7 +773,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                 .iter()
                 .zip(tys)
                 .zip(field_names)
-                .map(|((v, ty), n)| self.annotate_value(v, ty, limit).map(|v| (n, v)))
+                .map(|((v, ty), n)| self.annotate_value(v, ty, meter).map(|v| (n, v)))
                 .collect::<anyhow::Result<Vec<_>>>()
         };
 
@@ -764,7 +782,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                 abilities: ty.abilities,
                 ty_tag: struct_tag,
                 variant_info: None,
-                value: annotate_values(field_values, field_tys, limit)?,
+                value: annotate_values(field_values, field_tys, meter)?,
             }),
             FatStructLayout::Variants(variants) => match variant_tag {
                 Some(tag) if (tag as usize) < variants.len() => {
@@ -773,7 +791,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                         abilities: ty.abilities,
                         ty_tag: struct_tag,
                         variant_info,
-                        value: annotate_values(field_values, field_tys, limit)?,
+                        value: annotate_values(field_values, field_tys, meter)?,
                     })
                 },
                 _ => bail!("type and value mismatch: malformed variant tag"),
@@ -823,7 +841,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         move_closure: &MoveClosure,
         _ty: &FatFunctionType,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<AnnotatedMoveClosure> {
         let MoveClosure {
             module_id,
@@ -837,7 +855,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         // This gives fully named annotations (real struct and field names) instead of
         // the raw, nameless layouts stored with the closure, at the cost of requiring
         // the defining module to be loadable at the read version.
-        let captured_tys = self.resolve_captured_types(module_id, fun_id, ty_args, *mask, limit)?;
+        let captured_tys = self.resolve_captured_types(module_id, fun_id, ty_args, *mask, meter)?;
         let captured_tys = captured_tys.as_deref().map_or(&[][..], Vec::as_slice);
         anyhow::ensure!(
             captured.len() == captured_tys.len(),
@@ -848,7 +866,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         let captured = captured
             .iter()
             .zip(captured_tys)
-            .map(|((_layout, value), ty)| self.annotate_value(value, ty, limit))
+            .map(|((_layout, value), ty)| self.annotate_value(value, ty, meter))
             .collect::<anyhow::Result<Vec<_>>>()?;
         Ok(AnnotatedMoveClosure {
             module_id: module_id.clone(),
@@ -869,7 +887,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         fun_id: &IdentStr,
         ty_args: &[TypeTag],
         mask: ClosureMask,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<Option<Rc<Vec<FatType>>>> {
         if mask.captured_count() == 0 {
             return Ok(None);
@@ -879,11 +897,11 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             return Ok(Some(tys.clone()));
         }
 
-        let captured_tys = self.resolve_captured_parameter_types(module_id, fun_id, mask, limit)?;
+        let captured_tys = self.resolve_captured_parameter_types(module_id, fun_id, mask, meter)?;
 
         let ty_args = ty_args
             .iter()
-            .map(|ty| self.resolve_type_impl(ty, limit))
+            .map(|ty| self.resolve_type_impl(ty, meter))
             .collect::<anyhow::Result<Vec<_>>>()?;
         let resolved = captured_tys
             .into_iter()
@@ -891,7 +909,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                 if ty_args.is_empty() {
                     Ok(ty)
                 } else {
-                    ty.subst(&ty_args, &self.struct_substitutor(), limit)
+                    ty.subst(&ty_args, &self.struct_substitutor(), meter)
                         .map_err(anyhow::Error::from)
                 }
             })
@@ -912,15 +930,11 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         module_id: &ModuleId,
         fun_id: &IdentStr,
         mask: ClosureMask,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<Vec<FatType>> {
         let module = self.view_existing_module(module_id)?;
         let module = module.borrow();
-
-        // Pseudo-cost for loading + scanning this module's function table. Bounds the
-        // amplification where a vector of small closures forces repeated module loads
-        // and O(functions) scans; the captured data itself is already size-bounded.
-        limit.charge(10 * module.function_defs.len())?;
+        meter.check()?;
 
         for def in module.function_defs.iter() {
             let fhandle = module.function_handle_at(def.function);
@@ -942,7 +956,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                 return captured_tokens
                     .into_iter()
                     .map(|tok| {
-                        self.resolve_signature(BinaryIndexedView::Module(module), tok, limit)
+                        self.resolve_signature(BinaryIndexedView::Module(module), tok, meter)
                     })
                     .collect();
             }
@@ -958,8 +972,9 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         value: &MoveValue,
         ty: &FatType,
-        limit: &mut Limiter,
+        meter: &mut Meter,
     ) -> anyhow::Result<AnnotatedMoveValue> {
+        meter.check()?;
         Ok(match (value, ty) {
             (MoveValue::Bool(b), FatType::Bool) => AnnotatedMoveValue::Bool(*b),
             (MoveValue::U8(i), FatType::U8) => AnnotatedMoveValue::U8(*i),
@@ -984,18 +999,21 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                         })
                         .collect::<anyhow::Result<_>>()?,
                 ),
-                _ => AnnotatedMoveValue::Vector(
-                    ty.type_tag(limit).unwrap(),
-                    a.iter()
-                        .map(|v| self.annotate_value(v, ty.as_ref(), limit))
-                        .collect::<anyhow::Result<_>>()?,
-                ),
+                _ => {
+                    let elem_tag = ty.type_tag(meter)?;
+                    AnnotatedMoveValue::Vector(
+                        elem_tag,
+                        a.iter()
+                            .map(|v| self.annotate_value(v, ty.as_ref(), meter))
+                            .collect::<anyhow::Result<_>>()?,
+                    )
+                },
             },
             (MoveValue::Struct(s), FatType::Struct(ty)) => {
-                AnnotatedMoveValue::Struct(self.annotate_struct(s, ty.as_ref(), limit)?)
+                AnnotatedMoveValue::Struct(self.annotate_struct(s, ty.as_ref(), meter)?)
             },
             (MoveValue::Closure(c), FatType::Function(ty)) => {
-                AnnotatedMoveValue::Closure(self.annotate_closure(c, ty, limit)?)
+                AnnotatedMoveValue::Closure(self.annotate_closure(c, ty, meter)?)
             },
             (MoveValue::U8(_), _)
             | (MoveValue::U64(_), _)
@@ -1029,14 +1047,14 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         ty: &FatType,
         val: MoveValue,
-        limit: &mut Limiter,
+        meter: &mut Meter,
         infos: &mut Vec<MoveTableInfo>,
     ) -> anyhow::Result<()> {
         match (ty, val) {
             (FatType::Vector(elem_ty), MoveValue::Vector(elem_vals)) => {
                 if elem_ty.contains_tables() {
                     for val in elem_vals {
-                        self.collect_table_info_from_value(elem_ty, val, limit, infos)?
+                        self.collect_table_info_from_value(elem_ty, val, meter, infos)?
                     }
                 }
                 Ok(())
@@ -1048,8 +1066,8 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                     && let Some(MoveValue::Address(handle)) = vals.first()
                 {
                     infos.push(MoveTableInfo {
-                        key_type: key_type.type_tag(limit)?,
-                        value_type: value_type.type_tag(limit)?,
+                        key_type: key_type.type_tag(meter)?,
+                        value_type: value_type.type_tag(meter)?,
                         handle: *handle,
                     });
                     Ok(())
@@ -1060,7 +1078,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                             MoveStruct::Runtime(field_vals),
                         ) => {
                             for (ty, val) in field_tys.iter().zip(field_vals) {
-                                self.collect_table_info_from_value(ty, val, limit, infos)?
+                                self.collect_table_info_from_value(ty, val, meter, infos)?
                             }
                             Ok(())
                         },
@@ -1069,7 +1087,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                             MoveStruct::RuntimeVariant(tag, field_vals),
                         ) if (tag as usize) < variants.len() => {
                             for (ty, val) in variants[tag as usize].iter().zip(field_vals) {
-                                self.collect_table_info_from_value(ty, val, limit, infos)?
+                                self.collect_table_info_from_value(ty, val, meter, infos)?
                             }
                             Ok(())
                         },
@@ -1081,7 +1099,6 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                     Ok(())
                 }
             },
-
             // Every other combo cannot harbor tables.
             (FatType::Bool, _)
             | (FatType::U8, _)
@@ -1393,5 +1410,101 @@ impl Display for AnnotatedMoveValue {
 impl Display for AnnotatedMoveStruct {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         pretty_print_struct(f, self, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_binary_format::CompiledModule;
+    use move_core_types::language_storage::ModuleId;
+    use std::{cell::Cell, sync::Arc};
+
+    struct EmptyModuleView;
+    impl CompiledModuleView for EmptyModuleView {
+        type Item = Arc<CompiledModule>;
+
+        fn view_compiled_module(&self, _id: &ModuleId) -> anyhow::Result<Option<Self::Item>> {
+            Ok(None)
+        }
+    }
+
+    thread_local! {
+        // Simulated live-bytes counter for the metered annotation path. `fake_read` is a plain
+        // `fn() -> i64` (no captured state) so it can be installed as the annotator's reader.
+        static FAKE_LIVE: Cell<i64> = const { Cell::new(0) };
+    }
+    fn fake_read() -> i64 {
+        FAKE_LIVE.with(|c| c.get())
+    }
+    fn set_live(v: i64) {
+        FAKE_LIVE.with(|c| c.set(v));
+    }
+
+    /// With a metered reader, annotation aborts (rather than panicking) once the request's live
+    /// delta exceeds the budget.
+    #[test]
+    fn annotate_vector_of_struct_aborts_when_meter_over_budget() {
+        set_live(0);
+        let annotator =
+            MoveValueAnnotator::new_with_meter_config(EmptyModuleView, 1_000, fake_read);
+        let struct_ty = FatStructRef::new(FatStructType {
+            address: AccountAddress::ZERO,
+            module: Identifier::new("m").unwrap(),
+            name: Identifier::new("abcdefghij").unwrap(),
+            abilities: AbilitySet::EMPTY,
+            ty_args: vec![],
+            layout: FatStructLayout::Singleton(vec![]),
+            contains_tables: false,
+        });
+        let ty = FatType::Vector(Box::new(FatType::Struct(struct_ty)));
+        let mut meter = annotator.fresh_meter();
+        // Simulate the request having allocated past the budget before the meter is checked.
+        set_live(2_000);
+        let res = annotator.annotate_value(&MoveValue::Vector(vec![]), &ty, &mut meter);
+        let err = res.expect_err("must return Err, not panic");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Query exceeds size limit"),
+            "expected size-limit error, got: {msg}"
+        );
+    }
+
+    /// A configured metered reader bounds annotation: once the live delta since the meter was
+    /// constructed crosses the budget, the post-deserialize `check()` rejects the blob.
+    #[test]
+    fn view_value_uses_configured_meter() {
+        set_live(0);
+        let annotator =
+            MoveValueAnnotator::new_with_meter_config(EmptyModuleView, 1_000, fake_read);
+        let blob = MoveValue::Vector((0..100u8).map(MoveValue::U8).collect())
+            .simple_serialize()
+            .expect("serializes");
+        let ty = FatType::Vector(Box::new(FatType::U8));
+        // Construct the meter while live==0, then simulate the request allocating past the budget.
+        let mut meter = annotator.fresh_meter();
+        set_live(5_000);
+        let err = annotator
+            .view_value_by_fat_type(&ty, &blob, &mut meter)
+            .expect_err("configured meter must reject this blob");
+        assert!(
+            format!("{err}").contains("Query exceeds size limit"),
+            "expected size-limit error, got: {err}"
+        );
+    }
+
+    /// The default no-op meter (reader returns 0) never rejects: annotation succeeds regardless of
+    /// blob size.
+    #[test]
+    fn noop_meter_does_not_reject() {
+        let annotator = MoveValueAnnotator::new(EmptyModuleView);
+        let blob = MoveValue::Vector((0..100u8).map(MoveValue::U8).collect())
+            .simple_serialize()
+            .expect("serializes");
+        let ty = FatType::Vector(Box::new(FatType::U8));
+        let mut meter = annotator.fresh_meter();
+        annotator
+            .view_value_by_fat_type(&ty, &blob, &mut meter)
+            .expect("no-op meter must not reject");
     }
 }

--- a/third_party/move/tools/move-resource-viewer/src/limit.rs
+++ b/third_party/move/tools/move-resource-viewer/src/limit.rs
@@ -6,24 +6,77 @@
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::vm_status::StatusCode;
 
-// Default limit set to 100mb per query.
-const DEFAULT_LIMIT: usize = 100_000_000;
+// Default budget of live heap per query.
+pub const DEFAULT_MAX_ANNOTATION_BYTES: usize = 100_000_000_000;
 
-pub struct Limiter(usize);
+/// Observes real heap growth during a single synchronous annotation request and aborts when it
+/// exceeds `budget`. `read_live` returns the calling thread's current live bytes (see
+/// `aptos_jemalloc::current_live_bytes`); the difference from `start_live` is how much this
+/// request has allocated. We measure real heap growth rather than estimating per-node cost.
+///
+/// Checks run *after* allocation, so the meter bounds *cumulative* growth across the annotation
+/// tree, not the peak of any single `simple_deserialize`. The process-wide resident gate
+/// (`memory_admission_cap_bytes`) is the backstop for one oversized allocation that blows the
+/// budget before the next check fires.
+pub struct Meter {
+    budget: usize,
+    start_live: i64,
+    read_live: fn() -> i64,
+}
 
-impl Limiter {
-    pub fn charge(&mut self, cost: usize) -> PartialVMResult<()> {
-        if self.0 < cost {
+impl Meter {
+    pub fn new(budget: usize, read_live: fn() -> i64) -> Self {
+        let start_live = read_live();
+        Self {
+            budget,
+            start_live,
+            read_live,
+        }
+    }
+
+    /// Aborts if the request's live-byte delta since construction exceeds the budget.
+    pub fn check(&self) -> PartialVMResult<()> {
+        let delta = (self.read_live)() - self.start_live;
+        if delta > self.budget as i64 {
             return Err(PartialVMError::new(StatusCode::ABORTED)
                 .with_message("Query exceeds size limit".to_string()));
         }
-        self.0 -= cost;
         Ok(())
     }
 }
 
-impl Default for Limiter {
-    fn default() -> Self {
-        Limiter(DEFAULT_LIMIT)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    thread_local! {
+        static FAKE_LIVE: Cell<i64> = const { Cell::new(0) };
+    }
+    fn fake_read() -> i64 {
+        FAKE_LIVE.with(|c| c.get())
+    }
+    fn set_live(v: i64) {
+        FAKE_LIVE.with(|c| c.set(v));
+    }
+
+    #[test]
+    fn check_passes_under_budget_and_aborts_over() {
+        set_live(1_000);
+        let meter = Meter::new(500, fake_read);
+        set_live(1_400); // +400 ≤ 500
+        assert!(meter.check().is_ok());
+        set_live(1_600); // +600 > 500
+        assert!(meter.check().is_err());
+    }
+
+    #[test]
+    fn freed_transients_refund_the_budget() {
+        set_live(0);
+        let meter = Meter::new(500, fake_read);
+        set_live(600); // momentarily over
+        assert!(meter.check().is_err());
+        set_live(300); // transient freed → back under
+        assert!(meter.check().is_ok());
     }
 }


### PR DESCRIPTION
## Description

This change bounds memory growth in API resource annotation.

Resource annotation can allocate much more heap than the size of the stored Move value. This change meters annotation by live heap allocation using jemalloc counters and aborts requests that exceed `max_resource_annotation_bytes`.

It also adds API memory admission. When process resident memory is at or above `memory_admission_cap_bytes`, the API rejects new requests with HTTP 503 / `Overloaded`. Health checks are exempt. Setting the cap to `0` disables this admission gate.

Both sit behind the `metered-allocations` feature and lean on jemalloc. Turn the feature off, or build non-unix, and the readers just return 0 everything no-ops and default builds behave exactly like today minus the two limits.

The PR also adds a benchmark suite for resource annotation heap amplification, with realistic payloads and structural edge cases.

## How Has This Been Tested?

The PR adds focused coverage for:

- Resource annotation metering in `aptos-move/aptos-resource-viewer/tests/metering.rs`
- API memory admission behavior in `api/src/memory_admission.rs`
- Resident-memory cache behavior in `crates/aptos-jemalloc/src/resident.rs`
- New API config defaults and sanitization in `config/src/config/api_config.rs`
- The new `Overloaded` API error code in `api/types/src/error.rs`

Relevant commands:

- `cargo test -p aptos-api memory_admission`
- `cargo test -p aptos-jemalloc`
- `cargo test -p aptos-config resource_annotation`
- `cargo test -p aptos-resource-viewer --features metered-allocations`
- `cargo bench -p aptos-resource-viewer --bench annotate --features metered-allocations`

## Key Areas to Review

- `third_party/move/tools/move-resource-viewer`: replaces structural charging with live-heap metering through `Meter`.
- `api/types/src/convert.rs`: resource pages and resource groups intentionally share one annotation budget across the batch; single-resource conversions use a fresh budget.
- `api/src/memory_admission.rs`: rejects new API requests under high resident memory while leaving health checks available.
- `crates/aptos-jemalloc/src/resident.rs`: throttle-caches resident-memory reads and fails open when resident memory is unavailable.
- `config/src/config/api_config.rs`: adds `max_resource_annotation_bytes` and `memory_admission_cap_bytes` defaults and validation.
- `aptos-move/aptos-resource-viewer/benches/annotate.rs`: benchmark-only budget is deliberately high so benchmarks measure full annotation, not early aborts.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other: Move resource viewer, API resource annotation, jemalloc memory metrics

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation