### PR TITLE
[State Sync] Use saturating operations.

### DIFF
--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -290,22 +290,25 @@ impl AptosDataClient {
         let multi_fetch_config = self.data_client_config.data_multi_fetch_config;
         let num_peers_for_request = if multi_fetch_config.enable_multi_fetch {
             // Calculate the total number of priority serviceable peers
-            let mut num_serviceable_peers = 0;
+            let mut num_serviceable_peers: usize = 0;
             for (index, peers) in serviceable_peers_by_priorities.iter().enumerate() {
                 // Only include the lowest priority peers if no other peers are
                 // available (the lowest priority peers are generally unreliable).
                 if (num_serviceable_peers == 0)
                     || (index < serviceable_peers_by_priorities.len() - 1)
                 {
-                    num_serviceable_peers += peers.len();
+                    num_serviceable_peers = num_serviceable_peers.saturating_add(peers.len());
                 }
             }
 
             // Calculate the number of peers to select for the request
             let peer_ratio_for_request =
                 num_serviceable_peers / multi_fetch_config.multi_fetch_peer_bucket_size;
-            let mut num_peers_for_request = multi_fetch_config.min_peers_for_multi_fetch
-                + (peer_ratio_for_request * multi_fetch_config.additional_requests_per_peer_bucket);
+            let additional_peers_for_request = peer_ratio_for_request
+                .saturating_mul(multi_fetch_config.additional_requests_per_peer_bucket);
+            let mut num_peers_for_request = multi_fetch_config
+                .min_peers_for_multi_fetch
+                .saturating_add(additional_peers_for_request);
 
             // Bound the number of peers by the number of serviceable peers
             num_peers_for_request = min(num_peers_for_request, num_serviceable_peers);

--- a/state-sync/aptos-data-client/src/latency_monitor.rs
+++ b/state-sync/aptos-data-client/src/latency_monitor.rs
@@ -171,7 +171,7 @@ impl LatencyMonitor {
         // Split the advertised versions into synced and unsynced versions
         let unsynced_advertised_versions = self
             .advertised_versions
-            .split_off(&(highest_synced_version + 1));
+            .split_off(&highest_synced_version.saturating_add(1));
 
         // Update the metrics for all synced versions
         for (synced_version, advertised_version_metadata) in self.advertised_versions.iter() {
@@ -240,7 +240,9 @@ impl LatencyMonitor {
     ) {
         // Check if we're still catching up to the latest version
         if !self.caught_up_to_latest {
-            if highest_synced_version + MAX_VERSION_LAG_TO_TOLERATE >= highest_advertised_version {
+            if highest_synced_version.saturating_add(MAX_VERSION_LAG_TO_TOLERATE)
+                >= highest_advertised_version
+            {
                 info!(
                     (LogSchema::new(LogEntry::LatencyMonitor)
                         .event(LogEvent::CaughtUpToLatest)

--- a/state-sync/aptos-data-client/src/peer_states.rs
+++ b/state-sync/aptos-data-client/src/peer_states.rs
@@ -98,7 +98,7 @@ impl PeerState {
     fn increment_received_response_counter(&mut self, response_label: String) {
         self.received_responses_by_type
             .entry(response_label)
-            .and_modify(|counter| *counter += 1)
+            .and_modify(|counter| *counter = counter.saturating_add(1))
             .or_insert(1);
     }
 
@@ -106,7 +106,7 @@ impl PeerState {
     fn increment_sent_request_counter(&mut self, request_label: String) {
         self.sent_requests_by_type
             .entry(request_label)
-            .and_modify(|counter| *counter += 1)
+            .and_modify(|counter| *counter = counter.saturating_add(1))
             .or_insert(1);
     }
 
@@ -479,7 +479,7 @@ fn update_peer_ignored_metrics(peer_to_state: Arc<DashMap<PeerNetworkId, PeerSta
 
         // If the peer is ignored, increment the count
         if peer_state.is_ignored() {
-            *network_count_entry += 1;
+            *network_count_entry = network_count_entry.saturating_add(1);
         }
     }
 
@@ -539,9 +539,10 @@ fn update_peer_request_metrics(peer_to_state: Arc<DashMap<PeerNetworkId, PeerSta
             .entry(peer_bucket_id)
             .or_default();
         for (request_label, count) in sent_requests_by_type.iter() {
-            *sent_requests_by_bucket
+            let entry = sent_requests_by_bucket
                 .entry(request_label.clone())
-                .or_default() += count;
+                .or_default();
+            *entry = entry.saturating_add(*count);
         }
 
         // Aggregate the received response counts by peer bucket
@@ -549,9 +550,10 @@ fn update_peer_request_metrics(peer_to_state: Arc<DashMap<PeerNetworkId, PeerSta
             .entry(peer_bucket_id)
             .or_default();
         for (response_label, count) in received_responses_by_type.iter() {
-            *received_responses_by_bucket
+            let entry = received_responses_by_bucket
                 .entry(response_label.clone())
-                .or_default() += count;
+                .or_default();
+            *entry = entry.saturating_add(*count);
         }
     }
 

--- a/state-sync/aptos-data-client/src/poller.rs
+++ b/state-sync/aptos-data-client/src/poller.rs
@@ -172,7 +172,8 @@ impl DataSummaryPoller {
             num_peers_to_poll => {
                 // Select half the peers randomly, and the other half weighted by latency
                 let num_peers_to_poll_randomly = num_peers_to_poll / 2;
-                let num_peers_to_poll_by_latency = num_peers_to_poll - num_peers_to_poll_randomly;
+                let num_peers_to_poll_by_latency =
+                    num_peers_to_poll.saturating_sub(num_peers_to_poll_randomly);
 
                 // Select the random peers
                 let random_peers_to_poll =
@@ -357,8 +358,9 @@ pub(crate) fn calculate_num_peers_to_poll(
     let min_polls_per_second = data_poller_config.min_polls_per_second;
     let peer_bucket_sizes = data_poller_config.peer_bucket_size;
     let additional_polls_per_bucket = data_poller_config.additional_polls_per_peer_bucket;
-    let total_polls_per_second = min_polls_per_second
-        + (additional_polls_per_bucket * (potential_peers.len() as u64 / peer_bucket_sizes));
+    let additional_polls_for_peers = additional_polls_per_bucket
+        .saturating_mul(potential_peers.len() as u64 / peer_bucket_sizes);
+    let total_polls_per_second = min_polls_per_second.saturating_add(additional_polls_for_peers);
 
     // Bound the number of polls per second by the maximum configurable value
     let polls_per_second = cmp::min(

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -353,9 +353,10 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
 
             // Exponentially increase the timeout based on the number of
             // previous failures (but bounded by the max timeout).
+            let timeout_multiplier = 2u64.saturating_pow(self.request_failure_count as u32);
             let request_timeout_ms = min(
                 max_response_timeout_ms,
-                response_timeout_ms * (u32::pow(2, self.request_failure_count as u32) as u64),
+                response_timeout_ms.saturating_mul(timeout_multiplier),
             );
 
             // Update the retry counter and log the request
@@ -731,7 +732,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         data_client_request: &DataClientRequest,
     ) -> Result<(), Error> {
         // Increment the number of client failures for this request
-        self.request_failure_count += 1;
+        self.request_failure_count = self.request_failure_count.saturating_add(1);
 
         // Resend the client request
         let pending_client_response = self.send_client_request(true, data_client_request.clone());
@@ -879,12 +880,12 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
     /// Returns the number of pending requests in the sent data requests queue
     /// that have already completed (i.e., are no longer in-flight).
     fn get_num_complete_pending_requests(&mut self) -> Result<u64, Error> {
-        let mut num_complete_pending_requests = 0;
+        let mut num_complete_pending_requests: u64 = 0;
         for sent_data_request in self.get_sent_data_requests()? {
             if let Some(client_response) = sent_data_request.lock().client_response.as_ref() {
                 if client_response.is_ok() {
                     // Only count successful responses as complete. Failures will be retried
-                    num_complete_pending_requests += 1;
+                    num_complete_pending_requests = num_complete_pending_requests.saturating_add(1);
                 }
             }
         }

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -1995,7 +1995,7 @@ impl SubscriptionStream {
 
     /// Increments the next subscription stream index
     pub fn increment_subscription_stream_index(&mut self) {
-        self.next_subscription_stream_index += 1;
+        self.next_subscription_stream_index = self.next_subscription_stream_index.saturating_add(1);
     }
 }
 

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -220,7 +220,9 @@ pub async fn get_data_notification(
         Ok(data_notification)
     } else {
         // Increase the number of consecutive timeouts for the data stream
-        active_data_stream.num_consecutive_timeouts += 1;
+        active_data_stream.num_consecutive_timeouts = active_data_stream
+            .num_consecutive_timeouts
+            .saturating_add(1);
 
         // Check if we've timed out too many times
         if active_data_stream.num_consecutive_timeouts >= max_num_stream_timeouts {

--- a/state-sync/storage-service/server/src/moderator.rs
+++ b/state-sync/storage-service/server/src/moderator.rs
@@ -50,7 +50,7 @@ impl UnhealthyPeerState {
     /// Note: we only ignore peers on the public network.
     pub fn increment_invalid_request_count(&mut self, peer_network_id: &PeerNetworkId) {
         // Increment the invalid request count
-        self.invalid_request_count += 1;
+        self.invalid_request_count = self.invalid_request_count.saturating_add(1);
 
         // If the peer is a PFN and has sent too many invalid requests, start ignoring it
         if self.ignore_start_time.is_none()
@@ -88,7 +88,7 @@ impl UnhealthyPeerState {
                 self.ignore_start_time = None;
 
                 // Double the min time to ignore the peer
-                self.min_time_to_ignore_secs *= 2;
+                self.min_time_to_ignore_secs = self.min_time_to_ignore_secs.saturating_mul(2);
 
                 // Log the fact that we're no longer ignoring the peer
                 warn!(LogSchema::new(LogEntry::RequestModeratorIgnoredPeer)
@@ -265,7 +265,7 @@ impl RequestModerator {
             })?;
 
         // Refresh the unhealthy peer states and garbage collect disconnected peers
-        let mut num_ignored_peers = 0;
+        let mut num_ignored_peers: u64 = 0;
         self.unhealthy_peer_states
             .retain(|peer_network_id, unhealthy_peer_state| {
                 if connected_peers_and_metadata.contains_key(peer_network_id) {
@@ -274,7 +274,7 @@ impl RequestModerator {
 
                     // If the peer is ignored, increment the ignored peer count
                     if unhealthy_peer_state.is_ignored() {
-                        num_ignored_peers += 1;
+                        num_ignored_peers = num_ignored_peers.saturating_add(1);
                     }
 
                     true // The peer is still connected, so we should keep it

--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -609,18 +609,25 @@ fn update_optimistic_fetch_metrics(
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
 ) {
     // Calculate the total number of optimistic fetches for each network
-    let mut num_validator_optimistic_fetches = 0;
-    let mut num_vfn_optimistic_fetches = 0;
-    let mut num_public_optimistic_fetches = 0;
+    let mut num_validator_optimistic_fetches: u64 = 0;
+    let mut num_vfn_optimistic_fetches: u64 = 0;
+    let mut num_public_optimistic_fetches: u64 = 0;
     for optimistic_fetch in optimistic_fetches.iter() {
         // Get the peer network ID
         let peer_network_id = optimistic_fetch.key();
 
         // Increment the number of optimistic fetches for the peer's network
         match peer_network_id.network_id() {
-            NetworkId::Validator => num_validator_optimistic_fetches += 1,
-            NetworkId::Vfn => num_vfn_optimistic_fetches += 1,
-            NetworkId::Public => num_public_optimistic_fetches += 1,
+            NetworkId::Validator => {
+                num_validator_optimistic_fetches =
+                    num_validator_optimistic_fetches.saturating_add(1)
+            },
+            NetworkId::Vfn => {
+                num_vfn_optimistic_fetches = num_vfn_optimistic_fetches.saturating_add(1)
+            },
+            NetworkId::Public => {
+                num_public_optimistic_fetches = num_public_optimistic_fetches.saturating_add(1)
+            },
         }
     }
 
@@ -628,16 +635,16 @@ fn update_optimistic_fetch_metrics(
     metrics::set_gauge(
         &metrics::OPTIMISTIC_FETCH_COUNT,
         NetworkId::Validator.as_str(),
-        num_validator_optimistic_fetches as u64,
+        num_validator_optimistic_fetches,
     );
     metrics::set_gauge(
         &metrics::OPTIMISTIC_FETCH_COUNT,
         NetworkId::Vfn.as_str(),
-        num_vfn_optimistic_fetches as u64,
+        num_vfn_optimistic_fetches,
     );
     metrics::set_gauge(
         &metrics::OPTIMISTIC_FETCH_COUNT,
         NetworkId::Public.as_str(),
-        num_public_optimistic_fetches as u64,
+        num_public_optimistic_fetches,
     );
 }

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -432,9 +432,9 @@ impl StorageReader {
 
                     // Add the data items to the lists
                     let total_serialized_bytes = num_transaction_bytes
-                        + num_info_bytes
-                        + num_events_bytes
-                        + num_auxiliary_info_bytes;
+                        .saturating_add(num_info_bytes)
+                        .saturating_add(num_events_bytes)
+                        .saturating_add(num_auxiliary_info_bytes);
                     if response_progress_tracker
                         .data_items_fits_in_response(true, total_serialized_bytes)
                     {
@@ -659,9 +659,9 @@ impl StorageReader {
 
                     // Add the data items to the lists
                     let total_serialized_bytes = num_transaction_bytes
-                        + num_info_bytes
-                        + num_output_bytes
-                        + num_auxiliary_info_bytes;
+                        .saturating_add(num_info_bytes)
+                        .saturating_add(num_output_bytes)
+                        .saturating_add(num_auxiliary_info_bytes);
                     if response_progress_tracker.data_items_fits_in_response(
                         !is_transaction_or_output_request,
                         total_serialized_bytes,
@@ -881,7 +881,7 @@ impl StorageReader {
                 debug!("The request for {:?} outputs was too large (num bytes: {:?}, limit: {:?}). Current number of data reductions: {:?}",
                     num_outputs_to_fetch, num_bytes, max_response_size, num_output_reductions);
                 num_outputs_to_fetch = new_num_outputs_to_fetch; // Try again with half the amount of data
-                num_output_reductions += 1;
+                num_output_reductions = num_output_reductions.saturating_add(1);
             }
         }
 
@@ -1387,8 +1387,10 @@ impl ResponseDataProgressTracker {
     /// Adds a data item to the response, updating the number of items
     /// fetched and the cumulative serialized data size.
     pub fn add_data_item(&mut self, serialized_data_size: u64) {
-        self.num_items_fetched += 1;
-        self.serialized_data_size += serialized_data_size;
+        self.num_items_fetched = self.num_items_fetched.saturating_add(1);
+        self.serialized_data_size = self
+            .serialized_data_size
+            .saturating_add(serialized_data_size);
     }
 
     /// Returns true iff the given data item fits in the response

--- a/state-sync/storage-service/server/src/subscription.rs
+++ b/state-sync/storage-service/server/src/subscription.rs
@@ -541,17 +541,19 @@ impl SubscriptionStreamRequests {
         };
 
         // Update the highest known version
-        self.highest_known_version += num_data_items as u64;
+        self.highest_known_version = self
+            .highest_known_version
+            .saturating_add(num_data_items as u64);
 
         // Update the highest known epoch if we've now hit an epoch ending ledger info
         if self.highest_known_version == target_ledger_info.ledger_info().version()
             && target_ledger_info.ledger_info().ends_epoch()
         {
-            self.highest_known_epoch += 1;
+            self.highest_known_epoch = self.highest_known_epoch.saturating_add(1);
         }
 
         // Update the next index to serve
-        self.next_index_to_serve += 1;
+        self.next_index_to_serve = self.next_index_to_serve.saturating_add(1);
 
         // Refresh the last stream update time
         self.refresh_last_stream_update_time();
@@ -1025,18 +1027,22 @@ fn update_active_subscription_metrics(
     subscriptions: Arc<DashMap<PeerNetworkId, SubscriptionStreamRequests>>,
 ) {
     // Calculate the total number of subscriptions for each network
-    let mut num_validator_subscriptions = 0;
-    let mut num_vfn_subscriptions = 0;
-    let mut num_public_subscriptions = 0;
+    let mut num_validator_subscriptions: u64 = 0;
+    let mut num_vfn_subscriptions: u64 = 0;
+    let mut num_public_subscriptions: u64 = 0;
     for subscription in subscriptions.iter() {
         // Get the peer network ID
         let peer_network_id = *subscription.key();
 
         // Increment the number of subscriptions for the peer's network
         match peer_network_id.network_id() {
-            NetworkId::Validator => num_validator_subscriptions += 1,
-            NetworkId::Vfn => num_vfn_subscriptions += 1,
-            NetworkId::Public => num_public_subscriptions += 1,
+            NetworkId::Validator => {
+                num_validator_subscriptions = num_validator_subscriptions.saturating_add(1)
+            },
+            NetworkId::Vfn => num_vfn_subscriptions = num_vfn_subscriptions.saturating_add(1),
+            NetworkId::Public => {
+                num_public_subscriptions = num_public_subscriptions.saturating_add(1)
+            },
         }
     }
 
@@ -1044,16 +1050,16 @@ fn update_active_subscription_metrics(
     metrics::set_gauge(
         &metrics::SUBSCRIPTION_COUNT,
         NetworkId::Validator.as_str(),
-        num_validator_subscriptions as u64,
+        num_validator_subscriptions,
     );
     metrics::set_gauge(
         &metrics::SUBSCRIPTION_COUNT,
         NetworkId::Vfn.as_str(),
-        num_vfn_subscriptions as u64,
+        num_vfn_subscriptions,
     );
     metrics::set_gauge(
         &metrics::SUBSCRIPTION_COUNT,
         NetworkId::Public.as_str(),
-        num_public_subscriptions as u64,
+        num_public_subscriptions,
     );
 }

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -924,10 +924,10 @@ fn check_synced_ledger_lag(
 
         // Get the current timestamp and max version lag (in microseconds)
         let current_timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        let max_version_lag_usecs = max_lag_secs * NUM_MICROSECONDS_IN_SECOND;
+        let max_version_lag_usecs = max_lag_secs.saturating_mul(NUM_MICROSECONDS_IN_SECOND);
 
-        // Return true iff the synced ledger info timestamp is within the max version lag
-        ledger_info_timestamp_usecs + max_version_lag_usecs > current_timestamp_usecs
+        // Return true iff the synced ledger info timestamp is within the max version lag.
+        ledger_info_timestamp_usecs.saturating_add(max_version_lag_usecs) > current_timestamp_usecs
     } else {
         false // No synced ledger info was found!
     }


### PR DESCRIPTION
## Description
This PR updates the `state-sync/` directory to use saturating operations. Nothing else should change.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving defensive arithmetic with no API or config changes; edge cases only differ when values would have previously wrapped or panicked on overflow.
> 
> **Overview**
> Replaces plain integer `+`, `-`, and `*` (and one exponential timeout calculation) with **saturating** equivalents across the `state-sync/` tree so counters, version math, and sizing logic cannot overflow or underflow.
> 
> Touches **aptos-data-client** (multi-fetch peer counts, poller rates, latency monitor version splits and catch-up checks, peer metric aggregation), **data-streaming-service** (retry timeouts, failure/complete request counts, subscription indices), **state-sync-driver** (consecutive stream timeouts), **storage-service** (request moderation, optimistic fetch/subscription metrics, response byte totals and progress trackers), and **storage-service types** (ledger freshness lag checks).
> 
> A few call sites add explicit `usize`/`u64` types or drop redundant `as u64` casts on counters that are already `u64`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337f4ebae4b0096112ec66157dcfc3a13bbd3e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->