### PR TITLE
[Consensus] Small logging tweaks.

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1747,7 +1747,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                                 SecurityEvent::ConsensusInvalidMessage,
                                 remote_peer = peer_id,
                                 error = ?e,
-                                unverified_event = unverified_event
+                                unverified_event = %unverified_event,
                             );
                         },
                     }

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -301,7 +301,7 @@ impl NetworkSender {
             .map_err(|e| {
                 error!(
                     SecurityEvent::InvalidRetrievedBlock,
-                    request_block_response = response,
+                    request_block_response = %response,
                     error = ?e,
                 );
                 e
@@ -1050,7 +1050,7 @@ impl NetworkTask {
                         | ConsensusMsg::BlockRetrievalResponse(_)
                         | ConsensusMsg::BatchResponse(_)
                         | ConsensusMsg::BatchResponseV2(_) => {
-                            warn!(remote_peer = peer_id, "Unexpected RPC msg: {:?}", msg);
+                            warn!(remote_peer = peer_id, "Unexpected RPC msg: {}", msg.name());
                             continue;
                         },
                     };

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -300,8 +300,8 @@ impl PendingVotes {
                 error!(
                     SecurityEvent::ConsensusEquivocatingVote,
                     remote_peer = vote.author(),
-                    vote = vote,
-                    previous_vote = previously_seen_vote
+                    vote = %vote,
+                    previous_vote = %previously_seen_vote
                 );
 
                 return VoteReceptionResult::EquivocateVote;

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -75,7 +75,7 @@ use fail::fail_point;
 use futures::{channel::oneshot, stream::FuturesUnordered, Future, FutureExt, SinkExt, StreamExt};
 use serde::Serialize;
 use std::{
-    collections::BTreeMap, mem::Discriminant, ops::Add, pin::Pin, sync::Arc, time::Duration,
+    collections::BTreeMap, fmt, mem::Discriminant, ops::Add, pin::Pin, sync::Arc, time::Duration,
 };
 use tokio::{
     sync::oneshot as TokioOneshot,
@@ -289,6 +289,85 @@ impl UnverifiedEvent {
             UnverifiedEvent::BatchMsgV2(b) => b.epoch(),
             UnverifiedEvent::SignedBatchInfoMsgV2(sd) => sd.epoch(),
             UnverifiedEvent::ProofOfStoreMsgV2(p) => p.epoch(),
+        }
+    }
+}
+
+impl fmt::Display for UnverifiedEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            UnverifiedEvent::ProposalMsg(m) => write!(
+                f,
+                "ProposalMsg(epoch={}, round={}, id={}, author={})",
+                m.proposal().epoch(),
+                m.proposal().round(),
+                m.proposal().id(),
+                m.proposal()
+                    .author()
+                    .map_or_else(|| "NIL".to_string(), |a| a.short_str().to_string()),
+            ),
+            UnverifiedEvent::OptProposalMsg(m) => write!(
+                f,
+                "OptProposalMsg(epoch={}, round={}, author={})",
+                m.epoch(),
+                m.round(),
+                m.proposer().short_str(),
+            ),
+            UnverifiedEvent::VoteMsg(m) => write!(
+                f,
+                "VoteMsg(epoch={}, round={}, block_id={}, author={})",
+                m.epoch(),
+                m.vote().vote_data().proposed().round(),
+                m.proposed_block_id(),
+                m.vote().author().short_str(),
+            ),
+            UnverifiedEvent::OrderVoteMsg(m) => write!(
+                f,
+                "OrderVoteMsg(epoch={}, round={}, author={})",
+                m.epoch(),
+                m.order_vote().ledger_info().commit_info().round(),
+                m.order_vote().author().short_str(),
+            ),
+            UnverifiedEvent::SyncInfo(m) => write!(
+                f,
+                "SyncInfo(epoch={}, certified_round={}, ordered_round={}, commit_round={}, timeout_round={})",
+                m.epoch(),
+                m.highest_certified_round(),
+                m.highest_ordered_round(),
+                m.highest_commit_round(),
+                m.highest_timeout_round(),
+            ),
+            UnverifiedEvent::RoundTimeoutMsg(m) => write!(
+                f,
+                "RoundTimeoutMsg(epoch={}, round={}, author={})",
+                m.epoch(),
+                m.round(),
+                m.author().short_str(),
+            ),
+            UnverifiedEvent::BatchMsg(m) => match m.epoch() {
+                Ok(epoch) => write!(f, "BatchMsg(epoch={}, author={:?})", epoch, m.author()),
+                Err(e) => write!(f, "BatchMsg(epoch_error={})", e),
+            },
+            UnverifiedEvent::BatchMsgV2(m) => match m.epoch() {
+                Ok(epoch) => write!(f, "BatchMsgV2(epoch={}, author={:?})", epoch, m.author()),
+                Err(e) => write!(f, "BatchMsgV2(epoch_error={})", e),
+            },
+            UnverifiedEvent::SignedBatchInfo(m) => match m.epoch() {
+                Ok(epoch) => write!(f, "SignedBatchInfo(epoch={})", epoch),
+                Err(e) => write!(f, "SignedBatchInfo(epoch_error={})", e),
+            },
+            UnverifiedEvent::SignedBatchInfoMsgV2(m) => match m.epoch() {
+                Ok(epoch) => write!(f, "SignedBatchInfoMsgV2(epoch={})", epoch),
+                Err(e) => write!(f, "SignedBatchInfoMsgV2(epoch_error={})", e),
+            },
+            UnverifiedEvent::ProofOfStoreMsg(m) => match m.epoch() {
+                Ok(epoch) => write!(f, "ProofOfStoreMsg(epoch={})", epoch),
+                Err(e) => write!(f, "ProofOfStoreMsg(epoch_error={})", e),
+            },
+            UnverifiedEvent::ProofOfStoreMsgV2(m) => match m.epoch() {
+                Ok(epoch) => write!(f, "ProofOfStoreMsgV2(epoch={})", epoch),
+                Err(e) => write!(f, "ProofOfStoreMsgV2(epoch_error={})", e),
+            },
         }
     }
 }
@@ -932,7 +1011,7 @@ impl RoundManager {
             sync_info.verify(&self.epoch_state.verifier).map_err(|e| {
                 error!(
                     SecurityEvent::InvalidSyncInfoMsg,
-                    sync_info = sync_info,
+                    sync_info = %sync_info,
                     remote_peer = author,
                     error = ?e,
                 );

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -546,14 +546,21 @@ fn sum_voting_power(address_to_validator_info: &[ValidatorConsensusInfo]) -> u12
 
 impl fmt::Display for ValidatorVerifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        // Bound the number of validators to avoid excessive output
+        const MAX_VALIDATORS_TO_DISPLAY: usize = 300;
+
+        // Display the validator set
         write!(f, "ValidatorSet: [")?;
-        for info in &self.validator_infos {
+        for info in self.validator_infos.iter().take(MAX_VALIDATORS_TO_DISPLAY) {
             write!(
                 f,
                 "{}: {}, ",
                 info.address.short_str_lossless(),
                 info.voting_power
             )?;
+        }
+        if self.validator_infos.len() > MAX_VALIDATORS_TO_DISPLAY {
+            write!(f, "... ({} total validators)", self.validator_infos.len())?;
         }
         write!(f, "]")
     }


### PR DESCRIPTION
## Description
This PR makes several small logging tweaks to various log lines in the consensus crate.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and formatting only; no changes to message handling, verification, or consensus state transitions.
> 
> **Overview**
> Improves **consensus logging** so security and error lines are shorter and easier to scan, without changing consensus behavior.
> 
> Several `error!` / `warn!` fields switch from `Debug` (`?`) to **`Display` (`%`)** for types like `UnverifiedEvent`, votes, `SyncInfo`, and block retrieval responses. **`UnverifiedEvent`** gets a new `Display` implementation that prints a one-line summary per variant (epoch, round, block id, author, etc.) instead of dumping full structs.
> 
> In **`ValidatorVerifier`**, `Display` now prints at most **300** validators and appends a total count when the set is larger. Unexpected RPC messages in the network task are logged with **`msg.name()`** instead of the full `Debug` representation of the enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148498dfe655a8db76d2187ebe24a97bb3b07283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->