### PR TITLE
[mono-move] Seed features resource in unit test harness

### DIFF
--- a/third_party/move/mono-move/replay-benchmark/src/lib.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/lib.rs
@@ -9,7 +9,6 @@ pub mod capture;
 pub mod compare;
 pub mod data;
 pub mod report;
-pub mod resource;
 pub mod timing;
 pub mod v1;
 pub mod v2;

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -6,14 +6,15 @@
 
 use crate::{
     compare::{ExecOutcome, FailureKind},
-    data::BenchmarkInput,
-    resource::ReadSetResourceProvider,
+    data::{BenchmarkInput, ReadSet},
     timing::{collect_samples, TimingConfig},
     BenchmarkRun,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use aptos_types::{
-    state_store::TStateView, transaction::user_transaction_context::TransactionIndexKind,
+    access_path::Path,
+    state_store::{state_key::inner::StateKeyInner, TStateView},
+    transaction::user_transaction_context::TransactionIndexKind,
 };
 use bytes::Bytes;
 use mono_move_core::{
@@ -33,13 +34,15 @@ use mono_move_natives::{
 use mono_move_runtime::{
     ExecutionContext, InterpreterContext, RuntimeError, RuntimeStatus, TransactionContext,
 };
-use mono_move_testsuite::{build_natives, finalize_events_v2, InMemoryModuleProvider};
+use mono_move_testsuite::{
+    build_natives, finalize_events_v2, InMemoryModuleProvider, InMemoryResourceProvider,
+};
 use move_binary_format::{access::ModuleAccess, file_format::SignatureToken, CompiledModule};
 use move_core_types::{
     identifier::IdentStr,
     language_storage::{StructTag, TypeTag},
 };
-use std::time::Instant;
+use std::{collections::BTreeMap, time::Instant};
 
 /// Effectively unbounded gas budget.
 const GAS_BUDGET: u64 = u64::MAX;
@@ -87,7 +90,7 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
     let arena_size = total_bytes
         .saturating_mul(ARENA_BYTES_PER_RESOURCE_BYTE)
         .max(MIN_ARENA_BYTES);
-    let resource_provider = ReadSetResourceProvider::new(&guard, &input.read_set, arena_size)?;
+    let resource_provider = read_set_resource_provider(&guard, &input.read_set, arena_size)?;
 
     let (transaction_index, reserved_byte) = match input.user_context.transaction_index_kind() {
         TransactionIndexKind::BlockExecution { transaction_index } => (transaction_index, 0),
@@ -381,4 +384,39 @@ pub(crate) fn intern_struct_tag(
         .collect::<Result<Vec<_>>>()?;
     let ty_args = guard.type_list_of(&args);
     Ok(guard.nominal_of(module_id, name, ty_args))
+}
+
+/// Builds an [`InMemoryResourceProvider`] backed by the captured read-set.
+fn read_set_resource_provider<'guard, 'ctx>(
+    guard: &'guard ExecutionGuard<'ctx>,
+    read_set: &ReadSet,
+    heap_size: usize,
+) -> Result<InMemoryResourceProvider<'guard, 'ctx>> {
+    let mut provider = InMemoryResourceProvider::new(guard, heap_size);
+    for (state_key, value) in &read_set.data {
+        match state_key.inner() {
+            StateKeyInner::AccessPath(ap) => match ap.get_path() {
+                // Modules are ignored.
+                Path::Code(_) => {},
+                Path::Resource(struct_tag) => {
+                    let ty = intern_struct_tag(guard, &struct_tag)?;
+                    provider.add_resource(ap.address, ty, value.bytes().to_vec());
+                },
+                // A resource group: add each resource in the group individually.
+                Path::ResourceGroup(_) => {
+                    let members: BTreeMap<StructTag, Vec<u8>> = bcs::from_bytes(value.bytes())?;
+                    for (struct_tag, blob) in members {
+                        let ty = intern_struct_tag(guard, &struct_tag)?;
+                        provider.add_resource(ap.address, ty, blob);
+                    }
+                },
+            },
+            StateKeyInner::TableItem { handle, key } => {
+                provider.add_table_item(handle.0, key.clone(), value.bytes().to_vec());
+            },
+            // Neither resources nor table items.
+            StateKeyInner::Raw(_) | StateKeyInner::TradingNative(_) => {},
+        }
+    }
+    Ok(provider)
 }

--- a/third_party/move/mono-move/testsuite/src/lib.rs
+++ b/third_party/move/mono-move/testsuite/src/lib.rs
@@ -11,6 +11,7 @@ pub mod module_provider;
 pub mod parser;
 pub mod print_sections;
 pub mod programs;
+pub mod resource_provider;
 pub mod runner;
 pub mod unit_test;
 pub mod v1_test_natives;
@@ -22,4 +23,5 @@ pub use engine::{
     build_natives, with_loaded_mono_function, with_mono_function, MonoRunner, RunResult,
 };
 pub use module_provider::InMemoryModuleProvider;
+pub use resource_provider::InMemoryResourceProvider;
 pub use runner::{finalize_events_v1, finalize_events_v2};

--- a/third_party/move/mono-move/testsuite/src/resource_provider.rs
+++ b/third_party/move/mono-move/testsuite/src/resource_provider.rs
@@ -1,14 +1,13 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! A [`ResourceProvider`] backed by the captured read-set. Each resource is materialized
-//! (BCS → flat) into a long-lived heap arena on first access and served as a pointer thereafter.
-//! Materialization is lazy because a resource type's layout is only published once the function
-//! that accesses it has been lowered.
+//! An in-memory [`ResourceProvider`] shared by the MonoMove test harnesses.
+//!
+//! Resources and table items are held as BCS bytes and materialized (BCS ->
+//! flat) into a long-lived heap on first access, then served as a pointer.
+//! Materialization is lazy because a type's layout is only published once the
+//! function that accesses it has been lowered.
 
-use crate::{data::ReadSet, v2::intern_struct_tag};
-use anyhow::Result;
-use aptos_types::{access_path::Path, state_store::state_key::inner::StateKeyInner};
 use mono_move_core::{
     storage::resource_provider::{
         InMemoryStorageKey, ResourceProvider, ResourceProviderError, StorageRead,
@@ -18,15 +17,11 @@ use mono_move_core::{
 };
 use mono_move_global_context::ExecutionGuard;
 use mono_move_runtime::{deserialize_into, Heap};
-use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
-use std::{
-    cell::RefCell,
-    collections::{BTreeMap, HashMap},
-    ptr::NonNull,
-};
+use move_core_types::account_address::AccountAddress;
+use std::{cell::RefCell, collections::HashMap, ptr::NonNull};
 
-/// Serves the read-set's resources and table items to MonoMove, materializing each on first access.
-pub struct ReadSetResourceProvider<'guard, 'ctx> {
+/// Serves resources and table items to MonoMove, materializing each on first access.
+pub struct InMemoryResourceProvider<'guard, 'ctx> {
     guard: &'guard ExecutionGuard<'ctx>,
     /// BCS bytes of each resource, keyed by address and interned type.
     resources: HashMap<(AccountAddress, InternedType), Vec<u8>>,
@@ -42,48 +37,28 @@ struct Materialized {
     cache: HashMap<InMemoryStorageKey, NonNull<u8>>,
 }
 
-impl<'guard, 'ctx> ReadSetResourceProvider<'guard, 'ctx> {
-    pub fn new(
-        guard: &'guard ExecutionGuard<'ctx>,
-        read_set: &ReadSet,
-        heap_size: usize,
-    ) -> Result<Self> {
-        let mut resources = HashMap::new();
-        let mut table_items = HashMap::new();
-        for (state_key, value) in &read_set.data {
-            match state_key.inner() {
-                StateKeyInner::AccessPath(ap) => match ap.get_path() {
-                    // Modules are ignored.
-                    Path::Code(_) => {},
-                    Path::Resource(struct_tag) => {
-                        let ty = intern_struct_tag(guard, &struct_tag)?;
-                        resources.insert((ap.address, ty), value.bytes().to_vec());
-                    },
-                    // A resource group: add each resource in the group individually.
-                    Path::ResourceGroup(_) => {
-                        let members: BTreeMap<StructTag, Vec<u8>> = bcs::from_bytes(value.bytes())?;
-                        for (struct_tag, blob) in members {
-                            let ty = intern_struct_tag(guard, &struct_tag)?;
-                            resources.insert((ap.address, ty), blob);
-                        }
-                    },
-                },
-                StateKeyInner::TableItem { handle, key } => {
-                    table_items.insert((handle.0, key.clone()), value.bytes().to_vec());
-                },
-                // Neither resources nor table items.
-                StateKeyInner::Raw(_) | StateKeyInner::TradingNative(_) => {},
-            }
-        }
-        Ok(Self {
+impl<'guard, 'ctx> InMemoryResourceProvider<'guard, 'ctx> {
+    /// Creates an empty provider whose materialization arena is `heap_size` bytes.
+    pub fn new(guard: &'guard ExecutionGuard<'ctx>, heap_size: usize) -> Self {
+        Self {
             guard,
-            resources,
-            table_items,
+            resources: HashMap::new(),
+            table_items: HashMap::new(),
             materialized: RefCell::new(Materialized {
                 heap: Heap::new(heap_size),
                 cache: HashMap::new(),
             }),
-        })
+        }
+    }
+
+    /// Adds a resource of interned type `ty` published at `address`, given its BCS bytes.
+    pub fn add_resource(&mut self, address: AccountAddress, ty: InternedType, bytes: Vec<u8>) {
+        self.resources.insert((address, ty), bytes);
+    }
+
+    /// Adds a table item at `handle_address` keyed by serialized `key`, given its BCS bytes.
+    pub fn add_table_item(&mut self, handle_address: AccountAddress, key: Vec<u8>, bytes: Vec<u8>) {
+        self.table_items.insert((handle_address, key), bytes);
     }
 
     /// Returns the raw blob and the type to materialize it as, or `None` if the key isn't present.
@@ -104,7 +79,7 @@ impl<'guard, 'ctx> ReadSetResourceProvider<'guard, 'ctx> {
     }
 }
 
-impl ResourceProvider for ReadSetResourceProvider<'_, '_> {
+impl ResourceProvider for InMemoryResourceProvider<'_, '_> {
     fn get_resource(&self, key: &InMemoryStorageKey) -> Result<StorageRead, ResourceProviderError> {
         // Cache hit?
         {

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -7,13 +7,14 @@
 
 use crate::{
     engine::build_natives, extensions::seed_extensions, module_provider::InMemoryModuleProvider,
+    resource_provider::InMemoryResourceProvider,
 };
+use aptos_types::on_chain_config::{Features, OnChainConfig};
 use legacy_move_compiler::unit_test::{
     ExpectedFailure, ExpectedMoveError, NamedOrBytecodeModule, TestCase,
 };
 use mono_move_core::{
-    types::EMPTY_TYPE_LIST, DescriptorProvider, Function, GasMeter, LayoutProvider,
-    NO_RESOURCE_PROVIDER,
+    types::EMPTY_TYPE_LIST, DescriptorProvider, Function, GasMeter, Interner, LayoutProvider,
 };
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoaderError, LoadingPolicy, LoweringPolicy};
@@ -66,10 +67,19 @@ pub fn run_package_unit_tests(
         module_provider.add_module(module_of(info));
     }
 
+    let resource_provider = seed_features(&guard);
+
     let mut summary = RunSummary::default();
     for (module_id, module_plan) in &test_plan.module_tests {
         for (test_name, test) in &module_plan.tests {
-            let outcome = run_test(&guard, &module_provider, &natives, module_id, test);
+            let outcome = run_test(
+                &guard,
+                &module_provider,
+                &resource_provider,
+                &natives,
+                module_id,
+                test,
+            );
             summary.record(module_id, test_name, outcome);
         }
     }
@@ -83,18 +93,46 @@ fn module_of(info: &NamedOrBytecodeModule) -> &CompiledModule {
     }
 }
 
+/// Heap for the seeded `Features` resource. Only that one small resource lives
+/// here, so a modest fixed size is plenty.
+const RESOURCE_HEAP_SIZE: usize = 1 << 20;
+
+/// Builds a resource provider publishing the framework `Features` resource at
+/// `0x1`, initialized to [`Features::default_for_tests`].
+fn seed_features<'guard, 'ctx>(
+    guard: &'guard ExecutionGuard<'ctx>,
+) -> InMemoryResourceProvider<'guard, 'ctx> {
+    let struct_tag = Features::struct_tag();
+    let module_id = guard.module_id_of(&struct_tag.address, struct_tag.module.as_ident_str());
+    let name = guard.identifier_of(struct_tag.name.as_ident_str());
+    let ty = guard.nominal_of(module_id, name, guard.type_list_of(&[]));
+    let bytes = bcs::to_bytes(&Features::default_for_tests()).expect("Features serializes");
+
+    let mut provider = InMemoryResourceProvider::new(guard, RESOURCE_HEAP_SIZE);
+    provider.add_resource(struct_tag.address, ty, bytes);
+    provider
+}
+
 /// Execute one test function on mono-move and adjudicate it against its
 /// `#[expected_failure]` annotation. A panic on an unimplemented construct is
 /// caught and recorded as unsupported.
 fn run_test(
     guard: &ExecutionGuard<'_>,
     module_provider: &InMemoryModuleProvider,
+    resource_provider: &InMemoryResourceProvider<'_, '_>,
     natives: &ProductionNativeRegistry,
     module_id: &ModuleId,
     test: &TestCase,
 ) -> TestOutcome {
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        execute(guard, natives, module_provider, module_id, test)
+        execute(
+            guard,
+            natives,
+            module_provider,
+            resource_provider,
+            module_id,
+            test,
+        )
     }));
     match result {
         Ok(result) => adjudicate(result, &test.expected_failure),
@@ -106,6 +144,7 @@ fn execute(
     guard: &ExecutionGuard<'_>,
     natives: &ProductionNativeRegistry,
     module_provider: &InMemoryModuleProvider,
+    resource_provider: &InMemoryResourceProvider<'_, '_>,
     module_id: &ModuleId,
     test: &TestCase,
 ) -> TestResult {
@@ -118,7 +157,7 @@ fn execute(
     let mut txn_ctx = TransactionContext::new(
         loader,
         GasMeter::new(GAS_BUDGET),
-        &NO_RESOURCE_PROVIDER,
+        resource_provider,
         natives,
     )
     .with_extensions(seed_extensions());


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Framework unit tests were running with no `Features` resource in storage. That makes `features::is_enabled` return false for everything, so any code behind a feature gate silently took the wrong path and hit abort codes that didn't match what the tests expect — showing up as failures that had nothing to do with real bugs. Publishing `Features` (set to `Features::default_for_tests`) makes the gated code run as intended and clears most of those failures. Along the way, `replay-benchmark`'s `ReadSetResourceProvider` moved into the `testsuite` crate and was generalized into a shared `InMemoryResourceProvider`, so both harnesses build on one implementation instead of two.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and benchmark harness changes only; no validator or production VM execution path.
> 
> **Overview**
> The MonoMove unit-test harness now publishes the framework **`Features`** resource at `0x1` via `Features::default_for_tests`, and wires **`TransactionContext`** to that provider instead of **`NO_RESOURCE_PROVIDER`**, so feature-gated framework code sees the same flags as intended in tests.
> 
> **`ReadSetResourceProvider`** is removed from **`replay-benchmark`**. The testsuite gains a reusable **`InMemoryResourceProvider`** (empty constructor plus **`add_resource`** / **`add_table_item`**); replay V2 fills it from the captured read-set in a local **`read_set_resource_provider`** helper, preserving prior read-set behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc35ff66b147c9d03e16c2402e75f725cc26d26d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->