### PR TITLE
[move-flow] Bump version to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-move-flow"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "aptos-cli-common",

--- a/aptos-move/flow/CHANGELOG.md
+++ b/aptos-move/flow/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-11
+
+### Changed
+- **Breaking:** `facts` queries report function returns as `returnTypes`, an
+  array with one entry per tuple element, instead of the optional
+  `returnType` display string.
+- **Breaking:** struct types in function signatures, struct fields,
+  `resourceAccess`, and cross-module references are fully qualified
+  (`address::module::Name`) in `facts` output.
+- Package build failures in `move_package_query` return `invalid_params`
+  instead of internal errors.
+
+### Added
+- Attribute arguments and assignment values are preserved in `facts` output
+  (previously only attribute names were serialized).
+- Compiler-synthesized lambda-lifted functions are tagged with
+  `isLambdaLifted` and linked to their defining function via `definedIn`;
+  `module_summary` carries the same flag.
+- `move_package_query` is annotated read-only in its MCP tool annotations.
+
+### Fixed
+- The `facts` path is guarded against panics, matching `function_usage`.
+
 ## [1.1.0] - 2026-06-30
 
 ### Added
@@ -22,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `x86_64-apple-darwin`, `aarch64-apple-darwin`, and
   `x86_64-pc-windows-msvc`.
 
-[Unreleased]: https://github.com/aptos-labs/aptos-core/compare/move-flow-v1.1.0...HEAD
+[Unreleased]: https://github.com/aptos-labs/aptos-core/compare/move-flow-v2.0.0...HEAD
+[2.0.0]: https://github.com/aptos-labs/aptos-core/compare/move-flow-v1.1.0...move-flow-v2.0.0
 [1.1.0]: https://github.com/aptos-labs/aptos-core/compare/move-flow-v1.0.4...move-flow-v1.1.0
 [1.0.4]: https://github.com/aptos-labs/aptos-core/releases/tag/move-flow-v1.0.4

--- a/aptos-move/flow/Cargo.toml
+++ b/aptos-move/flow/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-move-flow"
 description = "MoveFlow: agent support for Move"
-version = "1.1.0"
+version = "2.0.0"
 
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Description

Bump `aptos-move-flow` to 2.0.0 and add the matching changelog entry, ahead of cutting the `move-flow-v2.0.0` release tag.

Covers the changes from #20174: attribute args/values in facts, fully qualified struct types, `returnTypes` array, lambda-lift tagging, panic guard on the facts path, and the read-only annotation on `move_package_query`. Major bump because the facts JSON output shape changed.

## How Has This Been Tested?

Version/changelog-only change; no code changes.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): move-flow release version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog update with no behavioral changes in the diff.
> 
> **Overview**
> Bumps **`aptos-move-flow`** from **1.1.0** to **2.0.0** in `Cargo.toml` and `Cargo.lock`, and documents the release in **`CHANGELOG.md`** ahead of the `move-flow-v2.0.0` tag.
> 
> The new changelog entry records the **breaking** `facts` JSON changes already landed elsewhere (`returnTypes` vs `returnType`, fully qualified struct types) plus non-breaking additions (attribute args/values, lambda-lift metadata, read-only MCP annotation) and fixes (facts panic guard, `invalid_params` on package build failures). **No runtime or library code is modified in this PR**—only version metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93f002c3ac9b60be42a9264f51ca333d7a40555b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->