### PR TITLE
cap gzip decompression in prometheus remote write client

### DIFF
--- a/crates/aptos-telemetry-service/src/clients/prometheus_remote_write.rs
+++ b/crates/aptos-telemetry-service/src/clients/prometheus_remote_write.rs
@@ -28,6 +28,7 @@
 //! ```
 
 pub use super::victoria_metrics::AuthToken;
+use crate::constants::MAX_DECOMPRESSED_LENGTH;
 use anyhow::{anyhow, Result};
 use debug_ignore::DebugIgnore;
 use flate2::read::GzDecoder;
@@ -159,9 +160,11 @@ impl PrometheusRemoteWriteClient {
     ) -> Result<reqwest::Response, anyhow::Error> {
         // Decompress if gzip encoded
         let decompressed = if encoding == "gzip" {
-            let mut decoder = GzDecoder::new(&raw_metrics_body[..]);
+            let decoder = GzDecoder::new(&raw_metrics_body[..]);
+            // Limit decompressed size to prevent decompression bomb attacks
+            let mut limited_decoder = decoder.take(MAX_DECOMPRESSED_LENGTH as u64);
             let mut decompressed = Vec::new();
-            decoder
+            limited_decoder
                 .read_to_end(&mut decompressed)
                 .map_err(|e| anyhow!("gzip decompression failed: {}", e))?;
             decompressed


### PR DESCRIPTION
## Description
`PrometheusRemoteWriteClient::post_prometheus_metrics` decompresses the node-supplied gzip metrics body with `GzDecoder::read_to_end` and no size limit, so a small gzip body from any authenticated node posting to `/ingest/metrics` (including the untrusted `UnknownValidator`/`UnknownFullNode` tiers) expands to unbounded memory when a Remote Write backend is configured. The two sibling ingest paths (`log_ingest` and `custom_contract_ingest`) already cap decompression at `MAX_DECOMPRESSED_LENGTH`; this client was the one path that missed it. Wrapping the decoder in `take(MAX_DECOMPRESSED_LENGTH)` brings it in line with them.

## How Has This Been Tested?
Reproduced the gap outside the tree: a 65 KiB gzip of zeros decompresses to 64 MiB via `read_to_end`, and to exactly `MAX_DECOMPRESSED_LENGTH` (10 MiB) once wrapped in `take(...)`. With the 1 MiB `MAX_CONTENT_LENGTH` cap on the request body, an unbounded expansion is far larger. Existing `parse_prometheus_text` unit tests still pass, and valid bodies under the cap decompress unchanged.

## Key Areas to Review
The `take(...)` truncates at the cap instead of erroring, matching `custom_contract_ingest`; a legitimate metrics payload is well under 10 MiB decompressed, so valid-input behavior is unchanged.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized defensive change to metrics ingest decompression with no auth or data-model changes; truncation-at-cap behavior matches an existing sibling ingest path.
> 
> **Overview**
> **Caps gzip decompression** in `PrometheusRemoteWriteClient::post_prometheus_metrics` by wrapping `GzDecoder` with `take(MAX_DECOMPRESSED_LENGTH)` (10 MiB), matching `log_ingest` and `custom_contract_ingest`.
> 
> This closes a **decompression-bomb** gap on the `/ingest/metrics` path where authenticated nodes could supply a small gzip body that expanded to unbounded memory before parsing. Legitimate metrics payloads stay under the cap, so normal behavior is unchanged; oversized expansion is truncated at the limit rather than rejected explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9812c2fae7430a7d2850c915d803a563810c9d06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->