### PR TITLE
[block-stm] Move value with layout out of executor/mvhashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,6 @@ dependencies = [
  "rayon",
  "serde",
  "test-case",
- "triomphe",
 ]
 
 [[package]]
@@ -5005,6 +5004,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap 7.0.0-rc2",
  "derivative",
+ "fail",
  "fixed",
  "fxhash",
  "hashbrown 0.14.3",
@@ -5048,6 +5048,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "triomphe",
  "url",
 ]
 

--- a/aptos-move/aptos-aggregator/src/delayed_change.rs
+++ b/aptos-move/aptos-aggregator/src/delayed_change.rs
@@ -189,7 +189,7 @@ impl<I: Copy + Clone> DelayedChange<I> {
 // TODO[agg_v2](cleanup): See if we need these separate/duplicate classes or not
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum DelayedApplyEntry<I: Clone> {
+pub enum DelayedApplyEntry<I> {
     AggregatorDelta {
         delta: DeltaOp,
     },

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -12,7 +12,6 @@ use aptos_types::{
         state_value::{StateValue, StateValueMetadata},
         StateView, StateViewId,
     },
-    write_set::WriteOp,
 };
 use bytes::Bytes;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
@@ -170,7 +169,7 @@ pub trait StateStorageView {
 /// TODO: audit and reconsider the default implementation (e.g. should not
 /// resolve AggregatorV2 via the state-view based default implementation, as it
 /// doesn't provide a value exchange functionality).
-pub trait TExecutorView<K, T, L, V>:
+pub trait TExecutorView<K, T, L>:
     TResourceView<Key = K, Layout = L>
     + TAggregatorV1View<Identifier = K>
     + TDelayedFieldView<Identifier = DelayedFieldID, ResourceKey = K, ResourceGroupTag = T>
@@ -178,7 +177,7 @@ pub trait TExecutorView<K, T, L, V>:
 {
 }
 
-impl<A, K, T, L, V> TExecutorView<K, T, L, V> for A where
+impl<A, K, T, L> TExecutorView<K, T, L> for A where
     A: TResourceView<Key = K, Layout = L>
         + TAggregatorV1View<Identifier = K>
         + TDelayedFieldView<Identifier = DelayedFieldID, ResourceKey = K, ResourceGroupTag = T>
@@ -186,9 +185,9 @@ impl<A, K, T, L, V> TExecutorView<K, T, L, V> for A where
 {
 }
 
-pub trait ExecutorView: TExecutorView<StateKey, StructTag, MoveTypeLayout, WriteOp> {}
+pub trait ExecutorView: TExecutorView<StateKey, StructTag, MoveTypeLayout> {}
 
-impl<T> ExecutorView for T where T: TExecutorView<StateKey, StructTag, MoveTypeLayout, WriteOp> {}
+impl<T> ExecutorView for T where T: TExecutorView<StateKey, StructTag, MoveTypeLayout> {}
 
 pub trait ResourceGroupView:
     TResourceGroupView<GroupKey = StateKey, ResourceTag = StructTag, Layout = MoveTypeLayout>

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -10,7 +10,7 @@ use aptos_block_executor::{
     errors::BlockExecutionError,
     executor::BlockExecutor,
     task::{
-        AfterMaterializationOutput, BeforeMaterializationOutput, ExecutorTask,
+        BeforeMaterializationOutput, ExecutorTask,
         TransactionOutput as BlockExecutorTransactionOutput,
     },
     txn_commit_hook::TransactionCommitHook,
@@ -20,6 +20,7 @@ use aptos_block_executor::{
 use aptos_types::{
     block_executor::{
         config::BlockExecutorConfig, transaction_slice_metadata::TransactionSliceMetadata,
+        value::ValueWithLayout,
     },
     contract_event::ContractEvent,
     error::{code_invariant_error, PanicError},
@@ -45,7 +46,6 @@ use move_core_types::{
 };
 use move_vm_runtime::execution_tracing::Trace;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
-use once_cell::sync::OnceCell;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
@@ -53,12 +53,11 @@ use std::{
 use triomphe::Arc as TriompheArc;
 use vm_wrapper::AptosExecutorTask;
 
-/// Output type wrapper used by block executor. VM output is stored first, then
-/// transformed into TransactionOutput type that is returned.
+/// Output type wrapper used by block executor. VM output is stored, and
+/// transformed into TransactionOutput type on materialization.
 #[derive(Debug)]
 pub struct AptosTransactionOutput {
     vm_output: Option<VMOutput>,
-    committed_output: OnceCell<TransactionOutput>,
     /// State keys read by the VM during the execution (incarnation) that produced this output.
     ///
     /// TODO(HotState): also consider recording the read kind (exists/metadata/value) and the
@@ -74,43 +73,8 @@ impl AptosTransactionOutput {
     pub fn new_with_read_set(output: VMOutput, read_set: UnorderedReadSet) -> Self {
         Self {
             vm_output: Some(output),
-            committed_output: OnceCell::new(),
             read_set,
         }
-    }
-
-    fn take_output(mut self) -> TransactionOutput {
-        match self.committed_output.take() {
-            Some(output) => output,
-            // TODO: revisit whether we should always get it via committed, or o.w. create a
-            // dedicated API without creating empty data structures.
-            // This is currently used because we do not commit skip_output() transactions.
-            None => self
-                .vm_output
-                .take()
-                .expect("Output must be set")
-                .into_transaction_output()
-                .expect("Transaction output is not already materialized"),
-        }
-    }
-}
-
-pub struct AfterMaterializationGuard<'a> {
-    output: &'a TransactionOutput,
-}
-
-impl<'a> AfterMaterializationOutput<SignatureVerifiedTransaction>
-    for AfterMaterializationGuard<'a>
-{
-    fn fee_statement(&self) -> FeeStatement {
-        if let Ok(Some(fee_statement)) = self.output.try_extract_fee_statement() {
-            return fee_statement;
-        }
-        FeeStatement::zero()
-    }
-
-    fn has_new_epoch_event(&self) -> bool {
-        self.output.has_new_epoch_event()
     }
 }
 
@@ -189,9 +153,9 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
     ) -> HashMap<
         StateKey,
         (
-            WriteOp,
+            ValueWithLayout<WriteOp>,
             ResourceGroupSize,
-            BTreeMap<StructTag, (WriteOp, Option<TriompheArc<MoveTypeLayout>>)>,
+            BTreeMap<StructTag, ValueWithLayout<WriteOp>>,
         ),
     > {
         self.guard
@@ -202,7 +166,10 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
                     Some((
                         key.clone(),
                         (
-                            group_write.metadata_op().clone(),
+                            ValueWithLayout::Exchanged(
+                                TriompheArc::new(group_write.metadata_op().clone()),
+                                None,
+                            ),
                             group_write
                                 .maybe_group_op_size()
                                 .unwrap_or(ResourceGroupSize::zero_combined()),
@@ -210,7 +177,13 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
                                 .inner_ops()
                                 .iter()
                                 .map(|(tag, (op, maybe_layout))| {
-                                    (tag.clone(), (op.clone(), maybe_layout.clone()))
+                                    (
+                                        tag.clone(),
+                                        ValueWithLayout::Exchanged(
+                                            TriompheArc::new(op.clone()),
+                                            maybe_layout.clone(),
+                                        ),
+                                    )
                                 })
                                 .collect(),
                         ),
@@ -278,19 +251,18 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
             .collect()
     }
 
-    fn resource_write_set(
-        &self,
-    ) -> HashMap<StateKey, (TriompheArc<WriteOp>, Option<TriompheArc<MoveTypeLayout>>)> {
+    fn resource_write_set(&self) -> HashMap<StateKey, ValueWithLayout<WriteOp>> {
         self.guard
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| match write {
-                AbstractResourceWriteOp::Write(write_op, _) => {
-                    Some((key.clone(), (TriompheArc::new(write_op.clone()), None)))
-                },
+                AbstractResourceWriteOp::Write(write_op, _) => Some((
+                    key.clone(),
+                    ValueWithLayout::Exchanged(TriompheArc::new(write_op.clone()), None),
+                )),
                 AbstractResourceWriteOp::WriteWithDelayedFields(write) => Some((
                     key.clone(),
-                    (
+                    ValueWithLayout::Exchanged(
                         TriompheArc::new(write.write_op.clone()),
                         Some(write.layout.clone()),
                     ),
@@ -372,24 +344,14 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
 }
 
 impl BlockExecutorTransactionOutput for AptosTransactionOutput {
-    type AfterMaterializationGuard<'a> = AfterMaterializationGuard<'a>;
     type BeforeMaterializationGuard<'a> = BeforeMaterializationGuard<'a>;
+    type CommittedOutput = TransactionOutput;
     type Txn = SignatureVerifiedTransaction;
-
-    fn committed_output(&self) -> &OnceCell<TransactionOutput> {
-        &self.committed_output
-    }
 
     /// Execution output for transactions that comes after SkipRest signal or when there was a
     /// problem creating the output (e.g. group serialization issue).
     fn skip_output() -> Self {
         Self::new(VMOutput::empty_with_status(TransactionStatus::Retry))
-    }
-
-    fn discard_output(discard_code: StatusCode) -> Self {
-        Self::new(VMOutput::empty_with_status(TransactionStatus::Discard(
-            discard_code,
-        )))
     }
 
     fn before_materialization<'a>(&'a self) -> Result<BeforeMaterializationGuard<'a>, PanicError> {
@@ -402,52 +364,11 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         })
     }
 
-    fn after_materialization<'a>(&'a self) -> Result<AfterMaterializationGuard<'a>, PanicError> {
-        Ok(AfterMaterializationGuard {
-            output: self
-                .committed_output
-                .get()
-                .ok_or_else(|| code_invariant_error("Output must be materialized"))?,
-        })
-    }
-
-    fn is_materialized_and_success(&self) -> bool {
-        if let Some(output) = self.committed_output.get() {
-            return output
-                .status()
-                .as_kept_status()
-                .is_ok_and(|status| status.is_success());
-        }
-        false
-    }
-
-    fn check_materialization(&self) -> Result<bool, PanicError> {
-        if let Some(output) = self.committed_output.get() {
-            if output.status().is_retry() {
-                return Err(code_invariant_error(
-                    "Committed output must not have is_retry set.",
-                ));
-            }
-            Ok(true)
-        } else {
-            if !self
-                .vm_output
-                .as_ref()
-                .is_some_and(|output| output.status().is_retry())
-            {
-                return Err(code_invariant_error(
-                    "Non-committed output must exist with is_retry set.",
-                ));
-            }
-            Ok(false)
-        }
-    }
-
     fn incorporate_materialized_txn_output(
         &mut self,
         materialized_resource_write_set: Vec<(StateKey, WriteOp)>,
         materialized_events: Vec<ContractEvent>,
-    ) -> Result<Trace, PanicError> {
+    ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
         // Before creating the output, extract the trace for replay.
         let mut vm_output = self
             .vm_output
@@ -455,34 +376,11 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .expect("Output must be set to incorporate materialized data");
         let trace = vm_output.take_trace();
 
-        self.committed_output
-            .set(
-                vm_output.into_transaction_output_with_materialized_write_set(
-                    materialized_resource_write_set,
-                    materialized_events,
-                )?,
-            )
-            .map_err(|_| {
-                code_invariant_error(
-                    "Could not combine VMOutput with the materialized resource and event data",
-                )
-            })?;
-        Ok(trace)
-    }
-
-    fn set_txn_output_for_non_dynamic_change_set(&mut self) {
-        assert!(
-            self.committed_output
-                .set(
-                    self.vm_output
-                        .take()
-                        .expect("Output must be set to incorporate materialized data")
-                        .into_transaction_output()
-                        .expect("We should be able to always convert to transaction output"),
-                )
-                .is_ok(),
-            "Could not combine VMOutput with the materialized resource and event data"
-        );
+        let committed_output = vm_output.into_transaction_output_with_materialized_write_set(
+            materialized_resource_write_set,
+            materialized_events,
+        )?;
+        Ok((committed_output, trace))
     }
 }
 
@@ -507,7 +405,7 @@ impl<
 {
     pub fn execute_block<
         S: StateView + Sync,
-        L: TransactionCommitHook,
+        L: TransactionCommitHook<TransactionOutput>,
         TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
     >(
         signature_verified_block: &TP,
@@ -549,13 +447,9 @@ impl<
         match ret {
             Ok(block_output) => {
                 let (transaction_outputs, block_epilogue_txn) = block_output.into_inner();
-                let output_vec: Vec<_> = transaction_outputs
-                    .into_iter()
-                    .map(|output| output.take_output())
-                    .collect();
 
                 // Flush the speculative logs of the committed transactions.
-                let pos = output_vec.partition_point(|o| !o.status().is_retry());
+                let pos = transaction_outputs.partition_point(|o| !o.status().is_retry());
 
                 if state_view.id() != StateViewId::Miscellaneous {
                     // Speculation is disabled in Miscellaneous context, which is used by testing and
@@ -563,7 +457,7 @@ impl<
                     flush_speculative_logs(pos);
                 }
 
-                Ok(BlockOutput::new(output_vec, block_epilogue_txn))
+                Ok(BlockOutput::new(transaction_outputs, block_epilogue_txn))
             },
             Err(BlockExecutionError::FatalBlockExecutorError(PanicError::CodeInvariantError(
                 err_msg,

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -6,11 +6,14 @@ use aptos_block_executor::task::{ExecutionStatus, ExecutorTask};
 use aptos_logger::{enabled, Level};
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    state_store::{StateView, StateViewId},
+    block_executor::value::ValueWithLayout,
+    state_store::{state_key::StateKey, StateView, StateViewId},
+    timestamp::TimestampResource,
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, Transaction,
         WriteSetPayload,
     },
+    write_set::WriteOp,
 };
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
@@ -22,7 +25,10 @@ use aptos_vm_types::{
     resolver::{BlockSynchronizationKillSwitch, ExecutorView, ResourceGroupView},
 };
 use fail::fail_point;
-use move_core_types::vm_status::{StatusCode, VMStatus};
+use move_core_types::{
+    account_address::AccountAddress,
+    vm_status::{StatusCode, VMStatus},
+};
 
 pub struct AptosExecutorTask {
     vm: AptosVM,
@@ -135,7 +141,43 @@ impl ExecutorTask for AptosExecutorTask {
         }
     }
 
-    fn is_transaction_dynamic_change_set_capable(txn: &Self::Txn) -> bool {
+    fn pre_write_values(txn: &Self::Txn) -> Vec<(StateKey, ValueWithLayout<WriteOp>)> {
+        let timestamp = match txn {
+            SignatureVerifiedTransaction::Valid(Transaction::BlockMetadataExt(metadata_txn)) => {
+                Some(metadata_txn.timestamp_usecs())
+            },
+            SignatureVerifiedTransaction::Valid(Transaction::BlockMetadata(metadata_txn)) => {
+                Some(metadata_txn.timestamp_usecs())
+            },
+            _ => None,
+        };
+
+        match timestamp {
+            Some(ts) => {
+                // Use typed StateKey creation to avoid string parsing.
+                // These unwraps are safe: TimestampResource is a valid MoveResource type,
+                // and u64 serialization via BCS cannot fail.
+                let state_key = StateKey::resource_typed::<TimestampResource>(&AccountAddress::ONE)
+                    .expect("TimestampResource is a valid MoveResource");
+                let value = WriteOp::legacy_modification(
+                    bcs::to_bytes(&ts)
+                        .expect("u64 BCS serialization cannot fail")
+                        .into(),
+                );
+                // The timestamp resource has no delayed fields, so the pre-written value
+                // is already in its exchanged form with no layout.
+                vec![(
+                    state_key,
+                    ValueWithLayout::Exchanged(triomphe::Arc::new(value), None),
+                )]
+            },
+            None => vec![],
+        }
+    }
+}
+
+impl AptosExecutorTask {
+    fn is_transaction_dynamic_change_set_capable(txn: &SignatureVerifiedTransaction) -> bool {
         if txn.is_valid() {
             if let Transaction::GenesisTransaction(WriteSetPayload::Direct(_)) = txn.expect_valid()
             {
@@ -145,5 +187,54 @@ impl ExecutorTask for AptosExecutorTask {
             }
         }
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_crypto::HashValue;
+    use aptos_types::block_metadata::BlockMetadata;
+
+    #[test]
+    fn test_pre_write_values_for_block_metadata() {
+        let timestamp_usecs = 1234567890u64;
+        let block_metadata = BlockMetadata::new(
+            HashValue::zero(),
+            1, // epoch
+            1, // round
+            AccountAddress::ONE,
+            vec![], // previous_block_votes_bitvec
+            vec![], // failed_proposer_indices
+            timestamp_usecs,
+        );
+
+        let txn = SignatureVerifiedTransaction::Valid(Transaction::BlockMetadata(block_metadata));
+        let pre_write_values = AptosExecutorTask::pre_write_values(&txn);
+
+        // Should return exactly one pre-write entry for the timestamp
+        assert_eq!(pre_write_values.len(), 1);
+
+        let (state_key, value) = &pre_write_values[0];
+
+        // Verify the state key is for the timestamp resource
+        let expected_state_key =
+            StateKey::resource_typed::<TimestampResource>(&AccountAddress::ONE)
+                .expect("TimestampResource is a valid MoveResource");
+        assert_eq!(state_key, &expected_state_key);
+
+        // Verify the value is the serialized timestamp, in the exchanged form
+        // with no layout.
+        let expected_value = bcs::to_bytes(&timestamp_usecs).unwrap();
+        assert!(matches!(value, ValueWithLayout::Exchanged(_, None)));
+        assert_eq!(value.extract_value().bytes(), Some(&expected_value.into()));
+    }
+
+    #[test]
+    fn test_pre_write_values_for_user_transaction_returns_empty() {
+        // For non-block-metadata transactions, pre_write_values should return empty
+        let state_checkpoint_txn =
+            SignatureVerifiedTransaction::Valid(Transaction::StateCheckpoint(HashValue::zero()));
+        assert!(AptosExecutorTask::pre_write_values(&state_checkpoint_txn).is_empty());
     }
 }

--- a/aptos-move/aptos-vm/src/sharded_block_executor/cross_shard_client.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/cross_shard_client.rs
@@ -14,7 +14,6 @@ use aptos_types::{
     transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
     write_set::TransactionWrite,
 };
-use once_cell::sync::OnceCell;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -100,18 +99,10 @@ impl CrossShardCommitSender {
         }
     }
 
-    fn send_remote_update_for_success(
-        &self,
-        txn_idx: TxnIndex,
-        txn_output: &OnceCell<TransactionOutput>,
-    ) {
+    fn send_remote_update_for_success(&self, txn_idx: TxnIndex, txn_output: &TransactionOutput) {
         let edges = self.dependent_edges.get(&txn_idx).unwrap();
-        let write_set = txn_output
-            .get()
-            .expect("Committed output must be set")
-            .write_set();
 
-        for (state_key, write_op) in write_set.expect_write_op_iter() {
+        for (state_key, write_op) in txn_output.write_set().expect_write_op_iter() {
             if let Some(dependent_shard_ids) = edges.get(state_key) {
                 for (dependent_shard_id, round_id) in dependent_shard_ids.iter() {
                     trace!("Sending remote update for success for shard id {:?} and txn_idx: {:?}, state_key: {:?}, dependent shard id: {:?}", self.shard_id, txn_idx, state_key, dependent_shard_id);
@@ -134,20 +125,12 @@ impl CrossShardCommitSender {
     }
 }
 
-impl TransactionCommitHook for CrossShardCommitSender {
-    fn on_transaction_committed(
-        &self,
-        txn_idx: TxnIndex,
-        txn_output: &OnceCell<TransactionOutput>,
-    ) {
+impl TransactionCommitHook<TransactionOutput> for CrossShardCommitSender {
+    fn on_transaction_committed(&self, txn_idx: TxnIndex, txn_output: &TransactionOutput) {
         let global_txn_idx = txn_idx + self.index_offset;
         if self.dependent_edges.contains_key(&global_txn_idx) {
             self.send_remote_update_for_success(global_txn_idx, txn_output);
         }
-    }
-
-    fn on_execution_aborted(&self, _txn_idx: TxnIndex) {
-        todo!("on_transaction_aborted not supported for sharded execution yet")
     }
 }
 

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -14,13 +14,14 @@ use aptos_aggregator::{
 use aptos_mvhashmap::{
     types::{
         Incarnation, MVDataError, MVDataOutput, MVDelayedFieldsError, MVGroupError, StorageVersion,
-        TxnIndex, ValueWithLayout, Version,
+        TxnIndex, Version,
     },
     versioned_data::VersionedData,
     versioned_delayed_fields::TVersionedDelayedFieldView,
     versioned_group_data::VersionedGroupData,
 };
 use aptos_types::{
+    block_executor::value::ValueWithLayout,
     error::{code_invariant_error, PanicError, PanicOr},
     executable::ModulePath,
     state_store::{state_value::StateValueMetadata, TStateView},
@@ -881,7 +882,7 @@ where
     fn validate_data_reads_impl<'a>(
         &'a self,
         iter: impl Iterator<Item = (&'a T::Key, &'a DataRead<T::Value>)>,
-        data_map: &VersionedData<T::Key, T::Value>,
+        data_map: &VersionedData<T::Key, ValueWithLayout<T::Value>>,
         idx_to_validate: TxnIndex,
     ) -> bool {
         use MVDataError::*;
@@ -909,7 +910,7 @@ where
 
     pub(crate) fn validate_data_reads(
         &self,
-        data_map: &VersionedData<T::Key, T::Value>,
+        data_map: &VersionedData<T::Key, ValueWithLayout<T::Value>>,
         idx_to_validate: TxnIndex,
     ) -> bool {
         if self.non_delayed_field_speculative_failure {
@@ -1003,7 +1004,7 @@ where
 
     pub(crate) fn validate_group_reads(
         &self,
-        group_map: &VersionedGroupData<T::Key, T::Tag, T::Value>,
+        group_map: &VersionedGroupData<T::Key, T::Tag, ValueWithLayout<T::Value>>,
         idx_to_validate: TxnIndex,
     ) -> bool {
         use MVGroupError::*;
@@ -2071,7 +2072,7 @@ mod test {
         assert!(captured_reads.non_delayed_field_speculative_failure);
         assert!(!captured_reads.delayed_field_speculative_failure);
 
-        let mvhashmap = MVHashMap::<KeyType<u32>, u32, ValueType, DelayedFieldID>::new();
+        let mvhashmap = MVHashMap::<KeyType<u32>, u32, _, DelayedFieldID>::new();
 
         captured_reads.incorrect_use = false;
         captured_reads.non_delayed_field_speculative_failure = false;

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -6,10 +6,7 @@ use crate::{
         DeltaTestKind, GroupSizeOrMetadata, MockIncarnation, MockTransaction, ValueType,
         RESERVED_TAG,
     },
-    task::{
-        AfterMaterializationOutput, BeforeMaterializationOutput, ExecutionStatus, ExecutorTask,
-        TransactionOutput,
-    },
+    task::{BeforeMaterializationOutput, ExecutionStatus, ExecutorTask, TransactionOutput},
     types::delayed_field_mock_serialization::{
         deserialize_to_delayed_field_id, serialize_from_delayed_field_id,
     },
@@ -21,6 +18,7 @@ use aptos_aggregator::{
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
+    block_executor::{output::CommittedTransactionOutput, value::ValueWithLayout},
     contract_event::TransactionEvent,
     error::PanicError,
     executable::ModulePath,
@@ -123,7 +121,7 @@ macro_rules! try_with_status {
     };
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct MockOutput<K, E> {
     pub(crate) writes: Vec<(K, ValueType, Option<TriompheArc<MoveTypeLayout>>)>,
     // Key, metadata_op, inner_ops
@@ -208,7 +206,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
     /// Returns self for method chaining
     pub(crate) fn add_resource_reads(
         &mut self,
-        view: &impl TExecutorView<K, u32, MoveTypeLayout, ValueType>,
+        view: &impl TExecutorView<K, u32, MoveTypeLayout>,
         key_pairs: &[(K, bool)],
         delayed_fields_enabled: bool,
     ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>> {
@@ -260,7 +258,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
     pub(crate) fn add_group_reads(
         &mut self,
         view: &(impl TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>
-              + TExecutorView<K, u32, MoveTypeLayout, ValueType>),
+              + TExecutorView<K, u32, MoveTypeLayout>),
         group_reads: &[(K, u32, bool)],
         delayed_fields_enabled: bool,
     ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>> {
@@ -299,7 +297,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
     pub(crate) fn add_group_queries(
         &mut self,
         view: &(impl TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>
-              + TExecutorView<K, u32, MoveTypeLayout, ValueType>),
+              + TExecutorView<K, u32, MoveTypeLayout>),
         group_queries: &[(K, bool)],
     ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>> {
         for (group_key, query_metadata) in group_queries {
@@ -343,7 +341,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
     ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>>
     where
         View: TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>
-            + TExecutorView<K, u32, MoveTypeLayout, ValueType>,
+            + TExecutorView<K, u32, MoveTypeLayout>,
     {
         // Group writes
         for (key, metadata, inner_ops) in group_writes {
@@ -483,7 +481,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
     // Group view is because get_delayed_field_id_from_resource dispatches, but there is
     // a TODO to have TExecutorView contain TResourceGroupView anyway.
     where
-        View: TExecutorView<K, u32, MoveTypeLayout, ValueType>
+        View: TExecutorView<K, u32, MoveTypeLayout>
             + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>,
     {
         for (k, new_value, has_delta) in resource_writes.iter() {
@@ -509,7 +507,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
     /// Returns self for method chaining
     pub(crate) fn add_deltas(
         &mut self,
-        view: &(impl TExecutorView<K, u32, MoveTypeLayout, ValueType>
+        view: &(impl TExecutorView<K, u32, MoveTypeLayout>
               + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>),
         deltas: &[(K, DeltaOp, Option<u32>)],
         delta_test_kind: DeltaTestKind,
@@ -548,7 +546,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
     /// Helper to extract a delayed field ID for a resource key (assuming value is exchanged).
     fn get_delayed_field_id_from_resource(
         &mut self,
-        view: &(impl TExecutorView<K, u32, MoveTypeLayout, ValueType>
+        view: &(impl TExecutorView<K, u32, MoveTypeLayout>
               + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>),
         key: &K,
         maybe_tag: Option<u32>,
@@ -589,7 +587,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
     /// Returns an error ExecutionStatus if the read fails.
     fn add_delayed_field_from_read_result(
         &mut self,
-        view: &impl TExecutorView<K, u32, MoveTypeLayout, ValueType>,
+        view: &impl TExecutorView<K, u32, MoveTypeLayout>,
         key: &K,
         bytes: &[u8],
     ) -> Result<(), ExecutionStatus<MockOutput<K, E>, usize>> {
@@ -689,54 +687,31 @@ where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
-    type AfterMaterializationGuard<'a> = &'a Self;
     type BeforeMaterializationGuard<'a> = &'a Self;
+    type CommittedOutput = MockOutput<K, E>;
     type Txn = MockTransaction<K, E>;
-
-    fn committed_output(&self) -> &OnceCell<aptos_types::transaction::TransactionOutput> {
-        unimplemented!("Not used in tests");
-    }
 
     fn skip_output() -> Self {
         Self::skipped_output(None)
-    }
-
-    fn discard_output(discard_code: StatusCode) -> Self {
-        Self::with_discard_code(discard_code)
     }
 
     fn before_materialization(&self) -> Result<Self::BeforeMaterializationGuard<'_>, PanicError> {
         Ok(self)
     }
 
-    fn after_materialization(&self) -> Result<Self::AfterMaterializationGuard<'_>, PanicError> {
-        Ok(self)
-    }
-
-    fn check_materialization(&self) -> Result<bool, PanicError> {
-        Ok(!self.skipped)
-    }
-
     fn incorporate_materialized_txn_output(
         &mut self,
         patched_resource_write_set: Vec<(K, ValueType)>,
         _patched_events: Vec<E>,
-    ) -> Result<Trace, PanicError> {
+    ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
         assert_ok!(self
             .patched_resource_write_set
             .set(patched_resource_write_set.clone().into_iter().collect()));
-        // TODO: Also test patched events.
-        Ok(Trace::empty())
-    }
+        // TODO: Also test patched events
 
-    fn set_txn_output_for_non_dynamic_change_set(&mut self) {
-        // No compatibility issues here since the move-vm doesn't use the dynamic flag.
-    }
-
-    fn is_materialized_and_success(&self) -> bool {
-        // TODO(BlockSTMv2): Actually test that materialize is called.
-        // A skipped transaction is not a success.
-        !self.skipped
+        // The mock's committed output is a snapshot of itself, carrying the reads
+        // and patched writes the baseline verifies.
+        Ok((self.clone(), Trace::empty()))
     }
 }
 
@@ -745,15 +720,16 @@ where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
-    fn resource_write_set(
-        &self,
-    ) -> HashMap<K, (TriompheArc<ValueType>, Option<TriompheArc<MoveTypeLayout>>)> {
+    fn resource_write_set(&self) -> HashMap<K, ValueWithLayout<ValueType>> {
         self.writes
             .iter()
             .map(|(key, value, maybe_layout)| {
                 (
                     key.clone(),
-                    (TriompheArc::new(value.clone()), maybe_layout.clone()),
+                    ValueWithLayout::Exchanged(
+                        TriompheArc::new(value.clone()),
+                        maybe_layout.clone(),
+                    ),
                 )
             })
             .collect()
@@ -807,14 +783,33 @@ where
     ) -> HashMap<
         K,
         (
-            ValueType,
+            ValueWithLayout<ValueType>,
             ResourceGroupSize,
-            BTreeMap<u32, (ValueType, Option<TriompheArc<MoveTypeLayout>>)>,
+            BTreeMap<u32, ValueWithLayout<ValueType>>,
         ),
     > {
         self.group_writes
             .iter()
-            .map(|(key, value, size, ops)| (key.clone(), (value.clone(), *size, ops.clone())))
+            .map(|(key, value, size, ops)| {
+                (
+                    key.clone(),
+                    (
+                        ValueWithLayout::Exchanged(TriompheArc::new(value.clone()), None),
+                        *size,
+                        ops.iter()
+                            .map(|(tag, (op, maybe_layout))| {
+                                (
+                                    *tag,
+                                    ValueWithLayout::Exchanged(
+                                        TriompheArc::new(op.clone()),
+                                        maybe_layout.clone(),
+                                    ),
+                                )
+                            })
+                            .collect(),
+                    ),
+                )
+            })
             .collect()
     }
 
@@ -870,7 +865,7 @@ where
     }
 }
 
-impl<K, E> AfterMaterializationOutput<MockTransaction<K, E>> for &MockOutput<K, E>
+impl<K, E> CommittedTransactionOutput for MockOutput<K, E>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
@@ -882,6 +877,22 @@ where
     fn has_new_epoch_event(&self) -> bool {
         // For tests, it is ok to return false.
         false
+    }
+
+    fn is_retry(&self) -> bool {
+        self.skipped
+    }
+
+    fn is_success(&self) -> bool {
+        !self.skipped
+    }
+
+    fn retry() -> Self {
+        Self::skipped_output(None)
+    }
+
+    fn discard(discard_code: StatusCode) -> Self {
+        Self::with_discard_code(discard_code)
     }
 }
 
@@ -932,7 +943,7 @@ where
 
     fn execute_transaction(
         &self,
-        view: &(impl TExecutorView<K, u32, MoveTypeLayout, ValueType>
+        view: &(impl TExecutorView<K, u32, MoveTypeLayout>
               + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>
               + AptosCodeStorage
               + BlockSynchronizationKillSwitch),
@@ -998,7 +1009,7 @@ where
                 ExecutionStatus::Success(builder.build())
             },
             MockTransaction::SkipRest(gas) => {
-                let mut mock_output = MockOutput::skip_output();
+                let mut mock_output = MockOutput::retry();
                 mock_output.total_gas = *gas;
                 ExecutionStatus::SkipRest(mock_output)
             },
@@ -1013,8 +1024,22 @@ where
         }
     }
 
-    fn is_transaction_dynamic_change_set_capable(_txn: &Self::Txn) -> bool {
-        true
+    fn pre_write_values(txn: &Self::Txn) -> Vec<(K, ValueWithLayout<ValueType>)> {
+        match txn {
+            MockTransaction::Write { pre_writes, .. } => pre_writes
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        ValueWithLayout::Exchanged(TriompheArc::new(v.clone()), None),
+                    )
+                })
+                .collect(),
+            MockTransaction::InterruptRequested
+            | MockTransaction::SkipRest(_)
+            | MockTransaction::Abort
+            | MockTransaction::StateCheckpoint => vec![],
+        }
     }
 }
 

--- a/aptos-move/block-executor/src/combinatorial_tests/types.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/types.rs
@@ -500,13 +500,6 @@ impl<
     fn state_checkpoint(_block_id: HashValue) -> Self {
         Self::StateCheckpoint
     }
-
-    fn pre_write_values(&self) -> Vec<(Self::Key, Self::Value)> {
-        match self {
-            MockTransaction::Write { pre_writes, .. } => pre_writes.clone(),
-            _ => vec![],
-        }
-    }
 }
 
 // TODO: try and test different strategies.
@@ -944,7 +937,7 @@ pub(crate) fn raw_metadata(v: u64) -> StateValueMetadata {
     StateValueMetadata::legacy(v, &CurrentTimeMicroseconds { microseconds: v })
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum GroupSizeOrMetadata {
     Size(u64),
     Metadata(Option<StateValueMetadata>),

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -18,10 +18,7 @@ use crate::{
     scheduler::{DependencyStatus, ExecutionTaskType, Scheduler, SchedulerTask, Wave},
     scheduler_v2::{AbortManager, CommitResult, SchedulerV2, TaskKind},
     scheduler_wrapper::SchedulerWrapper,
-    task::{
-        AfterMaterializationOutput, BeforeMaterializationOutput, ExecutionStatus, ExecutorTask,
-        TransactionOutput,
-    },
+    task::{BeforeMaterializationOutput, ExecutionStatus, ExecutorTask, TransactionOutput},
     txn_commit_hook::TransactionCommitHook,
     txn_last_input_output::TxnLastInputOutput,
     txn_provider::TxnProvider,
@@ -34,14 +31,17 @@ use aptos_crypto::HashValue;
 use aptos_drop_helper::DEFAULT_DROPPER;
 use aptos_logger::{error, info};
 use aptos_mvhashmap::{
-    types::{Incarnation, MVDelayedFieldsError, TxnIndex, ValueWithLayout},
+    types::{Incarnation, MVDelayedFieldsError, TxnIndex},
     unsync_map::UnsyncMap,
     versioned_delayed_fields::CommitError,
     MVHashMap,
 };
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorConfig, transaction_slice_metadata::TransactionSliceMetadata,
+        config::BlockExecutorConfig,
+        output::CommittedTransactionOutput,
+        transaction_slice_metadata::TransactionSliceMetadata,
+        value::{SpeculativeValue, ValueWithLayout},
     },
     error::{code_invariant_error, expect_ok, PanicError, PanicOr},
     on_chain_config::Features,
@@ -61,7 +61,7 @@ use claims::assert_none;
 use core::panic;
 use fail::fail_point;
 use move_binary_format::CompiledModule;
-use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout, vm_status::StatusCode};
+use move_core_types::{language_storage::ModuleId, vm_status::StatusCode};
 use move_vm_runtime::{Module, RuntimeEnvironment, TypeChecker, WithRuntimeEnvironment};
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use num_cpus;
@@ -74,6 +74,8 @@ use std::{
 };
 use triomphe::Arc as TriompheArc;
 
+type CommittedOutput<E> = <<E as ExecutorTask>::Output as TransactionOutput>::CommittedOutput;
+
 struct SharedSyncParams<'a, T, E, S>
 where
     T: BlockExecutableTransaction,
@@ -82,14 +84,14 @@ where
 {
     // TODO: should not need to pass base view.
     base_view: &'a S,
-    versioned_cache: &'a MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+    versioned_cache: &'a MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
     global_module_cache:
         &'a GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension>,
     last_input_output: &'a TxnLastInputOutput<T, E::Output>,
     start_shared_counter: u32,
     delayed_field_id_counter: &'a AtomicU32,
     block_limit_processor: &'a ExplicitSyncWrapper<BlockGasLimitProcessor<T>>,
-    final_results: &'a ExplicitSyncWrapper<Vec<E::Output>>,
+    final_results: &'a ExplicitSyncWrapper<Vec<CommittedOutput<E>>>,
     maybe_block_epilogue_txn_idx: &'a ExplicitSyncWrapper<Option<TxnIndex>>,
 }
 
@@ -107,7 +109,7 @@ where
     T: BlockExecutableTransaction,
     E: ExecutorTask<Txn = T, AuxiliaryInfo = A>,
     S: TStateView<Key = T::Key> + Sync,
-    L: TransactionCommitHook,
+    L: TransactionCommitHook<CommittedOutput<E>>,
     TP: TxnProvider<T, A> + Sync,
     A: AuxiliaryInfoTrait,
 {
@@ -165,7 +167,7 @@ where
     /// all pre-written keys were actually written, triggering fallback to sequential execution
     /// if not.
     fn verify_pre_writes(txn: &T, maybe_output: Option<&E::Output>) -> Result<(), PanicError> {
-        let pre_write_entries = T::pre_write_values(txn);
+        let pre_write_entries = E::pre_write_values(txn);
         if pre_write_entries.is_empty() {
             return Ok(()); // No pre-writes, nothing to verify
         }
@@ -195,7 +197,7 @@ where
         idx_to_execute: TxnIndex,
         incarnation: Incarnation,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         abort_manager: &mut AbortManager,
     ) -> Result<(), PanicError> {
         // The order is reversed in BlockSTMv2 as opposed to V1, avoiding the necessity
@@ -211,14 +213,13 @@ where
             idx_to_execute,
             |prev_key_ref| {
                 match resource_write_set.remove_entry(prev_key_ref) {
-                    Some((key, (value, maybe_layout))) => {
+                    Some((key, value)) => {
                         abort_manager.invalidate_dependencies(
                             versioned_cache.data().write_v2::<false>(
                                 key,
                                 idx_to_execute,
                                 incarnation,
                                 value,
-                                maybe_layout,
                             )?,
                         )?;
                     },
@@ -236,13 +237,12 @@ where
         )?;
 
         // Handle remaining entries in resource_write_set (new writes)
-        for (key, (value, maybe_layout)) in resource_write_set {
+        for (key, value) in resource_write_set {
             abort_manager.invalidate_dependencies(versioned_cache.data().write_v2::<false>(
                 key,
                 idx_to_execute,
                 incarnation,
                 value,
-                maybe_layout,
             )?)?;
         }
 
@@ -256,7 +256,7 @@ where
         idx_to_execute: TxnIndex,
         incarnation: Incarnation,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         abort_manager: &mut AbortManager,
     ) -> Result<(), PanicError> {
         // The order of applying new group writes versus clearing previous writes is reversed
@@ -283,8 +283,7 @@ where
                                 group_key.clone(),
                                 idx_to_execute,
                                 incarnation,
-                                TriompheArc::new(group_metadata_op),
-                                None,
+                                group_metadata_op,
                             )?,
                         )?;
                         abort_manager.invalidate_dependencies(
@@ -328,8 +327,7 @@ where
                     group_key.clone(),
                     idx_to_execute,
                     incarnation,
-                    TriompheArc::new(group_metadata_op),
-                    None,
+                    group_metadata_op,
                 )?,
             )?;
             abort_manager.invalidate_dependencies(versioned_cache.group_data().write_v2(
@@ -350,7 +348,7 @@ where
         idx_to_execute: TxnIndex,
         read_set: &mut CapturedReads<T, ModuleId, CompiledModule, Module, AptosModuleExtension>,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         is_v2: bool,
     ) -> Result<(), PanicError> {
         let mut prev_modified_delayed_fields = last_input_output
@@ -416,7 +414,7 @@ where
         txn: &T,
         auxiliary_info: &A,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         executor: &E,
         base_view: &S,
         global_module_cache: &GlobalModuleCache<
@@ -549,7 +547,7 @@ where
         // transaction starts processing the outputs, as well as when the execution is finished.
         maybe_scheduler: Option<&Scheduler>,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         executor: &E,
         base_view: &S,
         global_module_cache: &GlobalModuleCache<
@@ -660,13 +658,13 @@ where
             let resource_write_set = output_before_guard.resource_write_set();
 
             // Then, process resource writes (aggregator v1 writes are part of this set).
-            for (k, (v, maybe_layout)) in resource_write_set.into_iter() {
+            for (k, v) in resource_write_set.into_iter() {
                 if !prev_modified_resource_keys.remove(&k) {
                     needs_suffix_validation = true;
                 }
                 versioned_cache
                     .data()
-                    .write(k, idx_to_execute, incarnation, v, maybe_layout)?;
+                    .write(k, idx_to_execute, incarnation, v)?;
             }
 
             Ok(())
@@ -728,7 +726,7 @@ where
             Module,
             AptosModuleExtension,
         >,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
     ) -> Result<bool, PanicError> {
         // The previous read-set must be recorded because:
         // 1. The transaction has finished at least one execution in order for it
@@ -786,7 +784,7 @@ where
             Module,
             AptosModuleExtension,
         >,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         skip_module_reads_validation: bool,
     ) -> bool {
         let _timer = TASK_VALIDATE_SECONDS.start_timer();
@@ -825,7 +823,7 @@ where
         valid: bool,
         validation_wave: Wave,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         scheduler: &Scheduler,
     ) -> Result<SchedulerTask, PanicError> {
         let aborted = !valid && scheduler.try_abort(txn_idx, incarnation);
@@ -849,7 +847,7 @@ where
     /// returns false (indicating that transaction needs to be re-executed).
     fn validate_and_commit_delayed_fields(
         txn_idx: TxnIndex,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
     ) -> Result<bool, PanicError> {
         if last_input_output.is_speculative_failure(txn_idx) {
@@ -890,7 +888,7 @@ where
         txn_idx: TxnIndex,
         incarnation: Incarnation,
         scheduler: SchedulerWrapper,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
         start_shared_counter: u32,
         shared_counter: &AtomicU32,
@@ -1059,7 +1057,7 @@ where
         scheduler: SchedulerWrapper,
         environment: &AptosEnvironment,
         shared_sync_params: &SharedSyncParams<T, E, S>,
-    ) -> Result<(), PanicError> {
+    ) -> Result<CommittedOutput<E>, PanicError> {
         let last_input_output = shared_sync_params.last_input_output;
 
         // Do a final validation for safety as a part of (parallel) post-processing.
@@ -1128,7 +1126,7 @@ where
         let resource_writes_to_materialize = resource_writes_to_materialize!(
             resource_write_set,
             last_input_output,
-            last_input_output,
+            |key| last_input_output.fetch_exchanged_data(key, txn_idx),
             txn_idx
         )?;
         let materialized_resource_write_set =
@@ -1139,7 +1137,7 @@ where
         // This call finalizes the output and may not be concurrent with any other
         // accesses to the output (e.g. querying the write-set, events, etc), as
         // these read accesses are not synchronized and assumed to have terminated.
-        let trace = last_input_output.record_materialized_txn_output(
+        let (committed_output, trace) = last_input_output.record_materialized_txn_output(
             txn_idx,
             materialized_resource_write_set
                 .into_iter()
@@ -1189,13 +1187,14 @@ where
             }
         }
 
-        Ok(())
+        Ok(committed_output)
     }
 
     fn record_finalized_output(
         &self,
         txn_idx: TxnIndex,
         output_idx: TxnIndex,
+        committed_output: CommittedOutput<E>,
         shared_sync_params: &SharedSyncParams<T, E, S>,
     ) -> Result<(), PanicError> {
         if output_idx < txn_idx {
@@ -1205,14 +1204,12 @@ where
             )));
         }
 
-        let last_input_output = shared_sync_params.last_input_output;
-        if let Some(txn_commit_listener) = &self.transaction_commit_hook {
-            last_input_output.notify_listener(txn_idx, txn_commit_listener)?;
+        if let Some(hook) = &self.transaction_commit_hook {
+            hook.on_transaction_committed(txn_idx, &committed_output);
         }
-
         let mut final_results = shared_sync_params.final_results.acquire();
 
-        final_results[output_idx as usize] = last_input_output.take_output(txn_idx)?;
+        final_results[output_idx as usize] = committed_output;
         Ok(())
     }
 
@@ -1242,13 +1239,13 @@ where
 
         let drain_commit_queue = || -> Result<(), PanicError> {
             while let Ok(txn_idx) = scheduler.pop_from_commit_queue() {
-                self.materialize_txn_commit(
+                let output = self.materialize_txn_commit(
                     txn_idx,
                     scheduler_wrapper,
                     environment,
                     shared_sync_params,
                 )?;
-                self.record_finalized_output(txn_idx, txn_idx, shared_sync_params)?;
+                self.record_finalized_output(txn_idx, txn_idx, output, shared_sync_params)?;
             }
             Ok(())
         };
@@ -1451,13 +1448,13 @@ where
                     )?;
                 },
                 TaskKind::PostCommitProcessing(txn_idx) => {
-                    self.materialize_txn_commit(
+                    let output = self.materialize_txn_commit(
                         txn_idx,
                         scheduler_wrapper,
                         environment,
                         shared_sync_params,
                     )?;
-                    self.record_finalized_output(txn_idx, txn_idx, shared_sync_params)?;
+                    self.record_finalized_output(txn_idx, txn_idx, output, shared_sync_params)?;
                 },
                 TaskKind::NextTask => {
                     // TODO: Anything intelligent to do here?.
@@ -1537,11 +1534,8 @@ where
         {
             if epilogue_txn_idx == 0
                 || epilogue_txn_idx as usize > num_txns
-                || !final_results.dereference()[epilogue_txn_idx as usize - 1]
-                    .check_materialization()?
-                || final_results.dereference()[epilogue_txn_idx as usize - 1]
-                    .after_materialization()?
-                    .has_new_epoch_event()
+                || final_results.dereference()[epilogue_txn_idx as usize - 1].is_retry()
+                || final_results.dereference()[epilogue_txn_idx as usize - 1].has_new_epoch_event()
             {
                 // If this error fires, and epilogue_txn_idx is not 0 or > num_txns,
                 // then is_retry_check_after_commit would have created a panic error,
@@ -1551,7 +1545,7 @@ where
                             epilogue_txn_idx
                         )));
             }
-            if final_results.dereference()[epilogue_txn_idx as usize].check_materialization()? {
+            if !final_results.dereference()[epilogue_txn_idx as usize].is_retry() {
                 return Err(code_invariant_error(format!(
                     "Output at epilogue txn index {} must be placeholder (is_retry set)",
                     epilogue_txn_idx
@@ -1617,7 +1611,7 @@ where
                     runtime_environment,
                     &self.config,
                 )?;
-                self.materialize_txn_commit(
+                let output = self.materialize_txn_commit(
                     epilogue_txn_idx,
                     scheduler,
                     environment,
@@ -1626,6 +1620,7 @@ where
                 self.record_finalized_output(
                     epilogue_txn_idx,
                     num_txns as TxnIndex,
+                    output,
                     shared_sync_params,
                 )?;
 
@@ -1646,7 +1641,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<T, E::Output>, ()> {
+    ) -> Result<BlockOutput<T, CommittedOutput<E>>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // BlockSTMv2 should have less restrictions on the number of workers but we
         // still sanity check that it is not instantiated w. concurrency level 1.
@@ -1665,7 +1660,7 @@ where
         // +1 for potential BlockEpilogue txn.
         let final_results = ExplicitSyncWrapper::new(
             (0..num_txns + 1)
-                .map(|_| E::Output::skip_output())
+                .map(|_| CommittedOutput::<E>::retry())
                 .collect::<Vec<_>>(),
         );
 
@@ -1687,12 +1682,12 @@ where
         let mut versioned_cache = MVHashMap::new();
         if self.config.local.enable_pre_write {
             for txn_idx in 0..num_txns {
-                let values = T::pre_write_values(signature_verified_block.get_txn(txn_idx));
+                let values = E::pre_write_values(signature_verified_block.get_txn(txn_idx));
                 for (k, v) in values {
                     // pre-write doesn't need to use write_v2 because there's no dependencies.
                     versioned_cache
                         .data()
-                        .write(k, txn_idx, 0, triomphe::Arc::new(v), None)
+                        .write(k, txn_idx, 0, v)
                         .map_err(|e| {
                             error!("Pre-write failed for txn {}: {:?}", txn_idx, e);
                         })?;
@@ -1814,7 +1809,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<T, E::Output>, ()> {
+    ) -> Result<BlockOutput<T, CommittedOutput<E>>, ()> {
         self.execute_transactions_parallel(
             signature_verified_block,
             base_view,
@@ -1829,7 +1824,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<T, E::Output>, ()> {
+    ) -> Result<BlockOutput<T, CommittedOutput<E>>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // Using parallel execution with 1 thread currently will not work as it
         // will only have a coordinator role but no workers for rolling commit.
@@ -1843,11 +1838,11 @@ where
         let mut versioned_cache = MVHashMap::new();
         if self.config.local.enable_pre_write {
             for txn_idx in 0..signature_verified_block.num_txns() as u32 {
-                let values = T::pre_write_values(signature_verified_block.get_txn(txn_idx));
+                let values = E::pre_write_values(signature_verified_block.get_txn(txn_idx));
                 for (k, v) in values {
                     versioned_cache
                         .data()
-                        .write(k, txn_idx, 0, triomphe::Arc::new(v), None)
+                        .write(k, txn_idx, 0, v)
                         .map_err(|e| {
                             error!("Pre-write failed for txn {}: {:?}", txn_idx, e);
                         })?;
@@ -1873,7 +1868,7 @@ where
         let final_results = ExplicitSyncWrapper::new(
             // +1 for potential BlockEpilogue txn.
             (0..(num_txns + 1))
-                .map(|_| E::Output::skip_output())
+                .map(|_| CommittedOutput::<E>::retry())
                 .collect::<Vec<_>>(),
         );
 
@@ -1991,7 +1986,7 @@ where
         &self,
         block_id: HashValue,
         signature_verified_block: &TP,
-        outputs: impl Iterator<Item = &'a E::Output>,
+        outputs: impl Iterator<Item = &'a CommittedOutput<E>>,
         epilogue_txn_idx: TxnIndex,
         block_end_info: TBlockEndInfoExt<T::Key>,
         features: &Features,
@@ -2028,11 +2023,10 @@ where
             // TODO(grao): Also include other transactions that is "Keep" if we are confident
             // that we successfully charge enough gas amount as it appears in the FeeStatement
             // for every corner cases.
-            if !output.is_materialized_and_success() {
+            if !output.is_success() {
                 continue;
             }
-            let output_after_guard = output.after_materialization()?;
-            let fee_statement = output_after_guard.fee_statement();
+            let fee_statement = output.fee_statement();
 
             let txn = signature_verified_block.get_txn(i as TxnIndex);
             if let Some(user_txn) = txn.try_as_signed_user_txn() {
@@ -2088,22 +2082,19 @@ where
             Module,
             AptosModuleExtension,
         >,
-        unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        unsync_map: &UnsyncMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         output_before_guard: &<E::Output as TransactionOutput>::BeforeMaterializationGuard<'_>,
-        resource_write_set: HashMap<
-            T::Key,
-            (TriompheArc<T::Value>, Option<TriompheArc<MoveTypeLayout>>),
-        >,
+        resource_write_set: HashMap<T::Key, ValueWithLayout<T::Value>>,
     ) -> Result<(), SequentialBlockExecutionError<E::Error>> {
-        for (key, (write_op, layout)) in resource_write_set.into_iter() {
-            unsync_map.write(key, write_op, layout);
+        for (key, value) in resource_write_set.into_iter() {
+            unsync_map.write(key, value);
         }
 
         for (group_key, (metadata_op, group_size, group_ops)) in
             output_before_guard.resource_group_write_set().into_iter()
         {
             unsync_map.insert_group_ops(&group_key, group_ops, group_size)?;
-            unsync_map.write(group_key, TriompheArc::new(metadata_op), None);
+            unsync_map.write(group_key, metadata_op);
         }
 
         for write in output_before_guard.module_write_set().values() {
@@ -2173,7 +2164,7 @@ where
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
         resource_group_bcs_fallback: bool,
-    ) -> Result<BlockOutput<T, E::Output>, SequentialBlockExecutionError<E::Error>> {
+    ) -> Result<BlockOutput<T, CommittedOutput<E>>, SequentialBlockExecutionError<E::Error>> {
         let num_txns = signature_verified_block.num_txns();
 
         if num_txns == 0 {
@@ -2226,9 +2217,6 @@ where
             let must_skip = matches!(res, ExecutionStatus::SkipRest(_));
             match res {
                 ExecutionStatus::Abort(err) => {
-                    if let Some(commit_hook) = &self.transaction_commit_hook {
-                        commit_hook.on_execution_aborted(idx as TxnIndex);
-                    }
                     error!(
                         "Sequential execution FatalVMError by transaction {}",
                         idx as TxnIndex
@@ -2239,18 +2227,12 @@ where
                     ));
                 },
                 ExecutionStatus::DelayedFieldsCodeInvariantError(msg) => {
-                    if let Some(commit_hook) = &self.transaction_commit_hook {
-                        commit_hook.on_execution_aborted(idx as TxnIndex);
-                    }
                     alert!("Sequential execution DelayedFieldsCodeInvariantError error by transaction {}: {}", idx as TxnIndex, msg);
                     return Err(SequentialBlockExecutionError::ErrorToReturn(
                         BlockExecutionError::FatalBlockExecutorError(code_invariant_error(msg)),
                     ));
                 },
                 ExecutionStatus::SpeculativeExecutionAbortError(msg) => {
-                    if let Some(commit_hook) = &self.transaction_commit_hook {
-                        commit_hook.on_execution_aborted(idx as TxnIndex);
-                    }
                     alert!("Sequential execution SpeculativeExecutionAbortError error by transaction {}: {}", idx as TxnIndex, msg);
                     return Err(SequentialBlockExecutionError::ErrorToReturn(
                         BlockExecutionError::FatalBlockExecutorError(code_invariant_error(msg)),
@@ -2316,16 +2298,11 @@ where
                             (
                                 group
                                     .map(|(resource_tag, value_with_layout)| {
-                                        let value = match value_with_layout {
-                                            ValueWithLayout::RawFromStorage(value)
-                                            | ValueWithLayout::Exchanged(value, _) => value,
-                                        };
-                                        (
-                                            resource_tag,
-                                            value
-                                                .extract_raw_bytes()
-                                                .expect("Deletions should already be applied"),
-                                        )
+                                        let bytes = value_with_layout
+                                            .extract_value()
+                                            .extract_raw_bytes()
+                                            .expect("Deletions should already be applied");
+                                        (resource_tag, bytes)
                                     })
                                     .collect(),
                                 size,
@@ -2362,13 +2339,14 @@ where
                                     if output_group_size.get() != group_size.get() {
                                         return false;
                                     }
-                                    for (value_tag, (group_op, _)) in group_ops {
+                                    for (value_tag, group_op) in group_ops {
                                         if group_op.is_deletion() {
                                             finalized_group.remove(&value_tag);
                                         } else {
                                             finalized_group.insert(
                                                 value_tag,
                                                 group_op
+                                                    .extract_value()
                                                     .extract_raw_bytes()
                                                     .expect("Not a deletion"),
                                             );
@@ -2387,7 +2365,7 @@ where
                             // The corresponding error / alert must already be triggered, the goal in sequential
                             // fallback is to just skip any transactions that would cause such serialization errors.
                             alert!("Discarding transaction because serialization failed in bcs fallback");
-                            ret.push(E::Output::discard_output(
+                            ret.push(CommittedOutput::<E>::discard(
                                 StatusCode::DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR,
                             ));
                             idx += 1;
@@ -2417,7 +2395,7 @@ where
                     )?;
 
                     // If dynamic change set materialization part (indented for clarity/variable scope):
-                    {
+                    let committed_output = {
                         let finalized_groups = groups_to_finalize!(output_before_guard,)
                             .map(|((group_key, metadata_op), is_read_needing_exchange)| {
                                 let (group_ops_iter, group_size) =
@@ -2441,7 +2419,7 @@ where
                         let resource_writes_to_materialize = resource_writes_to_materialize!(
                             resource_write_set,
                             output_before_guard,
-                            unsync_map,
+                            |key| expect_exchanged_data(unsync_map.fetch_data(key)),
                         )?;
                         // Replace delayed field id with values in resource write set and read set.
                         let materialized_resource_write_set = map_id_to_values_in_write_set(
@@ -2458,13 +2436,14 @@ where
                         // output which needs a write lock.
                         drop(output_before_guard);
 
-                        let trace = output.incorporate_materialized_txn_output(
-                            materialized_resource_write_set
-                                .into_iter()
-                                .chain(serialized_groups.into_iter())
-                                .collect(),
-                            materialized_events,
-                        )?;
+                        let (committed_output, trace) = output
+                            .incorporate_materialized_txn_output(
+                                materialized_resource_write_set
+                                    .into_iter()
+                                    .chain(serialized_groups.into_iter())
+                                    .collect(),
+                                materialized_events,
+                            )?;
 
                         // Sequential execution never collects any traces.
                         if !trace.is_empty() {
@@ -2473,7 +2452,9 @@ where
                             );
                             return Err(err.into());
                         }
-                    }
+
+                        committed_output
+                    };
                     // If dynamic change set is disabled, this can be used to assert nothing needs patching instead:
                     //   output.set_txn_output_for_non_dynamic_change_set();
 
@@ -2484,10 +2465,9 @@ where
                     }
 
                     if let Some(commit_hook) = &self.transaction_commit_hook {
-                        commit_hook
-                            .on_transaction_committed(idx as TxnIndex, output.committed_output());
+                        commit_hook.on_transaction_committed(idx as TxnIndex, &committed_output);
                     }
-                    ret.push(output);
+                    ret.push(committed_output);
                 },
             };
 
@@ -2500,11 +2480,11 @@ where
             if must_skip || block_limit_processor.should_end_block_sequential() || idx == num_txns {
                 let mut has_reconfig = false;
                 if let Some(last_output) = ret.last() {
-                    if last_output.after_materialization()?.has_new_epoch_event() {
+                    if last_output.has_new_epoch_event() {
                         has_reconfig = true;
                     }
                 }
-                ret.resize_with(num_txns, E::Output::skip_output);
+                ret.resize_with(num_txns, CommittedOutput::<E>::retry);
                 if let Some(block_id) =
                     transaction_slice_metadata.append_state_checkpoint_to_block()
                 {
@@ -2544,7 +2524,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> BlockExecutionResult<BlockOutput<T, E::Output>, E::Error> {
+    ) -> BlockExecutionResult<BlockOutput<T, CommittedOutput<E>>, E::Error> {
         let _timer = BLOCK_EXECUTOR_INNER_EXECUTE_BLOCK.start_timer();
 
         if self.config.local.concurrency_level > 1 {
@@ -2652,7 +2632,7 @@ where
                 },
             };
             let ret = (0..signature_verified_block.num_txns())
-                .map(|_| E::Output::discard_output(error_code))
+                .map(|_| CommittedOutput::<E>::discard(error_code))
                 .collect();
             return Ok(BlockOutput::new(ret, None));
         }
@@ -2668,7 +2648,7 @@ where
         &self,
         block: &TP,
         transaction_slice_metadata: &TransactionSliceMetadata,
-        outputs: impl Iterator<Item = &'a E::Output>,
+        outputs: impl Iterator<Item = &'a CommittedOutput<E>>,
         epilogue_txn_idx: TxnIndex,
         block_limit_processor: &ExplicitSyncWrapper<BlockGasLimitProcessor<T>>,
         environment: &AptosEnvironment,

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -6,11 +6,9 @@ use crate::{
     view::LatestView,
 };
 use aptos_logger::error;
-use aptos_mvhashmap::{
-    types::{TxnIndex, ValueWithLayout},
-    MVHashMap,
-};
+use aptos_mvhashmap::{types::TxnIndex, MVHashMap};
 use aptos_types::{
+    block_executor::value::ValueWithLayout,
     contract_event::TransactionEvent,
     error::{code_invariant_error, PanicError},
     state_store::TStateView,
@@ -55,12 +53,12 @@ macro_rules! groups_to_finalize {
 // Since reads needing exchange also do not contain deletions (see 'does_value_need_exchange')
 // logic in value_exchange.rs, it is guaranteed that no returned values is a deletion.
 macro_rules! resource_writes_to_materialize {
-    ($writes:expr, $outputs:expr, $data_source:expr, $($txn_idx:expr),*) => {{
+    ($writes:expr, $outputs:expr, $fetch:expr, $($txn_idx:expr),*) => {{
 	$outputs
         .reads_needing_delayed_field_exchange($($txn_idx),*)
         .into_iter()
 	    .map(|(key, metadata, layout)| -> Result<_, PanicError> {
-	        let (value, existing_layout) = $data_source.fetch_exchanged_data(&key, $($txn_idx),*)?;
+	        let (value, existing_layout) = $fetch(&key)?;
             randomly_check_layout_matches(Some(&existing_layout), Some(layout.as_ref()))?;
             let new_value = TriompheArc::new(TransactionWrite::from_state_value(Some(
                 StateValue::new_with_metadata(
@@ -68,13 +66,11 @@ macro_rules! resource_writes_to_materialize {
                     metadata,
                 ))
             ));
-            Ok((key, new_value, layout))
+            Ok((key, ValueWithLayout::Exchanged(new_value, Some(layout))))
         })
         .chain(
-	        $writes.into_iter().filter_map(|(key, (value, maybe_layout))| {
-		        maybe_layout.map(|layout| {
-                    (!value.is_deletion()).then_some(Ok((key, value, layout)))
-                }).flatten()
+	        $writes.into_iter().filter_map(|(key, value)| {
+                (value.has_layout() && !value.is_deletion()).then_some(Ok((key, value)))
             })
         )
         .collect::<Result<Vec<_>, _>>()
@@ -83,6 +79,18 @@ macro_rules! resource_writes_to_materialize {
 
 pub(crate) use groups_to_finalize;
 pub(crate) use resource_writes_to_materialize;
+
+pub(crate) fn expect_exchanged_data<V: std::fmt::Debug>(
+    data: Option<ValueWithLayout<V>>,
+) -> Result<(TriompheArc<V>, TriompheArc<MoveTypeLayout>), PanicError> {
+    match data {
+        Some(ValueWithLayout::Exchanged(value, Some(layout))) => Ok((value, layout)),
+        data => Err(code_invariant_error(format!(
+            "Read value needing exchange {:?} does not exist or not in Exchanged format",
+            data
+        ))),
+    }
+}
 
 pub(crate) fn map_finalized_group<T: Transaction>(
     group_key: T::Key,
@@ -234,16 +242,19 @@ pub(crate) fn map_id_to_values_in_group_writes<
 // For each delayed field in resource write set, replace the identifiers with values
 // (ignoring other writes). Currently also checks the keys are unique.
 pub(crate) fn map_id_to_values_in_write_set<T: Transaction, S: TStateView<Key = T::Key> + Sync>(
-    resource_write_set: Vec<(T::Key, TriompheArc<T::Value>, TriompheArc<MoveTypeLayout>)>,
+    resource_write_set: Vec<(T::Key, ValueWithLayout<T::Value>)>,
     latest_view: &LatestView<T, S>,
 ) -> Result<Vec<(T::Key, T::Value)>, PanicError> {
     resource_write_set
         .into_iter()
-        .map(|(key, write_op, layout)| {
-            Ok::<_, PanicError>((
+        .map(|(key, value)| match value {
+            ValueWithLayout::Exchanged(write_op, Some(layout)) => Ok((
                 key,
                 replace_ids_with_values(&write_op, &layout, latest_view)?,
-            ))
+            )),
+            ValueWithLayout::Exchanged(_, None) | ValueWithLayout::RawFromStorage(_) => Err(
+                code_invariant_error("Resource write to materialize must have a layout"),
+            ),
         })
         .collect::<std::result::Result<_, PanicError>>()
 }
@@ -308,7 +319,7 @@ fn replace_ids_with_values<T: Transaction, S: TStateView<Key = T::Key> + Sync>(
 pub(crate) fn update_transaction_on_abort<T, E>(
     txn_idx: TxnIndex,
     last_input_output: &TxnLastInputOutput<T, E::Output>,
-    versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+    versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
 ) where
     T: Transaction,
     E: ExecutorTask<Txn = T>,

--- a/aptos-move/block-executor/src/scheduler_wrapper.rs
+++ b/aptos-move/block-executor/src/scheduler_wrapper.rs
@@ -12,7 +12,10 @@ use aptos_mvhashmap::{
     types::{Incarnation, TxnIndex},
     MVHashMap,
 };
-use aptos_types::{error::PanicError, transaction::BlockExecutableTransaction};
+use aptos_types::{
+    block_executor::value::ValueWithLayout, error::PanicError,
+    transaction::BlockExecutableTransaction,
+};
 use move_core_types::language_storage::ModuleId;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use std::{
@@ -108,7 +111,7 @@ impl SchedulerWrapper<'_> {
         txn_idx: TxnIndex,
         incarnation: Incarnation,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
     ) -> Result<(), PanicError>
     where
         T: BlockExecutableTransaction,
@@ -131,7 +134,7 @@ impl SchedulerWrapper<'_> {
         &self,
         block_epilogue_idx: TxnIndex,
         last_input_output: &TxnLastInputOutput<T, E::Output>,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
     ) -> Result<Incarnation, PanicError>
     where
         T: BlockExecutableTransaction,

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -5,12 +5,12 @@ use crate::types::InputOutputKey;
 use aptos_aggregator::delayed_change::DelayedChange;
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
+    block_executor::{output::CommittedTransactionOutput, value::ValueWithLayout},
     error::PanicError,
     fee_statement::FeeStatement,
     state_store::{state_value::StateValueMetadata, TStateView},
     transaction::{
-        AuxiliaryInfoTrait, BlockExecutableTransaction as Transaction,
-        TransactionOutput as TypesTransactionOutput,
+        AuxiliaryInfoTrait, BlockExecutableTransaction as Transaction, BlockExecutableTransaction,
     },
 };
 use aptos_vm_environment::environment::AptosEnvironment;
@@ -21,10 +21,9 @@ use aptos_vm_types::{
         BlockSynchronizationKillSwitch, ResourceGroupSize, TExecutorView, TResourceGroupView,
     },
 };
-use move_core_types::{value::MoveTypeLayout, vm_status::StatusCode};
+use move_core_types::value::MoveTypeLayout;
 use move_vm_runtime::execution_tracing::Trace;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
-use once_cell::sync::OnceCell;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
@@ -48,12 +47,6 @@ pub enum ExecutionStatus<O, E> {
     /// Code invariant error was detected during transaction execution, which
     /// can only be caused by the bug in the code.
     DelayedFieldsCodeInvariantError(String),
-}
-
-/// Inference result of a transaction.
-pub struct Accesses<K> {
-    pub keys_read: Vec<K>,
-    pub keys_written: Vec<K>,
 }
 
 /// Trait for single threaded transaction executor.
@@ -89,7 +82,6 @@ pub trait ExecutorTask {
             <Self::Txn as Transaction>::Key,
             <Self::Txn as Transaction>::Tag,
             MoveTypeLayout,
-            <Self::Txn as Transaction>::Value,
         > + TResourceGroupView<
             GroupKey = <Self::Txn as Transaction>::Key,
             ResourceTag = <Self::Txn as Transaction>::Tag,
@@ -101,16 +93,21 @@ pub trait ExecutorTask {
         txn_idx: TxnIndex,
     ) -> ExecutionStatus<Self::Output, Self::Error>;
 
-    fn is_transaction_dynamic_change_set_capable(txn: &Self::Txn) -> bool;
+    fn pre_write_values(
+        _txn: &Self::Txn,
+    ) -> Vec<(
+        <Self::Txn as BlockExecutableTransaction>::Key,
+        ValueWithLayout<<Self::Txn as BlockExecutableTransaction>::Value>,
+    )> {
+        vec![]
+    }
 }
 
 /// Traits for execution result of a single transaction.
 pub trait BeforeMaterializationOutput<Txn: Transaction> {
     /// Get the writes of a transaction from its output, separately for resources
     /// and modules. Aggregator V1 writes are ordinary entries of the resource write set.
-    fn resource_write_set(
-        &self,
-    ) -> HashMap<Txn::Key, (TriompheArc<Txn::Value>, Option<TriompheArc<MoveTypeLayout>>)>;
+    fn resource_write_set(&self) -> HashMap<Txn::Key, ValueWithLayout<Txn::Value>>;
 
     fn module_write_set(&self) -> &BTreeMap<Txn::Key, ModuleWrite<Txn::Value>>;
 
@@ -131,9 +128,9 @@ pub trait BeforeMaterializationOutput<Txn: Transaction> {
     ) -> HashMap<
         Txn::Key,
         (
-            Txn::Value,
+            ValueWithLayout<Txn::Value>,
             ResourceGroupSize,
-            BTreeMap<Txn::Tag, (Txn::Value, Option<TriompheArc<MoveTypeLayout>>)>,
+            BTreeMap<Txn::Tag, ValueWithLayout<Txn::Value>>,
         ),
     >;
 
@@ -155,7 +152,7 @@ pub trait BeforeMaterializationOutput<Txn: Transaction> {
     fn resource_group_metadata_ops(&self) -> Vec<(Txn::Key, Txn::Value)> {
         self.resource_group_write_set()
             .into_iter()
-            .map(|(key, (op, _, _))| (key, op))
+            .map(|(key, (op, _, _))| (key, op.extract_value().clone()))
             .collect()
     }
 
@@ -186,32 +183,18 @@ pub trait BeforeMaterializationOutput<Txn: Transaction> {
     fn storage_keys_written(&self) -> impl Iterator<Item = &Txn::Key>;
 }
 
-pub trait AfterMaterializationOutput<Txn: Transaction> {
-    /// Return the fee statement of the transaction.
-    fn fee_statement(&self) -> FeeStatement;
-
-    /// Returns true iff it has a new epoch event.
-    fn has_new_epoch_event(&self) -> bool;
-}
-
 pub trait TransactionOutput: Send + Debug {
     /// Type of transaction and its associated key and value.
     type Txn: Transaction;
+    /// The materialized output produced from this (speculative) output.
+    type CommittedOutput: CommittedTransactionOutput;
+
     type BeforeMaterializationGuard<'a>: BeforeMaterializationOutput<Self::Txn> + 'a
     where
         Self: 'a;
-    type AfterMaterializationGuard<'a>: AfterMaterializationOutput<Self::Txn> + 'a
-    where
-        Self: 'a;
-
-    // Used by transaction commit listener (for sharded executor).
-    fn committed_output(&self) -> &OnceCell<TypesTransactionOutput>;
 
     /// Execution output for transactions that comes after SkipRest signal.
     fn skip_output() -> Self;
-
-    /// Execution output for transactions that should be discarded.
-    fn discard_output(discard_code: StatusCode) -> Self;
 
     // Materialization transforms the stored txn output, and may require the
     // TransactionOutput implementation to have different processing for
@@ -221,22 +204,6 @@ pub trait TransactionOutput: Send + Debug {
     fn before_materialization<'a>(
         &'a self,
     ) -> Result<Self::BeforeMaterializationGuard<'a>, PanicError>;
-    fn after_materialization<'a>(
-        &'a self,
-    ) -> Result<Self::AfterMaterializationGuard<'a>, PanicError>;
-
-    /// Returns true iff the transaction status is Keep(Success).
-    fn is_materialized_and_success(&self) -> bool;
-    /// The purpose of this method is to return true if the output has been materialized
-    /// (i.e. incorporate_materialized_txn_output has been called), or false otherwise.
-    /// The method can also assert any invariants provided by the trait implementation
-    /// and the caller. For instance, in the current block executor implementation,
-    /// final output placeholders are initialized via skip_output method and not modified
-    /// until materialization - so if the output is not materialized, it must be a placeholder.
-    ///
-    /// Must be called after concurrent block execution is complete, including materializing
-    /// all required outputs (currently used to check invariants for block epilogue txn).
-    fn check_materialization(&self) -> Result<bool, PanicError>;
 
     // Below methods perform various types of materialization. These may modify
     // the stored output representation and hence must be carefully implemented
@@ -254,7 +221,5 @@ pub trait TransactionOutput: Send + Debug {
             <Self::Txn as Transaction>::Value,
         )>,
         patched_events: Vec<<Self::Txn as Transaction>::Event>,
-    ) -> Result<Trace, PanicError>;
-
-    fn set_txn_output_for_non_dynamic_change_set(&mut self);
+    ) -> Result<(Self::CommittedOutput, Trace), PanicError>;
 }

--- a/aptos-move/block-executor/src/txn_commit_hook.rs
+++ b/aptos-move/block-executor/src/txn_commit_hook.rs
@@ -1,17 +1,12 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//use crate::task::TransactionOutput;
 use aptos_mvhashmap::types::TxnIndex;
-use aptos_types::transaction::TransactionOutput;
-use once_cell::sync::OnceCell;
 
 /// An interface for listening to transaction commit events. The listener is called only once
 /// for each transaction commit.
-pub trait TransactionCommitHook: Send + Sync {
-    fn on_transaction_committed(&self, txn_idx: TxnIndex, output: &OnceCell<TransactionOutput>);
-
-    fn on_execution_aborted(&self, txn_idx: TxnIndex);
+pub trait TransactionCommitHook<O>: Send + Sync {
+    fn on_transaction_committed(&self, txn_idx: TxnIndex, output: &O);
 }
 
 pub struct NoOpTransactionCommitHook<E> {
@@ -32,12 +27,8 @@ impl<E: Sync + Send> NoOpTransactionCommitHook<E> {
     }
 }
 
-impl<E: Sync + Send> TransactionCommitHook for NoOpTransactionCommitHook<E> {
-    fn on_transaction_committed(&self, _txn_idx: TxnIndex, _output: &OnceCell<TransactionOutput>) {
-        // no-op
-    }
-
-    fn on_execution_aborted(&self, _txn_idx: TxnIndex) {
+impl<O, E: Sync + Send> TransactionCommitHook<O> for NoOpTransactionCommitHook<E> {
+    fn on_transaction_committed(&self, _txn_idx: TxnIndex, _output: &O) {
         // no-op
     }
 }

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -9,12 +9,12 @@ use crate::{
     limit_processor::BlockGasLimitProcessor,
     scheduler_wrapper::SchedulerWrapper,
     task::{BeforeMaterializationOutput, ExecutionStatus, TransactionOutput},
-    txn_commit_hook::TransactionCommitHook,
     types::ReadWriteSummary,
 };
 use aptos_logger::error;
 use aptos_mvhashmap::{types::TxnIndex, MVHashMap};
 use aptos_types::{
+    block_executor::value::ValueWithLayout,
     error::{code_invariant_error, PanicError, PanicOr},
     on_chain_config::BlockGasLimitType,
     state_store::state_value::StateValueMetadata,
@@ -179,14 +179,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
             ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {
                 Self::empty_with_status(OutputStatusKind::DelayedFieldsCodeInvariantError)
             },
-        })
-    }
-
-    fn take_output(&mut self) -> Result<O, PanicError> {
-        self.check_success_or_skip_status()?;
-
-        self.output.take().ok_or_else(|| {
-            code_invariant_error("[BlockSTM]: Output must be recorded after execution")
         })
     }
 
@@ -404,39 +396,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         Ok(())
     }
 
-    pub(crate) fn notify_listener<L: TransactionCommitHook>(
-        &self,
-        txn_idx: TxnIndex,
-        txn_listener: &L,
-    ) -> Result<(), PanicError> {
-        let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
-        match output_wrapper.output_status_kind {
-            OutputStatusKind::Success | OutputStatusKind::SkipRest => {
-                txn_listener.on_transaction_committed(
-                    txn_idx,
-                    output_wrapper
-                        .output
-                        .as_ref()
-                        .expect("Output must be set when status is success or skip rest")
-                        .committed_output(),
-                );
-            },
-            OutputStatusKind::Abort(_) => {
-                txn_listener.on_execution_aborted(txn_idx);
-            },
-            OutputStatusKind::SpeculativeExecutionAbortError
-            | OutputStatusKind::DelayedFieldsCodeInvariantError
-            | OutputStatusKind::None => {
-                return Err(code_invariant_error(format!(
-                    "Unexpected output status kind {:?}",
-                    output_wrapper.output_status_kind
-                )));
-            },
-        }
-
-        Ok(())
-    }
-
     pub(crate) fn for_each_resource_key_no_aggregator_v1(
         &self,
         txn_idx: TxnIndex,
@@ -503,7 +462,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
             Module,
             AptosModuleExtension,
         >,
-        versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        versioned_cache: &MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         runtime_environment: &RuntimeEnvironment,
         scheduler: &SchedulerWrapper<'_>,
     ) -> Result<bool, PanicError> {
@@ -597,10 +556,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     pub(crate) fn resource_write_set(
         &self,
         txn_idx: TxnIndex,
-    ) -> Result<
-        HashMap<T::Key, (TriompheArc<T::Value>, Option<TriompheArc<MoveTypeLayout>>)>,
-        PanicError,
-    > {
+    ) -> Result<HashMap<T::Key, ValueWithLayout<T::Value>>, PanicError> {
         with_success_or_skip_rest!(self, txn_idx, resource_write_set, HashMap::new())
     }
 
@@ -612,18 +568,15 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         txn_idx: TxnIndex,
         patched_resource_write_set: Vec<(T::Key, T::Value)>,
         patched_events: Vec<T::Event>,
-    ) -> Result<Trace, PanicError> {
+    ) -> Result<(O::CommittedOutput, Trace), PanicError> {
         with_success_or_skip_rest!(
             self,
             txn_idx,
             |mut t| t
                 .incorporate_materialized_txn_output(patched_resource_write_set, patched_events),
-            Ok(Trace::empty())
+            Err(code_invariant_error(
+                "[BlockSTM]: Output must be recorded after execution"
+            ))
         )
-    }
-
-    // Must be executed after parallel execution is done, grabs outputs.
-    pub(crate) fn take_output(&self, txn_idx: TxnIndex) -> Result<O, PanicError> {
-        self.output_wrappers[txn_idx as usize].lock().take_output()
     }
 }

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -32,13 +32,14 @@ use aptos_logger::error;
 use aptos_mvhashmap::{
     types::{
         Incarnation, MVDataError, MVDataOutput, MVDelayedFieldsError, MVGroupError, StorageVersion,
-        TxnIndex, UnknownOrLayout, UnsyncGroupError, ValueWithLayout,
+        TxnIndex, UnknownOrLayout, UnsyncGroupError,
     },
     unsync_map::UnsyncMap,
     versioned_delayed_fields::TVersionedDelayedFieldView,
     MVHashMap,
 };
 use aptos_types::{
+    block_executor::value::ValueWithLayout,
     error::{code_invariant_error, expect_ok, PanicError, PanicOr},
     executable::ModulePath,
     state_store::{
@@ -106,8 +107,8 @@ pub enum GroupReadResult {
 }
 
 impl ReadResult {
-    pub(crate) fn from_value<T: Transaction>(
-        value: ValueWithLayout<T::Value>,
+    pub(crate) fn from_value<V: TransactionWrite>(
+        value: ValueWithLayout<V>,
         kind: &ReadKind,
     ) -> Result<Self, PanicError> {
         // We set an arbitrary version, as in the end ReadResult does not require version
@@ -146,8 +147,8 @@ impl ReadResult {
 }
 
 impl GroupReadResult {
-    pub(crate) fn from_value<T: Transaction>(
-        value: ValueWithLayout<T::Value>,
+    pub(crate) fn from_value<V: TransactionWrite>(
+        value: ValueWithLayout<V>,
         kind: &ReadKind,
     ) -> Result<Self, PanicError> {
         // We set an arbitrary version, as below (from_data_read) internally ignores it.
@@ -205,10 +206,18 @@ trait ResourceState<T: Transaction> {
 }
 
 trait ResourceGroupState<T: Transaction> {
+    fn update_tagged_base_value_with_layout(
+        &self,
+        group_key: T::Key,
+        tag: T::Tag,
+        value: T::Value,
+        layout: Option<TriompheArc<MoveTypeLayout>>,
+    );
+
     fn set_raw_group_base_values(
         &self,
         group_key: T::Key,
-        base_values: Vec<(T::Tag, T::Value)>,
+        base_values: Vec<(T::Tag, ValueWithLayout<T::Value>)>,
     ) -> PartialVMResult<()>;
 
     fn read_cached_group_tagged_data_by_kind(
@@ -223,7 +232,8 @@ trait ResourceGroupState<T: Transaction> {
 }
 
 pub(crate) struct ParallelState<'a, T: Transaction> {
-    pub(crate) versioned_map: &'a MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+    pub(crate) versioned_map:
+        &'a MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
     scheduler: SchedulerWrapper<'a>,
     start_counter: u32,
     counter: &'a AtomicU32,
@@ -513,7 +523,7 @@ fn wait_for_dependency(
 
 impl<'a, T: Transaction> ParallelState<'a, T> {
     pub(crate) fn new(
-        shared_map: &'a MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        shared_map: &'a MVHashMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         shared_scheduler: SchedulerWrapper<'a>,
         start_shared_counter: u32,
         shared_counter: &'a AtomicU32,
@@ -594,7 +604,13 @@ impl<'a, T: Transaction> ParallelState<'a, T> {
 
 impl<T: Transaction> ResourceState<T> for ParallelState<'_, T> {
     fn set_base_value(&self, key: T::Key, value: ValueWithLayout<T::Value>) {
-        self.versioned_map.data().set_base_value(key, value);
+        self.versioned_map
+            .data()
+            .set_base_value(key, value, |prev, new| {
+                if matches!(prev, ValueWithLayout::RawFromStorage(_)) {
+                    *prev = new;
+                }
+            });
     }
 
     /// Captures a read from the VM execution, but not unresolved deltas, as in this case it is the
@@ -637,7 +653,7 @@ impl<T: Transaction> ResourceState<T> for ParallelState<'_, T> {
                             assert_eq!(version, Err(StorageVersion), "Fetched resource has unknown layout but the version is not Err(StorageVersion)");
                             match patch_base_value(v.as_ref(), layout) {
                                 Ok(patched_value) => {
-                                    self.versioned_map.data().set_base_value(
+                                    self.set_base_value(
                                         key.clone(),
                                         ValueWithLayout::Exchanged(
                                             TriompheArc::new(patched_value),
@@ -698,10 +714,31 @@ impl<T: Transaction> ResourceState<T> for ParallelState<'_, T> {
 }
 
 impl<T: Transaction> ResourceGroupState<T> for ParallelState<'_, T> {
+    fn update_tagged_base_value_with_layout(
+        &self,
+        group_key: T::Key,
+        tag: T::Tag,
+        value: T::Value,
+        layout: Option<TriompheArc<MoveTypeLayout>>,
+    ) {
+        self.versioned_map
+            .group_data()
+            .update_tagged_base_value_with_layout(
+                group_key,
+                tag,
+                ValueWithLayout::Exchanged(TriompheArc::new(value), layout.clone()),
+                |prev, new| {
+                    if matches!(prev, ValueWithLayout::RawFromStorage(_)) {
+                        *prev = new;
+                    }
+                },
+            );
+    }
+
     fn set_raw_group_base_values(
         &self,
         group_key: T::Key,
-        base_values: Vec<(T::Tag, T::Value)>,
+        base_values: Vec<(T::Tag, ValueWithLayout<T::Value>)>,
     ) -> PartialVMResult<()> {
         self.versioned_map
             .group_data()
@@ -760,14 +797,12 @@ impl<T: Transaction> ResourceGroupState<T> for ParallelState<'_, T> {
                             );
                             match patch_base_value(v.as_ref(), layout) {
                                 Ok(patched_value) => {
-                                    self.versioned_map
-                                        .group_data()
-                                        .update_tagged_base_value_with_layout(
-                                            group_key.clone(),
-                                            resource_tag.clone(),
-                                            patched_value,
-                                            layout.cloned().map(TriompheArc::new),
-                                        );
+                                    self.update_tagged_base_value_with_layout(
+                                        group_key.clone(),
+                                        resource_tag.clone(),
+                                        patched_value,
+                                        layout.cloned().map(TriompheArc::new),
+                                    );
                                     // Re-fetch in case a concurrent change went through.
                                     continue;
                                 },
@@ -794,14 +829,12 @@ impl<T: Transaction> ResourceGroupState<T> for ParallelState<'_, T> {
                     // TagNotFound means group was initialized (o.w. Uninitialized branch
                     // would be visited), but the tag didn't exist. So record an empty resource
                     // as a base value, and do continue to retry the read.
-                    self.versioned_map
-                        .group_data()
-                        .update_tagged_base_value_with_layout(
-                            group_key.clone(),
-                            resource_tag.clone(),
-                            TransactionWrite::from_state_value(None),
-                            None,
-                        );
+                    self.update_tagged_base_value_with_layout(
+                        group_key.clone(),
+                        resource_tag.clone(),
+                        TransactionWrite::from_state_value(None),
+                        None,
+                    );
                     continue;
                 },
                 Err(Dependency(dep_idx)) => {
@@ -820,7 +853,7 @@ impl<T: Transaction> ResourceGroupState<T> for ParallelState<'_, T> {
 }
 
 pub(crate) struct SequentialState<'a, T: Transaction> {
-    pub(crate) unsync_map: &'a UnsyncMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+    pub(crate) unsync_map: &'a UnsyncMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
     pub(crate) read_set: RefCell<UnsyncReadSet<T, ModuleId>>,
     pub(crate) start_counter: u32,
     pub(crate) counter: &'a RefCell<u32>,
@@ -828,7 +861,7 @@ pub(crate) struct SequentialState<'a, T: Transaction> {
 
 impl<'a, T: Transaction> SequentialState<'a, T> {
     pub fn new(
-        unsync_map: &'a UnsyncMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        unsync_map: &'a UnsyncMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         start_counter: u32,
         counter: &'a RefCell<u32>,
     ) -> Self {
@@ -894,7 +927,7 @@ impl<T: Transaction> ResourceState<T> for SequentialState<'_, T> {
                     }
                 }
 
-                match ReadResult::from_value::<T>(value, &target_kind) {
+                match ReadResult::from_value(value, &target_kind) {
                     Ok(read_result) => {
                         // Get read summary in CapturedReads filters only value reads,
                         // to be consistent, UnsyncReadSet does not record other kinds.
@@ -924,10 +957,24 @@ impl<T: Transaction> ResourceState<T> for SequentialState<'_, T> {
 }
 
 impl<T: Transaction> ResourceGroupState<T> for SequentialState<'_, T> {
+    fn update_tagged_base_value_with_layout(
+        &self,
+        group_key: T::Key,
+        tag: T::Tag,
+        value: T::Value,
+        layout: Option<TriompheArc<MoveTypeLayout>>,
+    ) {
+        self.unsync_map.update_tagged_base_value_with_layout(
+            group_key,
+            tag,
+            ValueWithLayout::Exchanged(TriompheArc::new(value.clone()), layout),
+        )
+    }
+
     fn set_raw_group_base_values(
         &self,
         group_key: T::Key,
-        base_values: Vec<(T::Tag, T::Value)>,
+        base_values: Vec<(T::Tag, ValueWithLayout<T::Value>)>,
     ) -> PartialVMResult<()> {
         self.unsync_map
             .set_group_base_values(group_key.clone(), base_values)
@@ -957,18 +1004,16 @@ impl<T: Transaction> ResourceGroupState<T> for SequentialState<'_, T> {
                     if let ValueWithLayout::RawFromStorage(v) = value {
                         match patch_base_value(v.as_ref(), layout) {
                             Ok(patched_value) => {
-                                let arced_layout = layout.cloned().map(TriompheArc::new);
+                                let patched_value = ValueWithLayout::Exchanged(
+                                    TriompheArc::new(patched_value),
+                                    layout.cloned().map(TriompheArc::new),
+                                );
                                 self.unsync_map.update_tagged_base_value_with_layout(
                                     group_key.clone(),
                                     resource_tag.clone(),
                                     patched_value.clone(),
-                                    arced_layout.clone(),
                                 );
-
-                                value = ValueWithLayout::Exchanged(
-                                    TriompheArc::new(patched_value),
-                                    arced_layout,
-                                );
+                                value = patched_value;
                             },
                             Err(e) => {
                                 error!("Couldn't patch a group value from unsync map: {}", e);
@@ -979,7 +1024,7 @@ impl<T: Transaction> ResourceGroupState<T> for SequentialState<'_, T> {
                     }
                 }
 
-                match GroupReadResult::from_value::<T>(value, &target_kind) {
+                match GroupReadResult::from_value(value, &target_kind) {
                     Ok(group_read_result) => {
                         // Only record Value reads into the read set to keep sequential
                         // and parallel ReadWriteSummary consistent. In the parallel path,
@@ -1322,7 +1367,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
     fn get_reads_needing_exchange_sequential(
         &self,
         read_set: &HashSet<T::Key>,
-        unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        unsync_map: &UnsyncMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         delayed_write_set_ids: &HashSet<DelayedFieldID>,
         skip: &HashSet<T::Key>,
     ) -> Result<BTreeMap<T::Key, (StateValueMetadata, u64, TriompheArc<MoveTypeLayout>)>, PanicError>
@@ -1412,7 +1457,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
     fn get_group_reads_needing_exchange_sequential(
         &self,
         group_read_set: &HashMap<T::Key, HashSet<T::Tag>>,
-        unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
+        unsync_map: &UnsyncMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         delayed_write_set_ids: &HashSet<DelayedFieldID>,
         skip: &HashSet<T::Key>,
     ) -> PartialVMResult<BTreeMap<T::Key, (StateValueMetadata, u64)>> {
@@ -1586,10 +1631,8 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         let base_group_sentinel_ops = base_group
             .into_iter()
             .map(|(t, bytes)| {
-                (
-                    t,
-                    TransactionWrite::from_state_value(Some(StateValue::new_legacy(bytes))),
-                )
+                let v = TransactionWrite::from_state_value(Some(StateValue::new_legacy(bytes)));
+                (t, ValueWithLayout::RawFromStorage(TriompheArc::new(v)))
             })
             .collect();
 
@@ -2925,7 +2968,7 @@ mod test {
     }
 
     struct Holder {
-        unsync_map: UnsyncMap<KeyType<u32>, u32, ValueType, DelayedFieldID>,
+        unsync_map: UnsyncMap<KeyType<u32>, u32, ValueWithLayout<ValueType>, DelayedFieldID>,
         counter: RefCell<u32>,
         base_view: MockStateView<KeyType<u32>>,
         empty_global_module_cache:
@@ -2974,7 +3017,7 @@ mod test {
         counter: AtomicU32,
         base_view: MockStateView<KeyType<u32>>,
         runtime_environment: RuntimeEnvironment,
-        versioned_map: MVHashMap<KeyType<u32>, u32, ValueType, DelayedFieldID>,
+        versioned_map: MVHashMap<KeyType<u32>, u32, ValueWithLayout<ValueType>, DelayedFieldID>,
         scheduler: Scheduler,
     }
 

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -14,10 +14,7 @@ use aptos_aggregator::{
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManagerGuard,
     executor::BlockExecutor,
-    task::{
-        AfterMaterializationOutput, BeforeMaterializationOutput, ExecutionStatus, ExecutorTask,
-        TransactionOutput,
-    },
+    task::{BeforeMaterializationOutput, ExecutionStatus, ExecutorTask, TransactionOutput},
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::default::DefaultTxnProvider,
     types::InputOutputKey,
@@ -27,6 +24,7 @@ use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
     block_executor::{
         config::BlockExecutorConfig, transaction_slice_metadata::TransactionSliceMetadata,
+        value::ValueWithLayout,
     },
     contract_event::ContractEvent,
     error::PanicError,
@@ -58,7 +56,7 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
     value::{MoveTypeLayout, MoveValue},
-    vm_status::{StatusCode, VMStatus},
+    vm_status::VMStatus,
 };
 use move_vm_runtime::{
     execution_tracing::Trace,
@@ -157,62 +155,35 @@ impl BlockExecutableTransaction for TestTransaction {
 }
 
 #[derive(Debug)]
-struct TestOutput {
-    committed: OnceCell<aptos_types::transaction::TransactionOutput>,
-}
+struct TestOutput;
 
 impl TransactionOutput for TestOutput {
-    type AfterMaterializationGuard<'a> = &'a Self;
     type BeforeMaterializationGuard<'a> = &'a Self;
+    type CommittedOutput = aptos_types::transaction::TransactionOutput;
     type Txn = TestTransaction;
 
-    fn committed_output(&self) -> &OnceCell<aptos_types::transaction::TransactionOutput> {
-        &self.committed
-    }
-
     fn skip_output() -> Self {
-        Self {
-            committed: OnceCell::new(),
-        }
-    }
-
-    fn discard_output(_discard_code: StatusCode) -> Self {
-        Self {
-            committed: OnceCell::new(),
-        }
+        Self
     }
 
     fn before_materialization(&self) -> Result<Self::BeforeMaterializationGuard<'_>, PanicError> {
         Ok(self)
     }
 
-    fn after_materialization(&self) -> Result<Self::AfterMaterializationGuard<'_>, PanicError> {
-        Ok(self)
-    }
-
-    fn is_materialized_and_success(&self) -> bool {
-        true
-    }
-
-    fn check_materialization(&self) -> Result<bool, PanicError> {
-        Ok(true)
-    }
-
     fn incorporate_materialized_txn_output(
         &mut self,
         _patched_resource_write_set: Vec<(StateKey, WriteOp)>,
         _patched_events: Vec<ContractEvent>,
-    ) -> Result<Trace, PanicError> {
-        Ok(Trace::empty())
+    ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
+        Ok((
+            aptos_types::transaction::TransactionOutput::new_empty_success(),
+            Trace::empty(),
+        ))
     }
-
-    fn set_txn_output_for_non_dynamic_change_set(&mut self) {}
 }
 
 impl BeforeMaterializationOutput<TestTransaction> for &TestOutput {
-    fn resource_write_set(
-        &self,
-    ) -> HashMap<StateKey, (TriompheArc<WriteOp>, Option<TriompheArc<MoveTypeLayout>>)> {
+    fn resource_write_set(&self) -> HashMap<StateKey, ValueWithLayout<WriteOp>> {
         HashMap::new()
     }
 
@@ -244,9 +215,9 @@ impl BeforeMaterializationOutput<TestTransaction> for &TestOutput {
     ) -> HashMap<
         StateKey,
         (
-            WriteOp,
+            ValueWithLayout<WriteOp>,
             ResourceGroupSize,
-            BTreeMap<StructTag, (WriteOp, Option<TriompheArc<MoveTypeLayout>>)>,
+            BTreeMap<StructTag, ValueWithLayout<WriteOp>>,
         ),
     > {
         HashMap::new()
@@ -288,16 +259,6 @@ impl BeforeMaterializationOutput<TestTransaction> for &TestOutput {
 
     fn storage_keys_written(&self) -> impl Iterator<Item = &StateKey> {
         std::iter::empty()
-    }
-}
-
-impl AfterMaterializationOutput<TestTransaction> for &TestOutput {
-    fn fee_statement(&self) -> FeeStatement {
-        FeeStatement::zero()
-    }
-
-    fn has_new_epoch_event(&self) -> bool {
-        false
     }
 }
 
@@ -375,13 +336,7 @@ impl ExecutorTask for TestTask {
         };
         *outcome_cell().lock().unwrap() = Some(outcome);
 
-        ExecutionStatus::Success(TestOutput {
-            committed: OnceCell::new(),
-        })
-    }
-
-    fn is_transaction_dynamic_change_set_capable(_txn: &Self::Txn) -> bool {
-        unreachable!("Never used for tests")
+        ExecutionStatus::Success(TestOutput)
     }
 }
 

--- a/aptos-move/mvhashmap/Cargo.toml
+++ b/aptos-move/mvhashmap/Cargo.toml
@@ -29,7 +29,6 @@ move-core-types = { workspace = true }
 move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true }
 serde = { workspace = true }
-triomphe = { workspace = true }
 
 [dev-dependencies]
 aptos-aggregator = { workspace = true, features = ["testing"] }

--- a/aptos-move/mvhashmap/src/lib.rs
+++ b/aptos-move/mvhashmap/src/lib.rs
@@ -5,9 +5,7 @@ use crate::{
     types::TxnIndex, versioned_data::VersionedData,
     versioned_delayed_fields::VersionedDelayedFields, versioned_group_data::VersionedGroupData,
 };
-use aptos_types::{
-    executable::ModulePath, vm::modules::AptosModuleExtension, write_set::TransactionWrite,
-};
+use aptos_types::{block_executor::value::SpeculativeValue, vm::modules::AptosModuleExtension};
 use move_binary_format::{file_format::CompiledScript, CompiledModule};
 use move_core_types::language_storage::ModuleId;
 use move_vm_runtime::{Module, Script};
@@ -38,7 +36,7 @@ mod unit_tests;
 /// different multi-version data-structures (MVData and MVGroupData). It would also
 /// allow performing a check on the path once during initialization (to determine
 /// if the path is for a resource or a group), and then checking invariants.
-pub struct MVHashMap<K, T, V: TransactionWrite, I: Clone> {
+pub struct MVHashMap<K, T, V, I> {
     data: VersionedData<K, V>,
     group_data: VersionedGroupData<K, T, V>,
     delayed_fields: VersionedDelayedFields<I>,
@@ -50,14 +48,13 @@ pub struct MVHashMap<K, T, V: TransactionWrite, I: Clone> {
 
 impl<K, T, V, I> MVHashMap<K, T, V, I>
 where
-    K: ModulePath + Hash + Clone + Eq + Debug,
+    K: Hash + Clone + Eq + Debug,
     T: Hash + Clone + Eq + Debug + Serialize,
-    V: TransactionWrite + PartialEq,
+    V: SpeculativeValue,
     I: Copy + Clone + Eq + Hash + Debug,
 {
     #[allow(clippy::new_without_default)]
     pub fn new() -> MVHashMap<K, T, V, I> {
-        #[allow(deprecated)]
         MVHashMap {
             data: VersionedData::empty(),
             group_data: VersionedGroupData::empty(),

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -2,14 +2,9 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_aggregator::types::DelayedFieldsSpeculativeError;
-use aptos_types::{
-    error::PanicOr,
-    write_set::{TransactionWrite, WriteOpKind},
-};
-use fail::fail_point;
+use aptos_types::error::PanicOr;
 use move_core_types::value::MoveTypeLayout;
 use std::sync::atomic::AtomicU32;
-use triomphe::Arc;
 
 pub type AtomicTxnIndex = AtomicU32;
 pub type TxnIndex = u32;
@@ -48,7 +43,7 @@ pub enum MVDataError {
 pub enum MVDataOutput<V> {
     /// Information from the last versioned-write. Note that the version is returned
     /// and not the data to avoid copying big values around.
-    Versioned(Version, ValueWithLayout<V>),
+    Versioned(Version, V),
 }
 
 // TODO[agg_v2](cleanup): once VersionedAggregators is separated from the MVHashMap,
@@ -117,72 +112,6 @@ impl ShiftedTxnIndex {
     }
 }
 
-// TODO[agg_v2](cleanup): consider adding `DoesntExist` variant.
-// Currently, "not existing value" is represented as Deletion.
-#[derive(Debug, PartialEq, Eq)]
-pub enum ValueWithLayout<V> {
-    // When we read from storage, but don't have access to layout, we can only store the raw value.
-    // This should never be returned to the user, before exchange is performed.
-    RawFromStorage(Arc<V>),
-    // We've used the optional layout, and applied exchange to the storage value.
-    // The type layout is Some if there is a delayed field in the resource.
-    // The type layout is None if there is no delayed field in the resource.
-    Exchanged(Arc<V>, Option<Arc<MoveTypeLayout>>),
-}
-
-impl<T> Clone for ValueWithLayout<T> {
-    fn clone(&self) -> Self {
-        match self {
-            ValueWithLayout::RawFromStorage(value) => {
-                ValueWithLayout::RawFromStorage(value.clone())
-            },
-            ValueWithLayout::Exchanged(value, layout) => {
-                ValueWithLayout::Exchanged(value.clone(), layout.clone())
-            },
-        }
-    }
-}
-
-impl<V: TransactionWrite> ValueWithLayout<V> {
-    pub fn write_op_kind(&self) -> WriteOpKind {
-        match self {
-            ValueWithLayout::RawFromStorage(value) => value.write_op_kind(),
-            ValueWithLayout::Exchanged(value, _) => value.write_op_kind(),
-        }
-    }
-
-    pub fn bytes_len(&self) -> Option<usize> {
-        fail_point!("value_with_layout_bytes_len", |_| { Some(10) });
-        match self {
-            ValueWithLayout::RawFromStorage(value) | ValueWithLayout::Exchanged(value, _) => {
-                value.bytes().map(|b| b.len())
-            },
-        }
-    }
-
-    pub fn extract_value_no_layout(&self) -> &V {
-        match self {
-            ValueWithLayout::RawFromStorage(value) => value.as_ref(),
-            ValueWithLayout::Exchanged(value, None) => value.as_ref(),
-            ValueWithLayout::Exchanged(_, Some(_)) => panic!("Unexpected layout"),
-        }
-    }
-
-    /// Returns a reference to the underlying value, regardless of whether a layout is present.
-    /// Unlike `extract_value_no_layout`, this method does not panic when a layout is present.
-    pub fn extract_value(&self) -> &V {
-        match self {
-            ValueWithLayout::RawFromStorage(value) => value.as_ref(),
-            ValueWithLayout::Exchanged(value, _) => value.as_ref(),
-        }
-    }
-
-    /// Returns true if this value has a layout (i.e., contains delayed fields).
-    pub fn has_layout(&self) -> bool {
-        matches!(self, ValueWithLayout::Exchanged(_, Some(_)))
-    }
-}
-
 #[derive(Clone, Debug)]
 pub enum UnknownOrLayout<'a> {
     Unknown,
@@ -194,33 +123,16 @@ pub enum UnknownOrLayout<'a> {
 pub(crate) mod test {
     use super::*;
     use aptos_types::{
-        executable::ModulePath,
+        block_executor::value::SpeculativeValue,
         state_store::state_value::StateValue,
         write_set::{TransactionWrite, WriteOpKind},
     };
     use bytes::Bytes;
     use claims::{assert_err, assert_ok_eq};
-    use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
     use std::{fmt::Debug, hash::Hash};
 
     #[derive(Clone, Eq, Hash, PartialEq, Debug)]
-    pub(crate) struct KeyType<K: Hash + Clone + Debug + Eq>(
-        /// Wrapping the types used for testing to add ModulePath trait implementation.
-        pub K,
-    );
-
-    impl<K: Hash + Clone + Eq + Debug> ModulePath for KeyType<K> {
-        fn is_module_path(&self) -> bool {
-            false
-        }
-
-        fn from_address_and_module_name(
-            _address: &AccountAddress,
-            _module_name: &IdentStr,
-        ) -> Self {
-            unreachable!("Irrelevant for test")
-        }
-    }
+    pub(crate) struct KeyType<K: Hash + Clone + Debug + Eq>(pub K);
 
     #[test]
     fn test_shifted_idx() {
@@ -299,6 +211,24 @@ pub(crate) mod test {
         }
     }
 
+    impl SpeculativeValue for TestValue {
+        fn eq_value(&self, other: &Self) -> bool {
+            self == other
+        }
+
+        fn eq_metadata(&self, _other: &Self) -> bool {
+            unimplemented!("Irrelevant for the test")
+        }
+
+        fn bytes_len(&self) -> Option<usize> {
+            (!self.bytes.is_empty()).then_some(self.bytes.len())
+        }
+
+        fn write_op_kind(&self) -> WriteOpKind {
+            self.kind.clone()
+        }
+    }
+
     impl TransactionWrite for TestValue {
         fn bytes(&self) -> Option<&Bytes> {
             (!self.bytes.is_empty()).then_some(&self.bytes)
@@ -322,13 +252,7 @@ pub(crate) mod test {
     }
 
     // Generate a Vec deterministically based on txn_idx and incarnation.
-    fn value_for(txn_idx: TxnIndex, incarnation: Incarnation) -> TestValue {
+    pub(crate) fn value_for(txn_idx: TxnIndex, incarnation: Incarnation) -> TestValue {
         TestValue::new(vec![txn_idx * 5, txn_idx + incarnation, incarnation * 5])
-    }
-
-    // Generate the value_for txn_idx and incarnation in arc.
-    pub(crate) fn arc_value_for(txn_idx: TxnIndex, incarnation: Incarnation) -> Arc<TestValue> {
-        // Generate a Vec deterministically based on txn_idx and incarnation.
-        Arc::new(value_for(txn_idx, incarnation))
     }
 }

--- a/aptos-move/mvhashmap/src/unit_tests/dependencies.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/dependencies.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
-    types::{test::KeyType, Incarnation, MVDataError, MVDataOutput, TxnIndex, ValueWithLayout},
+    types::{test::KeyType, Incarnation, MVDataError, MVDataOutput, TxnIndex},
     MVHashMap,
 };
 use crate::{types::ShiftedTxnIndex, unit_tests::proptest_types::MockValue};
@@ -19,7 +19,6 @@ use std::{
     time::Duration,
 };
 use test_case::test_case;
-use triomphe::Arc;
 
 #[derive(Debug, Clone)]
 enum Operator<V: Debug + Clone> {
@@ -132,8 +131,7 @@ fn test_dependencies(
                                                 key,
                                                 idx as TxnIndex,
                                                 0,
-                                                Arc::new(MockValue::new(Some(*v))),
-                                                None,
+                                                MockValue::new(Some(*v)),
                                             )
                                             .unwrap(),
                                     );
@@ -146,8 +144,7 @@ fn test_dependencies(
                                                 key.clone(),
                                                 idx as TxnIndex,
                                                 0,
-                                                Arc::new(MockValue::new(Some(*v))),
-                                                None,
+                                                MockValue::new(Some(*v)),
                                             )
                                             .unwrap(),
                                     );
@@ -191,30 +188,20 @@ fn test_dependencies(
                                         || {
                                             // Comparison ignores version since push invalidation
                                             // is based only on values.
-                                            value
-                                                == ValueWithLayout::Exchanged(
-                                                    Arc::new(MockValue::new(None)),
-                                                    None,
-                                                )
+                                            value == MockValue::new(None)
                                         },
                                         |(_expected_txn_idx, expected_output)| {
                                             // Comparison ignores expected_txn_idx since push
                                             // validation is based only on values.
-                                            value
-                                                == ValueWithLayout::Exchanged(
-                                                    Arc::new(expected_output.clone()),
-                                                    None,
-                                                )
+                                            value == expected_output.clone()
                                         },
                                     )
                             },
                             Err(MVDataError::Uninitialized) => {
                                 map.data().set_base_value(
                                     KeyType(key),
-                                    ValueWithLayout::Exchanged(
-                                        Arc::new(MockValue::new(None)),
-                                        None,
-                                    ),
+                                    MockValue::new(None),
+                                    |_, _| {},
                                 );
                                 assert_ok!(rescheduled_reads.push((txn_idx, incarnation + 1)));
                                 false

--- a/aptos-move/mvhashmap/src/unit_tests/mod.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/mod.rs
@@ -3,21 +3,18 @@
 
 use super::{
     types::{
-        test::{arc_value_for, KeyType, TestValue},
+        test::{KeyType, TestValue},
         MVDataError, MVDataOutput,
     },
     unsync_map::UnsyncMap,
     *,
 };
-use crate::types::ValueWithLayout;
+use crate::types::test::value_for;
 use aptos_types::{
-    on_chain_config::CurrentTimeMicroseconds,
-    state_store::state_value::{StateValue, StateValueMetadata},
+    on_chain_config::CurrentTimeMicroseconds, state_store::state_value::StateValueMetadata,
     write_set::WriteOpKind,
 };
-use bytes::Bytes;
 use claims::{assert_none, assert_some_eq};
-use triomphe::Arc;
 
 mod dependencies;
 mod proptest_types;
@@ -31,18 +28,11 @@ fn unsync_map_data_basic() {
     // Reads that should go the DB return None
     assert_none!(map.fetch_data(&ap));
     // Ensure write registers the new value.
-    //TODO[agg_v2](tests): Hardocoding layout to None. Test when layout is Some(.) as well.
-    map.write(ap.clone(), arc_value_for(10, 1), None);
-    assert_some_eq!(
-        map.fetch_data(&ap),
-        ValueWithLayout::Exchanged(arc_value_for(10, 1), None)
-    );
+    map.write(ap.clone(), value_for(10, 1));
+    assert_some_eq!(map.fetch_data(&ap), value_for(10, 1));
     // Ensure the next write overwrites the value.
-    map.write(ap.clone(), arc_value_for(14, 1), None);
-    assert_some_eq!(
-        map.fetch_data(&ap),
-        ValueWithLayout::Exchanged(arc_value_for(14, 1), None)
-    );
+    map.write(ap.clone(), value_for(14, 1));
+    assert_some_eq!(map.fetch_data(&ap), value_for(14, 1));
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,23 +40,7 @@ struct TestMetadataValue {
     metadata: u64,
 }
 
-impl TransactionWrite for TestMetadataValue {
-    fn bytes(&self) -> Option<&Bytes> {
-        unimplemented!("Irrelevant for the test")
-    }
-
-    fn write_op_kind(&self) -> WriteOpKind {
-        unimplemented!("Irrelevant for the test")
-    }
-
-    fn from_state_value(_maybe_state_value: Option<StateValue>) -> Self {
-        unimplemented!("Irrelevant for the test")
-    }
-
-    fn as_state_value(&self) -> Option<StateValue> {
-        unimplemented!("Irrelevant for the test")
-    }
-
+impl TestMetadataValue {
     fn as_state_value_metadata(&self) -> Option<StateValueMetadata> {
         Some(StateValueMetadata::legacy(
             self.metadata,
@@ -75,9 +49,23 @@ impl TransactionWrite for TestMetadataValue {
             },
         ))
     }
+}
 
-    fn set_bytes(&mut self, _bytes: Bytes) {
-        unimplemented!("Irrelevant for the test")
+impl SpeculativeValue for TestMetadataValue {
+    fn eq_value(&self, other: &Self) -> bool {
+        self == other
+    }
+
+    fn eq_metadata(&self, other: &Self) -> bool {
+        self.as_state_value_metadata() == other.as_state_value_metadata()
+    }
+
+    fn bytes_len(&self) -> Option<usize> {
+        None
+    }
+
+    fn write_op_kind(&self) -> WriteOpKind {
+        unimplemented!("Irrelevant for the tests")
     }
 }
 
@@ -123,7 +111,7 @@ fn create_write_read_placeholder_struct() {
     // Write by txn 10.
     mvtbl
         .data()
-        .write(ap1.clone(), 10, 1, arc_value_for(10, 1), None)
+        .write(ap1.clone(), 10, 1, value_for(10, 1))
         .unwrap();
 
     // Reads that should go the DB return Err(Uninitialized)
@@ -135,49 +123,25 @@ fn create_write_read_placeholder_struct() {
 
     // Reads for a higher txn return the entry written by txn 10.
     let r_10 = mvtbl.data().fetch_data_no_record(&ap1, 15);
-    assert_eq!(
-        Ok(Versioned(
-            Ok((10, 1)),
-            ValueWithLayout::Exchanged(arc_value_for(10, 1), None)
-        )),
-        r_10
-    );
+    assert_eq!(Ok(Versioned(Ok((10, 1)), value_for(10, 1))), r_10);
 
     // More writes.
     mvtbl
         .data()
-        .write(ap1.clone(), 12, 0, arc_value_for(12, 0), None)
+        .write(ap1.clone(), 12, 0, value_for(12, 0))
         .unwrap();
     mvtbl
         .data()
-        .write(ap1.clone(), 8, 3, arc_value_for(8, 3), None)
+        .write(ap1.clone(), 8, 3, value_for(8, 3))
         .unwrap();
 
     // Verify reads return the latest write below the reader index.
     let r_12 = mvtbl.data().fetch_data_no_record(&ap1, 15);
-    assert_eq!(
-        Ok(Versioned(
-            Ok((12, 0)),
-            ValueWithLayout::Exchanged(arc_value_for(12, 0), None)
-        )),
-        r_12
-    );
+    assert_eq!(Ok(Versioned(Ok((12, 0)), value_for(12, 0))), r_12);
     let r_10 = mvtbl.data().fetch_data_no_record(&ap1, 11);
-    assert_eq!(
-        Ok(Versioned(
-            Ok((10, 1)),
-            ValueWithLayout::Exchanged(arc_value_for(10, 1), None)
-        )),
-        r_10
-    );
+    assert_eq!(Ok(Versioned(Ok((10, 1)), value_for(10, 1))), r_10);
     let r_8 = mvtbl.data().fetch_data_no_record(&ap1, 10);
-    assert_eq!(
-        Ok(Versioned(
-            Ok((8, 3)),
-            ValueWithLayout::Exchanged(arc_value_for(8, 3), None)
-        )),
-        r_8
-    );
+    assert_eq!(Ok(Versioned(Ok((8, 3)), value_for(8, 3))), r_8);
 
     // Mark the entry written by 10 as an estimate.
     mvtbl.data().mark_estimate(&ap1, 10);
@@ -190,44 +154,26 @@ fn create_write_read_placeholder_struct() {
     mvtbl.data().remove(&ap1, 10);
     mvtbl
         .data()
-        .write(ap2.clone(), 10, 2, arc_value_for(10, 2), None)
+        .write(ap2.clone(), 10, 2, value_for(10, 2))
         .unwrap();
 
     // Read by txn 11 no longer observes entry from txn 10.
     let r_8 = mvtbl.data().fetch_data_no_record(&ap1, 11);
-    assert_eq!(
-        Ok(Versioned(
-            Ok((8, 3)),
-            ValueWithLayout::Exchanged(arc_value_for(8, 3), None)
-        )),
-        r_8
-    );
+    assert_eq!(Ok(Versioned(Ok((8, 3)), value_for(8, 3))), r_8);
 
     // Reads, writes for ap2 and ap3.
     mvtbl
         .data()
-        .write(ap2.clone(), 5, 0, arc_value_for(5, 0), None)
+        .write(ap2.clone(), 5, 0, value_for(5, 0))
         .unwrap();
     mvtbl
         .data()
-        .write(ap3.clone(), 20, 4, arc_value_for(20, 4), None)
+        .write(ap3.clone(), 20, 4, value_for(20, 4))
         .unwrap();
     let r_5 = mvtbl.data().fetch_data_no_record(&ap2, 10);
-    assert_eq!(
-        Ok(Versioned(
-            Ok((5, 0)),
-            ValueWithLayout::Exchanged(arc_value_for(5, 0), None)
-        )),
-        r_5
-    );
+    assert_eq!(Ok(Versioned(Ok((5, 0)), value_for(5, 0))), r_5);
     let r_20 = mvtbl.data().fetch_data_no_record(&ap3, 21);
-    assert_eq!(
-        Ok(Versioned(
-            Ok((20, 4)),
-            ValueWithLayout::Exchanged(arc_value_for(20, 4), None)
-        )),
-        r_20
-    );
+    assert_eq!(Ok(Versioned(Ok((20, 4)), value_for(20, 4))), r_20);
 
     // Clear ap1 and ap3.
     mvtbl.data().remove(&ap1, 12);
@@ -242,29 +188,5 @@ fn create_write_read_placeholder_struct() {
 
     // Read entry by txn 10 at ap2.
     let r_10 = mvtbl.data().fetch_data_no_record(&ap2, 15);
-    assert_eq!(
-        Ok(Versioned(
-            Ok((10, 2)),
-            ValueWithLayout::Exchanged(arc_value_for(10, 2), None)
-        )),
-        r_10
-    );
-}
-
-#[test]
-#[should_panic]
-fn aggregator_base_mismatch() {
-    let vd: VersionedData<KeyType<Vec<u8>>, TestValue> = VersionedData::empty();
-    let ap = KeyType(b"/foo/b".to_vec());
-
-    vd.set_base_value(
-        ap.clone(),
-        ValueWithLayout::RawFromStorage(Arc::new(TestValue::creation_with_len(1))),
-    );
-    // This call must panic, because it provides a mismatching base value:
-    // However, only base value length is compared in assert.
-    vd.set_base_value(
-        ap,
-        ValueWithLayout::RawFromStorage(Arc::new(TestValue::creation_with_len(2))),
-    );
+    assert_eq!(Ok(Versioned(Ok((10, 2)), value_for(10, 2))), r_10);
 }

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -5,11 +5,7 @@ use super::{
     types::{test::KeyType, MVDataError, MVDataOutput, MVGroupError, TxnIndex},
     MVHashMap,
 };
-use crate::types::ValueWithLayout;
-use aptos_types::{
-    state_store::state_value::StateValue,
-    write_set::{TransactionWrite, WriteOpKind},
-};
+use aptos_types::{block_executor::value::SpeculativeValue, write_set::WriteOpKind};
 use aptos_vm_types::resolver::ResourceGroupSize;
 use bytes::Bytes;
 use proptest::{collection::vec, prelude::*, sample::Index, strategy::Strategy};
@@ -19,7 +15,6 @@ use std::{
     hash::Hash,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use triomphe::Arc;
 
 const DEFAULT_TIMEOUT: u64 = 30;
 
@@ -57,25 +52,28 @@ impl<V: Into<Vec<u8>> + Clone + Eq + PartialEq> MockValue<V> {
     }
 }
 
-impl<V: Into<Vec<u8>> + Clone + Debug + Eq + PartialEq> TransactionWrite for MockValue<V> {
-    fn bytes(&self) -> Option<&Bytes> {
-        self.maybe_bytes.as_ref()
+impl<V: Into<Vec<u8>> + Clone + Debug + Eq + PartialEq + Send + Sync> SpeculativeValue
+    for MockValue<V>
+{
+    fn eq_value(&self, other: &Self) -> bool {
+        self == other
+    }
+
+    fn eq_metadata(&self, _other: &Self) -> bool {
+        unimplemented!("Irrelevant for the tests")
+    }
+
+    fn bytes_len(&self) -> Option<usize> {
+        self.maybe_value.as_ref().map(|v| v.clone().into().len())
+    }
+
+    fn is_deletion(&self) -> bool {
+        // A missing value represents a deletion.
+        self.maybe_value.is_none()
     }
 
     fn write_op_kind(&self) -> WriteOpKind {
-        unimplemented!("Irrelevant for the test")
-    }
-
-    fn from_state_value(_maybe_state_value: Option<StateValue>) -> Self {
-        unimplemented!("Irrelevant for the test")
-    }
-
-    fn as_state_value(&self) -> Option<StateValue> {
-        unimplemented!("Irrelevant for the test")
-    }
-
-    fn set_bytes(&mut self, bytes: Bytes) {
-        self.maybe_bytes = Some(bytes);
+        unimplemented!("Irrelevant for the tests")
     }
 }
 
@@ -167,7 +165,7 @@ where
                     key.clone(),
                     idx,
                     0,
-                    vec![(5, (value, None))],
+                    vec![(5, value)],
                     ResourceGroupSize::zero_combined(),
                     HashSet::new(),
                 )
@@ -176,9 +174,7 @@ where
             map.group_data()
                 .mark_estimate(&key, idx, tags_5.iter().collect());
         } else {
-            map.data()
-                .write(key.clone(), idx, 0, Arc::new(value), None)
-                .unwrap();
+            map.data().write(key.clone(), idx, 0, value).unwrap();
             map.data().mark_estimate(&key, idx);
         }
     }
@@ -202,11 +198,7 @@ where
                         use MVDataOutput::*;
 
                         let baseline = baseline.get(key, idx as TxnIndex);
-                        let assert_value = |v: ValueWithLayout<MockValue<V>>| match v
-                            .extract_value_no_layout()
-                            .maybe_value
-                            .as_ref()
-                        {
+                        let assert_value = |v: MockValue<V>| match v.maybe_value.as_ref() {
                             Some(w) => {
                                 assert_eq!(baseline, ExpectedOutput::Value(w.clone()), "{:?}", idx);
                             },
@@ -266,15 +258,13 @@ where
                                     key,
                                     idx as TxnIndex,
                                     1,
-                                    vec![(5, (value, None))],
+                                    vec![(5, value)],
                                     ResourceGroupSize::zero_combined(),
                                     HashSet::new(),
                                 )
                                 .unwrap();
                         } else {
-                            map.data()
-                                .write(key, idx as TxnIndex, 1, Arc::new(value), None)
-                                .unwrap();
+                            map.data().write(key, idx as TxnIndex, 1, value).unwrap();
                         }
                     },
                     Operator::Insert(v) => {
@@ -286,15 +276,13 @@ where
                                     key,
                                     idx as TxnIndex,
                                     1,
-                                    vec![(5, (value, None))],
+                                    vec![(5, value)],
                                     ResourceGroupSize::zero_combined(),
                                     HashSet::new(),
                                 )
                                 .unwrap();
                         } else {
-                            map.data()
-                                .write(key, idx as TxnIndex, 1, Arc::new(value), None)
-                                .unwrap();
+                            map.data().write(key, idx as TxnIndex, 1, value).unwrap();
                         }
                     },
                 }

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -2,20 +2,19 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    types::{TxnIndex, UnsyncGroupError, ValueWithLayout},
+    types::{TxnIndex, UnsyncGroupError},
     BlockStateStats,
 };
 use anyhow::anyhow;
 use aptos_aggregator::types::DelayedFieldValue;
 use aptos_types::{
+    block_executor::value::SpeculativeValue,
     error::{code_invariant_error, PanicError},
-    executable::ModulePath,
     vm::modules::AptosModuleExtension,
-    write_set::TransactionWrite,
 };
 use aptos_vm_types::{resolver::ResourceGroupSize, resource_group_adapter::group_size_as_sum};
 use move_binary_format::{file_format::CompiledScript, CompiledModule};
-use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout};
+use move_core_types::language_storage::ModuleId;
 use move_vm_runtime::{Module, Script};
 use move_vm_types::code::{ModuleCache, ModuleCode, UnsyncModuleCache, UnsyncScriptCache};
 use serde::Serialize;
@@ -29,19 +28,12 @@ use std::{
         Arc,
     },
 };
-use triomphe::Arc as TriompheArc;
 
 /// UnsyncMap is designed to mimic the functionality of MVHashMap for sequential execution.
 /// In this case only the latest recorded version is relevant, simplifying the implementation.
-pub struct UnsyncMap<
-    K: ModulePath,
-    T: Hash + Clone + Debug + Eq + Serialize,
-    V: TransactionWrite,
-    I: Copy,
-> {
-    // Only use Arc to provide unified interfaces with the MVHashMap.
-    resource_map: RefCell<HashMap<K, ValueWithLayout<V>>>,
-    group_cache: RefCell<HashMap<K, RefCell<(HashMap<T, ValueWithLayout<V>>, ResourceGroupSize)>>>,
+pub struct UnsyncMap<K, T, V, I> {
+    resource_map: RefCell<HashMap<K, V>>,
+    group_cache: RefCell<HashMap<K, RefCell<(HashMap<T, V>, ResourceGroupSize)>>>,
     delayed_field_map: RefCell<HashMap<I, DelayedFieldValue>>,
 
     // Code caches for modules and scripts.
@@ -53,13 +45,7 @@ pub struct UnsyncMap<
     total_base_delayed_field_size: AtomicU64,
 }
 
-impl<
-        K: ModulePath + Hash + Clone + Eq,
-        T: Hash + Clone + Debug + Eq + Serialize,
-        V: TransactionWrite,
-        I: Hash + Clone + Copy + Eq,
-    > Default for UnsyncMap<K, T, V, I>
-{
+impl<K, T, V, I> Default for UnsyncMap<K, T, V, I> {
     fn default() -> Self {
         Self {
             resource_map: RefCell::new(HashMap::new()),
@@ -73,12 +59,12 @@ impl<
     }
 }
 
-impl<
-        K: ModulePath + Hash + Clone + Eq + Debug,
-        T: Hash + Clone + Debug + Eq + Serialize,
-        V: TransactionWrite,
-        I: Hash + Clone + Copy + Eq,
-    > UnsyncMap<K, T, V, I>
+impl<K, T, V, I> UnsyncMap<K, T, V, I>
+where
+    K: Hash + Clone + Eq + Debug,
+    T: Hash + Clone + Debug + Eq + Serialize,
+    V: SpeculativeValue,
+    I: Hash + Clone + Copy + Eq,
 {
     pub fn new() -> Self {
         Self::default()
@@ -125,10 +111,7 @@ impl<
         group_key: K,
         base_values: impl IntoIterator<Item = (T, V)>,
     ) -> anyhow::Result<()> {
-        let base_map: HashMap<T, ValueWithLayout<V>> = base_values
-            .into_iter()
-            .map(|(t, v)| (t, ValueWithLayout::RawFromStorage(TriompheArc::new(v))))
-            .collect();
+        let base_map = base_values.into_iter().collect::<HashMap<_, _>>();
         let base_size = group_size_as_sum(
             base_map
                 .iter()
@@ -151,23 +134,14 @@ impl<
         Ok(())
     }
 
-    pub fn update_tagged_base_value_with_layout(
-        &self,
-        group_key: K,
-        tag: T,
-        value: V,
-        layout: Option<TriompheArc<MoveTypeLayout>>,
-    ) {
+    pub fn update_tagged_base_value_with_layout(&self, group_key: K, tag: T, value: V) {
         self.group_cache
             .borrow_mut()
             .get_mut(&group_key)
             .expect("Unable to fetch the entry for the group key in group_cache")
             .borrow_mut()
             .0
-            .insert(
-                tag,
-                ValueWithLayout::Exchanged(TriompheArc::new(value), layout),
-            );
+            .insert(tag, value);
     }
 
     pub fn get_group_size(&self, group_key: &K) -> Option<ResourceGroupSize> {
@@ -181,7 +155,7 @@ impl<
         &self,
         group_key: &K,
         value_tag: &T,
-    ) -> Result<ValueWithLayout<V>, UnsyncGroupError> {
+    ) -> Result<V, UnsyncGroupError> {
         self.group_cache.borrow().get(group_key).map_or(
             Err(UnsyncGroupError::Uninitialized),
             |group_map| {
@@ -200,7 +174,7 @@ impl<
         &self,
         group_key: &K,
     ) -> (
-        impl Iterator<Item = (T, ValueWithLayout<V>)> + use<K, T, V, I>,
+        impl Iterator<Item = (T, V)> + use<K, T, V, I>,
         ResourceGroupSize,
     ) {
         let binding = self.group_cache.borrow();
@@ -215,11 +189,11 @@ impl<
     pub fn insert_group_ops(
         &self,
         group_key: &K,
-        group_ops: impl IntoIterator<Item = (T, (V, Option<TriompheArc<MoveTypeLayout>>))>,
+        group_ops: impl IntoIterator<Item = (T, V)>,
         group_size: ResourceGroupSize,
     ) -> Result<(), PanicError> {
-        for (value_tag, (group_op, maybe_layout)) in group_ops.into_iter() {
-            self.insert_group_op(group_key, value_tag, group_op, maybe_layout)?;
+        for (tag, value) in group_ops.into_iter() {
+            self.insert_group_op(group_key, tag, value)?;
         }
         self.group_cache
             .borrow_mut()
@@ -230,13 +204,7 @@ impl<
         Ok(())
     }
 
-    fn insert_group_op(
-        &self,
-        group_key: &K,
-        value_tag: T,
-        v: V,
-        maybe_layout: Option<TriompheArc<MoveTypeLayout>>,
-    ) -> Result<(), PanicError> {
+    fn insert_group_op(&self, group_key: &K, value_tag: T, v: V) -> Result<(), PanicError> {
         use aptos_types::write_set::WriteOpKind::*;
         use std::collections::hash_map::Entry::*;
         match (
@@ -253,24 +221,15 @@ impl<
                 entry.remove();
             },
             (Occupied(mut entry), Modification) => {
-                entry.insert(ValueWithLayout::Exchanged(
-                    TriompheArc::new(v),
-                    maybe_layout,
-                ));
+                entry.insert(v);
             },
             (Vacant(entry), Creation) => {
-                entry.insert(ValueWithLayout::Exchanged(
-                    TriompheArc::new(v),
-                    maybe_layout,
-                ));
+                entry.insert(v);
             },
-            (l, r) => {
+            (_, kind) => {
                 return Err(code_invariant_error(format!(
-                    "WriteOp kind {:?} not consistent with previous value at tag {:?}. Existing: {:?}, new: {:?}",
-                    v.write_op_kind(),
-                    value_tag,
-		    l,
-		    r,
+                    "WriteOp kind {:?} not consistent with the existing value at tag {:?}",
+                    kind, value_tag,
                 )));
             },
         }
@@ -278,32 +237,17 @@ impl<
         Ok(())
     }
 
-    pub fn fetch_data(&self, key: &K) -> Option<ValueWithLayout<V>> {
+    pub fn fetch_data(&self, key: &K) -> Option<V> {
         self.resource_map.borrow().get(key).cloned()
     }
 
-    pub fn fetch_exchanged_data(
-        &self,
-        key: &K,
-    ) -> Result<(TriompheArc<V>, TriompheArc<MoveTypeLayout>), PanicError> {
-        let data = self.fetch_data(key);
-        if let Some(ValueWithLayout::Exchanged(value, Some(layout))) = data {
-            Ok((value, layout))
-        } else {
-            Err(code_invariant_error(format!(
-                "Read value needing exchange {:?} does not exist or not in Exchanged format",
-                data
-            )))
-        }
-    }
-
-    pub fn fetch_group_data(&self, key: &K) -> Option<Vec<(TriompheArc<T>, ValueWithLayout<V>)>> {
+    pub fn fetch_group_data(&self, key: &K) -> Option<Vec<(T, V)>> {
         self.group_cache.borrow().get(key).map(|group_map| {
             group_map
                 .borrow()
                 .0
                 .iter()
-                .map(|(tag, value)| (TriompheArc::new(tag.clone()), value.clone()))
+                .map(|(tag, value)| (tag.clone(), value.clone()))
                 .collect()
         })
     }
@@ -312,18 +256,11 @@ impl<
         self.delayed_field_map.borrow().get(id).cloned()
     }
 
-    pub fn write(
-        &self,
-        key: K,
-        value: TriompheArc<V>,
-        layout: Option<TriompheArc<MoveTypeLayout>>,
-    ) {
-        self.resource_map
-            .borrow_mut()
-            .insert(key, ValueWithLayout::Exchanged(value, layout));
+    pub fn write(&self, key: K, value: V) {
+        self.resource_map.borrow_mut().insert(key, value);
     }
 
-    pub fn set_base_value(&self, key: K, value: ValueWithLayout<V>) {
+    pub fn set_base_value(&self, key: K, value: V) {
         let cur_size = value.bytes_len();
         if self.resource_map.borrow_mut().insert(key, value).is_none() {
             if let Some(cur_size) = cur_size {
@@ -355,7 +292,7 @@ mod test {
     fn finalize_group_as_hashmap(
         map: &UnsyncMap<KeyType<Vec<u8>>, usize, TestValue, ()>,
         key: &KeyType<Vec<u8>>,
-    ) -> HashMap<usize, ValueWithLayout<TestValue>> {
+    ) -> HashMap<usize, TestValue> {
         map.finalize_group(key).0.collect()
     }
 
@@ -371,81 +308,44 @@ mod test {
             (1..4).map(|i| (i, TestValue::with_kind(i, true))),
         )
         .unwrap();
-        assert_ok!(map.insert_group_op(&ap, 2, TestValue::with_kind(202, false), None));
-        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(203, false), None));
+        assert_ok!(map.insert_group_op(&ap, 2, TestValue::with_kind(202, false)));
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(203, false)));
         let committed = finalize_group_as_hashmap(&map, &ap);
 
-        // // The value at tag 1 is from base, while 2 and 3 are from txn 3.
-        // // (Arc compares with value equality)
+        // The value at tag 1 is from base, while 2 and 3 are from txn 3.
         assert_eq!(committed.len(), 3);
-        assert_some_eq!(
-            committed.get(&1),
-            &ValueWithLayout::RawFromStorage(TriompheArc::new(TestValue::with_kind(1, true)))
-        );
-        assert_some_eq!(
-            committed.get(&2),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(202, false)), None)
-        );
-        assert_some_eq!(
-            committed.get(&3),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(203, false)), None)
-        );
+        assert_some_eq!(committed.get(&1), &TestValue::with_kind(1, true));
+        assert_some_eq!(committed.get(&2), &TestValue::with_kind(202, false));
+        assert_some_eq!(committed.get(&3), &TestValue::with_kind(203, false));
 
-        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(303, false), None));
-        assert_ok!(map.insert_group_op(&ap, 4, TestValue::with_kind(304, true), None));
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(303, false)));
+        assert_ok!(map.insert_group_op(&ap, 4, TestValue::with_kind(304, true)));
         let committed = finalize_group_as_hashmap(&map, &ap);
         assert_eq!(committed.len(), 4);
-        assert_some_eq!(
-            committed.get(&1),
-            &ValueWithLayout::RawFromStorage(TriompheArc::new(TestValue::with_kind(1, true)))
-        );
-        assert_some_eq!(
-            committed.get(&2),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(202, false)), None)
-        );
-        assert_some_eq!(
-            committed.get(&3),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(303, false)), None)
-        );
-        assert_some_eq!(
-            committed.get(&4),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(304, true)), None)
-        );
+        assert_some_eq!(committed.get(&1), &TestValue::with_kind(1, true));
+        assert_some_eq!(committed.get(&2), &TestValue::with_kind(202, false));
+        assert_some_eq!(committed.get(&3), &TestValue::with_kind(303, false));
+        assert_some_eq!(committed.get(&4), &TestValue::with_kind(304, true));
 
-        assert_ok!(map.insert_group_op(&ap, 0, TestValue::with_kind(100, true), None));
-        assert_ok!(map.insert_group_op(&ap, 1, TestValue::deletion(), None));
-        assert_err!(map.insert_group_op(&ap, 1, TestValue::deletion(), None));
+        assert_ok!(map.insert_group_op(&ap, 0, TestValue::with_kind(100, true)));
+        assert_ok!(map.insert_group_op(&ap, 1, TestValue::deletion()));
+        assert_err!(map.insert_group_op(&ap, 1, TestValue::deletion()));
         let committed = finalize_group_as_hashmap(&map, &ap);
         assert_eq!(committed.len(), 4);
-        assert_some_eq!(
-            committed.get(&0),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(100, true)), None)
-        );
+        assert_some_eq!(committed.get(&0), &TestValue::with_kind(100, true));
         assert_none!(committed.get(&1));
-        assert_some_eq!(
-            committed.get(&2),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(202, false)), None)
-        );
-        assert_some_eq!(
-            committed.get(&3),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(303, false)), None)
-        );
-        assert_some_eq!(
-            committed.get(&4),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(304, true)), None)
-        );
+        assert_some_eq!(committed.get(&2), &TestValue::with_kind(202, false));
+        assert_some_eq!(committed.get(&3), &TestValue::with_kind(303, false));
+        assert_some_eq!(committed.get(&4), &TestValue::with_kind(304, true));
 
-        assert_ok!(map.insert_group_op(&ap, 0, TestValue::deletion(), None));
-        assert_ok!(map.insert_group_op(&ap, 1, TestValue::with_kind(400, true), None));
-        assert_ok!(map.insert_group_op(&ap, 2, TestValue::deletion(), None));
-        assert_ok!(map.insert_group_op(&ap, 3, TestValue::deletion(), None));
-        assert_ok!(map.insert_group_op(&ap, 4, TestValue::deletion(), None));
+        assert_ok!(map.insert_group_op(&ap, 0, TestValue::deletion()));
+        assert_ok!(map.insert_group_op(&ap, 1, TestValue::with_kind(400, true)));
+        assert_ok!(map.insert_group_op(&ap, 2, TestValue::deletion()));
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::deletion()));
+        assert_ok!(map.insert_group_op(&ap, 4, TestValue::deletion()));
         let committed = finalize_group_as_hashmap(&map, &ap);
         assert_eq!(committed.len(), 1);
-        assert_some_eq!(
-            committed.get(&1),
-            &ValueWithLayout::Exchanged(TriompheArc::new(TestValue::with_kind(400, true)), None)
-        );
+        assert_some_eq!(committed.get(&1), &TestValue::with_kind(400, true));
     }
 
     #[should_panic]
@@ -470,7 +370,7 @@ mod test {
         let ap = KeyType(b"/foo/f".to_vec());
         let map = UnsyncMap::<KeyType<Vec<u8>>, usize, TestValue, ()>::new();
 
-        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(10, true), None));
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(10, true)));
     }
 
     #[should_panic]
@@ -497,10 +397,10 @@ mod test {
         .unwrap();
 
         let tag: usize = 5;
-        let one_entry_len = TestValue::creation_with_len(1).bytes().unwrap().len();
-        let two_entry_len = TestValue::creation_with_len(2).bytes().unwrap().len();
-        let three_entry_len = TestValue::creation_with_len(3).bytes().unwrap().len();
-        let four_entry_len = TestValue::creation_with_len(4).bytes().unwrap().len();
+        let one_entry_len = TestValue::creation_with_len(1).bytes_len().unwrap_or(0);
+        let two_entry_len = TestValue::creation_with_len(2).bytes_len().unwrap_or(0);
+        let three_entry_len = TestValue::creation_with_len(3).bytes_len().unwrap_or(0);
+        let four_entry_len = TestValue::creation_with_len(4).bytes_len().unwrap_or(0);
 
         let base_size = group_size_as_sum(vec![(&tag, one_entry_len); 4].into_iter()).unwrap();
         assert_some_eq!(map.get_group_size(&ap), base_size);
@@ -515,19 +415,19 @@ mod test {
         .unwrap();
         assert_err!(map.insert_group_ops(
             &ap,
-            vec![(0, (TestValue::modification_with_len(2), None))],
+            vec![(0, TestValue::modification_with_len(2))],
             exp_size,
         ));
         assert_err!(map.insert_group_ops(
             &ap,
-            vec![(1, (TestValue::creation_with_len(2), None))],
+            vec![(1, TestValue::creation_with_len(2))],
             exp_size,
         ));
         assert_ok!(map.insert_group_ops(
             &ap,
             vec![
-                (0, (TestValue::creation_with_len(2), None)),
-                (1, (TestValue::modification_with_len(2), None))
+                (0, TestValue::creation_with_len(2)),
+                (1, TestValue::modification_with_len(2))
             ],
             exp_size
         ));
@@ -543,8 +443,8 @@ mod test {
         assert_ok!(map.insert_group_ops(
             &ap,
             vec![
-                (4, (TestValue::modification_with_len(3), None)),
-                (5, (TestValue::creation_with_len(3), None)),
+                (4, TestValue::modification_with_len(3)),
+                (5, TestValue::creation_with_len(3)),
             ],
             exp_size
         ));
@@ -560,8 +460,8 @@ mod test {
         assert_ok!(map.insert_group_ops(
             &ap,
             vec![
-                (0, (TestValue::modification_with_len(4), None)),
-                (1, (TestValue::modification_with_len(4), None))
+                (0, TestValue::modification_with_len(4)),
+                (1, TestValue::modification_with_len(4))
             ],
             exp_size
         ));
@@ -589,7 +489,7 @@ mod test {
         for i in 1..5 {
             assert_ok_eq!(
                 map.fetch_group_tagged_data(&ap, &i),
-                ValueWithLayout::RawFromStorage(TriompheArc::new(TestValue::creation_with_len(i)),)
+                TestValue::creation_with_len(i)
             );
         }
         assert_err_eq!(
@@ -601,9 +501,9 @@ mod test {
             UnsyncGroupError::TagNotFound
         );
 
-        assert_ok!(map.insert_group_op(&ap, 1, TestValue::deletion(), None));
-        assert_ok!(map.insert_group_op(&ap, 3, TestValue::modification_with_len(8), None));
-        assert_ok!(map.insert_group_op(&ap, 6, TestValue::creation_with_len(9), None));
+        assert_ok!(map.insert_group_op(&ap, 1, TestValue::deletion()));
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::modification_with_len(8)));
+        assert_ok!(map.insert_group_op(&ap, 6, TestValue::creation_with_len(9)));
 
         assert_err_eq!(
             map.fetch_group_tagged_data(&ap, &1),
@@ -611,11 +511,11 @@ mod test {
         );
         assert_ok_eq!(
             map.fetch_group_tagged_data(&ap, &3),
-            ValueWithLayout::Exchanged(TriompheArc::new(TestValue::modification_with_len(8)), None,)
+            TestValue::modification_with_len(8)
         );
         assert_ok_eq!(
             map.fetch_group_tagged_data(&ap, &6),
-            ValueWithLayout::Exchanged(TriompheArc::new(TestValue::creation_with_len(9)), None,)
+            TestValue::creation_with_len(9)
         );
 
         // others unaffected.
@@ -625,11 +525,11 @@ mod test {
         );
         assert_ok_eq!(
             map.fetch_group_tagged_data(&ap, &2),
-            ValueWithLayout::RawFromStorage(TriompheArc::new(TestValue::creation_with_len(2)),)
+            TestValue::creation_with_len(2)
         );
         assert_ok_eq!(
             map.fetch_group_tagged_data(&ap, &4),
-            ValueWithLayout::RawFromStorage(TriompheArc::new(TestValue::creation_with_len(4)),)
+            TestValue::creation_with_len(4)
         );
     }
 }

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -5,26 +5,24 @@ use crate::{
     registered_dependencies::{
         check_lowest_dependency_idx, take_dependencies, RegisteredReadDependencies,
     },
-    types::{Incarnation, MVDataError, MVDataOutput, ShiftedTxnIndex, TxnIndex, ValueWithLayout},
+    types::{Incarnation, MVDataError, MVDataOutput, ShiftedTxnIndex, TxnIndex},
 };
 use anyhow::Result;
 use aptos_infallible::Mutex;
 use aptos_types::{
+    block_executor::value::SpeculativeValue,
     error::{code_invariant_error, PanicError},
-    write_set::TransactionWrite,
 };
 use claims::{assert_ok, assert_some};
 use crossbeam::utils::CachePadded;
 use dashmap::DashMap;
 use equivalent::Equivalent;
-use move_core_types::value::MoveTypeLayout;
 use std::{
     collections::btree_map::{self, BTreeMap},
     fmt::Debug,
     hash::Hash,
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
-use triomphe::Arc;
 
 pub(crate) const FLAG_DONE: bool = false;
 pub(crate) const FLAG_ESTIMATE: bool = true;
@@ -47,7 +45,7 @@ pub(crate) struct Entry<V> {
 /// a shared pointer (to ensure ownership and avoid clones).
 struct EntryCell<V> {
     incarnation: Incarnation,
-    value_with_layout: ValueWithLayout<V>,
+    value: V,
     dependencies: Mutex<RegisteredReadDependencies>,
 }
 
@@ -65,12 +63,12 @@ pub struct VersionedData<K, V> {
 
 fn new_write_entry<V>(
     incarnation: Incarnation,
-    value: ValueWithLayout<V>,
+    value: V,
     dependencies: BTreeMap<TxnIndex, Incarnation>,
 ) -> Entry<EntryCell<V>> {
     Entry::new(EntryCell {
         incarnation,
-        value_with_layout: value,
+        value,
         dependencies: Mutex::new(RegisteredReadDependencies::from_dependencies(dependencies)),
     })
 }
@@ -92,7 +90,7 @@ impl<V> Entry<V> {
     }
 }
 
-impl<V: TransactionWrite> Default for VersionedValue<V> {
+impl<V> Default for VersionedValue<V> {
     fn default() -> Self {
         Self {
             versioned_map: BTreeMap::new(),
@@ -100,12 +98,7 @@ impl<V: TransactionWrite> Default for VersionedValue<V> {
     }
 }
 
-// TODO(BlockSTMv2): remove TransactionWrite trait requirement from V, even if
-// AggregatorV1 code is not removed by definining a more specialized trait that can
-// runtime assert in other variants. Add other variants to stored cells that allow
-// storing group metadata and group size together at the group key (currently metadata
-// is stored in a fake write entry, and group size is stored in MVGroupData map).
-impl<V: TransactionWrite + PartialEq> VersionedValue<V> {
+impl<V: SpeculativeValue> VersionedValue<V> {
     // Extracts read dependencies from the data-structure that are affected by a write
     // of 'data' at 'txn_idx'. Some of these dependencies that remain valid can be
     // relocated by a caller to a different (new) entry in the data-structure. The
@@ -113,8 +106,7 @@ impl<V: TransactionWrite + PartialEq> VersionedValue<V> {
     fn split_off_affected_read_dependencies<const ONLY_COMPARE_METADATA: bool>(
         &self,
         txn_idx: TxnIndex,
-        new_data: &Arc<V>,
-        new_maybe_layout: &Option<Arc<MoveTypeLayout>>,
+        new_value: &V,
     ) -> (BTreeMap<TxnIndex, Incarnation>, bool) {
         let mut affected_deps = BTreeMap::new();
         let mut still_valid = false;
@@ -130,25 +122,17 @@ impl<V: TransactionWrite + PartialEq> VersionedValue<V> {
         {
             let EntryCell {
                 incarnation: _,
-                value_with_layout,
+                value,
                 dependencies,
             } = &entry.value;
 
             // Take dependencies above txn_idx
             affected_deps = dependencies.lock().split_off(txn_idx + 1);
             if !affected_deps.is_empty() {
-                // Non-exchanged format is default validation failure.
-                if let ValueWithLayout::Exchanged(
-                    previous_entry_value,
-                    previous_entry_maybe_layout,
-                ) = value_with_layout
-                {
-                    still_valid = compare_values_and_layouts::<ONLY_COMPARE_METADATA, V>(
-                        previous_entry_value,
-                        new_data,
-                        previous_entry_maybe_layout.as_ref(),
-                        new_maybe_layout.as_ref(),
-                    );
+                still_valid = if ONLY_COMPARE_METADATA {
+                    value.eq_metadata(new_value)
+                } else {
+                    value.eq_value(new_value)
                 }
             }
         }
@@ -164,8 +148,7 @@ impl<V: TransactionWrite + PartialEq> VersionedValue<V> {
         &mut self,
         txn_idx: TxnIndex,
         mut dependencies: BTreeMap<TxnIndex, Incarnation>,
-        removed_data: &Arc<V>,
-        removed_maybe_layout: &Option<Arc<MoveTypeLayout>>,
+        removed_value: &V,
     ) -> Result<BTreeMap<TxnIndex, Incarnation>, PanicError> {
         // If we have dependencies and a next (lower) entry exists, validate against it.
         if !dependencies.is_empty() {
@@ -180,25 +163,21 @@ impl<V: TransactionWrite + PartialEq> VersionedValue<V> {
                     "Entry at txn_idx must be removed before calling handle_removed_dependencies"
                 );
 
-                // Non-exchanged format is default validation failure.
-                if let EntryCell {
+                let EntryCell {
                     incarnation: _,
-                    value_with_layout: ValueWithLayout::Exchanged(entry_value, entry_maybe_layout),
+                    value,
                     dependencies: next_lower_deps,
-                } = &next_lower_entry.value
-                {
-                    let still_valid = compare_values_and_layouts::<ONLY_COMPARE_METADATA, V>(
-                        entry_value,
-                        removed_data,
-                        entry_maybe_layout.as_ref(),
-                        removed_maybe_layout.as_ref(),
-                    );
+                } = &next_lower_entry.value;
+                let still_valid = if ONLY_COMPARE_METADATA {
+                    value.eq_metadata(removed_value)
+                } else {
+                    value.eq_value(removed_value)
+                };
 
-                    if still_valid {
-                        next_lower_deps
-                            .lock()
-                            .extend_with_higher_dependencies(std::mem::take(&mut dependencies))?;
-                    }
+                if still_valid {
+                    next_lower_deps
+                        .lock()
+                        .extend_with_higher_dependencies(std::mem::take(&mut dependencies))?;
                 }
             }
         }
@@ -232,7 +211,7 @@ impl<V: TransactionWrite + PartialEq> VersionedValue<V> {
 
             let EntryCell {
                 incarnation,
-                value_with_layout,
+                value,
                 dependencies,
             } = &entry.value;
 
@@ -246,7 +225,7 @@ impl<V: TransactionWrite + PartialEq> VersionedValue<V> {
 
             return Ok(Versioned(
                 idx.idx().map(|idx| (idx, *incarnation)),
-                value_with_layout.clone(),
+                value.clone(),
             ));
         }
 
@@ -254,34 +233,7 @@ impl<V: TransactionWrite + PartialEq> VersionedValue<V> {
     }
 }
 
-// Helper function to perform push validation whereby a read of an entry containing
-// prev_value with prev_maybe_layout would now be reading an entry containing new_value
-// with new_maybe_layout.
-fn compare_values_and_layouts<
-    const ONLY_COMPARE_METADATA: bool,
-    V: TransactionWrite + PartialEq,
->(
-    prev_value: &V,
-    new_value: &V,
-    prev_maybe_layout: Option<&Arc<MoveTypeLayout>>,
-    new_maybe_layout: Option<&Arc<MoveTypeLayout>>,
-) -> bool {
-    // ONLY_COMPARE_METADATA is a const static flag that indicates that these entries are
-    // versioning metadata only, and not the actual value (Currently, only used for versioning
-    // resource group metadata). Hence, validation is only performed on the metadata.
-    if ONLY_COMPARE_METADATA {
-        prev_value.as_state_value_metadata() == new_value.as_state_value_metadata()
-    } else {
-        // Layouts pass validation only if they are both None. Otherwise, validation pessimistically
-        // fails. This is a simple logic that avoids potentially costly layout comparisons.
-        prev_maybe_layout.is_none() && new_maybe_layout.is_none() && prev_value == new_value
-    }
-    // TODO(BlockSTMv2): optimize layout validation (potentially based on size, or by having
-    // a more efficient representation. Optimizing value validation by having a configurable
-    // size threshold above which validation can automatically pessimistically fail.
-}
-
-impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedData<K, V> {
+impl<K: Hash + Clone + Debug + Eq, V: SpeculativeValue> VersionedData<K, V> {
     pub(crate) fn empty() -> Self {
         Self {
             values: DashMap::new(),
@@ -356,23 +308,11 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
 
         let EntryCell {
             incarnation: _,
-            value_with_layout,
+            value,
             dependencies,
         } = &removed_entry.value;
-        match value_with_layout {
-            ValueWithLayout::RawFromStorage(_) => {
-                unreachable!("Removed value written by txn {txn_idx} may not be RawFromStorage");
-            },
-            ValueWithLayout::Exchanged(data, layout) => {
-                let removed_deps = take_dependencies(dependencies);
-                v.handle_removed_dependencies::<ONLY_COMPARE_METADATA>(
-                    txn_idx,
-                    removed_deps,
-                    data,
-                    layout,
-                )
-            },
-        }
+        let removed_deps = take_dependencies(dependencies);
+        v.handle_removed_dependencies::<ONLY_COMPARE_METADATA>(txn_idx, removed_deps, value)
     }
 
     // Fetches data but does not record a read dependency. This is used for BlockSTMv1
@@ -410,76 +350,33 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
             .unwrap_or(Err(MVDataError::Uninitialized))
     }
 
-    // The caller needs to repeat the read after set_base_value (concurrent caller might have
-    // exchanged and stored a different delayed field ID).
-    pub fn set_base_value(&self, key: K, base_value_with_layout: ValueWithLayout<V>) {
+    /// Sets the base value (at index 0) for a key. On a vacant slot the value is inserted and
+    /// its size accounted; on an occupied slot 'on_occupied' runs under the entry lock, receiving
+    /// the stored value by reference and the incoming value, and decides whether to overwrite it
+    /// in place (dependencies and the estimate flag are preserved by construction). The caller
+    /// may need to repeat the read afterward, as a concurrent caller might have exchanged and
+    /// stored a different delayed field ID.
+    pub fn set_base_value(&self, key: K, base_value: V, on_occupied: impl FnOnce(&mut V, V)) {
         let mut v = self.values.entry(key).or_default();
         // For base value, incarnation is irrelevant, and is always set to 0.
 
         use btree_map::Entry::*;
-        use ValueWithLayout::*;
         match v.versioned_map.entry(ShiftedTxnIndex::zero_idx()) {
             Vacant(vacant_entry) => {
-                if let Some(base_size) = base_value_with_layout.bytes_len() {
+                if let Some(base_size) = base_value.bytes_len() {
                     self.total_base_value_size
                         .fetch_add(base_size as u64, Ordering::Relaxed);
                 }
                 vacant_entry.insert(CachePadded::new(new_write_entry(
                     0,
-                    base_value_with_layout,
+                    base_value,
                     BTreeMap::new(),
                 )));
             },
             Occupied(mut o) => {
-                let EntryCell {
-                    incarnation,
-                    value_with_layout: existing_value_with_layout,
-                    dependencies,
-                } = &o.get().value;
-                assert_eq!(*incarnation, 0);
-                match (existing_value_with_layout, &base_value_with_layout) {
-                    (RawFromStorage(existing_value), RawFromStorage(base_value)) => {
-                        // Base value from storage needs to be identical
-                        // Assert the length of bytes for efficiency (instead of full equality)
-                        assert_eq!(
-                            base_value.bytes().map(|b| b.len()),
-                            existing_value.bytes().map(|b| b.len())
-                        );
-                    },
-                    (Exchanged(_, _), RawFromStorage(_)) => {
-                        // Stored value contains more info, nothing to do.
-                    },
-                    (RawFromStorage(_), Exchanged(_, _)) => {
-                        // Received more info, update, but keep the same dependencies.
-                        // TODO(BlockSTMv2): Once we support dependency kind, here we could check
-                        // that carried over dependencies can be only size & metadata.
-                        o.insert(CachePadded::new(new_write_entry(
-                            0,
-                            base_value_with_layout,
-                            take_dependencies(dependencies),
-                        )));
-                    },
-                    (
-                        Exchanged(existing_value, existing_layout),
-                        Exchanged(base_value, base_layout),
-                    ) => {
-                        // base value may have already been provided by another transaction
-                        // executed simultaneously and asking for the same resource.
-                        // Value from storage must be identical, but then delayed field
-                        // identifier exchange could've modified it.
-                        //
-                        // If maybe_layout is None, they are required to be identical
-                        // If maybe_layout is Some, there might have been an exchange
-                        // Assert the length of bytes for efficiency (instead of full equality)
-                        assert_eq!(existing_layout.is_some(), base_layout.is_some());
-                        if existing_layout.is_none() {
-                            assert_eq!(
-                                existing_value.bytes().map(|b| b.len()),
-                                base_value.bytes().map(|b| b.len())
-                            );
-                        }
-                    },
-                }
+                let cell = &mut o.get_mut().value;
+                assert_eq!(cell.incarnation, 0);
+                on_occupied(&mut cell.value, base_value);
             },
         };
     }
@@ -488,11 +385,9 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
         versioned_values: &mut VersionedValue<V>,
         txn_idx: TxnIndex,
         incarnation: Incarnation,
-        value: ValueWithLayout<V>,
+        value: V,
         dependencies: BTreeMap<TxnIndex, Incarnation>,
     ) -> Result<(), PanicError> {
-        // Clone is cheap here: ValueWithLayout only contains Arc references,
-        // so cloning is just atomic reference count increments (O(1)).
         let value_clone = value.clone();
         let prev_entry = versioned_values.versioned_map.insert(
             ShiftedTxnIndex::new(txn_idx),
@@ -504,13 +399,11 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
         //
         // Special case for incarnation 0: Pre-write optimization may write the same key-value
         // at incarnation 0 before execution starts. When execution later writes the same value
-        // at incarnation 0, we allow this as long as the values are identical and neither has
-        // a layout. Values with layouts (delayed fields) require special handling and cannot
-        // be safely compared this way.
+        // at incarnation 0, we allow this as long as the values are identical.
         if let Some(entry) = prev_entry {
             let EntryCell {
                 incarnation: prev_incarnation,
-                value_with_layout: prev_value,
+                value: prev_value,
                 ..
             } = &entry.value;
             {
@@ -519,23 +412,15 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
                 // prev_dependencies is empty: they must have been drained beforehand
                 // (into dependencies) if there was an entry at the same index before.
                 if *prev_incarnation >= incarnation {
-                    // At incarnation 0, allow overwrite if values match and neither has a layout.
+                    // At incarnation 0, allow overwrite if values match.
                     // This supports the pre-write optimization where we pre-populate MVHashMap.
-                    if incarnation == 0
-                        && !prev_value.has_layout()
-                        && !value_clone.has_layout()
-                        && prev_value.extract_value() == value_clone.extract_value()
-                    {
+                    if incarnation == 0 && prev_value.eq_value(&value_clone) {
                         return Ok(());
                     }
 
                     // Determine the error cause for a more descriptive message.
                     let error_cause = if incarnation == 0 && *prev_incarnation == 0 {
-                        if prev_value.has_layout() || value_clone.has_layout() {
-                            "pre-write mismatch: values have layouts that cannot be compared"
-                        } else {
-                            "pre-write mismatch: values differ"
-                        }
+                        "pre-write mismatch"
                     } else {
                         "incarnation regression"
                     };
@@ -555,17 +440,10 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
         key: K,
         txn_idx: TxnIndex,
         incarnation: Incarnation,
-        data: Arc<V>,
-        maybe_layout: Option<Arc<MoveTypeLayout>>,
+        value: V,
     ) -> Result<(), PanicError> {
         let mut v = self.values.entry(key).or_default();
-        Self::write_impl(
-            &mut v,
-            txn_idx,
-            incarnation,
-            ValueWithLayout::Exchanged(data, maybe_layout),
-            BTreeMap::new(),
-        )
+        Self::write_impl(&mut v, txn_idx, incarnation, value, BTreeMap::new())
     }
 
     /// Write a value at a given key (and version) for BlockSTMv2.
@@ -575,16 +453,11 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
         key: K,
         txn_idx: TxnIndex,
         incarnation: Incarnation,
-        data: Arc<V>,
-        maybe_layout: Option<Arc<MoveTypeLayout>>,
+        value: V,
     ) -> Result<BTreeMap<TxnIndex, Incarnation>, PanicError> {
         let mut v = self.values.entry(key).or_default();
-        let (affected_dependencies, validation_passed) = v
-            .split_off_affected_read_dependencies::<ONLY_COMPARE_METADATA>(
-                txn_idx,
-                &data,
-                &maybe_layout,
-            );
+        let (affected_dependencies, validation_passed) =
+            v.split_off_affected_read_dependencies::<ONLY_COMPARE_METADATA>(txn_idx, &value);
 
         // Asserted (local, easily checkable invariant), since affected dependencies are obtained
         // by calling split_off at txn_idx + 1.
@@ -598,13 +471,7 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
             (BTreeMap::new(), affected_dependencies)
         };
 
-        Self::write_impl(
-            &mut v,
-            txn_idx,
-            incarnation,
-            ValueWithLayout::Exchanged(data, maybe_layout),
-            deps_to_retain,
-        )?;
+        Self::write_impl(&mut v, txn_idx, incarnation, value, deps_to_retain)?;
 
         Ok(deps_to_return)
     }
@@ -617,30 +484,20 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite + PartialEq> VersionedDat
         key: K,
         txn_idx: TxnIndex,
         incarnation: Incarnation,
-        data: V,
+        value: V,
     ) -> bool {
-        let arc_data = Arc::new(data);
+        let value_clone = value.clone();
 
         let mut v = self.values.entry(key).or_default();
         let prev_entry = v.versioned_map.insert(
             ShiftedTxnIndex::new(txn_idx),
-            CachePadded::new(new_write_entry(
-                incarnation,
-                ValueWithLayout::Exchanged(arc_data.clone(), None),
-                BTreeMap::new(),
-            )),
+            CachePadded::new(new_write_entry(incarnation, value, BTreeMap::new())),
         );
 
         // Changes versioned metadata that was stored.
-        prev_entry.is_none_or(|entry| -> bool {
-            let EntryCell {
-                value_with_layout: existing_value_with_layout,
-                ..
-            } = &entry.value;
-            arc_data.as_state_value_metadata()
-                != existing_value_with_layout
-                    .extract_value_no_layout()
-                    .as_state_value_metadata()
+        prev_entry.is_none_or(|entry| {
+            let EntryCell { value, .. } = &entry.value;
+            !value.eq_metadata(&value_clone)
         })
     }
 
@@ -668,11 +525,9 @@ mod tests {
     use super::*;
     use crate::types::StorageVersion;
     use aptos_types::{
-        on_chain_config::CurrentTimeMicroseconds,
-        state_store::state_value::{StateValue, StateValueMetadata},
-        write_set::{TransactionWrite, WriteOpKind},
+        on_chain_config::CurrentTimeMicroseconds, state_store::state_value::StateValueMetadata,
+        write_set::WriteOpKind,
     };
-    use bytes::Bytes;
     use claims::{assert_err, assert_ok_eq};
     use fail::FailScenario;
     use test_case::test_case;
@@ -687,28 +542,6 @@ mod tests {
         fn new(value: u64, metadata: u64) -> Self {
             Self { value, metadata }
         }
-    }
-
-    impl TransactionWrite for TestValueWithMetadata {
-        fn bytes(&self) -> Option<&Bytes> {
-            unimplemented!("Irrelevant for the test")
-        }
-
-        fn write_op_kind(&self) -> WriteOpKind {
-            unimplemented!("Irrelevant for the test")
-        }
-
-        fn from_state_value(_maybe_state_value: Option<StateValue>) -> Self {
-            unimplemented!("Irrelevant for the test")
-        }
-
-        fn as_state_value(&self) -> Option<StateValue> {
-            unimplemented!("Irrelevant for the test")
-        }
-
-        fn set_bytes(&mut self, _bytes: Bytes) {
-            unimplemented!("Irrelevant for the test")
-        }
 
         fn as_state_value_metadata(&self) -> Option<StateValueMetadata> {
             Some(StateValueMetadata::legacy(
@@ -717,6 +550,25 @@ mod tests {
                     microseconds: self.metadata,
                 },
             ))
+        }
+    }
+
+    impl SpeculativeValue for TestValueWithMetadata {
+        fn eq_value(&self, other: &Self) -> bool {
+            self == other
+        }
+
+        fn eq_metadata(&self, other: &Self) -> bool {
+            self.as_state_value_metadata() == other.as_state_value_metadata()
+        }
+
+        fn bytes_len(&self) -> Option<usize> {
+            fail::fail_point!("value_with_layout_bytes_len", |_| { Some(10) });
+            Some(16)
+        }
+
+        fn write_op_kind(&self) -> WriteOpKind {
+            unimplemented!("Irrelevant for the test")
         }
     }
 
@@ -749,7 +601,7 @@ mod tests {
             ShiftedTxnIndex::new(0),
             CachePadded::new(new_write_entry(
                 0,
-                ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), None),
+                TestValueWithMetadata::new(10, 100),
                 deps_idx0,
             )),
         );
@@ -757,7 +609,7 @@ mod tests {
             ShiftedTxnIndex::new(7),
             CachePadded::new(new_write_entry(
                 0,
-                ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(20, 200)), None),
+                TestValueWithMetadata::new(20, 200),
                 deps_idx7,
             )),
         );
@@ -779,8 +631,7 @@ mod tests {
         // Get the actual dependencies and verify they match expected.
         let (affected_deps, validation_passed) = v.split_off_affected_read_dependencies::<false>(
             idx,
-            &Arc::new(TestValueWithMetadata::new(10, 100)),
-            &None,
+            &TestValueWithMetadata::new(10, 100),
         );
         assert_eq!(
             affected_deps, expected_deps,
@@ -795,8 +646,7 @@ mod tests {
         if idx < 7 {
             let (remaining_deps, _) = v.split_off_affected_read_dependencies::<false>(
                 6,
-                &Arc::new(TestValueWithMetadata::new(10, 100)),
-                &None,
+                &TestValueWithMetadata::new(10, 100),
             );
             assert!(remaining_deps.is_empty());
             recorded_deps_idx0.retain(|txn_idx, _| *txn_idx <= idx);
@@ -828,7 +678,7 @@ mod tests {
             ShiftedTxnIndex::new(2),
             CachePadded::new(new_write_entry(
                 0,
-                ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), None),
+                TestValueWithMetadata::new(10, 100),
                 BTreeMap::from([(5, 2)]),
             )),
         );
@@ -843,68 +693,63 @@ mod tests {
                 // Test all combinations of value/metadata/layout comparison parameters
                 for same_value in [true, false] {
                     for same_metadata in [true, false] {
-                        for no_layouts in [true, false] {
-                            let mut v = VersionedValue::<TestValueWithMetadata>::default();
+                        let mut v = VersionedValue::<TestValueWithMetadata>::default();
 
-                            // Setup: Create a write with value 10, metadata 100 and one dependency
-                            let deps = BTreeMap::from([(1, 0)]);
-                            let layout = if no_layouts { None } else { Some(Arc::new(MoveTypeLayout::Bool)) };
-                            v.versioned_map.insert(
-                                ShiftedTxnIndex::new(0),
-                                CachePadded::new(new_write_entry(0, ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), layout), deps)),
-                            );
+                        // Setup: Create a write with value 10, metadata 100 and one dependency
+                        let deps = BTreeMap::from([(1, 0)]);
+                        v.versioned_map.insert(
+                            ShiftedTxnIndex::new(0),
+                            CachePadded::new(new_write_entry(0, TestValueWithMetadata::new(10, 100), deps)),
+                        );
 
-                            // Create test value based on parameters
-                            let test_value = TestValueWithMetadata::new(
-                                if same_value { 10 } else { 20 },
-                                if same_metadata { 100 } else { 200 }
-                            );
+                        // Create test value based on parameters
+                        let test_value = TestValueWithMetadata::new(
+                            if same_value { 10 } else { 20 },
+                            if same_metadata { 100 } else { 200 }
+                        );
 
-                            // Compute expected validation result
-                            let expected_validation = if $only_compare_metadata {
-                                same_metadata
-                            } else {
-                                same_value && same_metadata && no_layouts
-                            };
+                        // Compute expected validation result
+                        let expected_validation = if $only_compare_metadata {
+                            same_metadata
+                        } else {
+                            same_value && same_metadata
+                        };
 
-                            // Test split_off_affected_read_dependencies
-                            let (deps, validation_passed) = v.split_off_affected_read_dependencies::<{ $only_compare_metadata }>(
-                                0,
-                                &Arc::new(test_value.clone()),
-                                &None,
-                            );
+                        // Test split_off_affected_read_dependencies
+                        let (deps, validation_passed) = v.split_off_affected_read_dependencies::<{ $only_compare_metadata }>(
+                            0,
+                            &test_value.clone(),
+                        );
 
-                            // Verify results
-                            assert_eq!(
-                                validation_passed,
-                                expected_validation,
-                                "Validation failed for same_value={}, same_metadata={}, only_compare_metadata={}, no_layouts={}",
-                                same_value, same_metadata, $only_compare_metadata, no_layouts
-                            );
-                            assert_eq!(
-                                deps,
-                                BTreeMap::from([(1, 0)]),
-                                "Dependencies don't match for same_value={}, same_metadata={}, only_compare_metadata={}, no_layouts={}",
-                                same_value, same_metadata, $only_compare_metadata, no_layouts
-                            );
+                        // Verify results
+                        assert_eq!(
+                            validation_passed,
+                            expected_validation,
+                            "Validation failed for same_value={}, same_metadata={}, only_compare_metadata={}",
+                            same_value, same_metadata, $only_compare_metadata
+                        );
+                        assert_eq!(
+                            deps,
+                            BTreeMap::from([(1, 0)]),
+                            "Dependencies don't match for same_value={}, same_metadata={}, only_compare_metadata={}",
+                            same_value, same_metadata, $only_compare_metadata
+                        );
 
-                            // Test handle_removed_dependencies
-                            let remaining_deps = v.handle_removed_dependencies::<{ $only_compare_metadata }>(
-                                1,
-                                BTreeMap::from([(2, 0)]),
-                                &Arc::new(test_value),
-                                &None,
-                            ).unwrap();
+                        // Test handle_removed_dependencies
+                        let remaining_deps = v.handle_removed_dependencies::<{ $only_compare_metadata }>(
+                            1,
+                            BTreeMap::from([(2, 0)]),
+                            &test_value,
+                        ).unwrap();
 
-                            if expected_validation {
-                                assert!(remaining_deps.is_empty());
-                                // Verify that (2,0) is recorded in 0-th entry
-                                assert_eq!(get_deps_from_entry(v.versioned_map.get(&ShiftedTxnIndex::new(0)).unwrap()), BTreeMap::from([(2, 0)]));
-                            } else {
-                                assert_eq!(remaining_deps, BTreeMap::from([(2, 0)]));
-                                // Verify that dependencies are empty in 0-th entry
-                                assert_eq!(get_deps_from_entry(v.versioned_map.get(&ShiftedTxnIndex::new(0)).unwrap()).len(), 0);
-                            }
+                        if expected_validation {
+                            assert!(remaining_deps.is_empty());
+                            // Verify that (2,0) is recorded in 0-th entry
+                            assert_eq!(get_deps_from_entry(v.versioned_map.get(&ShiftedTxnIndex::new(0)).unwrap()), BTreeMap::from([(2, 0)]));
+                        } else {
+                            assert_eq!(remaining_deps, BTreeMap::from([(2, 0)]));
+                            // Verify that dependencies are empty in 0-th entry
+                            assert_eq!(get_deps_from_entry(v.versioned_map.get(&ShiftedTxnIndex::new(0)).unwrap()).len(), 0);
                         }
                     }
                 }
@@ -914,122 +759,6 @@ mod tests {
         // Test both cases
         test_metadata_layout_case!(true);
         test_metadata_layout_case!(false);
-    }
-
-    #[test]
-    fn test_same_layout_validation_fails() {
-        let mut v = VersionedValue::<TestValueWithMetadata>::default();
-
-        // Setup: Create a write with value 10, metadata 100 and layout Some(Bool)
-        let deps = BTreeMap::from([(1, 0)]);
-        let layout = Some(Arc::new(MoveTypeLayout::Bool));
-        v.versioned_map.insert(
-            ShiftedTxnIndex::new(0),
-            CachePadded::new(new_write_entry(
-                0,
-                ValueWithLayout::Exchanged(
-                    Arc::new(TestValueWithMetadata::new(10, 100)),
-                    layout.clone(),
-                ),
-                deps,
-            )),
-        );
-
-        // Create test value with same value, metadata, and layout
-        let test_value = TestValueWithMetadata::new(10, 100);
-
-        // Test split_off_affected_read_dependencies with ONLY_COMPARE_METADATA = false
-        let (deps, validation_passed) = v.split_off_affected_read_dependencies::<false>(
-            0,
-            &Arc::new(test_value.clone()),
-            &layout,
-        );
-
-        // Validation should fail because both layouts are Some, even though they're identical
-        assert!(
-            !validation_passed,
-            "Validation should fail when both layouts are Some, even if identical"
-        );
-        assert_eq!(
-            deps,
-            BTreeMap::from([(1, 0)]),
-            "Dependencies should be returned"
-        );
-
-        // Test handle_removed_dependencies
-        let remaining_deps = v
-            .handle_removed_dependencies::<false>(
-                1,
-                BTreeMap::from([(2, 0)]),
-                &Arc::new(test_value),
-                &layout,
-            )
-            .unwrap();
-
-        assert_eq!(
-            remaining_deps,
-            BTreeMap::from([(2, 0)]),
-            "Dependencies should be returned when validation fails"
-        );
-        // Verify that dependencies are empty in 0-th entry (invalidated)
-        assert_eq!(
-            get_deps_from_entry(v.versioned_map.get(&ShiftedTxnIndex::new(0)).unwrap()).len(),
-            0,
-            "Dependencies should be cleared when validation fails"
-        );
-    }
-
-    #[test]
-    fn test_raw_from_storage_validation() {
-        macro_rules! test_raw_from_storage_case {
-            ($only_compare_metadata:expr) => {
-                let mut v = VersionedValue::<TestValueWithMetadata>::default();
-
-                // Setup: Create a write with RawFromStorage value and one dependency
-                let deps = BTreeMap::from([(1, 0)]);
-                v.versioned_map.insert(
-                    ShiftedTxnIndex::new(0),
-                    CachePadded::new(new_write_entry(0, ValueWithLayout::RawFromStorage(Arc::new(TestValueWithMetadata::new(10, 100))), deps)),
-                );
-
-                // Test split_off_affected_read_dependencies with Exchanged value
-                let (deps, validation_passed) = v.split_off_affected_read_dependencies::<{ $only_compare_metadata }>(
-                    0,
-                    &Arc::new(TestValueWithMetadata::new(10, 100)),
-                    &None,
-                );
-
-                // Verify results - validation should fail even with same value and metadata
-                assert!(!validation_passed, "Validation should fail when comparing with RawFromStorage (only_compare_metadata={})", $only_compare_metadata);
-                assert_eq!(deps, BTreeMap::from([(1, 0)]), "Dependencies should be returned even when validation fails (only_compare_metadata={})", $only_compare_metadata);
-
-                // Test handle_removed_dependencies
-                let remaining_deps = v.handle_removed_dependencies::<{ $only_compare_metadata }>(
-                    1,
-                    BTreeMap::from([(2, 0)]),
-                    &Arc::new(TestValueWithMetadata::new(10, 100)),
-                    &None,
-                ).unwrap();
-
-                // Verify that dependencies are not passed and returned
-                assert_eq!(
-                    remaining_deps,
-                    BTreeMap::from([(2, 0)]),
-                    "Dependencies should be returned when validation fails (only_compare_metadata={})",
-                    $only_compare_metadata
-                );
-                assert_eq!(
-                    get_deps_from_entry(v.versioned_map.get(&ShiftedTxnIndex::new(0)).unwrap()).len(),
-                    0,
-                    "Dependencies should not be passed to next entry when validation fails (only_compare_metadata={})",
-                    $only_compare_metadata
-                );
-            };
-        }
-
-        // Test both cases
-        test_raw_from_storage_case!(true);
-        test_raw_from_storage_case!(false);
     }
 
     #[test]
@@ -1044,7 +773,7 @@ mod tests {
             ShiftedTxnIndex::new(0),
             CachePadded::new(new_write_entry(
                 0,
-                ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), None),
+                TestValueWithMetadata::new(10, 100),
                 BTreeMap::new(),
             )),
         );
@@ -1052,8 +781,7 @@ mod tests {
         v.handle_removed_dependencies::<false>(
             0,
             BTreeMap::from([(2, 0)]),
-            &Arc::new(TestValueWithMetadata::new(10, 100)),
-            &None,
+            &TestValueWithMetadata::new(10, 100),
         )
         .unwrap();
     }
@@ -1067,7 +795,7 @@ mod tests {
             ShiftedTxnIndex::new(3),
             CachePadded::new(new_write_entry(
                 0,
-                ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), None),
+                TestValueWithMetadata::new(10, 100),
                 BTreeMap::new(),
             )),
         );
@@ -1078,8 +806,7 @@ mod tests {
             v.handle_removed_dependencies::<true>(
                 1,
                 dependency_2_0.clone(),
-                &Arc::new(TestValueWithMetadata::new(10, 100)),
-                &None,
+                &TestValueWithMetadata::new(10, 100),
             )
             .unwrap()
         );
@@ -1088,8 +815,7 @@ mod tests {
             v.handle_removed_dependencies::<false>(
                 1,
                 dependency_2_0.clone(),
-                &Arc::new(TestValueWithMetadata::new(10, 100)),
-                &None,
+                &TestValueWithMetadata::new(10, 100),
             )
             .unwrap()
         );
@@ -1099,7 +825,7 @@ mod tests {
             ShiftedTxnIndex::new(0),
             CachePadded::new(new_write_entry(
                 0,
-                ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), None),
+                TestValueWithMetadata::new(10, 100),
                 BTreeMap::new(),
             )),
         );
@@ -1107,8 +833,7 @@ mod tests {
             v.handle_removed_dependencies::<true>(
                 1,
                 dependency_2_0.clone(),
-                &Arc::new(TestValueWithMetadata::new(10, 100)),
-                &None,
+                &TestValueWithMetadata::new(10, 100),
             )
             .unwrap()
             .len(),
@@ -1124,23 +849,20 @@ mod tests {
         assert_err!(v.handle_removed_dependencies::<false>(
             1,
             dependency_2_0.clone(),
-            &Arc::new(TestValueWithMetadata::new(10, 100)),
-            &None,
+            &TestValueWithMetadata::new(10, 100),
         ));
         // Error if removed dependencies contain a smaller or equal idx than itself.
         assert_err!(v.handle_removed_dependencies::<false>(
             2,
             dependency_2_0,
-            &Arc::new(TestValueWithMetadata::new(10, 100)),
-            &None,
+            &TestValueWithMetadata::new(10, 100),
         ));
 
         assert_eq!(
             v.handle_removed_dependencies::<false>(
                 2,
                 BTreeMap::from([(3, 1)]),
-                &Arc::new(TestValueWithMetadata::new(10, 100)),
-                &None,
+                &TestValueWithMetadata::new(10, 100),
             )
             .unwrap()
             .len(),
@@ -1181,19 +903,13 @@ mod tests {
         fail::cfg("value_with_layout_bytes_len", "return").unwrap();
         assert!(!fail::list().is_empty());
 
-        versioned_data.set_base_value(
-            (),
-            ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), None),
-        );
+        versioned_data.set_base_value((), TestValueWithMetadata::new(10, 100), |_, _| {});
         assert_eq!(versioned_data.total_base_value_size(), 10);
         scenario.teardown();
 
         assert_ok_eq!(
             versioned_data.fetch_data_and_record_dependency(&(), 5, 1),
-            MVDataOutput::Versioned(
-                Err(StorageVersion),
-                ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), None),
-            ),
+            MVDataOutput::Versioned(Err(StorageVersion), TestValueWithMetadata::new(10, 100),),
         );
         check_versioned_data_deps(
             &versioned_data,
@@ -1202,13 +918,7 @@ mod tests {
         );
 
         assert!(versioned_data
-            .write_v2::<true>(
-                (),
-                1,
-                1,
-                Arc::new(TestValueWithMetadata::new(10, 100)),
-                None,
-            )
+            .write_v2::<true>((), 1, 1, TestValueWithMetadata::new(10, 100),)
             .unwrap()
             .is_empty());
         check_versioned_data_deps(
@@ -1223,13 +933,7 @@ mod tests {
         );
 
         versioned_data
-            .write_v2::<true>(
-                (),
-                3,
-                0,
-                Arc::new(TestValueWithMetadata::new(10, 100)),
-                None,
-            )
+            .write_v2::<true>((), 3, 0, TestValueWithMetadata::new(10, 100))
             .unwrap();
         check_versioned_data_deps(
             &versioned_data,
@@ -1245,10 +949,7 @@ mod tests {
 
         assert_ok_eq!(
             versioned_data.fetch_data_and_record_dependency(&(), 2, 0),
-            MVDataOutput::Versioned(
-                Ok((1, 1)),
-                ValueWithLayout::Exchanged(Arc::new(TestValueWithMetadata::new(10, 100)), None),
-            ),
+            MVDataOutput::Versioned(Ok((1, 1)), TestValueWithMetadata::new(10, 100),),
         );
         assert_eq!(
             versioned_data.remove_v2::<_, false>(&(), 3).unwrap().len(),
@@ -1271,13 +972,7 @@ mod tests {
 
         // Add an entry at index 0
         versioned_data
-            .write(
-                (),
-                0,
-                0,
-                Arc::new(TestValueWithMetadata::new(10, 100)),
-                None,
-            )
+            .write((), 0, 0, TestValueWithMetadata::new(10, 100))
             .unwrap();
 
         // Try to remove a non-existent entry at index 1

--- a/aptos-move/mvhashmap/src/versioned_delayed_fields.rs
+++ b/aptos-move/mvhashmap/src/versioned_delayed_fields.rs
@@ -28,7 +28,7 @@ pub enum CommitError {
 // a potential bypass (based on the previously stored entry), which may allow a read
 // operation to not wait for the corresponding dependency.
 #[derive(Clone, Debug, PartialEq)]
-enum EstimatedEntry<K: Clone> {
+enum EstimatedEntry<K> {
     NoBypass,
     // If applicable, can bypass the Estimate by considering a apply change instead.
     Bypass(DelayedApplyEntry<K>),
@@ -38,7 +38,7 @@ enum EstimatedEntry<K: Clone> {
 // aggregator (as the ID will not be contained in a resource anymore). The write on the
 // previously holding resource and Block-STM read validation ensures correctness.
 #[derive(Debug)]
-enum VersionEntry<K: Clone> {
+enum VersionEntry<K> {
     // If the value is determined by a delta applied to a value read during the execution
     // of the same transaction, the delta may also be kept in the entry. This is useful
     // if speculative execution aborts and the entry is marked as estimate, as the delta
@@ -58,7 +58,7 @@ enum VersionEntry<K: Clone> {
 // A VersionedValue internally contains a BTreeMap from indices of transactions
 // that update a given aggregator, alongside the corresponding entries.
 #[derive(Debug)]
-struct VersionedValue<K: Clone> {
+struct VersionedValue<K> {
     versioned_map: BTreeMap<TxnIndex, Box<CachePadded<VersionEntry<K>>>>,
 
     // The value of the given aggregator prior to the block execution. None implies that
@@ -72,7 +72,7 @@ struct VersionedValue<K: Clone> {
 }
 
 #[derive(Debug, PartialEq)]
-enum VersionedRead<K: Clone> {
+enum VersionedRead<K> {
     Value(DelayedFieldValue),
     // The transaction index records the index at which the Snapshot was encountered.
     // This is required for the caller to resolve the value of the aggregator (with the
@@ -145,7 +145,7 @@ impl<K: Copy + Clone + Debug + Eq> VersionedValue<K> {
     }
 
     // Insert value computed from speculative transaction execution,
-    // potentially overwritting a previous entry.
+    // potentially overwriting a previous entry.
     fn insert_speculative_value(
         &mut self,
         txn_idx: TxnIndex,
@@ -404,7 +404,7 @@ pub trait TVersionedDelayedFieldView<K> {
 /// between Aggregator and AggregatorSnapshot. It is easy to provide this property from the
 /// caller side, even if IDs are re-used (say among incarnations) by e.g. assigning odd and
 /// even ids to Aggregators and AggregatorSnapshots, and it allows asserting the uses strictly.
-pub struct VersionedDelayedFields<K: Clone> {
+pub struct VersionedDelayedFields<K> {
     values: DashMap<K, VersionedValue<K>>,
 
     /// No deltas are allowed below next_idx_to_commit version, as all deltas (and snapshots)

--- a/aptos-move/mvhashmap/src/versioned_group_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_group_data.rs
@@ -4,8 +4,7 @@
 use crate::{
     registered_dependencies::{take_dependencies, RegisteredReadDependencies},
     types::{
-        Incarnation, MVDataError, MVDataOutput, MVGroupError, ShiftedTxnIndex, TxnIndex,
-        ValueWithLayout, Version,
+        Incarnation, MVDataError, MVDataOutput, MVGroupError, ShiftedTxnIndex, TxnIndex, Version,
     },
     versioned_data::Entry as SizeEntry,
     VersionedData,
@@ -14,14 +13,14 @@ use anyhow::anyhow;
 use aptos_aggregator::types::ReadPosition;
 use aptos_infallible::Mutex;
 use aptos_types::{
+    block_executor::value::SpeculativeValue,
     error::{code_invariant_error, PanicError},
-    write_set::{TransactionWrite, WriteOpKind},
+    write_set::WriteOpKind,
 };
 use aptos_vm_types::{resolver::ResourceGroupSize, resource_group_adapter::group_size_as_sum};
 use claims::{assert_ok, assert_some};
 use dashmap::DashMap;
 use equivalent::Equivalent;
-use move_core_types::value::MoveTypeLayout;
 use serde::Serialize;
 use std::{
     collections::{
@@ -31,7 +30,6 @@ use std::{
     fmt::Debug,
     hash::Hash,
 };
-use triomphe::Arc;
 
 struct SizeAndDependencies {
     size: ResourceGroupSize,
@@ -129,11 +127,11 @@ impl<'a, K: Debug, T: Debug> Debug for GroupKeyRef<'a, K, T> {
     }
 }
 
-impl<
-        K: Hash + Clone + Debug + Eq,
-        T: Hash + Clone + Debug + Eq + Serialize,
-        V: TransactionWrite + PartialEq,
-    > VersionedGroupData<K, T, V>
+impl<K, T, V> VersionedGroupData<K, T, V>
+where
+    K: Hash + Clone + Debug + Eq,
+    T: Hash + Clone + Debug + Eq + Serialize,
+    V: SpeculativeValue,
 {
     pub(crate) fn empty() -> Self {
         Self {
@@ -160,7 +158,7 @@ impl<
             let group_size = group_size_as_sum::<T>(
                 base_values
                     .iter()
-                    .flat_map(|(tag, value)| value.bytes().map(|b| (tag.clone(), b.len()))),
+                    .flat_map(|(tag, value)| value.bytes_len().map(|l| (tag.clone(), l))),
             )
             .map_err(|e| {
                 anyhow!(
@@ -175,10 +173,8 @@ impl<
             let mut superset_tags = self.group_tags.entry(group_key.clone()).or_default();
             for (tag, value) in base_values.into_iter() {
                 superset_tags.insert(tag.clone());
-                self.values.set_base_value(
-                    (group_key.clone(), tag),
-                    ValueWithLayout::RawFromStorage(Arc::new(value)),
-                );
+                self.values
+                    .set_base_value((group_key.clone(), tag), value, |_, _| {});
             }
         }
 
@@ -190,12 +186,10 @@ impl<
         group_key: K,
         tag: T,
         value: V,
-        layout: Option<Arc<MoveTypeLayout>>,
+        on_occupied: impl FnOnce(&mut V, V),
     ) {
-        self.values.set_base_value(
-            (group_key, tag),
-            ValueWithLayout::Exchanged(Arc::new(value), layout.clone()),
-        );
+        self.values
+            .set_base_value((group_key, tag), value, on_occupied);
     }
 
     /// Writes new resource group values (and size) specified by tag / value pair
@@ -208,7 +202,7 @@ impl<
         group_key: K,
         txn_idx: TxnIndex,
         incarnation: Incarnation,
-        values: impl IntoIterator<Item = (T, (V, Option<Arc<MoveTypeLayout>>))>,
+        values: impl IntoIterator<Item = (T, V)>,
         size: ResourceGroupSize,
         prev_tags: HashSet<T>,
     ) -> Result<bool, PanicError> {
@@ -263,7 +257,7 @@ impl<
         group_key: K,
         txn_idx: TxnIndex,
         incarnation: Incarnation,
-        values: impl IntoIterator<Item = (T, (V, Option<Arc<MoveTypeLayout>>))>,
+        values: impl IntoIterator<Item = (T, V)>,
         size: ResourceGroupSize,
         prev_tags: HashSet<&T>,
     ) -> Result<BTreeMap<TxnIndex, Incarnation>, PanicError> {
@@ -417,7 +411,7 @@ impl<
         group_key: &K,
         tag: &T,
         txn_idx: TxnIndex,
-    ) -> Result<(Version, ValueWithLayout<V>), MVGroupError> {
+    ) -> Result<(Version, V), MVGroupError> {
         let key_ref = GroupKeyRef { group_key, tag };
 
         // We are accessing group_sizes and values non-atomically, hence the order matters.
@@ -439,7 +433,7 @@ impl<
         tag: &T,
         txn_idx: TxnIndex,
         incarnation: Incarnation,
-    ) -> Result<(Version, ValueWithLayout<V>), MVGroupError> {
+    ) -> Result<(Version, V), MVGroupError> {
         let key_ref = GroupKeyRef { group_key, tag };
 
         // We are accessing group_sizes and values non-atomically, hence the order matters.
@@ -527,7 +521,7 @@ impl<
         &self,
         group_key: &K,
         txn_idx: TxnIndex,
-    ) -> Result<(Vec<(T, ValueWithLayout<V>)>, ResourceGroupSize), PanicError> {
+    ) -> Result<(Vec<(T, V)>, ResourceGroupSize), PanicError> {
         let superset_tags = self
             .group_tags
             .get(group_key)
@@ -565,11 +559,11 @@ impl<
 }
 
 // Private methods.
-impl<
-        K: Hash + Clone + Debug + Eq,
-        T: Hash + Clone + Debug + Eq + Serialize,
-        V: TransactionWrite + PartialEq,
-    > VersionedGroupData<K, T, V>
+impl<K, T, V> VersionedGroupData<K, T, V>
+where
+    K: Hash + Clone + Debug + Eq,
+    T: Hash + Clone + Debug + Eq + Serialize,
+    V: SpeculativeValue,
 {
     /// Private utility method to find the latest entry before a given transaction index,
     /// inclusive or exclusive depending on the read position. Encapsulates the common
@@ -618,7 +612,7 @@ impl<
         group_key: &K,
         txn_idx: TxnIndex,
         incarnation: Incarnation,
-        values: impl IntoIterator<Item = (T, (V, Option<Arc<MoveTypeLayout>>))>,
+        values: impl IntoIterator<Item = (T, V)>,
         mut prev_tags: HashSet<&T>,
     ) -> Result<(bool, RegisteredReadDependencies), PanicError> {
         let mut ret_v1 = false;
@@ -632,7 +626,7 @@ impl<
                 code_invariant_error("Group (tags) must be initialized to write to")
             })?;
 
-            for (tag, (value, layout)) in values.into_iter() {
+            for (tag, value) in values.into_iter() {
                 if !superset_tags.contains(&tag) {
                     tags_to_write.push(tag.clone());
                 }
@@ -644,17 +638,11 @@ impl<
                         (group_key.clone(), tag),
                         txn_idx,
                         incarnation,
-                        Arc::new(value),
-                        layout,
+                        value,
                     )?);
                 } else {
-                    self.values.write(
-                        (group_key.clone(), tag),
-                        txn_idx,
-                        incarnation,
-                        Arc::new(value),
-                        layout,
-                    )?;
+                    self.values
+                        .write((group_key.clone(), tag), txn_idx, incarnation, value)?;
                 }
             }
         }
@@ -677,7 +665,7 @@ impl<
         &self,
         data_value: anyhow::Result<MVDataOutput<V>, MVDataError>,
         initialized: bool,
-    ) -> Result<(Version, ValueWithLayout<V>), MVGroupError> {
+    ) -> Result<(Version, V), MVGroupError> {
         match data_value {
             Ok(MVDataOutput::Versioned(version, value)) => Ok((version, value)),
             Err(MVDataError::Uninitialized) => Err(if initialized {
@@ -731,7 +719,7 @@ mod test {
 
         // Calculate base_size based on the actual values (as it will be computed by set_raw_base_values).
         // Set high size arbitrary and determine mid_size.
-        let one_entry_len = base_value.bytes().unwrap().len();
+        let one_entry_len = base_value.bytes_len().unwrap_or(0);
         let base_size = group_size_as_sum(vec![(&tag, one_entry_len)].into_iter()).unwrap();
         let high_size = ResourceGroupSize::Combined {
             num_tagged_resources: 3,
@@ -757,7 +745,7 @@ mod test {
             group_key.clone(),
             high_idx,
             inc_1,
-            vec![(tag, (high_value.clone(), None))],
+            vec![(tag, high_value.clone())],
             high_size,
             HashSet::new(),
         ));
@@ -788,9 +776,9 @@ mod test {
                 assert_eq!(
                     res.1,
                     if idx > high_idx {
-                        ValueWithLayout::Exchanged(Arc::new(high_value.clone()), None)
+                        high_value.clone()
                     } else {
-                        ValueWithLayout::RawFromStorage(Arc::new(base_value.clone()))
+                        base_value.clone()
                     }
                 );
                 all_value_deps.insert(idx, inc_1);
@@ -807,16 +795,13 @@ mod test {
             group_key.clone(),
             tag,
             base_value.clone(),
-            None,
+            |_, _| {},
         );
         assert_eq!(
             group_data
                 .fetch_tagged_data_and_record_dependency(&group_key, &tag, 2, 1)
                 .unwrap(),
-            (
-                Err(StorageVersion),
-                ValueWithLayout::Exchanged(Arc::new(base_value.clone()), None)
-            )
+            (Err(StorageVersion), base_value.clone())
         );
 
         // Write another value at a middle index and check dependency handling.
@@ -825,7 +810,7 @@ mod test {
                 group_key.clone(),
                 mid_idx,
                 inc_1,
-                vec![(tag, (mid_value.clone(), None))],
+                vec![(tag, mid_value.clone())],
                 mid_size,
                 HashSet::new(),
             )
@@ -902,81 +887,11 @@ mod test {
                 &group_key, &tag, 21, inc_1, // higher than any idx.
             )
             .unwrap();
-        assert_eq!(value, ValueWithLayout::Exchanged(Arc::new(mid_value), None));
+        assert_eq!(value, mid_value);
         let size = group_data
             .get_group_size_and_record_dependency(&group_key, 21, inc_1)
             .unwrap();
         assert_eq!(size, mid_size);
-    }
-
-    // Entries from storage may contain a special layout, which has not been processed yet.
-    // It has to be validated (and fail) against a processed (Exchanged) layout (e.g. with
-    // IDs for delayed fields contained within). The other case checks that if the correct
-    // layout was provided and set (for transaction 0, the previous test instead provides
-    // layout for storage version), then it passes validation.
-    #[test_case(true; "raw storage layout fails validation")]
-    #[test_case(false; "exchanged layout passes validation")]
-    fn test_raw_storage_layout_validation(raw_storage_layout: bool) {
-        let group_key = KeyType(b"/group/test".to_vec());
-        let tag: usize = 1;
-
-        let group_data = VersionedGroupData::<KeyType<Vec<u8>>, usize, TestValue>::empty();
-        let base_value = TestValue::creation_with_len(1);
-        let one_entry_len = base_value.bytes().unwrap().len();
-        let base_size = group_size_as_sum(vec![(&tag, one_entry_len)].into_iter()).unwrap();
-
-        assert_ok!(
-            group_data.set_raw_base_values(group_key.clone(), vec![(tag, base_value.clone())])
-        );
-        if !raw_storage_layout {
-            assert_ok!(group_data.write_v2(
-                group_key.clone(),
-                0,
-                1,
-                vec![(tag, (base_value.clone(), None))],
-                base_size,
-                HashSet::new(),
-            ));
-        }
-
-        let (version, value) = group_data
-            .fetch_tagged_data_and_record_dependency(&group_key, &tag, 5, 2)
-            .unwrap();
-        assert_eq!(
-            version,
-            if raw_storage_layout {
-                Err(StorageVersion)
-            } else {
-                Ok((0, 1))
-            }
-        );
-        assert_eq!(
-            value,
-            if raw_storage_layout {
-                ValueWithLayout::RawFromStorage(Arc::new(base_value.clone()))
-            } else {
-                ValueWithLayout::Exchanged(Arc::new(base_value.clone()), None)
-            }
-        );
-
-        let invalidated_deps = group_data
-            .write_v2(
-                group_key.clone(),
-                2,
-                1,
-                vec![(tag, (base_value.clone(), None))],
-                base_size,
-                HashSet::new(),
-            )
-            .unwrap();
-        assert_eq!(
-            invalidated_deps,
-            if raw_storage_layout {
-                BTreeMap::from([(5, 2)])
-            } else {
-                BTreeMap::new()
-            }
-        );
     }
 
     // This tests the case when after a write and remove, some entries in the group may pass
@@ -996,15 +911,9 @@ mod test {
     //
     //  We ensure that if (A, B) is written, depA1 is invalidated, and vice versa. Then, a
     //  similar test considers the removal of txn 9's output.
-    //
-    // A != B for validation purposes, but the second parameter determines whether the
-    // values are different, or whether the layouts are set for both A and B (in which
-    // case validation fails instead of performing a deep layout comparison).
-    #[test_case(true, true; "partial: A, B, different values")]
-    #[test_case(true, false; "partial: A, B, set layouts")]
-    #[test_case(false, true; "partial: B, A, different values")]
-    #[test_case(false, false; "partial: B, A, set layouts")]
-    fn test_partial_invalidation(case_a_b: bool, different_values: bool) {
+    #[test_case(true; "partial: A, B")]
+    #[test_case(false; "partial: B, A")]
+    fn test_partial_invalidation(case_a_b: bool) {
         let group_key = KeyType(b"/group/test".to_vec());
         let tag0: usize = 0;
         let tag1: usize = 1;
@@ -1019,20 +928,6 @@ mod test {
             all_tagged_resources_size: 20,
         };
 
-        // Create pairs based on different_values parameter
-        // When different_values=true: use (value, None) so validation is based on value differences
-        // When different_values=false: use same value with (value, Some(layout)) so validation fails due to layout comparison being avoided
-        let pair_a = if different_values {
-            (value_a.clone(), None)
-        } else {
-            (value_a.clone(), Some(Arc::new(MoveTypeLayout::Bool)))
-        };
-        let pair_b = if different_values {
-            (value_b.clone(), None)
-        } else {
-            (value_a.clone(), Some(Arc::new(MoveTypeLayout::Bool))) // Same value as pair_a when different_values=false
-        };
-
         // Need to initialize the group - detected by missing size entry.
         assert_ok!(group_data.set_raw_base_values(group_key.clone(), vec![]));
 
@@ -1041,7 +936,7 @@ mod test {
             group_key.clone(),
             6,
             1,
-            vec![(tag0, pair_a.clone()), (tag1, pair_a.clone())],
+            vec![(tag0, value_a.clone()), (tag1, value_a.clone())],
             invariant_size,
             HashSet::new(),
         ));
@@ -1065,7 +960,7 @@ mod test {
             group_key.clone(),
             9,
             1,
-            vec![(tag0, pair_b.clone()), (tag1, pair_b.clone())],
+            vec![(tag0, value_b.clone()), (tag1, value_b.clone())],
             invariant_size,
             HashSet::new(),
         ));
@@ -1086,9 +981,9 @@ mod test {
 
         // Test write at txn 7 based on case_a_b
         let write_value = if case_a_b {
-            vec![(tag0, pair_a.clone()), (tag1, pair_b.clone())]
+            vec![(tag0, value_a.clone()), (tag1, value_b.clone())]
         } else {
-            vec![(tag0, pair_b.clone()), (tag1, pair_a.clone())]
+            vec![(tag0, value_b.clone()), (tag1, value_a.clone())]
         };
 
         let write_invalidated = group_data
@@ -1101,18 +996,12 @@ mod test {
                 HashSet::new(),
             )
             .unwrap();
-        let expected_invalidated = if different_values {
-            if case_a_b {
-                // If writing (A, B), depA1 should be invalidated (incarnation = tag)
-                BTreeMap::from([(8, 1)])
-            } else {
-                // If writing (B, A), depA0 should be invalidated
-                BTreeMap::from([(8, 0)])
-            }
+        let expected_invalidated = if case_a_b {
+            // If writing (A, B), depA1 should be invalidated (incarnation = tag)
+            BTreeMap::from([(8, 1)])
         } else {
-            // When different_values=false, both A and B are the same value with layouts set,
-            // so validation fails for both and both dependencies should be invalidated
-            BTreeMap::from([(8, 0), (8, 1)])
+            // If writing (B, A), depA0 should be invalidated
+            BTreeMap::from([(8, 0)])
         };
         assert_eq!(write_invalidated, expected_invalidated);
 
@@ -1120,16 +1009,10 @@ mod test {
         let remove_invalidated = group_data
             .remove_v2(&group_key, 9, HashSet::from([&tag0, &tag1]))
             .unwrap();
-        let expected_invalidated = if different_values {
-            if case_a_b {
-                BTreeMap::from([(10, 0)])
-            } else {
-                BTreeMap::from([(10, 1)])
-            }
+        let expected_invalidated = if case_a_b {
+            BTreeMap::from([(10, 0)])
         } else {
-            // When different_values=false, both A and B are the same value with layouts set,
-            // so validation fails for both and both dependencies should be invalidated
-            BTreeMap::from([(10, 0), (10, 1)])
+            BTreeMap::from([(10, 1)])
         };
         assert_eq!(remove_invalidated, expected_invalidated);
     }
@@ -1165,8 +1048,8 @@ mod test {
         assert_ok!(map.set_raw_base_values(ap_1.clone(), vec![]));
 
         let test_values = vec![
-            (0usize, (TestValue::creation_with_len(1), None)),
-            (1usize, (TestValue::creation_with_len(1), None)),
+            (0usize, TestValue::creation_with_len(1)),
+            (1usize, TestValue::creation_with_len(1)),
         ];
         let test_tags: HashSet<usize> = (0..2).collect();
 
@@ -1276,7 +1159,7 @@ mod test {
             ap.clone(),
             3,
             1,
-            (0..2).map(|i| (i, (TestValue::creation_with_len(1), None))),
+            (0..2).map(|i| (i, TestValue::creation_with_len(1))),
             idx_3_size,
             HashSet::new(),
         ));
@@ -1287,7 +1170,7 @@ mod test {
             3,
             1,
             // tags 0, 1, 2.
-            (0..2).map(|i| (i, (TestValue::creation_with_len(1), None))),
+            (0..2).map(|i| (i, TestValue::creation_with_len(1))),
             idx_3_size,
             HashSet::new(),
         ));
@@ -1311,10 +1194,7 @@ mod test {
         // ... but idx = 4 should find the previously stored value.
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &1, 4).unwrap(),
-            (
-                Ok((3, 1)),
-                ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(1)), None)
-            )
+            (Ok((3, 1)), TestValue::creation_with_len(1))
         );
 
         // ap_empty should still be uninitialized.
@@ -1345,7 +1225,7 @@ mod test {
             4,
             0,
             // tags 1, 2.
-            (1..3).map(|i| (i, (TestValue::creation_with_len(4), None))),
+            (1..3).map(|i| (i, TestValue::creation_with_len(4))),
             ResourceGroupSize::zero_combined(),
             HashSet::new(),
         ));
@@ -1360,24 +1240,15 @@ mod test {
         );
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &2, 5).unwrap(),
-            (
-                Ok((4, 0)),
-                ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(4)), None)
-            )
+            (Ok((4, 0)), TestValue::creation_with_len(4))
         );
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &1, 4).unwrap(),
-            (
-                Err(StorageVersion),
-                ValueWithLayout::RawFromStorage(Arc::new(TestValue::creation_with_len(2)))
-            )
+            (Err(StorageVersion), TestValue::creation_with_len(2))
         );
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &0, 6).unwrap(),
-            (
-                Err(StorageVersion),
-                ValueWithLayout::RawFromStorage(Arc::new(TestValue::creation_with_len(1)))
-            )
+            (Err(StorageVersion), TestValue::creation_with_len(1))
         );
     }
 
@@ -1398,32 +1269,26 @@ mod test {
             5,
             3,
             // tags 0, 1, values are derived from [txn_idx, incarnation] seed.
-            (0..2).map(|i| (i, (TestValue::new(vec![5, 3]), None))),
+            (0..2).map(|i| (i, TestValue::new(vec![5, 3]))),
             idx_5_size,
             HashSet::new(),
         ));
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &1, 12).unwrap(),
-            (
-                Ok((5, 3)),
-                ValueWithLayout::Exchanged(Arc::new(TestValue::new(vec![5, 3])), None)
-            )
+            (Ok((5, 3)), TestValue::new(vec![5, 3]))
         );
         assert_ok!(map.write(
             ap.clone(),
             10,
             1,
             // tags 1, 2, values are derived from [txn_idx, incarnation] seed.
-            (1..3).map(|i| (i, (TestValue::new(vec![10, 1]), None))),
+            (1..3).map(|i| (i, TestValue::new(vec![10, 1]))),
             ResourceGroupSize::zero_combined(),
             HashSet::new(),
         ));
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &1, 12).unwrap(),
-            (
-                Ok((10, 1)),
-                ValueWithLayout::Exchanged(Arc::new(TestValue::new(vec![10, 1])), None)
-            )
+            (Ok((10, 1)), TestValue::new(vec![10, 1]))
         );
 
         let tags_012: Vec<usize> = (1..3).collect();
@@ -1442,27 +1307,18 @@ mod test {
         );
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &0, 12).unwrap(),
-            (
-                Ok((5, 3)),
-                ValueWithLayout::Exchanged(Arc::new(TestValue::new(vec![5, 3])), None)
-            )
+            (Ok((5, 3)), TestValue::new(vec![5, 3]))
         );
         assert_matches!(map.get_group_size_no_record(&ap, 12), Err(Dependency(10)));
 
         map.remove(&ap, 10, (1..3).collect());
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &0, 12).unwrap(),
-            (
-                Ok((5, 3)),
-                ValueWithLayout::Exchanged(Arc::new(TestValue::new(vec![5, 3])), None)
-            )
+            (Ok((5, 3)), TestValue::new(vec![5, 3]))
         );
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &1, 12).unwrap(),
-            (
-                Ok((5, 3)),
-                ValueWithLayout::Exchanged(Arc::new(TestValue::new(vec![5, 3])), None)
-            )
+            (Ok((5, 3)), TestValue::new(vec![5, 3]))
         );
 
         // Size should also be removed at 10.
@@ -1475,8 +1331,8 @@ mod test {
         let map = VersionedGroupData::<KeyType<Vec<u8>>, usize, TestValue>::empty();
 
         let tag: usize = 5;
-        let one_entry_len = TestValue::creation_with_len(1).bytes().unwrap().len();
-        let two_entry_len = TestValue::creation_with_len(2).bytes().unwrap().len();
+        let one_entry_len = TestValue::creation_with_len(1).bytes_len().unwrap_or(0);
+        let two_entry_len = TestValue::creation_with_len(2).bytes_len().unwrap_or(0);
         let idx_5_size = group_size_as_sum(vec![(&tag, two_entry_len); 2].into_iter().chain(vec![
             (
                 &tag,
@@ -1501,7 +1357,7 @@ mod test {
             5,
             0,
             // tags 0, 1
-            (0..2).map(|i| (i, (TestValue::creation_with_len(2), None))),
+            (0..2).map(|i| (i, TestValue::creation_with_len(2))),
             idx_5_size,
             HashSet::new(),
         ));
@@ -1527,7 +1383,7 @@ mod test {
                 ap.clone(),
                 5,
                 1,
-                (0..3).map(|i| (i, (TestValue::creation_with_len(2), None))),
+                (0..3).map(|i| (i, TestValue::creation_with_len(2))),
                 idx_5_size,
                 (0..2).collect(),
             ),
@@ -1549,7 +1405,7 @@ mod test {
             ap.clone(),
             5,
             2,
-            (0..3).map(|i| (i, (TestValue::creation_with_len(1), None))),
+            (0..3).map(|i| (i, TestValue::creation_with_len(1))),
             idx_5_size_with_ones,
             (0..2).collect(),
         ));
@@ -1583,7 +1439,7 @@ mod test {
                 5,
                 0,
                 // tags 0, 1
-                (0..2).map(|i| (i, (TestValue::creation_with_len(2), None))),
+                (0..2).map(|i| (i, TestValue::creation_with_len(2))),
                 ResourceGroupSize::zero_combined(),
                 HashSet::new(),
             ),
@@ -1600,7 +1456,7 @@ mod test {
                 5,
                 1,
                 // tags 0 - contained among {0, 1}
-                (0..1).map(|i| (i, (TestValue::creation_with_len(2), None))),
+                (0..1).map(|i| (i, TestValue::creation_with_len(2))),
                 ResourceGroupSize::zero_combined(),
                 (0..2).collect(),
             ),
@@ -1612,7 +1468,7 @@ mod test {
                 5,
                 2,
                 // tags 0, 1 - not contained among {0}
-                (0..2).map(|i| (i, (TestValue::creation_with_len(2), None))),
+                (0..2).map(|i| (i, TestValue::creation_with_len(2))),
                 ResourceGroupSize::zero_combined(),
                 (0..1).collect(),
             ),
@@ -1624,10 +1480,7 @@ mod test {
         map: &VersionedGroupData<KeyType<Vec<u8>>, usize, TestValue>,
         key: &KeyType<Vec<u8>>,
         idx: TxnIndex,
-    ) -> (
-        HashMap<usize, ValueWithLayout<TestValue>>,
-        ResourceGroupSize,
-    ) {
+    ) -> (HashMap<usize, TestValue>, ResourceGroupSize) {
         let (group, size) = map.finalize_group(key, idx).unwrap();
 
         (group.into_iter().collect(), size)
@@ -1650,7 +1503,7 @@ mod test {
         let base_size = group_size_as_sum(
             base_values
                 .into_iter()
-                .map(|(tag, value)| (tag, value.bytes().unwrap().len())),
+                .map(|(tag, value)| (tag, value.bytes_len().unwrap_or(0))),
         )
         .unwrap();
 
@@ -1678,8 +1531,8 @@ mod test {
             3,
             // insert at 0, remove at 1.
             vec![
-                (0, (TestValue::creation_with_len(100), None)),
-                (1, (TestValue::deletion(), None)),
+                (0, TestValue::creation_with_len(100)),
+                (1, TestValue::deletion()),
             ],
             idx_7_size,
             HashSet::new(),
@@ -1689,7 +1542,7 @@ mod test {
             3,
             0,
             // tags 2, 3
-            (2..4).map(|i| (i, (TestValue::creation_with_len(200 + i), None))),
+            (2..4).map(|i| (i, TestValue::creation_with_len(200 + i))),
             idx_3_size,
             HashSet::new(),
         ));
@@ -1703,26 +1556,17 @@ mod test {
         // The value at tag 1 is from base, while 2 and 3 are from txn 3.
         // (Arc compares with value equality)
         assert_eq!(finalized_3.len(), 3);
-        assert_some_eq!(
-            finalized_3.get(&1),
-            &ValueWithLayout::RawFromStorage(Arc::new(TestValue::creation_with_len(1)))
-        );
-        assert_some_eq!(
-            finalized_3.get(&2),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(202)), None)
-        );
-        assert_some_eq!(
-            finalized_3.get(&3),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(203)), None)
-        );
+        assert_some_eq!(finalized_3.get(&1), &TestValue::creation_with_len(1));
+        assert_some_eq!(finalized_3.get(&2), &TestValue::creation_with_len(202),);
+        assert_some_eq!(finalized_3.get(&3), &TestValue::creation_with_len(203));
 
         assert_ok!(map.write(
             ap.clone(),
             5,
             3,
             vec![
-                (3, (TestValue::creation_with_len(303), None)),
-                (4, (TestValue::creation_with_len(304), None)),
+                (3, TestValue::creation_with_len(303)),
+                (4, TestValue::creation_with_len(304)),
             ],
             idx_5_size,
             HashSet::new(),
@@ -1731,43 +1575,19 @@ mod test {
         let (finalized_6, size_6) = finalize_group_as_hashmap(&map, &ap, 6);
         assert_eq!(size_6, idx_5_size);
         assert_eq!(finalized_6.len(), 4);
-        assert_some_eq!(
-            finalized_6.get(&1),
-            &ValueWithLayout::RawFromStorage(Arc::new(TestValue::creation_with_len(1)))
-        );
-        assert_some_eq!(
-            finalized_6.get(&2),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(202)), None)
-        );
-        assert_some_eq!(
-            finalized_6.get(&3),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(303)), None)
-        );
-        assert_some_eq!(
-            finalized_6.get(&4),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(304)), None)
-        );
+        assert_some_eq!(finalized_6.get(&1), &TestValue::creation_with_len(1));
+        assert_some_eq!(finalized_6.get(&2), &TestValue::creation_with_len(202));
+        assert_some_eq!(finalized_6.get(&3), &TestValue::creation_with_len(303));
+        assert_some_eq!(finalized_6.get(&4), &TestValue::creation_with_len(304));
 
         let (finalized_7, size_7) = finalize_group_as_hashmap(&map, &ap, 7);
         assert_eq!(size_7, idx_7_size);
         assert_eq!(finalized_7.len(), 4);
-        assert_some_eq!(
-            finalized_7.get(&0),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(100)), None)
-        );
+        assert_some_eq!(finalized_7.get(&0), &TestValue::creation_with_len(100));
         assert_none!(finalized_7.get(&1));
-        assert_some_eq!(
-            finalized_7.get(&2),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(202)), None)
-        );
-        assert_some_eq!(
-            finalized_7.get(&3),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(303)), None)
-        );
-        assert_some_eq!(
-            finalized_7.get(&4),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(304)), None)
-        );
+        assert_some_eq!(finalized_7.get(&2), &TestValue::creation_with_len(202));
+        assert_some_eq!(finalized_7.get(&3), &TestValue::creation_with_len(303));
+        assert_some_eq!(finalized_7.get(&4), &TestValue::creation_with_len(304));
 
         assert_ok!(map.write(
             ap.clone(),
@@ -1775,11 +1595,11 @@ mod test {
             0,
             // re-insert at 1, remove everything else
             vec![
-                (0, (TestValue::deletion(), None)),
-                (1, (TestValue::creation_with_len(400), None)),
-                (2, (TestValue::deletion(), None)),
-                (3, (TestValue::deletion(), None)),
-                (4, (TestValue::deletion(), None)),
+                (0, TestValue::deletion()),
+                (1, TestValue::creation_with_len(400)),
+                (2, TestValue::deletion()),
+                (3, TestValue::deletion()),
+                (4, TestValue::deletion()),
             ],
             idx_8_size,
             HashSet::new(),
@@ -1787,13 +1607,9 @@ mod test {
         let (finalized_8, size_8) = finalize_group_as_hashmap(&map, &ap, 8);
         assert_eq!(size_8, idx_8_size);
         assert_eq!(finalized_8.len(), 1);
-        assert_some_eq!(
-            finalized_8.get(&1),
-            &ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(400)), None)
-        );
+        assert_some_eq!(finalized_8.get(&1), &TestValue::creation_with_len(400));
     }
 
-    // TODO[agg_v2](test) Test with non trivial layout.
     #[test]
     fn group_base_layout() {
         let ap = KeyType(b"/foo/f".to_vec());
@@ -1802,24 +1618,20 @@ mod test {
         assert_ok!(map.set_raw_base_values(ap.clone(), vec![(1, TestValue::creation_with_len(1))],));
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &1, 6).unwrap(),
-            (
-                Err(StorageVersion),
-                ValueWithLayout::RawFromStorage(Arc::new(TestValue::creation_with_len(1)))
-            )
+            (Err(StorageVersion), TestValue::creation_with_len(1))
         );
 
         map.update_tagged_base_value_with_layout(
             ap.clone(),
             1,
-            TestValue::creation_with_len(1),
-            None,
+            TestValue::creation_with_len(2),
+            |prev, new| {
+                *prev = new;
+            },
         );
         assert_eq!(
             map.fetch_tagged_data_no_record(&ap, &1, 6).unwrap(),
-            (
-                Err(StorageVersion),
-                ValueWithLayout::Exchanged(Arc::new(TestValue::creation_with_len(1)), None)
-            )
+            (Err(StorageVersion), TestValue::creation_with_len(2))
         );
     }
 

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -37,7 +37,7 @@ use aptos_types::{
     state_store::{state_key::StateKey, state_value::StateValueMetadata, StateView},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockOutput,
-        Transaction, TransactionOutput, TransactionStatus, WriteSetPayload,
+        TransactionOutput, TransactionStatus,
     },
     write_set::WriteOp,
 };
@@ -157,18 +157,6 @@ impl ExecutorTask for NativeVMExecutorTask {
             },
             Err(_) => ExecutionStatus::SpeculativeExecutionAbortError("something".to_string()),
         }
-    }
-
-    fn is_transaction_dynamic_change_set_capable(txn: &Self::Txn) -> bool {
-        if txn.is_valid() {
-            if let Transaction::GenesisTransaction(WriteSetPayload::Direct(_)) = txn.expect_valid()
-            {
-                // WriteSetPayload::Direct cannot be handled in mode where delayed_field_optimization or
-                // resource_groups_split_in_change_set is enabled.
-                return false;
-            }
-        }
-        true
     }
 }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -51,6 +51,7 @@ chrono-tz = { workspace = true }
 crossbeam-utils = { workspace = true }
 dashmap = { workspace = true }
 derivative = { workspace = true }
+fail = { workspace = true }
 fixed = { workspace = true }
 fxhash = { workspace = true }
 hashbrown = { workspace = true }
@@ -89,6 +90,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+triomphe = { workspace = true }
 
 [dev-dependencies]
 ahash = { workspace = true }

--- a/types/src/block_executor/mod.rs
+++ b/types/src/block_executor/mod.rs
@@ -2,5 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod config;
+pub mod output;
 pub mod partitioner;
 pub mod transaction_slice_metadata;
+pub mod value;

--- a/types/src/block_executor/output.rs
+++ b/types/src/block_executor/output.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    contract_event::ContractEvent,
+    fee_statement::FeeStatement,
+    transaction::{TransactionAuxiliaryData, TransactionOutput, TransactionStatus},
+    write_set::WriteSet,
+};
+use move_core_types::vm_status::StatusCode;
+use std::fmt::Debug;
+
+/// The final, materialized transaction output the block executor stores in its
+/// results.
+pub trait CommittedTransactionOutput: Send + Debug {
+    /// Fee statement of the (kept) transaction.
+    fn fee_statement(&self) -> FeeStatement;
+
+    /// Whether the transaction emitted a new epoch event.
+    fn has_new_epoch_event(&self) -> bool;
+
+    /// Whether this is a placeholder for a not-yet-materialized (retry) slot.
+    /// Placeholders are created via [`Self::retry_placeholder`] and replaced on
+    /// materialization, so a slot that is still a placeholder was skipped.
+    fn is_retry(&self) -> bool;
+
+    /// Whether the transaction was kept and succeeded.
+    fn is_success(&self) -> bool;
+
+    /// Placeholder for a results slot that has not been materialized.
+    fn retry() -> Self;
+
+    /// Placeholder for a discarded transaction.
+    fn discard(discard_code: StatusCode) -> Self;
+}
+
+impl CommittedTransactionOutput for TransactionOutput {
+    fn fee_statement(&self) -> FeeStatement {
+        self.try_extract_fee_statement()
+            .ok()
+            .flatten()
+            .unwrap_or_else(FeeStatement::zero)
+    }
+
+    fn has_new_epoch_event(&self) -> bool {
+        self.events().iter().any(ContractEvent::is_new_epoch_event)
+    }
+
+    fn is_retry(&self) -> bool {
+        self.status().is_retry()
+    }
+
+    fn is_success(&self) -> bool {
+        self.status()
+            .as_kept_status()
+            .is_ok_and(|status| status.is_success())
+    }
+
+    fn retry() -> Self {
+        TransactionOutput::new(
+            WriteSet::default(),
+            vec![],
+            0,
+            TransactionStatus::Retry,
+            TransactionAuxiliaryData::None,
+        )
+    }
+
+    fn discard(discard_code: StatusCode) -> Self {
+        TransactionOutput::new(
+            WriteSet::default(),
+            vec![],
+            0,
+            TransactionStatus::Discard(discard_code),
+            TransactionAuxiliaryData::None,
+        )
+    }
+}

--- a/types/src/block_executor/value.rs
+++ b/types/src/block_executor/value.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Defines speculative value interfaces (writes produced by transactions)
+//! used by Block-STM.
+
+use crate::write_set::{TransactionWrite, WriteOpKind};
+use fail::fail_point;
+use move_core_types::value::MoveTypeLayout;
+use triomphe::Arc;
+
+/// A value stored in the multi-version data-structure during Block-STM
+/// speculative execution. Captures exactly the value-level operations the
+/// versioned map performs on a stored value.
+pub trait SpeculativeValue: Clone + Send + Sync {
+    /// Whether two values are equal by value.
+    fn eq_value(&self, other: &Self) -> bool;
+
+    /// Whether the metadata of two values is equal.
+    ///
+    /// Used for resource group metadata.
+    fn eq_metadata(&self, other: &Self) -> bool;
+
+    /// Serialized size of the value in bytes, or None for a deletion / absent value.
+    fn bytes_len(&self) -> Option<usize>;
+
+    /// Whether the value is a deletion.
+    fn is_deletion(&self) -> bool {
+        matches!(self.write_op_kind(), WriteOpKind::Deletion)
+    }
+
+    /// The kind of the write (creation, modification, or deletion).
+    fn write_op_kind(&self) -> WriteOpKind;
+}
+
+/// Value representation used by Block-STM for legacy Move VM.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ValueWithLayout<V> {
+    /// The value was read from storage, there is no layout. Never returned to
+    /// the user, before exchange is performed (see below).
+    RawFromStorage(Arc<V>),
+    /// Storage value that ran exchange or a write. The layout if set indicates
+    /// there are delayed fields inside and [`None`] otherwise.
+    Exchanged(Arc<V>, Option<Arc<MoveTypeLayout>>),
+}
+
+impl<T> Clone for ValueWithLayout<T> {
+    fn clone(&self) -> Self {
+        match self {
+            ValueWithLayout::RawFromStorage(value) => {
+                ValueWithLayout::RawFromStorage(value.clone())
+            },
+            ValueWithLayout::Exchanged(value, layout) => {
+                ValueWithLayout::Exchanged(value.clone(), layout.clone())
+            },
+        }
+    }
+}
+
+impl<V> ValueWithLayout<V> {
+    pub fn extract_value_no_layout(&self) -> &V {
+        match self {
+            ValueWithLayout::RawFromStorage(value) => value.as_ref(),
+            ValueWithLayout::Exchanged(value, None) => value.as_ref(),
+            ValueWithLayout::Exchanged(_, Some(_)) => panic!("Unexpected layout"),
+        }
+    }
+
+    /// Returns a reference to the underlying value, regardless of whether a layout is present.
+    /// Unlike `extract_value_no_layout`, this method does not panic when a layout is present.
+    pub fn extract_value(&self) -> &V {
+        match self {
+            ValueWithLayout::RawFromStorage(value) => value.as_ref(),
+            ValueWithLayout::Exchanged(value, _) => value.as_ref(),
+        }
+    }
+
+    /// Returns true if this value has a layout (i.e., contains delayed fields).
+    pub fn has_layout(&self) -> bool {
+        matches!(self, ValueWithLayout::Exchanged(_, Some(_)))
+    }
+}
+
+impl<V> SpeculativeValue for ValueWithLayout<V>
+where
+    V: TransactionWrite + PartialEq + Send + Sync,
+{
+    fn eq_value(&self, other: &Self) -> bool {
+        // Both must be exchanged with no layout, and their values must be equal.
+        // Layouts pass validation only if both are None; otherwise validation
+        // pessimistically fails, avoiding potentially costly layout comparisons.
+        use ValueWithLayout::*;
+        matches!((self, other), (Exchanged(a, None), Exchanged(b, None)) if a == b)
+    }
+
+    fn eq_metadata(&self, other: &Self) -> bool {
+        // Metadata comparison only passes against exchanged values.
+        use ValueWithLayout::*;
+        matches!((self, other), (Exchanged(a, _), Exchanged(b, _)) if a.as_state_value_metadata() == b.as_state_value_metadata())
+    }
+
+    fn bytes_len(&self) -> Option<usize> {
+        fail_point!("value_with_layout_bytes_len", |_| { Some(10) });
+        match self {
+            ValueWithLayout::RawFromStorage(value) | ValueWithLayout::Exchanged(value, _) => {
+                value.bytes().map(|b| b.len())
+            },
+        }
+    }
+
+    fn write_op_kind(&self) -> WriteOpKind {
+        self.extract_value().write_op_kind()
+    }
+}

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -3569,10 +3569,6 @@ pub trait BlockExecutableTransaction: Sync + Send + Clone + 'static {
     ) -> Self {
         unimplemented!()
     }
-
-    fn pre_write_values(&self) -> Vec<(Self::Key, Self::Value)> {
-        vec![]
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/types/src/transaction/signature_verified_transaction.rs
+++ b/types/src/transaction/signature_verified_transaction.rs
@@ -4,7 +4,6 @@
 use crate::{
     contract_event::ContractEvent,
     state_store::state_key::StateKey,
-    timestamp::TimestampResource,
     transaction::{
         BlockEndInfo, BlockExecutableTransaction, FeeDistribution, SignedTransaction,
         TBlockEndInfoExt, Transaction,
@@ -135,35 +134,6 @@ impl BlockExecutableTransaction for SignatureVerifiedTransaction {
         Transaction::block_epilogue_v2(block_id, block_end_info, fee_distribution, to_make_hot)
             .into()
     }
-
-    fn pre_write_values(&self) -> Vec<(Self::Key, Self::Value)> {
-        let timestamp = match self {
-            SignatureVerifiedTransaction::Valid(Transaction::BlockMetadataExt(metadata_txn)) => {
-                Some(metadata_txn.timestamp_usecs())
-            },
-            SignatureVerifiedTransaction::Valid(Transaction::BlockMetadata(metadata_txn)) => {
-                Some(metadata_txn.timestamp_usecs())
-            },
-            _ => None,
-        };
-
-        match timestamp {
-            Some(ts) => {
-                // Use typed StateKey creation to avoid string parsing.
-                // These unwraps are safe: TimestampResource is a valid MoveResource type,
-                // and u64 serialization via BCS cannot fail.
-                let state_key = StateKey::resource_typed::<TimestampResource>(&AccountAddress::ONE)
-                    .expect("TimestampResource is a valid MoveResource");
-                let value = WriteOp::legacy_modification(
-                    bcs::to_bytes(&ts)
-                        .expect("u64 BCS serialization cannot fail")
-                        .into(),
-                );
-                vec![(state_key, value)]
-            },
-            None => vec![],
-        }
-    }
 }
 
 impl From<Transaction> for SignatureVerifiedTransaction {
@@ -199,52 +169,5 @@ impl TransactionProvider for SignatureVerifiedTransaction {
 impl TransactionProvider for Transaction {
     fn get_transaction(&self) -> Option<&Transaction> {
         Some(self)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::block_metadata::BlockMetadata;
-    use aptos_crypto::HashValue;
-
-    #[test]
-    fn test_pre_write_values_for_block_metadata() {
-        let timestamp_usecs = 1234567890u64;
-        let block_metadata = BlockMetadata::new(
-            HashValue::zero(),
-            1, // epoch
-            1, // round
-            AccountAddress::ONE,
-            vec![], // previous_block_votes_bitvec
-            vec![], // failed_proposer_indices
-            timestamp_usecs,
-        );
-
-        let txn = SignatureVerifiedTransaction::Valid(Transaction::BlockMetadata(block_metadata));
-        let pre_write_values = txn.pre_write_values();
-
-        // Should return exactly one pre-write entry for the timestamp
-        assert_eq!(pre_write_values.len(), 1);
-
-        let (state_key, write_op) = &pre_write_values[0];
-
-        // Verify the state key is for the timestamp resource
-        let expected_state_key =
-            StateKey::resource_typed::<TimestampResource>(&AccountAddress::ONE)
-                .expect("TimestampResource is a valid MoveResource");
-        assert_eq!(state_key, &expected_state_key);
-
-        // Verify the value is the serialized timestamp
-        let expected_value = bcs::to_bytes(&timestamp_usecs).unwrap();
-        assert_eq!(write_op.bytes(), Some(&expected_value.into()));
-    }
-
-    #[test]
-    fn test_pre_write_values_for_user_transaction_returns_empty() {
-        // For non-block-metadata transactions, pre_write_values should return empty
-        let state_checkpoint_txn =
-            SignatureVerifiedTransaction::Valid(Transaction::StateCheckpoint(HashValue::zero()));
-        assert!(state_checkpoint_txn.pre_write_values().is_empty());
     }
 }


### PR DESCRIPTION
## Description

The multi-version data structures (`MVHashMap`, `VersionedData`, `VersionedGroupData`, `UnsyncMap`) stored every value as `ValueWithLayout<V>`: the value plus an optional `MoveTypeLayout` used for the delayed-field exchange. The layout is a legacy Move VM concept, and the maps only need a handful of operations on the values they store. This PR moves the layout handling out of the maps and behind a trait.

What changes:

- **New `SpeculativeValue` trait** (in `aptos-types`). It lists exactly what the maps do with a stored value: value equality, metadata equality, serialized length, and write kind. `ValueWithLayout` moves to `aptos-types` and implements the trait. The validation rule that only exchanged values with no layout compare equal now lives in this impl instead of inside the map.

- **The maps become generic.** `MVHashMap`, `VersionedData`, `VersionedGroupData`, and `UnsyncMap` store an opaque `V: SpeculativeValue`. They no longer reference `TransactionWrite`, `ModulePath`, `MoveTypeLayout`, or the raw/exchanged distinction. Where a map used to decide whether a raw base value should be replaced by an exchanged one, the caller now passes a closure. Block-STM instantiates the maps with `ValueWithLayout<T::Value>`, so behavior stays the same.

- **Committed outputs are returned, not stashed.** Before, materialization stored the committed `TransactionOutput` inside `AptosTransactionOutput` behind a `OnceCell`, and the executor read it back through `after_materialization`, `check_materialization`, and `is_materialized_and_success`. Now `incorporate_materialized_txn_output` returns the committed output, and the executor writes it into the final results directly (`BlockOutput<T, CommittedOutput>`). A new `CommittedTransactionOutput` trait covers what the executor needs from a committed output: fee statement, epoch-event check, retry/success checks, and the retry/discard placeholders. The `OnceCell` and the after-materialization guards are deleted.

- **`TransactionCommitHook` is generic over the output type.** The hook receives the committed output instead of a `OnceCell`, and the unused `on_execution_aborted` is removed.

- **`pre_write_values` moves from `BlockExecutableTransaction` to `ExecutorTask`.** The timestamp pre-write for block metadata transactions produces a value in the executor's representation (an exchanged `ValueWithLayout` with no layout), so it belongs to the VM integration in `aptos-vm`, not to `aptos-types`.

- **`TExecutorView` drops its unused `V` type parameter.**

With this, the multi-version maps are plain data structures with a small trait boundary, and all layout and exchange logic sits in the block executor and the legacy VM adapter. A VM with a different value representation can reuse the same Block-STM infrastructure by instantiating the maps with its own value type.

## How Has This Been Tested?

Existing tests were updated to the new interfaces: mvhashmap unit tests and proptests, the block-executor mock/combinatorial tests, and the delayed-field e2e tests. The pre-write unit tests moved next to the code in `vm_wrapper.rs`. No behavior change is intended.

## Key Areas to Review

- **Validation equality rules.** `eq_value` and `eq_metadata` on `ValueWithLayout` must match the old `compare_values_and_layouts`: value validation passes only for exchanged values with no layouts, and metadata validation passes only between exchanged values.
- **Base-value replacement closures.** `set_base_value` and `update_tagged_base_value_with_layout` take the replacement policy from the caller now.
- **Committed output plumbing.** The commit hook and the final results receive committed outputs directly; retry placeholders replace the old not-yet-materialized slots.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core parallel execution, MVHashMap validation/commit plumbing, and pre-write verification for block metadata; behavior is intended to be unchanged but regressions could affect speculative reads, materialization, or sharded commit hooks.
> 
> **Overview**
> Refactors Block-STM so multi-version maps (`MVHashMap`, `VersionedData`, group/unsync maps) store opaque `V: SpeculativeValue` instead of owning `ValueWithLayout` and Move layouts. **`ValueWithLayout` and `SpeculativeValue` move to `aptos-types`**; layout/exchange and validation equality rules live there and in the executor, while maps only call trait methods and accept **caller-supplied closures** for raw→exchanged base-value upgrades.
> 
> **Materialization/commit path:** `incorporate_materialized_txn_output` now **returns** `(CommittedOutput, Trace)` instead of filling a `OnceCell` on the speculative wrapper. Block results are `CommittedOutput` values; **`AfterMaterializationOutput`**, **`check_materialization`**, **`discard_output`**, and related guards are removed in favor of **`CommittedTransactionOutput`**.
> 
> **Integration tweaks:** `TransactionCommitHook<O>` gets committed outputs directly (no `OnceCell`; **`on_execution_aborted` removed**). **`pre_write_values`** moves from `BlockExecutableTransaction` to **`ExecutorTask`** (e.g. block-metadata timestamp pre-write in `AptosExecutorTask`). **`TExecutorView`** drops an unused value type parameter. Write-set APIs use **`ValueWithLayout<WriteOp>`** end-to-end through the executor and mocks/tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 356ae1821e01aa9c06981cb16cfb0ce331996094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->