### PR TITLE
[vm] Bound fail-closed delayed-field squash to [1.46, 1.48)

### DIFF
--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -650,12 +650,13 @@ impl VMChangeSet {
                             }),
                         ) => {
                             if strict_delayed_field_squash {
-                                // SAFETY (gas_feature_version >= RELEASE_V1_46): fail closed, the
+                                // SAFETY (fail-closed window [RELEASE_V1_46, RELEASE_V1_48)): the
                                 // standalone-resource analogue of the resource-group arm below. A
                                 // full resource write squashed with a later in-place delayed-field
                                 // exchange on the same key is rejected; a matching materialized
                                 // size does not prove the later exchange reconciles with what the
-                                // earlier session wrote.
+                                // earlier session wrote. From RELEASE_V1_48 the view-layer fix makes
+                                // this sound again and we fall through to the legacy merge.
                                 return Err(code_invariant_error(format!(
                                     "Refusing to squash a resource write with a later in-place \
                                      delayed-field change on the same key (fail-closed for safety): \
@@ -663,7 +664,7 @@ impl VMChangeSet {
                                     key, additional_entry
                                 )));
                             }
-                            // Legacy behavior (gas_feature_version < RELEASE_V1_46): a read cannot
+                            // Legacy behavior (outside the fail-closed window): a read cannot
                             // change the size (i.e. delayed fields don't modify size), so allow the
                             // merge only when the materialized sizes match.
                             if materialized_size != &Some(*additional_materialized_size) {
@@ -689,7 +690,7 @@ impl VMChangeSet {
                             ),
                         ) => {
                             if strict_delayed_field_squash {
-                                // SAFETY (gas_feature_version >= RELEASE_V1_46): fail closed. We
+                                // SAFETY (fail-closed window [RELEASE_V1_46, RELEASE_V1_48)): we
                                 // deliberately do NOT allow squashing a full resource-group write
                                 // (an earlier session that wrote the group, e.g. structurally
                                 // changed its membership) with a later in-place delayed-field
@@ -701,7 +702,8 @@ impl VMChangeSet {
                                 // abort the transaction. This is asset-safe: no change set is
                                 // applied. Legitimate flows touch the group purely in place
                                 // (ResourceGroupInPlaceDelayedFieldChange on both sides), handled by
-                                // the arm below.
+                                // the arm below. From RELEASE_V1_48 the view-layer fix makes this
+                                // sound again and we fall through to the legacy merge.
                                 return Err(code_invariant_error(format!(
                                     "Refusing to squash a resource-group write with a later \
                                      in-place delayed-field change on the same group (fail-closed \
@@ -709,7 +711,7 @@ impl VMChangeSet {
                                     key, additional_entry
                                 )));
                             }
-                            // Legacy behavior (gas_feature_version < RELEASE_V1_46): a read cannot
+                            // Legacy behavior (outside the fail-closed window): a read cannot
                             // change the size (i.e. delayed fields don't modify size), so allow the
                             // merge only when the materialized sizes match.
                             if materialized_size.map(|v| v.get())

--- a/aptos-move/aptos-vm-types/src/storage/change_set_configs.rs
+++ b/aptos-move/aptos-vm-types/src/storage/change_set_configs.rs
@@ -65,17 +65,24 @@ impl ChangeSetConfigs {
         self.gas_feature_version < 3
     }
 
-    /// From `RELEASE_V1_46`, squashing a full write (an earlier session that wrote a value or a
-    /// resource group) with a later *in-place delayed-field change* on the *same* key (e.g. the gas
-    /// epilogue exchanging an aggregator in that value/group) is rejected outright (fail-closed).
-    /// This covers both the resource-group arm (`WriteResourceGroup ⊕
-    /// ResourceGroupInPlaceDelayedFieldChange`) and the standalone-resource arm
-    /// (`WriteWithDelayedFields ⊕ InPlaceDelayedFieldChange`). Before that version, the merge was
-    /// permitted whenever the materialized sizes happened to match -- a matching size does not
-    /// prove the later session's delayed-field exchange reconciles with what the earlier session
-    /// wrote, so we no longer rely on it. See `VMChangeSet::squash_additional_resource_writes`.
+    /// Fail-closed window `[RELEASE_V1_46, RELEASE_V1_48)`. Within it, squashing a full write (an
+    /// earlier session that wrote a value or a resource group) with a later *in-place delayed-field
+    /// change* on the *same* key (e.g. the gas epilogue exchanging an aggregator in that
+    /// value/group) is rejected outright. This covers both the resource-group arm
+    /// (`WriteResourceGroup ⊕ ResourceGroupInPlaceDelayedFieldChange`) and the standalone-resource
+    /// arm (`WriteWithDelayedFields ⊕ InPlaceDelayedFieldChange`).
+    ///
+    /// Before `RELEASE_V1_46`, the merge was permitted whenever the materialized sizes happened to
+    /// match -- a matching size does not by itself prove the later session's delayed-field exchange
+    /// reconciles with what the earlier session wrote, hence the defensive fail-closed interim.
+    ///
+    /// From `RELEASE_V1_48`, the view-layer reconciliation fix (which layers the earlier change set
+    /// so the later session's in-place exchange reflects the earlier write) is active, so the
+    /// materialized-size match is once again a sound proof and we revert to the legacy squash. See
+    /// `VMChangeSet::squash_additional_resource_writes`.
     pub fn strict_delayed_field_squash(&self) -> bool {
-        self.gas_feature_version >= aptos_gas_schedule::gas_feature_versions::RELEASE_V1_46
+        use aptos_gas_schedule::gas_feature_versions::{RELEASE_V1_46, RELEASE_V1_48};
+        (RELEASE_V1_46..RELEASE_V1_48).contains(&self.gas_feature_version)
     }
 
     fn for_feature_version_3() -> Self {

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -577,8 +577,8 @@ fn test_resource_groups_squashing() {
 
     {
         // WriteResourceGroup ⊕ in-place delayed-field change of *matching* size: permitted under
-        // the legacy rules (the group write is kept), but fail-closed from RELEASE_V1_46. This is
-        // the gas-version-gated behavior change.
+        // the legacy rules (the group write is kept), but fail-closed inside the window
+        // [RELEASE_V1_46, RELEASE_V1_48). This is the gas-version-gated behavior change.
         let matching_inplace = ExpandedVMChangeSetBuilder::new()
             .with_group_reads_needing_delayed_field_exchange(vec![(
                 as_state_key!("1"),
@@ -640,8 +640,8 @@ fn test_write_and_read_discrepancy_caught() {
 
 /// Standalone-resource analogue of the resource-group gate: a `WriteWithDelayedFields` squashed
 /// with a later `InPlaceDelayedFieldChange` on the same key is rejected outright under the strict
-/// (gas_feature_version >= RELEASE_V1_46) squash, regardless of whether the materialized sizes
-/// match. (The group analogue is exercised in `test_resource_groups_squashing`.)
+/// squash (fail-closed window [RELEASE_V1_46, RELEASE_V1_48)), regardless of whether the
+/// materialized sizes match. (The group analogue is exercised in `test_resource_groups_squashing`.)
 #[test]
 fn test_squash_standalone_write_then_inplace_delayed_field_gated() {
     let layout = TriompheArc::new(MoveTypeLayout::U64);
@@ -661,7 +661,7 @@ fn test_squash_standalone_write_then_inplace_delayed_field_gated() {
         )])
         .build();
 
-    // Strict (>= RELEASE_V1_46): rejected outright, fail-closed.
+    // Strict (fail-closed window [RELEASE_V1_46, RELEASE_V1_48)): rejected outright.
     let mut strict = write.clone();
     let err = assert_err!(strict.squash_additional_change_set(inplace.clone(), true));
     assert!(

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
@@ -43,6 +43,7 @@ pub struct ExecutorViewWithChangeSet<'r> {
 
 /// Test-only constructor so cross-session squash PoCs can layer a prior session's change set
 /// over an executor view (mirrors how the respawned epilogue session is built).
+#[cfg(any(test, feature = "testing"))]
 pub fn new_for_executor_view_with_change_set_for_test<'r>(
     base_executor_view: &'r dyn ExecutorView,
     base_resource_group_view: &'r dyn ResourceGroupView,

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -5,10 +5,10 @@
 //! aptos-core-private #292). Each scenario runs two VM sessions over a test-only `0x1::session`
 //! package — session_1 transforms a delayed-field container, session_2 touches the aggregator —
 //! then squashes their change sets, exactly mirroring the prologue/user/epilogue interaction but
-//! with full control over both sessions. Asserted under the STRICT resource-group squash
-//! (`gas_feature_version >= RELEASE_V1_46`): benign delta+delta flows and disjoint controls
-//! succeed with correct materialized values, while cross-session structural cases fail closed with
-//! the exact expected error (see `session.move` for the scenarios).
+//! with full control over both sessions. Asserted under the STRICT resource-group squash (the
+//! fail-closed window `[RELEASE_V1_46, RELEASE_V1_48)`): benign delta+delta flows and disjoint
+//! controls succeed with correct materialized values, while cross-session structural cases fail
+//! closed with the exact expected error (see `session.move` for the scenarios).
 
 use crate::{assert_success, tests::common, MoveHarness};
 use aptos_aggregator::{
@@ -356,8 +356,9 @@ impl ExecutorTask for TestTask {
         let change_set_2 = self.run(&new_resolver, view, &txn.session_2);
         println!("  [session_2] change set: {:?}", change_set_2);
 
-        // Use the strict (gas_feature_version >= RELEASE_V1_46) resource-group squash, matching
-        // production behavior at the latest gas feature version.
+        // Exercise the strict resource-group squash (the fail-closed window
+        // [RELEASE_V1_46, RELEASE_V1_48)) by passing `true` explicitly, independent of the harness's
+        // gas feature version.
         let outcome = match change_set_1.squash_additional_change_set(change_set_2, true) {
             Ok(()) => {
                 // Resolve every aggregator in the SQUASHED change set to its final, materialized
@@ -483,8 +484,9 @@ fn test_session_with_delayed_fields() {
 
 fn run_all_scenarios() {
     // (label, session_1, session_2, expected), asserted under the STRICT resource-group squash
-    // (gas_feature_version >= RELEASE_V1_46). Cross-session structural cases fail closed with the
-    // exact error; benign delta+delta flows and disjoint controls succeed with correct values.
+    // (fail-closed window [RELEASE_V1_46, RELEASE_V1_48)). Cross-session structural cases fail
+    // closed with the exact error; benign delta+delta flows and disjoint controls succeed with
+    // correct values.
     let scenarios = [
         // NORMAL concurrent-FA flow: same aggregator delta'd in BOTH sessions, NO structural
         // change (user-session transfer delta + epilogue gas delta). Must stay allowed + correct.

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -1,14 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Cross-session delayed-field squash regression matrix (harness originally from
-//! aptos-core-private #292). Each scenario runs two VM sessions over a test-only `0x1::session`
-//! package — session_1 transforms a delayed-field container, session_2 touches the aggregator —
-//! then squashes their change sets, exactly mirroring the prologue/user/epilogue interaction but
-//! with full control over both sessions. Asserted under the STRICT resource-group squash (the
-//! fail-closed window `[RELEASE_V1_46, RELEASE_V1_48)`): benign delta+delta flows and disjoint
-//! controls succeed with correct materialized values, while cross-session structural cases fail
-//! closed with the exact expected error (see `session.move` for the scenarios).
+//! Cross-session delayed-field squash regression matrix. Each scenario runs two VM sessions over a
+//! test-only `0x1::session` package (session_1 transforms a delayed-field container, session_2
+//! touches the aggregator), then squashes their change sets, mirroring the prologue/user/epilogue
+//! interaction. Under the strict squash, benign delta+delta and disjoint flows succeed with correct
+//! materialized values, while cross-session structural cases fail closed (see `session.move`).
 
 use crate::{assert_success, tests::common, MoveHarness};
 use aptos_aggregator::{

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -244,8 +244,9 @@ pub fn encode_aptos_mainnet_genesis_transaction(
         HashValue::new(new_id),
         framework,
     );
-    // Genesis runs at the latest gas feature version, so use the strict resource-group squash.
-    assert_ok!(change_set.squash_additional_change_set(additional_change_set, true));
+    // Genesis runs at the latest gas feature version, which is outside the fail-closed window
+    // [RELEASE_V1_46, RELEASE_V1_48), so it uses the legacy (non-strict) resource-group squash.
+    assert_ok!(change_set.squash_additional_change_set(additional_change_set, false));
 
     let change_set = assert_ok!(change_set.try_combine_into_storage_change_set(module_write_set));
     verify_genesis_module_write_set(change_set.write_set());
@@ -421,8 +422,9 @@ pub fn encode_genesis_change_set(
         HashValue::new(new_id),
         framework,
     );
-    // Genesis runs at the latest gas feature version, so use the strict resource-group squash.
-    assert_ok!(change_set.squash_additional_change_set(additional_change_set, true));
+    // Genesis runs at the latest gas feature version, which is outside the fail-closed window
+    // [RELEASE_V1_46, RELEASE_V1_48), so it uses the legacy (non-strict) resource-group squash.
+    assert_ok!(change_set.squash_additional_change_set(additional_change_set, false));
 
     let change_set = assert_ok!(change_set.try_combine_into_storage_change_set(module_write_set));
     verify_genesis_module_write_set(change_set.write_set());


### PR DESCRIPTION
## Summary

Follow-up to the strict delayed-field squash (already on `main`). That change made the fail-closed squash of a full write with a later in-place delayed-field change active **from `RELEASE_V1_46` onward**. This PR turns it into a **bounded window `[RELEASE_V1_46, RELEASE_V1_48)`**.

The fail-closed behavior was always intended as a **defensive interim**: rely on it only until the view-layer reconciliation fix is active. From `RELEASE_V1_48` — where the view layer makes the later session's in-place delayed-field exchange reflect the earlier write — the materialized-size match is once again a sound proof, so we revert to the legacy squash.

| Gas version | Squash behavior |
|---|---|
| `< 1.46` | legacy (allow when materialized sizes match) |
| `1.46`, `1.47` | **fail-closed** (defensive interim) |
| `≥ 1.48` | legacy again (view-layer fix makes the size-match sound) |

## Changes

- `change_set_configs.rs`: `strict_delayed_field_squash()` becomes `(RELEASE_V1_46..RELEASE_V1_48).contains(&gas_feature_version)` instead of `>= RELEASE_V1_46`.
- `change_set.rs`, `test_change_set.rs`, `sessions_with_delayed_fields.rs`: doc/comment updates to describe the window.
- `vm-genesis/src/lib.rs`: genesis runs at the latest gas feature version (outside the window), so it uses the legacy (non-strict) squash. This is a no-op in practice (genesis change sets touch disjoint keys; `false` is strictly more permissive than `true`).

The squash gate is exercised by the existing unit tests and cross-session matrix (added in the strict-squash PR), which pass the `strict` flag as a literal, so they validate both arms of the gate directly regardless of the window boundaries.

## Pre-flight

- `cargo +nightly fmt` — clean
- `cargo sort --workspace --check` — clean
- `cargo machete` — clean
- `cargo test -p aptos-vm-types` — 42/42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes VM change-set merging for resource groups and delayed-field resources at gas ≥1.48, where transactions that would have aborted under strict squash may succeed again—intended once the view fix is active, but correctness depends on that fix being live at those versions.
> 
> **Overview**
> **Narrows when cross-session change-set squash rejects “full write + later in-place delayed-field change” on the same key.** `ChangeSetConfigs::strict_delayed_field_squash()` now returns true only for gas feature versions in **`[RELEASE_V1_46, RELEASE_V1_48)`** (1.46 and 1.47), instead of staying on from 1.46 forever. Below 1.46 and from **1.48 onward**, squash again uses the legacy rule: allow the merge when materialized sizes match, on the assumption that from 1.48 the view-layer fix makes that check sound.
> 
> Comments in `change_set.rs` and tests describe this as a **temporary fail-closed window** between the interim safety gate and the reconciliation fix. **Genesis** squashes the framework session with **`strict_delayed_field_squash: false`**, since latest gas version is outside the window (behavior unchanged in practice for disjoint keys). The e2e matrix still passes `true` explicitly to exercise the strict arm. `new_for_executor_view_with_change_set_for_test` is gated with **`feature = "testing"`** in addition to `test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f202f35966a4413f88a962c40e6aa1b5105e41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->