### PR TITLE
[mono-move] Decouple gas instrumentation from lowering

### DIFF
--- a/third_party/move/mono-move/specializer/src/destack/mod.rs
+++ b/third_party/move/mono-move/specializer/src/destack/mod.rs
@@ -29,16 +29,7 @@ pub fn destack(module: CompiledModule, interner: &impl Interner) -> Result<Modul
     // Gas instrumentation: emit a per-block cost formula for each function.
     // TODO(metering): could be hoisted before optimization, at the cost of
     // over-approximating (charging for instructions that optimization removes).
-    let ModuleIR { module, functions } = &mut module_ir;
-    for func in functions.iter_mut().flatten() {
-        func.block_costs = gas::function_block_costs(
-            module,
-            interner,
-            &func.blocks,
-            &func.home_slot_types,
-            func.num_xfer_positions,
-        )?;
-    }
+    gas::instrument(&mut module_ir, interner)?;
 
     // Debug-mode failsafe: verify xfer invariants hold after optimization.
     #[cfg(debug_assertions)]

--- a/third_party/move/mono-move/specializer/src/destack/mod.rs
+++ b/third_party/move/mono-move/specializer/src/destack/mod.rs
@@ -11,7 +11,7 @@ mod ssa_function;
 mod test_utils;
 mod translate;
 
-use crate::stackless_exec_ir::ModuleIR;
+use crate::{gas, stackless_exec_ir::ModuleIR};
 use anyhow::{bail, Result};
 use mono_move_core::{Interner, PreparedModule};
 use move_binary_format::CompiledModule;
@@ -25,6 +25,21 @@ pub fn destack(module: CompiledModule, interner: &impl Interner) -> Result<Modul
     let module = PreparedModule::build(module, interner)?;
     let mut module_ir = translate::translate_module(module, interner)?;
     optimize::optimize_module(&mut module_ir);
+
+    // Gas instrumentation: emit a per-block cost formula for each function.
+    // TODO(metering): could be hoisted before optimization, at the cost of
+    // over-approximating (charging for instructions that optimization removes).
+    let ModuleIR { module, functions } = &mut module_ir;
+    for func in functions.iter_mut().flatten() {
+        func.block_costs = gas::function_block_costs(
+            module,
+            interner,
+            &func.blocks,
+            &func.home_slot_types,
+            func.num_xfer_positions,
+        )?;
+    }
+
     // Debug-mode failsafe: verify xfer invariants hold after optimization.
     #[cfg(debug_assertions)]
     for func in module_ir.functions.iter().flatten() {

--- a/third_party/move/mono-move/specializer/src/destack/translate.rs
+++ b/third_party/move/mono-move/specializer/src/destack/translate.rs
@@ -77,7 +77,7 @@ pub fn translate_module(module: PreparedModule, interner: &impl Interner) -> Res
                 num_xfer_positions: alloc.num_xfer_positions,
                 blocks: alloc.blocks,
                 home_slot_types: alloc.home_slot_types,
-                // Emitted by a later pass, after optimization.
+                // Populated by the gas instrumentation pass.
                 block_costs: Vec::new(),
             }))
         })

--- a/third_party/move/mono-move/specializer/src/destack/translate.rs
+++ b/third_party/move/mono-move/specializer/src/destack/translate.rs
@@ -77,6 +77,8 @@ pub fn translate_module(module: PreparedModule, interner: &impl Interner) -> Res
                 num_xfer_positions: alloc.num_xfer_positions,
                 blocks: alloc.blocks,
                 home_slot_types: alloc.home_slot_types,
+                // Emitted by a later pass, after optimization.
+                block_costs: Vec::new(),
             }))
         })
         .collect::<Result<Vec<_>>>()?;

--- a/third_party/move/mono-move/specializer/src/gas.rs
+++ b/third_party/move/mono-move/specializer/src/gas.rs
@@ -5,10 +5,15 @@
 //!
 //! A cost is either fixed (constant, e.g. arithmetic and branches) or
 //! size-dependent (scaling with a type's byte size, e.g. moves and reference
-//! reads/writes). Size-dependent costs still resolve to a constant here, since
-//! types are concrete by the time costs are computed, so every instruction
-//! ends up with a single constant cost. The costs over-approximate the work,
-//! and the numbers are placeholders.
+//! reads/writes). Every cost is affine in type sizes — `base + Σ coeff * size(T)`
+//! — which lets costing split in two:
+//!
+//! - [`function_block_costs`] sums each block into a [`BlockCost`] formula. The
+//!   size terms stay symbolic (types may be polymorphic).
+//! - [`CostResolver::resolve_block_cost`] evaluates a formula for a concrete
+//!   instantiation.
+//!
+//! The costs over-approximate the work, and the numbers are placeholders.
 //!
 //! A cost may also have a runtime-dependent component, knowable only during
 //! execution (e.g. the IO of a global-storage operation, or the size of the
@@ -17,26 +22,24 @@
 //!
 //! TODO(metering): the deep-copy component of heap-backed copies/reads is uncharged
 //! — these arms charge only the shallow byte move.
-//!
-//! TODO(metering): split cost computation from resolution. Emit size-dependent costs as
-//! formulas (e.g. `a + b * size(T)`) and resolve them later, rather than
-//! resolving each as it is computed.
 
 use crate::{
-    lower::context::{concrete_type_size, ref_pointee_size},
-    stackless_exec_ir::{Instr, Slot},
+    lower::context::concrete_type_size,
+    stackless_exec_ir::{instr_utils::for_each_value_use, BasicBlock, Instr, Slot},
 };
 use anyhow::{bail, Result};
-use mono_move_core::{types::InternedType, LayoutProvider};
+use mono_move_core::{
+    types::{strip_ref, view_type, view_type_list, InternedType, InternedTypeList, Type},
+    Interner, LayoutProvider, PreparedModule,
+};
 use move_binary_format::file_format::FieldHandleIndex;
 
 // --- Loads ---
 const LD: u64 = 2;
 
 // --- Data movement ---
-fn move_bytes(num_bytes: u32) -> u64 {
-    2 + 3 * num_bytes as u64
-}
+const MOVE_BASE: u64 = 2;
+const MOVE_PER_BYTE: u64 = 3;
 
 // --- Operators ---
 /// Any unary or binary operator: arithmetic, bitwise, shift, negate,
@@ -50,9 +53,8 @@ const TEST_VARIANT: u64 = 4;
 
 // --- References ---
 const BORROW: u64 = 2;
-fn read_write_ref(num_bytes: u32) -> u64 {
-    2 + 3 * num_bytes as u64
-}
+const REF_RW_BASE: u64 = 2;
+const REF_RW_PER_BYTE: u64 = 3;
 /// A field read whose size isn't known here (variant forms).
 const FIELD_READ: u64 = 5;
 
@@ -68,9 +70,8 @@ const PACK_CLOSURE: u64 = 9;
 const VEC_NEW: u64 = 10;
 const VEC_LEN: u64 = 2;
 const VEC_BORROW: u64 = 3;
-fn vec_elem(elem_size: u32) -> u64 {
-    4 + 3 * elem_size as u64
-}
+const VEC_ELEM_BASE: u64 = 4;
+const VEC_ELEM_PER_BYTE: u64 = 3;
 
 // --- Control flow ---
 const RETURN: u64 = 2;
@@ -80,167 +81,344 @@ const JUMP: u64 = 2;
 const COND_JUMP: u64 = 3;
 const FORCE_GC: u64 = 100;
 
-/// Operand size and type queries used by [`instr_cost`]. A slot's size comes
-/// from the resolved layout, not its type, which may be polymorphic.
-pub(crate) trait CostContext {
-    /// Monomorphised byte size of the type bound to `slot`.
-    fn slot_size(&self, slot: Slot) -> Result<u32>;
+// =============================================================================
+// Cost formula
+// =============================================================================
 
-    /// Interned type bound to `slot` (may be polymorphic).
-    fn slot_ty(&self, slot: Slot) -> Result<InternedType>;
-
-    /// Byte size of field `fh` of struct type `struct_ty`.
-    fn field_size(&self, struct_ty: InternedType, fh: FieldHandleIndex) -> Result<u32>;
-
-    /// Substitutes the instantiation's type arguments into an
-    /// instruction-embedded type.
-    /// TODO(metering): reconsider whether this is the right abstraction. Charging
-    /// substitutes types here only to read monomorphized sizes,
-    /// duplicating the substitution lowering already performs.
-    fn concrete_ty(&self, ty: InternedType) -> Result<InternedType>;
-
-    /// Published value layouts, used to resolve concrete type sizes.
-    fn layouts(&self) -> &dyn LayoutProvider;
+/// A block's cost as an affine formula `base + Σ coeff * size(ty)`, left
+/// unresolved until the instantiation's type sizes are known.
+#[derive(Clone, Default)]
+pub(crate) struct BlockCost {
+    base: u64,
+    terms: Vec<(u64, InternedType)>,
 }
 
-/// Total move cost over a list of source slots.
-fn sum_move(cx: &impl CostContext, slots: &[Slot]) -> Result<u64> {
-    let mut total = 0;
-    for slot in slots {
-        total += move_bytes(cx.slot_size(*slot)?);
+impl BlockCost {
+    /// Add a fixed cost.
+    fn add_constant(&mut self, c: u64) {
+        self.base += c;
     }
-    Ok(total)
+
+    /// Add a size-dependent cost `base + per_byte * size(ty)`.
+    fn add_sized(&mut self, base: u64, per_byte: u64, ty: InternedType) {
+        self.base += base;
+        self.terms.push((per_byte, ty));
+    }
 }
 
-/// Gas cost of `instr` at the IR level.
-pub(crate) fn instr_cost(instr: &Instr, cx: &impl CostContext) -> Result<u64> {
-    Ok(match instr {
-        // --- Loads ---
-        Instr::LdConst(..)
-        | Instr::LdTrue(..)
-        | Instr::LdFalse(..)
-        | Instr::LdU8(..)
-        | Instr::LdU16(..)
-        | Instr::LdU32(..)
-        | Instr::LdU64(..)
-        | Instr::LdU128(..)
-        | Instr::LdU256(..)
-        | Instr::LdI8(..)
-        | Instr::LdI16(..)
-        | Instr::LdI32(..)
-        | Instr::LdI64(..)
-        | Instr::LdI128(..)
-        | Instr::LdI256(..) => LD,
+// =============================================================================
+// Emission: polymorphic IR -> per-block cost formulas
+// =============================================================================
 
-        // --- Slot ops ---
-        Instr::Copy(_, src) | Instr::Move(_, src) => move_bytes(cx.slot_size(*src)?),
-
-        // --- Unary / Binary ---
-        Instr::UnaryOp(..) | Instr::BinaryOp(..) | Instr::BinaryOpImm(..) => OP,
-
-        // --- Structs ---
-        Instr::Pack(_, struct_ty, _) | Instr::Unpack(_, struct_ty, _) => move_bytes(
-            concrete_type_size(cx.layouts(), cx.concrete_ty(*struct_ty)?, "struct type")?,
-        ),
-
-        // --- Enums ---
-        Instr::PackVariant(..) | Instr::UnpackVariant(..) => PACK_UNPACK,
-        Instr::TestVariant(..) => TEST_VARIANT,
-
-        // --- References ---
-        Instr::ImmBorrowLoc(..)
-        | Instr::MutBorrowLoc(..)
-        | Instr::ImmBorrowField(..)
-        | Instr::MutBorrowField(..)
-        | Instr::ImmBorrowVariantField(..)
-        | Instr::MutBorrowVariantField(..) => BORROW,
-        Instr::ReadRef(_, ref_src) => {
-            read_write_ref(ref_pointee_size(cx.layouts(), cx.slot_ty(*ref_src)?)?)
-        },
-        Instr::WriteRef(ref_dst, _) => {
-            read_write_ref(ref_pointee_size(cx.layouts(), cx.slot_ty(*ref_dst)?)?)
-        },
-
-        // --- Fused field access (borrow + read/write) ---
-        Instr::ReadField(_, owner, fh, _) => {
-            read_write_ref(cx.field_size(cx.concrete_ty(*owner)?, *fh)?)
-        },
-        Instr::WriteField(_, _, _, val) => read_write_ref(cx.slot_size(*val)?),
-        Instr::ReadVariantField(..) => FIELD_READ,
-        Instr::WriteVariantField(_, _, _, val) => read_write_ref(cx.slot_size(*val)?),
-
-        // --- Fused inline-struct field access ---
-        Instr::ImmBorrowLocField(..) | Instr::MutBorrowLocField(..) => BORROW,
-        Instr::ReadLocalField(_, owner, fh, _) => {
-            move_bytes(cx.field_size(cx.concrete_ty(*owner)?, *fh)?)
-        },
-        Instr::WriteLocalField(_, _, _, val) => move_bytes(cx.slot_size(*val)?),
-
-        // --- Globals ---
-        Instr::Exists(..)
-        | Instr::MoveFrom(..)
-        | Instr::MoveTo(..)
-        | Instr::ImmBorrowGlobal(..)
-        | Instr::MutBorrowGlobal(..) => GLOBAL,
-
-        // --- Calls ---
-        Instr::Call(rets, _, _, args) => call_cost(cx, args, rets)?,
-
-        // --- Closures ---
-        Instr::PackClosure(_, _, _, _, args) => PACK_CLOSURE + sum_move(cx, args)?,
-        Instr::CallClosure(rets, _, args) => call_cost(cx, args, rets)?,
-
-        // --- Vector ---
-        Instr::VecPack(_, _, elems) => VEC_NEW + sum_move(cx, elems)?,
-        Instr::VecLen(..) => VEC_LEN,
-        Instr::VecImmBorrow(..) | Instr::VecMutBorrow(..) => VEC_BORROW,
-        Instr::VecPushBack(elem_ty, _, _) | Instr::VecPopBack(_, elem_ty, _) => vec_elem(
-            concrete_type_size(cx.layouts(), cx.concrete_ty(*elem_ty)?, "vector elem type")?,
-        ),
-        Instr::VecUnpack(dsts, elem_ty, _) => {
-            VEC_NEW
-                + dsts.len() as u64
-                    * move_bytes(concrete_type_size(
-                        cx.layouts(),
-                        cx.concrete_ty(*elem_ty)?,
-                        "vector elem type",
-                    )?)
-        },
-        Instr::VecSwap(elem_ty, _, _, _) => {
-            2 * vec_elem(concrete_type_size(
-                cx.layouts(),
-                cx.concrete_ty(*elem_ty)?,
-                "vector elem type",
-            )?)
-        },
-
-        // --- Control flow ---
-        Instr::Branch(..) => JUMP,
-        Instr::BrTrue(..) | Instr::BrFalse(..) | Instr::BrCmp(..) | Instr::BrCmpImm(..) => {
-            COND_JUMP
-        },
-        // 2x per slot upper-bounds the cycle-breaking scratch moves
-        // `emit_parallel_copy` adds for a cyclic (e.g. swap-style) return.
-        Instr::Ret(slots) => RETURN + 2 * sum_move(cx, slots)?,
-        Instr::Abort(..) => ABORT,
-        Instr::AbortMsg(..) => ABORT_MSG,
-
-        Instr::ForceGC => FORCE_GC,
-    })
+/// Emit one [`BlockCost`] formula per block, indexed by block label.
+pub(crate) fn function_block_costs<I: Interner>(
+    module: &PreparedModule,
+    interner: &I,
+    blocks: &[BasicBlock],
+    home_slot_types: &[InternedType],
+    num_xfer_positions: u16,
+) -> Result<Vec<BlockCost>> {
+    let mut emitter = Emitter {
+        module,
+        interner,
+        home_slot_types,
+        xfer_ret_types: vec![None; num_xfer_positions as usize],
+    };
+    // Indexed by block label (dense `0..blocks.len()`).
+    let mut costs = vec![BlockCost::default(); blocks.len()];
+    for block in blocks {
+        costs[block.label.0 as usize] = emitter.block_cost(block)?;
+    }
+    Ok(costs)
 }
 
-/// Cost of a call: the dispatch, a move per argument, and a move per
-/// Home-slot return.
-fn call_cost(cx: &impl CostContext, args: &[Slot], rets: &[Slot]) -> Result<u64> {
-    let mut cost = CALL + sum_move(cx, args)?;
-    for ret in rets {
-        match *ret {
-            Slot::Xfer(_) => {
-                // Placed without a copy.
-            },
-            Slot::Home(_) => cost += move_bytes(cx.slot_size(*ret)?),
-            Slot::Vid(_) => bail!("Vid slot in post-allocation IR"),
+/// Builds cost formulas by walking the IR. Xfer slots carry no type in the IR,
+/// so the emitter tracks the type flowing through each one.
+struct Emitter<'a, I: Interner> {
+    module: &'a PreparedModule,
+    interner: &'a I,
+    /// Type of each Home slot, indexed by Home slot id.
+    home_slot_types: &'a [InternedType],
+    /// Type bound to each Xfer position by the most recent call's returns.
+    /// Block-local: reset per block and clobbered by every call.
+    xfer_ret_types: Vec<Option<InternedType>>,
+}
+
+impl<I: Interner> Emitter<'_, I> {
+    /// Type of the value in `slot`. An Xfer slot read here always holds a prior
+    /// call's return (call arguments are costed from the callee signature).
+    fn slot_ty(&self, slot: Slot) -> Result<InternedType> {
+        match slot {
+            Slot::Home(i) => Ok(self.home_slot_types[i as usize]),
+            Slot::Xfer(j) => self.xfer_ret_types[j as usize].ok_or_else(|| {
+                anyhow::anyhow!("Xfer({}) read without a prior call-return binding", j)
+            }),
+            Slot::Vid(i) => bail!("Vid({}) in post-allocation IR", i),
         }
     }
-    Ok(cost)
+
+    /// Pointee type of a reference slot (`ReadRef`/`WriteRef` touch the pointee).
+    fn pointee_ty(&self, ref_slot: Slot) -> Result<InternedType> {
+        strip_ref(self.slot_ty(ref_slot)?)
+    }
+
+    /// Type of struct field `fh`, with the owner nominal's type arguments applied.
+    fn field_ty(&self, owner: InternedType, fh: FieldHandleIndex) -> Result<InternedType> {
+        let Type::Nominal { ty_args, .. } = view_type(owner) else {
+            bail!("field owner is not a struct type");
+        };
+        self.interner
+            .subst_type(self.module.interned_field_type_at(fh), *ty_args)
+    }
+
+    /// Cost of the formula for one block, resetting Xfer tracking at its start.
+    fn block_cost(&mut self, block: &BasicBlock) -> Result<BlockCost> {
+        // Xfer slots are block-local.
+        self.xfer_ret_types.iter_mut().for_each(|t| *t = None);
+        let mut b = BlockCost::default();
+        for instr in &block.instrs {
+            self.instr_cost(&mut b, instr)?;
+            self.advance_xfer_tracking(instr);
+        }
+        Ok(b)
+    }
+
+    /// After costing `instr`, drop the Xfer slots it consumed. Calls manage
+    /// their own return bindings in [`Self::call_cost`].
+    fn advance_xfer_tracking(&mut self, instr: &Instr) {
+        if matches!(instr, Instr::Call(..) | Instr::CallClosure(..)) {
+            return;
+        }
+        for_each_value_use(instr, |s| {
+            if let Slot::Xfer(j) = s {
+                self.xfer_ret_types[j as usize] = None;
+            }
+        });
+    }
+
+    /// Emit the cost of `instr` into `b`.
+    fn instr_cost(&mut self, b: &mut BlockCost, instr: &Instr) -> Result<()> {
+        match instr {
+            // --- Loads ---
+            Instr::LdConst(..)
+            | Instr::LdTrue(..)
+            | Instr::LdFalse(..)
+            | Instr::LdU8(..)
+            | Instr::LdU16(..)
+            | Instr::LdU32(..)
+            | Instr::LdU64(..)
+            | Instr::LdU128(..)
+            | Instr::LdU256(..)
+            | Instr::LdI8(..)
+            | Instr::LdI16(..)
+            | Instr::LdI32(..)
+            | Instr::LdI64(..)
+            | Instr::LdI128(..)
+            | Instr::LdI256(..) => b.add_constant(LD),
+
+            // --- Slot ops ---
+            Instr::Copy(_, src) | Instr::Move(_, src) => {
+                b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*src)?)
+            },
+
+            // --- Unary / Binary ---
+            Instr::UnaryOp(..) | Instr::BinaryOp(..) | Instr::BinaryOpImm(..) => b.add_constant(OP),
+
+            // --- Structs ---
+            Instr::Pack(_, struct_ty, _) | Instr::Unpack(_, struct_ty, _) => {
+                b.add_sized(MOVE_BASE, MOVE_PER_BYTE, *struct_ty)
+            },
+
+            // --- Enums ---
+            Instr::PackVariant(..) | Instr::UnpackVariant(..) => b.add_constant(PACK_UNPACK),
+            Instr::TestVariant(..) => b.add_constant(TEST_VARIANT),
+
+            // --- References ---
+            Instr::ImmBorrowLoc(..)
+            | Instr::MutBorrowLoc(..)
+            | Instr::ImmBorrowField(..)
+            | Instr::MutBorrowField(..)
+            | Instr::ImmBorrowVariantField(..)
+            | Instr::MutBorrowVariantField(..) => b.add_constant(BORROW),
+            Instr::ReadRef(_, ref_src) => {
+                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.pointee_ty(*ref_src)?)
+            },
+            Instr::WriteRef(ref_dst, _) => {
+                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.pointee_ty(*ref_dst)?)
+            },
+
+            // --- Fused field access (borrow + read/write) ---
+            Instr::ReadField(_, owner, fh, _) => {
+                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.field_ty(*owner, *fh)?)
+            },
+            Instr::WriteField(_, _, _, val) => {
+                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.slot_ty(*val)?)
+            },
+            Instr::ReadVariantField(..) => b.add_constant(FIELD_READ),
+            Instr::WriteVariantField(_, _, _, val) => {
+                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.slot_ty(*val)?)
+            },
+
+            // --- Fused inline-struct field access ---
+            Instr::ImmBorrowLocField(..) | Instr::MutBorrowLocField(..) => b.add_constant(BORROW),
+            Instr::ReadLocalField(_, owner, fh, _) => {
+                b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.field_ty(*owner, *fh)?)
+            },
+            Instr::WriteLocalField(_, _, _, val) => {
+                b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*val)?)
+            },
+
+            // --- Globals ---
+            Instr::Exists(..)
+            | Instr::MoveFrom(..)
+            | Instr::MoveTo(..)
+            | Instr::ImmBorrowGlobal(..)
+            | Instr::MutBorrowGlobal(..) => b.add_constant(GLOBAL),
+
+            // --- Calls ---
+            Instr::Call(rets, handle, ty_args, _args) => {
+                let sig = self.module.function_signature_at(*handle);
+                let params = self.interner.subst_type_list(sig.params, *ty_args)?;
+                let returns = self.interner.subst_type_list(sig.returns, *ty_args)?;
+                self.call_cost(b, params, rets, returns)?;
+            },
+
+            // --- Closures ---
+            Instr::PackClosure(_, _, _, _, args) => {
+                b.add_constant(PACK_CLOSURE);
+                for arg in args {
+                    b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*arg)?);
+                }
+            },
+            Instr::CallClosure(rets, sig_types, _args) => {
+                let (closure_ty, params, returns) = closure_signature(*sig_types)?;
+                self.call_cost(b, params, rets, returns)?;
+                // The closure value is passed as the last operand; charge its move.
+                b.add_sized(MOVE_BASE, MOVE_PER_BYTE, closure_ty);
+            },
+
+            // --- Vector ---
+            Instr::VecPack(_, _, elems) => {
+                b.add_constant(VEC_NEW);
+                for elem in elems {
+                    b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*elem)?);
+                }
+            },
+            Instr::VecLen(..) => b.add_constant(VEC_LEN),
+            Instr::VecImmBorrow(..) | Instr::VecMutBorrow(..) => b.add_constant(VEC_BORROW),
+            Instr::VecPushBack(elem_ty, _, _) | Instr::VecPopBack(_, elem_ty, _) => {
+                b.add_sized(VEC_ELEM_BASE, VEC_ELEM_PER_BYTE, *elem_ty)
+            },
+            Instr::VecUnpack(dsts, elem_ty, _) => {
+                let n = dsts.len() as u64;
+                b.add_constant(VEC_NEW);
+                b.add_sized(n * MOVE_BASE, n * MOVE_PER_BYTE, *elem_ty);
+            },
+            Instr::VecSwap(elem_ty, _, _, _) => {
+                // 2x per-element: two element accesses.
+                b.add_sized(2 * VEC_ELEM_BASE, 2 * VEC_ELEM_PER_BYTE, *elem_ty);
+            },
+
+            // --- Control flow ---
+            Instr::Branch(..) => b.add_constant(JUMP),
+            Instr::BrTrue(..) | Instr::BrFalse(..) | Instr::BrCmp(..) | Instr::BrCmpImm(..) => {
+                b.add_constant(COND_JUMP)
+            },
+            Instr::Ret(slots) => {
+                b.add_constant(RETURN);
+                // 2x per slot upper-bounds the cycle-breaking scratch moves
+                // `emit_parallel_copy` adds for a cyclic (e.g. swap-style) return.
+                for slot in slots {
+                    b.add_sized(2 * MOVE_BASE, 2 * MOVE_PER_BYTE, self.slot_ty(*slot)?);
+                }
+            },
+            Instr::Abort(..) => b.add_constant(ABORT),
+            Instr::AbortMsg(..) => b.add_constant(ABORT_MSG),
+
+            Instr::ForceGC => b.add_constant(FORCE_GC),
+        }
+        Ok(())
+    }
+
+    /// Dispatch, a move per argument (sized from the callee signature), and a
+    /// move per Home-slot return. Also binds the call's Xfer returns.
+    fn call_cost(
+        &mut self,
+        b: &mut BlockCost,
+        param_types: InternedTypeList,
+        ret_slots: &[Slot],
+        ret_types: InternedTypeList,
+    ) -> Result<()> {
+        b.add_constant(CALL);
+        for &param in view_type_list(param_types) {
+            b.add_sized(MOVE_BASE, MOVE_PER_BYTE, param);
+        }
+        for ret in ret_slots {
+            match *ret {
+                Slot::Xfer(_) => {
+                    // Placed without a copy.
+                },
+                Slot::Home(i) => {
+                    b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.home_slot_types[i as usize])
+                },
+                Slot::Vid(_) => bail!("Vid slot in post-allocation IR"),
+            }
+        }
+        self.bind_call_returns(ret_slots, ret_types)?;
+        Ok(())
+    }
+
+    /// Clobber all Xfer slots, then bind each Xfer return to its callee type.
+    fn bind_call_returns(&mut self, ret_slots: &[Slot], ret_types: InternedTypeList) -> Result<()> {
+        self.xfer_ret_types.iter_mut().for_each(|t| *t = None);
+        let ret_types = view_type_list(ret_types);
+        for (k, ret) in ret_slots.iter().enumerate() {
+            if let Slot::Xfer(j) = *ret {
+                let ty = *ret_types.get(k).ok_or_else(|| {
+                    anyhow::anyhow!("call return {} has no matching signature type", k)
+                })?;
+                self.xfer_ret_types[j as usize] = Some(ty);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The closure's function type and its `(param types, result types)`, from the
+/// leading `Function` type of a `CallClosure` signature.
+fn closure_signature(
+    sig_types: InternedTypeList,
+) -> Result<(InternedType, InternedTypeList, InternedTypeList)> {
+    let closure_ty = view_type_list(sig_types)
+        .first()
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("CallClosure signature is empty"))?;
+    match view_type(closure_ty) {
+        Type::Function { args, results, .. } => Ok((closure_ty, *args, *results)),
+        _ => bail!("CallClosure signature must start with a Function type"),
+    }
+}
+
+// =============================================================================
+// Resolution: cost formula -> concrete gas
+// =============================================================================
+
+/// Resolves the types in a [`BlockCost`] to concrete sizes for an instantiation.
+pub(crate) trait CostResolver {
+    /// Substitute the instantiation's type arguments into `ty`.
+    fn concrete_ty(&self, ty: InternedType) -> Result<InternedType>;
+
+    /// Value layouts, for reading concrete type sizes.
+    fn layouts(&self) -> &dyn LayoutProvider;
+
+    /// Evaluate a block's cost formula to concrete gas for this instantiation.
+    fn resolve_block_cost(&self, cost: &BlockCost) -> Result<u64> {
+        let mut total = cost.base;
+        for &(coeff, ty) in &cost.terms {
+            let concrete_ty = self.concrete_ty(ty)?;
+            let size = concrete_type_size(self.layouts(), concrete_ty, "cost term type")?;
+            total += coeff * size as u64;
+        }
+        Ok(total)
+    }
 }

--- a/third_party/move/mono-move/specializer/src/gas.rs
+++ b/third_party/move/mono-move/specializer/src/gas.rs
@@ -8,8 +8,8 @@
 //! reads/writes). Every cost is affine in type sizes — `base + Σ coeff * size(T)`
 //! — which lets costing split in two:
 //!
-//! - [`function_block_costs`] sums each block into a [`BlockCost`] formula. The
-//!   size terms stay symbolic (types may be polymorphic).
+//! - [`instrument`] sums each block into a [`BlockCost`] formula. The size
+//!   terms stay symbolic (types may be polymorphic).
 //! - [`CostResolver::resolve_block_cost`] evaluates a formula for a concrete
 //!   instantiation.
 //!
@@ -25,7 +25,7 @@
 
 use crate::{
     lower::context::concrete_type_size,
-    stackless_exec_ir::{instr_utils::for_each_value_use, BasicBlock, Instr, Slot},
+    stackless_exec_ir::{instr_utils::for_each_value_use, BasicBlock, Instr, ModuleIR, Slot},
 };
 use anyhow::{bail, Result};
 use mono_move_core::{
@@ -33,6 +33,7 @@ use mono_move_core::{
     Interner, LayoutProvider, PreparedModule,
 };
 use move_binary_format::file_format::FieldHandleIndex;
+use smallvec::SmallVec;
 
 // --- Loads ---
 const LD: u64 = 2;
@@ -87,13 +88,22 @@ const FORCE_GC: u64 = 100;
 
 /// A block's cost as an affine formula `base + Σ coeff * size(ty)`, left
 /// unresolved until the instantiation's type sizes are known.
-#[derive(Clone, Default)]
+/// TODO(metering): consider merging terms, or canonicalizing.
+#[derive(Clone)]
 pub(crate) struct BlockCost {
     base: u64,
-    terms: Vec<(u64, InternedType)>,
+    terms: SmallVec<[(u64, InternedType); 2]>,
 }
 
 impl BlockCost {
+    /// An empty formula (cost zero).
+    fn zero() -> Self {
+        Self {
+            base: 0,
+            terms: SmallVec::new(),
+        }
+    }
+
     /// Add a fixed cost.
     fn add_constant(&mut self, c: u64) {
         self.base += c;
@@ -110,26 +120,24 @@ impl BlockCost {
 // Emission: polymorphic IR -> per-block cost formulas
 // =============================================================================
 
-/// Emit one [`BlockCost`] formula per block, indexed by block label.
-pub(crate) fn function_block_costs<I: Interner>(
-    module: &PreparedModule,
-    interner: &I,
-    blocks: &[BasicBlock],
-    home_slot_types: &[InternedType],
-    num_xfer_positions: u16,
-) -> Result<Vec<BlockCost>> {
-    let mut emitter = Emitter {
-        module,
-        interner,
-        home_slot_types,
-        xfer_ret_types: vec![None; num_xfer_positions as usize],
-    };
-    // Indexed by block label (dense `0..blocks.len()`).
-    let mut costs = vec![BlockCost::default(); blocks.len()];
-    for block in blocks {
-        costs[block.label.0 as usize] = emitter.block_cost(block)?;
+/// Emit a per-block [`BlockCost`] formula for every function in `module_ir`.
+pub(crate) fn instrument<I: Interner>(module_ir: &mut ModuleIR, interner: &I) -> Result<()> {
+    let ModuleIR { module, functions } = module_ir;
+    for func in functions.iter_mut().flatten() {
+        let mut emitter = Emitter {
+            module,
+            interner,
+            home_slot_types: &func.home_slot_types,
+            xfer_ret_types: vec![None; func.num_xfer_positions as usize],
+        };
+        // Indexed by block label (dense `0..blocks.len()`).
+        let mut costs = vec![BlockCost::zero(); func.blocks.len()];
+        for block in &func.blocks {
+            costs[block.label.0 as usize] = emitter.block_cost(block)?;
+        }
+        func.block_costs = costs;
     }
-    Ok(costs)
+    Ok(())
 }
 
 /// Builds cost formulas by walking the IR. Xfer slots carry no type in the IR,
@@ -171,11 +179,31 @@ impl<I: Interner> Emitter<'_, I> {
             .subst_type(self.module.interned_field_type_at(fh), *ty_args)
     }
 
+    /// Field types of enum `enum_ty`'s variant `variant`, with the enum's type
+    /// arguments applied.
+    fn variant_field_tys(&self, enum_ty: InternedType, variant: u16) -> Result<Vec<InternedType>> {
+        let Type::Nominal { name, ty_args, .. } = view_type(enum_ty) else {
+            bail!("variant owner is not an enum type");
+        };
+        let def_idx = self
+            .module
+            .interned_nominal_type_def_idx(*name)
+            .ok_or_else(|| anyhow::anyhow!("enum definition not found"))?;
+        let fields = self
+            .module
+            .interned_variant_field_types_at(def_idx, variant)
+            .ok_or_else(|| anyhow::anyhow!("type is not an enum"))?;
+        fields
+            .iter()
+            .map(|&f| self.interner.subst_type(f, *ty_args))
+            .collect()
+    }
+
     /// Cost of the formula for one block, resetting Xfer tracking at its start.
     fn block_cost(&mut self, block: &BasicBlock) -> Result<BlockCost> {
         // Xfer slots are block-local.
-        self.xfer_ret_types.iter_mut().for_each(|t| *t = None);
-        let mut b = BlockCost::default();
+        self.xfer_ret_types.fill(None);
+        let mut b = BlockCost::zero();
         for instr in &block.instrs {
             self.instr_cost(&mut b, instr)?;
             self.advance_xfer_tracking(instr);
@@ -230,7 +258,13 @@ impl<I: Interner> Emitter<'_, I> {
             },
 
             // --- Enums ---
-            Instr::PackVariant(..) | Instr::UnpackVariant(..) => b.add_constant(PACK_UNPACK),
+            Instr::PackVariant(_, enum_ty, variant, _)
+            | Instr::UnpackVariant(_, enum_ty, variant, _) => {
+                b.add_constant(PACK_UNPACK);
+                for field_ty in self.variant_field_tys(*enum_ty, *variant)? {
+                    b.add_sized(MOVE_BASE, MOVE_PER_BYTE, field_ty);
+                }
+            },
             Instr::TestVariant(..) => b.add_constant(TEST_VARIANT),
 
             // --- References ---
@@ -370,7 +404,7 @@ impl<I: Interner> Emitter<'_, I> {
 
     /// Clobber all Xfer slots, then bind each Xfer return to its callee type.
     fn bind_call_returns(&mut self, ret_slots: &[Slot], ret_types: InternedTypeList) -> Result<()> {
-        self.xfer_ret_types.iter_mut().for_each(|t| *t = None);
+        self.xfer_ret_types.fill(None);
         let ret_types = view_type_list(ret_types);
         for (k, ret) in ret_slots.iter().enumerate() {
             if let Slot::Xfer(j) = *ret {

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -13,7 +13,7 @@ use super::{
     parallel_copy,
 };
 use crate::{
-    gas,
+    gas::{self, CostResolver},
     stackless_exec_ir::{
         instr_utils::{clobbers_xfer, for_each_value_use, is_fallthrough_terminator},
         BinaryOp, FunctionIR, ImmValue, Instr, Label, Slot, UnaryOp,
@@ -81,10 +81,10 @@ pub(super) fn lower_function(
         );
         state.xfer_bindings.fill(None);
         state.label_map[block.label.0 as usize] = Some(state.out_buf.len() as u32);
+        // Resolve this block's cost formula to concrete gas for this instantiation.
+        state.block_costs[block.label.0 as usize] =
+            state.resolve_block_cost(&func_ir.block_costs[block.label.0 as usize])?;
         for instr in &block.instrs {
-            // Cost is computed before lowering so Xfer operand bindings are live.
-            let cost = gas::instr_cost(instr, &state)?;
-            state.block_costs[block.label.0 as usize] += cost;
             state.lower_instr(func_ir, instr)?;
             state.commit_xfer_bindings_after(instr);
         }
@@ -170,19 +170,7 @@ struct LoweringState<'a> {
     pending_safe_points: Vec<SafePointEntry>,
 }
 
-impl gas::CostContext for LoweringState<'_> {
-    fn slot_size(&self, slot: Slot) -> Result<u32> {
-        Ok(self.slot(slot)?.size)
-    }
-
-    fn slot_ty(&self, slot: Slot) -> Result<InternedType> {
-        self.slot_interned_type(slot)
-    }
-
-    fn field_size(&self, struct_ty: InternedType, fh: FieldHandleIndex) -> Result<u32> {
-        Ok(self.resolve_field(struct_ty, fh)?.1)
-    }
-
+impl gas::CostResolver for LoweringState<'_> {
     fn concrete_ty(&self, ty: InternedType) -> Result<InternedType> {
         LoweringState::concrete_ty(self, ty)
     }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -365,6 +365,8 @@ pub struct FunctionIR {
     /// Type of each Home slot (indexed by Home slot index, 0..num_home_slots-1).
     /// Xfer slots have no entry here — their types are inferred from call signatures.
     pub home_slot_types: Vec<InternedType>,
+    /// Gas cost of each block as an unresolved formula, indexed by block label.
+    pub(crate) block_costs: Vec<crate::gas::BlockCost>,
 }
 
 impl FunctionIR {

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -9,6 +9,7 @@
 mod display;
 pub(crate) mod instr_utils;
 
+use crate::gas::BlockCost;
 pub use mono_move_core::CmpKind;
 use mono_move_core::{
     types::{InternedType, InternedTypeList},
@@ -366,7 +367,7 @@ pub struct FunctionIR {
     /// Xfer slots have no entry here — their types are inferred from call signatures.
     pub home_slot_types: Vec<InternedType>,
     /// Gas cost of each block as an unresolved formula, indexed by block label.
-    pub(crate) block_costs: Vec<crate::gas::BlockCost>,
+    pub(crate) block_costs: Vec<BlockCost>,
 }
 
 impl FunctionIR {

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/basic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/basic.exp
@@ -3,19 +3,19 @@
 
 fun circle_value() {
   frame_data_size: 64
-  entry_gas: 17
+  entry_gas: 43
   code:
     0: EnumNew [8] desc=2 tag #0
     1: HeapMoveTo8 [8]+8 <- [0]
     2: SlotBorrow [16] <- &[8]
     3: EnumTestTag [32] <- (*[16]).tag == #0
-    4: JumpZeroByte @9 [32] gas_taken=7 gas_fallthrough=62
+    4: JumpZeroByte @9 [32] gas_taken=7 gas_fallthrough=88
     5: EnumCheckVariant assert [8].tag == #0
     6: HeapMoveFrom8 [40] <- [8]+8
     7: Move8 [0] <- [40]
     8: Return
     9: EnumTestTag [32] <- (*[16]).tag == #1
-    10: JumpZeroByte @17 [32] gas_taken=4 gas_fallthrough=67
+    10: JumpZeroByte @17 [32] gas_taken=4 gas_fallthrough=119
     11: EnumCheckVariant assert [8].tag == #1
     12: HeapMoveFrom8 [40] <- [8]+8
     13: HeapMoveFrom8 [48] <- [8]+16
@@ -30,7 +30,7 @@ fun circle_value() {
 
 fun is_circle() {
   frame_data_size: 56
-  entry_gas: 17
+  entry_gas: 43
   code:
     0: EnumNew [8] desc=2 tag #0
     1: HeapMoveTo8 [8]+8 <- [0]
@@ -49,7 +49,7 @@ fun is_circle() {
 
 fun is_rect() {
   frame_data_size: 64
-  entry_gas: 17
+  entry_gas: 69
   code:
     0: EnumNew [16] desc=2 tag #1
     1: HeapMoveTo8 [16]+8 <- [0]
@@ -69,20 +69,20 @@ fun is_rect() {
 
 fun rect_sum() {
   frame_data_size: 72
-  entry_gas: 17
+  entry_gas: 69
   code:
     0: EnumNew [16] desc=2 tag #1
     1: HeapMoveTo8 [16]+8 <- [0]
     2: HeapMoveTo8 [16]+16 <- [8]
     3: SlotBorrow [24] <- &[16]
     4: EnumTestTag [40] <- (*[24]).tag == #0
-    5: JumpZeroByte @10 [40] gas_taken=7 gas_fallthrough=62
+    5: JumpZeroByte @10 [40] gas_taken=7 gas_fallthrough=88
     6: EnumCheckVariant assert [16].tag == #0
     7: HeapMoveFrom8 [48] <- [16]+8
     8: Move8 [0] <- [48]
     9: Return
     10: EnumTestTag [40] <- (*[24]).tag == #1
-    11: JumpZeroByte @18 [40] gas_taken=4 gas_fallthrough=67
+    11: JumpZeroByte @18 [40] gas_taken=4 gas_fallthrough=119
     12: EnumCheckVariant assert [16].tag == #1
     13: HeapMoveFrom8 [48] <- [16]+8
     14: HeapMoveFrom8 [56] <- [16]+16

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/copy_lowering.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/copy_lowering.exp
@@ -3,7 +3,7 @@
 
 fun enum_copy() {
   frame_data_size: 72
-  entry_gas: 109
+  entry_gas: 135
   code:
     0: StoreImm8 [16] <- #1
     1: EnumNew [0] desc=2 tag #0
@@ -32,7 +32,7 @@ fun scalar_copy() {
 
 fun struct_copy() {
   frame_data_size: 104
-  entry_gas: 193
+  entry_gas: 245
   code:
     0: StoreImm8 [32] <- #1
     1: EnumNew [40] desc=2 tag #0

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/variant_field_by_ref_param.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/variant_field_by_ref_param.exp
@@ -13,7 +13,7 @@ fun read_x() {
 
 fun read_x_a() {
   frame_data_size: 24
-  entry_gas: 86
+  entry_gas: 96
   code:
     0: StoreImm1 [8] <- #0
     1: StoreImm1 [9] <- #7
@@ -30,7 +30,7 @@ fun read_x_a() {
 
 fun read_x_b() {
   frame_data_size: 32
-  entry_gas: 86
+  entry_gas: 117
   code:
     0: StoreImm8 [8] <- #256
     1: StoreImm1 [16] <- #9

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/variant_field_uniform.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/variant_field_uniform.exp
@@ -3,7 +3,7 @@
 
 fun read_value() {
   frame_data_size: 64
-  entry_gas: 69
+  entry_gas: 95
   code:
     0: EnumNew [8] desc=2 tag #0
     1: HeapMoveTo8 [8]+8 <- [0]
@@ -17,7 +17,7 @@ fun read_value() {
 
 fun run_computed() {
   frame_data_size: 72
-  entry_gas: 159
+  entry_gas: 211
   code:
     0: StoreImm8 [24] <- #0
     1: EnumNew [16] desc=2 tag #1
@@ -36,7 +36,7 @@ fun run_computed() {
 
 fun run_simple() {
   frame_data_size: 72
-  entry_gas: 157
+  entry_gas: 183
   code:
     0: EnumNew [16] desc=2 tag #0
     1: HeapMoveTo8 [16]+8 <- [0]

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_enum_basic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_enum_basic.exp
@@ -3,19 +3,19 @@
 
 fun left_u64() {
   frame_data_size: 56
-  entry_gas: 17
+  entry_gas: 43
   code:
     0: EnumNew [8] desc=2 tag #0
     1: HeapMoveTo8 [8]+8 <- [0]
     2: SlotBorrow [16] <- &[8]
     3: EnumTestTag [32] <- (*[16]).tag == #0
-    4: JumpZeroByte @9 [32] gas_taken=7 gas_fallthrough=62
+    4: JumpZeroByte @9 [32] gas_taken=7 gas_fallthrough=88
     5: EnumCheckVariant assert [8].tag == #0
     6: HeapMoveFrom8 [40] <- [8]+8
     7: Move8 [0] <- [40]
     8: Return
     9: EnumTestTag [32] <- (*[16]).tag == #1
-    10: JumpZeroByte @16 [32] gas_taken=4 gas_fallthrough=64
+    10: JumpZeroByte @16 [32] gas_taken=4 gas_fallthrough=69
     11: EnumCheckVariant assert [8].tag == #1
     12: HeapMoveFrom [32] <- [8]+8 (size=1)
     13: StoreImm8 [40] <- #0
@@ -31,19 +31,19 @@ fun pick_variant() {
   frame_data_size: 56
   entry_gas: 3
   code:
-    0: JumpIntCmp @24 [0] != u64 #0 gas_taken=10 gas_fallthrough=10
+    0: JumpIntCmp @24 [0] != u64 #0 gas_taken=36 gas_fallthrough=15
     1: StoreImm1 [32] <- #1
     2: EnumNew [8] desc=2 tag #1
     3: HeapMoveTo [8]+8 <- [32] (size=1)
     4: SlotBorrow [16] <- &[8]
     5: EnumTestTag [32] <- (*[16]).tag == #0
-    6: JumpZeroByte @11 [32] gas_taken=7 gas_fallthrough=62
+    6: JumpZeroByte @11 [32] gas_taken=7 gas_fallthrough=88
     7: EnumCheckVariant assert [8].tag == #0
     8: HeapMoveFrom8 [40] <- [8]+8
     9: Move8 [0] <- [40]
     10: Return
     11: EnumTestTag [32] <- (*[16]).tag == #1
-    12: JumpZeroByte @22 [32] gas_taken=4 gas_fallthrough=11
+    12: JumpZeroByte @22 [32] gas_taken=4 gas_fallthrough=16
     13: EnumCheckVariant assert [8].tag == #1
     14: HeapMoveFrom [32] <- [8]+8 (size=1)
     15: JumpZeroByte @19 [32] gas_taken=56 gas_fallthrough=56
@@ -65,13 +65,13 @@ fun pick_variant() {
 
 fun swapped_right_u64() {
   frame_data_size: 56
-  entry_gas: 17
+  entry_gas: 43
   code:
     0: EnumNew [8] desc=3 tag #1
     1: HeapMoveTo8 [8]+8 <- [0]
     2: SlotBorrow [16] <- &[8]
     3: EnumTestTag [32] <- (*[16]).tag == #0
-    4: JumpZeroByte @14 [32] gas_taken=7 gas_fallthrough=11
+    4: JumpZeroByte @14 [32] gas_taken=7 gas_fallthrough=16
     5: EnumCheckVariant assert [8].tag == #0
     6: HeapMoveFrom [32] <- [8]+8 (size=1)
     7: JumpZeroByte @11 [32] gas_taken=56 gas_fallthrough=56
@@ -82,7 +82,7 @@ fun swapped_right_u64() {
     12: Move8 [0] <- [40]
     13: Return
     14: EnumTestTag [32] <- (*[16]).tag == #1
-    15: JumpZeroByte @20 [32] gas_taken=4 gas_fallthrough=62
+    15: JumpZeroByte @20 [32] gas_taken=4 gas_fallthrough=88
     16: EnumCheckVariant assert [8].tag == #1
     17: HeapMoveFrom8 [40] <- [8]+8
     18: Move8 [0] <- [40]
@@ -97,7 +97,7 @@ fun test_is_left() {
   frame_data_size: 56
   entry_gas: 3
   code:
-    0: JumpIntCmp @13 [0] != u64 #0 gas_taken=12 gas_fallthrough=10
+    0: JumpIntCmp @13 [0] != u64 #0 gas_taken=17 gas_fallthrough=36
     1: StoreImm8 [16] <- #5
     2: EnumNew [8] desc=2 tag #0
     3: HeapMoveTo8 [8]+8 <- [16]

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_enum_variant_field.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_enum_variant_field.exp
@@ -5,7 +5,7 @@ fun divergent_u128() {
   frame_data_size: 96
   entry_gas: 3
   code:
-    0: JumpIntCmp @14 [0] != u64 #0 gas_taken=15 gas_fallthrough=10
+    0: JumpIntCmp @14 [0] != u64 #0 gas_taken=41 gas_fallthrough=86
     1: StoreImm16 [56] <- #9
     2: EnumNew [16] desc=2 tag #0
     3: HeapMoveTo [16]+8 <- [56] (size=16)
@@ -32,7 +32,7 @@ fun divergent_u8() {
   frame_data_size: 80
   entry_gas: 3
   code:
-    0: JumpIntCmp @14 [0] != u64 #0 gas_taken=15 gas_fallthrough=10
+    0: JumpIntCmp @14 [0] != u64 #0 gas_taken=41 gas_fallthrough=41
     1: StoreImm1 [56] <- #9
     2: EnumNew [16] desc=3 tag #0
     3: HeapMoveTo [16]+8 <- [56] (size=1)
@@ -59,7 +59,7 @@ fun uniform_u128() {
   frame_data_size: 88
   entry_gas: 3
   code:
-    0: JumpIntCmp @9 [0] != u64 #0 gas_taken=17 gas_fallthrough=10
+    0: JumpIntCmp @9 [0] != u64 #0 gas_taken=93 gas_fallthrough=86
     1: StoreImm16 [24] <- #1
     2: EnumNew [16] desc=4 tag #0
     3: HeapMoveTo [16]+8 <- [24] (size=16)
@@ -83,7 +83,7 @@ fun uniform_u8() {
   frame_data_size: 80
   entry_gas: 3
   code:
-    0: JumpIntCmp @9 [0] != u64 #0 gas_taken=17 gas_fallthrough=10
+    0: JumpIntCmp @9 [0] != u64 #0 gas_taken=48 gas_fallthrough=41
     1: StoreImm1 [24] <- #1
     2: EnumNew [16] desc=5 tag #0
     3: HeapMoveTo [16]+8 <- [24] (size=1)
@@ -105,7 +105,7 @@ fun uniform_u8() {
 
 fun write_uniform() {
   frame_data_size: 80
-  entry_gas: 109
+  entry_gas: 161
   code:
     0: StoreImm8 [32] <- #5
     1: EnumNew [8] desc=6 tag #0


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Per-block gas costs were computed during lowering and re-derived on every monomorphization; they're now emitted once per polymorphic function (after optimization) as affine formulas `base + Σ coeff * size(ty)`, stored on `FunctionIR`, and resolved to concrete gas per instantiation at lowering via `CostResolver::resolve_block_cost`. Pure refactor with no behavior change — gas values are identical and all differential tests pass.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Move VM gas metering for mono-move (block entry and branch costs); incorrect formula emission or Xfer type tracking could mischarge execution, though behavior is locked by updated differential expectations.
> 
> **Overview**
> Moves **per-block gas** out of monomorphization lowering and into the destack pipeline, so each polymorphic function gets one cost pass instead of recomputing on every instantiation.
> 
> After optimization, **`gas::instrument`** walks stackless IR and stores **`BlockCost`** affine formulas (`base + Σ coeff × size(ty)`) on **`FunctionIR.block_costs`**. Size-dependent charges stay symbolic on **`InternedType`** until lowering; **`CostResolver::resolve_block_cost`** substitutes type args and uses layouts to produce concrete **`u64`** block costs (and jump **`gas_taken` / `gas_fallthrough`**). The old **`CostContext` + `instr_cost`** during lowering is removed in favor of an **`Emitter`** that tracks **`Xfer`** return types for call/return move charging.
> 
> **Enum pack/unpack** costing now adds per-variant-field move terms (not just a flat **`PACK_UNPACK`**), which is why differential **`.exp`** files show higher **`entry_gas`** and branch gas on enum/generic tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820f10a0fa196aa1ba1ed1cd6ed5ccc763b55bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->