### PR TITLE
cap response body size in crawler image and json fetchers

### DIFF
--- a/ecosystem/nft-metadata-crawler/src/utils/image_optimizer.rs
+++ b/ecosystem/nft-metadata-crawler/src/utils/image_optimizer.rs
@@ -72,9 +72,8 @@ impl ImageOptimizer {
                 while let Some(chunk) = stream.next().await {
                     let chunk = chunk.context("Failed to load image bytes")?;
                     if img_bytes.len() + chunk.len() > max_file_size_bytes as usize {
-                        FAILED_TO_OPTIMIZE_IMAGE_COUNT
-                            .with_label_values(&["Image file too large"])
-                            .inc();
+                        // The outer retry match arm records the failure metric, so
+                        // don't increment here or a single oversize body counts twice.
                         return Err(backoff::Error::permanent(anyhow::anyhow!(
                             "Image optimizer received file exceeding {} bytes, skipping",
                             max_file_size_bytes
@@ -87,7 +86,7 @@ impl ImageOptimizer {
                     image::guess_format(&img_bytes).context("Failed to guess image format")?;
 
                 match format {
-                    ImageFormat::Gif | ImageFormat::Avif => Ok((img_bytes.to_vec(), format)),
+                    ImageFormat::Gif | ImageFormat::Avif => Ok((img_bytes, format)),
                     _ => {
                         let img = image::load_from_memory(&img_bytes)
                             .context(format!("Failed to load image from memory: {} bytes", size))?;

--- a/ecosystem/nft-metadata-crawler/src/utils/image_optimizer.rs
+++ b/ecosystem/nft-metadata-crawler/src/utils/image_optimizer.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use anyhow::Context;
 use backoff::{future::retry, ExponentialBackoff};
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use image::{
     imageops::{resize, FilterType},
     DynamicImage, GenericImageView, ImageBuffer, ImageFormat, ImageOutputFormat,
@@ -64,10 +64,24 @@ impl ImageOptimizer {
                     .await
                     .context("Failed to get image")?;
 
-                let img_bytes = response
-                    .bytes()
-                    .await
-                    .context("Failed to load image bytes")?;
+                // The size check above uses the HEAD Content-Length, which the
+                // origin controls and can omit or understate. Cap the body as it
+                // streams so the GET can't exceed max_file_size_bytes.
+                let mut img_bytes = Vec::new();
+                let mut stream = response.bytes_stream();
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk.context("Failed to load image bytes")?;
+                    if img_bytes.len() + chunk.len() > max_file_size_bytes as usize {
+                        FAILED_TO_OPTIMIZE_IMAGE_COUNT
+                            .with_label_values(&["Image file too large"])
+                            .inc();
+                        return Err(backoff::Error::permanent(anyhow::anyhow!(
+                            "Image optimizer received file exceeding {} bytes, skipping",
+                            max_file_size_bytes
+                        )));
+                    }
+                    img_bytes.extend_from_slice(&chunk);
+                }
 
                 let format =
                     image::guess_format(&img_bytes).context("Failed to guess image format")?;

--- a/ecosystem/nft-metadata-crawler/src/utils/json_parser.rs
+++ b/ecosystem/nft-metadata-crawler/src/utils/json_parser.rs
@@ -71,9 +71,8 @@ impl JSONParser {
                 while let Some(chunk) = stream.next().await {
                     let chunk = chunk.context("Failed to get JSON")?;
                     if body.len() + chunk.len() > max_file_size_bytes as usize {
-                        FAILED_TO_PARSE_JSON_COUNT
-                            .with_label_values(&["json file too large"])
-                            .inc();
+                        // The outer retry match arm records the failure metric, so
+                        // don't increment here or a single oversize body counts twice.
                         return Err(backoff::Error::permanent(anyhow::anyhow!(
                             "JSON parser received file exceeding {} bytes, skipping",
                             max_file_size_bytes

--- a/ecosystem/nft-metadata-crawler/src/utils/json_parser.rs
+++ b/ecosystem/nft-metadata-crawler/src/utils/json_parser.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use anyhow::Context;
 use backoff::{future::retry, ExponentialBackoff};
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use image::ImageFormat;
 use reqwest::Client;
 use serde_json::Value;
@@ -63,10 +63,27 @@ impl JSONParser {
                     .await
                     .context("Failed to get JSON")?;
 
-                let parsed_json = response
-                    .json::<Value>()
-                    .await
-                    .context("Failed to parse JSON")?;
+                // The size check above uses the HEAD Content-Length, which the
+                // origin controls and can omit or understate. Cap the body as it
+                // streams so the GET can't exceed max_file_size_bytes.
+                let mut body = Vec::new();
+                let mut stream = response.bytes_stream();
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk.context("Failed to get JSON")?;
+                    if body.len() + chunk.len() > max_file_size_bytes as usize {
+                        FAILED_TO_PARSE_JSON_COUNT
+                            .with_label_values(&["json file too large"])
+                            .inc();
+                        return Err(backoff::Error::permanent(anyhow::anyhow!(
+                            "JSON parser received file exceeding {} bytes, skipping",
+                            max_file_size_bytes
+                        )));
+                    }
+                    body.extend_from_slice(&chunk);
+                }
+
+                let parsed_json: Value =
+                    serde_json::from_slice(&body).context("Failed to parse JSON")?;
 
                 let raw_image_uri = parsed_json["image"].as_str().map(|s| s.to_string());
                 let raw_animation_uri =


### PR DESCRIPTION
## Description
`ImageOptimizer::optimize` and `JSONParser::parse` in the metadata crawler check `max_file_size_bytes` only against the `Content-Length` from `get_uri_metadata`'s HEAD request, and that check fails open: `get_uri_metadata` parses the header with `unwrap_or(0)`, so a metadata URI that omits `Content-Length` (or serves a chunked response, or understates it) is treated as size 0 and passes the 15MB cap. The follow-up GET then buffers the whole body with no limit via `response.bytes()` / `response.json()`, so the size control is bypassable by any origin the untrusted on-chain `image` / `animation_url` / asset URI points at. Both fetch helpers had the same gap, so this streams the body with `bytes_stream()` and enforces `max_file_size_bytes` as the bytes arrive.

## How Has This Been Tested?
`cargo check`, `cargo clippy`, and `cargo test -p aptos-nft-metadata-crawler` are clean (existing `uri_parser` tests pass). Confirmed the fail-open: with the 15MB cap, a missing/`0`/non-numeric HEAD `Content-Length` all pass `size > max_file_size_bytes`, after which the unbounded `bytes()`/`json()` read the full body; with the streaming cap the read stops and errors once the accumulated body passes `max_file_size_bytes`. Valid payloads under the cap stream to identical bytes, so behavior is unchanged.

## Key Areas to Review
The too-large case returns `backoff::Error::permanent` so it is not retried, matching the existing pre-fetch size check which also rejects without retry; transient network errors still go through the normal `?` path and stay retryable. In the image path `img_bytes` is now a `Vec<u8>`, which `guess_format`, `load_from_memory`, and `to_vec` all accept unchanged.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes untrusted-URI resource exhaustion on full-node indexer infrastructure; behavior for bodies under the cap should be unchanged, but oversize responses now fail at stream time rather than after full download.
> 
> **Overview**
> **Closes a bypass** where `max_file_size_bytes` relied only on HEAD `Content-Length` from `get_uri_metadata`, so origins could omit or understate size and the crawler would still buffer the full GET body.
> 
> `ImageOptimizer::optimize` and `JSONParser::parse` now read responses with `bytes_stream()`, accumulate into a `Vec`, and **abort with a permanent backoff error** once the running total would exceed `max_file_size_bytes` (no extra failure metric on that path). JSON is parsed via `serde_json::from_slice` on the capped buffer instead of unbounded `response.json()` / `response.bytes()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad861894d23c0cc08a397ddd1969baa3b8b7d2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->