### PR TITLE
[block-stm] Concrete types for modules

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -25,22 +25,25 @@ use aptos_types::{
     contract_event::ContractEvent,
     error::{code_invariant_error, PanicError},
     fee_statement::FeeStatement,
-    state_store::{state_key::StateKey, state_value::StateValueMetadata, StateView, StateViewId},
+    state_store::{
+        state_key::StateKey,
+        state_value::{StateValue, StateValueMetadata},
+        StateView, StateViewId,
+    },
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockOutput,
         TransactionOutput, TransactionStatus,
     },
-    write_set::WriteOp,
+    write_set::{TransactionWrite, WriteOp},
 };
 use aptos_vm_logging::{flush_speculative_logs, init_speculative_logs};
 use aptos_vm_types::{
     abstract_write_op::AbstractResourceWriteOp,
-    module_write_set::ModuleWrite,
     output::{UnorderedReadSet, VMOutput},
     resolver::ResourceGroupSize,
 };
 use move_core_types::{
-    language_storage::StructTag,
+    language_storage::{ModuleId, StructTag},
     value::MoveTypeLayout,
     vm_status::{StatusCode, VMStatus},
 };
@@ -273,8 +276,18 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
     }
 
     /// Should never be called after incorporating materialized output, as that consumes vm_output.
-    fn module_write_set(&self) -> &BTreeMap<StateKey, ModuleWrite<WriteOp>> {
-        self.guard.module_write_set()
+    fn for_each_module_write(
+        &self,
+        callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>,
+    ) -> Result<(), PanicError> {
+        for write in self.guard.module_write_set().values() {
+            let state_value = write
+                .write_op()
+                .as_state_value()
+                .ok_or_else(|| code_invariant_error("Modules cannot be deleted"))?;
+            callback(write.module_id(), state_value)?;
+        }
+        Ok(())
     }
 
     /// Should never be called after incorporating materialized output, as that consumes vm_output.

--- a/aptos-move/block-executor/src/code_cache_global.rs
+++ b/aptos-move/block-executor/src/code_cache_global.rs
@@ -4,10 +4,8 @@
 use crate::counters::GLOBAL_LAYOUT_CACHE_MISSES;
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    error::PanicError, transaction::BlockExecutableTransaction, vm::modules::AptosModuleExtension,
-    write_set::TransactionWrite,
+    error::PanicError, state_store::state_value::StateValue, vm::modules::AptosModuleExtension,
 };
-use aptos_vm_types::module_write_set::ModuleWrite;
 use dashmap::DashMap;
 use hashbrown::{Equivalent, HashMap};
 use move_binary_format::{errors::PartialVMResult, CompiledModule};
@@ -273,9 +271,11 @@ where
     }
 }
 
-/// Converts module write into cached module representation, and adds it to the module cache.
-pub(crate) fn add_module_write_to_module_cache<T: BlockExecutableTransaction>(
-    write: &ModuleWrite<T::Value>,
+/// Converts a published module's state value into the cached module representation, and adds it
+/// to the module cache.
+pub(crate) fn add_module_write_to_module_cache(
+    module_id: &ModuleId,
+    state_value: StateValue,
     txn_idx: TxnIndex,
     runtime_environment: &RuntimeEnvironment,
     global_module_cache: &GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension>,
@@ -287,11 +287,6 @@ pub(crate) fn add_module_write_to_module_cache<T: BlockExecutableTransaction>(
         Version = Option<TxnIndex>,
     >,
 ) -> Result<(), PanicError> {
-    let state_value = write
-        .write_op()
-        .as_state_value()
-        .ok_or_else(|| PanicError::CodeInvariantError("Modules cannot be deleted".to_string()))?;
-
     // Since we have successfully serialized the module when converting into this transaction
     // write, the deserialization should never fail.
     let compiled_module = runtime_environment
@@ -303,23 +298,15 @@ pub(crate) fn add_module_write_to_module_cache<T: BlockExecutableTransaction>(
     let extension = Arc::new(AptosModuleExtension::new(state_value));
 
     per_block_module_cache
-        .insert_deserialized_module(
-            write.module_id().clone(),
-            compiled_module,
-            extension,
-            Some(txn_idx),
-        )
+        .insert_deserialized_module(module_id.clone(), compiled_module, extension, Some(txn_idx))
         .map_err(|err| {
             let msg = format!(
-                "Failed to insert code for module {}::{} at version {} to module cache: {:?}",
-                write.module_address(),
-                write.module_name(),
-                txn_idx,
-                err
+                "Failed to insert code for module {} at version {} to module cache: {:?}",
+                module_id, txn_idx, err
             );
             PanicError::CodeInvariantError(msg)
         })?;
-    global_module_cache.mark_overridden(write.module_id());
+    global_module_cache.mark_overridden(module_id);
     Ok(())
 }
 

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -20,10 +20,13 @@ use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
     block_executor::{output::CommittedTransactionOutput, value::ValueWithLayout},
     contract_event::TransactionEvent,
-    error::PanicError,
+    error::{code_invariant_error, PanicError},
     executable::ModulePath,
     fee_statement::FeeStatement,
-    state_store::{state_value::StateValueMetadata, TStateView},
+    state_store::{
+        state_value::{StateValue, StateValueMetadata},
+        TStateView,
+    },
     transaction::AuxiliaryInfo,
     write_set::{TransactionWrite, WriteOpKind},
 };
@@ -735,8 +738,18 @@ where
             .collect()
     }
 
-    fn module_write_set(&self) -> &BTreeMap<K, ModuleWrite<ValueType>> {
-        &self.module_writes
+    fn for_each_module_write(
+        &self,
+        callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>,
+    ) -> Result<(), PanicError> {
+        for write in self.module_writes.values() {
+            let state_value = write
+                .write_op()
+                .as_state_value()
+                .ok_or_else(|| code_invariant_error("Modules cannot be deleted"))?;
+            callback(write.module_id(), state_value)?;
+        }
+        Ok(())
     }
 
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>> {

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -2097,15 +2097,16 @@ where
             unsync_map.write(group_key, metadata_op);
         }
 
-        for write in output_before_guard.module_write_set().values() {
-            add_module_write_to_module_cache::<T>(
-                write,
+        output_before_guard.for_each_module_write(&mut |module_id, state_value| {
+            add_module_write_to_module_cache(
+                module_id,
+                state_value,
                 txn_idx,
                 runtime_environment,
                 global_module_cache,
                 unsync_map.module_cache(),
-            )?;
-        }
+            )
+        })?;
 
         let mut second_phase = Vec::new();
         let mut updates = HashMap::new();

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -8,7 +8,10 @@ use aptos_types::{
     block_executor::{output::CommittedTransactionOutput, value::ValueWithLayout},
     error::PanicError,
     fee_statement::FeeStatement,
-    state_store::{state_value::StateValueMetadata, TStateView},
+    state_store::{
+        state_value::{StateValue, StateValueMetadata},
+        TStateView,
+    },
     transaction::{
         AuxiliaryInfoTrait, BlockExecutableTransaction as Transaction, BlockExecutableTransaction,
     },
@@ -16,12 +19,11 @@ use aptos_types::{
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_types::{
     module_and_script_storage::code_storage::AptosCodeStorage,
-    module_write_set::ModuleWrite,
     resolver::{
         BlockSynchronizationKillSwitch, ResourceGroupSize, TExecutorView, TResourceGroupView,
     },
 };
-use move_core_types::value::MoveTypeLayout;
+use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout};
 use move_vm_runtime::execution_tracing::Trace;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use std::{
@@ -109,8 +111,6 @@ pub trait BeforeMaterializationOutput<Txn: Transaction> {
     /// and modules. Aggregator V1 writes are ordinary entries of the resource write set.
     fn resource_write_set(&self) -> HashMap<Txn::Key, ValueWithLayout<Txn::Value>>;
 
-    fn module_write_set(&self) -> &BTreeMap<Txn::Key, ModuleWrite<Txn::Value>>;
-
     /// Get the delayed field changes of a transaction from its output.
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>>;
 
@@ -144,6 +144,13 @@ pub trait BeforeMaterializationOutput<Txn: Transaction> {
         // This is &mut dyn and not Impl to sidestep an internal compiler error:
         // https://github.com/rust-lang/rust/issues/145188.
         callback: &mut dyn FnMut(&Txn::Key, HashSet<&Txn::Tag>) -> Result<(), PanicError>,
+    ) -> Result<(), PanicError>;
+
+    /// Invokes the callback for each module published by this transaction.
+    /// Modules cannot be deleted, so all writes are concrete state values.
+    fn for_each_module_write(
+        &self,
+        callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>,
     ) -> Result<(), PanicError>;
 
     // For now, the below interfaces for keys and metada and keys and tags are provided

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -473,19 +473,20 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
 
         let mut published = false;
         let mut module_ids_for_v2 = BTreeSet::new();
-        for write in output_before_guard.module_write_set().values() {
+        output_before_guard.for_each_module_write(&mut |module_id, state_value| {
             published = true;
             if scheduler.is_v2() {
-                module_ids_for_v2.insert(write.module_id().clone());
+                module_ids_for_v2.insert(module_id.clone());
             }
-            add_module_write_to_module_cache::<T>(
-                write,
+            add_module_write_to_module_cache(
+                module_id,
+                state_value,
                 txn_idx,
                 runtime_environment,
                 global_module_cache,
                 versioned_cache.module_cache(),
-            )?;
-        }
+            )
+        })?;
         if published {
             // Record validation requirements after the modules are published.
             scheduler.record_validation_requirements(txn_idx, module_ids_for_v2)?;

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -29,7 +29,11 @@ use aptos_types::{
     contract_event::ContractEvent,
     error::PanicError,
     fee_statement::FeeStatement,
-    state_store::{state_key::StateKey, state_value::StateValueMetadata, TStateView},
+    state_store::{
+        state_key::StateKey,
+        state_value::{StateValue, StateValueMetadata},
+        TStateView,
+    },
     transaction::{AuxiliaryInfo, BlockExecutableTransaction},
     write_set::WriteOp,
 };
@@ -44,7 +48,6 @@ use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_types::{
     change_set::VMChangeSet,
     module_and_script_storage::code_storage::AptosCodeStorage,
-    module_write_set::ModuleWrite,
     resolver::{
         BlockSynchronizationKillSwitch, ExecutorView, ResourceGroupSize, ResourceGroupView,
     },
@@ -64,7 +67,6 @@ use move_vm_runtime::{
     ModuleStorage,
 };
 use move_vm_types::{delayed_values::delayed_field_id::DelayedFieldID, gas::UnmeteredGasMeter};
-use once_cell::sync::OnceCell;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     str::FromStr,
@@ -187,9 +189,11 @@ impl BeforeMaterializationOutput<TestTransaction> for &TestOutput {
         HashMap::new()
     }
 
-    fn module_write_set(&self) -> &BTreeMap<StateKey, ModuleWrite<WriteOp>> {
-        static EMPTY: OnceCell<BTreeMap<StateKey, ModuleWrite<WriteOp>>> = OnceCell::new();
-        EMPTY.get_or_init(BTreeMap::new)
+    fn for_each_module_write(
+        &self,
+        _callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>,
+    ) -> Result<(), PanicError> {
+        Ok(())
     }
 
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>> {


### PR DESCRIPTION
## Description

`BeforeMaterializationOutput::module_write_set()` returned `&BTreeMap<Txn::Key, ModuleWrite<Txn::Value>>`, keeping the module-publish handoff generic over the transaction's value type. Both consumers — `publish_module_write_set` on the parallel commit path and `apply_output_sequential` on the sequential path — immediately converted each write to a `ModuleId` plus a `StateValue`. That pair is all the destination caches and BlockSTMv2 cold validation need: the per-block and global module caches are already fully concrete (`ModuleId`, `CompiledModule`, `Module`, `AptosModuleExtension`). Only the handoff was generic.

What changes:

- **The map accessor becomes a callback.** `for_each_module_write(&self, callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>)` replaces `module_write_set()`, following the existing `for_each_resource_key` pattern on the trait. The map key was never used by consumers (both iterated `.values()`), and `ModuleWrite` already carried the `ModuleId`.

- **Each output impl converts its own value.** The production guard and the test mock call `write_op().as_state_value()` and reject deletions with a `PanicError`. The "modules cannot be deleted" check moves out of `add_module_write_to_module_cache` into the impls, so a deletion is unrepresentable at the trait boundary — a `StateValue` cannot express "absent".

- **`add_module_write_to_module_cache` loses its transaction type parameter.** It now takes `(&ModuleId, StateValue)` directly and is a plain concrete function.

- **Hot state is unaffected.** Module state keys still reach the hot-state accumulator through `storage_keys_written`, which uses the inherent `VMOutput::module_write_set()`. Module contents cross the trait boundary only as `(ModuleId, StateValue)`.

- **Empty impls need no representation.** `TestOutput` drops its `static OnceCell` empty-map hack and returns `Ok(())`. A future mono-move output implements the callback the same way, sidestepping "what is a module write in mono" entirely — module publishing stays legacy-only without generic machinery pretending otherwise.

## How Has This Been Tested?

No behavior change intended. Existing coverage exercises the path: the block-executor combinatorial tests publish modules through both the BlockSTMv1/v2 parallel commit path (including cold-validation requirement recording) and the sequential path, verified against the baseline; the delayed-field e2e tests cover the stub output.

## Key Areas to Review

- **The deletion check moved.** Previously in `add_module_write_to_module_cache`, now in each impl's `for_each_module_write`. Same `PanicError`, raised one step earlier.
- **Commit-path bookkeeping in the closure.** The `published` flag and the v2 `module_ids_for_v2` set are now populated inside the callback; `record_validation_requirements` and the side-effect-at-commit wakeup are unchanged.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of BlockSTM commit-time module caching with no intended semantic change; risk is limited to subtle regressions in module publish or BlockSTMv2 validation bookkeeping if the callback path diverges from the old map iteration.
> 
> **Overview**
> **BlockSTM module publish handoff is now concrete** instead of generic over `ModuleWrite` and transaction value types.
> 
> `BeforeMaterializationOutput` drops `module_write_set()` in favor of **`for_each_module_write`**, which invokes a callback with **`(&ModuleId, StateValue)`** for each published module (same pattern as resource key iteration). Production VM output, combinatorial mocks, and e2e stubs implement the callback; empty test outputs no longer need a static empty map.
> 
> **Consumers** on parallel commit (`publish_module_write_set`), sequential apply (`apply_output_sequential`), and **`add_module_write_to_module_cache`** now take `module_id` + `state_value` directly—the cache helper is no longer generic over the transaction type. The **“modules cannot be deleted”** invariant is enforced in each `for_each_module_write` impl when converting write ops to `StateValue`, not inside the cache helper.
> 
> **Unchanged:** `VMOutput` still exposes `module_write_set()` for hot-state / `storage_keys_written`; only the trait boundary to the block executor changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dededead2716eb8fa50f73d2811d7f753014c83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->