### PR TITLE
[framework] Enable concurrent balance on testnet

### DIFF
--- a/aptos-move/aptos-release-builder/data/enable_concurrent_fungible_balance.yaml
+++ b/aptos-move/aptos-release-builder/data/enable_concurrent_fungible_balance.yaml
@@ -1,0 +1,16 @@
+---
+remote_endpoint: ~
+name: "v1.48-enable-concurrent-fungible-balance"
+proposals:
+  - name: enable_concurrent_fungible_balance
+    metadata:
+      title: "Enable CONCURRENT_FUNGIBLE_BALANCE on testnet"
+      description: "Enable opt-in upgrades of fungible stores to concurrent balances on testnet without changing the default for new stores."
+      source_code_url: "https://github.com/aptos-labs/aptos-core/pull/11183"
+      discussion_url: "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-070-parallelize-fungible-assets.md"
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - concurrent_fungible_balance
+          disabled: []


### PR DESCRIPTION
## Summary
- add a v1.48 release-builder proposal enabling `CONCURRENT_FUNGIBLE_BALANCE` on testnet
- keep `DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE` unchanged so store upgrades remain opt-in
- link the original implementation and AIP-70 design

## Test plan
- [x] Generate proposal scripts with `aptos-release-builder`
- [x] `cargo +nightly fmt`
- [x] `cargo xclippy`
- [x] `cargo machete`
- [x] `cargo test -p aptos-release-builder`
- [ ] `cargo sort --workspace --check` (the v1.48 branch has pre-existing unsorted manifests; this PR changes no manifests)

Made with [Cursor](https://cursor.com)