### PR TITLE
[rosetta] Audit fixes for currency config, construction, balances

### DIFF
--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -297,7 +297,7 @@ async fn get_staking_info(
     let mut balances = vec![];
     let mut lockup_expiration: u64 = 0;
     let mut maybe_operators = None;
-    let mut total_balance = 0;
+    let mut total_balance: u64 = 0;
     let mut has_staking = false;
 
     if let Ok(response) = rest_client
@@ -313,7 +313,18 @@ async fn get_staking_info(
                 Ok(Some(balance_result)) => {
                     if let Some(balance) = balance_result.balance {
                         has_staking = true;
-                        total_balance += u64::from_str(&balance.value).unwrap_or_default();
+                        let parsed = u64::from_str(&balance.value).map_err(|_| {
+                            ApiError::InternalError(Some(format!(
+                                "Failed to parse stake balance value '{}' for pool {}",
+                                balance.value, contract.pool_address
+                            )))
+                        })?;
+                        total_balance = total_balance.checked_add(parsed).ok_or_else(|| {
+                            ApiError::InternalError(Some(format!(
+                                "Stake balance overflow while summing pools for account {}",
+                                owner_address
+                            )))
+                        })?;
                     }
                     // TODO: This seems like it only works if there's only one staking contract (hopefully it stays that way)
                     lockup_expiration = balance_result.lockup_expiration;
@@ -403,6 +414,13 @@ async fn get_base_balances(
                     }),
                 ..
             } => {
+                let fa_metadata_address =
+                    AccountAddress::from_str(fa_address).map_err(|err| {
+                        ApiError::InvalidInput(Some(format!(
+                            "Invalid fungible asset address in currency {}: {}",
+                            currency.symbol, err
+                        )))
+                    })?;
                 let response = view::<Vec<u64>>(
                     rest_client,
                     version,
@@ -416,8 +434,8 @@ async fn get_base_balances(
                         type_args: vec![],
                     }))],
                     vec![
-                        bcs::to_bytes(&owner_address).unwrap(),
-                        bcs::to_bytes(&AccountAddress::from_str(fa_address).unwrap()).unwrap(),
+                        bcs::to_bytes(&owner_address)?,
+                        bcs::to_bytes(&fa_metadata_address)?,
                     ],
                 )
                 .await?;

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -297,7 +297,7 @@ async fn get_staking_info(
     let mut balances = vec![];
     let mut lockup_expiration: u64 = 0;
     let mut maybe_operators = None;
-    let mut total_balance: u64 = 0;
+    let mut total_balance = 0;
     let mut has_staking = false;
 
     if let Ok(response) = rest_client
@@ -313,18 +313,9 @@ async fn get_staking_info(
                 Ok(Some(balance_result)) => {
                     if let Some(balance) = balance_result.balance {
                         has_staking = true;
-                        let parsed = u64::from_str(&balance.value).map_err(|_| {
-                            ApiError::InternalError(Some(format!(
-                                "Failed to parse stake balance value '{}' for pool {}",
-                                balance.value, contract.pool_address
-                            )))
-                        })?;
-                        total_balance = total_balance.checked_add(parsed).ok_or_else(|| {
-                            ApiError::InternalError(Some(format!(
-                                "Stake balance overflow while summing pools for account {}",
-                                owner_address
-                            )))
-                        })?;
+                        // Prefer availability over failing the whole balance call if a value is
+                        // malformed; treat unparsable amounts as zero.
+                        total_balance += u64::from_str(&balance.value).unwrap_or_default();
                     }
                     // TODO: This seems like it only works if there's only one staking contract (hopefully it stays that way)
                     lockup_expiration = balance_result.lockup_expiration;

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -256,15 +256,20 @@ pub async fn get_block_index_from_request(
     partial_block_identifier: Option<PartialBlockIdentifier>,
 ) -> ApiResult<u64> {
     Ok(match partial_block_identifier {
-        // If Index and hash are provided, we use index, because it's easier to use.
-        // Note, we don't handle if they mismatch.
-        //
-        // This is required.  Rosetta originally only took one or the other, and this failed in
-        // integration testing.
+        // If index and hash are both provided, require them to agree.
         Some(PartialBlockIdentifier {
             index: Some(block_index),
-            hash: Some(_),
-        }) => block_index,
+            hash: Some(hash),
+        }) => {
+            let parsed_height = BlockHash::from_str(&hash)?.block_height(server_context.chain_id)?;
+            if parsed_height != block_index {
+                return Err(ApiError::InvalidInput(Some(format!(
+                    "Block index {} does not match block hash {} (height {})",
+                    block_index, hash, parsed_height
+                ))));
+            }
+            block_index
+        },
 
         // Lookup by block index
         Some(PartialBlockIdentifier {
@@ -454,5 +459,15 @@ mod test {
         for str in invalid_block_hashes {
             BlockHash::from_str(str).expect_err("Invalid block hash");
         }
+    }
+
+    #[test]
+    pub fn block_hash_and_index_must_agree() {
+        // Covered via get_block_index_from_request logic; unit-test BlockHash parsing agreement.
+        let chain_id = ChainId::test();
+        let hash = BlockHash::new(chain_id, 42).to_string();
+        let parsed = BlockHash::from_str(&hash).unwrap();
+        assert_eq!(parsed.block_height(chain_id).unwrap(), 42);
+        assert_ne!(parsed.block_height(chain_id).unwrap(), 41);
     }
 }

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -256,20 +256,13 @@ pub async fn get_block_index_from_request(
     partial_block_identifier: Option<PartialBlockIdentifier>,
 ) -> ApiResult<u64> {
     Ok(match partial_block_identifier {
-        // If index and hash are both provided, require them to agree.
+        // If index and hash are both provided, prefer index and ignore hash.
+        // Rosetta clients may send both; validating agreement broke integration testing
+        // historically, so hash is intentionally not checked when index is present.
         Some(PartialBlockIdentifier {
             index: Some(block_index),
-            hash: Some(hash),
-        }) => {
-            let parsed_height = BlockHash::from_str(&hash)?.block_height(server_context.chain_id)?;
-            if parsed_height != block_index {
-                return Err(ApiError::InvalidInput(Some(format!(
-                    "Block index {} does not match block hash {} (height {})",
-                    block_index, hash, parsed_height
-                ))));
-            }
-            block_index
-        },
+            hash: Some(_),
+        }) => block_index,
 
         // Lookup by block index
         Some(PartialBlockIdentifier {
@@ -459,15 +452,5 @@ mod test {
         for str in invalid_block_hashes {
             BlockHash::from_str(str).expect_err("Invalid block hash");
         }
-    }
-
-    #[test]
-    pub fn block_hash_and_index_must_agree() {
-        // Covered via get_block_index_from_request logic; unit-test BlockHash parsing agreement.
-        let chain_id = ChainId::test();
-        let hash = BlockHash::new(chain_id, 42).to_string();
-        let parsed = BlockHash::from_str(&hash).unwrap();
-        assert_eq!(parsed.block_height(chain_id).unwrap(), 42);
-        assert_ne!(parsed.block_height(chain_id).unwrap(), 41);
     }
 }

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -1505,6 +1505,8 @@ async fn construction_preprocess(
 
     // Simulation can be skipped only when both max gas and gas price are provided.
     // Otherwise public keys are required so metadata can simulate/estimate.
+    // TODO: Support simulation without public keys so callers can omit them when only
+    // estimating gas (Aptos REST simulation currently requires a public key).
     if !(has_max_gas && has_gas_price) && !has_public_keys {
         return Err(ApiError::InvalidInput(Some(
             "Must provide either both max gas amount and gas price, or public keys for simulation"

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -429,7 +429,7 @@ async fn simulate_transaction(
         };
 
         // Multiply the gas price times the max gas amount to use
-        let suggested_fee = Amount::suggested_gas_fee(simulated_gas_unit_price, max_gas_amount);
+        let suggested_fee = Amount::suggested_gas_fee(simulated_gas_unit_price, max_gas_amount)?;
 
         Ok((suggested_fee, simulated_gas_unit_price, max_gas_amount))
     } else {
@@ -476,15 +476,27 @@ async fn construction_metadata(
     )
     .await?;
 
-    // If both are present, we skip simulation
-    let (suggested_fee, gas_unit_price, max_gas_amount) = simulate_transaction(
-        rest_client.as_ref(),
-        server_context.chain_id,
-        &request.options,
-        &internal_operation,
-        sequence_number,
-    )
-    .await?;
+    // If both max gas and gas price are provided, skip simulation.
+    let (suggested_fee, gas_unit_price, max_gas_amount) =
+        if let (Some(max_gas_amount), Some(gas_price_per_unit)) = (
+            request.options.max_gas_amount.as_ref(),
+            request.options.gas_price_per_unit.as_ref(),
+        ) {
+            (
+                Amount::suggested_gas_fee(gas_price_per_unit.0, max_gas_amount.0)?,
+                gas_price_per_unit.0,
+                max_gas_amount.0,
+            )
+        } else {
+            simulate_transaction(
+                rest_client.as_ref(),
+                server_context.chain_id,
+                &request.options,
+                &internal_operation,
+                sequence_number,
+            )
+            .await?
+        };
 
     Ok(ConstructionMetadataResponse {
         metadata: ConstructionMetadata {
@@ -1477,20 +1489,25 @@ async fn construction_preprocess(
         .metadata
         .as_ref()
         .and_then(|inner| inner.public_keys.as_ref());
-
-    // A public key can be provided for simulation, otherwise, a max gas amount would be given.
-    if request
+    let has_max_gas = request
         .metadata
         .as_ref()
         .and_then(|inner| inner.max_gas_amount)
-        .is_none()
-        && public_keys
-            .as_ref()
-            .map(|inner| inner.is_empty())
-            .unwrap_or(false)
-    {
+        .is_some();
+    let has_gas_price = request
+        .metadata
+        .as_ref()
+        .and_then(|inner| inner.gas_price)
+        .is_some();
+    let has_public_keys = public_keys
+        .map(|inner| !inner.is_empty())
+        .unwrap_or(false);
+
+    // Simulation can be skipped only when both max gas and gas price are provided.
+    // Otherwise public keys are required so metadata can simulate/estimate.
+    if !(has_max_gas && has_gas_price) && !has_public_keys {
         return Err(ApiError::InvalidInput(Some(
-            "Must provide either max gas amount or public keys to estimate max gas amount"
+            "Must provide either both max gas amount and gas price, or public keys for simulation"
                 .to_string(),
         )));
     }
@@ -1530,7 +1547,7 @@ async fn construction_preprocess(
     })
 }
 
-/// Construction submit command (OFFLINE)
+/// Construction submit command (ONLINE)
 ///
 /// Submits a transaction to the blockchain
 ///

--- a/crates/aptos-rosetta/src/currencies.rs
+++ b/crates/aptos-rosetta/src/currencies.rs
@@ -1,0 +1,150 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Currency configuration loading and validation for Rosetta.
+
+use crate::{common::native_coin, types::Currency};
+use aptos_logger::warn;
+use aptos_types::account_address::AccountAddress;
+use move_core_types::language_storage::StructTag;
+use std::{collections::HashSet, str::FromStr};
+
+/// Loads the default native coin plus any valid currencies from a config list.
+///
+/// A configured currency is accepted when it has a non-empty symbol and either:
+/// - no metadata,
+/// - a valid Move coin type (`move_type`), or
+/// - a valid fungible-asset metadata address (`fa_address`).
+pub fn load_supported_currencies(configured: Vec<Currency>) -> HashSet<Currency> {
+    let mut supported_currencies = HashSet::new();
+    supported_currencies.insert(native_coin());
+
+    for item in configured {
+        if item.symbol.as_str().is_empty() {
+            warn!(
+                "Currency {:?} has an empty symbol, and is being skipped",
+                item
+            );
+            continue;
+        }
+
+        let Some(metadata) = item.metadata.as_ref() else {
+            supported_currencies.insert(item);
+            continue;
+        };
+
+        let move_type_valid = match metadata.move_type.as_ref() {
+            Some(move_type) => StructTag::from_str(move_type).is_ok(),
+            None => false,
+        };
+        let fa_address_valid = match metadata.fa_address.as_ref() {
+            Some(fa_address) => AccountAddress::from_str(fa_address).is_ok(),
+            None => false,
+        };
+
+        // Reject when move_type is present but invalid.
+        if metadata.move_type.is_some() && !move_type_valid {
+            warn!(
+                "Currency {:?} has an invalid metadata coin type, and is being skipped",
+                item
+            );
+            continue;
+        }
+
+        // Reject when fa_address is present but invalid.
+        if metadata.fa_address.is_some() && !fa_address_valid {
+            warn!(
+                "Currency {:?} has an invalid fungible asset address, and is being skipped",
+                item
+            );
+            continue;
+        }
+
+        // Accept coin-type, FA-only, or combined metadata.
+        if move_type_valid || fa_address_valid {
+            supported_currencies.insert(item);
+        } else {
+            warn!(
+                "Currency {:?} has neither a valid move type nor fungible asset address, and is being skipped",
+                item
+            );
+        }
+    }
+
+    supported_currencies
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::CurrencyMetadata;
+
+    #[test]
+    fn accepts_fa_only_currency() {
+        let currencies = load_supported_currencies(vec![Currency {
+            symbol: "TFA".to_string(),
+            decimals: 4,
+            metadata: Some(CurrencyMetadata {
+                move_type: None,
+                fa_address: Some(
+                    "0x7e51ad6e79cd113f5abe08f53ed6a3c2bfbf88561a24ae10b9e1e822e0623dfd"
+                        .to_string(),
+                ),
+            }),
+        }]);
+
+        assert!(currencies.iter().any(|c| c.symbol == "TFA"));
+    }
+
+    #[test]
+    fn accepts_coin_type_currency() {
+        let currencies = load_supported_currencies(vec![Currency {
+            symbol: "TC".to_string(),
+            decimals: 4,
+            metadata: Some(CurrencyMetadata {
+                move_type: Some(
+                    "0xf5a9b6ccc95f8ad3c671ddf1e227416e71f7bcd3c971efe83c0ae8e5e028350f::test_faucet::TestFaucetCoin"
+                        .to_string(),
+                ),
+                fa_address: Some(
+                    "0xb528ad40e472f8fcf0f21aa78aecd09fe68f6208036a5845e6d16b7d561c83b8"
+                        .to_string(),
+                ),
+            }),
+        }]);
+
+        assert!(currencies.iter().any(|c| c.symbol == "TC"));
+    }
+
+    #[test]
+    fn rejects_invalid_fa_address() {
+        let currencies = load_supported_currencies(vec![Currency {
+            symbol: "BAD".to_string(),
+            decimals: 4,
+            metadata: Some(CurrencyMetadata {
+                move_type: None,
+                fa_address: Some("not-an-address".to_string()),
+            }),
+        }]);
+
+        assert!(!currencies.iter().any(|c| c.symbol == "BAD"));
+    }
+
+    #[test]
+    fn rejects_empty_symbol() {
+        let currencies = load_supported_currencies(vec![Currency {
+            symbol: "".to_string(),
+            decimals: 4,
+            metadata: Some(CurrencyMetadata {
+                move_type: None,
+                fa_address: Some(
+                    "0x7e51ad6e79cd113f5abe08f53ed6a3c2bfbf88561a24ae10b9e1e822e0623dfd"
+                        .to_string(),
+                ),
+            }),
+        }]);
+
+        assert_eq!(currencies.len(), 1);
+        assert!(currencies.contains(&native_coin()));
+    }
+}

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -29,6 +29,7 @@ mod network;
 
 pub mod client;
 pub mod common;
+pub mod currencies;
 pub mod error;
 pub mod types;
 

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -8,8 +8,7 @@
 use aptos_config::config::{ApiConfig, DEFAULT_MAX_PAGE_SIZE};
 use aptos_logger::prelude::*;
 use aptos_node::AptosNodeArgs;
-use aptos_rosetta::{bootstrap, common::native_coin, types::Currency};
-use aptos_sdk::move_types::language_storage::StructTag;
+use aptos_rosetta::{bootstrap, currencies::load_supported_currencies, types::Currency};
 use aptos_types::chain_id::ChainId;
 use clap::Parser;
 use std::{
@@ -17,7 +16,6 @@ use std::{
     fs::File,
     net::SocketAddr,
     path::PathBuf,
-    str::FromStr,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -239,37 +237,13 @@ impl ServerArgs for OfflineArgs {
     }
 
     fn supported_currencies(&self) -> HashSet<Currency> {
-        let mut supported_currencies = HashSet::new();
-        supported_currencies.insert(native_coin());
-
-        if let Some(ref filepath) = self.currency_config_file {
-            let file = File::open(filepath).unwrap();
-            let currencies: Vec<Currency> = serde_json::from_reader(file).unwrap();
-            for item in currencies.into_iter() {
-                // Do a safety check on possible currencies on startup
-                if item.symbol.as_str() == "" {
-                    warn!(
-                        "Currency {:?} has an empty symbol, and is being skipped",
-                        item
-                    );
-                } else if let Some(metadata) = item.metadata.as_ref() {
-                    if let Some(move_type) = metadata.move_type.as_ref() {
-                        if StructTag::from_str(move_type).is_ok() {
-                            supported_currencies.insert(item);
-                            continue;
-                        }
-                    }
-                    warn!(
-                        "Currency {:?} has an invalid metadata coin type, and is being skipped",
-                        item
-                    );
-                } else {
-                    supported_currencies.insert(item);
-                }
-            }
-        }
-
-        supported_currencies
+        let configured = if let Some(ref filepath) = self.currency_config_file {
+            let file = File::open(filepath).expect("Failed to open currency config file");
+            serde_json::from_reader(file).expect("Failed to parse currency config file")
+        } else {
+            vec![]
+        };
+        load_supported_currencies(configured)
     }
 }
 

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -117,11 +117,17 @@ pub struct Amount {
 }
 
 impl Amount {
-    pub fn suggested_gas_fee(gas_unit_price: u64, max_gas_amount: u64) -> Amount {
-        Amount {
-            value: (gas_unit_price * max_gas_amount).to_string(),
+    pub fn suggested_gas_fee(gas_unit_price: u64, max_gas_amount: u64) -> ApiResult<Amount> {
+        let value = gas_unit_price.checked_mul(max_gas_amount).ok_or_else(|| {
+            ApiError::InvalidInput(Some(format!(
+                "Suggested fee overflowed for gas unit price {} and max gas amount {}",
+                gas_unit_price, max_gas_amount
+            )))
+        })?;
+        Ok(Amount {
+            value: value.to_string(),
             currency: native_coin(),
-        }
+        })
     }
 
     pub fn value(&self) -> ApiResult<i128> {
@@ -1029,7 +1035,8 @@ impl Transaction {
             ));
         }
 
-        // TODO: Handle storage gas refund (though nothing currently in Rosetta refunds)
+        // TODO: Storage fee refunds are already parsed above via FeeStatement events.
+        // This leftover note previously claimed they were not handled.
 
         Ok(Transaction {
             transaction_identifier: (&txn_info).into(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a few correctness bugs in `crates/aptos-rosetta` found during review:

- Accept FA-only currencies from `--currency-config-file` (previously skipped when `move_type` was absent)
- Skip `/construction/metadata` simulation when both max gas and gas price are provided
- Require public keys for preprocess unless both gas fields are set (with a TODO to support simulation without them)
- Use `checked_mul` for suggested fee calculation
- Avoid panicking on invalid FA addresses during balance lookup

## Test plan

- [x] `cargo test -p aptos-rosetta --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79a9cd9d-cba2-49e9-9367-30484486984b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79a9cd9d-cba2-49e9-9367-30484486984b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

