### PR TITLE
[move] Add more charges for string natives

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/move_stdlib.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/move_stdlib.rs
@@ -4,7 +4,7 @@
 //! This module defines the gas parameters for Move Stdlib.
 
 use crate::{
-    gas_feature_versions::{RELEASE_V1_18, RELEASE_V1_24},
+    gas_feature_versions::{RELEASE_V1_18, RELEASE_V1_24, RELEASE_V1_50},
     gas_schedule::NativeGasParameters,
 };
 use aptos_gas_algebra::{
@@ -32,9 +32,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [string_check_utf8_base: InternalGas, "string.check_utf8.base", 11020],
         [string_check_utf8_per_byte: InternalGasPerByte, "string.check_utf8.per_byte", 290],
         [string_is_char_boundary_base: InternalGas, "string.is_char_boundary.base", 11020],
+        [string_is_char_boundary_per_byte: InternalGasPerByte, { RELEASE_V1_50.. => "string.is_char_boundary.per_byte" }, 290],
         [string_sub_string_base: InternalGas, "string.sub_string.base", 14700],
         [string_sub_string_per_byte: InternalGasPerByte, "string.sub_string.per_byte", 110],
         [string_index_of_base: InternalGas, "string.index_of.base", 14700],
+        [string_index_of_per_byte: InternalGasPerByte, { RELEASE_V1_50.. => "string.index_of.per_byte" }, 360],
         [string_index_of_per_byte_pattern: InternalGasPerByte, "string.index_of.per_byte_pattern", 730],
         [string_index_of_per_byte_searched: InternalGasPerByte, "string.index_of.per_byte_searched", 360],
 

--- a/aptos-move/framework/move-stdlib/src/natives/string.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/string.rs
@@ -7,7 +7,9 @@
 
 //! Implementation of native functions for utf8 strings.
 
-use aptos_gas_schedule::gas_params::natives::move_stdlib::*;
+use aptos_gas_schedule::{
+    gas_feature_versions::RELEASE_V1_50, gas_params::natives::move_stdlib::*,
+};
 use aptos_native_interface::{
     safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeResult,
 };
@@ -63,7 +65,7 @@ fn native_check_utf8(
 /***************************************************************************************************
  * native fun internal_is_char_boundary
  *
- *   gas cost: base_cost
+ *   gas cost: base_cost + unit_cost * length_in_bytes
  *
  **************************************************************************************************/
 fn native_is_char_boundary(
@@ -78,6 +80,9 @@ fn native_is_char_boundary(
     let i = safely_pop_arg!(args, u64);
     let s_arg = safely_pop_arg!(args, VectorRef);
     let s_ref = s_arg.as_bytes_ref()?;
+
+    context.charge(STRING_IS_CHAR_BOUNDARY_PER_BYTE * NumBytes::new(s_ref.len() as u64))?;
+
     let ok = from_utf8_checked(s_ref.as_slice())?.is_char_boundary(i as usize);
 
     Ok(smallvec![Value::bool(ok)])
@@ -110,6 +115,11 @@ fn native_sub_string(
 
     let s_arg = safely_pop_arg!(args, VectorRef);
     let s_ref = s_arg.as_bytes_ref()?;
+
+    if context.gas_feature_version() >= RELEASE_V1_50 {
+        context.charge(STRING_SUB_STRING_PER_BYTE * NumBytes::new(s_ref.len() as u64))?;
+    }
+
     let s_str = from_utf8_checked(s_ref.as_slice())?;
     let v = Value::vector_u8(s_str[i..j].as_bytes().iter().cloned());
 
@@ -139,6 +149,9 @@ fn native_index_of(
 
     let s_arg = safely_pop_arg!(args, VectorRef);
     let s_ref = s_arg.as_bytes_ref()?;
+
+    context.charge(STRING_INDEX_OF_PER_BYTE * NumBytes::new(s_ref.len() as u64))?;
+
     let s_str = from_utf8_checked(s_ref.as_slice())?;
     let pos = match s_str.find(r_str) {
         Some(size) => size,


### PR DESCRIPTION
## Description

Adding more charges for string natives.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Gas schedule changes affect transaction cost and out-of-gas behavior for all contracts using string natives once RELEASE_V1_50 is active; substring charging is version-gated but index_of/is_char_boundary per-byte params activate with the new schedule version.
> 
> **Overview**
> Tightens **Move stdlib string native gas** so cost scales with string size, reducing cheap abuse of UTF-8 work on large buffers.
> 
> **`internal_is_char_boundary`** now charges **base + per-byte of the full string** (new `string.is_char_boundary.per_byte`, 290 gas/byte from **RELEASE_V1_50**). **`internal_index_of`** adds a **per-byte charge on the searched string** (`string.index_of.per_byte`, 360) on top of existing pattern and bytes-searched costs. **`internal_sub_string`** at **RELEASE_V1_50+** adds an extra **`string.sub_string.per_byte`** charge on the **entire source string length**, not only the slice length.
> 
> Gas schedule entries for the new per-byte knobs are version-gated in `move_stdlib.rs`; native code imports `RELEASE_V1_50` for the substring behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e028d87c26b285809c5ee55f398168651f29b436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->