### PR TITLE
[rosetta] reject negative deposit amount in extract_transfer

### DIFF
--- a/crates/aptos-rosetta/src/test/mod.rs
+++ b/crates/aptos-rosetta/src/test/mod.rs
@@ -1047,3 +1047,37 @@ async fn test_storage_refund_exceeds_gas_fee() {
         "Net should equal storage_refund - gas_fee"
     );
 }
+
+#[tokio::test]
+async fn test_extract_transfer_rejects_negative_deposit() {
+    use crate::types::{Amount, Operation, OperationIdentifier, Transfer};
+
+    let context = test_rosetta_context().await;
+    let sender = AccountAddress::ONE;
+    let receiver = AccountAddress::TWO;
+
+    let op = |index: u64, op_type: OperationType, account: AccountAddress, value: &str| Operation {
+        operation_identifier: OperationIdentifier { index },
+        operation_type: op_type.to_string(),
+        status: None,
+        account: Some(AccountIdentifier::base_account(account)),
+        amount: Some(Amount {
+            value: value.to_string(),
+            currency: native_coin(),
+        }),
+        metadata: None,
+    };
+
+    // Signs flipped: the withdraw is positive and the deposit is negative.
+    let operations = vec![
+        op(0, OperationType::Withdraw, sender, "5"),
+        op(1, OperationType::Deposit, receiver, "-5"),
+    ];
+
+    let result = Transfer::extract_transfer(&context, &operations);
+    assert!(
+        result.is_err(),
+        "negative deposit amount must be rejected, got {:?}",
+        result.map(|t| t.amount.0)
+    );
+}

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -2943,13 +2943,11 @@ impl Transfer {
 
         // We converted to u128 to ensure no loss of precision in comparison,
         // but now we actually have to check it's a u64
-        if deposit_value > u64::MAX as i128 {
-            return Err(ApiError::InvalidTransferOperations(Some(
-                "Transfer amount must not be greater than u64 max",
-            )));
-        }
-
-        let transfer_amount = deposit_value as u64;
+        let transfer_amount = u64::try_from(deposit_value).map_err(|_| {
+            ApiError::InvalidTransferOperations(Some(
+                "Transfer amount must not be negative or greater than u64 max",
+            ))
+        })?;
 
         Ok(Transfer {
             sender,


### PR DESCRIPTION
## Description

`Transfer::extract_transfer` parses the withdraw and deposit operation amounts as `i128`, then converts the deposit to `u64` for the transfer payload. It verifies the two amounts negate each other and that the deposit is not above `u64::MAX`, but never checks the lower bound, and `-withdraw_value != deposit_value` holds for either sign orientation. A construction request carrying `withdraw.amount.value = "5"` and `deposit.amount.value = "-5"` passes both guards, and `deposit_value as u64` wraps to 18446744073709551611.

The amount flows into `aptos_stdlib::transfer` through `InternalOperation::payload`, so the unsigned transaction returned by `/construction/payloads` does not match the operations that were submitted, and nothing downstream re-derives it from those operations. Swapping the one-sided comparison for `u64::try_from` covers both bounds in the conversion that actually performs the narrowing.

## How Has This Been Tested?

Added `test_extract_transfer_rejects_negative_deposit` in `crates/aptos-rosetta/src/test/mod.rs`, which builds the sign-flipped operation pair and asserts the extraction is rejected.

Before the change:

```
test test::test_extract_transfer_rejects_negative_deposit ... FAILED
panicked at crates/aptos-rosetta/src/test/mod.rs:1078:5:
negative deposit amount must be rejected, got Ok(18446744073709551611)
```

After, `cargo test -p aptos-rosetta` reports 22 passed, 0 failed, so the existing transfer coverage is unchanged.

## Key Areas to Review

Whether the merged error message is acceptable. The over-`u64::MAX` and negative cases now share one `InvalidTransferOperations` string instead of the previous upper-bound-only wording; happy-path amounts convert exactly as before.

## Type of Change

- [x] Bug fix

## Which Components or Systems Does This Change Impact?

- [x] Full Node (API, Indexer, etc.)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Rosetta construction transfer validation; incorrect handling could still break `/construction/payloads`, but the change is a narrow bounds check with a targeted test.
> 
> **Overview**
> Fixes a Rosetta construction bug where **sign-flipped** withdraw/deposit operations could pass validation and produce a bogus transfer amount.
> 
> `Transfer::extract_transfer` still requires withdraw and deposit to negate each other, but it now narrows the deposit with **`u64::try_from`** instead of an upper-bound check plus `as u64`. Negative deposits (and values above `u64::MAX`) return **`InvalidTransferOperations`** instead of wrapping into a huge unsigned amount that would flow into **`/construction/payloads`** via `InternalOperation::payload`.
> 
> Adds **`test_extract_transfer_rejects_negative_deposit`** for withdraw `5` / deposit `-5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0f3d14582de210d112fa3f4f56a6d56bda73388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->