### PR TITLE
[mono-move] Add write-set and VM output generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12953,12 +12953,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mono-move-output"
+version = "0.1.0"
+dependencies = [
+ "aptos-types",
+ "bcs 0.1.4",
+ "mono-move-core",
+ "mono-move-natives",
+ "mono-move-runtime",
+ "move-core-types",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "mono-move-replay-benchmark"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
  "aptos-cached-packages",
+ "aptos-framework-natives",
  "aptos-move-debugger",
  "aptos-rest-client",
  "aptos-types",
@@ -12972,6 +12986,7 @@ dependencies = [
  "mono-move-global-context",
  "mono-move-loader",
  "mono-move-natives",
+ "mono-move-output",
  "mono-move-runtime",
  "mono-move-testsuite",
  "move-binary-format",
@@ -12988,6 +13003,7 @@ name = "mono-move-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-types",
  "bcs 0.1.4",
  "hashbrown 0.14.3",
  "mono-move-alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,6 +215,7 @@ members = [
     "third_party/move/mono-move/loader",
     "third_party/move/mono-move/natives",
     "third_party/move/mono-move/orchestrator",
+    "third_party/move/mono-move/output",
     "third_party/move/mono-move/replay-benchmark",
     "third_party/move/mono-move/runtime",
     "third_party/move/mono-move/specializer",
@@ -906,6 +907,7 @@ mono-move-global-context = { path = "third_party/move/mono-move/global-context" 
 mono-move-loader = { path = "third_party/move/mono-move/loader" }
 mono-move-natives = { path = "third_party/move/mono-move/natives" }
 mono-move-orchestrator = { path = "third_party/move/mono-move/orchestrator" }
+mono-move-output = { path = "third_party/move/mono-move/output" }
 mono-move-runtime = { path = "third_party/move/mono-move/runtime" }
 mono-move-testsuite = { path = "third_party/move/mono-move/testsuite" }
 move-abigen = { path = "third_party/move/tools/move-abigen" }

--- a/third_party/move/mono-move/core/src/interner.rs
+++ b/third_party/move/mono-move/core/src/interner.rs
@@ -4,11 +4,16 @@
 //! Interning APIs.
 
 use crate::{
-    types::{InternedType, InternedTypeList},
+    types::{view_name, view_type, view_type_list, InternedType, InternedTypeList, Type},
     ExecutionErrorKind, IntoExecutionError,
 };
 use mono_move_alloc::GlobalArenaPtr;
-use move_core_types::{ability::AbilitySet, account_address::AccountAddress, identifier::IdentStr};
+use move_core_types::{
+    ability::AbilitySet,
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
+    language_storage::{StructTag, TypeTag},
+};
 use thiserror::Error;
 
 /// Pointer to interned Move identifier allocated in global arena.
@@ -39,6 +44,17 @@ impl ModuleId {
 
 /// Pointer to interned module ID allocated in global arena.
 pub type InternedModuleId = GlobalArenaPtr<ModuleId>;
+
+/// Dereferences an interned module ID.
+///
+/// # Safety contract
+///
+/// Same as the other `view_*` helpers: the arena must be alive for as long as
+/// the returned reference is used (holds during the execution phase).
+pub fn view_module_id(ptr: InternedModuleId) -> &'static ModuleId {
+    // SAFETY: see the safety contract above.
+    unsafe { ptr.as_ref_unchecked() }
+}
 
 /// Symbolic identity of a function: the same `(module, name, type arguments)`
 /// triple the loader keys function code on, bundled so a single thin arena
@@ -176,4 +192,62 @@ pub trait Interner {
         tys: InternedTypeList,
         ty_args: InternedTypeList,
     ) -> Result<InternedTypeList, TypeSubstitutionError>;
+}
+
+/// The [`TypeTag`] for an interned type, or [`None`] for types that have no tag
+/// representation (references, functions, and unsubstituted type parameters).
+///
+/// TODO(perf): cache the tag per interned type (e.g. in the global context)
+/// instead of re-walking the type graph on every call.
+///
+/// TODO(correctness): add runtime bounds here, or ensure the transaction already
+/// charges gas for the tag and guarantees this conversion is infallible.
+pub fn type_tag_of(ty: InternedType) -> Option<TypeTag> {
+    Some(match view_type(ty) {
+        Type::Bool => TypeTag::Bool,
+        Type::U8 => TypeTag::U8,
+        Type::U16 => TypeTag::U16,
+        Type::U32 => TypeTag::U32,
+        Type::U64 => TypeTag::U64,
+        Type::U128 => TypeTag::U128,
+        Type::U256 => TypeTag::U256,
+        Type::I8 => TypeTag::I8,
+        Type::I16 => TypeTag::I16,
+        Type::I32 => TypeTag::I32,
+        Type::I64 => TypeTag::I64,
+        Type::I128 => TypeTag::I128,
+        Type::I256 => TypeTag::I256,
+        Type::Address => TypeTag::Address,
+        Type::Signer => TypeTag::Signer,
+        Type::Vector { elem } => TypeTag::Vector(Box::new(type_tag_of(*elem)?)),
+        Type::Nominal { .. } => TypeTag::Struct(Box::new(struct_tag_of(ty)?)),
+        Type::ImmutRef { .. }
+        | Type::MutRef { .. }
+        | Type::Function { .. }
+        | Type::TypeParam { .. } => return None,
+    })
+}
+
+/// The [`StructTag`] for an interned nominal (struct/enum) type, or [`None`] if
+/// `ty` is not nominal.
+pub fn struct_tag_of(ty: InternedType) -> Option<StructTag> {
+    let Type::Nominal {
+        module_id,
+        name,
+        ty_args,
+    } = view_type(ty)
+    else {
+        return None;
+    };
+    let module_id = view_module_id(*module_id);
+    let type_args = view_type_list(*ty_args)
+        .iter()
+        .map(|arg| type_tag_of(*arg))
+        .collect::<Option<Vec<_>>>()?;
+    Some(StructTag {
+        address: *module_id.address(),
+        module: Identifier::new(view_name(module_id.name())).ok()?,
+        name: Identifier::new(view_name(*name)).ok()?,
+        type_args,
+    })
 }

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -39,7 +39,8 @@ pub use instruction::{
     VEC_LENGTH_OFFSET,
 };
 pub use interner::{
-    view_function_ref, FunctionRef, InternedFunctionRef, Interner, ModuleId, TypeSubstitutionError,
+    struct_tag_of, type_tag_of, view_function_ref, view_module_id, FunctionRef,
+    InternedFunctionRef, Interner, ModuleId, TypeSubstitutionError,
 };
 pub use move_binary_format::file_format::ConstantPoolIndex;
 pub use object_descriptor::{

--- a/third_party/move/mono-move/core/src/vm_error.rs
+++ b/third_party/move/mono-move/core/src/vm_error.rs
@@ -93,6 +93,9 @@ pub enum RuntimeError {
     #[error("AbortMsg: message size {len} exceeds maximum {max}")]
     AbortMessageTooLong { len: usize, max: usize },
 
+    #[error("resource type is too deeply nested to encode as a state key")]
+    StateKeyTypeTooDeep,
+
     #[error("invariant violation: {0}")]
     InvariantViolation(#[from] RuntimeInvariantViolation),
 
@@ -143,7 +146,8 @@ impl IntoExecutionError for RuntimeError {
             | OutOfHeapMemory { .. }
             | AllocationTooLarge { .. }
             | VecAllocSizeOverflow
-            | AbortMessageTooLong { .. } => ExecutionErrorKind::RuntimeLimitExceeded,
+            | AbortMessageTooLong { .. }
+            | StateKeyTypeTooDeep => ExecutionErrorKind::RuntimeLimitExceeded,
 
             BCSEof
             | BCSInvalidUleb

--- a/third_party/move/mono-move/output/Cargo.toml
+++ b/third_party/move/mono-move/output/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mono-move-output"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+mono-move-core = { workspace = true }
+mono-move-natives = { workspace = true }
+mono-move-runtime = { workspace = true }
+move-core-types = { workspace = true }
+thiserror = { workspace = true }

--- a/third_party/move/mono-move/output/src/error.rs
+++ b/third_party/move/mono-move/output/src/error.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Errors raised while building a transaction output.
+
+use mono_move_core::{ExecutionErrorKind, IntoExecutionError, RuntimeError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum OutputError {
+    #[error("event type is not a valid type tag")]
+    InvalidEventType,
+
+    #[error("event guid did not decode to an EventKey: {0}")]
+    InvalidEventGuid(#[from] bcs::Error),
+
+    #[error("failed to build contract event: {0}")]
+    InvalidEvent(String),
+
+    #[error(transparent)]
+    Runtime(#[from] RuntimeError),
+}
+
+impl IntoExecutionError for OutputError {
+    fn kind(&self) -> ExecutionErrorKind {
+        match self {
+            OutputError::InvalidEventType => ExecutionErrorKind::InvariantViolation,
+            OutputError::InvalidEventGuid(_) => ExecutionErrorKind::InvalidOperation,
+            OutputError::InvalidEvent(_) => ExecutionErrorKind::RuntimeLimitExceeded,
+            OutputError::Runtime(err) => err.kind(),
+        }
+    }
+}
+
+pub type OutputResult<T> = Result<T, OutputError>;

--- a/third_party/move/mono-move/output/src/events.rs
+++ b/third_party/move/mono-move/output/src/events.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! MonoMove event store → Aptos [`ContractEvent`]s.
+
+use crate::error::{OutputError, OutputResult};
+use aptos_types::{contract_event::ContractEvent, event::EventKey};
+use mono_move_core::{native::NativeExtensions, type_tag_of, value_layout::LayoutProvider};
+use mono_move_natives::{EventKind, EventStore};
+use mono_move_runtime::serialize;
+
+/// Materializes the emitted events into [`ContractEvent`]s, in emission order.
+/// `layouts` BCS-serializes each event's value.
+///
+/// # Safety
+///
+/// The heap the event values point into must be live.
+pub unsafe fn to_contract_events(
+    extensions: &NativeExtensions,
+    layouts: &impl LayoutProvider,
+) -> OutputResult<Vec<ContractEvent>> {
+    let store = extensions
+        .get_mut::<EventStore>()
+        .map_err(|e| e.into_runtime_error())?;
+    store
+        .entries()
+        .iter()
+        .map(|entry| {
+            let type_tag = type_tag_of(entry.msg_ty).ok_or(OutputError::InvalidEventType)?;
+            // SAFETY: forwarded from this function's contract — the heap is live.
+            let data = unsafe { serialize(layouts, entry.msg_data.as_ptr(), entry.msg_ty) }?;
+            let event = match &entry.kind {
+                EventKind::V2 => ContractEvent::new_v2(type_tag, data),
+                EventKind::V1 {
+                    guid,
+                    sequence_number,
+                } => {
+                    let key: EventKey = bcs::from_bytes(guid)?;
+                    ContractEvent::new_v1(key, *sequence_number, type_tag, data)
+                },
+            };
+            event.map_err(|e| OutputError::InvalidEvent(e.to_string()))
+        })
+        .collect()
+}

--- a/third_party/move/mono-move/output/src/lib.rs
+++ b/third_party/move/mono-move/output/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Converts a finished MonoMove transaction into an Aptos [`TransactionOutput`].
+//!
+//! [`to_transaction_output`] builds the DB-facing output (write set, events,
+//! gas, status) from a transaction's [`mono_move_runtime::SessionEffects`];
+//! [`to_contract_events`] and [`to_transaction_status`] are the pieces.
+//!
+//! Not yet modelled: storage metadata / refunds (write ops are metadata-less);
+//! resource groups and delayed fields; and a faithful `ExecutionError` mapping
+//! (see [`to_transaction_status`]).
+
+pub mod error;
+pub mod events;
+pub mod output;
+
+pub use error::{OutputError, OutputResult};
+pub use events::to_contract_events;
+pub use output::{to_transaction_output, to_transaction_status};

--- a/third_party/move/mono-move/output/src/output.rs
+++ b/third_party/move/mono-move/output/src/output.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! MonoMove effects → Aptos [`TransactionOutput`].
+
+use crate::{error::OutputResult, events::to_contract_events};
+use aptos_types::{
+    transaction::{
+        AbortInfo, ExecutionStatus, TransactionAuxiliaryData, TransactionOutput, TransactionStatus,
+    },
+    write_set::WriteSet,
+};
+use mono_move_core::{value_layout::LayoutProvider, ExecutionErrorKind, ExecutionResult};
+use mono_move_runtime::SessionEffects;
+use move_core_types::vm_status::AbortLocation;
+
+/// Builds the [`TransactionOutput`] for a finished MonoMove transaction from its
+/// [`SessionEffects`] and run `result`. `layouts` serializes the written values
+/// and event payloads; `gas_used` and `auxiliary_data` are supplied by the caller.
+///
+/// A successful run commits its writes and events; an abort or failure commits
+/// an empty write set with the mapped status.
+///
+/// TODO(cleanup): decide where this belongs — maybe a `materialize` method on
+/// `SessionEffects` rather than a free function taking `&SessionEffects`.
+pub fn to_transaction_output(
+    effects: &SessionEffects,
+    layouts: &impl LayoutProvider,
+    result: ExecutionResult,
+    gas_used: u64,
+    auxiliary_data: TransactionAuxiliaryData,
+) -> OutputResult<TransactionOutput> {
+    let (write_set, events) = match &result {
+        ExecutionResult::Success => {
+            let write_set = effects.write_set(layouts)?;
+            // SAFETY: the effects' frozen heap (which event payloads point into) is intact.
+            let events = unsafe { to_contract_events(&effects.extensions, layouts) }?;
+            (write_set, events)
+        },
+        ExecutionResult::Aborted { .. } | ExecutionResult::Failed(_) => {
+            (WriteSet::default(), Vec::new())
+        },
+    };
+    Ok(TransactionOutput::new(
+        write_set,
+        events,
+        gas_used,
+        to_transaction_status(result),
+        auxiliary_data,
+    ))
+}
+
+/// Maps a MonoMove [`ExecutionResult`] to an Aptos [`TransactionStatus`].
+///
+/// The abort location is a placeholder (the runtime status carries none yet),
+/// and non-abort failures other than out-of-gas collapse to a miscellaneous
+/// error.
+pub fn to_transaction_status(result: ExecutionResult) -> TransactionStatus {
+    let status = match result {
+        ExecutionResult::Success => ExecutionStatus::Success,
+        // TODO(completeness): report the real abort location (module or script)
+        // once the runtime status carries it, rather than always Script.
+        ExecutionResult::Aborted { code, message } => ExecutionStatus::MoveAbort {
+            location: AbortLocation::Script,
+            code,
+            info: message.map(|description| AbortInfo {
+                // TODO(completeness): `reason_name` is filled from the module error map by a later
+                // injection pass (see `inject_abort_info_if_available`); the new VM still needs to
+                // wire that up.
+                reason_name: String::new(),
+                description,
+            }),
+        },
+        // TODO(completeness): figure out how to represent MonoMove failures as
+        // Aptos statuses — e.g. dedicated StatusCodes — instead of collapsing
+        // everything but out-of-gas to a miscellaneous error.
+        ExecutionResult::Failed(err) => match err.kind {
+            ExecutionErrorKind::OutOfGas => ExecutionStatus::OutOfGas,
+            ExecutionErrorKind::RuntimeLimitExceeded
+            | ExecutionErrorKind::InvalidOperation
+            | ExecutionErrorKind::LinkingError
+            | ExecutionErrorKind::InvariantViolation
+            | ExecutionErrorKind::Placeholder => ExecutionStatus::MiscellaneousError(None),
+        },
+    };
+    TransactionStatus::Keep(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mono_move_core::ExecutionError;
+
+    #[test]
+    fn status_mapping() {
+        assert!(matches!(
+            to_transaction_status(ExecutionResult::Success),
+            TransactionStatus::Keep(ExecutionStatus::Success)
+        ));
+        assert!(matches!(
+            to_transaction_status(ExecutionResult::Aborted {
+                code: 42,
+                message: None
+            }),
+            TransactionStatus::Keep(ExecutionStatus::MoveAbort { code: 42, .. })
+        ));
+        assert!(matches!(
+            to_transaction_status(ExecutionResult::Failed(ExecutionError {
+                kind: ExecutionErrorKind::OutOfGas,
+                message: String::new(),
+            })),
+            TransactionStatus::Keep(ExecutionStatus::OutOfGas)
+        ));
+    }
+}

--- a/third_party/move/mono-move/replay-benchmark/Cargo.toml
+++ b/third_party/move/mono-move/replay-benchmark/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 aptos-block-executor = { workspace = true }
 aptos-cached-packages = { workspace = true }
+aptos-framework-natives = { workspace = true }
 aptos-move-debugger = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-types = { workspace = true }
@@ -33,6 +34,7 @@ mono-move-core = { workspace = true }
 mono-move-global-context = { workspace = true }
 mono-move-loader = { workspace = true }
 mono-move-natives = { workspace = true }
+mono-move-output = { workspace = true }
 mono-move-runtime = { workspace = true }
 mono-move-testsuite = { workspace = true }
 move-binary-format = { workspace = true }

--- a/third_party/move/mono-move/replay-benchmark/src/compare.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/compare.rs
@@ -4,6 +4,19 @@
 //! VM-agnostic execution outcomes ([`ExecOutcome`]) and the coarse three-category correctness
 //! check: both succeeding is a match, Move abort compares the abort code and message, other
 //! failures compare by kind, and anything else is a non-match.
+//!
+//! On success the two VMs are also compared on their **write set** — the writes each made, keyed
+//! by [`StateKey`] so both sides use the same `TransactionOutput` types.
+
+use aptos_types::{
+    contract_event::ContractEvent,
+    state_store::state_key::StateKey,
+    write_set::{TransactionWrite, WriteOp, WriteOpKind},
+};
+use std::collections::BTreeMap;
+
+/// A transaction's writes, keyed by [`StateKey`]. `BTreeMap` gives a canonical order for free.
+pub type WriteSet = BTreeMap<StateKey, WriteOp>;
 
 /// A normalized, VM-agnostic class of non-abort runtime failure. The two VMs use different error
 /// types, so we match on the kind rather than a raw status code or message.
@@ -39,9 +52,11 @@ impl std::fmt::Display for FailureKind {
 
 /// A VM-agnostic execution outcome, in one of the three comparable categories.
 pub enum ExecOutcome {
-    /// The entry function returned.
-    /// TODO(completeness): also compare write sets.
-    Success { events: Vec<String> },
+    /// The entry function returned, emitting these events and producing this write set.
+    Success {
+        events: Vec<ContractEvent>,
+        writes: WriteSet,
+    },
     /// The function executed a Move `abort` with this code. `message` is the optional abort message
     /// (populated only for the message form of abort).
     Aborted { code: u64, message: Option<String> },
@@ -73,9 +88,18 @@ pub fn compare_outcomes(v1: &ExecOutcome, v2: Result<&ExecOutcome, &str>) -> Cor
 
     match (v1, v2) {
         (
-            ExecOutcome::Success { events: v1_events },
-            ExecOutcome::Success { events: v2_events },
-        ) => compare_events(v1_events, v2_events),
+            ExecOutcome::Success {
+                events: v1_events,
+                writes: v1_writes,
+            },
+            ExecOutcome::Success {
+                events: v2_events,
+                writes: v2_writes,
+            },
+        ) => match compare_events(v1_events, v2_events) {
+            Correctness::Match => compare_write_sets(v1_writes, v2_writes),
+            mismatch => mismatch,
+        },
         (
             ExecOutcome::Aborted {
                 code: c1,
@@ -131,10 +155,9 @@ fn describe(outcome: &ExecOutcome) -> String {
     }
 }
 
-/// Compares the events emitted by the two VMs. Each event is a normalized rendering (type, kind,
-/// and payload) produced by the shared testsuite renderers; events are emitted in a deterministic
-/// order, so the sequences must agree element-for-element.
-fn compare_events(v1: &[String], v2: &[String]) -> Correctness {
+/// Compares the events emitted by the two VMs. Events are emitted in a deterministic order, so the
+/// sequences must agree element-for-element on type tag and payload.
+fn compare_events(v1: &[ContractEvent], v2: &[ContractEvent]) -> Correctness {
     if v1.len() != v2.len() {
         return Correctness::Mismatch {
             detail: format!(
@@ -147,9 +170,179 @@ fn compare_events(v1: &[String], v2: &[String]) -> Correctness {
     for (i, (e1, e2)) in v1.iter().zip(v2).enumerate() {
         if e1 != e2 {
             return Correctness::Mismatch {
-                detail: format!("event {} differs: V1 [{}], V2 [{}]", i, e1, e2),
+                detail: format!(
+                    "event {} differs: V1 {}, V2 {}",
+                    i,
+                    describe_event(e1),
+                    describe_event(e2)
+                ),
             };
         }
     }
     Correctness::Match
+}
+
+fn describe_event(event: &ContractEvent) -> String {
+    format!(
+        "{} ({} B)",
+        event.type_tag().to_canonical_string(),
+        event.event_data().len()
+    )
+}
+
+/// Drops writes that did not actually change state, so a write set reflects real modifications.
+///
+/// Both VMs over-approximate: `borrow_global_mut` marks a resource written even if the borrow never
+/// mutates it, leaving a `Modification` whose new bytes equal the pre-transaction value. Pruning
+/// both sides makes the comparison about real state changes rather than these no-op copies.
+///
+/// `pre_state` returns the pre-transaction bytes, or `None` if the slot did not exist. A write is
+/// dropped only when the pre-state is known and byte-identical.
+pub fn prune_unchanged_modifications(
+    writes: &mut WriteSet,
+    pre_state: impl Fn(&StateKey) -> Option<Vec<u8>>,
+) {
+    writes.retain(|key, op| {
+        if !matches!(op.write_op_kind(), WriteOpKind::Modification) {
+            return true;
+        }
+        let Some(new_bytes) = op.bytes() else {
+            return true;
+        };
+        pre_state(key).is_none_or(|old_bytes| new_bytes.as_ref() != old_bytes.as_slice())
+    });
+}
+
+/// Compares the two VMs' write sets. A mismatch is reported for a key present on only one side or a
+/// differing write op (kind or bytes).
+///
+/// The comparison is strict: because both VMs over-approximate modifications, a write only one side
+/// emits — even with identical bytes — is surfaced rather than hidden.
+fn compare_write_sets(v1: &WriteSet, v2: &WriteSet) -> Correctness {
+    for key in v1.keys() {
+        if !v2.contains_key(key) {
+            return Correctness::Mismatch {
+                detail: format!("write to {:?} present in V1 but not V2", key),
+            };
+        }
+    }
+    for key in v2.keys() {
+        if !v1.contains_key(key) {
+            return Correctness::Mismatch {
+                detail: format!("write to {:?} present in V2 but not V1", key),
+            };
+        }
+    }
+    for (key, op1) in v1 {
+        let op2 = &v2[key];
+        if op1 != op2 {
+            return Correctness::Mismatch {
+                detail: format!(
+                    "write to {:?} differs: V1 {}, V2 {}",
+                    key,
+                    describe_op(op1),
+                    describe_op(op2)
+                ),
+            };
+        }
+    }
+    Correctness::Match
+}
+
+fn describe_op(op: &WriteOp) -> String {
+    let kind = match op.write_op_kind() {
+        WriteOpKind::Creation => "creation",
+        WriteOpKind::Modification => "modification",
+        WriteOpKind::Deletion => "deletion",
+    };
+    match op.bytes() {
+        Some(bytes) => format!("{kind} ({} B)", bytes.len()),
+        None => kind.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(name: &str) -> StateKey {
+        StateKey::raw(name.as_bytes())
+    }
+
+    fn success(writes: WriteSet) -> ExecOutcome {
+        ExecOutcome::Success {
+            events: vec![],
+            writes,
+        }
+    }
+
+    fn ws(entries: Vec<(&str, WriteOp)>) -> WriteSet {
+        entries.into_iter().map(|(n, op)| (key(n), op)).collect()
+    }
+
+    fn is_match(v1: &ExecOutcome, v2: &ExecOutcome) -> bool {
+        matches!(compare_outcomes(v1, Ok(v2)), Correctness::Match)
+    }
+
+    #[test]
+    fn identical_write_sets_match() {
+        let w = || ws(vec![("A", WriteOp::legacy_creation(vec![1, 2, 3].into()))]);
+        assert!(is_match(&success(w()), &success(w())));
+    }
+
+    #[test]
+    fn missing_key_is_a_mismatch() {
+        let v1 = success(ws(vec![("A", WriteOp::legacy_creation(vec![1].into()))]));
+        let v2 = success(ws(vec![]));
+        assert!(!is_match(&v1, &v2));
+        assert!(!is_match(&v2, &v1));
+    }
+
+    #[test]
+    fn differing_bytes_are_a_mismatch() {
+        let v1 = success(ws(vec![(
+            "A",
+            WriteOp::legacy_modification(vec![1, 2, 3].into()),
+        )]));
+        let v2 = success(ws(vec![(
+            "A",
+            WriteOp::legacy_modification(vec![1, 2, 4].into()),
+        )]));
+        assert!(!is_match(&v1, &v2));
+    }
+
+    #[test]
+    fn differing_op_kind_is_a_mismatch() {
+        let v1 = success(ws(vec![("A", WriteOp::legacy_creation(vec![1].into()))]));
+        let v2 = success(ws(vec![(
+            "A",
+            WriteOp::legacy_modification(vec![1].into()),
+        )]));
+        assert!(!is_match(&v1, &v2));
+    }
+
+    #[test]
+    fn prune_drops_only_unchanged_modifications() {
+        let mut writes = ws(vec![
+            ("Same", WriteOp::legacy_modification(vec![1, 2, 3].into())), // no-op: dropped
+            ("Changed", WriteOp::legacy_modification(vec![9].into())),    // real change: kept
+            ("New", WriteOp::legacy_creation(vec![1, 2, 3].into())),      // creation: kept
+            ("Gone", WriteOp::legacy_deletion()),                         // deletion: kept
+            ("Unknown", WriteOp::legacy_modification(vec![7].into())),    // no pre-state: kept
+        ]);
+        prune_unchanged_modifications(&mut writes, |k| {
+            if *k == key("Same") || *k == key("Changed") {
+                Some(vec![1, 2, 3])
+            } else {
+                None
+            }
+        });
+
+        assert!(!writes.contains_key(&key("Same")));
+        assert!(writes.contains_key(&key("Changed")));
+        assert!(writes.contains_key(&key("New")));
+        assert!(writes.contains_key(&key("Gone")));
+        assert!(writes.contains_key(&key("Unknown")));
+        assert_eq!(writes.len(), 4);
+    }
 }

--- a/third_party/move/mono-move/replay-benchmark/src/lib.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/lib.rs
@@ -13,7 +13,9 @@ pub mod timing;
 pub mod v1;
 pub mod v2;
 
-pub use compare::{compare_outcomes, Correctness, ExecOutcome};
+pub use compare::{
+    compare_outcomes, prune_unchanged_modifications, Correctness, ExecOutcome, WriteSet,
+};
 pub use data::{BenchmarkInput, ReadSet};
 pub use report::TransactionReport;
 pub use timing::{Samples, TimingConfig};

--- a/third_party/move/mono-move/replay-benchmark/src/report.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/report.rs
@@ -122,7 +122,13 @@ fn print_vm(label: &str, run: &Option<Result<BenchmarkRun, String>>) {
 
 fn describe_outcome(outcome: &ExecOutcome) -> String {
     match outcome {
-        ExecOutcome::Success { .. } => "success".to_string(),
+        ExecOutcome::Success { events, writes } => {
+            format!(
+                "success ({} event(s), {} write(s))",
+                events.len(),
+                writes.len()
+            )
+        },
         ExecOutcome::Aborted { code, message } => match message {
             Some(m) => format!("Move abort (code {}: {})", code, m),
             None => format!("Move abort (code {})", code),

--- a/third_party/move/mono-move/replay-benchmark/src/v1.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v1.rs
@@ -9,14 +9,16 @@
 //! checks and gas metering are off; only argument deserialization + execution are timed.
 
 use crate::{
-    compare::{ExecOutcome, FailureKind},
+    compare::{prune_unchanged_modifications, ExecOutcome, FailureKind, WriteSet},
     data::BenchmarkInput,
     timing::{collect_samples, TimingConfig},
     BenchmarkRun,
 };
 use anyhow::anyhow;
+use aptos_framework_natives::event::NativeEventContext;
 use aptos_types::{
-    chain_id::ChainId, transaction::user_transaction_context::UserTransactionContext,
+    chain_id::ChainId, state_store::state_key::StateKey,
+    transaction::user_transaction_context::UserTransactionContext, write_set::WriteOp,
 };
 use aptos_vm::{
     data_cache::AsMoveResolver,
@@ -24,9 +26,9 @@ use aptos_vm::{
 };
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_types::module_and_script_storage::AsAptosCodeStorage;
-use mono_move_testsuite::finalize_events_v1;
 use move_binary_format::errors::{VMError, VMResult};
 use move_core_types::{
+    effects::{Changes, Op},
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
     value::MoveValue,
@@ -65,9 +67,9 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> anyhow::Result<Benc
             build_args(&func, input)?
         };
 
-        // Trial run: determine the outcome. Also warms the hot module cache (lazily loading the
-        // modules the execution touches) so the measured runs are warm.
-        let outcome = trial(
+        // Trial run: determine the outcome (and extract the write set). Also warms the hot module
+        // cache (lazily loading the modules the execution touches) so the measured runs are warm.
+        let mut outcome = trial(
             &loader,
             &resolver,
             &module_id,
@@ -79,6 +81,18 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> anyhow::Result<Benc
             &input.session_id,
             env.vm_config(),
         )?;
+
+        // Drop no-op modifications, matching the V2 side, so both write sets reflect real state
+        // changes (the legacy VM usually filters these already, so this is typically a no-op here).
+        if let ExecOutcome::Success { writes, .. } = &mut outcome {
+            prune_unchanged_modifications(writes, |key| {
+                input
+                    .read_set
+                    .data
+                    .get(key)
+                    .map(|value| value.bytes().to_vec())
+            });
+        }
 
         // Timing: measure only "deserialize args + execute" across many samples.
         let samples = collect_samples(timing, || {
@@ -181,12 +195,45 @@ fn trial<L: Loader + InstantiatedFunctionLoader, R: AptosMoveResolver>(
     );
 
     let outcome = match result {
-        Ok(_) => ExecOutcome::Success {
-            events: finalize_events_v1(&extensions),
+        Ok(_) => {
+            let events = extensions
+                .get::<NativeEventContext>()
+                .events_iter()
+                .cloned()
+                .collect();
+            // The data cache still owns the transaction's resource changes (the adapter only
+            // borrowed it for the call). Turn them into a normalized write set. This is on the
+            // untimed path, so it does not affect timing.
+            let changes = data_cache
+                .into_effects(loader.unmetered_module_storage())
+                .map_err(|e| anyhow!("failed to extract V1 write set: {:?}", e))?;
+            ExecOutcome::Success {
+                events,
+                writes: change_set_to_write_set(changes)?,
+            }
         },
         Err(err) => classify_error(err),
     };
     Ok(outcome)
+}
+
+/// Converts the legacy Move VM's resource change set into a [`StateKey`]-keyed
+/// write set (resources only), matching V2's format for comparison.
+fn change_set_to_write_set(changes: Changes<bytes::Bytes>) -> anyhow::Result<WriteSet> {
+    let mut writes = WriteSet::new();
+    for (address, account_changes) in changes.into_inner() {
+        for (struct_tag, op) in account_changes.into_resources() {
+            let state_key = StateKey::resource(&address, &struct_tag)
+                .map_err(|e| anyhow!("failed to build resource state key: {:?}", e))?;
+            let write_op = match op {
+                Op::New(bytes) => WriteOp::legacy_creation(bytes),
+                Op::Modify(bytes) => WriteOp::legacy_modification(bytes),
+                Op::Delete => WriteOp::legacy_deletion(),
+            };
+            writes.insert(state_key, write_op);
+        }
+    }
+    Ok(writes)
 }
 
 /// Times a single "deserialize args + execute" region. Per-run state (the empty data cache, fresh

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -5,7 +5,7 @@
 //! and timing.
 
 use crate::{
-    compare::{ExecOutcome, FailureKind},
+    compare::{prune_unchanged_modifications, ExecOutcome, FailureKind, WriteSet},
     data::{BenchmarkInput, ReadSet},
     timing::{collect_samples, TimingConfig},
     BenchmarkRun,
@@ -31,10 +31,9 @@ use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
 use mono_move_natives::{
     EventStore, ObjectContextExtension, StorageUsageAtEpochBoundary, TransactionContextExtension,
 };
+use mono_move_output::to_contract_events;
 use mono_move_runtime::{InterpreterContext, RuntimeError, RuntimeStatus};
-use mono_move_testsuite::{
-    build_natives, finalize_events_v2, InMemoryModuleProvider, InMemoryResourceProvider,
-};
+use mono_move_testsuite::{build_natives, InMemoryModuleProvider, InMemoryResourceProvider};
 use move_binary_format::{access::ModuleAccess, file_format::SignatureToken, CompiledModule};
 use move_core_types::{
     identifier::IdentStr,
@@ -169,10 +168,26 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
     )?;
     let outcome = match interp.run() {
         Ok(RuntimeStatus::Success) => {
-            // Capture events while the trial run's heap is still live (before the timed runs reset
-            // it). SAFETY: the heap objects backing each event value are still live here.
-            let events = unsafe { finalize_events_v2(interp.extensions(), &guard) };
-            ExecOutcome::Success { events }
+            // Capture events and the write set while the trial run's heap is still live (before the
+            // timed runs reset it). SAFETY: the heap objects backing each event value are still
+            // live here; likewise the resource values the write set serializes.
+            let events = unsafe { to_contract_events(interp.extensions(), &guard) }
+                .map_err(|e| anyhow!("failed to generate V2 events: {:?}", e))?;
+            let mut writes: WriteSet = interp
+                .write_set()
+                .map_err(|e| anyhow!("failed to generate V2 write set: {:?}", e))?
+                .into_write_op_iter()
+                .collect();
+            // Drop no-op modifications (unchanged bytes) so the write set reflects real state
+            // changes, matching what V1's change set already does.
+            prune_unchanged_modifications(&mut writes, |key| {
+                input
+                    .read_set
+                    .data
+                    .get(key)
+                    .map(|value| value.bytes().to_vec())
+            });
+            ExecOutcome::Success { events, writes }
         },
         Ok(RuntimeStatus::Aborted { code, message }) => ExecOutcome::Aborted { code, message },
         Err(err) => classify_error(err),
@@ -314,7 +329,8 @@ fn classify_error(err: RuntimeError) -> ExecOutcome {
         E::StackOverflow
         | E::OutOfHeapMemory { .. }
         | E::AllocationTooLarge { .. }
-        | E::VecAllocSizeOverflow => FailureKind::RuntimeLimitExceeded,
+        | E::VecAllocSizeOverflow
+        | E::StateKeyTypeTooDeep => FailureKind::RuntimeLimitExceeded,
         E::InvalidAbortMessage
         | E::AbortMessageTooLong { .. }
         | E::BCSEof

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-types = { workspace = true }
 bcs = { workspace = true }
 hashbrown = { workspace = true }
 mono-move-alloc = { workspace = true }

--- a/third_party/move/mono-move/runtime/src/global_storage.rs
+++ b/third_party/move/mono-move/runtime/src/global_storage.rs
@@ -104,6 +104,18 @@ pub struct Entry {
     pub write: StorageWrite,
 }
 
+/// The write an [`Entry`] contributes to the write set, by its `(read, write)`
+/// pair.
+pub(crate) enum WriteClass {
+    /// Did not exist before, now does. Carries the value pointer to serialize.
+    Creation(NonNull<u8>),
+    /// Existed before, now (possibly) modified — any mutable borrow counts,
+    /// even if the value is unchanged. Carries the value pointer to serialize.
+    Modification(NonNull<u8>),
+    /// Existed before, now moved out.
+    Deletion,
+}
+
 /// Represents the state of data pointer in the map: owned by local allocation
 /// with up-to-date epoch - writable and can be directly used for mutation or
 /// needing a copy (if it is read-only or has an outdated epoch).
@@ -128,6 +140,27 @@ impl Entry {
             },
             StorageWrite::Deleted { .. } => false,
             StorageWrite::LocalHeap { .. } => true,
+        }
+    }
+
+    /// Classifies this entry's `(read, write)` into a [`WriteClass`], or
+    /// [`None`] if it is not a write.
+    pub(crate) fn write_class(&self) -> Option<WriteClass> {
+        match self.write {
+            StorageWrite::NotModified => None,
+            StorageWrite::LocalHeap { ptr, .. } => Some(match self.read {
+                StorageRead::DoesNotExist => WriteClass::Creation(ptr),
+                // TODO(correctness, perf): over-approximation — a `borrow_global_mut` copies to the
+                // local heap even if nothing changed. Compare against the read value to drop no-op
+                // modifications here rather than downstream.
+                StorageRead::ExternalHeap { .. } => WriteClass::Modification(ptr),
+            }),
+            StorageWrite::Deleted { .. } => match self.read {
+                // Published and then removed in the same transaction: the
+                // on-chain slot never existed, so this is not a write.
+                StorageRead::DoesNotExist => None,
+                StorageRead::ExternalHeap { .. } => Some(WriteClass::Deletion),
+            },
         }
     }
 
@@ -372,6 +405,14 @@ impl ResourceReadWriteSet {
     /// Returns the number of entries in the journal (undo log).
     pub fn journal_len(&self) -> usize {
         self.journal.len()
+    }
+
+    /// Yields each entry that is a write, with its [`WriteClass`]. Order is
+    /// unspecified (backing hash map); callers must sort before emitting.
+    pub(crate) fn writes(&self) -> impl Iterator<Item = (&InMemoryStorageKey, WriteClass)> {
+        self.entries
+            .iter()
+            .filter_map(|(key, entry)| entry.write_class().map(|class| (key, class)))
     }
 
     /// Save the current state and advance the epoch. A subsequent roll back
@@ -965,6 +1006,46 @@ mod tests {
         let _ = rws.try_borrow_global_mut(&provider, &k).unwrap();
         rws.commit_borrow_global_mut(&k, fake_ptr(0xD2));
         assert_eq!(rws.journal_len(), 1);
+    }
+
+    // -- Write classification -------------------------------------------------
+
+    fn class_of(read: StorageRead, write: StorageWrite) -> Option<WriteClass> {
+        entry(read, write).write_class()
+    }
+
+    #[test]
+    fn write_class_covers_the_read_write_matrix() {
+        let ext = || StorageRead::ExternalHeap {
+            ptr: fake_ptr(0x10),
+            version: 0,
+        };
+        let local = || StorageWrite::LocalHeap {
+            ptr: fake_ptr(0x11),
+            epoch: 0,
+        };
+        let deleted = || StorageWrite::Deleted { epoch: 0 };
+
+        // Untouched / read-only: no write.
+        assert!(class_of(StorageRead::DoesNotExist, StorageWrite::NotModified).is_none());
+        assert!(class_of(ext(), StorageWrite::NotModified).is_none());
+        // Published this txn -> Creation.
+        assert!(matches!(
+            class_of(StorageRead::DoesNotExist, local()),
+            Some(WriteClass::Creation(_))
+        ));
+        // Pre-existing + local write -> Modification.
+        assert!(matches!(
+            class_of(ext(), local()),
+            Some(WriteClass::Modification(_))
+        ));
+        // Pre-existing + deleted -> Deletion.
+        assert!(matches!(
+            class_of(ext(), deleted()),
+            Some(WriteClass::Deletion)
+        ));
+        // Published then removed within the txn: net no-op, not a write.
+        assert!(class_of(StorageRead::DoesNotExist, deleted()).is_none());
     }
 
     // -- GC scan --------------------------------------------------------------

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -30,6 +30,7 @@ use crate::{
     },
     value_utils,
 };
+use aptos_types::write_set::WriteSet;
 use mono_move_core::{
     captured_values_size,
     interner::{InternedIdentifier, InternedModuleId},
@@ -40,6 +41,7 @@ use mono_move_core::{
     next_captured_value_offset,
     storage::resource_provider::InMemoryStorageKey,
     types::{view_type_list, InternedType, InternedTypeList},
+    value_layout::LayoutProvider,
     CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, ConstantPoolIndex, DescriptorId,
     FrameOffset, Function, FunctionPtr, FunctionRef, GasMeter, IntBinaryOp, IntCastOp, IntNegateOp,
     IntOperand, IntShiftOp, IntTy, MicroOp, PackClosureOp, ResourceProvider, ShiftOperand,
@@ -85,6 +87,28 @@ impl VMRegisters {
             fp: unsafe { stack_base.add(FRAME_METADATA_SIZE) },
             func: NonNull::from(func),
         }
+    }
+}
+
+/// What a finished transaction leaves behind: the frozen heap, the
+/// global-storage read-write set, and the native extensions (event store and
+/// friends). Read-write-set and extension entries point into `heap`, so the
+/// parts are only valid together; external read pointers remain owned by the
+/// resource provider.
+///
+// TODO(correctness): the effects hold interned types but carry no lifetime, so
+// they can outlive the guard and dereference freed arenas after a maintenance
+// reset. Tie them to the guard lifetime (`SessionEffects<'guard>`).
+pub struct SessionEffects {
+    pub heap: Heap,
+    pub read_write_set: ResourceReadWriteSet,
+    pub extensions: NativeExtensions,
+}
+
+impl SessionEffects {
+    /// The transaction's write set.
+    pub fn write_set(&self, layouts: &impl LayoutProvider) -> RuntimeResult<WriteSet> {
+        crate::write_set::build_write_set(&self.read_write_set, layouts)
     }
 }
 
@@ -301,6 +325,30 @@ impl<'guard> InterpreterContext<'guard> {
 
     pub fn journal_len(&self) -> usize {
         self.read_write_set.journal_len()
+    }
+
+    /// Remaining gas balance.
+    pub fn gas_balance(&self) -> u64 {
+        self.gas_meter.balance()
+    }
+
+    /// Consumes the context, returning the transaction's side effects for
+    /// publication. No execution can follow, so the heap is frozen and every
+    /// heap pointer inside the read-write set and extensions stays valid for
+    /// as long as the returned effects live.
+    pub fn finish(self) -> SessionEffects {
+        SessionEffects {
+            heap: self.heap,
+            read_write_set: self.read_write_set,
+            extensions: self.extensions,
+        }
+    }
+
+    /// The transaction's write set, read out of the still-live context.
+    ///
+    /// Used for testing and benchmarking.
+    pub fn write_set(&self) -> RuntimeResult<WriteSet> {
+        crate::write_set::build_write_set(&self.read_write_set, self.loader.guard())
     }
 
     /// Reset the context to call a different function, preserving the heap.

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -12,10 +12,12 @@ mod native_context;
 mod types;
 mod value_utils;
 mod verifier;
+mod write_set;
 
 pub use error::{RuntimeError, RuntimeStatus};
+pub use global_storage::ResourceReadWriteSet;
 pub use heap::Heap;
-pub use interpreter::InterpreterContext;
+pub use interpreter::{InterpreterContext, SessionEffects};
 pub use memory::{
     read_ptr, read_u32, read_u64, vec_elem_ptr, write_object_header, write_ptr, write_u32,
     write_u64, MemoryRegion,

--- a/third_party/move/mono-move/runtime/src/write_set.rs
+++ b/third_party/move/mono-move/runtime/src/write_set.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Transaction write-set generation.
+//!
+//! Serializes the resources and table items a finished transaction wrote into
+//! an Aptos [`WriteSet`], keyed by [`StateKey`].
+//!
+//! Every `borrow_global_mut` / `move_to` counts as a write, even when the value
+//! is unchanged (see `../docs/global_storage_design.md`).
+//!
+//! TODO(correctness, perf): revisit this over-approximation — drop writes whose
+//! value equals the pre-state so the write set reflects real changes only.
+
+use crate::{
+    error::{RuntimeError, RuntimeResult},
+    global_storage::{ResourceReadWriteSet, WriteClass},
+    invariant_violation, value_utils,
+};
+use aptos_types::{
+    state_store::{state_key::StateKey, table::TableHandle},
+    write_set::{WriteOp, WriteSet},
+};
+use mono_move_core::{
+    storage::resource_provider::InMemoryStorageKey, struct_tag_of, types::InternedType,
+    value_layout::LayoutProvider,
+};
+use std::ptr::NonNull;
+
+/// Builds the Aptos [`WriteSet`] from a read-write set. `layouts` BCS-serializes
+/// created / modified values.
+///
+/// Write ops carry no `StateValueMetadata` (slot deposits, refunds) — that is a
+/// separate workstream.
+pub(crate) fn build_write_set<L: LayoutProvider + ?Sized>(
+    rws: &ResourceReadWriteSet,
+    layouts: &L,
+) -> RuntimeResult<WriteSet> {
+    let mut writes = Vec::new();
+    for (key, class) in rws.writes() {
+        let state_key = state_key_of(key)?;
+        // TODO(correctness): these are metadata-less legacy write ops; we need to set the
+        // `StateValueMetadata` (slot deposit / refund) carried over from the pre-state.
+        let op = match class {
+            WriteClass::Creation(ptr) => {
+                WriteOp::legacy_creation(serialize_value(layouts, ptr, value_type(key))?.into())
+            },
+            WriteClass::Modification(ptr) => {
+                WriteOp::legacy_modification(serialize_value(layouts, ptr, value_type(key))?.into())
+            },
+            WriteClass::Deletion => WriteOp::legacy_deletion(),
+        };
+        writes.push((state_key, op));
+    }
+    // Collects into a `BTreeMap`, so the result is canonically ordered by
+    // `StateKey` regardless of the read-write set's iteration order.
+    match WriteSet::new(writes) {
+        Ok(write_set) => Ok(write_set),
+        Err(_) => invariant_violation!(Unreachable("failed to freeze write set".to_string())),
+    }
+}
+
+/// The Aptos [`StateKey`] for a read-write-set key.
+fn state_key_of(key: &InMemoryStorageKey) -> RuntimeResult<StateKey> {
+    match key {
+        InMemoryStorageKey::Resource { address, ty } => {
+            let Some(struct_tag) = struct_tag_of(*ty) else {
+                invariant_violation!(Unreachable(
+                    "resource key type must be a nominal type".to_string()
+                ));
+            };
+            // A resource type nested deeper than the state key encoding allows is a runtime limit,
+            // not an invariant violation: it is reachable with a sufficiently nested type.
+            StateKey::resource(address, &struct_tag).map_err(|_| RuntimeError::StateKeyTypeTooDeep)
+        },
+        InMemoryStorageKey::TableItem { handle, key, .. } => {
+            Ok(StateKey::table_item(&TableHandle(handle.address()), key))
+        },
+    }
+}
+
+/// The interned type of the value stored at a key (used to serialize it).
+fn value_type(key: &InMemoryStorageKey) -> InternedType {
+    match key {
+        InMemoryStorageKey::Resource { ty, .. } => *ty,
+        InMemoryStorageKey::TableItem { value_ty, .. } => *value_ty,
+    }
+}
+
+/// BCS-serializes the value at `ptr` of type `ty`.
+fn serialize_value<L: LayoutProvider + ?Sized>(
+    layouts: &L,
+    ptr: NonNull<u8>,
+    ty: InternedType,
+) -> RuntimeResult<Vec<u8>> {
+    // SAFETY: `ptr` is the current value of a `LocalHeap` entry — a fully
+    // initialized value of type `ty` living in this transaction's heap. The
+    // heap stays alive for the call and no GC runs during write-set
+    // generation, so the value (and everything it reaches) remains valid.
+    unsafe { value_utils::serialize(layouts, ptr.as_ptr(), ty) }
+}

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -343,7 +343,8 @@ fn classify_runtime_error(err: &RuntimeError) -> TestResult {
         | RuntimeError::OutOfHeapMemory { .. }
         | RuntimeError::AllocationTooLarge { .. }
         | RuntimeError::VecAllocSizeOverflow
-        | RuntimeError::AbortMessageTooLong { .. } => TestResult::RuntimeFailure(err.to_string()),
+        | RuntimeError::AbortMessageTooLong { .. }
+        | RuntimeError::StateKeyTypeTooDeep => TestResult::RuntimeFailure(err.to_string()),
 
         // Genuine problems: runaway gas, infrastructure failure, or a VM bug.
         RuntimeError::GasExhausted(_)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Adds APIs to turn a finished MonoMove transaction into its write set and Aptos transaction output.

- **`mono-move-runtime`**: `InterpreterContext::finish() -> SessionEffects`; `SessionEffects::write_set()` produces an Aptos `WriteSet` (`StateKey` → `WriteOp`).
- **`mono-move-core`**: `type_tag_of` / `struct_tag_of` decode interned types back to `TypeTag` / `StructTag`.
- **`mono-move-output`** (new crate): `to_transaction_output` — `SessionEffects` → `TransactionOutput`, plus `to_contract_events` and `to_transaction_status`.
- **replay-benchmark**: compares V1 and V2 write sets.

Usage:
```rust
let effects = interp.finish();
let output = mono_move_output::to_transaction_output(&effects, layouts, result, gas_used)?;
```

Stubbed: storage metadata/refunds (metadata-less write ops), resource groups, delayed fields, and the error→status mapping.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how MonoMove materializes state writes and transaction outputs (serialization and `StateKey` encoding), which is on the path to production VM parity, though much remains stubbed (metadata, error mapping).
> 
> **Overview**
> Adds the plumbing to turn a finished MonoMove run into **Aptos-facing transaction effects**: resource/table **write sets** keyed by `StateKey`, **contract events**, and a coarse **`TransactionOutput`** / status mapping.
> 
> **Runtime (`mono-move-runtime`)** introduces `SessionEffects` via `InterpreterContext::finish()`, classifies global-storage journal entries into creation/modification/deletion, and builds a canonical `WriteSet` by BCS-serializing written values (metadata-less legacy ops for now). **`mono-move-core`** adds `type_tag_of` / `struct_tag_of` (and `view_module_id`) so interned types can become `TypeTag`/`StructTag` for keys and events, plus `StateKeyTypeTooDeep` when a resource type is too nested to encode.
> 
> **New `mono-move-output`** crate wires `SessionEffects` + `ExecutionResult` → `TransactionOutput` (`to_transaction_output`), with separate helpers for events and status; abort location and most failure kinds are still placeholders.
> 
> **Replay benchmark** now compares V1 vs V2 on **`ContractEvent`** sequences and **`StateKey` write sets**, with `prune_unchanged_modifications` on both sides to ignore no-op `borrow_global_mut` modifications; V1 harvests writes from the legacy data cache, V2 uses the new output APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30d777a0b1efba66bf26db0405b766b87110db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->