### PR TITLE
[executor-benchmark] add run_mix_with_default_params for weighted txn mixes

### DIFF
--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -774,6 +774,28 @@ pub fn run_single_with_default_params(
     use_blockstm_v2: bool,
     mode: SingleRunMode,
 ) -> SingleRunResults {
+    run_mix_with_default_params(
+        vec![(transaction_type, 1)],
+        test_folder,
+        concurrency_level,
+        use_blockstm_v2,
+        mode,
+    )
+}
+
+/// Like [`run_single_with_default_params`], but runs a weighted *mix* of
+/// transaction types. Each generated transaction is sampled across
+/// `transaction_mix` by the given integer weights (e.g. `[(perp, 80), (spot,
+/// 20)]`), and the mix is interleaved within every block. Each entry is set up
+/// independently (for `Workflow` entries, each runs its own `construct_workflow`),
+/// so the entries do not share on-chain state unless they are constructed to.
+pub fn run_mix_with_default_params(
+    transaction_mix: Vec<(TransactionType, usize)>,
+    test_folder: impl AsRef<Path>,
+    concurrency_level: usize,
+    use_blockstm_v2: bool,
+    mode: SingleRunMode,
+) -> SingleRunResults {
     aptos_logger::Logger::new().init();
 
     match mode {
@@ -937,7 +959,7 @@ pub fn run_single_with_default_params(
     run_benchmark::<AptosVMBlockExecutor>(
         benchmark_block_size, /* block_size */
         num_blocks,           /* num_blocks */
-        BenchmarkWorkload::TransactionMix(vec![(transaction_type, 1)]),
+        BenchmarkWorkload::TransactionMix(transaction_mix),
         1, /* transactions per sender */
         num_main_signer_accounts,
         num_dst_pool_accounts,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only API refactor in executor-benchmark; no validator or production execution path changes.
> 
> **Overview**
> Adds **`run_mix_with_default_params`**, which runs the standard single-run benchmark path with a **weighted mix** of `TransactionType`s (integer weights, interleaved per block) instead of a single txn type.
> 
> **`run_single_with_default_params`** is now a thin wrapper that calls the mix API with `vec![(transaction_type, 1)]`, so existing callers keep the same behavior. The mix vector is passed through to **`BenchmarkWorkload::TransactionMix`** instead of always using a one-type mix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bcc0b5296b6b8c0a8a5abf0ccc737fc39ad527d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->