### PR TITLE
[indexer] Add crate docs and cleanup TODO anchors

### DIFF
--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -37,6 +37,9 @@ pub struct IndexerGrpcConfig {
     /// instead of the standard fullnode GRPC stream interface. In other words, with
     /// this enabled, you can use an indexer fullnode like it is an instance of the
     /// indexer-grpc data service (aka the Transaction Stream Service API).
+    ///
+    /// TODO(#20246): the dual interface exists because the v1 (cache-worker) and v2
+    /// (manager) stream pipelines coexist; remove once v1 is retired.
     pub use_data_service_interface: bool,
 
     /// The address that the grpc server will listen on.

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
@@ -346,6 +346,8 @@ pub fn convert_move_type(move_type: &MoveType) -> transaction::MoveType {
         MoveType::Struct(_) => transaction::MoveTypes::Struct,
         MoveType::GenericTypeParam { .. } => transaction::MoveTypes::GenericTypeParam,
         MoveType::Reference { .. } => transaction::MoveTypes::Reference,
+        // TODO(#20246): function type info is silently lost here; the protos have no
+        // function type variant.
         MoveType::Function { .. } => transaction::MoveTypes::Unparsable,
         MoveType::Unparsable(_) => transaction::MoveTypes::Unparsable,
     };

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/internal_indexer_db_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/internal_indexer_db_service.rs
@@ -51,6 +51,8 @@ impl InternalIndexerDBService {
                 .expect("Failed to open internal indexer db"),
         );
 
+        // TODO(#20246): the restore-path config is hardcoded instead of derived from
+        // the node config.
         let internal_indexer_db_config =
             InternalIndexerDBConfig::new(true, true, true, 0, true, 10_000);
         Some(InternalIndexerDB::new(arc_db, internal_indexer_db_config))

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/table_info_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/table_info_service.rs
@@ -79,7 +79,7 @@ impl TableInfoService {
     ///        If backup service is enabled, it will also snapshot the rocksdb at the end of each epoch.
     /// 2. Optional backup service loop: it monitors if new snapshots are available to backup and uploads them to GCS.
     pub async fn run(&self) {
-        // TODO: fix the restore logic.
+        // TODO(#20246): fix the restore logic (TableInfoServiceMode::Restore is never wired up).
         let backup_is_enabled = match self.backup_restore_operator.clone() {
             Some(backup_restore_operator) => {
                 let context = self.context.clone();
@@ -441,7 +441,7 @@ impl TableInfoService {
     /// 1. If current epoch is backuped, it will skip the backup.
     /// 2. If the chain id in the backup metadata does not match with the current network, it will panic.
     /// Not thread safe.
-    /// TODO(larry): improve the error handling.
+    /// TODO(#20246): improve the error handling.
     async fn backup_snapshot_if_present(
         context: Arc<ApiContext>,
         backup_restore_operator: Arc<GcsBackupRestoreOperator>,
@@ -490,7 +490,7 @@ impl TableInfoService {
         }
     }
 
-    /// TODO(jill): consolidate it with `ensure_highest_known_version`
+    /// TODO(#20246): consolidate it with `ensure_highest_known_version`
     /// Will keep looping and checking the latest ledger info to see if there are new transactions
     /// If there are, it will update the ledger version version
     async fn get_highest_known_version(&self) -> Result<u64, Error> {

--- a/storage/indexer/CLAUDE.md
+++ b/storage/indexer/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+This directory contains the `aptos-db-indexer` crate — the AptosDB **internal indexer**. Repo-wide commands (lint, formatting, framework rebuilds) are covered by the root `CLAUDE.md`; this file covers what is specific to this crate.
+
+## Commands
+
+```bash
+cargo check -p aptos-db-indexer     # Quick compile check
+cargo build -p aptos-db-indexer
+cargo test -p aptos-db-indexer      # Note: crate has no in-crate unit tests (see Testing below)
+```
+
+New Rust files here use the Innovation-Enabling license header (`Copyright (c) Aptos Foundation` + license URL), matching existing files.
+
+## Purpose
+
+This crate builds **secondary indices** over the main AptosDB ledger so that queries the ledger schema can't serve (events by key, transactions by account, state keys by prefix, table-handle type info) stay off the storage critical path. It maintains two separate RocksDB databases, opened via `db_ops.rs`:
+
+1. **Internal indexer DB** (`internal_indexer_db`) — owned by `DBIndexer` in `db_indexer.rs`
+2. **Table info DB** — owned by `IndexerAsyncV2` in `db_v2.rs`
+
+All schemas (column families, key/value codecs) live in the sibling crate `storage/indexer_schemas` (`aptos-db-indexer-schemas`). **Adding or changing an index means editing that crate first** (schema definition plus the `column_families()` / `internal_indexer_column_families()` lists), then the write/read paths here.
+
+Consumption note: everything `DBIndexer` builds is served exclusively through the **JSON REST API** (`api/`). The gRPC transaction stream (`ecosystem/indexer-grpc/indexer-grpc-fullnode`, enabled via `indexer_grpc.enabled`, off by default) is a separate serving surface that consumes only the table-info half of this crate (to resolve table handles when converting transactions to protobuf); it does not use the `DBIndexer` indices.
+
+## Architecture
+
+### Write path (`db_indexer.rs`)
+
+`DBIndexer::process(start, end)` tail-follows the main DB: it zips the transaction, event, and write-set iterators from `DbReader`, builds one `SchemaBatch` per batch (size from config), and hands it to a dedicated committer thread (`DBCommitter`) over an mpsc channel.
+
+- **Writes are asynchronous.** `process_a_batch` returns before data is durable. Anything that reads back its own writes (tests especially) must call `DBIndexer::flush()` first.
+- Each enabled index records its own progress version under `InternalIndexerMetadataSchema` (`MetadataKey::{LatestVersion, EventVersion, StateVersion, TransactionVersion, EventV2TranslationVersion}`) in the same batch, so progress is atomic with the indexed data.
+- Which indices are populated is gated per-flag by `InternalIndexerDBConfig` (`config/src/config/internal_indexer_db_config.rs`): `enable_transaction`, `enable_event`, `enable_event_v2_translation`, `enable_statekeys`, `batch_size`.
+
+The driver loop lives outside this crate: `InternalIndexerDBService` in `ecosystem/indexer-grpc/indexer-grpc-table-info/src/internal_indexer_db_service.rs` (the crate name reflects the ecosystem tree it sits in, not gRPC serving), wired up in `aptos-node/src/services.rs`. The backup/restore path (`storage/backup/backup-cli`) writes state keys directly via `InternalIndexerDB::write_keys_to_indexer_db`.
+
+### Event V2→V1 translation (`event_v2_translator.rs`)
+
+Module events (`ContractEventV2`) carry no event key or sequence number, but old API queries are keyed on them. `EventV2TranslationEngine` holds a registry of per-`TypeTag` `EventV2Translator` impls (coin deposit/withdraw, token/collection events, etc.). Each translator reconstructs the V1 `EventKey` and sequence number by reading the corresponding on-chain resource's event handle from the main DB's latest state checkpoint view, then the result is stored in `TranslatedV1EventSchema` and mirrored into the event-by-key/version indices.
+
+- Sequence numbers are tracked in an in-memory `DashMap` cache backed by `EventSequenceNumberSchema`; `get_next_sequence_number` falls back to the on-chain handle count.
+- Translation failure is non-fatal: the event is skipped (`Ok(None)`) with a warning. "Resource not found" for Mint/Burn is expected and silently ignored (ConcurrentSupply collections have no V1-style supply resource).
+
+### Table info indexing (`db_v2.rs`)
+
+`IndexerAsyncV2` maps `TableHandle` → `TableInfo` (key/value type tags) by running `AptosValueAnnotator` over write sets. Nested tables create an ordering problem — a table item may appear before its parent's type info is known — handled by parking raw bytes in the `pending_on` map and re-parsing when the parent's info arrives. `get_table_info_with_retry` spins (10ms sleeps) because readers may race the async parser.
+
+The driver (`TableInfoService`) also lives in `ecosystem/indexer-grpc/indexer-grpc-table-info`; it fetches transactions via the API `Context` and the fullnode stream coordinator machinery, gated by `IndexerTableInfoConfig` (`table_info_service_mode`, `parser_task_count`, `parser_batch_size`).
+
+### Read path (`indexer_reader.rs`)
+
+`IndexerReaders` implements the `IndexerReader` trait from `aptos_types::indexer::indexer_db_reader` over optional `IndexerAsyncV2` and `DBIndexer` handles; this is what the API layer consumes. Reads guard against serving data the indexer hasn't caught up to via `ensure_cover_ledger_version`. State-prefix queries (`utils.rs::PrefixedStateValueIterator`) iterate state keys from the indexer DB but fetch values from the main DB at the requested version.
+
+## Testing
+
+There are no unit tests in this crate. Coverage lives in:
+
+- `execution/executor/tests/internal_indexer_test.rs` — end-to-end indexing over executed blocks
+- `storage/db-tool/src/tests.rs` — restore-path tests
+- `api/test-context` (`MockInternalIndexerDBService`) and `testsuite/smoke-test/src/fullnode.rs` — API-level and node-level integration
+
+When writing tests that assert on indexed data, remember the async commit: call `flush()` on the `DBIndexer` before reading.

--- a/storage/indexer/src/db_v2.rs
+++ b/storage/indexer/src/db_v2.rs
@@ -1,10 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-/// This file is a copy of the file storage/indexer/src/lib.rs.
-/// At the end of the migration to migrate table info mapping
-/// from storage critical path to indexer, the other file will be removed
-/// and this file will be moved to /ecosystem/indexer-grpc/indexer-grpc-table-info.
+/// TODO(#20246): this file was planned to move to `indexer-grpc-table-info` as part
+/// of a migration that stalled; consolidate code placement of the indexer stack.
 use aptos_db_indexer_schemas::{
     metadata::{MetadataKey, MetadataValue},
     schema::{indexer_metadata::IndexerMetadataSchema, table_info::TableInfoSchema},


### PR DESCRIPTION
## Description

Preparation for incremental indexer refactoring (no functional changes):

- Adds `storage/indexer/CLAUDE.md` documenting the internal indexer crate: two-DB layout, async commit behavior, event V2→V1 translation, table info indexing, and where the driver services and test coverage live — including the clarification that the `DBIndexer` indices serve only the JSON REST API, while the gRPC stream consumes just the table-info half.
- Anchors known unfinished state to tracking issue #20246 via `TODO(#20246)` comments (three existing TODOs converted, four added): stalled code-placement migration (`db_v2.rs`), lossy `MoveType::Function` → `Unparsable` proto mapping, unwired table info restore mode, hardcoded restore-path config, and the v1/v2 stream pipeline duality behind `use_data_service_interface`.

## How Has This Been Tested?

Comment/doc-only change; touched crates compile (`aptos-db-indexer`, `aptos-config`, `aptos-indexer-grpc-table-info`, `aptos-indexer-grpc-fullnode`) and fmt is clean.

## Key Areas to Review

Accuracy of the CLAUDE.md description and the TODO placements.

## Type of Change
- [x] Documentation update

## Which Components or Systems Does This Change Impact?
- [x] Full Node (API, Indexer, etc.)

Co-authored with Claude.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation only; no logic, config defaults, or API behavior changes.
> 
> **Overview**
> Documentation-only prep for incremental indexer refactoring—**no runtime behavior changes**.
> 
> Adds **`storage/indexer/CLAUDE.md`** describing the `aptos-db-indexer` crate: dual RocksDB layout, async `DBIndexer` commit semantics, event V2→V1 translation, table-info indexing, driver services in `indexer-grpc-table-info`, and the split where **REST** uses `DBIndexer` indices while **gRPC** only needs table-info for protobuf conversion.
> 
> **TODO(#20246)** is applied across seven spots (three existing author-tagged TODOs retargeted, four new): stalled `db_v2.rs` placement, lossy `MoveType::Function` → `Unparsable` in gRPC convert, unwired table-info restore mode, hardcoded internal-indexer restore config, and v1/v2 stream duality behind `use_data_service_interface`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 668c4e86bc2c31248502c7d3470b0211164648f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->