### PR TITLE
[state-sync] Fix fast-sync wedge on invalid first snapshot chunk

### DIFF
--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -260,10 +260,6 @@ pub(crate) struct StateValueSyncer {
 
     // The transaction output (inc. info and proof) for the version we're syncing
     transaction_output_to_sync: Option<TransactionOutputListWithProofV2>,
-
-    // Whether a data stream has been requested for this kind at the current
-    // target (distinguishes "not yet streamed" from "streamed, empty tree").
-    stream_requested: bool,
 }
 
 impl StateValueSyncer {
@@ -273,7 +269,6 @@ impl StateValueSyncer {
             ledger_info_to_sync: None,
             next_state_index_to_process: 0,
             transaction_output_to_sync: None,
-            stream_requested: false,
         }
     }
 
@@ -300,6 +295,10 @@ impl StateValueSyncer {
 pub struct Bootstrapper<MetadataStorage, StorageSyncer, StreamingClient> {
     // The currently active data stream (provided by the data streaming service)
     active_data_stream: Option<DataStreamListener>,
+
+    // The snapshot kind of the active data stream, if it is a state-value
+    // snapshot stream (used to detect an empty tree on a clean end-of-stream).
+    active_snapshot_kind: Option<StateKind>,
 
     // The channel used to notify a listener of successful bootstrapping
     bootstrap_notifier_channel: Option<oneshot::Sender<Result<(), Error>>>,
@@ -361,6 +360,7 @@ impl<
             state_value_syncer: StateValueSyncer::new(),
             position_value_syncer: StateValueSyncer::new(),
             active_data_stream: None,
+            active_snapshot_kind: None,
             bootstrap_notifier_channel: None,
             bootstrapped: false,
             driver_configuration,
@@ -718,7 +718,6 @@ impl<
         // Fetch the missing state values
         self.state_value_syncer_mut(kind)
             .update_next_state_index_to_process(next_state_index_to_process);
-        self.state_value_syncer_mut(kind).stream_requested = true;
         let data_stream = self
             .streaming_client
             .get_all_state_values(
@@ -728,6 +727,7 @@ impl<
             )
             .await?;
         self.active_data_stream = Some(data_stream);
+        self.active_snapshot_kind = Some(kind);
 
         Ok(())
     }
@@ -808,6 +808,7 @@ impl<
             highest_synced_version,
         ));
         self.active_data_stream = Some(data_stream);
+        self.active_snapshot_kind = None;
 
         Ok(())
     }
@@ -861,6 +862,7 @@ impl<
                 .get_all_epoch_ending_ledger_infos(next_epoch_end)
                 .await?;
             self.active_data_stream = Some(epoch_ending_stream);
+            self.active_snapshot_kind = None;
         } else if self.verified_epoch_states.verified_waypoint() {
             info!(LogSchema::new(LogEntry::Bootstrapper).message(
                 "No new epoch ending ledger infos to fetch! All peers are in the same epoch!"
@@ -1160,6 +1162,7 @@ impl<
                 .get_all_transaction_outputs(version, version, version)
                 .await?;
             self.active_data_stream = Some(data_stream);
+            self.active_snapshot_kind = None;
             return Ok(());
         }
 
@@ -1193,30 +1196,9 @@ impl<
                     )));
                 },
                 None => {
-                    // No progress recorded. If the stream was already requested and
-                    // returned no state values, the tree is empty: verify emptiness
-                    // against the committed root (not the unproved peer count) rather
-                    // than re-streaming. Otherwise, start streaming.
-                    let stream_requested = self.state_value_syncer(kind).stream_requested;
-                    let receiver_initialized = self
-                        .state_value_syncer(kind)
-                        .initialized_state_snapshot_receiver;
-                    if stream_requested && !receiver_initialized {
-                        if self.expected_snapshot_root(kind)? == *SPARSE_MERKLE_PLACEHOLDER_HASH {
-                            self.metadata_storage.update_last_persisted_index(
-                                &target_ledger_info,
-                                0,
-                                true,
-                                kind,
-                            )?;
-                            continue;
-                        }
-                        return Err(Error::UnexpectedError(format!(
-                            "The {:?} snapshot stream ended without any state values, but the \
-                             committed snapshot root is not the empty-tree placeholder! Target: {:?}",
-                            kind, target_ledger_info,
-                        )));
-                    }
+                    // This kind hasn't started syncing yet. Stream it from the
+                    // beginning. An empty tree (a stream that ends without any state
+                    // values) is completed by the end-of-stream handler.
                     return self
                         .fetch_missing_state_values(target_ledger_info, false, kind)
                         .await;
@@ -1657,8 +1639,52 @@ impl<
 
         // Return an error if the payload was invalid
         match data_notification.data_payload {
-            DataPayload::EndOfStream => Ok(()),
+            DataPayload::EndOfStream => self.complete_empty_snapshot_if_applicable().await,
             _ => Err(Error::InvalidPayload("Unexpected payload type!".into())),
+        }
+    }
+
+    /// Completes a snapshot whose stream ended cleanly without serving any state
+    /// value (i.e. no receiver was ever initialized), which only happens for an
+    /// empty tree. Emptiness is decided by the committed snapshot root, never the
+    /// unproved peer count; a non-empty root here means the peer ended the stream
+    /// early, which is surfaced as an error so the stream is retried. A stream
+    /// aborted mid-chunk (e.g. a bad root hash) never reaches this path: it is
+    /// reset with an error before end-of-stream, so it is retried rather than
+    /// mistaken for an empty tree.
+    async fn complete_empty_snapshot_if_applicable(&mut self) -> Result<(), Error> {
+        let kind = match self.active_snapshot_kind {
+            Some(kind) => kind,
+            None => return Ok(()),
+        };
+        if !self.get_bootstrapping_mode().is_fast_sync()
+            || self
+                .state_value_syncer(kind)
+                .initialized_state_snapshot_receiver
+        {
+            return Ok(());
+        }
+        let target_ledger_info = self
+            .state_value_syncer(kind)
+            .ledger_info_to_sync
+            .clone()
+            .ok_or_else(|| {
+                Error::UnexpectedError(format!("The {:?} ledger info to sync is missing!", kind))
+            })?;
+        if self.expected_snapshot_root(kind)? == *SPARSE_MERKLE_PLACEHOLDER_HASH {
+            self.metadata_storage.update_last_persisted_index(
+                &target_ledger_info,
+                0,
+                true,
+                kind,
+            )?;
+            Ok(())
+        } else {
+            Err(Error::UnexpectedError(format!(
+                "The {:?} snapshot stream ended without any state values, but the committed \
+                 snapshot root is not the empty-tree placeholder! Target: {:?}",
+                kind, target_ledger_info,
+            )))
         }
     }
 

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -15,7 +15,7 @@ use crate::{
             create_epoch_ending_ledger_info_for_epoch, create_full_node_driver_configuration,
             create_global_summary, create_global_summary_with_version,
             create_output_list_with_proof, create_random_epoch_ending_ledger_info,
-            create_transaction_list_with_proof,
+            create_state_value_chunk_with_proof, create_transaction_list_with_proof,
         },
     },
     utils::OutputFallbackHandler,
@@ -34,7 +34,10 @@ use aptos_types::{
 };
 use claims::{assert_matches, assert_none, assert_ok};
 use futures::{channel::oneshot, FutureExt, SinkExt};
-use mockall::{predicate::eq, Sequence};
+use mockall::{
+    predicate::{always, eq},
+    Sequence,
+};
 use std::{sync::Arc, time::Duration};
 
 #[tokio::test]
@@ -1075,6 +1078,102 @@ async fn test_snapshot_sync_epoch_change_genesis() {
         .unwrap();
 
     // Drive progress again to start the state value stream
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_snapshot_sync_state_values_invalid_chunk_retries() {
+    // Create test data
+    let synced_version = GENESIS_TRANSACTION_VERSION;
+    let highest_version = 10000;
+    let notification_id = 54321;
+    let highest_ledger_info = create_random_epoch_ending_ledger_info(highest_version, 1);
+
+    // Create a driver configuration with a genesis waypoint and fast syncing
+    let mut driver_configuration = create_full_node_driver_configuration();
+    driver_configuration.config.bootstrapping_mode = BootstrappingMode::DownloadLatestStates;
+
+    // Create the mock streaming client. A first chunk with a bad root hash must
+    // cause the state value stream to be retried (not wedge the bootstrapper),
+    // so the state value stream is expected to be requested twice.
+    let mut mock_streaming_client = create_mock_streaming_client();
+    let mut expectation_sequence = Sequence::new();
+    let (mut notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
+    let (_notification_sender_2, data_stream_listener_2) = create_data_stream_listener();
+    let data_stream_id_1 = data_stream_listener_1.data_stream_id;
+    for data_stream_listener in [data_stream_listener_1, data_stream_listener_2] {
+        mock_streaming_client
+            .expect_get_all_state_values()
+            .times(1)
+            .with(always(), eq(Some(0)), eq(StateKind::MainState))
+            .return_once(move |_, _, _| Ok(data_stream_listener))
+            .in_sequence(&mut expectation_sequence);
+    }
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .with(
+            eq(data_stream_id_1),
+            eq(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            ))),
+        )
+        .return_const(Ok(()));
+
+    // Create the mock metadata storage (no snapshot progress recorded yet)
+    let mut metadata_storage = MockMetadataStorage::new();
+    metadata_storage
+        .expect_previous_snapshot_sync_target()
+        .returning(move |_| Ok(None));
+
+    // Create the bootstrapper
+    let mut bootstrapper = create_bootstrapper_with_storage(
+        driver_configuration,
+        mock_streaming_client,
+        metadata_storage,
+        None,
+        synced_version,
+        true,
+    );
+
+    // Insert an epoch ending ledger info into the verified states of the bootstrapper
+    manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
+
+    // Manually insert a transaction output to sync
+    bootstrapper
+        .get_state_value_syncer()
+        .set_transaction_output_to_sync(create_output_list_with_proof());
+
+    // Create a global data summary
+    let mut global_data_summary = create_global_summary(1);
+    global_data_summary.advertised_data.synced_ledger_infos = vec![highest_ledger_info.clone()];
+
+    // Drive progress to start the state value stream
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+
+    // Send a state value chunk whose root hash does not match the expected root
+    let data_notification = DataNotification::new(
+        notification_id,
+        DataPayload::StateValuesWithProof(
+            StateKind::MainState,
+            create_state_value_chunk_with_proof(false),
+        ),
+    );
+    notification_sender_1.send(data_notification).await.unwrap();
+
+    // Drive progress and ensure we get a verification error for the bad root
+    let error = drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap_err();
+    assert_matches!(error, Error::VerificationError(_));
+
+    // Drive progress again: the stream must be retried, not wedged. (Regression:
+    // a bad first chunk previously left the in-memory sync state believing the
+    // stream had ended empty, permanently erroring on the non-empty root.)
     drive_progress(&mut bootstrapper, &global_data_summary, false)
         .await
         .unwrap();


### PR DESCRIPTION
## Problem

A fresh node doing fast sync can be permanently wedged (until restart) by a single Byzantine storage-service / state-sync peer.

An empty state snapshot was detected by inferring "the stream was requested but no receiver was ever initialized" in the drive loop. A stream reset by a bad first chunk (e.g. an invalid root hash) leaves that **exact same** in-memory state. So after rejecting a bad first chunk, the bootstrapper misread it as an empty tree and — because the committed snapshot root is non-empty for normal main-state snapshots — returned a permanent `UnexpectedError` on every subsequent tick instead of retrying with another peer. The driver only logs bootstrapper errors and retries, so the poisoned in-memory flag wedges the node until restart.

This is reachable from a Byzantine peer and impacts fresh nodes using fast sync, including fullnodes and validators bootstrapping from the network.

## Fix

Detect an empty tree only from a **clean end-of-stream** that never initialized a receiver (keyed by the active snapshot kind), and verify emptiness against the committed snapshot root — never the unproved peer count. A non-empty root at end-of-stream is surfaced as an error so the stream is retried. A stream aborted mid-chunk (bad root hash, bad indices, etc.) is reset with an error *before* end-of-stream, so it is retried rather than mistaken for an empty tree.

This replaces the drive-loop `stream_requested` inference with an `active_snapshot_kind` marker plus end-of-stream handling.

## Test

`test_snapshot_sync_state_values_invalid_chunk_retries`: a bad-root first chunk during fast sync produces a `VerificationError` and the state-value stream is re-requested (rather than the bootstrapper wedging on an `UnexpectedError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fast-sync bootstrap logic for fresh nodes; behavior change is narrowly scoped to when empty trees are recognized and how failed streams retry.
> 
> **Overview**
> Fixes a **permanent fast-sync wedge** when the first state-value chunk fails verification (e.g. bad root hash): the bootstrapper no longer treats that situation like a completed empty snapshot.
> 
> **Before:** `StateValueSyncer.stream_requested` plus “no receiver initialized” in `drive_snapshot_stages` inferred an empty tree. Resetting the stream after a bad first chunk left the same flags, so every later tick hit a non-retryable `UnexpectedError` instead of opening a new stream.
> 
> **After:** Snapshot streams are tagged with `active_snapshot_kind` on the bootstrapper. Empty snapshots are finalized only on a **clean** `EndOfStream` via `complete_empty_snapshot_if_applicable`, checking the committed snapshot root against `SPARSE_MERKLE_PLACEHOLDER_HASH`. Mid-stream failures still reset before end-of-stream, so they retry normally.
> 
> Adds regression test `test_snapshot_sync_state_values_invalid_chunk_retries` (verification error, then second `get_all_state_values`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817666c54f1f23cf41c521d0842b1d513c0519d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->