### PR TITLE
[cli] prevent path traversal from on-chain package name

### DIFF
--- a/aptos-move/cli/src/commands.rs
+++ b/aptos-move/cli/src/commands.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     script_compile::CompileScriptFunction,
     sim::Sim,
-    stored_package::CachedPackageRegistry,
+    stored_package::{ensure_safe_name, CachedPackageRegistry},
     transactions::TxnOptions,
     MoveEnv, ResourceAccountSeed, WithMoveEnv,
 };
@@ -2051,6 +2051,8 @@ impl CliCommand<&'static str> for DownloadPackage {
         if self.print_metadata {
             println!("{}", package);
         }
+        ensure_safe_name(package.name())
+            .map_err(|err| CliError::CommandArgumentError(err.to_string()))?;
         let package_path = output_dir.join(package.name());
         package
             .save_package_to_disk(package_path.as_path())

--- a/aptos-move/cli/src/stored_package.rs
+++ b/aptos-move/cli/src/stored_package.rs
@@ -9,7 +9,30 @@ use aptos_framework::{
 use aptos_rest_client::Client;
 use aptos_types::account_address::AccountAddress;
 use move_package::compilation::package_layout::CompiledPackageLayout;
-use std::{collections::BTreeMap, fmt, fs, path::Path};
+use std::{
+    collections::BTreeMap,
+    ffi::OsStr,
+    fmt, fs,
+    path::{Component, Path},
+};
+
+/// On-chain package metadata names (the package name and each module name) are not
+/// constrained to Move identifiers, so a published package can carry a name such as
+/// `../../evil`. Reject anything that is not a single, non-traversing path component
+/// before it is joined onto an output directory, so writing a downloaded package can
+/// never escape that directory.
+pub(crate) fn ensure_safe_name(name: &str) -> anyhow::Result<()> {
+    let mut components = Path::new(name).components();
+    let single_component = matches!(
+        (components.next(), components.next()),
+        (Some(Component::Normal(component)), None) if component == OsStr::new(name)
+    );
+    if single_component {
+        Ok(())
+    } else {
+        bail!("unsafe name in package metadata: {:?}", name)
+    }
+}
 
 // TODO: this is a first naive implementation of the package registry. Before mainnet
 // we need to use tables for the package registry.
@@ -170,6 +193,7 @@ impl CachedPackageMetadata<'_> {
                     println!("module without code: {}", module.name);
                 },
                 false => {
+                    ensure_safe_name(&module.name)?;
                     let source = unzip_metadata_str(&module.source)?;
                     fs::write(sources_dir.join(format!("{}.move", module.name)), source)?;
                 },
@@ -184,6 +208,7 @@ impl CachedPackageMetadata<'_> {
         module_name: &str,
         bytecode: &[u8],
     ) -> anyhow::Result<()> {
+        ensure_safe_name(module_name)?;
         let bytecode_dir = path.join(CompiledPackageLayout::CompiledModules.path());
         fs::create_dir_all(&bytecode_dir)?;
         fs::write(bytecode_dir.join(format!("{}.mv", module_name)), bytecode)?;
@@ -252,5 +277,74 @@ impl CachedModuleMetadata<'_> {
 
     pub fn zipped_source_map_raw(&self) -> &[u8] {
         &self.metadata.source_map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_framework::zip_metadata_str;
+
+    fn package(modules: Vec<ModuleMetadata>) -> PackageMetadata {
+        PackageMetadata {
+            name: "pkg".to_string(),
+            upgrade_policy: UpgradePolicy { policy: 1 },
+            upgrade_number: 0,
+            source_digest: String::new(),
+            manifest: zip_metadata_str("[package]\nname = \"pkg\"\n").unwrap(),
+            modules,
+            deps: vec![],
+            extension: None,
+        }
+    }
+
+    #[test]
+    fn ensure_safe_name_accepts_plain_names() {
+        for name in ["pkg", "my_module", "Module1", "my.pkg"] {
+            assert!(ensure_safe_name(name).is_ok(), "{name} should be allowed");
+        }
+    }
+
+    #[test]
+    fn ensure_safe_name_rejects_traversal() {
+        for name in ["..", "../evil", "a/b", "/abs", "", ".", "sub/../../evil"] {
+            assert!(ensure_safe_name(name).is_err(), "{name} should be rejected");
+        }
+    }
+
+    #[test]
+    fn save_bytecode_to_disk_refuses_traversal() {
+        let pkg = package(vec![]);
+        let cached = CachedPackageMetadata { metadata: &pkg };
+        let dir = tempfile::tempdir().unwrap();
+
+        // A malicious on-chain module name must not escape the destination directory.
+        assert!(cached
+            .save_bytecode_to_disk(dir.path(), "../../escape", b"payload")
+            .is_err());
+
+        // A normal name still writes under the destination.
+        cached
+            .save_bytecode_to_disk(dir.path(), "counter", b"payload")
+            .unwrap();
+        assert!(dir
+            .path()
+            .join(CompiledPackageLayout::CompiledModules.path())
+            .join("counter.mv")
+            .exists());
+    }
+
+    #[test]
+    fn save_package_to_disk_refuses_module_name_traversal() {
+        let pkg = package(vec![ModuleMetadata {
+            name: "../../evil".to_string(),
+            source: zip_metadata_str("module {}").unwrap(),
+            source_map: vec![],
+            extension: None,
+        }]);
+        let cached = CachedPackageMetadata { metadata: &pkg };
+        let dir = tempfile::tempdir().unwrap();
+
+        assert!(cached.save_package_to_disk(dir.path()).is_err());
     }
 }


### PR DESCRIPTION
## Description

`aptos move download` builds its output directory as `output_dir.join(package.name())`. A package name in on-chain `0x1::code` metadata is not constrained to a Move identifier the way module names are: the VM checks every module name against the compiled bytecode at publish time, but the package name is only ever compared for equality, so an account can publish a package named `../../evil`. Downloading it then writes `Move.toml` and the source files outside the chosen directory. `save_package_to_disk` and `save_bytecode_to_disk` join module names onto their destination the same way. This adds `ensure_safe_name`, which rejects any name that is not a single non-traversing path component, and applies it at each name-to-path join in the download flow.

## How Has This Been Tested?

New unit tests in `stored_package.rs`: `ensure_safe_name` accept/reject cases, and `save_bytecode_to_disk` / `save_package_to_disk` refuse a `../../` name while a normal name still writes under the destination. Run with `cargo test -p aptos-move-cli --lib stored_package`.

## Key Areas to Review

`ensure_safe_name` in `stored_package.rs` and its three call sites. A legitimate package or module name is a single path component, so real packages are unaffected; only names containing a path separator, a `..` segment, or an absolute prefix are rejected.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI-side path validation on download/save only; no chain or VM behavior changes, with tests for reject and happy paths.
> 
> **Overview**
> Fixes a **path traversal** issue in `aptos move download` where untrusted on-chain package and module names could be joined onto the output path and write `Move.toml`, sources, or bytecode **outside** the chosen directory (e.g. a package named `../../evil`).
> 
> Adds **`ensure_safe_name`**, which only allows a single normal path segment (no `..`, separators, or absolute prefixes), and applies it when building the download subdirectory, when saving module sources in **`save_package_to_disk`**, and when saving bytecode in **`save_bytecode_to_disk`**. Legitimate single-component names are unchanged; malicious names fail with a clear error. Unit tests cover validation and the save helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3f1ba7228e3a052f94c79a8289df2b682f8c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->