### PR TITLE
[block-stm] Remove generic error from output

### DIFF
--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -15,9 +15,9 @@ use aptos_types::{
     contract_event::ContractEvent,
     state_store::TStateView,
     transaction::{
-        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockOutput,
-        PersistedAuxiliaryInfo, SignedTransaction, Transaction, TransactionExecutableRef,
-        TransactionInfo, TransactionOutput, TransactionPayload, Version,
+        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
+        BlockOutput, PersistedAuxiliaryInfo, SignedTransaction, Transaction,
+        TransactionExecutableRef, TransactionInfo, TransactionOutput, TransactionPayload, Version,
     },
     vm_status::VMStatus,
 };
@@ -545,7 +545,7 @@ fn execute_block_no_limit(
     txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo>,
     state_view: &DebuggerStateView,
     concurrency_level: usize,
-) -> Result<Vec<TransactionOutput>, VMStatus> {
+) -> Result<Vec<TransactionOutput>, BlockError> {
     let executor = AptosVMBlockExecutor::new();
     executor
         .execute_block_with_config(

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -77,11 +77,11 @@ use aptos_types::{
         },
         block_epilogue::{BlockEpiloguePayload, FeeDistribution},
         signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockOutput, EntryFunction, ExecutionError, ExecutionStatus, ModuleBundle,
-        MultisigTransactionPayload, ReplayProtector, Script, SignedTransaction, Transaction,
-        TransactionArgument, TransactionExecutableRef, TransactionExtraConfig, TransactionOutput,
-        TransactionPayload, TransactionStatus, TxnLimitsRequest, VMValidatorResult,
-        ViewFunctionOutput, WriteSetPayload,
+        AuxiliaryInfo, BlockExecutionResult, EntryFunction, ExecutionError, ExecutionStatus,
+        ModuleBundle, MultisigTransactionPayload, ReplayProtector, Script, SignedTransaction,
+        Transaction, TransactionArgument, TransactionExecutableRef, TransactionExtraConfig,
+        TransactionOutput, TransactionPayload, TransactionStatus, TxnLimitsRequest,
+        VMValidatorResult, ViewFunctionOutput, WriteSetPayload,
     },
     vm::module_metadata::{
         get_compilation_metadata, get_metadata, get_randomness_annotation_for_entry_function,
@@ -3384,11 +3384,11 @@ impl AptosVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> BlockExecutionResult<SignatureVerifiedTransaction, TransactionOutput> {
         fail_point!("aptos_vm_block_executor::execute_block_with_config", |_| {
-            Err(VMStatus::error(
-                StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                None,
+            use aptos_types::transaction::BlockError;
+            Err(BlockError::new(
+                "fail point: aptos_vm_block_executor::execute_block_with_config".to_string(),
             ))
         });
 
@@ -3432,7 +3432,7 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> BlockExecutionResult<SignatureVerifiedTransaction, TransactionOutput> {
         let config = BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
                 blockstm_v2: AptosVM::get_blockstm_v2_enabled(),

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -7,7 +7,6 @@ use crate::counters::{BLOCK_EXECUTOR_CONCURRENCY, BLOCK_EXECUTOR_EXECUTE_BLOCK_S
 use aptos_aggregator::delayed_change::DelayedChange;
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManager,
-    errors::BlockExecutionError,
     executor::BlockExecutor,
     task::{
         BeforeMaterializationOutput, ExecutorTask,
@@ -31,8 +30,8 @@ use aptos_types::{
         StateView, StateViewId,
     },
     transaction::{
-        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockOutput,
-        TransactionOutput, TransactionStatus,
+        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
+        BlockExecutionResult, BlockOutput, TransactionOutput, TransactionStatus,
     },
     write_set::{TransactionWrite, WriteOp},
 };
@@ -45,7 +44,6 @@ use aptos_vm_types::{
 use move_core_types::{
     language_storage::{ModuleId, StructTag},
     value::MoveTypeLayout,
-    vm_status::{StatusCode, VMStatus},
 };
 use move_vm_runtime::execution_tracing::Trace;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
@@ -398,11 +396,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 }
 
 pub struct AptosBlockExecutorWrapper<
-    E: ExecutorTask<
-        Txn = SignatureVerifiedTransaction,
-        Error = VMStatus,
-        Output = AptosTransactionOutput,
-    >,
+    E: ExecutorTask<Txn = SignatureVerifiedTransaction, Output = AptosTransactionOutput>,
 > {
     _phantom: PhantomData<E>,
 }
@@ -411,7 +405,6 @@ impl<
         E: ExecutorTask<
             Txn = SignatureVerifiedTransaction,
             AuxiliaryInfo = AuxiliaryInfo,
-            Error = VMStatus,
             Output = AptosTransactionOutput,
         >,
     > AptosBlockExecutorWrapper<E>
@@ -427,7 +420,7 @@ impl<
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
         transaction_commit_listener: Option<L>,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> BlockExecutionResult<SignatureVerifiedTransaction, TransactionOutput> {
         let _timer = BLOCK_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
 
         let num_txns = signature_verified_block.num_txns();
@@ -439,11 +432,13 @@ impl<
 
         BLOCK_EXECUTOR_CONCURRENCY.set(config.local.concurrency_level as i64);
 
-        let mut module_cache_manager_guard = module_cache_manager.try_lock(
-            &state_view,
-            &config.local.module_cache_config,
-            transaction_slice_metadata,
-        )?;
+        let mut module_cache_manager_guard = module_cache_manager
+            .try_lock(
+                &state_view,
+                &config.local.module_cache_config,
+                transaction_slice_metadata,
+            )
+            .map_err(|status| BlockError::new(status.to_string()))?;
 
         let executor =
             BlockExecutor::<SignatureVerifiedTransaction, E, S, L, TP, AuxiliaryInfo>::new(
@@ -472,14 +467,7 @@ impl<
 
                 Ok(BlockOutput::new(transaction_outputs, block_epilogue_txn))
             },
-            Err(BlockExecutionError::FatalBlockExecutorError(PanicError::CodeInvariantError(
-                err_msg,
-            ))) => Err(VMStatus::Error {
-                status_code: StatusCode::DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR,
-                sub_status: None,
-                message: Some(err_msg),
-            }),
-            Err(BlockExecutionError::FatalVMError(err)) => Err(err),
+            Err(err) => Err(err),
         }
     }
 }

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -25,10 +25,7 @@ use aptos_vm_types::{
     resolver::{BlockSynchronizationKillSwitch, ExecutorView, ResourceGroupView},
 };
 use fail::fail_point;
-use move_core_types::{
-    account_address::AccountAddress,
-    vm_status::{StatusCode, VMStatus},
-};
+use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
 
 pub struct AptosExecutorTask {
     vm: AptosVM,
@@ -37,7 +34,6 @@ pub struct AptosExecutorTask {
 
 impl ExecutorTask for AptosExecutorTask {
     type AuxiliaryInfo = AuxiliaryInfo;
-    type Error = VMStatus;
     type Output = AptosTransactionOutput;
     type Txn = SignatureVerifiedTransaction;
 
@@ -63,7 +59,7 @@ impl ExecutorTask for AptosExecutorTask {
         txn: &SignatureVerifiedTransaction,
         auxiliary_info: &Self::AuxiliaryInfo,
         txn_idx: TxnIndex,
-    ) -> ExecutionStatus<AptosTransactionOutput, VMStatus> {
+    ) -> ExecutionStatus<AptosTransactionOutput> {
         fail_point!("aptos_vm::vm_wrapper::execute_transaction", |_| {
             ExecutionStatus::DelayedFieldsCodeInvariantError("fail points error".into())
         });
@@ -135,7 +131,7 @@ impl ExecutorTask for AptosExecutorTask {
                         err.message().cloned().unwrap_or_default(),
                     )
                 } else {
-                    ExecutionStatus::Abort(err)
+                    ExecutionStatus::Abort(err.to_string())
                 }
             },
         }

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -134,8 +134,8 @@ use aptos_types::{
     },
     state_store::StateView,
     transaction::{
-        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockOutput,
-        SignedTransaction, TransactionOutput, VMValidatorResult,
+        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
+        BlockExecutionResult, BlockOutput, SignedTransaction, TransactionOutput, VMValidatorResult,
     },
     vm_status::VMStatus,
 };
@@ -173,7 +173,7 @@ pub trait VMBlockExecutor: Send + Sync {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus>;
+    ) -> BlockExecutionResult<SignatureVerifiedTransaction, TransactionOutput>;
 
     /// Executes a block of transactions and returns output for each one of them, without applying
     /// any block limit.
@@ -181,7 +181,7 @@ pub trait VMBlockExecutor: Send + Sync {
         &self,
         txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo>,
         state_view: &(impl StateView + Sync),
-    ) -> Result<Vec<TransactionOutput>, VMStatus> {
+    ) -> Result<Vec<TransactionOutput>, BlockError> {
         self.execute_block(
             txn_provider,
             state_view,

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -153,6 +153,13 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                     cross_shard_commit_sender,
                 )
                 .map(BlockOutput::into_transaction_outputs_forced);
+                let ret = match ret {
+                    Ok(ret) => Ok(ret),
+                    Err(err) => {
+                        // TODO: figure out what to do with failed blocks
+                        unimplemented!("unsupported sharded block execution error: {}", err)
+                    },
+                };
                 if let Some(shard_id) = shard_id {
                     trace!(
                         "executed sub block for shard {} and round {}",

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -156,7 +156,11 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                 let ret = match ret {
                     Ok(ret) => Ok(ret),
                     Err(err) => {
-                        // TODO: figure out what to do with failed blocks
+                        // Sharded execution is not enabled in production, so a
+                        // block-level error here is unreachable on the production
+                        // path. Rather than plumbing BlockError through the whole
+                        // sharded stack, we panic.
+                        // TODO: figure out what to do with failed blocks.
                         unimplemented!("unsupported sharded block execution error: {}", err)
                     },
                 };

--- a/aptos-move/block-executor/src/combinatorial_tests/baseline.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/baseline.rs
@@ -9,7 +9,6 @@ use crate::{
             MockTransaction, ValueType, RESERVED_TAG, STORAGE_AGGREGATOR_VALUE,
         },
     },
-    errors::{BlockExecutionError, BlockExecutionResult},
     types::delayed_field_mock_serialization::{
         deserialize_to_delayed_field_id, deserialize_to_delayed_field_u128,
         serialize_from_delayed_field_u128,
@@ -18,8 +17,10 @@ use crate::{
 use aptos_aggregator::delta_change_set::DeltaOp;
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    contract_event::TransactionEvent, executable::ModulePath,
-    state_store::state_value::StateValueMetadata, transaction::BlockOutput,
+    contract_event::TransactionEvent,
+    executable::ModulePath,
+    state_store::state_value::StateValueMetadata,
+    transaction::{BlockError, BlockOutput},
     write_set::TransactionWrite,
 };
 use aptos_vm_types::{
@@ -992,19 +993,23 @@ where
     // itself to be easily traceable in case of an error.
     pub(crate) fn assert_output<E: Clone + Debug + Send + Sync + TransactionEvent + 'static>(
         &self,
-        results: &BlockExecutionResult<BlockOutput<MockTransaction<K, E>, MockOutput<K, E>>, usize>,
+        results: &Result<BlockOutput<MockTransaction<K, E>, MockOutput<K, E>>, BlockError>,
     ) {
         match results {
             Ok(block_output) => {
                 self.assert_success(block_output);
             },
-            Err(BlockExecutionError::FatalVMError(idx)) => {
+            Err(err) => {
+                // The mock aborts with the index of the aborting transaction as the message,
+                // and the baseline breaks at that index, so it equals the count of successfully
+                // processed transactions.
                 assert_matches!(&self.status, BaselineStatus::Aborted);
-                assert_eq!(*idx, self.read_values.len());
-                assert_eq!(*idx, self.resolved_deltas.len());
-            },
-            Err(BlockExecutionError::FatalBlockExecutorError(e)) => {
-                unimplemented!("not tested here FallbackToSequential({:?})", e);
+                let idx: usize = err
+                    .message()
+                    .parse()
+                    .expect("mock abort message is the aborting transaction index");
+                assert_eq!(idx, self.read_values.len());
+                assert_eq!(idx, self.resolved_deltas.len());
             },
         }
     }

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -189,7 +189,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
         &mut self,
         view: &S,
         module_ids: &[ModuleId],
-    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>> {
+    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>>> {
         for module_id in module_ids {
             let metadata = try_with_status!(
                 view.unmetered_get_module_state_value_metadata(
@@ -212,7 +212,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
         view: &impl TExecutorView<K, u32, MoveTypeLayout>,
         key_pairs: &[(K, bool)],
         delayed_fields_enabled: bool,
-    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>> {
+    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>>> {
         for (key, has_deltas) in key_pairs {
             match (has_deltas, delayed_fields_enabled) {
                 // Regular resource read (no delayed fields)
@@ -264,7 +264,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
               + TExecutorView<K, u32, MoveTypeLayout>),
         group_reads: &[(K, u32, bool)],
         delayed_fields_enabled: bool,
-    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>> {
+    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>>> {
         for (group_key, resource_tag, has_delta) in group_reads {
             let maybe_layout =
                 (*has_delta && delayed_fields_enabled && *resource_tag == RESERVED_TAG)
@@ -302,7 +302,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
         view: &(impl TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>
               + TExecutorView<K, u32, MoveTypeLayout>),
         group_queries: &[(K, bool)],
-    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>> {
+    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>>> {
         for (group_key, query_metadata) in group_queries {
             let res = if *query_metadata {
                 // Query metadata
@@ -341,7 +341,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
         group_writes: &[(K, StateValueMetadata, HashMap<u32, (ValueType, bool)>)],
         delayed_fields_enabled: bool,
         txn_idx: u32,
-    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>>
+    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>>>
     where
         View: TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>
             + TExecutorView<K, u32, MoveTypeLayout>,
@@ -480,7 +480,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
         resource_writes: &[(K, ValueType, bool)],
         delayed_fields_enabled: bool,
         txn_idx: u32,
-    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>>
+    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>>>
     // Group view is because get_delayed_field_id_from_resource dispatches, but there is
     // a TODO to have TExecutorView contain TResourceGroupView anyway.
     where
@@ -514,7 +514,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
               + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>),
         deltas: &[(K, DeltaOp, Option<u32>)],
         delta_test_kind: DeltaTestKind,
-    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>, usize>> {
+    ) -> Result<&mut Self, ExecutionStatus<MockOutput<K, E>>> {
         match delta_test_kind {
             DeltaTestKind::DelayedFields => {
                 for (k, delta, maybe_tag) in deltas {
@@ -553,7 +553,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
               + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>),
         key: &K,
         maybe_tag: Option<u32>,
-    ) -> Result<DelayedFieldID, ExecutionStatus<MockOutput<K, E>, usize>> {
+    ) -> Result<DelayedFieldID, ExecutionStatus<MockOutput<K, E>>> {
         let bytes = match maybe_tag {
             None => try_with_status!(
                 view.get_resource_bytes(key, Some(&*MOCK_LAYOUT)),
@@ -593,7 +593,7 @@ impl<K: Ord + Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder
         view: &impl TExecutorView<K, u32, MoveTypeLayout>,
         key: &K,
         bytes: &[u8],
-    ) -> Result<(), ExecutionStatus<MockOutput<K, E>, usize>> {
+    ) -> Result<(), ExecutionStatus<MockOutput<K, E>>> {
         let id = deserialize_to_delayed_field_id(bytes)
             .expect("Must deserialize delayed field tuple")
             .0;
@@ -942,7 +942,6 @@ where
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
     type AuxiliaryInfo = AuxiliaryInfo;
-    type Error = usize;
     type Output = MockOutput<K, E>;
     type Txn = MockTransaction<K, E>;
 
@@ -963,7 +962,7 @@ where
         txn: &Self::Txn,
         _auxiliary_info: &Self::AuxiliaryInfo,
         txn_idx: TxnIndex,
-    ) -> ExecutionStatus<Self::Output, Self::Error> {
+    ) -> ExecutionStatus<Self::Output> {
         match txn {
             MockTransaction::Write {
                 incarnation_counter,
@@ -1026,7 +1025,7 @@ where
                 mock_output.total_gas = *gas;
                 ExecutionStatus::SkipRest(mock_output)
             },
-            MockTransaction::Abort => ExecutionStatus::Abort(txn_idx as usize),
+            MockTransaction::Abort => ExecutionStatus::Abort(txn_idx.to_string()),
             MockTransaction::InterruptRequested => {
                 while !view.interrupt_requested() {}
                 ExecutionStatus::SkipRest(MockOutput::skip_output())
@@ -1062,7 +1061,7 @@ where
 /// that might fail, allowing for a cleaner code flow.
 struct BuilderOperation<'a, K: Clone + Debug, E: Clone> {
     builder: &'a mut MockOutputBuilder<K, E>,
-    status: Option<ExecutionStatus<MockOutput<K, E>, usize>>,
+    status: Option<ExecutionStatus<MockOutput<K, E>>>,
 }
 
 impl<'a, K: Clone + Debug, E: Clone> BuilderOperation<'a, K, E> {
@@ -1078,7 +1077,7 @@ impl<'a, K: Clone + Debug, E: Clone> BuilderOperation<'a, K, E> {
         F: FnOnce(
             &mut MockOutputBuilder<K, E>,
         )
-            -> Result<&mut MockOutputBuilder<K, E>, ExecutionStatus<MockOutput<K, E>, usize>>,
+            -> Result<&mut MockOutputBuilder<K, E>, ExecutionStatus<MockOutput<K, E>>>,
     {
         if self.status.is_none() {
             if let Err(status) = op(self.builder) {
@@ -1088,9 +1087,7 @@ impl<'a, K: Clone + Debug, E: Clone> BuilderOperation<'a, K, E> {
         self
     }
 
-    fn finish(
-        self,
-    ) -> Result<&'a mut MockOutputBuilder<K, E>, ExecutionStatus<MockOutput<K, E>, usize>> {
+    fn finish(self) -> Result<&'a mut MockOutputBuilder<K, E>, ExecutionStatus<MockOutput<K, E>>> {
         match self.status {
             None => Ok(self.builder),
             Some(status) => Err(status),

--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use aptos_types::error::PanicError;
+use aptos_types::{error::PanicError, transaction::BlockError};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ParallelBlockExecutionError {
@@ -20,35 +20,15 @@ pub(crate) struct ResourceGroupSerializationError;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Logging is bottlenecked in constructors.
-pub(crate) enum SequentialBlockExecutionError<E> {
+pub(crate) enum SequentialBlockExecutionError {
     // This is separate error because we need to match the error variant to provide a specialized
     // fallback logic if a resource group serialization error occurs.
     ResourceGroupSerializationError,
-    ErrorToReturn(BlockExecutionError<E>),
+    ErrorToReturn(BlockError),
 }
 
-/// If the unrecoverable error occurs during sequential execution (e.g. fallback),
-/// the error is propagated back to the caller (block execution is aborted).
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum BlockExecutionError<E> {
-    /// unrecoverable BlockSTM error
-    FatalBlockExecutorError(PanicError),
-    /// unrecoverable VM error
-    FatalVMError(E),
-}
-
-pub type BlockExecutionResult<T, E> = Result<T, BlockExecutionError<E>>;
-
-impl<E> From<PanicError> for BlockExecutionError<E> {
+impl From<PanicError> for SequentialBlockExecutionError {
     fn from(err: PanicError) -> Self {
-        BlockExecutionError::FatalBlockExecutorError(err)
-    }
-}
-
-impl<E> From<PanicError> for SequentialBlockExecutionError<E> {
-    fn from(err: PanicError) -> Self {
-        SequentialBlockExecutionError::ErrorToReturn(BlockExecutionError::FatalBlockExecutorError(
-            err,
-        ))
+        SequentialBlockExecutionError::ErrorToReturn(BlockError::from(err))
     }
 }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -47,8 +47,8 @@ use aptos_types::{
     on_chain_config::Features,
     state_store::TStateView,
     transaction::{
-        block_epilogue::TBlockEndInfoExt, AuxiliaryInfoTrait, BlockExecutableTransaction,
-        BlockOutput, FeeDistribution,
+        block_epilogue::TBlockEndInfoExt, AuxiliaryInfoTrait, BlockError,
+        BlockExecutableTransaction, BlockExecutionResult, BlockOutput, FeeDistribution,
     },
     vm::modules::AptosModuleExtension,
     write_set::TransactionWrite,
@@ -130,7 +130,7 @@ where
 
     // The bool in the result indicates whether execution result is a speculative abort.
     fn process_execution_result<'a>(
-        execution_result: &'a ExecutionStatus<E::Output, E::Error>,
+        execution_result: &'a ExecutionStatus<E::Output>,
         read_set: &mut CapturedReads<T, ModuleId, CompiledModule, Module, AptosModuleExtension>,
         txn_idx: TxnIndex,
     ) -> Result<(Option<&'a E::Output>, bool), PanicError> {
@@ -2052,7 +2052,7 @@ where
         unsync_map: &UnsyncMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         output_before_guard: &<E::Output as TransactionOutput>::BeforeMaterializationGuard<'_>,
         resource_write_set: HashMap<T::Key, ValueWithLayout<T::Value>>,
-    ) -> Result<(), SequentialBlockExecutionError<E::Error>> {
+    ) -> Result<(), SequentialBlockExecutionError> {
         for (key, value) in resource_write_set.into_iter() {
             unsync_map.write(key, value);
         }
@@ -2132,7 +2132,7 @@ where
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
         resource_group_bcs_fallback: bool,
-    ) -> Result<BlockOutput<T, CommittedOutput<E>>, SequentialBlockExecutionError<E::Error>> {
+    ) -> Result<BlockOutput<T, CommittedOutput<E>>, SequentialBlockExecutionError> {
         let num_txns = signature_verified_block.num_txns();
 
         if num_txns == 0 {
@@ -2191,20 +2191,20 @@ where
                     );
                     // Record the status indicating the unrecoverable VM failure.
                     return Err(SequentialBlockExecutionError::ErrorToReturn(
-                        BlockExecutionError::FatalVMError(err),
+                        BlockError::new(err),
                     ));
                 },
                 ExecutionStatus::DelayedFieldsCodeInvariantError(msg) => {
                     alert!("Sequential execution DelayedFieldsCodeInvariantError error by transaction {}: {}", idx as TxnIndex, msg);
-                    return Err(SequentialBlockExecutionError::ErrorToReturn(
-                        BlockExecutionError::FatalBlockExecutorError(code_invariant_error(msg)),
-                    ));
+                    return Err(SequentialBlockExecutionError::from(code_invariant_error(
+                        msg,
+                    )));
                 },
                 ExecutionStatus::SpeculativeExecutionAbortError(msg) => {
                     alert!("Sequential execution SpeculativeExecutionAbortError error by transaction {}: {}", idx as TxnIndex, msg);
-                    return Err(SequentialBlockExecutionError::ErrorToReturn(
-                        BlockExecutionError::FatalBlockExecutorError(code_invariant_error(msg)),
-                    ));
+                    return Err(SequentialBlockExecutionError::from(code_invariant_error(
+                        msg,
+                    )));
                 },
                 ExecutionStatus::Success(mut output) | ExecutionStatus::SkipRest(mut output) => {
                     let output_before_guard = output.before_materialization()?;
@@ -2462,7 +2462,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> BlockExecutionResult<BlockOutput<T, CommittedOutput<E>>, E::Error> {
+    ) -> BlockExecutionResult<T, CommittedOutput<E>> {
         let _timer = BLOCK_EXECUTOR_INNER_EXECUTE_BLOCK.start_timer();
 
         if self.config.local.concurrency_level > 1 {
@@ -2548,7 +2548,7 @@ where
                         return Ok(output);
                     },
                     Err(SequentialBlockExecutionError::ResourceGroupSerializationError) => {
-                        BlockExecutionError::FatalBlockExecutorError(code_invariant_error(
+                        BlockError::from(code_invariant_error(
                             "resource group serialization during bcs fallback should not happen",
                         ))
                     },
@@ -2561,16 +2561,10 @@ where
         if self.config.local.discard_failed_blocks {
             // We cannot execute block, discard everything (including block metadata and validator transactions)
             // (TODO: maybe we should add fallback here to first try BlockMetadataTransaction alone)
-            let error_code = match sequential_error {
-                BlockExecutionError::FatalBlockExecutorError(_) => {
-                    StatusCode::DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR
-                },
-                BlockExecutionError::FatalVMError(_) => {
-                    StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
-                },
-            };
             let ret = (0..signature_verified_block.num_txns())
-                .map(|_| CommittedOutput::<E>::discard(error_code))
+                .map(|_| {
+                    CommittedOutput::<E>::discard(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                })
                 .collect();
             return Ok(BlockOutput::new(ret, None));
         }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -34,12 +34,12 @@ use triomphe::Arc as TriompheArc;
 
 /// The execution result of a transaction
 #[derive(Debug)]
-pub enum ExecutionStatus<O, E> {
+pub enum ExecutionStatus<O> {
     /// Transaction was executed successfully.
     Success(O),
     /// Transaction hit a none recoverable error during execution, halt the execution and propagate
     /// the error back to the caller.
-    Abort(E),
+    Abort(String),
     /// Transaction was executed successfully, but will skip the execution of the trailing
     /// transactions in the list
     SkipRest(O),
@@ -61,9 +61,6 @@ pub trait ExecutorTask {
 
     /// The output of a transaction. This should contain the side effect of this transaction.
     type Output: TransactionOutput<Txn = Self::Txn> + 'static;
-
-    /// Type of error when the executor failed to process a transaction and needs to abort.
-    type Error: Debug + Clone + Send + Sync + Eq + 'static;
 
     /// Create an instance of the transaction executor.
     fn init(
@@ -93,7 +90,7 @@ pub trait ExecutorTask {
         txn: &Self::Txn,
         auxiliary_info: &Self::AuxiliaryInfo,
         txn_idx: TxnIndex,
-    ) -> ExecutionStatus<Self::Output, Self::Error>;
+    ) -> ExecutionStatus<Self::Output>;
 
     fn pre_write_values(
         _txn: &Self::Txn,

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -37,8 +37,8 @@ use triomphe::Arc as TriompheArc;
 pub enum ExecutionStatus<O> {
     /// Transaction was executed successfully.
     Success(O),
-    /// Transaction hit a none recoverable error during execution, halt the execution and propagate
-    /// the error back to the caller.
+    /// Transaction hit a non-recoverable error during execution. Halts execution
+    /// and returns the error message to the caller.
     Abort(String),
     /// Transaction was executed successfully, but will skip the execution of the trailing
     /// transactions in the list

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -30,7 +30,6 @@ use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use parking_lot::Mutex;
 use std::{
     collections::{BTreeSet, HashSet},
-    fmt::Debug,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -126,8 +125,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
         }
     }
 
-    fn from_execution_status<E: Debug>(
-        output: ExecutionStatus<O, E>,
+    fn from_execution_status(
+        output: ExecutionStatus<O>,
         read_set: &TxnInput<T>,
         block_gas_limit_type: &BlockGasLimitType,
         user_txn_bytes_len: u64,
@@ -168,9 +167,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
                     },
                 }
             },
-            ExecutionStatus::Abort(err) => {
-                Self::empty_with_status(OutputStatusKind::Abort(format!("{:?}", err)))
-            },
+            ExecutionStatus::Abort(err) => Self::empty_with_status(OutputStatusKind::Abort(err)),
             ExecutionStatus::SpeculativeExecutionAbortError(_) => {
                 Self::empty_with_status(OutputStatusKind::SpeculativeExecutionAbortError)
             },
@@ -227,11 +224,11 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         }
     }
 
-    pub(crate) fn record<E: Debug>(
+    pub(crate) fn record(
         &self,
         txn_idx: TxnIndex,
         input: TxnInput<T>,
-        output: ExecutionStatus<O, E>,
+        output: ExecutionStatus<O>,
         block_gas_limit_type: &BlockGasLimitType,
         user_txn_bytes_len: u64,
     ) -> Result<(), PanicError> {

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -59,7 +59,6 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
     value::{MoveTypeLayout, MoveValue},
-    vm_status::VMStatus,
 };
 use move_vm_runtime::{
     execution_tracing::Trace,
@@ -268,7 +267,6 @@ impl BeforeMaterializationOutput<TestTransaction> for &TestOutput {
 
 impl ExecutorTask for TestTask {
     type AuxiliaryInfo = AuxiliaryInfo;
-    type Error = VMStatus;
     type Output = TestOutput;
     type Txn = TestTransaction;
 
@@ -291,7 +289,7 @@ impl ExecutorTask for TestTask {
         txn: &Self::Txn,
         _auxiliary_info: &Self::AuxiliaryInfo,
         _txn_idx: TxnIndex,
-    ) -> ExecutionStatus<Self::Output, Self::Error> {
+    ) -> ExecutionStatus<Self::Output> {
         let resolver = self.vm.as_move_resolver_with_group_view(view);
         let mut change_set_1 = self.run(&resolver, view, &txn.session_1);
         println!("  [session_1] change set: {:?}", change_set_1);

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -58,7 +58,7 @@ use aptos_types::{
         Transaction, TransactionExecutableRef, TransactionOutput, TransactionStatus,
         VMValidatorResult, ViewFunctionOutput,
     },
-    vm_status::VMStatus,
+    vm_status::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
     AptosCoinType, CoinType,
 };
@@ -884,7 +884,14 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
             )
             .map(BlockOutput::into_transaction_outputs_forced)
         };
-        let outputs = result?;
+        // This test harness threads VMStatus, while block execution now returns BlockError.
+        // Block-level errors are fatal and rare here, so we stringify into a generic VMStatus.
+        let outputs = result.map_err(|err| {
+            VMStatus::error(
+                StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                Some(err.message().to_string()),
+            )
+        })?;
         Ok(outputs)
     }
 

--- a/aptos-move/e2e-testsuite/src/tests/genesis.rs
+++ b/aptos-move/e2e-testsuite/src/tests/genesis.rs
@@ -59,6 +59,10 @@ fn fail_no_epoch_change_write_set() {
     let receiver = executor.create_raw_account_data(100_000, 10);
     let txn2 = peer_to_peer_txn(sender.account(), receiver.account(), 11, 1000, 0);
 
-    let output = executor.execute_transaction_block(vec![txn, Transaction::UserTransaction(txn2)]);
-    assert!(output.is_err());
+    let output_err = executor
+        .execute_transaction_block(vec![txn, Transaction::UserTransaction(txn2)])
+        .unwrap_err();
+    // Block execution no longer threads the original StatusCode; the specific
+    // failure reason survives only in the stringified error message.
+    assert!(output_err.message().unwrap().contains("INVALID_WRITE_SET"));
 }

--- a/aptos-move/e2e-testsuite/src/tests/genesis.rs
+++ b/aptos-move/e2e-testsuite/src/tests/genesis.rs
@@ -7,7 +7,6 @@ use aptos_types::{
     transaction::{ChangeSet, Transaction, TransactionStatus, WriteSetPayload},
     write_set::TransactionWrite,
 };
-use move_core_types::vm_status::StatusCode;
 
 #[test]
 fn no_deletion_in_genesis() {
@@ -60,8 +59,6 @@ fn fail_no_epoch_change_write_set() {
     let receiver = executor.create_raw_account_data(100_000, 10);
     let txn2 = peer_to_peer_txn(sender.account(), receiver.account(), 11, 1000, 0);
 
-    let output_err = executor
-        .execute_transaction_block(vec![txn, Transaction::UserTransaction(txn2)])
-        .unwrap_err();
-    assert_eq!(StatusCode::INVALID_WRITE_SET, output_err.status_code());
+    let output = executor.execute_transaction_block(vec![txn, Transaction::UserTransaction(txn2)]);
+    assert!(output.is_err());
 }

--- a/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
+++ b/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
@@ -13,9 +13,8 @@ use aptos_types::{
     state_store::StateView,
     transaction::{
         block_epilogue::BlockEndInfo, signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockOutput, Transaction, TransactionOutput,
+        AuxiliaryInfo, BlockError, BlockOutput, Transaction, TransactionOutput,
     },
-    vm_status::VMStatus,
 };
 use aptos_vm::{AptosVM, VMBlockExecutor};
 use aptos_vm_environment::environment::AptosEnvironment;
@@ -36,7 +35,7 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
         let _timer = BLOCK_EXECUTOR_INNER_EXECUTE_BLOCK.start_timer();
 
         // let features = Features::fetch_config(&state_view).unwrap_or_default();
@@ -51,27 +50,29 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
             BlockEndInfo::new_empty(),
         );
 
-        let transaction_outputs = NATIVE_EXECUTOR_POOL.install(|| {
-            txn_provider
-                .get_txns()
-                .par_iter()
-                .chain(vec![block_epilogue_txn.clone().into()].par_iter())
-                .enumerate()
-                .map(|(txn_idx, txn)| {
-                    let log_context = AdapterLogSchema::new(state_view.id(), txn_idx);
-                    let code_storage = state_view.as_aptos_code_storage(&env);
+        let transaction_outputs = NATIVE_EXECUTOR_POOL
+            .install(|| {
+                txn_provider
+                    .get_txns()
+                    .par_iter()
+                    .chain(vec![block_epilogue_txn.clone().into()].par_iter())
+                    .enumerate()
+                    .map(|(txn_idx, txn)| {
+                        let log_context = AdapterLogSchema::new(state_view.id(), txn_idx);
+                        let code_storage = state_view.as_aptos_code_storage(&env);
 
-                    vm.execute_single_transaction(
-                        txn,
-                        &vm.as_move_resolver(state_view),
-                        &code_storage,
-                        &log_context,
-                        &AuxiliaryInfo::default(),
-                    )
-                    .map(|(_vm_status, vm_output)| vm_output.into_transaction_output().unwrap())
-                })
-                .collect::<Result<Vec<_>, _>>()
-        })?;
+                        vm.execute_single_transaction(
+                            txn,
+                            &vm.as_move_resolver(state_view),
+                            &code_storage,
+                            &log_context,
+                            &AuxiliaryInfo::default(),
+                        )
+                        .map(|(_vm_status, vm_output)| vm_output.into_transaction_output().unwrap())
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(|status| BlockError::new(status.to_string()))?;
 
         Ok(BlockOutput::new(
             transaction_outputs,

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -36,8 +36,8 @@ use aptos_types::{
     move_utils::move_event_v2::MoveEventV2Type,
     state_store::{state_key::StateKey, state_value::StateValueMetadata, StateView},
     transaction::{
-        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockOutput,
-        TransactionOutput, TransactionStatus,
+        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
+        BlockOutput, TransactionOutput, TransactionStatus,
     },
     write_set::WriteOp,
 };
@@ -85,7 +85,7 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
         AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block::<
             _,
             NoOpTransactionCommitHook<VMStatus>,
@@ -116,7 +116,6 @@ pub(crate) struct NativeVMExecutorTask {
 
 impl ExecutorTask for NativeVMExecutorTask {
     type AuxiliaryInfo = AuxiliaryInfo;
-    type Error = VMStatus;
     type Output = AptosTransactionOutput;
     type Txn = SignatureVerifiedTransaction;
 
@@ -139,7 +138,7 @@ impl ExecutorTask for NativeVMExecutorTask {
         txn: &SignatureVerifiedTransaction,
         _auxiliary_info: &AuxiliaryInfo,
         _txn_idx: TxnIndex,
-    ) -> ExecutionStatus<AptosTransactionOutput, VMStatus> {
+    ) -> ExecutionStatus<AptosTransactionOutput> {
         match self.execute_transaction_impl(executor_with_group_view, txn) {
             Ok((change_set, gas_units)) => {
                 ExecutionStatus::Success(AptosTransactionOutput::new(VMOutput::new(

--- a/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
+++ b/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
@@ -28,10 +28,9 @@ use aptos_types::{
     state_store::{state_key::StateKey, StateView},
     transaction::{
         block_epilogue::BlockEndInfo, signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockOutput, ExecutionStatus, Transaction, TransactionAuxiliaryData,
-        TransactionOutput, TransactionStatus,
+        AuxiliaryInfo, BlockError, BlockOutput, ExecutionStatus, Transaction,
+        TransactionAuxiliaryData, TransactionOutput, TransactionStatus,
     },
-    vm_status::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSetMut},
 };
 use aptos_vm::VMBlockExecutor;
@@ -81,7 +80,7 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
         let block_epilogue_txn = Transaction::block_epilogue_v0(
             transaction_slice_metadata
                 .append_state_checkpoint_to_block()
@@ -109,12 +108,7 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
                     .map(|txn| self.executor.execute_transaction(txn, state_view, &state))
                     .collect::<Result<Vec<_>>>()
             })
-            .map_err(|e| {
-                VMStatus::error(
-                    StatusCode::DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR,
-                    Some(format!("{:?}", e).to_string()),
-                )
-            })?;
+            .map_err(|e| BlockError::new(format!("{:?}", e)))?;
 
         Ok(BlockOutput::new(
             transaction_outputs,

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -19,7 +19,7 @@ use aptos_types::{
         signature_verified_transaction::{
             into_signature_verified_block, SignatureVerifiedTransaction,
         },
-        AuxiliaryInfo, BlockOutput, Transaction, TransactionOutput, Version,
+        AuxiliaryInfo, BlockError, BlockOutput, Transaction, TransactionOutput, Version,
     },
     vm_status::VMStatus,
 };
@@ -81,7 +81,7 @@ impl VMBlockExecutor for FakeVM {
         _state_view: &impl StateView,
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
         Ok(BlockOutput::new(vec![], None))
     }
 }

--- a/execution/executor/src/tests/mock_vm/mod.rs
+++ b/execution/executor/src/tests/mock_vm/mod.rs
@@ -22,9 +22,9 @@ use aptos_types::{
     state_store::{state_key::StateKey, StateView},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockEndInfo,
-        BlockOutput, ChangeSet, ExecutionStatus, RawTransaction, Script, SignedTransaction,
-        Transaction, TransactionArgument, TransactionAuxiliaryData, TransactionExecutableRef,
-        TransactionOutput, TransactionStatus, WriteSetPayload,
+        BlockError, BlockOutput, ChangeSet, ExecutionStatus, RawTransaction, Script,
+        SignedTransaction, Transaction, TransactionArgument, TransactionAuxiliaryData,
+        TransactionExecutableRef, TransactionOutput, TransactionStatus, WriteSetPayload,
     },
     vm_status::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
@@ -71,7 +71,7 @@ impl VMBlockExecutor for MockVM {
         state_view: &impl StateView,
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
         // output_cache is used to store the output of transactions so they are visible to later
         // transactions.
         let mut output_cache = HashMap::new();

--- a/experimental/execution/ptx-executor/src/lib.rs
+++ b/experimental/execution/ptx-executor/src/lib.rs
@@ -32,8 +32,8 @@ use aptos_types::{
     },
     state_store::StateView,
     transaction::{
-        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockOutput,
-        TransactionOutput,
+        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
+        BlockOutput, TransactionOutput,
     },
 };
 use aptos_vm::{
@@ -56,7 +56,7 @@ impl VMBlockExecutor for PtxBlockExecutor {
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
         let _timer = TIMER.timer_with(&["block_total"]);
 
         let concurrency_level = AptosVM::get_concurrency_level();

--- a/types/src/transaction/block_output.rs
+++ b/types/src/transaction/block_output.rs
@@ -2,7 +2,41 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::BlockExecutableTransaction;
-use std::fmt::Debug;
+use crate::error::PanicError;
+use std::fmt::{self, Debug, Display};
+
+/// Unrecoverable error that aborts execution of an entire block.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockError {
+    message: String,
+}
+
+impl BlockError {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Display for BlockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for BlockError {}
+
+impl From<PanicError> for BlockError {
+    fn from(err: PanicError) -> Self {
+        Self::new(err.to_string())
+    }
+}
+
+/// Result of executing a block: either its output, or an unrecoverable [BlockError].
+pub type BlockExecutionResult<T, Output> = Result<BlockOutput<T, Output>, BlockError>;
 
 #[derive(Debug)]
 pub struct BlockOutput<T, Output>

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -72,7 +72,7 @@ use crate::{
     validator_txn::ValidatorTransaction,
     write_set::TransactionWrite,
 };
-pub use block_output::BlockOutput;
+pub use block_output::{BlockError, BlockExecutionResult, BlockOutput};
 pub use change_set::ChangeSet;
 pub use module::{Module, ModuleBundle};
 pub use move_core_types::transaction_argument::TransactionArgument;


### PR DESCRIPTION
## What

`ExecutorTask::Error` was a generic associated type (`VMStatus` in production) threaded
through `ExecutionStatus`, the block-level error enums, and the sequential/parallel result
types. It carried no information any caller actually used.

- The parallel path stringified the error immediately.
- The sequential path kept a `VMStatus`, but `DoGetExecutionOutput::execute_block` flattens
  it into `anyhow` via `?`. Nothing upstream inspects the status code.

## Changes

- Remove `ExecutorTask::Error`. `ExecutionStatus::Abort` now carries a `String`.
- Add `BlockError` (a message wrapper) and the `BlockExecutionResult<T, O>` alias in
  `aptos-types`, next to `BlockOutput`. Block execution returns `Result<BlockOutput, BlockError>`.
- Delete the generic `BlockExecutionError<E>`. `SequentialBlockExecutionError` is now
  non-generic.
- `VMBlockExecutor::execute_block` / `execute_block_no_limit` return `BlockError`; the
  aptos-vm wrapper no longer rebuilds a `VMStatus`.
- The VM abort is stringified once, at the source in `vm_wrapper`, using `VMStatus`'s
  `Display` so the surfaced message is unchanged.

## Behavior notes

- `discard_failed_blocks` (off by default) chose a discard status code from the error
  variant. With a flat `BlockError` it now uses a single `UNKNOWN_INVARIANT_VIOLATION_ERROR`.
- The sharded executor still threads `VMStatus` internally. It is not used in production, so
  its error path is left `unimplemented!` with a TODO rather than plumbing `BlockError`
  through the whole sharded stack.

## Testing

`cargo check` passes for the touched crates (block-executor, aptos-vm, executor,
executor-benchmark, ptx-executor, e2e-tests, e2e-move-tests, debugger, comparison-testing,
transactional-test-harness, db-tool, executor-service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core block execution and VM abort paths used in production; error typing is simpler but discard-failed-blocks and test assertions change slightly.
> 
> **Overview**
> **Block-STM / VM block execution** now reports fatal failures through a single **`BlockError`** (message string) and **`BlockExecutionResult`**, instead of threading a generic VM error type through the executor stack.
> 
> **Executor task API:** **`ExecutorTask::Error`** is removed. **`ExecutionStatus::Abort`** carries a **`String`** (production VM aborts are stringified once in **`vm_wrapper`** via **`VMStatus`**’s **`Display`**). The generic **`BlockExecutionError<E>`** is deleted; **`SequentialBlockExecutionError`** is non-generic and wraps **`BlockError`**.
> 
> **Public surfaces:** **`VMBlockExecutor::execute_block`** / **`execute_block_no_limit`** and **`AptosVMBlockExecutor`** return **`BlockExecutionResult`** / **`BlockError`** rather than **`VMStatus`**. The aptos-vm block wrapper no longer maps executor failures back into **`VMStatus`**.
> 
> **Behavior tweaks:** With **`discard_failed_blocks`**, discarded txs always use **`UNKNOWN_INVARIANT_VIOLATION_ERROR`** (previously depended on error variant). Sharded execution maps **`BlockError`** to **`unimplemented!`** with a TODO. Test harnesses (e2e, genesis) adapt assertions to message strings where status codes are no longer propagated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5228a181791333b0aa2dcb9a6d6af1d871ffb1c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->