### PR TITLE
[mono-move] Reduce and pin the stackless IR instruction size to 32 byte

### DIFF
--- a/third_party/move/mono-move/specializer/src/destack/analysis.rs
+++ b/third_party/move/mono-move/specializer/src/destack/analysis.rs
@@ -80,7 +80,10 @@
 #[cfg(debug_assertions)]
 use crate::stackless_exec_ir::instr_utils::for_each_value_use;
 use crate::stackless_exec_ir::{
-    instr_utils::{clobbers_xfer, for_each_def, for_each_use, mut_local_borrow_target},
+    instr_utils::{
+        call_boundary_rets_and_args, clobbers_xfer, for_each_def, for_each_use,
+        mut_local_borrow_target,
+    },
     Instr, Slot,
 };
 #[cfg(debug_assertions)]
@@ -389,7 +392,7 @@ impl BlockAnalysis {
         // only spills to the heap for genuinely wide signatures.
         let mut args_claim: Vec<SmallBitVec> = Vec::with_capacity(call_positions.len());
         for &call_pos in &call_positions {
-            let Some((rets, args)) = call_rets_and_args(&instrs[call_pos]) else {
+            let Some((rets, args)) = direct_call_rets_and_args(&instrs[call_pos]) else {
                 args_claim.push(SmallBitVec::new());
                 continue;
             };
@@ -413,13 +416,13 @@ impl BlockAnalysis {
         // re-insert an args-side precolor and undo the cascade).
         let mut handled_rets: UnorderedSet<Slot> = UnorderedSet::new();
         for (call_idx, &call_pos) in call_positions.iter().enumerate() {
-            let Some((rets, _)) = call_rets_and_args(&instrs[call_pos]) else {
+            let Some((rets, _)) = direct_call_rets_and_args(&instrs[call_pos]) else {
                 continue;
             };
             let next_call_opt = call_positions.get(call_idx + 1).copied();
             let next_call = next_call_opt.unwrap_or(instrs.len());
-            let next_args =
-                next_call_opt.and_then(|p| call_rets_and_args(&instrs[p]).map(|(_, a)| a));
+            let next_args = next_call_opt
+                .and_then(|pos| direct_call_rets_and_args(&instrs[pos]).map(|(_, args)| args));
             let next_args_claim = args_claim.get(call_idx + 1);
 
             let mut found_home = false;
@@ -478,7 +481,7 @@ impl BlockAnalysis {
 
         // Args walk — args fill-in.
         for (call_idx, &call_pos) in call_positions.iter().enumerate() {
-            let Some((_, args)) = call_rets_and_args(&instrs[call_pos]) else {
+            let Some((_, args)) = direct_call_rets_and_args(&instrs[call_pos]) else {
                 continue;
             };
             let claim = &args_claim[call_idx];
@@ -635,7 +638,7 @@ fn assert_xfer_invariants(
     };
 
     for (call_idx, &call_pos) in call_positions.iter().enumerate() {
-        let Some((rets, args)) = call_rets_and_args(&instrs[call_pos]) else {
+        let Some((rets, args)) = direct_call_rets_and_args(&instrs[call_pos]) else {
             continue;
         };
         let prev_call = (call_idx > 0).then(|| call_positions[call_idx - 1]);
@@ -756,7 +759,7 @@ fn assert_xfer_invariants(
     let mut by_slot: BTreeMap<Slot, Vec<Slot>> = BTreeMap::new();
     let mut seen_vids: UnorderedSet<Slot> = UnorderedSet::new();
     for &call_pos in call_positions {
-        let Some((rets, args)) = call_rets_and_args(&instrs[call_pos]) else {
+        let Some((rets, args)) = direct_call_rets_and_args(&instrs[call_pos]) else {
             continue;
         };
         for vid in rets.iter().chain(args.iter()) {
@@ -799,11 +802,12 @@ fn assert_xfer_invariants(
 /// Returns `(rets, args)` for `Call`. `CallClosure` is
 /// intentionally excluded: Xfer precoloring leaves closure calls alone
 /// (they still count as call boundaries via `clobbers_xfer`, just not
-/// destructured for slot inspection).
+/// destructured for slot inspection). For the boundary-wide counterpart
+/// covering both variants, see `instr_utils::call_boundary_rets_and_args`.
 #[inline]
-fn call_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[Slot])> {
-    if let Instr::Call(rets, _, _, args) = instr {
-        Some((rets, args))
+fn direct_call_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[Slot])> {
+    if let Instr::Call(data) = instr {
+        Some((&data.rets, &data.args))
     } else {
         None
     }
@@ -875,13 +879,7 @@ pub(crate) fn assert_xfer_invariants_on_final_ir(
             // (2) at a call boundary, every bound Xfer slot must
             // be consumed by this call's args as args[j] = Xfer(j)
             // (arg positionality).
-            if clobbers_xfer(instr) {
-                let (rets, args): (&[Slot], &[Slot]) = match instr {
-                    Instr::Call(rets, _, _, args) | Instr::CallClosure(rets, _, args) => {
-                        (rets, args)
-                    },
-                    _ => unreachable!("clobbers_xfer matches only Call variants"),
-                };
+            if let Some((rets, args)) = call_boundary_rets_and_args(instr) {
                 // Structural invariants (arg positionality, return Xfer prefix,
                 // return monotonicity).
                 check_call_structural_invariants(args, rets, |s| match s {
@@ -949,6 +947,7 @@ pub(crate) fn assert_xfer_invariants_on_final_ir(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stackless_exec_ir::CallData;
     use mono_move_core::types::EMPTY_TYPE_LIST;
     use move_binary_format::file_format::FunctionHandleIndex;
 
@@ -957,13 +956,13 @@ mod tests {
     #[test]
     fn analyze_handles_wide_call_signatures() {
         // 200 args exercises `SmallBitVec`'s heap-allocated path.
-        let args: Vec<Slot> = (0..200).map(Slot::Vid).collect();
-        let instrs = vec![Instr::Call(
-            vec![],
-            FunctionHandleIndex(0),
-            EMPTY_TYPE_LIST,
+        let args: Box<[Slot]> = (0..200).map(Slot::Vid).collect();
+        let instrs = vec![Instr::Call(Box::new(CallData {
+            rets: Box::new([]),
+            function_handle: FunctionHandleIndex(0),
+            ty_args: EMPTY_TYPE_LIST,
             args,
-        )];
+        }))];
         let analysis = BlockAnalysis::analyze(&instrs);
         assert_eq!(analysis.max_xfer_positions, 200);
     }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -8,7 +8,10 @@
 //! are mutable across blocks and keep their original slot indices.
 
 use super::ssa_function::SSAFunction;
-use crate::stackless_exec_ir::{BasicBlock, BinaryOp, CmpKind, Instr, Label, Slot, UnaryOp};
+use crate::stackless_exec_ir::{
+    BasicBlock, BinaryOp, CallClosureData, CallData, CmpKind, ImmValue, Instr, Label,
+    PackClosureData, Slot, UnaryOp,
+};
 use mono_move_core::{
     convert_mut_to_immut_ref, strip_ref,
     types::{self as ty, view_type, view_type_list, InternedType, InternedTypeList, Type},
@@ -190,12 +193,22 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             .ok_or_else(|| VMInternalError::new(SsaConversionError::StackUnderflow))
     }
 
-    fn pop_n_reverse(&mut self, n: usize) -> VMResult<Vec<Slot>> {
+    fn pop_n_reverse(&mut self, n: usize) -> VMResult<Box<[Slot]>> {
         if self.stack.len() < n {
             return Err(VMInternalError::new(SsaConversionError::StackUnderflow));
         }
         let start = self.stack.len() - n;
         Ok(self.stack.drain(start..).collect())
+    }
+
+    /// Freeze a result-slot list, push each result onto the simulated stack,
+    /// and return the frozen list for the emitted instruction's operand.
+    fn push_results(&mut self, results: Vec<Slot>) -> Box<[Slot]> {
+        let results = results.into_boxed_slice();
+        for &slot in &results {
+            self.push_slot(slot);
+        }
+        results
     }
 
     /// Returns the type of a Vid slot by looking it up in `vid_types`.
@@ -390,88 +403,32 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
     /// Converts a single stack-based bytecode into slot-based SSA instruction(s).
     ///
-    /// Each bytecode pops its operands from the simulated stack, allocates a fresh
-    /// value ID for each result, emits the corresponding slot-based instruction, and
-    /// pushes the results back. The stack is only a compile-time simulation — the
-    /// emitted IR is purely slot-based.
+    /// Each bytecode pops its operands from the simulated stack, allocates a
+    /// fresh value ID for each result, emits the corresponding slot-based
+    /// instruction, and pushes the results back. The stack is only a compile-time
+    /// simulation — the emitted IR is purely slot-based.
     fn convert_bytecode(&mut self, module: &PreparedModule, bc: &Bytecode) -> VMResult<()> {
         use Bytecode as B;
         match bc {
             // --- Loads ---
-            B::LdU8(v) => {
-                let dst = self.alloc_vid(ty::U8_TY)?;
-                self.current_block_instrs.push(Instr::LdU8(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdU16(v) => {
-                let dst = self.alloc_vid(ty::U16_TY)?;
-                self.current_block_instrs.push(Instr::LdU16(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdU32(v) => {
-                let dst = self.alloc_vid(ty::U32_TY)?;
-                self.current_block_instrs.push(Instr::LdU32(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdU64(v) => {
-                let dst = self.alloc_vid(ty::U64_TY)?;
-                self.current_block_instrs.push(Instr::LdU64(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdU128(v) => {
-                let dst = self.alloc_vid(ty::U128_TY)?;
-                self.current_block_instrs.push(Instr::LdU128(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdU256(v) => {
-                let dst = self.alloc_vid(ty::U256_TY)?;
-                self.current_block_instrs.push(Instr::LdU256(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdI8(v) => {
-                let dst = self.alloc_vid(ty::I8_TY)?;
-                self.current_block_instrs.push(Instr::LdI8(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdI16(v) => {
-                let dst = self.alloc_vid(ty::I16_TY)?;
-                self.current_block_instrs.push(Instr::LdI16(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdI32(v) => {
-                let dst = self.alloc_vid(ty::I32_TY)?;
-                self.current_block_instrs.push(Instr::LdI32(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdI64(v) => {
-                let dst = self.alloc_vid(ty::I64_TY)?;
-                self.current_block_instrs.push(Instr::LdI64(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdI128(v) => {
-                let dst = self.alloc_vid(ty::I128_TY)?;
-                self.current_block_instrs.push(Instr::LdI128(dst, *v));
-                self.push_slot(dst);
-            },
-            B::LdI256(v) => {
-                let dst = self.alloc_vid(ty::I256_TY)?;
-                self.current_block_instrs.push(Instr::LdI256(dst, *v));
-                self.push_slot(dst);
-            },
+            B::LdU8(value) => self.convert_load(ty::U8_TY, ImmValue::U8(*value))?,
+            B::LdU16(value) => self.convert_load(ty::U16_TY, ImmValue::U16(*value))?,
+            B::LdU32(value) => self.convert_load(ty::U32_TY, ImmValue::U32(*value))?,
+            B::LdU64(value) => self.convert_load(ty::U64_TY, ImmValue::U64(*value))?,
+            B::LdU128(value) => self.convert_load(ty::U128_TY, ImmValue::U128(Box::new(*value)))?,
+            B::LdU256(value) => self.convert_load(ty::U256_TY, ImmValue::U256(Box::new(*value)))?,
+            B::LdI8(value) => self.convert_load(ty::I8_TY, ImmValue::I8(*value))?,
+            B::LdI16(value) => self.convert_load(ty::I16_TY, ImmValue::I16(*value))?,
+            B::LdI32(value) => self.convert_load(ty::I32_TY, ImmValue::I32(*value))?,
+            B::LdI64(value) => self.convert_load(ty::I64_TY, ImmValue::I64(*value))?,
+            B::LdI128(value) => self.convert_load(ty::I128_TY, ImmValue::I128(Box::new(*value)))?,
+            B::LdI256(value) => self.convert_load(ty::I256_TY, ImmValue::I256(Box::new(*value)))?,
+            B::LdTrue => self.convert_load(ty::BOOL_TY, ImmValue::Bool(true))?,
+            B::LdFalse => self.convert_load(ty::BOOL_TY, ImmValue::Bool(false))?,
             B::LdConst(idx) => {
                 let ty = module.interned_constant_type_at(*idx);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs.push(Instr::LdConst(dst, *idx));
-                self.push_slot(dst);
-            },
-            B::LdTrue => {
-                let dst = self.alloc_vid(ty::BOOL_TY)?;
-                self.current_block_instrs.push(Instr::LdTrue(dst));
-                self.push_slot(dst);
-            },
-            B::LdFalse => {
-                let dst = self.alloc_vid(ty::BOOL_TY)?;
-                self.current_block_instrs.push(Instr::LdFalse(dst));
                 self.push_slot(dst);
             },
 
@@ -588,12 +545,10 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 for &fty in ftypes {
                     dsts.push(self.alloc_vid(fty)?);
                 }
+                let dsts = self.push_results(dsts);
                 let struct_ty = module.interned_nominal_def_type_at(*idx);
                 self.current_block_instrs
-                    .push(Instr::Unpack(dsts.clone(), struct_ty, src));
-                for dst in dsts {
-                    self.push_slot(dst);
-                }
+                    .push(Instr::Unpack(dsts, struct_ty, src));
             },
             B::UnpackGeneric(idx) => {
                 let src = self.pop_slot()?;
@@ -610,11 +565,9 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     let fty = self.interner.subst_type(fty, ty_args)?;
                     dsts.push(self.alloc_vid(fty)?);
                 }
+                let dsts = self.push_results(dsts);
                 self.current_block_instrs
-                    .push(Instr::Unpack(dsts.clone(), inst_ty, src));
-                for dst in dsts {
-                    self.push_slot(dst);
-                }
+                    .push(Instr::Unpack(dsts, inst_ty, src));
             },
 
             // --- Variant ops ---
@@ -656,16 +609,10 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 for &fty in ftypes {
                     dsts.push(self.alloc_vid(fty)?);
                 }
+                let dsts = self.push_results(dsts);
                 let enum_ty = module.interned_nominal_def_type_at(handle.struct_index);
-                self.current_block_instrs.push(Instr::UnpackVariant(
-                    dsts.clone(),
-                    enum_ty,
-                    variant,
-                    src,
-                ));
-                for dst in dsts {
-                    self.push_slot(dst);
-                }
+                self.current_block_instrs
+                    .push(Instr::UnpackVariant(dsts, enum_ty, variant, src));
             },
             B::UnpackVariantGeneric(idx) => {
                 let src = self.pop_slot()?;
@@ -681,15 +628,13 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     let fty = self.interner.subst_type(fty, ty_args)?;
                     dsts.push(self.alloc_vid(fty)?);
                 }
+                let dsts = self.push_results(dsts);
                 self.current_block_instrs.push(Instr::UnpackVariant(
-                    dsts.clone(),
+                    dsts,
                     inst_ty,
                     variant_ord,
                     src,
                 ));
-                for dst in dsts {
-                    self.push_slot(dst);
-                }
             },
             B::TestVariant(idx) => {
                 let src = self.pop_slot()?;
@@ -919,15 +864,14 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 for &rty in ret_types {
                     rets.push(self.alloc_vid(rty)?);
                 }
-                self.current_block_instrs.push(Instr::Call(
-                    rets.clone(),
-                    *idx,
-                    ty::EMPTY_TYPE_LIST,
-                    args,
-                ));
-                for r in rets {
-                    self.push_slot(r);
-                }
+                let rets = self.push_results(rets);
+                self.current_block_instrs
+                    .push(Instr::Call(Box::new(CallData {
+                        rets,
+                        function_handle: *idx,
+                        ty_args: ty::EMPTY_TYPE_LIST,
+                        args,
+                    })));
             },
             B::CallGeneric(idx) => {
                 let (handle_idx, ty_args) = self.fun_inst_parts(module, *idx);
@@ -941,15 +885,14 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     let rty = self.interner.subst_type(rty, ty_args)?;
                     rets.push(self.alloc_vid(rty)?);
                 }
-                self.current_block_instrs.push(Instr::Call(
-                    rets.clone(),
-                    handle_idx,
-                    ty_args,
-                    args,
-                ));
-                for r in rets {
-                    self.push_slot(r);
-                }
+                let rets = self.push_results(rets);
+                self.current_block_instrs
+                    .push(Instr::Call(Box::new(CallData {
+                        rets,
+                        function_handle: handle_idx,
+                        ty_args,
+                        args,
+                    })));
             },
 
             // --- Closures ---
@@ -969,13 +912,14 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     move_core_types::ability::AbilitySet::EMPTY,
                 );
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs.push(Instr::PackClosure(
-                    dst,
-                    *fhi,
-                    ty::EMPTY_TYPE_LIST,
-                    *mask,
-                    captured,
-                ));
+                self.current_block_instrs
+                    .push(Instr::PackClosure(Box::new(PackClosureData {
+                        dst,
+                        function_handle: *fhi,
+                        ty_args: ty::EMPTY_TYPE_LIST,
+                        mask: *mask,
+                        captured,
+                    })));
                 self.push_slot(dst);
             },
             B::PackClosureGeneric(fii, mask) => {
@@ -998,44 +942,43 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     move_core_types::ability::AbilitySet::EMPTY,
                 );
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs.push(Instr::PackClosure(
-                    dst, handle_idx, ty_args, *mask, captured,
-                ));
+                self.current_block_instrs
+                    .push(Instr::PackClosure(Box::new(PackClosureData {
+                        dst,
+                        function_handle: handle_idx,
+                        ty_args,
+                        mask: *mask,
+                        captured,
+                    })));
                 self.push_slot(dst);
             },
             B::CallClosure(sig_idx) => {
-                let sig_types = module.interned_types_at(*sig_idx);
-                let first = sig_types
+                // The bytecode verifier pins the instruction's signature to a
+                // single element: the closure's function type.
+                let closure_ty = module
+                    .interned_types_at(*sig_idx)
                     .first()
                     .copied()
                     .ok_or(SsaConversionError::ClosureSignatureEmpty)?;
-                let (num_args, ret_types) =
-                    if let Type::Function { args, results, .. } = view_type(first) {
-                        (
-                            view_type_list(*args).len(),
-                            view_type_list(*results).to_vec(),
-                        )
-                    } else {
-                        return Err(VMInternalError::new(
-                            SsaConversionError::ClosureSignatureNotFunction,
-                        ));
-                    };
-                let closure = self.pop_slot()?;
-                let mut all_args = self.pop_n_reverse(num_args)?;
-                all_args.push(closure);
+                let Type::Function { args, results, .. } = view_type(closure_ty) else {
+                    return Err(VMInternalError::new(
+                        SsaConversionError::ClosureSignatureNotFunction,
+                    ));
+                };
+                let num_args = view_type_list(*args).len();
+                let ret_types = view_type_list(*results);
+                // The closure sits on top of its arguments, so it lands last —
+                // as `CallClosureData::args` requires.
+                let all_args = self.pop_n_reverse(num_args + 1)?;
                 let mut rets = Vec::with_capacity(ret_types.len());
-                for rty in &ret_types {
-                    rets.push(self.alloc_vid(*rty)?);
+                for &rty in ret_types {
+                    rets.push(self.alloc_vid(rty)?);
                 }
-                let signature_types = self.interner.type_list_of(sig_types);
-                self.current_block_instrs.push(Instr::CallClosure(
-                    rets.clone(),
-                    signature_types,
-                    all_args,
-                ));
-                for r in rets {
-                    self.push_slot(r);
-                }
+                let rets = self.push_results(rets);
+                self.current_block_instrs
+                    .push(Instr::CallClosure(Box::new(CallClosureData::new(
+                        rets, closure_ty, all_args,
+                    ))));
             },
 
             // --- Vector ops ---
@@ -1102,11 +1045,9 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 for _ in 0..count {
                     dsts.push(self.alloc_vid(elem_ty)?);
                 }
+                let dsts = self.push_results(dsts);
                 self.current_block_instrs
-                    .push(Instr::VecUnpack(dsts.clone(), elem_ty, src));
-                for dst in dsts {
-                    self.push_slot(dst);
-                }
+                    .push(Instr::VecUnpack(dsts, elem_ty, src));
             },
             B::VecSwap(sig_idx) => {
                 let j = self.pop_slot()?;
@@ -1133,7 +1074,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 self.current_block_instrs.push(Instr::BrFalse(label, cond));
             },
             B::Ret => {
-                let rets: Vec<Slot> = self.stack.drain(..).collect();
+                let rets: Box<[Slot]> = self.stack.drain(..).collect();
                 self.current_block_instrs.push(Instr::Ret(rets));
             },
             B::Abort => {
@@ -1148,6 +1089,13 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
             B::Nop => {},
         }
+        Ok(())
+    }
+
+    fn convert_load(&mut self, result_ty: InternedType, imm: ImmValue) -> VMResult<()> {
+        let dst = self.alloc_vid(result_ty)?;
+        self.current_block_instrs.push(Instr::LdImm(dst, imm));
+        self.push_slot(dst);
         Ok(())
     }
 

--- a/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
@@ -9,7 +9,7 @@
 //! once within its block and never crosses a block boundary.
 
 use crate::stackless_exec_ir::{
-    instr_utils::{extract_imm_value, for_each_value_use, is_commutative},
+    instr_utils::{for_each_value_use, is_commutative},
     BasicBlock, BinaryOp, FieldPath, Instr, Slot,
 };
 use mono_move_core::types::InternedType;
@@ -323,12 +323,9 @@ fn try_build_chain(
         Instr::MutBorrowLoc(..) | Instr::MutBorrowField(..)
     );
     let (root, mut cur_ref, mut idx, mut path) = match &instrs[start] {
-        Instr::ImmBorrowLoc(produced, local) | Instr::MutBorrowLoc(produced, local) => (
-            ChainRoot::Local(*local),
-            *produced,
-            start + 1,
-            FieldPath::new(),
-        ),
+        Instr::ImmBorrowLoc(produced, local) | Instr::MutBorrowLoc(produced, local) => {
+            (ChainRoot::Local(*local), *produced, start + 1, Vec::new())
+        },
         Instr::ImmBorrowField(produced, owner, fh, src)
         | Instr::MutBorrowField(produced, owner, fh, src) => {
             (ChainRoot::Ref(*src), *produced, start + 1, vec![(
@@ -397,7 +394,7 @@ fn try_build_chain(
     };
 
     Some(FusedChain {
-        instr: build_chain_instr(root, is_mut, path, terminal),
+        instr: build_chain_instr(root, is_mut, path.into(), terminal),
         place_at,
         borrow_end,
     })
@@ -428,15 +425,16 @@ fn build_chain_instr(
     }
 }
 
-/// Try to fuse a `Ld*` + `BinaryOp` pair into a `BinaryOpImm` instruction.
+/// Try to fuse a `LdImm` + `BinaryOp` pair into a `BinaryOpImm` instruction.
 fn try_fuse_immediate_binop(first: &Instr, second: &Instr) -> Option<Instr> {
-    let (tmp, imm) = extract_imm_value(first)?;
-    match second {
-        Instr::BinaryOp(dst, op, lhs, rhs) if *rhs == tmp => {
-            Some(Instr::BinaryOpImm(*dst, *op, *lhs, imm))
+    match (first, second) {
+        (Instr::LdImm(tmp, imm), Instr::BinaryOp(dst, op, lhs, rhs)) if *tmp == *rhs => {
+            Some(Instr::BinaryOpImm(*dst, *op, *lhs, imm.clone()))
         },
-        Instr::BinaryOp(dst, op, lhs, rhs) if *lhs == tmp && is_commutative(op) => {
-            Some(Instr::BinaryOpImm(*dst, *op, *rhs, imm))
+        (Instr::LdImm(tmp, imm), Instr::BinaryOp(dst, op, lhs, rhs))
+            if *tmp == *lhs && is_commutative(op) =>
+        {
+            Some(Instr::BinaryOpImm(*dst, *op, *rhs, imm.clone()))
         },
         _ => None,
     }

--- a/third_party/move/mono-move/specializer/src/destack/test_utils.rs
+++ b/third_party/move/mono-move/specializer/src/destack/test_utils.rs
@@ -37,10 +37,10 @@ impl SSAFunction {
     pub(crate) fn with_test_utils_passes(mut self, module: &PreparedModule) -> VMResult<Self> {
         for block in &mut self.blocks {
             for instr in &mut block.instrs {
-                if let Instr::Call(rets, handle, _, args) = instr
-                    && is_force_gc(module, *handle)
+                if let Instr::Call(data) = instr
+                    && is_force_gc(module, data.function_handle)
                 {
-                    if !rets.is_empty() || !args.is_empty() {
+                    if !data.rets.is_empty() || !data.args.is_empty() {
                         return Err(VMInternalError::new(ForceGcBadSignature));
                     }
                     *instr = Instr::ForceGC;

--- a/third_party/move/mono-move/specializer/src/gas.rs
+++ b/third_party/move/mono-move/specializer/src/gas.rs
@@ -25,7 +25,10 @@
 
 use crate::{
     lower::context::concrete_type_size,
-    stackless_exec_ir::{instr_utils::for_each_value_use, BasicBlock, Instr, ModuleIR, Slot},
+    stackless_exec_ir::{
+        instr_utils::{clobbers_xfer, for_each_value_use},
+        BasicBlock, Instr, ModuleIR, Slot,
+    },
 };
 use mono_move_core::{
     types::{strip_ref, view_type, view_type_list, InternedType, InternedTypeList, Type},
@@ -65,9 +68,6 @@ enum GasInstrumentationError {
     #[error("call return {ret_idx} has no matching signature type")]
     CallReturnNoSignatureType { ret_idx: usize },
 
-    #[error("CallClosure signature is empty")]
-    ClosureSignatureEmpty,
-
     #[error("CallClosure signature must start with a Function type")]
     ClosureSignatureNotFunction,
 }
@@ -85,7 +85,6 @@ impl IntoExecutionError for GasInstrumentationError {
             | EnumDefinitionNotFound
             | NotAnEnum
             | CallReturnNoSignatureType { .. }
-            | ClosureSignatureEmpty
             | ClosureSignatureNotFunction => ExecutionErrorKind::InvariantViolation,
         }
     }
@@ -295,7 +294,7 @@ impl<I: Interner> Emitter<'_, I> {
     /// After costing `instr`, drop the Xfer slots it consumed. Calls manage
     /// their own return bindings in [`Self::call_cost`].
     fn advance_xfer_tracking(&mut self, instr: &Instr) {
-        if matches!(instr, Instr::Call(..) | Instr::CallClosure(..)) {
+        if clobbers_xfer(instr) {
             return;
         }
         for_each_value_use(instr, |s| {
@@ -309,21 +308,7 @@ impl<I: Interner> Emitter<'_, I> {
     fn instr_cost(&mut self, b: &mut BlockCost, instr: &Instr) -> VMResult<()> {
         match instr {
             // --- Loads ---
-            Instr::LdConst(..)
-            | Instr::LdTrue(..)
-            | Instr::LdFalse(..)
-            | Instr::LdU8(..)
-            | Instr::LdU16(..)
-            | Instr::LdU32(..)
-            | Instr::LdU64(..)
-            | Instr::LdU128(..)
-            | Instr::LdU256(..)
-            | Instr::LdI8(..)
-            | Instr::LdI16(..)
-            | Instr::LdI32(..)
-            | Instr::LdI64(..)
-            | Instr::LdI128(..)
-            | Instr::LdI256(..) => b.add_constant(LD),
+            Instr::LdConst(..) | Instr::LdImm(..) => b.add_constant(LD),
 
             // --- Slot ops ---
             Instr::Copy(_, src) | Instr::Move(_, src) => {
@@ -410,25 +395,25 @@ impl<I: Interner> Emitter<'_, I> {
             | Instr::MutBorrowGlobal(..) => b.add_constant(GLOBAL),
 
             // --- Calls ---
-            Instr::Call(rets, handle, ty_args, _args) => {
-                let sig = self.module.function_signature_at(*handle);
-                let params = self.interner.subst_type_list(sig.params, *ty_args)?;
-                let returns = self.interner.subst_type_list(sig.returns, *ty_args)?;
-                self.call_cost(b, params, rets, returns)?;
+            Instr::Call(data) => {
+                let sig = self.module.function_signature_at(data.function_handle);
+                let params = self.interner.subst_type_list(sig.params, data.ty_args)?;
+                let returns = self.interner.subst_type_list(sig.returns, data.ty_args)?;
+                self.call_cost(b, params, &data.rets, returns)?;
             },
 
             // --- Closures ---
-            Instr::PackClosure(_, _, _, _, args) => {
+            Instr::PackClosure(data) => {
                 b.add_constant(PACK_CLOSURE);
-                for arg in args {
+                for arg in &data.captured {
                     b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*arg)?);
                 }
             },
-            Instr::CallClosure(rets, sig_types, _args) => {
-                let (closure_ty, params, returns) = closure_signature(*sig_types)?;
-                self.call_cost(b, params, rets, returns)?;
+            Instr::CallClosure(data) => {
+                let (params, returns) = closure_signature(data.closure_ty)?;
+                self.call_cost(b, params, &data.rets, returns)?;
                 // The closure value is passed as the last operand; charge its move.
-                b.add_sized(MOVE_BASE, MOVE_PER_BYTE, closure_ty);
+                b.add_sized(MOVE_BASE, MOVE_PER_BYTE, data.closure_ty);
             },
 
             // --- Vector ---
@@ -526,17 +511,10 @@ impl<I: Interner> Emitter<'_, I> {
     }
 }
 
-/// The closure's function type and its `(param types, result types)`, from the
-/// leading `Function` type of a `CallClosure` signature.
-fn closure_signature(
-    sig_types: InternedTypeList,
-) -> VMResult<(InternedType, InternedTypeList, InternedTypeList)> {
-    let closure_ty = view_type_list(sig_types)
-        .first()
-        .copied()
-        .ok_or(GasInstrumentationError::ClosureSignatureEmpty)?;
+/// The `(param types, result types)` of a closure's `Function` type.
+fn closure_signature(closure_ty: InternedType) -> VMResult<(InternedTypeList, InternedTypeList)> {
     match view_type(closure_ty) {
-        Type::Function { args, results, .. } => Ok((closure_ty, *args, *results)),
+        Type::Function { args, results, .. } => Ok((*args, *results)),
         _ => Err(VMInternalError::new(
             GasInstrumentationError::ClosureSignatureNotFunction,
         )),

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -613,31 +613,31 @@ pub fn try_build_context<'a>(
     let mut closure_pack_idx = 0usize;
     for instr in func_ir.instrs() {
         let (handle_idx, param_list, ret_list, call_ty_args) = match instr {
-            Instr::Call(_, handle_idx, call_ty_args, _) => {
-                let resolved_ty_args = interner.subst_type_list(*call_ty_args, ty_args)?;
+            Instr::Call(data) => {
+                let resolved_ty_args = interner.subst_type_list(data.ty_args, ty_args)?;
                 let (params, returns) = instantiate_callee_signature(
                     &module_ir.module,
                     interner,
-                    *handle_idx,
+                    data.function_handle,
                     resolved_ty_args,
                 )?;
-                (*handle_idx, params, returns, resolved_ty_args)
+                (data.function_handle, params, returns, resolved_ty_args)
             },
-            Instr::PackClosure(_, handle_idx, call_ty_args, _, _) => {
-                let closure_ty_args = interner.subst_type_list(*call_ty_args, ty_args)?;
+            Instr::PackClosure(data) => {
+                let closure_ty_args = interner.subst_type_list(data.ty_args, ty_args)?;
                 // Bytecode verifier's instruction consistency check should
                 // guarantee the invariant below.
                 debug_assert!(
-                    !call_ty_args.is_empty()
+                    !data.ty_args.is_empty()
                         || module_ir
                             .module
-                            .function_handle_at(*handle_idx)
+                            .function_handle_at(data.function_handle)
                             .type_parameters
                             .is_empty(),
                     "non-generic PackClosure must target a non-generic function"
                 );
                 let (callee_module_id, callee_func_name) =
-                    callee_identity(&module_ir.module, *handle_idx);
+                    callee_identity(&module_ir.module, data.function_handle);
                 // TODO(completeness): support native closure targets. `CallClosure` resolves
                 // via `load_function`, which has no IR for natives, so skip them.
                 if natives
@@ -670,12 +670,8 @@ pub fn try_build_context<'a>(
                 });
                 continue;
             },
-            Instr::CallClosure(_, sig_types, _) => {
-                let first = view_type_list(*sig_types)
-                    .first()
-                    .copied()
-                    .ok_or(LoweringError::ClosureSignatureEmpty)?;
-                let Type::Function { results, .. } = view_type(first) else {
+            Instr::CallClosure(data) => {
+                let Type::Function { results, .. } = view_type(data.closure_ty) else {
                     return Err(VMInternalError::new(
                         LoweringError::ClosureSignatureNotFunction,
                     ));
@@ -1098,18 +1094,18 @@ fn try_discover_types_for_lowering_in_function_impl(
         // still discovered. Otherwise, we need to feed `CallClosure` signature
         // types here and recurse into `Type::Function`.
         let (params, returns, handle_idx, callee_ty_args) = match instr {
-            Instr::Call(_, handle_idx, call_ty_args, _) => {
+            Instr::Call(data) => {
                 let (params, returns) = instantiate_callee_signature(
                     &module_ir.module,
                     interner,
-                    *handle_idx,
-                    *call_ty_args,
+                    data.function_handle,
+                    data.ty_args,
                 )?;
                 (
                     Some(params),
                     Some(returns),
-                    Some(*handle_idx),
-                    *call_ty_args,
+                    Some(data.function_handle),
+                    data.ty_args,
                 )
             },
             _ => (None, None, None, EMPTY_TYPE_LIST),
@@ -1159,14 +1155,14 @@ fn try_discover_types_for_lowering_in_function_impl(
 
         // `PackClosure`: resolve the captured-data layout and record it
         // positionally, in IR order, for the build pass.
-        if let Instr::PackClosure(_, handle_idx, call_ty_args, mask, _) = instr {
-            let closure_ty_args = interner.subst_type_list(*call_ty_args, ty_args)?;
+        if let Instr::PackClosure(data) = instr {
+            let closure_ty_args = interner.subst_type_list(data.ty_args, ty_args)?;
             let layout = discover_captured_data_descriptor(
                 ctx,
                 interner,
                 module_ir,
-                *handle_idx,
-                *mask,
+                data.function_handle,
+                data.mask,
                 closure_ty_args,
             )?;
             descriptors.closure_captured.push(layout);

--- a/third_party/move/mono-move/specializer/src/lower/mod.rs
+++ b/third_party/move/mono-move/specializer/src/lower/mod.rs
@@ -23,9 +23,6 @@ enum LoweringError {
     #[error("expected a reference type")]
     ExpectedReferenceType,
 
-    #[error("CallClosure signature is empty")]
-    ClosureSignatureEmpty,
-
     #[error("CallClosure signature must start with a Function type")]
     ClosureSignatureNotFunction,
 
@@ -159,9 +156,6 @@ enum LoweringError {
     #[error("{op}: neither reverse nor forward emit is overlap-safe")]
     NotOverlapSafe { op: &'static str },
 
-    #[error("CallClosure has no closure operand")]
-    CallClosureNoOperand,
-
     // ---- global storage ----
     #[error("{op}: box-pointer slot not reserved")]
     BoxPtrSlotNotReserved { op: &'static str },
@@ -196,7 +190,6 @@ impl IntoExecutionError for LoweringError {
         match self {
             NativeAbi(e) => e.kind(),
             ExpectedReferenceType
-            | ClosureSignatureEmpty
             | ClosureSignatureNotFunction
             | VidInPostAllocationIr
             | ScratchSlotRequiredForParallelCopy
@@ -234,7 +227,6 @@ impl IntoExecutionError for LoweringError {
             | ComparisonNoLowering
             | FieldCountMismatch { .. }
             | NotOverlapSafe { .. }
-            | CallClosureNoOperand
             | BoxPtrSlotNotReserved { .. }
             | ResourceTypeNoDescriptor { .. }
             | VectorTypeNoDescriptor { .. }

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -690,111 +690,12 @@ impl<'a> LoweringState<'a> {
     fn lower_instr(&mut self, func_ir: &FunctionIR, instr: &Instr) -> VMResult<()> {
         match instr {
             // --- Loads ---
-            Instr::LdU64(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm8 {
-                    dst: dst_info.offset,
-                    imm: v.to_le_bytes(),
-                })?;
-            },
-            Instr::LdTrue(dst) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm1 {
-                    dst: dst_info.offset,
-                    imm: 1,
-                })?;
-            },
-            Instr::LdFalse(dst) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm1 {
-                    dst: dst_info.offset,
-                    imm: 0,
-                })?;
-            },
             // TODO(correctness): audit every integer-width use across the
             // specializer and confirm each is the correct width (slot sizes,
             // immediate widths, sign extension).
-            // 1-byte integers store directly into their 1-byte slot.
-            Instr::LdU8(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm1 {
-                    dst: dst_info.offset,
-                    imm: *v,
-                })?;
-            },
-            // 2-/4-byte integers store directly into their 2-/4-byte slot.
-            Instr::LdU16(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm2 {
-                    dst: dst_info.offset,
-                    imm: v.to_le_bytes(),
-                })?;
-            },
-            Instr::LdU32(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm4 {
-                    dst: dst_info.offset,
-                    imm: v.to_le_bytes(),
-                })?;
-            },
-            // 1-byte integers store directly into their 1-byte slot.
-            Instr::LdI8(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm1 {
-                    dst: dst_info.offset,
-                    imm: *v as u8,
-                })?;
-            },
-            // 2-/4-byte signed integers store their two's-complement LE bytes
-            // directly into their 2-/4-byte slot.
-            Instr::LdI16(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm2 {
-                    dst: dst_info.offset,
-                    imm: v.to_le_bytes(),
-                })?;
-            },
-            Instr::LdI32(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm4 {
-                    dst: dst_info.offset,
-                    imm: v.to_le_bytes(),
-                })?;
-            },
-            Instr::LdI64(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm8 {
-                    dst: dst_info.offset,
-                    imm: v.to_le_bytes(),
-                })?;
-            },
-            Instr::LdU128(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm16 {
-                    dst: dst_info.offset,
-                    imm: Box::new(v.to_le_bytes()),
-                })?;
-            },
-            Instr::LdI128(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm16 {
-                    dst: dst_info.offset,
-                    imm: Box::new(v.to_le_bytes()),
-                })?;
-            },
-            Instr::LdU256(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm32 {
-                    dst: dst_info.offset,
-                    imm: Box::new(v.to_le_bytes()),
-                })?;
-            },
-            Instr::LdI256(dst, v) => {
-                let dst_info = self.def_slot(*dst)?;
-                self.emit(MicroOp::StoreImm32 {
-                    dst: dst_info.offset,
-                    imm: Box::new(v.to_le_bytes()),
-                })?;
+            Instr::LdImm(dst, imm) => {
+                let dst_off = self.def_slot(*dst)?.offset;
+                self.emit(store_imm_op(dst_off, imm))?;
             },
             Instr::LdConst(dst, idx) => {
                 let ty = view_type(self.ctx.module.interned_constant_type_at(*idx));
@@ -1416,8 +1317,8 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Calls ---
-            Instr::Call(rets, _handle_idx, _ty_args, args) => {
-                self.lower_call(func_ir, args, rets)?;
+            Instr::Call(data) => {
+                self.lower_call(func_ir, &data.args, &data.rets)?;
             },
 
             // --- Return ---
@@ -1748,40 +1649,36 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Closures ---
-            Instr::PackClosure(dst, _, _, mask, captured) => {
+            Instr::PackClosure(data) => {
                 // Target identity (with composed type arguments for the
                 // generic form) + captured-data descriptor were resolved in
                 // `try_build_context`; read them positionally.
                 let info = &self.ctx.closure_pack_sites[self.closure_pack_cursor];
                 self.closure_pack_cursor += 1;
-                let dst_off = self.def_slot(*dst)?.offset;
+                let dst_off = self.def_slot(data.dst)?.offset;
                 // Captured sources, in ascending captured-param order (the
                 // destacker already ordered the IR `captured` list this way).
-                let captured_slots = self.slots_to_sized_slots(captured)?;
+                let captured_slots = self.slots_to_sized_slots(&data.captured)?;
                 self.emit(MicroOp::PackClosure(Box::new(PackClosureOp {
                     dst: dst_off,
                     func_ref: ClosureFuncRef::Unresolved(info.func_ref),
-                    mask: mask.bits(),
+                    mask: data.mask.bits(),
                     captured_data_descriptor_id: info.captured_data_descriptor_id,
                     values_size: info.values_size,
                     captured: captured_slots,
                 })))?;
             },
-            Instr::CallClosure(rets, _sig_types, all_args) => {
+            Instr::CallClosure(data) => {
                 let ret_slots = &self.ctx.closure_call_sites[self.closure_call_cursor];
                 self.closure_call_cursor += 1;
-                // The destacker pushes the closure as the last operand;
-                // everything before it is a provided (non-captured) argument.
-                let Some((closure_slot, provided)) = all_args.split_last() else {
-                    return Err(VMInternalError::new(LoweringError::CallClosureNoOperand));
-                };
-                let closure_src = self.slot(*closure_slot)?.offset;
+                let (closure_slot, provided) = data.closure_and_provided();
+                let closure_src = self.slot(closure_slot)?.offset;
                 let provided_args = self.slots_to_sized_slots(provided)?;
                 self.emit(MicroOp::CallClosure(Box::new(CallClosureOp {
                     closure_src,
                     provided_args,
                 })))?;
-                self.bind_call_returns(rets, ret_slots)?;
+                self.bind_call_returns(&data.rets, ret_slots)?;
             },
 
             // --- Global storage ---
@@ -2589,8 +2486,65 @@ fn cmp_operand_from_imm(imm: &ImmValue) -> VMResult<IntOperand> {
     }
 }
 
+/// Build the `StoreImm*` micro-op storing `imm` at frame offset `dst`.
+/// Values store their two's-complement LE bytes directly into the slot of
+/// their width.
+fn store_imm_op(dst: FrameOffset, imm: &ImmValue) -> MicroOp {
+    match imm {
+        ImmValue::Bool(value) => MicroOp::StoreImm1 {
+            dst,
+            imm: *value as u8,
+        },
+        ImmValue::U8(value) => MicroOp::StoreImm1 { dst, imm: *value },
+        ImmValue::I8(value) => MicroOp::StoreImm1 {
+            dst,
+            imm: *value as u8,
+        },
+        ImmValue::U16(value) => MicroOp::StoreImm2 {
+            dst,
+            imm: value.to_le_bytes(),
+        },
+        ImmValue::I16(value) => MicroOp::StoreImm2 {
+            dst,
+            imm: value.to_le_bytes(),
+        },
+        ImmValue::U32(value) => MicroOp::StoreImm4 {
+            dst,
+            imm: value.to_le_bytes(),
+        },
+        ImmValue::I32(value) => MicroOp::StoreImm4 {
+            dst,
+            imm: value.to_le_bytes(),
+        },
+        ImmValue::U64(value) => MicroOp::StoreImm8 {
+            dst,
+            imm: value.to_le_bytes(),
+        },
+        ImmValue::I64(value) => MicroOp::StoreImm8 {
+            dst,
+            imm: value.to_le_bytes(),
+        },
+        ImmValue::U128(value) => MicroOp::StoreImm16 {
+            dst,
+            imm: Box::new(value.to_le_bytes()),
+        },
+        ImmValue::I128(value) => MicroOp::StoreImm16 {
+            dst,
+            imm: Box::new(value.to_le_bytes()),
+        },
+        ImmValue::U256(value) => MicroOp::StoreImm32 {
+            dst,
+            imm: Box::new(value.to_le_bytes()),
+        },
+        ImmValue::I256(value) => MicroOp::StoreImm32 {
+            dst,
+            imm: Box::new(value.to_le_bytes()),
+        },
+    }
+}
+
 /// Build an [`IntOperand`] imm arm matching `imm`. The destacker emits an
-/// `ImmValue` variant whose type matches the typed slot's `Ld*` source,
+/// `ImmValue` variant whose type matches the typed slot's `LdImm` source,
 /// so a 1:1 map is enough here.
 fn int_operand_from_imm(imm: &ImmValue) -> VMResult<IntOperand> {
     Ok(match imm {

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -193,61 +193,9 @@ fn display_instr(
             write_dst(f, *d)?;
             write!(f, "ld_const #{}", idx.0)
         },
-        Instr::LdTrue(d) => {
+        Instr::LdImm(d, imm) => {
             write_dst(f, *d)?;
-            write!(f, "ld_true")
-        },
-        Instr::LdFalse(d) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_false")
-        },
-        Instr::LdU8(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_u8 {}", v)
-        },
-        Instr::LdU16(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_u16 {}", v)
-        },
-        Instr::LdU32(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_u32 {}", v)
-        },
-        Instr::LdU64(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_u64 {}", v)
-        },
-        Instr::LdU128(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_u128 {}", v)
-        },
-        Instr::LdU256(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_u256 {}", v)
-        },
-        Instr::LdI8(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_i8 {}", v)
-        },
-        Instr::LdI16(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_i16 {}", v)
-        },
-        Instr::LdI32(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_i32 {}", v)
-        },
-        Instr::LdI64(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_i64 {}", v)
-        },
-        Instr::LdI128(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_i128 {}", v)
-        },
-        Instr::LdI256(d, v) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_i256 {}", v)
+            write_load_imm(f, imm)
         },
 
         // --- Slot ops: dst := copy/move src ---
@@ -558,27 +506,31 @@ fn display_instr(
         },
 
         // --- Calls ---
-        Instr::Call(rets, idx, ty_args, args) => {
-            write_dsts(f, rets)?;
-            write!(f, "call {}", func_name(module, *idx))?;
-            write_ty_args(f, *ty_args)?;
-            write!(f, ", {}", slot_names(args))
+        Instr::Call(data) => {
+            write_dsts(f, &data.rets)?;
+            write!(f, "call {}", func_name(module, data.function_handle))?;
+            write_ty_args(f, data.ty_args)?;
+            write!(f, ", {}", slot_names(&data.args))
         },
 
         // --- Closures ---
-        Instr::PackClosure(d, idx, ty_args, mask, captured) => {
-            write_dst(f, *d)?;
-            write!(f, "pack_closure {}", func_name(module, *idx))?;
-            write_ty_args(f, *ty_args)?;
-            write!(f, ", {}, {}", mask, slot_names(captured))
+        Instr::PackClosure(data) => {
+            write_dst(f, data.dst)?;
+            write!(
+                f,
+                "pack_closure {}",
+                func_name(module, data.function_handle)
+            )?;
+            write_ty_args(f, data.ty_args)?;
+            write!(f, ", {}, {}", data.mask, slot_names(&data.captured))
         },
-        Instr::CallClosure(rets, sig_types, args) => {
-            write_dsts(f, rets)?;
+        Instr::CallClosure(data) => {
+            write_dsts(f, &data.rets)?;
             write!(f, "call_closure ")?;
             write!(f, "[")?;
-            display_type_list(f, *sig_types)?;
+            display_type(f, data.closure_ty)?;
             write!(f, "]")?;
-            write!(f, ", {}", slot_names(args))
+            write!(f, ", {}", slot_names(&data.args))
         },
 
         // --- Vector ---
@@ -699,6 +651,26 @@ fn cmp_op_name(op: &CmpKind) -> &'static str {
         CmpKind::Ge => "ge",
         CmpKind::Eq => "eq",
         CmpKind::Neq => "neq",
+    }
+}
+
+/// Load mnemonic for an immediate: `ld_true`, `ld_false`, or `ld_<width> <value>`.
+fn write_load_imm(f: &mut fmt::Formatter<'_>, imm: &ImmValue) -> fmt::Result {
+    match imm {
+        ImmValue::Bool(true) => write!(f, "ld_true"),
+        ImmValue::Bool(false) => write!(f, "ld_false"),
+        ImmValue::U8(value) => write!(f, "ld_u8 {}", value),
+        ImmValue::U16(value) => write!(f, "ld_u16 {}", value),
+        ImmValue::U32(value) => write!(f, "ld_u32 {}", value),
+        ImmValue::U64(value) => write!(f, "ld_u64 {}", value),
+        ImmValue::U128(value) => write!(f, "ld_u128 {}", value),
+        ImmValue::U256(value) => write!(f, "ld_u256 {}", value),
+        ImmValue::I8(value) => write!(f, "ld_i8 {}", value),
+        ImmValue::I16(value) => write!(f, "ld_i16 {}", value),
+        ImmValue::I32(value) => write!(f, "ld_i32 {}", value),
+        ImmValue::I64(value) => write!(f, "ld_i64 {}", value),
+        ImmValue::I128(value) => write!(f, "ld_i128 {}", value),
+        ImmValue::I256(value) => write!(f, "ld_i256 {}", value),
     }
 }
 

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
@@ -6,7 +6,7 @@
 //! Provides read-only slot visitors (`for_each_def`, `for_each_use`,
 //! `for_each_slot`, `collect_defs_and_uses`), in-place slot rewriters
 //! (`remap_all_slots_with`, `remap_source_slots_with`), and miscellaneous
-//! instruction helpers (`extract_imm_value`, `is_commutative`).
+//! instruction helpers (`call_boundary_rets_and_args`, `is_commutative`).
 //!
 //! # Architecture
 //!
@@ -30,7 +30,7 @@
 //!   caller-provided closures (`impl FnMut`) are monomorphized and inlined
 //!   at each call site.
 
-use super::{BinaryOp, FieldPath, ImmValue, Instr, Slot};
+use super::{BinaryOp, FieldPath, Instr, Slot};
 use mono_move_core::types::InternedType;
 use smallvec::SmallVec;
 
@@ -117,10 +117,81 @@ pub(crate) fn remap_source_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> 
 // Other instruction utilities
 // =============================================================================
 
+/// `(rets, args)` of a call-boundary instruction (`Call`, `CallClosure`),
+/// `None` for everything else.
+#[inline]
+pub(crate) fn call_boundary_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[Slot])> {
+    match instr {
+        Instr::Call(data) => Some((&data.rets, &data.args)),
+        Instr::CallClosure(data) => Some((&data.rets, &data.args)),
+
+        // Every other instruction: not a call boundary.
+        Instr::LdConst(..)
+        | Instr::LdImm(..)
+        | Instr::Copy(..)
+        | Instr::Move(..)
+        | Instr::UnaryOp(..)
+        | Instr::BinaryOp(..)
+        | Instr::BinaryOpImm(..)
+        | Instr::Pack(..)
+        | Instr::Unpack(..)
+        | Instr::PackVariant(..)
+        | Instr::UnpackVariant(..)
+        | Instr::TestVariant(..)
+        | Instr::ImmBorrowLoc(..)
+        | Instr::MutBorrowLoc(..)
+        | Instr::ImmBorrowField(..)
+        | Instr::MutBorrowField(..)
+        | Instr::ImmBorrowVariantField(..)
+        | Instr::MutBorrowVariantField(..)
+        | Instr::ReadRef(..)
+        | Instr::WriteRef(..)
+        | Instr::ReadField(..)
+        | Instr::WriteField(..)
+        | Instr::ReadVariantField(..)
+        | Instr::WriteVariantField(..)
+        | Instr::ImmBorrowLocField(..)
+        | Instr::MutBorrowLocField(..)
+        | Instr::ReadLocalField(..)
+        | Instr::WriteLocalField(..)
+        | Instr::ReadFieldChain(..)
+        | Instr::WriteFieldChain(..)
+        | Instr::ImmBorrowFieldChain(..)
+        | Instr::MutBorrowFieldChain(..)
+        | Instr::ReadLocalFieldChain(..)
+        | Instr::WriteLocalFieldChain(..)
+        | Instr::ImmBorrowLocalFieldChain(..)
+        | Instr::MutBorrowLocalFieldChain(..)
+        | Instr::Exists(..)
+        | Instr::MoveFrom(..)
+        | Instr::MoveTo(..)
+        | Instr::ImmBorrowGlobal(..)
+        | Instr::MutBorrowGlobal(..)
+        | Instr::PackClosure(..)
+        | Instr::VecPack(..)
+        | Instr::VecLen(..)
+        | Instr::VecImmBorrow(..)
+        | Instr::VecMutBorrow(..)
+        | Instr::VecPushBack(..)
+        | Instr::VecPopBack(..)
+        | Instr::VecUnpack(..)
+        | Instr::VecSwap(..)
+        | Instr::Branch(..)
+        | Instr::BrTrue(..)
+        | Instr::BrFalse(..)
+        | Instr::BrCmp(..)
+        | Instr::BrCmpImm(..)
+        | Instr::Ret(..)
+        | Instr::Abort(..)
+        | Instr::AbortMsg(..)
+        | Instr::ForceGC => None,
+    }
+}
+
 /// Call-like instructions (`Call`, `CallClosure`) that clobber Xfer slots.
 #[inline]
 pub(crate) fn clobbers_xfer(instr: &Instr) -> bool {
-    matches!(instr, Instr::Call(..) | Instr::CallClosure(..))
+    call_boundary_rets_and_args(instr).is_some()
 }
 
 /// The local whose storage `instr` mutably borrows, if any. A later write
@@ -174,20 +245,7 @@ pub(crate) fn mut_local_borrow_target(instr: &Instr) -> Option<Slot> {
         | Instr::VecUnpack(..)
         | Instr::VecSwap(..)
         | Instr::LdConst(..)
-        | Instr::LdTrue(..)
-        | Instr::LdFalse(..)
-        | Instr::LdU8(..)
-        | Instr::LdU16(..)
-        | Instr::LdU32(..)
-        | Instr::LdU64(..)
-        | Instr::LdU128(..)
-        | Instr::LdU256(..)
-        | Instr::LdI8(..)
-        | Instr::LdI16(..)
-        | Instr::LdI32(..)
-        | Instr::LdI64(..)
-        | Instr::LdI128(..)
-        | Instr::LdI256(..)
+        | Instr::LdImm(..)
         | Instr::Copy(..)
         | Instr::Move(..)
         | Instr::UnaryOp(..)
@@ -224,7 +282,8 @@ pub(crate) fn resource_type_in_instr(instr: &Instr) -> Option<InternedType> {
         | Instr::MutBorrowGlobal(_, ty, _) => Some(*ty),
 
         // Every other instruction: no resource type involved.
-        Instr::Pack(..)
+        Instr::LdImm(..)
+        | Instr::Pack(..)
         | Instr::Unpack(..)
         | Instr::PackVariant(..)
         | Instr::UnpackVariant(..)
@@ -260,20 +319,6 @@ pub(crate) fn resource_type_in_instr(instr: &Instr) -> Option<InternedType> {
         | Instr::VecUnpack(..)
         | Instr::VecSwap(..)
         | Instr::LdConst(..)
-        | Instr::LdTrue(..)
-        | Instr::LdFalse(..)
-        | Instr::LdU8(..)
-        | Instr::LdU16(..)
-        | Instr::LdU32(..)
-        | Instr::LdU64(..)
-        | Instr::LdU128(..)
-        | Instr::LdU256(..)
-        | Instr::LdI8(..)
-        | Instr::LdI16(..)
-        | Instr::LdI32(..)
-        | Instr::LdI64(..)
-        | Instr::LdI128(..)
-        | Instr::LdI256(..)
         | Instr::Copy(..)
         | Instr::Move(..)
         | Instr::UnaryOp(..)
@@ -377,20 +422,7 @@ pub(crate) fn field_layout_nominal_in_instr(instr: &Instr) -> Option<(InternedTy
 
         // No struct type involved.
         Instr::LdConst(..)
-        | Instr::LdTrue(..)
-        | Instr::LdFalse(..)
-        | Instr::LdU8(..)
-        | Instr::LdU16(..)
-        | Instr::LdU32(..)
-        | Instr::LdU64(..)
-        | Instr::LdU128(..)
-        | Instr::LdU256(..)
-        | Instr::LdI8(..)
-        | Instr::LdI16(..)
-        | Instr::LdI32(..)
-        | Instr::LdI64(..)
-        | Instr::LdI128(..)
-        | Instr::LdI256(..)
+        | Instr::LdImm(..)
         | Instr::Copy(..)
         | Instr::Move(..)
         | Instr::UnaryOp(..)
@@ -459,20 +491,7 @@ pub(crate) fn chain_field_path(instr: &Instr) -> Option<&FieldPath> {
         | Instr::VecUnpack(..)
         | Instr::VecSwap(..)
         | Instr::LdConst(..)
-        | Instr::LdTrue(..)
-        | Instr::LdFalse(..)
-        | Instr::LdU8(..)
-        | Instr::LdU16(..)
-        | Instr::LdU32(..)
-        | Instr::LdU64(..)
-        | Instr::LdU128(..)
-        | Instr::LdU256(..)
-        | Instr::LdI8(..)
-        | Instr::LdI16(..)
-        | Instr::LdI32(..)
-        | Instr::LdI64(..)
-        | Instr::LdI128(..)
-        | Instr::LdI256(..)
+        | Instr::LdImm(..)
         | Instr::Copy(..)
         | Instr::Move(..)
         | Instr::UnaryOp(..)
@@ -506,20 +525,7 @@ pub(crate) fn is_fallthrough_terminator(instr: &Instr) -> bool {
         | Instr::Abort(..)
         | Instr::AbortMsg(..)
         | Instr::LdConst(..)
-        | Instr::LdTrue(..)
-        | Instr::LdFalse(..)
-        | Instr::LdU8(..)
-        | Instr::LdU16(..)
-        | Instr::LdU32(..)
-        | Instr::LdU64(..)
-        | Instr::LdU128(..)
-        | Instr::LdU256(..)
-        | Instr::LdI8(..)
-        | Instr::LdI16(..)
-        | Instr::LdI32(..)
-        | Instr::LdI64(..)
-        | Instr::LdI128(..)
-        | Instr::LdI256(..)
+        | Instr::LdImm(..)
         | Instr::Copy(..)
         | Instr::Move(..)
         | Instr::UnaryOp(..)
@@ -571,97 +577,6 @@ pub(crate) fn is_fallthrough_terminator(instr: &Instr) -> bool {
         | Instr::VecUnpack(..)
         | Instr::VecSwap(..)
         | Instr::ForceGC => false,
-    }
-}
-
-/// Extract the destination slot and immediate value from a load instruction.
-// TODO(perf): the wide arms (`LdU128`/`LdU256`/`LdI128`/`LdI256`) each allocate
-// a `Box` here, even when `try_fuse_immediate_binop` decides not to fuse.
-// Consider splitting `extract_imm_value` into a cheap "would this fuse?"
-// check + a separate constructor, or otherwise pulling allocation behind
-// the fusion-eligibility check.
-pub(crate) fn extract_imm_value(instr: &Instr) -> Option<(Slot, ImmValue)> {
-    match instr {
-        Instr::LdTrue(dst) => Some((*dst, ImmValue::Bool(true))),
-        Instr::LdFalse(dst) => Some((*dst, ImmValue::Bool(false))),
-        Instr::LdU8(dst, val) => Some((*dst, ImmValue::U8(*val))),
-        Instr::LdU16(dst, val) => Some((*dst, ImmValue::U16(*val))),
-        Instr::LdU32(dst, val) => Some((*dst, ImmValue::U32(*val))),
-        Instr::LdU64(dst, val) => Some((*dst, ImmValue::U64(*val))),
-        Instr::LdU128(dst, val) => Some((*dst, ImmValue::U128(Box::new(*val)))),
-        Instr::LdU256(dst, val) => Some((*dst, ImmValue::U256(Box::new(*val)))),
-        Instr::LdI8(dst, val) => Some((*dst, ImmValue::I8(*val))),
-        Instr::LdI16(dst, val) => Some((*dst, ImmValue::I16(*val))),
-        Instr::LdI32(dst, val) => Some((*dst, ImmValue::I32(*val))),
-        Instr::LdI64(dst, val) => Some((*dst, ImmValue::I64(*val))),
-        Instr::LdI128(dst, val) => Some((*dst, ImmValue::I128(Box::new(*val)))),
-        Instr::LdI256(dst, val) => Some((*dst, ImmValue::I256(Box::new(*val)))),
-
-        // `LdConst` loads from the constant pool — its payload isn't a
-        // fixed-width integer literal, so it's never fusible into
-        // `BinaryOpImm`.
-        Instr::LdConst(_, _) => None,
-
-        // Non-load instructions.
-        Instr::Copy(_, _)
-        | Instr::Move(_, _)
-        | Instr::UnaryOp(_, _, _)
-        | Instr::BinaryOp(_, _, _, _)
-        | Instr::BinaryOpImm(_, _, _, _)
-        | Instr::Pack(_, _, _)
-        | Instr::Unpack(_, _, _)
-        | Instr::PackVariant(_, _, _, _)
-        | Instr::UnpackVariant(_, _, _, _)
-        | Instr::TestVariant(_, _, _, _)
-        | Instr::ImmBorrowLoc(_, _)
-        | Instr::MutBorrowLoc(_, _)
-        | Instr::ImmBorrowField(_, _, _, _)
-        | Instr::MutBorrowField(_, _, _, _)
-        | Instr::ImmBorrowVariantField(_, _, _, _)
-        | Instr::MutBorrowVariantField(_, _, _, _)
-        | Instr::ReadRef(_, _)
-        | Instr::WriteRef(_, _)
-        | Instr::ReadField(_, _, _, _)
-        | Instr::WriteField(_, _, _, _)
-        | Instr::ReadVariantField(_, _, _, _)
-        | Instr::WriteVariantField(_, _, _, _)
-        | Instr::ImmBorrowLocField(_, _, _, _)
-        | Instr::MutBorrowLocField(_, _, _, _)
-        | Instr::ReadLocalField(_, _, _, _)
-        | Instr::WriteLocalField(_, _, _, _)
-        | Instr::ReadFieldChain(_, _, _)
-        | Instr::WriteFieldChain(_, _, _)
-        | Instr::ImmBorrowFieldChain(_, _, _)
-        | Instr::MutBorrowFieldChain(_, _, _)
-        | Instr::ReadLocalFieldChain(_, _, _)
-        | Instr::WriteLocalFieldChain(_, _, _)
-        | Instr::ImmBorrowLocalFieldChain(_, _, _)
-        | Instr::MutBorrowLocalFieldChain(_, _, _)
-        | Instr::Exists(_, _, _)
-        | Instr::MoveFrom(_, _, _)
-        | Instr::MoveTo(_, _, _)
-        | Instr::ImmBorrowGlobal(_, _, _)
-        | Instr::MutBorrowGlobal(_, _, _)
-        | Instr::Call(_, _, _, _)
-        | Instr::PackClosure(_, _, _, _, _)
-        | Instr::CallClosure(_, _, _)
-        | Instr::VecPack(_, _, _)
-        | Instr::VecLen(_, _, _)
-        | Instr::VecImmBorrow(_, _, _, _)
-        | Instr::VecMutBorrow(_, _, _, _)
-        | Instr::VecPushBack(_, _, _)
-        | Instr::VecPopBack(_, _, _)
-        | Instr::VecUnpack(_, _, _)
-        | Instr::VecSwap(_, _, _, _)
-        | Instr::Branch(_)
-        | Instr::BrTrue(_, _)
-        | Instr::BrFalse(_, _)
-        | Instr::BrCmp(_, _, _, _)
-        | Instr::BrCmpImm(_, _, _, _)
-        | Instr::Ret(_)
-        | Instr::Abort(_)
-        | Instr::AbortMsg(_, _)
-        | Instr::ForceGC => None,
     }
 }
 
@@ -738,21 +653,7 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
     mut f: impl FnMut(Slot, SlotRole),
 ) {
     match instr {
-        Instr::LdConst(dst, _)
-        | Instr::LdTrue(dst)
-        | Instr::LdFalse(dst)
-        | Instr::LdU8(dst, _)
-        | Instr::LdU16(dst, _)
-        | Instr::LdU32(dst, _)
-        | Instr::LdU64(dst, _)
-        | Instr::LdU128(dst, _)
-        | Instr::LdU256(dst, _)
-        | Instr::LdI8(dst, _)
-        | Instr::LdI16(dst, _)
-        | Instr::LdI32(dst, _)
-        | Instr::LdI64(dst, _)
-        | Instr::LdI128(dst, _)
-        | Instr::LdI256(dst, _) => def::<DEFS>(*dst, &mut f),
+        Instr::LdConst(dst, _) | Instr::LdImm(dst, _) => def::<DEFS>(*dst, &mut f),
 
         Instr::Copy(dst, src) | Instr::Move(dst, src) | Instr::UnaryOp(dst, _, src) => {
             def::<DEFS>(*dst, &mut f);
@@ -850,13 +751,17 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
             used::<USES>(*addr, &mut f);
         },
 
-        Instr::Call(rets, _, _, args) | Instr::CallClosure(rets, _, args) => {
-            defs::<DEFS>(rets, &mut f);
-            uses::<USES>(args, &mut f);
+        Instr::Call(data) => {
+            defs::<DEFS>(&data.rets, &mut f);
+            uses::<USES>(&data.args, &mut f);
         },
-        Instr::PackClosure(dst, _, _, _, captured) => {
-            def::<DEFS>(*dst, &mut f);
-            uses::<USES>(captured, &mut f);
+        Instr::CallClosure(data) => {
+            defs::<DEFS>(&data.rets, &mut f);
+            uses::<USES>(&data.args, &mut f);
+        },
+        Instr::PackClosure(data) => {
+            def::<DEFS>(data.dst, &mut f);
+            uses::<USES>(&data.captured, &mut f);
         },
 
         Instr::VecPack(dst, _, elems) => {
@@ -933,21 +838,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
     mut f: impl FnMut(Slot) -> Slot,
 ) {
     match instr {
-        Instr::LdConst(dst, _)
-        | Instr::LdTrue(dst)
-        | Instr::LdFalse(dst)
-        | Instr::LdU8(dst, _)
-        | Instr::LdU16(dst, _)
-        | Instr::LdU32(dst, _)
-        | Instr::LdU64(dst, _)
-        | Instr::LdU128(dst, _)
-        | Instr::LdU256(dst, _)
-        | Instr::LdI8(dst, _)
-        | Instr::LdI16(dst, _)
-        | Instr::LdI32(dst, _)
-        | Instr::LdI64(dst, _)
-        | Instr::LdI128(dst, _)
-        | Instr::LdI256(dst, _) => {
+        Instr::LdConst(dst, _) | Instr::LdImm(dst, _) => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -1104,20 +995,28 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        Instr::Call(rets, _, _, args) | Instr::CallClosure(rets, _, args) => {
+        Instr::Call(data) => {
             if DEFS {
-                rewrite_slots(rets, &mut f);
+                rewrite_slots(&mut data.rets, &mut f);
             }
             if USES {
-                rewrite_slots(args, &mut f);
+                rewrite_slots(&mut data.args, &mut f);
             }
         },
-        Instr::PackClosure(dst, _, _, _, captured) => {
+        Instr::CallClosure(data) => {
             if DEFS {
-                rewrite_slot(dst, &mut f);
+                rewrite_slots(&mut data.rets, &mut f);
             }
             if USES {
-                rewrite_slots(captured, &mut f);
+                rewrite_slots(&mut data.args, &mut f);
+            }
+        },
+        Instr::PackClosure(data) => {
+            if DEFS {
+                rewrite_slot(&mut data.dst, &mut f);
+            }
+            if USES {
+                rewrite_slots(&mut data.captured, &mut f);
             }
         },
 

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -92,8 +92,8 @@ pub enum BinaryOp {
     And,
 }
 
-/// Immediate values for `BinaryOpImm`. Wide widths (u128 / U256 / i128 /
-/// I256) are boxed.
+/// Immediate values used by `Instr`. Wide widths (u128 / U256 / i128 / I256)
+/// are boxed.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ImmValue {
     Bool(bool),
@@ -117,33 +117,83 @@ const _: () = assert!(std::mem::size_of::<ImmValue>() == 16);
 
 /// A chain of inline-struct field selections, each an `(instantiated owner
 /// type, field handle)` pair.
-pub type FieldPath = Vec<(InternedType, FieldHandleIndex)>;
+pub type FieldPath = Box<[(InternedType, FieldHandleIndex)]>;
+
+/// Payload of [`Instr::Call`].
+///
+/// `function_handle` gives the callee identity; `ty_args` is the
+/// instantiation's type arguments, and is `EMPTY_TYPE_LIST` for a
+/// non-generic call. Inside a generic function `ty_args` may still
+/// contain the enclosing function's `TypeParam`s.
+#[derive(Clone)]
+pub struct CallData {
+    pub rets: Box<[Slot]>,
+    pub function_handle: FunctionHandleIndex,
+    pub ty_args: InternedTypeList,
+    pub args: Box<[Slot]>,
+}
+
+/// Payload of [`Instr::PackClosure`] (same `(function_handle, ty_args)`
+/// contract as [`CallData`]).
+#[derive(Clone)]
+pub struct PackClosureData {
+    pub dst: Slot,
+    pub function_handle: FunctionHandleIndex,
+    pub ty_args: InternedTypeList,
+    pub mask: ClosureMask,
+    pub captured: Box<[Slot]>,
+}
+
+/// Payload of [`Instr::CallClosure`].
+#[derive(Clone)]
+pub struct CallClosureData {
+    pub rets: Box<[Slot]>,
+    /// The closure's type; always a `Type::Function`.
+    pub closure_ty: InternedType,
+    /// The arguments provided to the closure, followed by the closure
+    /// itself as the last element. Never empty; enforced by [`Self::new`].
+    args: Box<[Slot]>,
+}
+
+impl CallClosureData {
+    /// `args` must end with the closure operand (hence be non-empty).
+    pub(crate) fn new(rets: Box<[Slot]>, closure_ty: InternedType, args: Box<[Slot]>) -> Self {
+        debug_assert!(
+            !args.is_empty(),
+            "CallClosure args must include the closure"
+        );
+        Self {
+            rets,
+            closure_ty,
+            args,
+        }
+    }
+
+    /// Splits `args` into `(closure, provided arguments)`.
+    pub fn closure_and_provided(&self) -> (Slot, &[Slot]) {
+        let (closure, provided) = self
+            .args
+            .split_last()
+            .expect("CallClosure args are non-empty by construction");
+        (*closure, provided)
+    }
+}
 
 /// A stackless IR instruction with explicit named-slot operands.
 ///
 /// TODO(cleanup):
 /// (1) convert variants to struct-style (named fields) so call sites read
-/// `Instr::Move { dst, src }` rather than positional tuples.
+/// `Instr::Move { dst, src }` rather than positional tuples. Payloads that
+/// would push a variant past the size/align asserts below get a boxed
+/// named-field `*Data` struct instead (as the call-ish variants do).
 /// (2) add description for each instruction variant.
 /// (3) change uses of raw integers into newtypes/type-aliases.
 #[derive(Clone)]
 pub enum Instr {
     // --- Loads ---
     LdConst(Slot, ConstantPoolIndex),
-    LdTrue(Slot),
-    LdFalse(Slot),
-    LdU8(Slot, u8),
-    LdU16(Slot, u16),
-    LdU32(Slot, u32),
-    LdU64(Slot, u64),
-    LdU128(Slot, u128),
-    LdU256(Slot, U256),
-    LdI8(Slot, i8),
-    LdI16(Slot, i16),
-    LdI32(Slot, i32),
-    LdI64(Slot, i64),
-    LdI128(Slot, i128),
-    LdI256(Slot, I256),
+    /// `dst = imm` — load a bool or integer literal.
+    LdImm(Slot, ImmValue),
 
     // --- Slot ops ---
     /// `dst = copy(src)`, source remains valid.
@@ -164,13 +214,13 @@ pub enum Instr {
     // Contract: the carried `InternedType` is the instantiated nominal, with
     // the instantiation's type arguments already applied. Inside a generic
     // function it may still contain the enclosing function's `TypeParam`s.
-    Pack(Slot, InternedType, Vec<Slot>),
-    Unpack(Vec<Slot>, InternedType, Slot),
+    Pack(Slot, InternedType, Box<[Slot]>),
+    Unpack(Box<[Slot]>, InternedType, Slot),
 
     // --- Variant (enum type + variant ordinal; same type contract as
     // `Pack`/`Unpack`) ---
-    PackVariant(Slot, InternedType, u16, Vec<Slot>),
-    UnpackVariant(Vec<Slot>, InternedType, u16, Slot),
+    PackVariant(Slot, InternedType, u16, Box<[Slot]>),
+    UnpackVariant(Box<[Slot]>, InternedType, u16, Slot),
     TestVariant(Slot, InternedType, u16, Slot),
 
     // --- References ---
@@ -244,36 +294,21 @@ pub enum Instr {
     ImmBorrowGlobal(Slot, InternedType, Slot),
     MutBorrowGlobal(Slot, InternedType, Slot),
 
-    // --- Calls ---
-    //
-    // Carries `(inner FunctionHandleIndex, target ty_args)`: the handle gives the
-    // callee identity; `ty_args` is the instantiation's type arguments, and is
-    // `EMPTY_TYPE_LIST` for a non-generic call. Same type contract as
-    // `Pack`/`Unpack` — inside a generic function the args may still contain the
-    // enclosing function's `TypeParam`s.
-    Call(Vec<Slot>, FunctionHandleIndex, InternedTypeList, Vec<Slot>),
+    // --- Calls (payload boxed to keep `Instr` small; see `CallData`) ---
+    Call(Box<CallData>),
 
-    // --- Closures (same `(inner handle, target ty_args)` contract as `Call`) ---
-    PackClosure(
-        Slot,
-        FunctionHandleIndex,
-        InternedTypeList,
-        ClosureMask,
-        Vec<Slot>,
-    ),
-    /// `CallClosure(rets, signature_types, args)` — `signature_types` is the
-    /// interned list of types from the closure's signature (arg types followed
-    /// by result types, matching the source `SignatureIndex`).
-    CallClosure(Vec<Slot>, InternedTypeList, Vec<Slot>),
+    // --- Closures (payloads boxed; see `PackClosureData`/`CallClosureData`) ---
+    PackClosure(Box<PackClosureData>),
+    CallClosure(Box<CallClosureData>),
 
     // --- Vector (second field is the vector's element type) ---
-    VecPack(Slot, InternedType, Vec<Slot>),
+    VecPack(Slot, InternedType, Box<[Slot]>),
     VecLen(Slot, InternedType, Slot),
     VecImmBorrow(Slot, InternedType, Slot, Slot),
     VecMutBorrow(Slot, InternedType, Slot, Slot),
     VecPushBack(InternedType, Slot, Slot),
     VecPopBack(Slot, InternedType, Slot),
-    VecUnpack(Vec<Slot>, InternedType, Slot),
+    VecUnpack(Box<[Slot]>, InternedType, Slot),
     VecSwap(InternedType, Slot, Slot, Slot),
 
     // --- Control flow ---
@@ -284,7 +319,7 @@ pub enum Instr {
     BrCmp(Label, CmpKind, Slot, Slot),
     /// `BrCmpImm(target, op, src, imm)` — branch to `target` if `op(src, imm)` is true.
     BrCmpImm(Label, CmpKind, Slot, ImmValue),
-    Ret(Vec<Slot>),
+    Ret(Box<[Slot]>),
     Abort(Slot),
     AbortMsg(Slot, Slot),
 
@@ -293,26 +328,26 @@ pub enum Instr {
     ForceGC,
 }
 
+const _: () = assert!(
+    std::mem::size_of::<Instr>() == 32,
+    "Instr is no longer 32 bytes; if it grew, box the offending variant's \
+    payload — if the widest variant shrank, re-pin this constant"
+);
+// The align assert matters on its own: a raw `u128`-family payload could keep
+// the size at 32 while bumping the alignment (and allocator padding) to 16.
+const _: () = assert!(
+    std::mem::align_of::<Instr>() == 8,
+    "Instr alignment is no longer 8; if it grew, box the align-16 \
+     (u128-family) payload — if it shrank, re-pin this constant"
+);
+
 impl Instr {
     /// Returns the variant tag as a static string. Useful for terse error
     /// messages that don't need the full operand dump.
     pub fn opcode_name(&self) -> &'static str {
         match self {
             Instr::LdConst(..) => "LdConst",
-            Instr::LdTrue(..) => "LdTrue",
-            Instr::LdFalse(..) => "LdFalse",
-            Instr::LdU8(..) => "LdU8",
-            Instr::LdU16(..) => "LdU16",
-            Instr::LdU32(..) => "LdU32",
-            Instr::LdU64(..) => "LdU64",
-            Instr::LdU128(..) => "LdU128",
-            Instr::LdU256(..) => "LdU256",
-            Instr::LdI8(..) => "LdI8",
-            Instr::LdI16(..) => "LdI16",
-            Instr::LdI32(..) => "LdI32",
-            Instr::LdI64(..) => "LdI64",
-            Instr::LdI128(..) => "LdI128",
-            Instr::LdI256(..) => "LdI256",
+            Instr::LdImm(..) => "LdImm",
             Instr::Copy(..) => "Copy",
             Instr::Move(..) => "Move",
             Instr::UnaryOp(..) => "UnaryOp",


### PR DESCRIPTION
## Description

In this PR, we shrink the stackless-exec IR instruction from 80 to 32 bytes. Every function's IR is a vector of instructions walked repeatedly by the destack, analysis, slot-allocation, and lowering passes at module-load/JIT time, so instruction size directly drives that phase's memory footprint and cache traffic — two to three instructions now fit per cache line instead of less than one. The new size and alignment are locked by compile-time asserts.

- The fifteen literal-load instruction variants folded into a single immediate-load carrying a compact immediate value (wide integers boxed).
- Call-like instruction payloads moved behind boxed, named-field structs; variable-length operand lists became boxed slices, including the fused field-chain paths.
- Zero behavior change: execution semantics, printed IR (golden baselines), gas formulas, and error surfaces are all byte-identical, verified by the unit and differential test suites plus multiple adversarial review passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide IR refactor across JIT-time passes (destack, gas, lowering); behavior is intended to be identical but any missed match arm or operand layout bug could surface as subtle codegen or xfer-slot bugs.
> 
> **Overview**
> **Shrinks each stackless-exec `Instr` to 32 bytes / 8-byte alignment** (from ~80 bytes), with compile-time asserts so future enum growth forces boxing instead of silent bloat.
> 
> **IR shape changes (same semantics, different representation):**
> - Fifteen bool/integer literal opcodes collapse into **`Instr::LdImm(dst, ImmValue)`**; SSA conversion uses `convert_load`, fusion matches `LdImm` directly, lowering goes through shared **`store_imm_op`**.
> - **`Call` / `PackClosure` / `CallClosure`** use boxed **`CallData`**, **`PackClosureData`**, and **`CallClosureData`**; multi-slot operands (`Pack`/`Unpack`/`Ret`/vectors/etc.) use **`Box<[Slot]>`** instead of inline `Vec`s.
> - **`CallClosure`** carries a single **`closure_ty`** (`InternedType`) instead of a signature type list; **`closure_and_provided()`** replaces manual split-last logic.
> - **`FieldPath`** is a boxed slice; fused chains build paths as `Vec` then `.into()`.
> 
> **Pass updates:** `instr_utils` adds **`call_boundary_rets_and_args`** (shared by xfer verification and **`clobbers_xfer`**); destack xfer precolor still inspects direct **`Call`** only via **`direct_call_rets_and_args`**. Gas, display, slot visitors, and context discovery match on the new struct fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8edee507c74353895acd66d73bb515998ee7928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->