### PR TITLE
[block-stm] Refactor recorded outputs

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -376,7 +376,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
     }
 
     fn incorporate_materialized_txn_output(
-        &mut self,
+        mut self,
         materialized_resource_write_set: Vec<(StateKey, WriteOp)>,
         materialized_events: Vec<ContractEvent>,
     ) -> Result<(Self::CommittedOutput, Trace), PanicError> {

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -7,6 +7,7 @@ use aptos_logger::{enabled, Level};
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
     block_executor::value::ValueWithLayout,
+    error::{code_invariant_error, PanicError},
     state_store::{state_key::StateKey, StateView, StateViewId},
     timestamp::TimestampResource,
     transaction::{
@@ -59,9 +60,9 @@ impl ExecutorTask for AptosExecutorTask {
         txn: &SignatureVerifiedTransaction,
         auxiliary_info: &Self::AuxiliaryInfo,
         txn_idx: TxnIndex,
-    ) -> ExecutionStatus<AptosTransactionOutput> {
+    ) -> Result<ExecutionStatus<AptosTransactionOutput>, PanicError> {
         fail_point!("aptos_vm::vm_wrapper::execute_transaction", |_| {
-            ExecutionStatus::DelayedFieldsCodeInvariantError("fail points error".into())
+            Err(code_invariant_error("fail points error"))
         });
 
         let log_context = AdapterLogSchema::new(self.id, txn_idx as usize);
@@ -90,48 +91,46 @@ impl ExecutorTask for AptosExecutorTask {
                     )
                 };
                 if vm_status.status_code() == StatusCode::SPECULATIVE_EXECUTION_ABORT_ERROR {
-                    ExecutionStatus::SpeculativeExecutionAbortError(
-                        vm_status.message().cloned().unwrap_or_default(),
-                    )
+                    Ok(ExecutionStatus::SpeculativeFailure)
                 } else if vm_status.status_code()
                     == StatusCode::DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR
                 {
-                    ExecutionStatus::DelayedFieldsCodeInvariantError(
+                    Err(code_invariant_error(
                         vm_status.message().cloned().unwrap_or_default(),
-                    )
+                    ))
                 } else if AptosVM::should_restart_execution(vm_output.events()) {
                     speculative_info!(
                         &log_context,
                         "Reconfiguration occurred: restart required".into()
                     );
-                    ExecutionStatus::SkipRest(AptosTransactionOutput::new_with_read_set(
-                        vm_output, read_set,
-                    ))
+                    Ok(ExecutionStatus::Executed {
+                        output: AptosTransactionOutput::new_with_read_set(vm_output, read_set),
+                        skips_rest: true,
+                    })
                 } else {
                     assert!(
                         Self::is_transaction_dynamic_change_set_capable(txn),
                         "DirectWriteSet should always create SkipRest transaction, validate_waypoint_change_set provides this guarantee"
                     );
-                    ExecutionStatus::Success(AptosTransactionOutput::new_with_read_set(
-                        vm_output, read_set,
-                    ))
+                    Ok(ExecutionStatus::Executed {
+                        output: AptosTransactionOutput::new_with_read_set(vm_output, read_set),
+                        skips_rest: false,
+                    })
                 }
             },
             // execute_single_transaction only returns an error when transactions that should never fail
             // (BlockMetadataTransaction and GenesisTransaction) return an error themselves.
             Err(err) => {
                 if err.status_code() == StatusCode::SPECULATIVE_EXECUTION_ABORT_ERROR {
-                    ExecutionStatus::SpeculativeExecutionAbortError(
-                        err.message().cloned().unwrap_or_default(),
-                    )
+                    Ok(ExecutionStatus::SpeculativeFailure)
                 } else if err.status_code()
                     == StatusCode::DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR
                 {
-                    ExecutionStatus::DelayedFieldsCodeInvariantError(
+                    Err(code_invariant_error(
                         err.message().cloned().unwrap_or_default(),
-                    )
+                    ))
                 } else {
-                    ExecutionStatus::Abort(err.to_string())
+                    Ok(ExecutionStatus::Aborted(err.to_string()))
                 }
             },
         }

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -68,10 +68,10 @@ use triomphe::Arc as TriompheArc;
 pub(crate) static MOCK_LAYOUT: once_cell::sync::Lazy<MoveTypeLayout> =
     once_cell::sync::Lazy::new(|| MoveTypeLayout::new_struct(MoveStructLayout::new(vec![])));
 
-/// Macro for returning an error directly when Result is an error
+/// Macro for early-returning the `Err` value as a successful output.
 ///
-/// This macro unwraps a Result or returns the error directly.
-/// Used when the function returns the same error type as the Result.
+/// This macro unwraps the `Ok` value of a Result. On `Err`, the error value is
+/// itself a valid `ExecutionStatus`, so it is returned wrapped in `Ok`.
 ///
 /// Usage:
 ///   try_with_direct!(result_expr)
@@ -80,7 +80,7 @@ macro_rules! try_with_direct {
     ($expr:expr) => {
         match $expr {
             Ok(val) => val,
-            Err(e) => return e,
+            Err(e) => return Ok(e),
         }
     };
 }
@@ -105,7 +105,7 @@ macro_rules! try_with_error {
 /// Macro for returning an ExecutionStatus with error message
 ///
 /// This macro unwraps a Result or returns an error wrapped in
-/// ExecutionStatus::Success(MockOutput::with_error(...)).
+/// executed status.
 ///
 /// Usage:
 ///   try_with_status!(result_expr, "error message")
@@ -115,10 +115,10 @@ macro_rules! try_with_status {
         match $expr {
             Ok(val) => val,
             Err(e) => {
-                return Err(ExecutionStatus::Success(MockOutput::with_error(&format!(
-                    "{}: {:?}",
-                    $msg, e
-                ))))
+                return Err(ExecutionStatus::Executed {
+                    output: MockOutput::with_error(&format!("{}: {:?}", $msg, e)),
+                    skips_rest: false,
+                })
             },
         }
     };
@@ -703,18 +703,18 @@ where
     }
 
     fn incorporate_materialized_txn_output(
-        &mut self,
+        self,
         patched_resource_write_set: Vec<(K, ValueType)>,
         _patched_events: Vec<E>,
     ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
         assert_ok!(self
             .patched_resource_write_set
-            .set(patched_resource_write_set.clone().into_iter().collect()));
+            .set(patched_resource_write_set.into_iter().collect()));
         // TODO: Also test patched events
 
         // The mock's committed output is a snapshot of itself, carrying the reads
         // and patched writes the baseline verifies.
-        Ok((self.clone(), Trace::empty()))
+        Ok((self, Trace::empty()))
     }
 }
 
@@ -962,8 +962,8 @@ where
         txn: &Self::Txn,
         _auxiliary_info: &Self::AuxiliaryInfo,
         txn_idx: TxnIndex,
-    ) -> ExecutionStatus<Self::Output> {
-        match txn {
+    ) -> Result<ExecutionStatus<Self::Output>, PanicError> {
+        Ok(match txn {
             MockTransaction::Write {
                 incarnation_counter,
                 incarnation_behaviors,
@@ -1015,25 +1015,34 @@ where
                     .and_then(|b| b.add_deltas(view, &behavior.deltas, *delta_test_kind))
                     .finish();
 
-                // Use the direct return variant for ExecutionStatus functions
                 try_with_direct!(builder_result);
 
-                ExecutionStatus::Success(builder.build())
+                ExecutionStatus::Executed {
+                    output: builder.build(),
+                    skips_rest: false,
+                }
             },
             MockTransaction::SkipRest(gas) => {
                 let mut mock_output = MockOutput::retry();
                 mock_output.total_gas = *gas;
-                ExecutionStatus::SkipRest(mock_output)
+                ExecutionStatus::Executed {
+                    output: mock_output,
+                    skips_rest: true,
+                }
             },
-            MockTransaction::Abort => ExecutionStatus::Abort(txn_idx.to_string()),
+            MockTransaction::Abort => ExecutionStatus::Aborted(txn_idx.to_string()),
             MockTransaction::InterruptRequested => {
                 while !view.interrupt_requested() {}
-                ExecutionStatus::SkipRest(MockOutput::skip_output())
+                ExecutionStatus::Executed {
+                    output: MockOutput::skip_output(),
+                    skips_rest: true,
+                }
             },
-            MockTransaction::StateCheckpoint => {
-                ExecutionStatus::Success(MockOutput::empty_success_output())
+            MockTransaction::StateCheckpoint => ExecutionStatus::Executed {
+                output: MockOutput::empty_success_output(),
+                skips_rest: false,
             },
-        }
+        })
     }
 
     fn pre_write_values(txn: &Self::Txn) -> Vec<(K, ValueWithLayout<ValueType>)> {

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -128,35 +128,6 @@ where
         }
     }
 
-    // The bool in the result indicates whether execution result is a speculative abort.
-    fn process_execution_result<'a>(
-        execution_result: &'a ExecutionStatus<E::Output>,
-        read_set: &mut CapturedReads<T, ModuleId, CompiledModule, Module, AptosModuleExtension>,
-        txn_idx: TxnIndex,
-    ) -> Result<(Option<&'a E::Output>, bool), PanicError> {
-        match execution_result {
-            ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
-                Ok((Some(output), false))
-            },
-            ExecutionStatus::SpeculativeExecutionAbortError(_msg) => {
-                // TODO(BlockSTMv2): cleaner to rename or distinguish V2 early abort
-                // from DeltaApplicationFailure. This is also why we return the bool
-                // separately for now instead of relying on the read set.
-                read_set.capture_delayed_field_read_error(&PanicOr::Or(
-                    MVDelayedFieldsError::DeltaApplicationFailure,
-                ));
-                Ok((None, true))
-            },
-            ExecutionStatus::Abort(_err) => Ok((None, false)),
-            ExecutionStatus::DelayedFieldsCodeInvariantError(msg) => {
-                Err(code_invariant_error(format!(
-                    "[Execution] At txn {}, failed with DelayedFieldsCodeInvariantError: {:?}",
-                    txn_idx, msg
-                )))
-            },
-        }
-    }
-
     /// Verifies that all pre-written keys are present in the actual write set.
     ///
     /// Pre-write optimization populates the MVHashMap with expected writes before execution.
@@ -437,7 +408,7 @@ where
             idx_to_execute,
         );
         let execution_result =
-            executor.execute_transaction(&sync_view, txn, auxiliary_info, idx_to_execute);
+            executor.execute_transaction(&sync_view, txn, auxiliary_info, idx_to_execute)?;
 
         let mut read_set = sync_view.take_parallel_reads();
         if read_set.is_incorrect_use() {
@@ -446,10 +417,7 @@ where
             )));
         }
 
-        let (maybe_output, is_speculative_failure) =
-            Self::process_execution_result(&execution_result, &mut read_set, idx_to_execute)?;
-
-        if is_speculative_failure {
+        if execution_result.is_speculative_failure() {
             // Recording in order to check the invariant that the final, committed incarnation
             // of each transaction is not a speculative failure.
             last_input_output.record_speculative_failure(idx_to_execute);
@@ -468,6 +436,8 @@ where
             }
             return Ok(());
         }
+
+        let maybe_output = execution_result.get_output();
 
         // Verify that all pre-written keys were actually written by the transaction.
         // If not, fallback to sequential execution to avoid speculative reads seeing
@@ -569,7 +539,7 @@ where
             idx_to_execute,
         );
         let execution_result =
-            executor.execute_transaction(&sync_view, txn, auxiliary_info, idx_to_execute);
+            executor.execute_transaction(&sync_view, txn, auxiliary_info, idx_to_execute)?;
 
         let mut read_set = sync_view.take_parallel_reads();
         if read_set.is_incorrect_use() {
@@ -578,8 +548,17 @@ where
                 idx_to_execute, incarnation
             )));
         }
-        let (processed_output, _) =
-            Self::process_execution_result(&execution_result, &mut read_set, idx_to_execute)?;
+        if execution_result.is_speculative_failure() {
+            // BlockSTMv1 relies on the read set carrying the speculative failure so
+            // that its own validation fails and it re-executes.
+            // TODO(BlockSTMv2): cleaner to rename or distinguish V2 early abort
+            // from DeltaApplicationFailure. This is also why V2 records the
+            // speculative failure separately instead of relying on the read set.
+            read_set.capture_delayed_field_read_error(&PanicOr::Or(
+                MVDelayedFieldsError::DeltaApplicationFailure,
+            ));
+        }
+        let processed_output = execution_result.get_output();
 
         // Verify that all pre-written keys were actually written by the transaction.
         // If not, fallback to sequential execution to avoid speculative reads seeing
@@ -2180,33 +2159,35 @@ where
                 ViewState::Unsync(SequentialState::new(&unsync_map, start_counter, &counter)),
                 idx as TxnIndex,
             );
-            let res =
-                executor.execute_transaction(&latest_view, txn, &auxiliary_info, idx as TxnIndex);
-            let must_skip = matches!(res, ExecutionStatus::SkipRest(_));
-            match res {
-                ExecutionStatus::Abort(err) => {
+            let res = executor
+                .execute_transaction(&latest_view, txn, &auxiliary_info, idx as TxnIndex)
+                .inspect_err(|err| {
+                    alert!(
+                        "Sequential execution failed to execute transaction {}: {}",
+                        idx as TxnIndex,
+                        err
+                    );
+                })?;
+            let must_skip = match res {
+                ExecutionStatus::Aborted(msg) => {
                     error!(
                         "Sequential execution FatalVMError by transaction {}",
                         idx as TxnIndex
                     );
-                    // Record the status indicating the unrecoverable VM failure.
                     return Err(SequentialBlockExecutionError::ErrorToReturn(
-                        BlockError::new(err),
+                        BlockError::new(msg),
                     ));
                 },
-                ExecutionStatus::DelayedFieldsCodeInvariantError(msg) => {
-                    alert!("Sequential execution DelayedFieldsCodeInvariantError error by transaction {}: {}", idx as TxnIndex, msg);
+                ExecutionStatus::SpeculativeFailure => {
+                    alert!(
+                        "Sequential execution observed a speculative failure at transaction {}",
+                        idx as TxnIndex
+                    );
                     return Err(SequentialBlockExecutionError::from(code_invariant_error(
-                        msg,
+                        "Speculative failure must not occur during sequential execution",
                     )));
                 },
-                ExecutionStatus::SpeculativeExecutionAbortError(msg) => {
-                    alert!("Sequential execution SpeculativeExecutionAbortError error by transaction {}: {}", idx as TxnIndex, msg);
-                    return Err(SequentialBlockExecutionError::from(code_invariant_error(
-                        msg,
-                    )));
-                },
-                ExecutionStatus::Success(mut output) | ExecutionStatus::SkipRest(mut output) => {
+                ExecutionStatus::Executed { output, skips_rest } => {
                     let output_before_guard = output.before_materialization()?;
                     // Calculating the accumulated gas costs of the committed txns.
 
@@ -2362,17 +2343,14 @@ where
                     )?;
 
                     // The guard borrows the output immutably; drop it before
-                    // materialization, which needs the output mutably.
+                    // materialization, which consumes the output by value.
                     drop(output_before_guard);
 
                     // If dynamic change set materialization part (indented for clarity/variable scope):
                     let committed_output = {
                         let materializer = SequentialMaterializer::new(&latest_view);
-                        let (committed_output, trace) = materialize_output(
-                            &mut output,
-                            &materializer,
-                        )
-                        .map_err(|e| match e {
+                        let (committed_output, trace) = materialize_output(output, &materializer)
+                            .map_err(|e| match e {
                             PanicOr::CodeInvariantError(msg) => {
                                 SequentialBlockExecutionError::from(PanicError::CodeInvariantError(
                                     msg,
@@ -2406,6 +2384,7 @@ where
                         commit_hook.on_transaction_committed(idx as TxnIndex, &committed_output);
                     }
                     ret.push(committed_output);
+                    skips_rest
                 },
             };
 

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -182,7 +182,7 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> Materializer<T>
 /// results into the output.
 /// !!! [CAUTION] !!!: May not be concurrent with any other accesses to the output.
 pub(crate) fn materialize_output<T, O, M>(
-    output: &mut O,
+    output: O,
     materializer: &M,
 ) -> Result<(O::CommittedOutput, Trace), PanicOr<ResourceGroupSerializationError>>
 where

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -32,23 +32,31 @@ use std::{
 };
 use triomphe::Arc as TriompheArc;
 
-/// The execution result of a transaction
+/// The outcome of executing a transaction.
 #[derive(Debug)]
 pub enum ExecutionStatus<O> {
     /// Transaction was executed successfully.
-    Success(O),
+    Executed { output: O, skips_rest: bool },
     /// Transaction hit a non-recoverable error during execution. Halts execution
     /// and returns the error message to the caller.
-    Abort(String),
-    /// Transaction was executed successfully, but will skip the execution of the trailing
-    /// transactions in the list
-    SkipRest(O),
-    /// Transaction detected that it is in inconsistent state due to speculative
-    /// reads it did, and needs to be re-executed.
-    SpeculativeExecutionAbortError(String),
-    /// Code invariant error was detected during transaction execution, which
-    /// can only be caused by the bug in the code.
-    DelayedFieldsCodeInvariantError(String),
+    Aborted(String),
+    /// Speculative failure during parallel execution; the transaction
+    /// re-executes.
+    SpeculativeFailure,
+}
+
+impl<O> ExecutionStatus<O> {
+    /// The output, present only for an executed transaction.
+    pub(crate) fn get_output(&self) -> Option<&O> {
+        match self {
+            ExecutionStatus::Executed { output, .. } => Some(output),
+            ExecutionStatus::Aborted(_) | ExecutionStatus::SpeculativeFailure => None,
+        }
+    }
+
+    pub(crate) fn is_speculative_failure(&self) -> bool {
+        matches!(self, ExecutionStatus::SpeculativeFailure)
+    }
 }
 
 /// Trait for single threaded transaction executor.
@@ -90,7 +98,7 @@ pub trait ExecutorTask {
         txn: &Self::Txn,
         auxiliary_info: &Self::AuxiliaryInfo,
         txn_idx: TxnIndex,
-    ) -> ExecutionStatus<Self::Output>;
+    ) -> Result<ExecutionStatus<Self::Output>, PanicError>;
 
     fn pre_write_values(
         _txn: &Self::Txn,
@@ -219,7 +227,7 @@ pub trait TransactionOutput: Send + Debug {
     /// !!! [CAUTION] !!!: This method must be called in quiescence, i.e. may not be
     /// concurrent with any other method that accesses the output.
     fn incorporate_materialized_txn_output(
-        &mut self,
+        self,
         patched_resource_write_set: Vec<(
             <Self::Txn as Transaction>::Key,
             <Self::Txn as Transaction>::Value,

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -38,91 +38,23 @@ use std::{
 
 type TxnInput<T> = CapturedReads<T, ModuleId, CompiledModule, Module, AptosModuleExtension>;
 
-macro_rules! with_success_or_skip_rest {
-    // The simple form for a single method call.
-    ($self:ident, $txn_idx:ident, $f:ident, $fallback:expr) => {
-        with_success_or_skip_rest!(
-            $self,
-            $txn_idx,
-            |t| t.before_materialization().map(|inner| inner.$f()),
-            Ok($fallback)
-        )
-    };
-    // The flexible form for any expression.
-    ($self:ident, $txn_idx:ident, | $t:ident | $body:expr, $fallback:expr) => {{
-        let wrapper = $self.output_wrappers[$txn_idx as usize].lock();
-        let status_kind = wrapper.output_status_kind.clone();
-        match (&status_kind, &wrapper.output) {
-            (OutputStatusKind::Success, Some($t)) | (OutputStatusKind::SkipRest, Some($t)) => $body,
-            (OutputStatusKind::Abort(_), None)
-            | (OutputStatusKind::SpeculativeExecutionAbortError, None)
-            | (OutputStatusKind::DelayedFieldsCodeInvariantError, None)
-            | (OutputStatusKind::None, None) => $fallback,
-            // The remaining arms are all unreachable.
-            (OutputStatusKind::Success, None)
-            | (OutputStatusKind::SkipRest, None)
-            | (OutputStatusKind::Abort(_), Some(_))
-            | (OutputStatusKind::SpeculativeExecutionAbortError, Some(_))
-            | (OutputStatusKind::DelayedFieldsCodeInvariantError, Some(_))
-            | (OutputStatusKind::None, Some(_)) => {
-                unreachable!(
-                    "Inconsistent wrapper status kind {:?} and output {:?}",
-                    status_kind, wrapper.output
-                )
-            },
-        }
-    }};
-    // The flexible form for any expression where the output needs to be mutable.
-    ($self:ident, $txn_idx:ident, | mut $t:ident | $body:expr, $fallback:expr) => {{
-        let mut wrapper = $self.output_wrappers[$txn_idx as usize].lock();
-        let status_kind = wrapper.output_status_kind.clone();
-        match (&status_kind, &mut wrapper.output) {
-            (OutputStatusKind::Success, Some($t)) | (OutputStatusKind::SkipRest, Some($t)) => $body,
-            (OutputStatusKind::Abort(_), None)
-            | (OutputStatusKind::SpeculativeExecutionAbortError, None)
-            | (OutputStatusKind::DelayedFieldsCodeInvariantError, None)
-            | (OutputStatusKind::None, None) => $fallback,
-            // The remaining arms are all unreachable.
-            (OutputStatusKind::Success, None)
-            | (OutputStatusKind::SkipRest, None)
-            | (OutputStatusKind::Abort(_), Some(_))
-            | (OutputStatusKind::SpeculativeExecutionAbortError, Some(_))
-            | (OutputStatusKind::DelayedFieldsCodeInvariantError, Some(_))
-            | (OutputStatusKind::None, Some(_)) => {
-                unreachable!(
-                    "Inconsistent wrapper status kind {:?} and output {:?}",
-                    status_kind, wrapper.output
-                )
-            },
-        }
-    }};
-}
-
-#[derive(Debug, PartialEq, Clone)]
-enum OutputStatusKind {
-    Success,
-    SkipRest,
-    Abort(String),
-    SpeculativeExecutionAbortError,
-    DelayedFieldsCodeInvariantError,
-    None,
-}
-
 struct OutputWrapper<T: Transaction, O: TransactionOutput<Txn = T>> {
-    output: Option<O>,
+    output: Option<ExecutionStatus<O>>,
     maybe_read_write_summary: Option<ReadWriteSummary<T>>,
     maybe_approx_output_size: Option<u64>,
-    output_status_kind: OutputStatusKind,
 }
 
 impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
-    fn empty_with_status(output_status_kind: OutputStatusKind) -> Self {
+    fn empty() -> Self {
         Self {
             output: None,
             maybe_read_write_summary: None,
             maybe_approx_output_size: None,
-            output_status_kind,
         }
+    }
+
+    fn get_output(&self) -> Option<&O> {
+        self.output.as_ref().and_then(|status| status.get_output())
     }
 
     fn from_execution_status(
@@ -131,12 +63,10 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
         block_gas_limit_type: &BlockGasLimitType,
         user_txn_bytes_len: u64,
     ) -> Result<Self, PanicError> {
-        let is_skip_rest = matches!(output, ExecutionStatus::SkipRest(_));
-
-        Ok(match output {
-            ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+        // Summaries are only meaningful for an executed output.
+        let (maybe_approx_output_size, maybe_read_write_summary) = match &output {
+            ExecutionStatus::Executed { output, .. } => {
                 let output_before_guard = output.before_materialization()?;
-
                 let maybe_approx_output_size =
                     block_gas_limit_type.block_output_limit().map(|_| {
                         output_before_guard.output_approx_size()
@@ -146,7 +76,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
                                 0
                             }
                     });
-
                 let maybe_read_write_summary =
                     block_gas_limit_type.conflict_penalty_window().map(|_| {
                         ReadWriteSummary::new(
@@ -154,43 +83,16 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
                             output_before_guard.get_write_summary(),
                         )
                     });
-                drop(output_before_guard);
+                (maybe_approx_output_size, maybe_read_write_summary)
+            },
+            ExecutionStatus::Aborted(_) | ExecutionStatus::SpeculativeFailure => (None, None),
+        };
 
-                Self {
-                    output: Some(output),
-                    maybe_approx_output_size,
-                    maybe_read_write_summary,
-                    output_status_kind: if is_skip_rest {
-                        OutputStatusKind::SkipRest
-                    } else {
-                        OutputStatusKind::Success
-                    },
-                }
-            },
-            ExecutionStatus::Abort(err) => Self::empty_with_status(OutputStatusKind::Abort(err)),
-            ExecutionStatus::SpeculativeExecutionAbortError(_) => {
-                Self::empty_with_status(OutputStatusKind::SpeculativeExecutionAbortError)
-            },
-            ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {
-                Self::empty_with_status(OutputStatusKind::DelayedFieldsCodeInvariantError)
-            },
+        Ok(Self {
+            output: Some(output),
+            maybe_read_write_summary,
+            maybe_approx_output_size,
         })
-    }
-
-    fn check_success_or_skip_status(&self) -> Result<&O, PanicError> {
-        if self.output_status_kind != OutputStatusKind::Success
-            && self.output_status_kind != OutputStatusKind::SkipRest
-        {
-            return Err(code_invariant_error(format!(
-                "Output status {:?}!= success or skip rest",
-                self.output_status_kind
-            )));
-        }
-
-        Ok(self
-            .output
-            .as_ref()
-            .expect("Output must be set when status is success or skip rest"))
     }
 }
 
@@ -212,11 +114,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
                 .map(|_| CachePadded::new(Mutex::new(None)))
                 .collect(),
             output_wrappers: (0..num_txns)
-                .map(|_| {
-                    CachePadded::new(Mutex::new(OutputWrapper::empty_with_status(
-                        OutputStatusKind::None,
-                    )))
-                })
+                .map(|_| CachePadded::new(Mutex::new(OutputWrapper::empty())))
                 .collect(),
             speculative_failures: (0..num_txns)
                 .map(|_| CachePadded::new(AtomicBool::new(false)))
@@ -279,43 +177,39 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     ) -> Result<(), PanicOr<ParallelBlockExecutionError>> {
         let mut output_wrapper = self.output_wrappers[txn_idx as usize].lock();
         let maybe_read_write_summary = output_wrapper.maybe_read_write_summary.take();
+        let maybe_approx_output_size = output_wrapper.maybe_approx_output_size;
 
-        // Transaction cannot be committed with below statuses, as:
-        // - Speculative error must have failed validation.
-        // - Execution w. delayed field code error propagates the error directly
-        // and does not finish execution. Similar for FatalVMError / abort.
-        // - None means there is no output to commit.
-        // check_success_or_skip_status below returns an invariant error for all
-        // these cases, but we handle Abort case separately first.
-        if let OutputStatusKind::Abort(msg) = &output_wrapper.output_status_kind {
-            // Fatal VM error.
-            error!(
-                "FatalVMError from parallel execution {:?} at txn {}",
-                msg, txn_idx
-            );
-            return Err(PanicOr::Or(ParallelBlockExecutionError::FatalVMError));
-        }
-        let output_before_guard = output_wrapper
-            .check_success_or_skip_status()?
-            .before_materialization()?;
+        // Only an executed transaction can commit: Aborted is a fatal VM error,
+        // SpeculativeFailure must have failed validation earlier, and None means
+        // nothing was recorded.
+        let (output, skips_rest_flag) = match &mut output_wrapper.output {
+            Some(ExecutionStatus::Executed { output, skips_rest }) => (&*output, skips_rest),
+            Some(ExecutionStatus::Aborted(msg)) => {
+                error!(
+                    "FatalVMError from parallel execution {:?} at txn {}",
+                    msg, txn_idx
+                );
+                return Err(PanicOr::Or(ParallelBlockExecutionError::FatalVMError));
+            },
+            Some(ExecutionStatus::SpeculativeFailure) | None => {
+                return Err(code_invariant_error(format!(
+                    "Transaction {} has no executed output to commit",
+                    txn_idx
+                ))
+                .into());
+            },
+        };
 
-        let (mut skips_rest, mut must_create_epilogue_txn) =
-            if output_wrapper.output_status_kind == OutputStatusKind::SkipRest {
-                (true, !output_before_guard.has_new_epoch_event())
-            } else {
-                assert!(output_wrapper.output_status_kind == OutputStatusKind::Success);
-                (
-                    false,
-                    txn_idx == num_txns - 1 && !output_before_guard.has_new_epoch_event(),
-                )
-            };
+        // Read the output facts before flipping the disjoint skips_rest flag.
+        let output_before_guard = output.before_materialization()?;
+        let has_new_epoch_event = output_before_guard.has_new_epoch_event();
         let fee_statement = output_before_guard.fee_statement();
 
         // For committed txns, calculate the accumulated gas costs.
         block_limit_processor.accumulate_fee_statement(
             fee_statement,
             maybe_read_write_summary,
-            output_wrapper.maybe_approx_output_size,
+            maybe_approx_output_size,
         );
         if block_limit_processor.is_hot_state_accumulation_enabled() {
             block_limit_processor.accumulate_hot_state_rw(
@@ -323,17 +217,22 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
                 output_before_guard.storage_keys_read(),
             );
         }
+        drop(output_before_guard);
+
+        let mut must_create_epilogue_txn = if *skips_rest_flag {
+            !has_new_epoch_event
+        } else {
+            txn_idx == num_txns - 1 && !has_new_epoch_event
+        };
 
         if txn_idx < num_txns - 1
             && block_limit_processor.should_end_block_parallel()
-            && !skips_rest
+            && !*skips_rest_flag
         {
-            if output_wrapper.output_status_kind == OutputStatusKind::Success {
-                must_create_epilogue_txn |= !output_before_guard.has_new_epoch_event();
-                drop(output_before_guard);
-                output_wrapper.output_status_kind = OutputStatusKind::SkipRest;
-            }
-            skips_rest = true;
+            // The output did not skip the rest; the block gas limit ends the
+            // block early here.
+            must_create_epilogue_txn |= !has_new_epoch_event;
+            *skips_rest_flag = true;
         }
 
         // Add before halt, so SchedulerV2 can organically observe and process post commit
@@ -349,7 +248,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         // a) all transactions are scheduled for committing, or
         // b) we skip_rest after a transaction
         // Either all txn committed, or a committed txn caused an early halt.
-        if (txn_idx + 1 == num_txns || skips_rest) && scheduler.halt() {
+        if (txn_idx + 1 == num_txns || *skips_rest_flag) && scheduler.halt() {
             block_limit_processor.finish_parallel_update_counters_and_log_info(
                 txn_idx + 1,
                 num_txns,
@@ -377,7 +276,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         mut callback: impl FnMut(&T::Key) -> Result<(), PanicError>,
     ) -> Result<(), PanicError> {
         let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
-        if let Some(output) = output_wrapper.output.as_ref() {
+        if let Some(output) = output_wrapper.get_output() {
             output
                 .before_materialization()?
                 .for_each_resource_key(&mut callback)?;
@@ -393,7 +292,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         mut callback: impl FnMut(&T::Key, HashSet<&T::Tag>) -> Result<(), PanicError>,
     ) -> Result<(), PanicError> {
         let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
-        if let Some(output) = output_wrapper.output.as_ref() {
+        if let Some(output) = output_wrapper.get_output() {
             output
                 .before_materialization()?
                 .for_each_resource_group_key_and_tags(&mut callback)?;
@@ -406,8 +305,14 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         &self,
         txn_idx: TxnIndex,
     ) -> Vec<(T::Key, HashSet<T::Tag>)> {
-        with_success_or_skip_rest!(self, txn_idx, legacy_v1_resource_group_tags, vec![])
-            .expect("Output must be set")
+        let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
+        match output_wrapper.get_output() {
+            Some(output) => output
+                .before_materialization()
+                .expect("Output must be set")
+                .legacy_v1_resource_group_tags(),
+            None => vec![],
+        }
     }
 
     // Extracts a set of resource paths (keys) written or updated during execution from
@@ -416,18 +321,18 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         &self,
         txn_idx: TxnIndex,
     ) -> Option<impl Iterator<Item = T::Key>> {
-        with_success_or_skip_rest!(
-            self,
-            txn_idx,
-            |t| {
-                let inner = t.before_materialization().expect("Output must be set");
-                Some(inner.resource_write_set().into_keys())
-            },
-            None
+        let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
+        let output = output_wrapper.get_output()?;
+        Some(
+            output
+                .before_materialization()
+                .expect("Output must be set")
+                .resource_write_set()
+                .into_keys(),
         )
     }
 
-    // The output needs to be Success or SkipRest, o.w. invariant error is returned.
+    // The output must be an executed output, o.w. an invariant error is returned.
     pub(crate) fn publish_module_write_set(
         &self,
         txn_idx: TxnIndex,
@@ -442,9 +347,13 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         scheduler: &SchedulerWrapper<'_>,
     ) -> Result<bool, PanicError> {
         let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
-        let output_before_guard = output_wrapper
-            .check_success_or_skip_status()?
-            .before_materialization()?;
+        let output = output_wrapper.get_output().ok_or_else(|| {
+            code_invariant_error(format!(
+                "Module publish requires an executed output, txn {}",
+                txn_idx
+            ))
+        })?;
+        let output_before_guard = output.before_materialization()?;
 
         let mut published = false;
         let mut module_ids_for_v2 = BTreeSet::new();
@@ -473,16 +382,14 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         &self,
         txn_idx: TxnIndex,
     ) -> Option<impl Iterator<Item = DelayedFieldID>> {
-        with_success_or_skip_rest!(
-            self,
-            txn_idx,
-            |t| Some(
-                t.before_materialization()
-                    .expect("Output must be set")
-                    .delayed_field_change_set()
-                    .into_keys()
-            ),
-            None
+        let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
+        let output = output_wrapper.get_output()?;
+        Some(
+            output
+                .before_materialization()
+                .expect("Output must be set")
+                .delayed_field_change_set()
+                .into_keys(),
         )
     }
 
@@ -498,11 +405,17 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         txn_idx: TxnIndex,
         materializer: &M,
     ) -> Result<(O::CommittedOutput, Trace), PanicOr<ResourceGroupSerializationError>> {
-        with_success_or_skip_rest!(
-            self,
-            txn_idx,
-            |mut t| materialize_output(t, materializer),
-            Err(code_invariant_error("[BlockSTM]: Output must be recorded after execution").into())
-        )
+        let output = self.output_wrappers[txn_idx as usize].lock().output.take();
+        match output {
+            Some(ExecutionStatus::Executed { output, .. }) => {
+                materialize_output(output, materializer)
+            },
+            Some(ExecutionStatus::Aborted(_))
+            | Some(ExecutionStatus::SpeculativeFailure)
+            | None => Err(code_invariant_error(
+                "[BlockSTM]: Output must be recorded after execution",
+            )
+            .into()),
+        }
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -172,7 +172,7 @@ impl TransactionOutput for TestOutput {
     }
 
     fn incorporate_materialized_txn_output(
-        &mut self,
+        self,
         _patched_resource_write_set: Vec<(StateKey, WriteOp)>,
         _patched_events: Vec<ContractEvent>,
     ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
@@ -289,7 +289,7 @@ impl ExecutorTask for TestTask {
         txn: &Self::Txn,
         _auxiliary_info: &Self::AuxiliaryInfo,
         _txn_idx: TxnIndex,
-    ) -> ExecutionStatus<Self::Output> {
+    ) -> Result<ExecutionStatus<Self::Output>, PanicError> {
         let resolver = self.vm.as_move_resolver_with_group_view(view);
         let mut change_set_1 = self.run(&resolver, view, &txn.session_1);
         println!("  [session_1] change set: {:?}", change_set_1);
@@ -338,7 +338,10 @@ impl ExecutorTask for TestTask {
         };
         *outcome_cell().lock().unwrap() = Some(outcome);
 
-        ExecutionStatus::Success(TestOutput)
+        Ok(ExecutionStatus::Executed {
+            output: TestOutput,
+            skips_rest: false,
+        })
     }
 }
 

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -32,6 +32,7 @@ use aptos_types::{
         transaction_slice_metadata::TransactionSliceMetadata,
     },
     contract_event::ContractEvent,
+    error::PanicError,
     fee_statement::FeeStatement,
     move_utils::move_event_v2::MoveEventV2Type,
     state_store::{state_key::StateKey, state_value::StateValueMetadata, StateView},
@@ -138,24 +139,27 @@ impl ExecutorTask for NativeVMExecutorTask {
         txn: &SignatureVerifiedTransaction,
         _auxiliary_info: &AuxiliaryInfo,
         _txn_idx: TxnIndex,
-    ) -> ExecutionStatus<AptosTransactionOutput> {
-        match self.execute_transaction_impl(executor_with_group_view, txn) {
-            Ok((change_set, gas_units)) => {
-                ExecutionStatus::Success(AptosTransactionOutput::new(VMOutput::new(
-                    change_set,
-                    ModuleWriteSet::empty(),
-                    FeeStatement::builder()
-                        .total_charge_gas_units(gas_units)
-                        .execution_gas_units(gas_units)
-                        .io_gas_units(0)
-                        .storage_fee_octas(0)
-                        .storage_fee_refund_octas(0)
-                        .build(),
-                    TransactionStatus::Keep(aptos_types::transaction::ExecutionStatus::Success),
-                )))
+    ) -> Result<ExecutionStatus<AptosTransactionOutput>, PanicError> {
+        Ok(
+            match self.execute_transaction_impl(executor_with_group_view, txn) {
+                Ok((change_set, gas_units)) => ExecutionStatus::Executed {
+                    output: AptosTransactionOutput::new(VMOutput::new(
+                        change_set,
+                        ModuleWriteSet::empty(),
+                        FeeStatement::builder()
+                            .total_charge_gas_units(gas_units)
+                            .execution_gas_units(gas_units)
+                            .io_gas_units(0)
+                            .storage_fee_octas(0)
+                            .storage_fee_refund_octas(0)
+                            .build(),
+                        TransactionStatus::Keep(aptos_types::transaction::ExecutionStatus::Success),
+                    )),
+                    skips_rest: false,
+                },
+                Err(_) => ExecutionStatus::SpeculativeFailure,
             },
-            Err(_) => ExecutionStatus::SpeculativeExecutionAbortError("something".to_string()),
-        }
+        )
     }
 }
 


### PR DESCRIPTION
## Description

Stacked on #20256 (`[block-stm] Remove generic error from output`).

Refactors the block executor's per-transaction result type and removes the
macro-based output store.

Replaces `task::ExecutionStatus<O>` with `ExecutionStatus<O>`:
- `Success` / `SkipRest` collapse into `Executed { output, skips_rest }`, with
  the output stored inline — present exactly for committable transactions.
- `Abort(String)` becomes `Aborted(String)`.
- `SpeculativeExecutionAbortError(String)` becomes `SpeculativeFailure`; the
  message is dropped (it was only logged).
- `DelayedFieldsCodeInvariantError` is removed. `execute_transaction` now returns
  `Result<ExecutionStatus<O>, PanicError>`, so a code-invariant bug surfaces as
  `Err(PanicError)` and is never stored.

Because the output lives inline in `Committed`, the `with_success_or_skip_rest!`
macro and `OutputStatusKind` in `txn_last_input_output.rs` collapse into matching
`ExecutionStatus` directly (`OutputWrapper` now holds `Option<ExecutionStatus<O>>`).

Output ownership now flows through materialization, setting up removal of the
`before_materialization` guard in a later change:
- `TxnLastInputOutput::materialize` takes the output out of its slot (lock held
  only for the take; the finalize runs on the owned value).
- `materialize_output` takes `O` by value and
  `TransactionOutput::incorporate_materialized_txn_output` takes `self`.

No functional change intended — a representation refactor. Behavior preserved:
aborts fail the block with the same (`txn_idx`-derived) message, `SkipRest` ends
the block and creates the epilogue txn, the block-gas-limit early-halt flips a
committed txn to skip-rest, and code-invariant errors still abort (now via `Err`).

## How Has This Been Tested?

- `cargo nextest run -p aptos-block-executor` — 265/265 pass (full combinatorial
  suite: abort, skip-rest, block-gas-limit, resource groups).
- `cargo nextest run -p e2e-move-tests sessions_with_delayed_fields` — passes.
- `cargo check` on `aptos-block-executor`, `aptos-vm`, `aptos-executor-benchmark`,
  `e2e-move-tests` (all targets).

## Key Areas to Review

- `txn_last_input_output.rs`: the macro removal and the `commit` rewrite
  (disjoint borrow of `output` vs `skips_rest`; guard dropped before flipping the
  flag), and `materialize` taking the output out of its slot.
- `executor.rs`: the speculative-failure read-set capture moved inline into the
  v1/v2 execute paths (v1 needs it for re-validation; v2 discards the read set).
- `mock_executor.rs`: keeps its builder railway via a module-internal
  `ExecutionStatus` — so the baseline's abort assertion is unchanged.

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Block-STM commit, speculative-failure, and materialization paths across VM and executor; behavior is intended to be equivalent but mistakes in status handling or output ownership could affect block execution.
> 
> **Overview**
> This PR reshapes how Block-STM records and commits per-transaction results, with **no intended behavior change**.
> 
> **`ExecutionStatus` is simplified:** `Success` and `SkipRest` become **`Executed { output, skips_rest }`** (output only when committable). **`Abort` → `Aborted`**, speculative abort becomes **`SpeculativeFailure`** (message dropped). **`DelayedFieldsCodeInvariantError` is removed** — `ExecutorTask::execute_transaction` now returns **`Result<ExecutionStatus<O>, PanicError>`** so invariant bugs propagate as `Err` instead of being stored.
> 
> **`txn_last_input_output` drops `OutputStatusKind` and the `with_success_or_skip_rest!` macro:** wrappers hold **`Option<ExecutionStatus<O>>`** and match on that directly in `commit`, accessors, and **`materialize`** (which **takes** the output from its slot).
> 
> **Ownership through materialization:** `materialize_output` and **`incorporate_materialized_txn_output`** take the output **by value** (`self` instead of `&mut self`), so sequential/parallel paths move owned outputs through finalize/commit.
> 
> **Executor wiring:** `process_execution_result` is removed; parallel v1/v2 paths **`?` propagate** executor `PanicError`, use **`is_speculative_failure()` / `get_output()`**, and v1 still injects the delayed-field read error on speculative failure. Aptos VM wrapper, mocks, benchmarks, and e2e tests are updated to the new enum and `Result` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b51ba11baa306029f0d20b39c72b47002c300d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->