### PR TITLE
[mono-move] Stackless execution IR now has named fields and doc comments

### DIFF
--- a/third_party/move/mono-move/specializer/src/destack/analysis.rs
+++ b/third_party/move/mono-move/specializer/src/destack/analysis.rs
@@ -159,7 +159,7 @@ pub(crate) struct BlockAnalysis {
     /// Vid's slot can be reused.
     pub live_end: UnorderedMap<Slot, usize>,
     /// `Vid` → Home slot, when the Vid will later be moved into the Home
-    /// slot (`Move(Home, vid)`, the `st_loc` shape produced by destack)
+    /// slot (`Move { dst: Home, src: vid }`, the `st_loc` shape produced by destack)
     /// and the Home slot is not accessed between the Vid's def and the
     /// store. Sound because destack emits this shape only for `StLoc`,
     /// where the Vid is popped — the move is its last use, so coloring
@@ -191,7 +191,7 @@ impl BlockAnalysis {
     /// skips Vids already in `stloc_targets`, and `xfer_precolor` skips
     /// Vids already in either earlier map. (`coalesce_to_local` ∩ call
     /// rets is empty by SSA: a Vid defined by a `Call` is never the
-    /// `dst` of `Copy/Move(vid, Home)`.)
+    /// `dst` of `Copy`/`Move { dst: vid, src: Home }`.)
     pub(crate) fn analyze(instrs: &[Instr]) -> Self {
         // Forward scan: build per-`Vid` and per-`Home` position indices.
         // `Vid` -> last instruction index where it appears as def or use.
@@ -258,7 +258,7 @@ impl BlockAnalysis {
         // per candidate.
         let mut stloc_targets: UnorderedMap<Slot, Slot> = UnorderedMap::new();
         for (i, instr) in instrs.iter().enumerate() {
-            if let Instr::Move(dst, src) = instr
+            if let Instr::Move { dst, src } = instr
                 && dst.is_home()
                 && src.is_vid()
                 && !stloc_targets.contains_key(src)
@@ -277,8 +277,9 @@ impl BlockAnalysis {
         // via binary search.
         let mut coalesce_to_local: UnorderedMap<Slot, Slot> = UnorderedMap::new();
         for (i, instr) in instrs.iter().enumerate() {
-            if let Instr::Copy(dst @ Slot::Vid(_), src @ Slot::Home(_))
-            | Instr::Move(dst @ Slot::Vid(_), src @ Slot::Home(_)) = instr
+            if let Instr::Copy { dst, src } | Instr::Move { dst, src } = instr
+                && dst.is_vid()
+                && src.is_home()
             {
                 let vid = *dst;
                 if let Some(&lu) = live_end.get(&vid)
@@ -806,7 +807,7 @@ fn assert_xfer_invariants(
 /// covering both variants, see `instr_utils::call_boundary_rets_and_args`.
 #[inline]
 fn direct_call_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[Slot])> {
-    if let Instr::Call(data) = instr {
+    if let Instr::Call { data } = instr {
         Some((&data.rets, &data.args))
     } else {
         None
@@ -957,12 +958,14 @@ mod tests {
     fn analyze_handles_wide_call_signatures() {
         // 200 args exercises `SmallBitVec`'s heap-allocated path.
         let args: Box<[Slot]> = (0..200).map(Slot::Vid).collect();
-        let instrs = vec![Instr::Call(Box::new(CallData {
-            rets: Box::new([]),
-            function_handle: FunctionHandleIndex(0),
-            ty_args: EMPTY_TYPE_LIST,
-            args,
-        }))];
+        let instrs = vec![Instr::Call {
+            data: Box::new(CallData {
+                rets: Box::new([]),
+                function_handle: FunctionHandleIndex(0),
+                ty_args: EMPTY_TYPE_LIST,
+                args,
+            }),
+        }];
         let analysis = BlockAnalysis::analyze(&instrs);
         assert_eq!(analysis.max_xfer_positions, 200);
     }

--- a/third_party/move/mono-move/specializer/src/destack/optimize.rs
+++ b/third_party/move/mono-move/specializer/src/destack/optimize.rs
@@ -55,11 +55,11 @@ pub fn optimize_module(module_ir: &mut ModuleIR) {
 /// reference (via `WriteRef`, function calls, etc.) without appearing as a
 /// def in `get_defs_uses`. So we kill subst entries for the borrowed slot
 /// at `MutBorrowLoc` — conservatively assuming hidden writes may follow.
-/// `MutBorrowLocField` and `WriteLocalField` have the same hazard.
+/// `MutBorrowLocField` and `WriteLocField` have the same hazard.
 ///
 /// `ImmBorrowLoc` does NOT need this kill — the verifier guarantees the
 /// borrowed slot cannot be modified while immutably borrowed. The same
-/// holds for `ImmBorrowLocField` and `ReadLocalField`.
+/// holds for `ImmBorrowLocField` and `ReadLocField`.
 ///
 /// ## Why cross-block mutable borrows are safe
 ///
@@ -78,13 +78,13 @@ fn copy_propagation(func: &mut FunctionIR) {
 
             // Kill subst for locals whose storage may be mutated without a
             // full def: mut borrows (writes go through the ref) and
-            // `WriteLocalField` (partial write). `WriteLocalFieldChain`
+            // `WriteLocField` (partial write). `WriteLocFieldChain`
             // reports its root local as a def, so it is covered by the
             // `for_each_def` kill below; the ref-rooted `WriteFieldChain`
             // writes through a reference whose originating mut borrow was
             // already killed here.
             let mut hidden_write = mut_local_borrow_target(instr);
-            if let Instr::WriteLocalField(_, _, local, _) = instr {
+            if let Instr::WriteLocField { local, .. } = instr {
                 hidden_write = Some(*local);
             }
             if let Some(src) = hidden_write {
@@ -98,7 +98,7 @@ fn copy_propagation(func: &mut FunctionIR) {
             });
 
             match instr {
-                Instr::Copy(dst, src) | Instr::Move(dst, src) => {
+                Instr::Copy { dst, src } | Instr::Move { dst, src } => {
                     // Xfer slot values don't survive a call boundary,
                     // so don't copy propagate from them.
                     if !matches!(src, Slot::Xfer(_)) {
@@ -111,12 +111,14 @@ fn copy_propagation(func: &mut FunctionIR) {
     }
 }
 
-/// Pass: Remove `Move(r, r)` and `Copy(r, r)` instructions.
+/// Pass: Remove `Move` and `Copy` instructions whose `dst == src`.
 fn eliminate_identity_moves(func: &mut FunctionIR) {
     for block in &mut func.blocks {
         block
             .instrs
-            .retain(|instr| !matches!(instr, Instr::Move(d, s) | Instr::Copy(d, s) if d == s));
+            .retain(|instr| {
+                !matches!(instr, Instr::Move { dst, src } | Instr::Copy { dst, src } if dst == src)
+            });
     }
 }
 
@@ -152,7 +154,9 @@ fn dead_instruction_elimination(func: &mut FunctionIR) {
 
         for (i, instr) in block.instrs.iter().enumerate().rev() {
             let is_removable = match instr {
-                Instr::Copy(dst, _) | Instr::Move(dst, _) if !cross_block_slots.contains(dst) => {
+                Instr::Copy { dst, .. } | Instr::Move { dst, .. }
+                    if !cross_block_slots.contains(dst) =>
+                {
                     !live.contains(dst)
                 },
                 _ => false,

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -428,7 +428,10 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::LdConst(idx) => {
                 let ty = module.interned_constant_type_at(*idx);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs.push(Instr::LdConst(dst, *idx));
+                self.current_block_instrs.push(Instr::LdConst {
+                    dst,
+                    const_idx: *idx,
+                });
                 self.push_slot(dst);
             },
 
@@ -437,20 +440,20 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let src = Slot::Home(*idx as u16);
                 let ty = self.local_types[*idx as usize];
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs.push(Instr::Copy(dst, src));
+                self.current_block_instrs.push(Instr::Copy { dst, src });
                 self.push_slot(dst);
             },
             B::MoveLoc(idx) => {
                 let src = Slot::Home(*idx as u16);
                 let ty = self.local_types[*idx as usize];
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs.push(Instr::Move(dst, src));
+                self.current_block_instrs.push(Instr::Move { dst, src });
                 self.push_slot(dst);
             },
             B::StLoc(idx) => {
                 let src = self.pop_slot()?;
                 let dst = Slot::Home(*idx as u16);
-                self.current_block_instrs.push(Instr::Move(dst, src));
+                self.current_block_instrs.push(Instr::Move { dst, src });
             },
 
             // --- Pop ---
@@ -519,21 +522,27 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             // --- Struct ops ---
             B::Pack(idx) => {
                 let n = struct_field_count(module, *idx);
-                let fields = self.pop_n_reverse(n)?;
-                let result_ty = module.interned_nominal_def_type_at(*idx);
-                let dst = self.alloc_vid(result_ty)?;
-                self.current_block_instrs
-                    .push(Instr::Pack(dst, result_ty, fields));
+                let srcs = self.pop_n_reverse(n)?;
+                let struct_ty = module.interned_nominal_def_type_at(*idx);
+                let dst = self.alloc_vid(struct_ty)?;
+                self.current_block_instrs.push(Instr::Pack {
+                    dst,
+                    struct_ty,
+                    srcs,
+                });
                 self.push_slot(dst);
             },
             B::PackGeneric(idx) => {
                 let inst = &module.struct_def_instantiations[idx.0 as usize];
                 let n = struct_field_count(module, inst.def);
-                let fields = self.pop_n_reverse(n)?;
-                let result_ty = self.struct_inst_ty(module, *idx)?;
-                let dst = self.alloc_vid(result_ty)?;
-                self.current_block_instrs
-                    .push(Instr::Pack(dst, result_ty, fields));
+                let srcs = self.pop_n_reverse(n)?;
+                let struct_ty = self.struct_inst_ty(module, *idx)?;
+                let dst = self.alloc_vid(struct_ty)?;
+                self.current_block_instrs.push(Instr::Pack {
+                    dst,
+                    struct_ty,
+                    srcs,
+                });
                 self.push_slot(dst);
             },
             B::Unpack(idx) => {
@@ -547,8 +556,11 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 }
                 let dsts = self.push_results(dsts);
                 let struct_ty = module.interned_nominal_def_type_at(*idx);
-                self.current_block_instrs
-                    .push(Instr::Unpack(dsts, struct_ty, src));
+                self.current_block_instrs.push(Instr::Unpack {
+                    dsts,
+                    struct_ty,
+                    src,
+                });
             },
             B::UnpackGeneric(idx) => {
                 let src = self.pop_slot()?;
@@ -556,7 +568,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let fields = module
                     .interned_struct_field_types_at(inst.def)
                     .ok_or(SsaConversionError::ExpectedStructType)?;
-                let inst_ty = self.struct_inst_ty(module, *idx)?;
+                let struct_ty = self.struct_inst_ty(module, *idx)?;
                 let ty_args = self
                     .interner
                     .type_list_of(module.interned_types_at(inst.type_parameters));
@@ -566,8 +578,11 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     dsts.push(self.alloc_vid(fty)?);
                 }
                 let dsts = self.push_results(dsts);
-                self.current_block_instrs
-                    .push(Instr::Unpack(dsts, inst_ty, src));
+                self.current_block_instrs.push(Instr::Unpack {
+                    dsts,
+                    struct_ty,
+                    src,
+                });
             },
 
             // --- Variant ops ---
@@ -575,11 +590,15 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let handle = module.struct_variant_handle_at(*idx);
                 let variant = handle.variant;
                 let n = variant_field_count(module, handle.struct_index, variant);
-                let fields = self.pop_n_reverse(n)?;
-                let result_ty = module.interned_nominal_def_type_at(handle.struct_index);
-                let dst = self.alloc_vid(result_ty)?;
-                self.current_block_instrs
-                    .push(Instr::PackVariant(dst, result_ty, variant, fields));
+                let srcs = self.pop_n_reverse(n)?;
+                let enum_ty = module.interned_nominal_def_type_at(handle.struct_index);
+                let dst = self.alloc_vid(enum_ty)?;
+                self.current_block_instrs.push(Instr::PackVariant {
+                    dst,
+                    enum_ty,
+                    variant,
+                    srcs,
+                });
                 self.push_slot(dst);
             },
             B::PackVariantGeneric(idx) => {
@@ -587,15 +606,15 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let handle = &module.struct_variant_handles[inst.handle.0 as usize];
                 let variant = handle.variant;
                 let n = variant_field_count(module, handle.struct_index, variant);
-                let fields = self.pop_n_reverse(n)?;
-                let (inst_ty, variant_ord, _) = self.variant_inst_parts(module, *idx)?;
-                let dst = self.alloc_vid(inst_ty)?;
-                self.current_block_instrs.push(Instr::PackVariant(
+                let srcs = self.pop_n_reverse(n)?;
+                let (enum_ty, variant_ord, _) = self.variant_inst_parts(module, *idx)?;
+                let dst = self.alloc_vid(enum_ty)?;
+                self.current_block_instrs.push(Instr::PackVariant {
                     dst,
-                    inst_ty,
-                    variant_ord,
-                    fields,
-                ));
+                    enum_ty,
+                    variant: variant_ord,
+                    srcs,
+                });
                 self.push_slot(dst);
             },
             B::UnpackVariant(idx) => {
@@ -611,8 +630,12 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 }
                 let dsts = self.push_results(dsts);
                 let enum_ty = module.interned_nominal_def_type_at(handle.struct_index);
-                self.current_block_instrs
-                    .push(Instr::UnpackVariant(dsts, enum_ty, variant, src));
+                self.current_block_instrs.push(Instr::UnpackVariant {
+                    dsts,
+                    enum_ty,
+                    variant,
+                    src,
+                });
             },
             B::UnpackVariantGeneric(idx) => {
                 let src = self.pop_slot()?;
@@ -622,19 +645,19 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let fields = module
                     .interned_variant_field_types_at(handle.struct_index, variant)
                     .ok_or(SsaConversionError::ExpectedEnumType)?;
-                let (inst_ty, variant_ord, ty_args) = self.variant_inst_parts(module, *idx)?;
+                let (enum_ty, variant_ord, ty_args) = self.variant_inst_parts(module, *idx)?;
                 let mut dsts = Vec::with_capacity(fields.len());
                 for &fty in fields {
                     let fty = self.interner.subst_type(fty, ty_args)?;
                     dsts.push(self.alloc_vid(fty)?);
                 }
                 let dsts = self.push_results(dsts);
-                self.current_block_instrs.push(Instr::UnpackVariant(
+                self.current_block_instrs.push(Instr::UnpackVariant {
                     dsts,
-                    inst_ty,
-                    variant_ord,
+                    enum_ty,
+                    variant: variant_ord,
                     src,
-                ));
+                });
             },
             B::TestVariant(idx) => {
                 let src = self.pop_slot()?;
@@ -642,116 +665,160 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let variant = handle.variant;
                 let enum_ty = module.interned_nominal_def_type_at(handle.struct_index);
                 let dst = self.alloc_vid(ty::BOOL_TY)?;
-                self.current_block_instrs
-                    .push(Instr::TestVariant(dst, enum_ty, variant, src));
+                self.current_block_instrs.push(Instr::TestVariant {
+                    dst,
+                    enum_ty,
+                    variant,
+                    src,
+                });
                 self.push_slot(dst);
             },
             B::TestVariantGeneric(idx) => {
                 let src = self.pop_slot()?;
-                let (inst_ty, variant, _) = self.variant_inst_parts(module, *idx)?;
+                let (enum_ty, variant, _) = self.variant_inst_parts(module, *idx)?;
                 let dst = self.alloc_vid(ty::BOOL_TY)?;
-                self.current_block_instrs
-                    .push(Instr::TestVariant(dst, inst_ty, variant, src));
+                self.current_block_instrs.push(Instr::TestVariant {
+                    dst,
+                    enum_ty,
+                    variant,
+                    src,
+                });
                 self.push_slot(dst);
             },
 
             // --- References ---
             B::ImmBorrowLoc(idx) => {
-                let src = Slot::Home(*idx as u16);
+                let local = Slot::Home(*idx as u16);
                 let inner = self.local_types[*idx as usize];
                 let ty = self.interner.immut_ref_of(inner);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs
-                    .push(Instr::ImmBorrowLoc(dst, src));
+                    .push(Instr::ImmBorrowLoc { dst, local });
                 self.push_slot(dst);
             },
             B::MutBorrowLoc(idx) => {
-                let src = Slot::Home(*idx as u16);
+                let local = Slot::Home(*idx as u16);
                 let inner = self.local_types[*idx as usize];
                 let ty = self.interner.mut_ref_of(inner);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs
-                    .push(Instr::MutBorrowLoc(dst, src));
+                    .push(Instr::MutBorrowLoc { dst, local });
                 self.push_slot(dst);
             },
             B::ImmBorrowField(idx) => {
                 let src = self.pop_slot()?;
                 let owner_idx = module.field_handle_at(*idx).owner;
-                let owner = module.interned_nominal_def_type_at(owner_idx);
+                let owner_ty = module.interned_nominal_def_type_at(owner_idx);
                 let fty = module.interned_field_type_at(*idx);
                 let ty = self.interner.immut_ref_of(fty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::ImmBorrowField(dst, owner, *idx, src));
+                self.current_block_instrs.push(Instr::ImmBorrowField {
+                    dst,
+                    owner_ty,
+                    field: *idx,
+                    src,
+                });
                 self.push_slot(dst);
             },
             B::MutBorrowField(idx) => {
                 let src = self.pop_slot()?;
                 let owner_idx = module.field_handle_at(*idx).owner;
-                let owner = module.interned_nominal_def_type_at(owner_idx);
+                let owner_ty = module.interned_nominal_def_type_at(owner_idx);
                 let fty = module.interned_field_type_at(*idx);
                 let ty = self.interner.mut_ref_of(fty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::MutBorrowField(dst, owner, *idx, src));
+                self.current_block_instrs.push(Instr::MutBorrowField {
+                    dst,
+                    owner_ty,
+                    field: *idx,
+                    src,
+                });
                 self.push_slot(dst);
             },
             B::ImmBorrowFieldGeneric(idx) => {
                 let src = self.pop_slot()?;
-                let (handle, owner, fty) = self.field_inst_parts(module, *idx)?;
+                let (field, owner_ty, fty) = self.field_inst_parts(module, *idx)?;
                 let ty = self.interner.immut_ref_of(fty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::ImmBorrowField(dst, owner, handle, src));
+                self.current_block_instrs.push(Instr::ImmBorrowField {
+                    dst,
+                    owner_ty,
+                    field,
+                    src,
+                });
                 self.push_slot(dst);
             },
             B::MutBorrowFieldGeneric(idx) => {
                 let src = self.pop_slot()?;
-                let (handle, owner, fty) = self.field_inst_parts(module, *idx)?;
+                let (field, owner_ty, fty) = self.field_inst_parts(module, *idx)?;
                 let ty = self.interner.mut_ref_of(fty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::MutBorrowField(dst, owner, handle, src));
+                self.current_block_instrs.push(Instr::MutBorrowField {
+                    dst,
+                    owner_ty,
+                    field,
+                    src,
+                });
                 self.push_slot(dst);
             },
             B::ImmBorrowVariantField(idx) => {
                 let src = self.pop_slot()?;
                 let owner_idx = module.variant_field_handle_at(*idx).struct_index;
-                let owner = module.interned_nominal_def_type_at(owner_idx);
+                let owner_ty = module.interned_nominal_def_type_at(owner_idx);
                 let fty = module.interned_variant_field_type_at(*idx);
                 let ty = self.interner.immut_ref_of(fty);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs
-                    .push(Instr::ImmBorrowVariantField(dst, owner, *idx, src));
+                    .push(Instr::ImmBorrowVariantField {
+                        dst,
+                        owner_ty,
+                        field: *idx,
+                        src,
+                    });
                 self.push_slot(dst);
             },
             B::MutBorrowVariantField(idx) => {
                 let src = self.pop_slot()?;
                 let owner_idx = module.variant_field_handle_at(*idx).struct_index;
-                let owner = module.interned_nominal_def_type_at(owner_idx);
+                let owner_ty = module.interned_nominal_def_type_at(owner_idx);
                 let fty = module.interned_variant_field_type_at(*idx);
                 let ty = self.interner.mut_ref_of(fty);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs
-                    .push(Instr::MutBorrowVariantField(dst, owner, *idx, src));
+                    .push(Instr::MutBorrowVariantField {
+                        dst,
+                        owner_ty,
+                        field: *idx,
+                        src,
+                    });
                 self.push_slot(dst);
             },
             B::ImmBorrowVariantFieldGeneric(idx) => {
                 let src = self.pop_slot()?;
-                let (handle, owner, fty) = self.variant_field_inst_parts(module, *idx)?;
+                let (field, owner_ty, fty) = self.variant_field_inst_parts(module, *idx)?;
                 let ty = self.interner.immut_ref_of(fty);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs
-                    .push(Instr::ImmBorrowVariantField(dst, owner, handle, src));
+                    .push(Instr::ImmBorrowVariantField {
+                        dst,
+                        owner_ty,
+                        field,
+                        src,
+                    });
                 self.push_slot(dst);
             },
             B::MutBorrowVariantFieldGeneric(idx) => {
                 let src = self.pop_slot()?;
-                let (handle, owner, fty) = self.variant_field_inst_parts(module, *idx)?;
+                let (field, owner_ty, fty) = self.variant_field_inst_parts(module, *idx)?;
                 let ty = self.interner.mut_ref_of(fty);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs
-                    .push(Instr::MutBorrowVariantField(dst, owner, handle, src));
+                    .push(Instr::MutBorrowVariantField {
+                        dst,
+                        owner_ty,
+                        field,
+                        src,
+                    });
                 self.push_slot(dst);
             },
             B::ReadRef => {
@@ -760,96 +827,127 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 // The bytecode verifier guarantees the operand is `&T` or `&mut T`.
                 let ty = strip_ref(src_ty).ok_or(SsaConversionError::ExpectedReferenceType)?;
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs.push(Instr::ReadRef(dst, src));
+                self.current_block_instrs.push(Instr::ReadRef { dst, src });
                 self.push_slot(dst);
             },
             B::WriteRef => {
-                let ref_r = self.pop_slot()?;
+                let dst_ref = self.pop_slot()?;
                 let val = self.pop_slot()?;
-                self.current_block_instrs.push(Instr::WriteRef(ref_r, val));
+                self.current_block_instrs
+                    .push(Instr::WriteRef { dst_ref, val });
             },
 
             // --- Globals ---
             B::Exists(idx) => {
                 let addr = self.pop_slot()?;
-                let struct_ty = module.interned_nominal_def_type_at(*idx);
+                let resource_ty = module.interned_nominal_def_type_at(*idx);
                 let dst = self.alloc_vid(ty::BOOL_TY)?;
-                self.current_block_instrs
-                    .push(Instr::Exists(dst, struct_ty, addr));
+                self.current_block_instrs.push(Instr::Exists {
+                    dst,
+                    resource_ty,
+                    addr,
+                });
                 self.push_slot(dst);
             },
             B::ExistsGeneric(idx) => {
                 let addr = self.pop_slot()?;
-                let inst_ty = self.struct_inst_ty(module, *idx)?;
+                let resource_ty = self.struct_inst_ty(module, *idx)?;
                 let dst = self.alloc_vid(ty::BOOL_TY)?;
-                self.current_block_instrs
-                    .push(Instr::Exists(dst, inst_ty, addr));
+                self.current_block_instrs.push(Instr::Exists {
+                    dst,
+                    resource_ty,
+                    addr,
+                });
                 self.push_slot(dst);
             },
             B::MoveFrom(idx) => {
                 let addr = self.pop_slot()?;
-                let ty = module.interned_nominal_def_type_at(*idx);
-                let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::MoveFrom(dst, ty, addr));
+                let resource_ty = module.interned_nominal_def_type_at(*idx);
+                let dst = self.alloc_vid(resource_ty)?;
+                self.current_block_instrs.push(Instr::MoveFrom {
+                    dst,
+                    resource_ty,
+                    addr,
+                });
                 self.push_slot(dst);
             },
             B::MoveFromGeneric(idx) => {
                 let addr = self.pop_slot()?;
-                let ty = self.struct_inst_ty(module, *idx)?;
-                let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::MoveFrom(dst, ty, addr));
+                let resource_ty = self.struct_inst_ty(module, *idx)?;
+                let dst = self.alloc_vid(resource_ty)?;
+                self.current_block_instrs.push(Instr::MoveFrom {
+                    dst,
+                    resource_ty,
+                    addr,
+                });
                 self.push_slot(dst);
             },
             B::MoveTo(idx) => {
                 let val = self.pop_slot()?;
                 let signer = self.pop_slot()?;
-                let struct_ty = module.interned_nominal_def_type_at(*idx);
-                self.current_block_instrs
-                    .push(Instr::MoveTo(struct_ty, signer, val));
+                let resource_ty = module.interned_nominal_def_type_at(*idx);
+                self.current_block_instrs.push(Instr::MoveTo {
+                    resource_ty,
+                    signer,
+                    val,
+                });
             },
             B::MoveToGeneric(idx) => {
                 let val = self.pop_slot()?;
                 let signer = self.pop_slot()?;
-                let inst_ty = self.struct_inst_ty(module, *idx)?;
-                self.current_block_instrs
-                    .push(Instr::MoveTo(inst_ty, signer, val));
+                let resource_ty = self.struct_inst_ty(module, *idx)?;
+                self.current_block_instrs.push(Instr::MoveTo {
+                    resource_ty,
+                    signer,
+                    val,
+                });
             },
             B::ImmBorrowGlobal(idx) => {
                 let addr = self.pop_slot()?;
-                let inner = module.interned_nominal_def_type_at(*idx);
-                let ty = self.interner.immut_ref_of(inner);
+                let resource_ty = module.interned_nominal_def_type_at(*idx);
+                let ty = self.interner.immut_ref_of(resource_ty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::ImmBorrowGlobal(dst, inner, addr));
+                self.current_block_instrs.push(Instr::ImmBorrowGlobal {
+                    dst,
+                    resource_ty,
+                    addr,
+                });
                 self.push_slot(dst);
             },
             B::ImmBorrowGlobalGeneric(idx) => {
                 let addr = self.pop_slot()?;
-                let inner = self.struct_inst_ty(module, *idx)?;
-                let ty = self.interner.immut_ref_of(inner);
+                let resource_ty = self.struct_inst_ty(module, *idx)?;
+                let ty = self.interner.immut_ref_of(resource_ty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::ImmBorrowGlobal(dst, inner, addr));
+                self.current_block_instrs.push(Instr::ImmBorrowGlobal {
+                    dst,
+                    resource_ty,
+                    addr,
+                });
                 self.push_slot(dst);
             },
             B::MutBorrowGlobal(idx) => {
                 let addr = self.pop_slot()?;
-                let inner = module.interned_nominal_def_type_at(*idx);
-                let ty = self.interner.mut_ref_of(inner);
+                let resource_ty = module.interned_nominal_def_type_at(*idx);
+                let ty = self.interner.mut_ref_of(resource_ty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::MutBorrowGlobal(dst, inner, addr));
+                self.current_block_instrs.push(Instr::MutBorrowGlobal {
+                    dst,
+                    resource_ty,
+                    addr,
+                });
                 self.push_slot(dst);
             },
             B::MutBorrowGlobalGeneric(idx) => {
                 let addr = self.pop_slot()?;
-                let inner = self.struct_inst_ty(module, *idx)?;
-                let ty = self.interner.mut_ref_of(inner);
+                let resource_ty = self.struct_inst_ty(module, *idx)?;
+                let ty = self.interner.mut_ref_of(resource_ty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::MutBorrowGlobal(dst, inner, addr));
+                self.current_block_instrs.push(Instr::MutBorrowGlobal {
+                    dst,
+                    resource_ty,
+                    addr,
+                });
                 self.push_slot(dst);
             },
 
@@ -865,13 +963,14 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     rets.push(self.alloc_vid(rty)?);
                 }
                 let rets = self.push_results(rets);
-                self.current_block_instrs
-                    .push(Instr::Call(Box::new(CallData {
+                self.current_block_instrs.push(Instr::Call {
+                    data: Box::new(CallData {
                         rets,
                         function_handle: *idx,
                         ty_args: ty::EMPTY_TYPE_LIST,
                         args,
-                    })));
+                    }),
+                });
             },
             B::CallGeneric(idx) => {
                 let (handle_idx, ty_args) = self.fun_inst_parts(module, *idx);
@@ -886,13 +985,14 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     rets.push(self.alloc_vid(rty)?);
                 }
                 let rets = self.push_results(rets);
-                self.current_block_instrs
-                    .push(Instr::Call(Box::new(CallData {
+                self.current_block_instrs.push(Instr::Call {
+                    data: Box::new(CallData {
                         rets,
                         function_handle: handle_idx,
                         ty_args,
                         args,
-                    })));
+                    }),
+                });
             },
 
             // --- Closures ---
@@ -912,14 +1012,15 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     move_core_types::ability::AbilitySet::EMPTY,
                 );
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::PackClosure(Box::new(PackClosureData {
+                self.current_block_instrs.push(Instr::PackClosure {
+                    data: Box::new(PackClosureData {
                         dst,
                         function_handle: *fhi,
                         ty_args: ty::EMPTY_TYPE_LIST,
                         mask: *mask,
                         captured,
-                    })));
+                    }),
+                });
                 self.push_slot(dst);
             },
             B::PackClosureGeneric(fii, mask) => {
@@ -942,14 +1043,15 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     move_core_types::ability::AbilitySet::EMPTY,
                 );
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::PackClosure(Box::new(PackClosureData {
+                self.current_block_instrs.push(Instr::PackClosure {
+                    data: Box::new(PackClosureData {
                         dst,
                         function_handle: handle_idx,
                         ty_args,
                         mask: *mask,
                         captured,
-                    })));
+                    }),
+                });
                 self.push_slot(dst);
             },
             B::CallClosure(sig_idx) => {
@@ -975,65 +1077,81 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     rets.push(self.alloc_vid(rty)?);
                 }
                 let rets = self.push_results(rets);
-                self.current_block_instrs
-                    .push(Instr::CallClosure(Box::new(CallClosureData::new(
-                        rets, closure_ty, all_args,
-                    ))));
+                self.current_block_instrs.push(Instr::CallClosure {
+                    data: Box::new(CallClosureData::new(rets, closure_ty, all_args)),
+                });
             },
 
             // --- Vector ops ---
             B::VecPack(sig_idx, count) => {
                 // The bytecode verifier bounds the count to u16::MAX, so this cast is lossless.
                 let count = *count as u16;
-                let elems = self.pop_n_reverse(count as usize)?;
+                let srcs = self.pop_n_reverse(count as usize)?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let ty = self.interner.vector_of(elem_ty);
                 let dst = self.alloc_vid(ty)?;
                 self.current_block_instrs
-                    .push(Instr::VecPack(dst, elem_ty, elems));
+                    .push(Instr::VecPack { dst, elem_ty, srcs });
                 self.push_slot(dst);
             },
             B::VecLen(sig_idx) => {
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let dst = self.alloc_vid(ty::U64_TY)?;
-                self.current_block_instrs
-                    .push(Instr::VecLen(dst, elem_ty, vec_ref));
+                self.current_block_instrs.push(Instr::VecLen {
+                    dst,
+                    elem_ty,
+                    vec_ref,
+                });
                 self.push_slot(dst);
             },
             B::VecImmBorrow(sig_idx) => {
-                let idx_r = self.pop_slot()?;
+                let idx = self.pop_slot()?;
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let ty = self.interner.immut_ref_of(elem_ty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::VecImmBorrow(dst, elem_ty, vec_ref, idx_r));
+                self.current_block_instrs.push(Instr::VecImmBorrow {
+                    dst,
+                    elem_ty,
+                    vec_ref,
+                    idx,
+                });
                 self.push_slot(dst);
             },
             B::VecMutBorrow(sig_idx) => {
-                let idx_r = self.pop_slot()?;
+                let idx = self.pop_slot()?;
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let ty = self.interner.mut_ref_of(elem_ty);
                 let dst = self.alloc_vid(ty)?;
-                self.current_block_instrs
-                    .push(Instr::VecMutBorrow(dst, elem_ty, vec_ref, idx_r));
+                self.current_block_instrs.push(Instr::VecMutBorrow {
+                    dst,
+                    elem_ty,
+                    vec_ref,
+                    idx,
+                });
                 self.push_slot(dst);
             },
             B::VecPushBack(sig_idx) => {
                 let val = self.pop_slot()?;
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
-                self.current_block_instrs
-                    .push(Instr::VecPushBack(elem_ty, vec_ref, val));
+                self.current_block_instrs.push(Instr::VecPushBack {
+                    vec_ref,
+                    elem_ty,
+                    val,
+                });
             },
             B::VecPopBack(sig_idx) => {
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let dst = self.alloc_vid(elem_ty)?;
-                self.current_block_instrs
-                    .push(Instr::VecPopBack(dst, elem_ty, vec_ref));
+                self.current_block_instrs.push(Instr::VecPopBack {
+                    dst,
+                    elem_ty,
+                    vec_ref,
+                });
                 self.push_slot(dst);
             },
             B::VecUnpack(sig_idx, count) => {
@@ -1047,44 +1165,51 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 }
                 let dsts = self.push_results(dsts);
                 self.current_block_instrs
-                    .push(Instr::VecUnpack(dsts, elem_ty, src));
+                    .push(Instr::VecUnpack { dsts, elem_ty, src });
             },
             B::VecSwap(sig_idx) => {
-                let j = self.pop_slot()?;
-                let i = self.pop_slot()?;
+                let idx_b = self.pop_slot()?;
+                let idx_a = self.pop_slot()?;
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
-                self.current_block_instrs
-                    .push(Instr::VecSwap(elem_ty, vec_ref, i, j));
+                self.current_block_instrs.push(Instr::VecSwap {
+                    vec_ref,
+                    elem_ty,
+                    idx_a,
+                    idx_b,
+                });
             },
 
             // --- Control flow ---
-            B::Branch(target) => {
-                let label = *self.label_map.get(target).expect("branch target label");
-                self.current_block_instrs.push(Instr::Branch(label));
+            B::Branch(offset) => {
+                let target = *self.label_map.get(offset).expect("branch target label");
+                self.current_block_instrs.push(Instr::Branch { target });
             },
-            B::BrTrue(target) => {
+            B::BrTrue(offset) => {
                 let cond = self.pop_slot()?;
-                let label = *self.label_map.get(target).expect("branch target label");
-                self.current_block_instrs.push(Instr::BrTrue(label, cond));
+                let target = *self.label_map.get(offset).expect("branch target label");
+                self.current_block_instrs
+                    .push(Instr::BrTrue { target, cond });
             },
-            B::BrFalse(target) => {
+            B::BrFalse(offset) => {
                 let cond = self.pop_slot()?;
-                let label = *self.label_map.get(target).expect("branch target label");
-                self.current_block_instrs.push(Instr::BrFalse(label, cond));
+                let target = *self.label_map.get(offset).expect("branch target label");
+                self.current_block_instrs
+                    .push(Instr::BrFalse { target, cond });
             },
             B::Ret => {
-                let rets: Box<[Slot]> = self.stack.drain(..).collect();
-                self.current_block_instrs.push(Instr::Ret(rets));
+                let srcs: Box<[Slot]> = self.stack.drain(..).collect();
+                self.current_block_instrs.push(Instr::Ret { srcs });
             },
             B::Abort => {
                 let code = self.pop_slot()?;
-                self.current_block_instrs.push(Instr::Abort(code));
+                self.current_block_instrs.push(Instr::Abort { code });
             },
             B::AbortMsg => {
                 let msg = self.pop_slot()?;
                 let code = self.pop_slot()?;
-                self.current_block_instrs.push(Instr::AbortMsg(code, msg));
+                self.current_block_instrs
+                    .push(Instr::AbortMsg { code, msg });
             },
 
             B::Nop => {},
@@ -1094,7 +1219,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
     fn convert_load(&mut self, result_ty: InternedType, imm: ImmValue) -> VMResult<()> {
         let dst = self.alloc_vid(result_ty)?;
-        self.current_block_instrs.push(Instr::LdImm(dst, imm));
+        self.current_block_instrs.push(Instr::LdImm { dst, imm });
         self.push_slot(dst);
         Ok(())
     }
@@ -1109,7 +1234,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
         };
         let dst = self.alloc_vid(result_ty)?;
         self.current_block_instrs
-            .push(Instr::BinaryOp(dst, op, lhs, rhs));
+            .push(Instr::BinaryOp { dst, op, lhs, rhs });
         self.push_slot(dst);
         Ok(())
     }
@@ -1117,7 +1242,8 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
     fn convert_unop(&mut self, op: UnaryOp, result_ty: InternedType) -> VMResult<()> {
         let src = self.pop_slot()?;
         let dst = self.alloc_vid(result_ty)?;
-        self.current_block_instrs.push(Instr::UnaryOp(dst, op, src));
+        self.current_block_instrs
+            .push(Instr::UnaryOp { dst, op, src });
         self.push_slot(dst);
         Ok(())
     }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
@@ -81,25 +81,68 @@ fn fuse_pairs(instrs: &mut Vec<Instr>, try_fuse: fn(&Instr, &Instr) -> Option<In
 /// Try to fuse a borrow+deref pair into a combined field access instruction.
 fn try_fuse_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
     match (first, second) {
-        (Instr::ImmBorrowField(ref_r, owner, fld, src), Instr::ReadRef(dst, read_src))
-            if *ref_r == *read_src =>
-        {
-            Some(Instr::ReadField(*dst, *owner, *fld, *src))
-        },
-        (Instr::MutBorrowField(ref_r, owner, fld, dst_ref), Instr::WriteRef(write_ref, val))
-            if *ref_r == *write_ref =>
-        {
-            Some(Instr::WriteField(*owner, *fld, *dst_ref, *val))
-        },
-        (Instr::ImmBorrowVariantField(ref_r, owner, fld, src), Instr::ReadRef(dst, read_src))
-            if *ref_r == *read_src =>
-        {
-            Some(Instr::ReadVariantField(*dst, *owner, *fld, *src))
-        },
         (
-            Instr::MutBorrowVariantField(ref_r, owner, fld, dst_ref),
-            Instr::WriteRef(write_ref, val),
-        ) if *ref_r == *write_ref => Some(Instr::WriteVariantField(*owner, *fld, *dst_ref, *val)),
+            Instr::ImmBorrowField {
+                dst: ref_r,
+                owner_ty,
+                field,
+                src,
+            },
+            Instr::ReadRef { dst, src: read_src },
+        ) if *ref_r == *read_src => Some(Instr::ReadField {
+            dst: *dst,
+            owner_ty: *owner_ty,
+            field: *field,
+            src: *src,
+        }),
+        (
+            Instr::MutBorrowField {
+                dst: ref_r,
+                owner_ty,
+                field,
+                src: dst_ref,
+            },
+            Instr::WriteRef {
+                dst_ref: write_ref,
+                val,
+            },
+        ) if *ref_r == *write_ref => Some(Instr::WriteField {
+            dst_ref: *dst_ref,
+            owner_ty: *owner_ty,
+            field: *field,
+            val: *val,
+        }),
+        (
+            Instr::ImmBorrowVariantField {
+                dst: ref_r,
+                owner_ty,
+                field,
+                src,
+            },
+            Instr::ReadRef { dst, src: read_src },
+        ) if *ref_r == *read_src => Some(Instr::ReadVariantField {
+            dst: *dst,
+            owner_ty: *owner_ty,
+            field: *field,
+            src: *src,
+        }),
+        (
+            Instr::MutBorrowVariantField {
+                dst: ref_r,
+                owner_ty,
+                field,
+                src: dst_ref,
+            },
+            Instr::WriteRef {
+                dst_ref: write_ref,
+                val,
+            },
+        ) if *ref_r == *write_ref => Some(Instr::WriteVariantField {
+            dst_ref: *dst_ref,
+            owner_ty: *owner_ty,
+            field: *field,
+            val: *val,
+        }),
         _ => None,
     }
 }
@@ -108,26 +151,62 @@ fn try_fuse_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
 /// single local-field op, eliding the intermediate fat pointer.
 fn try_fuse_local_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
     match (first, second) {
-        (Instr::ImmBorrowLoc(ref_r, local), Instr::ImmBorrowField(dst, owner, fld, src))
-            if *ref_r == *src =>
-        {
-            Some(Instr::ImmBorrowLocField(*dst, *owner, *fld, *local))
-        },
-        (Instr::MutBorrowLoc(ref_r, local), Instr::MutBorrowField(dst, owner, fld, src))
-            if *ref_r == *src =>
-        {
-            Some(Instr::MutBorrowLocField(*dst, *owner, *fld, *local))
-        },
-        (Instr::ImmBorrowLoc(ref_r, local), Instr::ReadField(dst, owner, fld, src))
-            if *ref_r == *src =>
-        {
-            Some(Instr::ReadLocalField(*dst, *owner, *fld, *local))
-        },
-        (Instr::MutBorrowLoc(ref_r, local), Instr::WriteField(owner, fld, dst_ref, val))
-            if *ref_r == *dst_ref =>
-        {
-            Some(Instr::WriteLocalField(*owner, *fld, *local, *val))
-        },
+        (
+            Instr::ImmBorrowLoc { dst: ref_r, local },
+            Instr::ImmBorrowField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            },
+        ) if *ref_r == *src => Some(Instr::ImmBorrowLocField {
+            dst: *dst,
+            owner_ty: *owner_ty,
+            field: *field,
+            local: *local,
+        }),
+        (
+            Instr::MutBorrowLoc { dst: ref_r, local },
+            Instr::MutBorrowField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            },
+        ) if *ref_r == *src => Some(Instr::MutBorrowLocField {
+            dst: *dst,
+            owner_ty: *owner_ty,
+            field: *field,
+            local: *local,
+        }),
+        (
+            Instr::ImmBorrowLoc { dst: ref_r, local },
+            Instr::ReadField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            },
+        ) if *ref_r == *src => Some(Instr::ReadLocField {
+            dst: *dst,
+            owner_ty: *owner_ty,
+            field: *field,
+            local: *local,
+        }),
+        (
+            Instr::MutBorrowLoc { dst: ref_r, local },
+            Instr::WriteField {
+                dst_ref,
+                owner_ty,
+                field,
+                val,
+            },
+        ) if *ref_r == *dst_ref => Some(Instr::WriteLocField {
+            local: *local,
+            owner_ty: *owner_ty,
+            field: *field,
+            val: *val,
+        }),
         _ => None,
     }
 }
@@ -137,30 +216,62 @@ fn try_fuse_local_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
 /// Handles both `BrTrue` (keeps the comparison operator) and `BrFalse` (negates it).
 fn try_fuse_compare_branch(first: &Instr, second: &Instr) -> Option<Instr> {
     match (first, second) {
-        // BinaryOp(dst, Cmp(cmp), lhs, rhs) + BrTrue(label, dst)
-        (Instr::BinaryOp(dst, BinaryOp::Cmp(cmp), lhs, rhs), Instr::BrTrue(label, cond))
-            if *dst == *cond =>
-        {
-            Some(Instr::BrCmp(*label, *cmp, *lhs, *rhs))
-        },
-        // BinaryOp(dst, Cmp(cmp), lhs, rhs) + BrFalse(label, dst)
-        (Instr::BinaryOp(dst, BinaryOp::Cmp(cmp), lhs, rhs), Instr::BrFalse(label, cond))
-            if *dst == *cond =>
-        {
-            Some(Instr::BrCmp(*label, cmp.negate(), *lhs, *rhs))
-        },
-        // BinaryOpImm(dst, Cmp(cmp), src, imm) + BrTrue(label, dst)
-        (Instr::BinaryOpImm(dst, BinaryOp::Cmp(cmp), src, imm), Instr::BrTrue(label, cond))
-            if *dst == *cond =>
-        {
-            Some(Instr::BrCmpImm(*label, *cmp, *src, imm.clone()))
-        },
-        // BinaryOpImm(dst, Cmp(cmp), src, imm) + BrFalse(label, dst)
-        (Instr::BinaryOpImm(dst, BinaryOp::Cmp(cmp), src, imm), Instr::BrFalse(label, cond))
-            if *dst == *cond =>
-        {
-            Some(Instr::BrCmpImm(*label, cmp.negate(), *src, imm.clone()))
-        },
+        (
+            Instr::BinaryOp {
+                dst,
+                op: BinaryOp::Cmp(cmp),
+                lhs,
+                rhs,
+            },
+            Instr::BrTrue { target, cond },
+        ) if *dst == *cond => Some(Instr::BrCmp {
+            target: *target,
+            op: *cmp,
+            lhs: *lhs,
+            rhs: *rhs,
+        }),
+        (
+            Instr::BinaryOp {
+                dst,
+                op: BinaryOp::Cmp(cmp),
+                lhs,
+                rhs,
+            },
+            Instr::BrFalse { target, cond },
+        ) if *dst == *cond => Some(Instr::BrCmp {
+            target: *target,
+            op: cmp.negate(),
+            lhs: *lhs,
+            rhs: *rhs,
+        }),
+        (
+            Instr::BinaryOpImm {
+                dst,
+                op: BinaryOp::Cmp(cmp),
+                lhs,
+                imm,
+            },
+            Instr::BrTrue { target, cond },
+        ) if *dst == *cond => Some(Instr::BrCmpImm {
+            target: *target,
+            op: *cmp,
+            lhs: *lhs,
+            imm: imm.clone(),
+        }),
+        (
+            Instr::BinaryOpImm {
+                dst,
+                op: BinaryOp::Cmp(cmp),
+                lhs,
+                imm,
+            },
+            Instr::BrFalse { target, cond },
+        ) if *dst == *cond => Some(Instr::BrCmpImm {
+            target: *target,
+            op: cmp.negate(),
+            lhs: *lhs,
+            imm: imm.clone(),
+        }),
         _ => None,
     }
 }
@@ -224,7 +335,12 @@ fn fuse_field_chains(instrs: &mut Vec<Instr>) {
     // (the common case).
     let field_borrows = instrs
         .iter()
-        .filter(|instr| matches!(instr, Instr::ImmBorrowField(..) | Instr::MutBorrowField(..)))
+        .filter(|instr| {
+            matches!(
+                instr,
+                Instr::ImmBorrowField { .. } | Instr::MutBorrowField { .. }
+            )
+        })
         .take(MIN_CHAIN_DEPTH)
         .count();
     if field_borrows < MIN_CHAIN_DEPTH {
@@ -320,18 +436,31 @@ fn try_build_chain(
     // each Imm/Mut head pair.
     let is_mut = matches!(
         &instrs[start],
-        Instr::MutBorrowLoc(..) | Instr::MutBorrowField(..)
+        Instr::MutBorrowLoc { .. } | Instr::MutBorrowField { .. }
     );
     let (root, mut cur_ref, mut idx, mut path) = match &instrs[start] {
-        Instr::ImmBorrowLoc(produced, local) | Instr::MutBorrowLoc(produced, local) => {
-            (ChainRoot::Local(*local), *produced, start + 1, Vec::new())
-        },
-        Instr::ImmBorrowField(produced, owner, fh, src)
-        | Instr::MutBorrowField(produced, owner, fh, src) => {
-            (ChainRoot::Ref(*src), *produced, start + 1, vec![(
-                *owner, *fh,
-            )])
-        },
+        Instr::ImmBorrowLoc {
+            dst: produced,
+            local,
+        }
+        | Instr::MutBorrowLoc {
+            dst: produced,
+            local,
+        } => (ChainRoot::Local(*local), *produced, start + 1, Vec::new()),
+        Instr::ImmBorrowField {
+            dst: produced,
+            owner_ty,
+            field,
+            src,
+        }
+        | Instr::MutBorrowField {
+            dst: produced,
+            owner_ty,
+            field,
+            src,
+        } => (ChainRoot::Ref(*src), *produced, start + 1, vec![(
+            *owner_ty, *field,
+        )]),
         _ => return None,
     };
 
@@ -340,13 +469,23 @@ fn try_build_chain(
     // may be separated, by a write's right-hand-side computation.)
     while linkable(cur_ref) {
         match instrs.get(idx) {
-            Some(Instr::ImmBorrowField(produced, owner, fh, src)) if !is_mut && *src == cur_ref => {
-                path.push((*owner, *fh));
+            Some(Instr::ImmBorrowField {
+                dst: produced,
+                owner_ty,
+                field,
+                src,
+            }) if !is_mut && *src == cur_ref => {
+                path.push((*owner_ty, *field));
                 cur_ref = *produced;
                 idx += 1;
             },
-            Some(Instr::MutBorrowField(produced, owner, fh, src)) if is_mut && *src == cur_ref => {
-                path.push((*owner, *fh));
+            Some(Instr::MutBorrowField {
+                dst: produced,
+                owner_ty,
+                field,
+                src,
+            }) if is_mut && *src == cur_ref => {
+                path.push((*owner_ty, *field));
                 cur_ref = *produced;
                 idx += 1;
             },
@@ -375,10 +514,10 @@ fn try_build_chain(
         None
     };
     let terminal_consumer = sole_use_pos.and_then(|term_idx| match &instrs[term_idx] {
-        Instr::ReadRef(dst, src) if *src == cur_ref => {
+        Instr::ReadRef { dst, src } if *src == cur_ref => {
             Some((ChainTerminal::Read { dst: *dst }, term_idx))
         },
-        Instr::WriteRef(ref_slot, val) if *ref_slot == cur_ref => {
+        Instr::WriteRef { dst_ref, val } if *dst_ref == cur_ref => {
             Some((ChainTerminal::Write { val: *val }, term_idx))
         },
         _ => None,
@@ -409,18 +548,24 @@ fn build_chain_instr(
 ) -> Instr {
     match root {
         ChainRoot::Local(local) => match terminal {
-            ChainTerminal::Read { dst } => Instr::ReadLocalFieldChain(dst, path, local),
-            ChainTerminal::Write { val } => Instr::WriteLocalFieldChain(path, local, val),
+            ChainTerminal::Read { dst } => Instr::ReadLocFieldChain { dst, path, local },
+            ChainTerminal::Write { val } => Instr::WriteLocFieldChain { local, path, val },
             ChainTerminal::Borrow { dst } if is_mut => {
-                Instr::MutBorrowLocalFieldChain(dst, path, local)
+                Instr::MutBorrowLocFieldChain { dst, path, local }
             },
-            ChainTerminal::Borrow { dst } => Instr::ImmBorrowLocalFieldChain(dst, path, local),
+            ChainTerminal::Borrow { dst } => Instr::ImmBorrowLocFieldChain { dst, path, local },
         },
         ChainRoot::Ref(src) => match terminal {
-            ChainTerminal::Read { dst } => Instr::ReadFieldChain(dst, path, src),
-            ChainTerminal::Write { val } => Instr::WriteFieldChain(path, src, val),
-            ChainTerminal::Borrow { dst } if is_mut => Instr::MutBorrowFieldChain(dst, path, src),
-            ChainTerminal::Borrow { dst } => Instr::ImmBorrowFieldChain(dst, path, src),
+            ChainTerminal::Read { dst } => Instr::ReadFieldChain { dst, path, src },
+            ChainTerminal::Write { val } => Instr::WriteFieldChain {
+                dst_ref: src,
+                path,
+                val,
+            },
+            ChainTerminal::Borrow { dst } if is_mut => {
+                Instr::MutBorrowFieldChain { dst, path, src }
+            },
+            ChainTerminal::Borrow { dst } => Instr::ImmBorrowFieldChain { dst, path, src },
         },
     }
 }
@@ -428,13 +573,23 @@ fn build_chain_instr(
 /// Try to fuse a `LdImm` + `BinaryOp` pair into a `BinaryOpImm` instruction.
 fn try_fuse_immediate_binop(first: &Instr, second: &Instr) -> Option<Instr> {
     match (first, second) {
-        (Instr::LdImm(tmp, imm), Instr::BinaryOp(dst, op, lhs, rhs)) if *tmp == *rhs => {
-            Some(Instr::BinaryOpImm(*dst, *op, *lhs, imm.clone()))
+        (Instr::LdImm { dst: tmp, imm }, Instr::BinaryOp { dst, op, lhs, rhs }) if *tmp == *rhs => {
+            Some(Instr::BinaryOpImm {
+                dst: *dst,
+                op: *op,
+                lhs: *lhs,
+                imm: imm.clone(),
+            })
         },
-        (Instr::LdImm(tmp, imm), Instr::BinaryOp(dst, op, lhs, rhs))
+        (Instr::LdImm { dst: tmp, imm }, Instr::BinaryOp { dst, op, lhs, rhs })
             if *tmp == *lhs && is_commutative(op) =>
         {
-            Some(Instr::BinaryOpImm(*dst, *op, *rhs, imm.clone()))
+            Some(Instr::BinaryOpImm {
+                dst: *dst,
+                op: *op,
+                lhs: *rhs,
+                imm: imm.clone(),
+            })
         },
         _ => None,
     }

--- a/third_party/move/mono-move/specializer/src/destack/test_utils.rs
+++ b/third_party/move/mono-move/specializer/src/destack/test_utils.rs
@@ -37,7 +37,7 @@ impl SSAFunction {
     pub(crate) fn with_test_utils_passes(mut self, module: &PreparedModule) -> VMResult<Self> {
         for block in &mut self.blocks {
             for instr in &mut block.instrs {
-                if let Instr::Call(data) = instr
+                if let Instr::Call { data } = instr
                     && is_force_gc(module, data.function_handle)
                 {
                     if !data.rets.is_empty() || !data.args.is_empty() {

--- a/third_party/move/mono-move/specializer/src/gas.rs
+++ b/third_party/move/mono-move/specializer/src/gas.rs
@@ -308,63 +308,75 @@ impl<I: Interner> Emitter<'_, I> {
     fn instr_cost(&mut self, b: &mut BlockCost, instr: &Instr) -> VMResult<()> {
         match instr {
             // --- Loads ---
-            Instr::LdConst(..) | Instr::LdImm(..) => b.add_constant(LD),
+            Instr::LdConst { .. } | Instr::LdImm { .. } => b.add_constant(LD),
 
             // --- Slot ops ---
-            Instr::Copy(_, src) | Instr::Move(_, src) => {
+            Instr::Copy { src, .. } | Instr::Move { src, .. } => {
                 b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*src)?)
             },
 
             // --- Unary / Binary ---
-            Instr::UnaryOp(..) | Instr::BinaryOp(..) | Instr::BinaryOpImm(..) => b.add_constant(OP),
+            Instr::UnaryOp { .. } | Instr::BinaryOp { .. } | Instr::BinaryOpImm { .. } => {
+                b.add_constant(OP)
+            },
 
             // --- Structs ---
-            Instr::Pack(_, struct_ty, _) | Instr::Unpack(_, struct_ty, _) => {
+            Instr::Pack { struct_ty, .. } | Instr::Unpack { struct_ty, .. } => {
                 b.add_sized(MOVE_BASE, MOVE_PER_BYTE, *struct_ty)
             },
 
             // --- Enums ---
-            Instr::PackVariant(_, enum_ty, variant, _)
-            | Instr::UnpackVariant(_, enum_ty, variant, _) => {
+            Instr::PackVariant {
+                enum_ty, variant, ..
+            }
+            | Instr::UnpackVariant {
+                enum_ty, variant, ..
+            } => {
                 b.add_constant(PACK_UNPACK);
                 for field_ty in self.variant_field_tys(*enum_ty, *variant)? {
                     b.add_sized(MOVE_BASE, MOVE_PER_BYTE, field_ty);
                 }
             },
-            Instr::TestVariant(..) => b.add_constant(TEST_VARIANT),
+            Instr::TestVariant { .. } => b.add_constant(TEST_VARIANT),
 
             // --- References ---
-            Instr::ImmBorrowLoc(..)
-            | Instr::MutBorrowLoc(..)
-            | Instr::ImmBorrowField(..)
-            | Instr::MutBorrowField(..)
-            | Instr::ImmBorrowVariantField(..)
-            | Instr::MutBorrowVariantField(..) => b.add_constant(BORROW),
-            Instr::ReadRef(_, ref_src) => {
-                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.pointee_ty(*ref_src)?)
+            Instr::ImmBorrowLoc { .. }
+            | Instr::MutBorrowLoc { .. }
+            | Instr::ImmBorrowField { .. }
+            | Instr::MutBorrowField { .. }
+            | Instr::ImmBorrowVariantField { .. }
+            | Instr::MutBorrowVariantField { .. } => b.add_constant(BORROW),
+            Instr::ReadRef { src, .. } => {
+                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.pointee_ty(*src)?)
             },
-            Instr::WriteRef(ref_dst, _) => {
-                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.pointee_ty(*ref_dst)?)
+            Instr::WriteRef { dst_ref, .. } => {
+                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.pointee_ty(*dst_ref)?)
             },
 
             // --- Fused field access (borrow + read/write) ---
-            Instr::ReadField(_, owner, fh, _) => {
-                b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.field_ty(*owner, *fh)?)
-            },
-            Instr::WriteField(_, _, _, val) => {
+            Instr::ReadField {
+                owner_ty, field, ..
+            } => b.add_sized(
+                REF_RW_BASE,
+                REF_RW_PER_BYTE,
+                self.field_ty(*owner_ty, *field)?,
+            ),
+            Instr::WriteField { val, .. } => {
                 b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.slot_ty(*val)?)
             },
-            Instr::ReadVariantField(..) => b.add_constant(FIELD_READ),
-            Instr::WriteVariantField(_, _, _, val) => {
+            Instr::ReadVariantField { .. } => b.add_constant(FIELD_READ),
+            Instr::WriteVariantField { val, .. } => {
                 b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.slot_ty(*val)?)
             },
 
             // --- Fused inline-struct field access ---
-            Instr::ImmBorrowLocField(..) | Instr::MutBorrowLocField(..) => b.add_constant(BORROW),
-            Instr::ReadLocalField(_, owner, fh, _) => {
-                b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.field_ty(*owner, *fh)?)
+            Instr::ImmBorrowLocField { .. } | Instr::MutBorrowLocField { .. } => {
+                b.add_constant(BORROW)
             },
-            Instr::WriteLocalField(_, _, _, val) => {
+            Instr::ReadLocField {
+                owner_ty, field, ..
+            } => b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.field_ty(*owner_ty, *field)?),
+            Instr::WriteLocField { val, .. } => {
                 b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*val)?)
             },
 
@@ -372,30 +384,31 @@ impl<I: Interner> Emitter<'_, I> {
             // sequence charges, so fusing never changes a program's gas.
             // TODO(metering): emit gas from pre-optimization IR instead of
             // hand-replicating pre-fusion costs per fused op. ---
-            Instr::ImmBorrowFieldChain(_, path, _)
-            | Instr::MutBorrowFieldChain(_, path, _)
-            | Instr::ImmBorrowLocalFieldChain(_, path, _)
-            | Instr::MutBorrowLocalFieldChain(_, path, _) => {
+            Instr::ImmBorrowFieldChain { path, .. }
+            | Instr::MutBorrowFieldChain { path, .. }
+            | Instr::ImmBorrowLocFieldChain { path, .. }
+            | Instr::MutBorrowLocFieldChain { path, .. } => {
                 b.add_constant(BORROW * path.len() as u64)
             },
-            Instr::ReadFieldChain(_, path, _) | Instr::ReadLocalFieldChain(_, path, _) => {
+            Instr::ReadFieldChain { path, .. } | Instr::ReadLocFieldChain { path, .. } => {
                 b.add_constant(BORROW * (path.len() as u64).saturating_sub(1));
                 b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.chain_terminal_ty(path)?);
             },
-            Instr::WriteFieldChain(path, _, val) | Instr::WriteLocalFieldChain(path, _, val) => {
+            Instr::WriteFieldChain { path, val, .. }
+            | Instr::WriteLocFieldChain { path, val, .. } => {
                 b.add_constant(BORROW * (path.len() as u64).saturating_sub(1));
                 b.add_sized(REF_RW_BASE, REF_RW_PER_BYTE, self.slot_ty(*val)?);
             },
 
             // --- Globals ---
-            Instr::Exists(..)
-            | Instr::MoveFrom(..)
-            | Instr::MoveTo(..)
-            | Instr::ImmBorrowGlobal(..)
-            | Instr::MutBorrowGlobal(..) => b.add_constant(GLOBAL),
+            Instr::Exists { .. }
+            | Instr::MoveFrom { .. }
+            | Instr::MoveTo { .. }
+            | Instr::ImmBorrowGlobal { .. }
+            | Instr::MutBorrowGlobal { .. } => b.add_constant(GLOBAL),
 
             // --- Calls ---
-            Instr::Call(data) => {
+            Instr::Call { data } => {
                 let sig = self.module.function_signature_at(data.function_handle);
                 let params = self.interner.subst_type_list(sig.params, data.ty_args)?;
                 let returns = self.interner.subst_type_list(sig.returns, data.ty_args)?;
@@ -403,13 +416,13 @@ impl<I: Interner> Emitter<'_, I> {
             },
 
             // --- Closures ---
-            Instr::PackClosure(data) => {
+            Instr::PackClosure { data } => {
                 b.add_constant(PACK_CLOSURE);
                 for arg in &data.captured {
                     b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*arg)?);
                 }
             },
-            Instr::CallClosure(data) => {
+            Instr::CallClosure { data } => {
                 let (params, returns) = closure_signature(data.closure_ty)?;
                 self.call_cost(b, params, &data.rets, returns)?;
                 // The closure value is passed as the last operand; charge its move.
@@ -417,42 +430,43 @@ impl<I: Interner> Emitter<'_, I> {
             },
 
             // --- Vector ---
-            Instr::VecPack(_, _, elems) => {
+            Instr::VecPack { srcs, .. } => {
                 b.add_constant(VEC_NEW);
-                for elem in elems {
+                for elem in srcs {
                     b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.slot_ty(*elem)?);
                 }
             },
-            Instr::VecLen(..) => b.add_constant(VEC_LEN),
-            Instr::VecImmBorrow(..) | Instr::VecMutBorrow(..) => b.add_constant(VEC_BORROW),
-            Instr::VecPushBack(elem_ty, _, _) | Instr::VecPopBack(_, elem_ty, _) => {
+            Instr::VecLen { .. } => b.add_constant(VEC_LEN),
+            Instr::VecImmBorrow { .. } | Instr::VecMutBorrow { .. } => b.add_constant(VEC_BORROW),
+            Instr::VecPushBack { elem_ty, .. } | Instr::VecPopBack { elem_ty, .. } => {
                 b.add_sized(VEC_ELEM_BASE, VEC_ELEM_PER_BYTE, *elem_ty)
             },
-            Instr::VecUnpack(dsts, elem_ty, _) => {
+            Instr::VecUnpack { dsts, elem_ty, .. } => {
                 let n = dsts.len() as u64;
                 b.add_constant(VEC_NEW);
                 b.add_sized(n * MOVE_BASE, n * MOVE_PER_BYTE, *elem_ty);
             },
-            Instr::VecSwap(elem_ty, _, _, _) => {
+            Instr::VecSwap { elem_ty, .. } => {
                 // 2x per-element: two element accesses.
                 b.add_sized(2 * VEC_ELEM_BASE, 2 * VEC_ELEM_PER_BYTE, *elem_ty);
             },
 
             // --- Control flow ---
-            Instr::Branch(..) => b.add_constant(JUMP),
-            Instr::BrTrue(..) | Instr::BrFalse(..) | Instr::BrCmp(..) | Instr::BrCmpImm(..) => {
-                b.add_constant(COND_JUMP)
-            },
-            Instr::Ret(slots) => {
+            Instr::Branch { .. } => b.add_constant(JUMP),
+            Instr::BrTrue { .. }
+            | Instr::BrFalse { .. }
+            | Instr::BrCmp { .. }
+            | Instr::BrCmpImm { .. } => b.add_constant(COND_JUMP),
+            Instr::Ret { srcs } => {
                 b.add_constant(RETURN);
                 // 2x per slot upper-bounds the cycle-breaking scratch moves
                 // `emit_parallel_copy` adds for a cyclic (e.g. swap-style) return.
-                for slot in slots {
+                for slot in srcs {
                     b.add_sized(2 * MOVE_BASE, 2 * MOVE_PER_BYTE, self.slot_ty(*slot)?);
                 }
             },
-            Instr::Abort(..) => b.add_constant(ABORT),
-            Instr::AbortMsg(..) => b.add_constant(ABORT_MSG),
+            Instr::Abort { .. } => b.add_constant(ABORT),
+            Instr::AbortMsg { .. } => b.add_constant(ABORT_MSG),
 
             Instr::ForceGC => b.add_constant(FORCE_GC),
         }

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -574,7 +574,7 @@ pub fn try_build_context<'a>(
     //    GC-tracked.
     let needs_resource_box_slot = func_ir
         .instrs()
-        .any(|instr| matches!(instr, Instr::MoveTo(..) | Instr::MoveFrom(..)));
+        .any(|instr| matches!(instr, Instr::MoveTo { .. } | Instr::MoveFrom { .. }));
     let resource_box_slot = needs_resource_box_slot.then(|| reserve_slot(&mut frame_data_size, 8));
 
     // 6. Single IR pass over the function's enum ops: (1) verify each one's enum
@@ -595,7 +595,10 @@ pub fn try_build_context<'a>(
         // Pack/unpack may need an 8-byte scratch to keep the enum pointer out of
         // an aliased field slot (resolved per-instruction in lowering; the exact
         // alias depends on final slot offsets, which aren't known yet here).
-        if matches!(instr, Instr::PackVariant(..) | Instr::UnpackVariant(..)) {
+        if matches!(
+            instr,
+            Instr::PackVariant { .. } | Instr::UnpackVariant { .. }
+        ) {
             needs_enum_ptr_scratch = true;
         }
     }
@@ -613,7 +616,7 @@ pub fn try_build_context<'a>(
     let mut closure_pack_idx = 0usize;
     for instr in func_ir.instrs() {
         let (handle_idx, param_list, ret_list, call_ty_args) = match instr {
-            Instr::Call(data) => {
+            Instr::Call { data } => {
                 let resolved_ty_args = interner.subst_type_list(data.ty_args, ty_args)?;
                 let (params, returns) = instantiate_callee_signature(
                     &module_ir.module,
@@ -623,7 +626,7 @@ pub fn try_build_context<'a>(
                 )?;
                 (data.function_handle, params, returns, resolved_ty_args)
             },
-            Instr::PackClosure(data) => {
+            Instr::PackClosure { data } => {
                 let closure_ty_args = interner.subst_type_list(data.ty_args, ty_args)?;
                 // Bytecode verifier's instruction consistency check should
                 // guarantee the invariant below.
@@ -670,7 +673,7 @@ pub fn try_build_context<'a>(
                 });
                 continue;
             },
-            Instr::CallClosure(data) => {
+            Instr::CallClosure { data } => {
                 let Type::Function { results, .. } = view_type(data.closure_ty) else {
                     return Err(VMInternalError::new(
                         LoweringError::ClosureSignatureNotFunction,
@@ -1094,7 +1097,7 @@ fn try_discover_types_for_lowering_in_function_impl(
         // still discovered. Otherwise, we need to feed `CallClosure` signature
         // types here and recurse into `Type::Function`.
         let (params, returns, handle_idx, callee_ty_args) = match instr {
-            Instr::Call(data) => {
+            Instr::Call { data } => {
                 let (params, returns) = instantiate_callee_signature(
                     &module_ir.module,
                     interner,
@@ -1155,7 +1158,7 @@ fn try_discover_types_for_lowering_in_function_impl(
 
         // `PackClosure`: resolve the captured-data layout and record it
         // positionally, in IR order, for the build pass.
-        if let Instr::PackClosure(data) = instr {
+        if let Instr::PackClosure { data } = instr {
             let closure_ty_args = interner.subst_type_list(data.ty_args, ty_args)?;
             let layout = discover_captured_data_descriptor(
                 ctx,
@@ -1182,8 +1185,8 @@ fn try_discover_types_for_lowering_in_function_impl(
         // constant needs its (possibly nested) vector descriptors published
         // so `StoreImmVec` can resolve them at runtime, so discover the
         // constant's type here.
-        if let Instr::LdConst(_, idx) = instr {
-            let ty = module_ir.module.interned_constant_type_at(*idx);
+        if let Instr::LdConst { const_idx, .. } = instr {
+            let ty = module_ir.module.interned_constant_type_at(*const_idx);
             discover_type_metadata(ctx, interner, ty, ty_args, visited, descriptors)?;
         }
     }

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -693,13 +693,13 @@ impl<'a> LoweringState<'a> {
             // TODO(correctness): audit every integer-width use across the
             // specializer and confirm each is the correct width (slot sizes,
             // immediate widths, sign extension).
-            Instr::LdImm(dst, imm) => {
+            Instr::LdImm { dst, imm } => {
                 let dst_off = self.def_slot(*dst)?.offset;
                 self.emit(store_imm_op(dst_off, imm))?;
             },
-            Instr::LdConst(dst, idx) => {
-                let ty = view_type(self.ctx.module.interned_constant_type_at(*idx));
-                let bcs_bytes = self.ctx.module.constant_data_at(*idx);
+            Instr::LdConst { dst, const_idx } => {
+                let ty = view_type(self.ctx.module.interned_constant_type_at(*const_idx));
+                let bcs_bytes = self.ctx.module.constant_data_at(*const_idx);
                 let dst_info = self.def_slot(*dst)?;
                 // Constants store their value BCS-encoded. Fixed-width
                 // integers encode as their raw little-endian bytes and
@@ -714,43 +714,43 @@ impl<'a> LoweringState<'a> {
                     Type::Bool | Type::U8 | Type::I8 => {
                         self.emit(MicroOp::StoreImm1 {
                             dst: dst_info.offset,
-                            imm: const_imm::<1>(*idx, bcs_bytes)?[0],
+                            imm: const_imm::<1>(*const_idx, bcs_bytes)?[0],
                         })?;
                     },
                     Type::U16 | Type::I16 => {
                         self.emit(MicroOp::StoreImm2 {
                             dst: dst_info.offset,
-                            imm: const_imm::<2>(*idx, bcs_bytes)?,
+                            imm: const_imm::<2>(*const_idx, bcs_bytes)?,
                         })?;
                     },
                     Type::U32 | Type::I32 => {
                         self.emit(MicroOp::StoreImm4 {
                             dst: dst_info.offset,
-                            imm: const_imm::<4>(*idx, bcs_bytes)?,
+                            imm: const_imm::<4>(*const_idx, bcs_bytes)?,
                         })?;
                     },
                     Type::U64 | Type::I64 => {
                         self.emit(MicroOp::StoreImm8 {
                             dst: dst_info.offset,
-                            imm: const_imm::<8>(*idx, bcs_bytes)?,
+                            imm: const_imm::<8>(*const_idx, bcs_bytes)?,
                         })?;
                     },
                     Type::U128 | Type::I128 => {
                         self.emit(MicroOp::StoreImm16 {
                             dst: dst_info.offset,
-                            imm: Box::new(const_imm::<16>(*idx, bcs_bytes)?),
+                            imm: Box::new(const_imm::<16>(*const_idx, bcs_bytes)?),
                         })?;
                     },
                     Type::U256 | Type::I256 | Type::Address => {
                         self.emit(MicroOp::StoreImm32 {
                             dst: dst_info.offset,
-                            imm: Box::new(const_imm::<32>(*idx, bcs_bytes)?),
+                            imm: Box::new(const_imm::<32>(*const_idx, bcs_bytes)?),
                         })?;
                     },
                     Type::Vector { .. } => {
                         self.emit(MicroOp::StoreImmVec {
                             dst: dst_info.offset,
-                            idx: *idx,
+                            idx: *const_idx,
                         })?;
                     },
                     // The bytecode verifier rejects constants of these types,
@@ -762,7 +762,7 @@ impl<'a> LoweringState<'a> {
                     | Type::Function { .. }
                     | Type::TypeParam { .. } => {
                         return Err(VMInternalError::new(
-                            LoweringError::LdConstTypeNotPermitted { idx: idx.0 },
+                            LoweringError::LdConstTypeNotPermitted { idx: const_idx.0 },
                         ))
                     },
                 }
@@ -770,14 +770,14 @@ impl<'a> LoweringState<'a> {
 
             // --- Copy/Move ---
             // `Move` transfers ownership: a byte copy is the whole operation.
-            Instr::Move(dst, src) => {
+            Instr::Move { dst, src } => {
                 let src_info = self.slot(*src)?;
                 let dst_info = self.def_slot(*dst)?;
                 self.emit_single_move(dst_info.offset, src_info)?;
             },
             // `Copy` must produce an independent value: byte copy, then deep-copy
             // any owned heap pointers so a heap-backed value does not alias.
-            Instr::Copy(dst, src) => {
+            Instr::Copy { dst, src } => {
                 let src_info = self.slot(*src)?;
                 let dst_info = self.def_typed_slot(*dst)?;
                 self.emit_single_move(dst_info.slot.offset, src_info)?;
@@ -785,7 +785,7 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Binary ops ---
-            Instr::BinaryOp(dst, op, lhs, rhs) => {
+            Instr::BinaryOp { dst, op, lhs, rhs } => {
                 // TODO(cleanup): BinaryOp / BinaryOpImm share most of their shape
                 // (operand resolution + per-kind emit); consider factoring
                 // out the common skeleton once cast / cmp ops settle.
@@ -925,20 +925,20 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Binary ops with immediate ---
-            Instr::BinaryOpImm(dst, op, src, imm) => {
+            Instr::BinaryOpImm { dst, op, lhs, imm } => {
                 // TODO(cleanup): see [`Instr::BinaryOp`] above on factoring out the
                 // shared skeleton between the reg-reg and imm forms.
-                let src_info = self.slot(*src)?;
+                let lhs_info = self.slot(*lhs)?;
                 let dst_info = self.def_slot(*dst)?;
-                let src_ty = self.slot_type(*src)?;
+                let lhs_ty = self.slot_type(*lhs)?;
                 let dst = dst_info.offset;
-                let lhs = src_info.offset;
+                let lhs = lhs_info.offset;
 
                 // Fast path: u64 specialized imm variants where they exist.
                 // u64 BitAnd/BitOr/BitXor/Cmp/Or/And imm have no specialized
                 // variant and fall through to the unspecialized path below.
                 let mut handled = false;
-                if src_ty.is_u64() {
+                if lhs_ty.is_u64() {
                     let emitted = match op {
                         BinaryOp::Add => Some(MicroOp::AddU64Imm {
                             dst,
@@ -1028,7 +1028,7 @@ impl<'a> LoweringState<'a> {
                             })?;
                         },
                         BinaryOp::Shl | BinaryOp::Shr => {
-                            let ty = IntTy::from_type(src_ty)
+                            let ty = IntTy::from_type(lhs_ty)
                                 .filter(|t| !t.is_signed())
                                 .ok_or(LoweringError::ShiftRequiresUnsignedNonU64)?;
                             let shift_op = IntShiftOp {
@@ -1071,7 +1071,7 @@ impl<'a> LoweringState<'a> {
                             };
                             let identity = matches!(op, BinaryOp::And);
                             if *b == identity {
-                                self.emit_single_move(dst, src_info)?;
+                                self.emit_single_move(dst, lhs_info)?;
                             } else {
                                 self.emit(MicroOp::StoreImm1 {
                                     dst,
@@ -1084,7 +1084,7 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Unary ops ---
-            Instr::UnaryOp(dst, op, src) => match op {
+            Instr::UnaryOp { dst, op, src } => match op {
                 UnaryOp::Cast(to) => self.lower_cast(*dst, *src, *to)?,
                 UnaryOp::Negate => {
                     let src_ty = self.slot_type(*src)?;
@@ -1119,21 +1119,21 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- References ---
-            Instr::ImmBorrowLoc(dst, src) | Instr::MutBorrowLoc(dst, src) => {
-                let src_info = self.slot(*src)?;
+            Instr::ImmBorrowLoc { dst, local } | Instr::MutBorrowLoc { dst, local } => {
+                let src_info = self.slot(*local)?;
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::SlotBorrow {
                     dst: dst_info.offset,
                     local: src_info.offset,
                 })?;
             },
-            Instr::ReadRef(dst, ref_src) => {
+            Instr::ReadRef { dst, src } => {
                 // TODO(perf): `size` could equivalently come from `dst_info.size`
                 // (the loaded value's slot) — IR typing forces it to equal
                 // the ref's pointee size. `ref_pointee_size` is the more
                 // type-faithful path; `dst_info.size` would be cheaper.
-                let size = self.ref_pointee_size(*ref_src)?;
-                let ref_info = self.slot(*ref_src)?;
+                let size = self.ref_pointee_size(*src)?;
+                let ref_info = self.slot(*src)?;
                 let dst_info = self.def_typed_slot(*dst)?;
                 self.emit(MicroOp::ReadRef {
                     dst: dst_info.slot.offset,
@@ -1142,14 +1142,14 @@ impl<'a> LoweringState<'a> {
                 })?;
                 self.maybe_deep_copy(dst_info.ty, dst_info.slot.offset)?;
             },
-            Instr::WriteRef(ref_dst, src) => {
+            Instr::WriteRef { dst_ref, val } => {
                 // TODO(perf): `size` could equivalently come from `src_info.size`
                 // (the value being written) — IR typing forces it to equal
                 // the ref's pointee size. `ref_pointee_size` is the more
                 // type-faithful path; `src_info.size` would be cheaper.
-                let size = self.ref_pointee_size(*ref_dst)?;
-                let ref_info = self.slot(*ref_dst)?;
-                let src_info = self.slot(*src)?;
+                let size = self.ref_pointee_size(*dst_ref)?;
+                let ref_info = self.slot(*dst_ref)?;
+                let src_info = self.slot(*val)?;
                 self.emit(MicroOp::WriteRef {
                     ref_ptr: ref_info.offset,
                     src: src_info.offset,
@@ -1158,28 +1158,36 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Control flow ---
-            Instr::Branch(Label(l)) => {
+            Instr::Branch {
+                target: Label(label),
+            } => {
                 self.record_branch_fixup();
                 self.emit(MicroOp::Jump {
-                    target: CodeOffset(encode_label(*l)),
+                    target: CodeOffset(encode_label(*label)),
                     gas: 0,
                 })?;
             },
-            Instr::BrTrue(Label(l), cond) => {
+            Instr::BrTrue {
+                target: Label(label),
+                cond,
+            } => {
                 let cond_info = self.slot(*cond)?;
                 self.record_branch_fixup();
                 self.emit(MicroOp::JumpNotZeroByte {
-                    target: CodeOffset(encode_label(*l)),
+                    target: CodeOffset(encode_label(*label)),
                     src: cond_info.offset,
                     gas_taken: 0,
                     gas_fallthrough: 0,
                 })?;
             },
-            Instr::BrFalse(Label(l), cond) => {
+            Instr::BrFalse {
+                target: Label(label),
+                cond,
+            } => {
                 let cond_info = self.slot(*cond)?;
                 self.record_branch_fixup();
                 self.emit(MicroOp::JumpZeroByte {
-                    target: CodeOffset(encode_label(*l)),
+                    target: CodeOffset(encode_label(*label)),
                     src: cond_info.offset,
                     gas_taken: 0,
                     gas_fallthrough: 0,
@@ -1187,13 +1195,18 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Fused compare+branch ---
-            Instr::BrCmp(Label(l), op, lhs, rhs) => {
+            Instr::BrCmp {
+                target: Label(label),
+                op,
+                lhs,
+                rhs,
+            } => {
                 let lhs_interned = self.slot_interned_type(*lhs)?;
                 let lhs_ty = view_type(lhs_interned);
                 let lhs_info = self.slot(*lhs)?;
                 let lhs_off = lhs_info.offset;
                 let rhs_off = self.slot(*rhs)?.offset;
-                let target = CodeOffset(encode_label(*l));
+                let target = CodeOffset(encode_label(*label));
                 self.record_branch_fixup();
                 // Fast path: unsigned `u64` ordering / not-equal use the
                 // specialized jumps. Everything else goes through the general
@@ -1267,12 +1280,17 @@ impl<'a> LoweringState<'a> {
                     },
                 }
             },
-            Instr::BrCmpImm(Label(l), op, src, imm) => {
-                let src_ty = self.slot_type(*src)?;
-                let src_off = self.slot(*src)?.offset;
-                let target = CodeOffset(encode_label(*l));
+            Instr::BrCmpImm {
+                target: Label(label),
+                op,
+                lhs,
+                imm,
+            } => {
+                let lhs_ty = self.slot_type(*lhs)?;
+                let lhs_off = self.slot(*lhs)?.offset;
+                let target = CodeOffset(encode_label(*label));
                 self.record_branch_fixup();
-                if src_ty.is_u64() {
+                if lhs_ty.is_u64() {
                     // Fast path: specialized unsigned `u64` ordering jumps.
                     // Note: equality has no specialized imm jump, so it uses
                     // the general `JumpIntCmp`.
@@ -1280,58 +1298,58 @@ impl<'a> LoweringState<'a> {
                     match op {
                         CmpKind::Ge => self.emit(MicroOp::JumpGreaterEqualU64Imm {
                             target,
-                            src: src_off,
+                            src: lhs_off,
                             imm: v,
                             gas_taken: 0,
                             gas_fallthrough: 0,
                         })?,
                         CmpKind::Lt => self.emit(MicroOp::JumpLessU64Imm {
                             target,
-                            src: src_off,
+                            src: lhs_off,
                             imm: v,
                             gas_taken: 0,
                             gas_fallthrough: 0,
                         })?,
                         CmpKind::Gt => self.emit(MicroOp::JumpGreaterU64Imm {
                             target,
-                            src: src_off,
+                            src: lhs_off,
                             imm: v,
                             gas_taken: 0,
                             gas_fallthrough: 0,
                         })?,
                         CmpKind::Le => self.emit(MicroOp::JumpLessEqualU64Imm {
                             target,
-                            src: src_off,
+                            src: lhs_off,
                             imm: v,
                             gas_taken: 0,
                             gas_fallthrough: 0,
                         })?,
                         CmpKind::Eq | CmpKind::Neq => {
-                            self.emit_jump_int_cmp(target, *op, src_off, IntOperand::ImmU64(v))?
+                            self.emit_jump_int_cmp(target, *op, lhs_off, IntOperand::ImmU64(v))?
                         },
                     }
                 } else {
                     let rhs_op = cmp_operand_from_imm(imm)?;
-                    self.emit_jump_int_cmp(target, *op, src_off, rhs_op)?;
+                    self.emit_jump_int_cmp(target, *op, lhs_off, rhs_op)?;
                 }
             },
 
             // --- Calls ---
-            Instr::Call(data) => {
+            Instr::Call { data } => {
                 self.lower_call(func_ir, &data.args, &data.rets)?;
             },
 
             // --- Return ---
-            Instr::Ret(slots) => {
+            Instr::Ret { srcs } => {
                 // `return_slots` overlap the home region (calling
                 // convention reuses that space), so a function like
                 // `swap(a, b) -> (b, a)` produces a swap-cycle in the
                 // copy graph. `emit_parallel_copy` handles arbitrary
                 // cycles via the function's reserved scratch slot.
-                let mut copies = Vec::with_capacity(slots.len());
-                for (k, slot) in slots.iter().enumerate() {
+                let mut copies = Vec::with_capacity(srcs.len());
+                for (ret_idx, slot) in srcs.iter().enumerate() {
                     let src = self.slot(*slot)?;
-                    let dst = self.ctx.return_slots[k];
+                    let dst = self.ctx.return_slots[ret_idx];
                     copies.push(parallel_copy::Copy {
                         src: src.offset,
                         dst: dst.offset,
@@ -1343,13 +1361,13 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Abort ---
-            Instr::Abort(code) => {
+            Instr::Abort { code } => {
                 let code = self.slot(*code)?;
                 self.emit(MicroOp::Abort { code: code.offset })?;
             },
-            Instr::AbortMsg(code, message) => {
+            Instr::AbortMsg { code, msg } => {
                 let code = self.slot(*code)?;
-                let message = self.slot(*message)?;
+                let message = self.slot(*msg)?;
                 self.emit(MicroOp::AbortMsg {
                     code: code.offset,
                     message: message.offset,
@@ -1357,7 +1375,7 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Vector ---
-            Instr::VecLen(dst, _elem_ty, vec_ref) => {
+            Instr::VecLen { dst, vec_ref, .. } => {
                 let vec_ref_info = self.slot(*vec_ref)?;
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::VecLen {
@@ -1365,8 +1383,18 @@ impl<'a> LoweringState<'a> {
                     vec_ref: vec_ref_info.offset,
                 })?;
             },
-            Instr::VecImmBorrow(dst, elem_ty, vec_ref, idx)
-            | Instr::VecMutBorrow(dst, elem_ty, vec_ref, idx) => {
+            Instr::VecImmBorrow {
+                dst,
+                elem_ty,
+                vec_ref,
+                idx,
+            }
+            | Instr::VecMutBorrow {
+                dst,
+                elem_ty,
+                vec_ref,
+                idx,
+            } => {
                 let elem_size = concrete_type_size(
                     self.ctx.layouts,
                     self.concrete_ty(*elem_ty)?,
@@ -1383,7 +1411,11 @@ impl<'a> LoweringState<'a> {
                     elem_size,
                 })?;
             },
-            Instr::VecPopBack(dst, elem_ty, vec_ref) => {
+            Instr::VecPopBack {
+                dst,
+                elem_ty,
+                vec_ref,
+            } => {
                 let elem_size = concrete_type_size(
                     self.ctx.layouts,
                     self.concrete_ty(*elem_ty)?,
@@ -1397,7 +1429,11 @@ impl<'a> LoweringState<'a> {
                     elem_size,
                 })?;
             },
-            Instr::VecPack(dst, elem_ty, elems) => {
+            Instr::VecPack {
+                dst,
+                elem_ty,
+                srcs: elems,
+            } => {
                 let dst_typed = self.def_typed_slot(*dst)?;
                 // Empty literal keeps the fast path: null pointer is the empty
                 // vector — no allocation, no descriptor needed.
@@ -1424,7 +1460,7 @@ impl<'a> LoweringState<'a> {
                     })))?;
                 }
             },
-            Instr::VecUnpack(dsts, elem_ty, src) => {
+            Instr::VecUnpack { dsts, elem_ty, src } => {
                 // TODO(completeness): the Move compiler only emits `VecUnpack` with count 0,
                 // but handwritten bytecode may use it with any count. If we
                 // restrict to count 0, we can apply simplifications.
@@ -1444,7 +1480,12 @@ impl<'a> LoweringState<'a> {
                     dsts: dst_offsets,
                 })))?;
             },
-            Instr::VecSwap(elem_ty, vec_ref, idx_a, idx_b) => {
+            Instr::VecSwap {
+                vec_ref,
+                elem_ty,
+                idx_a,
+                idx_b,
+            } => {
                 let elem_size = concrete_type_size(
                     self.ctx.layouts,
                     self.concrete_ty(*elem_ty)?,
@@ -1460,7 +1501,11 @@ impl<'a> LoweringState<'a> {
                     elem_size,
                 })?;
             },
-            Instr::VecPushBack(elem_ty, vec_ref, val) => {
+            Instr::VecPushBack {
+                vec_ref,
+                elem_ty,
+                val,
+            } => {
                 let elem_size = concrete_type_size(
                     self.ctx.layouts,
                     self.concrete_ty(*elem_ty)?,
@@ -1484,17 +1529,37 @@ impl<'a> LoweringState<'a> {
             // The struct lives in a frame slot at compile-time-known offset;
             // the field's absolute frame offset is therefore also compile-time.
             // No fat pointer is materialized.
-            Instr::ImmBorrowLocField(dst, owner, fh, local)
-            | Instr::MutBorrowLocField(dst, owner, fh, local) => {
-                let (field_offset, _) = self.resolve_field(self.concrete_ty(*owner)?, *fh)?;
+            Instr::ImmBorrowLocField {
+                dst,
+                owner_ty,
+                field,
+                local,
+            }
+            | Instr::MutBorrowLocField {
+                dst,
+                owner_ty,
+                field,
+                local,
+            } => {
+                let (field_offset, _) = self.resolve_field(self.concrete_ty(*owner_ty)?, *field)?;
                 self.lower_local_field_borrow(field_offset, *local, *dst)?;
             },
-            Instr::ReadLocalField(dst, owner, fh, local) => {
-                let field = self.resolve_field(self.concrete_ty(*owner)?, *fh)?;
+            Instr::ReadLocField {
+                dst,
+                owner_ty,
+                field,
+                local,
+            } => {
+                let field = self.resolve_field(self.concrete_ty(*owner_ty)?, *field)?;
                 self.lower_local_field_read(field, *local, *dst)?;
             },
-            Instr::WriteLocalField(owner, fh, local, val) => {
-                let field = self.resolve_field(self.concrete_ty(*owner)?, *fh)?;
+            Instr::WriteLocField {
+                local,
+                owner_ty,
+                field,
+                val,
+            } => {
+                let field = self.resolve_field(self.concrete_ty(*owner_ty)?, *field)?;
                 self.lower_local_field_write(field, *local, *val)?;
             },
 
@@ -1504,17 +1569,37 @@ impl<'a> LoweringState<'a> {
             // pointer in `src` (or `dst_ref`). Use the offset-bearing ref
             // micro-ops to fold the field offset into the address compute in a
             // single dispatch.
-            Instr::ImmBorrowField(dst, owner, fh, src)
-            | Instr::MutBorrowField(dst, owner, fh, src) => {
-                let (field_offset, _) = self.resolve_field(self.concrete_ty(*owner)?, *fh)?;
+            Instr::ImmBorrowField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            }
+            | Instr::MutBorrowField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            } => {
+                let (field_offset, _) = self.resolve_field(self.concrete_ty(*owner_ty)?, *field)?;
                 self.lower_ref_field_borrow(field_offset, *src, *dst)?;
             },
-            Instr::ReadField(dst, owner, fh, src) => {
-                let field = self.resolve_field(self.concrete_ty(*owner)?, *fh)?;
+            Instr::ReadField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            } => {
+                let field = self.resolve_field(self.concrete_ty(*owner_ty)?, *field)?;
                 self.lower_ref_field_read(field, *src, *dst)?;
             },
-            Instr::WriteField(owner, fh, dst_ref, val) => {
-                let field = self.resolve_field(self.concrete_ty(*owner)?, *fh)?;
+            Instr::WriteField {
+                dst_ref,
+                owner_ty,
+                field,
+                val,
+            } => {
+                let field = self.resolve_field(self.concrete_ty(*owner_ty)?, *field)?;
                 self.lower_ref_field_write(field, *dst_ref, *val)?;
             },
 
@@ -1523,29 +1608,29 @@ impl<'a> LoweringState<'a> {
             // The whole run reaches one field at `base(root) + Σ offsets`, so
             // each lowers to exactly one micro-op (the same one the single-field
             // op uses), with the summed offset and terminal size folded in.
-            Instr::ReadLocalFieldChain(dst, path, local) => {
+            Instr::ReadLocFieldChain { dst, path, local } => {
                 let field = self.resolve_field_path(path)?;
                 self.lower_local_field_read(field, *local, *dst)?;
             },
-            Instr::WriteLocalFieldChain(path, local, val) => {
+            Instr::WriteLocFieldChain { local, path, val } => {
                 let field = self.resolve_field_path(path)?;
                 self.lower_local_field_write(field, *local, *val)?;
             },
-            Instr::ImmBorrowLocalFieldChain(dst, path, local)
-            | Instr::MutBorrowLocalFieldChain(dst, path, local) => {
+            Instr::ImmBorrowLocFieldChain { dst, path, local }
+            | Instr::MutBorrowLocFieldChain { dst, path, local } => {
                 let (field_offset, _) = self.resolve_field_path(path)?;
                 self.lower_local_field_borrow(field_offset, *local, *dst)?;
             },
-            Instr::ReadFieldChain(dst, path, src) => {
+            Instr::ReadFieldChain { dst, path, src } => {
                 let field = self.resolve_field_path(path)?;
                 self.lower_ref_field_read(field, *src, *dst)?;
             },
-            Instr::WriteFieldChain(path, dst_ref, val) => {
+            Instr::WriteFieldChain { dst_ref, path, val } => {
                 let field = self.resolve_field_path(path)?;
                 self.lower_ref_field_write(field, *dst_ref, *val)?;
             },
-            Instr::ImmBorrowFieldChain(dst, path, src)
-            | Instr::MutBorrowFieldChain(dst, path, src) => {
+            Instr::ImmBorrowFieldChain { dst, path, src }
+            | Instr::MutBorrowFieldChain { dst, path, src } => {
                 let (field_offset, _) = self.resolve_field_path(path)?;
                 self.lower_ref_field_borrow(field_offset, *src, *dst)?;
             },
@@ -1557,21 +1642,25 @@ impl<'a> LoweringState<'a> {
             // else forward if `forward_emit_is_safe`, else bail. A true
             // copy cycle (which neither order resolves) needs a swap-style
             // bytecode op which does not currently exist.
-            Instr::Pack(dst, struct_ty, args) => {
+            Instr::Pack {
+                dst,
+                struct_ty,
+                srcs,
+            } => {
                 // After substitution, `struct_ty` must be a concrete nominal
                 // with a populated layout.
                 let struct_ty = self.concrete_ty(*struct_ty)?;
                 // (offset, size, align) per field.
                 let field_layouts = self.struct_field_layouts(struct_ty, "Pack")?;
-                if field_layouts.len() != args.len() {
+                if field_layouts.len() != srcs.len() {
                     return Err(VMInternalError::new(LoweringError::FieldCountMismatch {
                         op: "Pack",
-                        provided: args.len(),
+                        provided: srcs.len(),
                         expected: field_layouts.len(),
                     }));
                 }
                 let dst_info = self.def_slot(*dst)?;
-                let arg_infos = args
+                let arg_infos = srcs
                     .iter()
                     .map(|s| self.slot(*s))
                     .collect::<VMResult<Vec<_>>>()?;
@@ -1603,7 +1692,11 @@ impl<'a> LoweringState<'a> {
                     })?;
                 }
             },
-            Instr::Unpack(dsts, struct_ty, src) => {
+            Instr::Unpack {
+                dsts,
+                struct_ty,
+                src,
+            } => {
                 // See the `Instr::Pack` arm above for the `struct_ty` contract.
                 let struct_ty = self.concrete_ty(*struct_ty)?;
                 let field_layouts = self.struct_field_layouts(struct_ty, "Unpack")?;
@@ -1649,7 +1742,7 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Closures ---
-            Instr::PackClosure(data) => {
+            Instr::PackClosure { data } => {
                 // Target identity (with composed type arguments for the
                 // generic form) + captured-data descriptor were resolved in
                 // `try_build_context`; read them positionally.
@@ -1668,7 +1761,7 @@ impl<'a> LoweringState<'a> {
                     captured: captured_slots,
                 })))?;
             },
-            Instr::CallClosure(data) => {
+            Instr::CallClosure { data } => {
                 let ret_slots = &self.ctx.closure_call_sites[self.closure_call_cursor];
                 self.closure_call_cursor += 1;
                 let (closure_slot, provided) = data.closure_and_provided();
@@ -1682,8 +1775,12 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Global storage ---
-            Instr::Exists(dst, ty, addr) => {
-                let concrete_ty = self.concrete_ty(*ty)?;
+            Instr::Exists {
+                dst,
+                resource_ty,
+                addr,
+            } => {
+                let concrete_ty = self.concrete_ty(*resource_ty)?;
                 let addr_info = self.slot(*addr)?;
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::Exists {
@@ -1692,8 +1789,12 @@ impl<'a> LoweringState<'a> {
                     dst: dst_info.offset,
                 })?;
             },
-            Instr::ImmBorrowGlobal(dst, ty, addr) => {
-                let concrete_ty = self.concrete_ty(*ty)?;
+            Instr::ImmBorrowGlobal {
+                dst,
+                resource_ty,
+                addr,
+            } => {
+                let concrete_ty = self.concrete_ty(*resource_ty)?;
                 let addr_info = self.slot(*addr)?;
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::BorrowGlobal {
@@ -1702,8 +1803,12 @@ impl<'a> LoweringState<'a> {
                     ty: concrete_ty,
                 })?;
             },
-            Instr::MutBorrowGlobal(dst, ty, addr) => {
-                let concrete_ty = self.concrete_ty(*ty)?;
+            Instr::MutBorrowGlobal {
+                dst,
+                resource_ty,
+                addr,
+            } => {
+                let concrete_ty = self.concrete_ty(*resource_ty)?;
                 let addr_info = self.slot(*addr)?;
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::BorrowGlobalMut {
@@ -1712,12 +1817,16 @@ impl<'a> LoweringState<'a> {
                     ty: concrete_ty,
                 })?;
             },
-            Instr::MoveFrom(dst, ty, addr) => {
+            Instr::MoveFrom {
+                dst,
+                resource_ty,
+                addr,
+            } => {
                 // Move the resource out as an 8-byte heap pointer into
                 // `box_ptr`, then unbox its inline value into `dst`. `MoveFrom`
                 // may GC (deep-copy) before it writes `box_ptr`; the unbox copy
                 // that follows does not allocate.
-                let concrete_ty = self.concrete_ty(*ty)?;
+                let concrete_ty = self.concrete_ty(*resource_ty)?;
                 let box_ptr = self
                     .ctx
                     .resource_box_slot
@@ -1736,7 +1845,11 @@ impl<'a> LoweringState<'a> {
                 );
                 self.emit_heap_move_from(dst_info.offset, box_ptr, dst_info.size)?;
             },
-            Instr::MoveTo(ty, signer, val) => {
+            Instr::MoveTo {
+                resource_ty,
+                signer,
+                val,
+            } => {
                 // Box the inline resource value into a fresh heap object, then
                 // publish the pointer. `HeapNew` allocates (and may GC) before
                 // it writes `box_ptr`; the `HeapMoveTo` box copy and `MoveTo`
@@ -1751,7 +1864,7 @@ impl<'a> LoweringState<'a> {
                 // the relocated child pointer, not a stale one. This relies on
                 // `frame_layout` being a whole-function root set; it would break
                 // if safe points became per-PC / liveness-based.
-                let concrete_ty = self.concrete_ty(*ty)?;
+                let concrete_ty = self.concrete_ty(*resource_ty)?;
                 let descriptor_id = self
                     .ctx
                     .descriptor_id(concrete_ty)
@@ -1787,22 +1900,27 @@ impl<'a> LoweringState<'a> {
             // others read/write/borrow through the heap pointer. Field offsets
             // come from the derived `EnumLayout`; the `enum_*` helpers add
             // `ENUM_DATA_OFFSET`.
-            Instr::PackVariant(dst, enum_ty, variant_ord, args) => {
+            Instr::PackVariant {
+                dst,
+                enum_ty,
+                variant,
+                srcs,
+            } => {
                 let enum_ty = self.concrete_ty(*enum_ty)?;
                 let ctx = self.ctx;
                 let layout = ctx
                     .enum_layout(enum_ty)
                     .ok_or(LoweringError::EnumLayoutNotDerived { op: "PackVariant" })?;
-                let variant_fields = layout.variants.get(*variant_ord as usize).ok_or(
+                let variant_fields = layout.variants.get(*variant as usize).ok_or(
                     LoweringError::VariantOrdinalOutOfRange {
                         op: "PackVariant",
-                        ordinal: *variant_ord as usize,
+                        ordinal: *variant as usize,
                     },
                 )?;
-                if variant_fields.len() != args.len() {
+                if variant_fields.len() != srcs.len() {
                     return Err(VMInternalError::new(LoweringError::FieldCountMismatch {
                         op: "PackVariant",
-                        provided: args.len(),
+                        provided: srcs.len(),
                         expected: variant_fields.len(),
                     }));
                 }
@@ -1814,7 +1932,7 @@ impl<'a> LoweringState<'a> {
                 let dst_off = self.def_slot(*dst)?.offset;
                 // Resolve the field arg slots up front so we can detect aliasing
                 // before emitting.
-                let arg_slots = self.slots_to_sized_slots(args)?;
+                let arg_slots = self.slots_to_sized_slots(srcs)?;
                 // `EnumNew` writes the heap pointer to its target slot BEFORE the
                 // field stores read the args. The slot allocator may thread the
                 // enum dst and a field arg through one Xfer position (its
@@ -1838,7 +1956,7 @@ impl<'a> LoweringState<'a> {
                 } else {
                     dst_off
                 };
-                self.emit(MicroOp::enum_new(pack_ptr, descriptor_id, *variant_ord))?;
+                self.emit(MicroOp::enum_new(pack_ptr, descriptor_id, *variant))?;
                 // `enum_store` is non-allocating: no safe point between `EnumNew`
                 // and the final store, so the scratch pointer never spans a GC.
                 for (field, arg) in variant_fields.iter().zip(arg_slots.iter()) {
@@ -1857,7 +1975,12 @@ impl<'a> LoweringState<'a> {
                     })?;
                 }
             },
-            Instr::UnpackVariant(dsts, enum_ty, variant_ord, src) => {
+            Instr::UnpackVariant {
+                dsts,
+                enum_ty,
+                variant,
+                src,
+            } => {
                 let enum_ty = self.concrete_ty(*enum_ty)?;
                 let ctx = self.ctx;
                 let layout =
@@ -1865,10 +1988,10 @@ impl<'a> LoweringState<'a> {
                         .ok_or(LoweringError::EnumLayoutNotDerived {
                             op: "UnpackVariant",
                         })?;
-                let variant_fields = layout.variants.get(*variant_ord as usize).ok_or(
+                let variant_fields = layout.variants.get(*variant as usize).ok_or(
                     LoweringError::VariantOrdinalOutOfRange {
                         op: "UnpackVariant",
-                        ordinal: *variant_ord as usize,
+                        ordinal: *variant as usize,
                     },
                 )?;
                 if variant_fields.len() != dsts.len() {
@@ -1934,7 +2057,7 @@ impl<'a> LoweringState<'a> {
                 // one. The fact must key on the shared local (TestVariant takes
                 // a `&enum`, UnpackVariant the value); there is no
                 // `VariantSwitch` in this IR to shortcut through.
-                self.emit(MicroOp::enum_check_variant(load_ptr, *variant_ord as u64))?;
+                self.emit(MicroOp::enum_check_variant(load_ptr, *variant as u64))?;
                 for (field, &dst_off) in variant_fields.iter().zip(dst_offs.iter()) {
                     let size = field.size;
                     let load = if size == 8 {
@@ -1945,23 +2068,26 @@ impl<'a> LoweringState<'a> {
                     self.emit(load)?;
                 }
             },
-            Instr::TestVariant(dst, _enum_ty, variant_ord, src) => {
+            Instr::TestVariant {
+                dst, variant, src, ..
+            } => {
                 // `src` is an enum reference.
                 let enum_ref = self.slot(*src)?.offset;
                 let dst_off = self.def_slot(*dst)?.offset;
-                self.emit(MicroOp::enum_test_tag(
-                    enum_ref,
-                    *variant_ord as u64,
-                    dst_off,
-                ))?;
+                self.emit(MicroOp::enum_test_tag(enum_ref, *variant as u64, dst_off))?;
             },
             // By-reference field read/write: `src`/`dst_ref` is an enum fat
             // pointer. The uniform-offset fast path fuses the heap deref and the
             // value copy into one `Enum{Read,Write}VariantField`; the divergent
             // path fuses the tag dispatch and the copy into one
             // `Enum{Read,Write}VariantFieldByTag`. Both are non-allocating.
-            Instr::ReadVariantField(dst, enum_ty, vfh, src) => {
-                let access = self.resolve_variant_field(self.concrete_ty(*enum_ty)?, *vfh)?;
+            Instr::ReadVariantField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            } => {
+                let access = self.resolve_variant_field(self.concrete_ty(*owner_ty)?, *field)?;
                 let src_off = self.slot(*src)?.offset;
                 let dst_typed = self.def_typed_slot(*dst)?;
                 let dst_off = dst_typed.slot.offset;
@@ -1983,8 +2109,13 @@ impl<'a> LoweringState<'a> {
                 // itself heap-backed, make it independent.
                 self.maybe_deep_copy(dst_typed.ty, dst_off)?;
             },
-            Instr::WriteVariantField(enum_ty, vfh, dst_ref, val) => {
-                let access = self.resolve_variant_field(self.concrete_ty(*enum_ty)?, *vfh)?;
+            Instr::WriteVariantField {
+                dst_ref,
+                owner_ty,
+                field,
+                val,
+            } => {
+                let access = self.resolve_variant_field(self.concrete_ty(*owner_ty)?, *field)?;
                 let ref_off = self.slot(*dst_ref)?.offset;
                 let val_off = self.slot(*val)?.offset;
                 match access.uniform_offset {
@@ -2006,9 +2137,19 @@ impl<'a> LoweringState<'a> {
             // into `dst`; the borrow derefs the enum and offsets into the heap
             // object — statically when uniform, else by runtime tag (aborting
             // when the variant does not declare the field).
-            Instr::ImmBorrowVariantField(dst, enum_ty, vfh, src)
-            | Instr::MutBorrowVariantField(dst, enum_ty, vfh, src) => {
-                let access = self.resolve_variant_field(self.concrete_ty(*enum_ty)?, *vfh)?;
+            Instr::ImmBorrowVariantField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            }
+            | Instr::MutBorrowVariantField {
+                dst,
+                owner_ty,
+                field,
+                src,
+            } => {
+                let access = self.resolve_variant_field(self.concrete_ty(*owner_ty)?, *field)?;
                 let src_off = self.slot(*src)?.offset;
                 let dst_off = self.def_slot(*dst)?.offset;
                 match access.uniform_offset {

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -189,324 +189,399 @@ fn display_instr(
 ) -> fmt::Result {
     match instr {
         // --- Loads: dst := instr literal ---
-        Instr::LdConst(d, idx) => {
-            write_dst(f, *d)?;
-            write!(f, "ld_const #{}", idx.0)
+        Instr::LdConst { dst, const_idx } => {
+            write_dst(f, *dst)?;
+            write!(f, "ld_const #{}", const_idx.0)
         },
-        Instr::LdImm(d, imm) => {
-            write_dst(f, *d)?;
+        Instr::LdImm { dst, imm } => {
+            write_dst(f, *dst)?;
             write_load_imm(f, imm)
         },
 
         // --- Slot ops: dst := copy/move src ---
-        Instr::Copy(d, s) => {
-            write_dst(f, *d)?;
-            write!(f, "copy {}", slot_name(*s))
+        Instr::Copy { dst, src } => {
+            write_dst(f, *dst)?;
+            write!(f, "copy {}", slot_name(*src))
         },
-        Instr::Move(d, s) => {
-            write_dst(f, *d)?;
-            write!(f, "move {}", slot_name(*s))
+        Instr::Move { dst, src } => {
+            write_dst(f, *dst)?;
+            write!(f, "move {}", slot_name(*src))
         },
 
         // --- Unary: dst := op src ---
-        Instr::UnaryOp(d, op, s) => {
-            write_dst(f, *d)?;
+        Instr::UnaryOp { dst, op, src } => {
+            write_dst(f, *dst)?;
             write_unary_op(f, op)?;
-            write!(f, " {}", slot_name(*s))
+            write!(f, " {}", slot_name(*src))
         },
         // --- Binary: dst := op lhs, rhs ---
-        Instr::BinaryOp(d, op, l, r) => {
-            write_dst(f, *d)?;
+        Instr::BinaryOp { dst, op, lhs, rhs } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "{} {}, {}",
                 binary_op_name(op),
-                slot_name(*l),
-                slot_name(*r)
+                slot_name(*lhs),
+                slot_name(*rhs)
             )
         },
         // --- Binary immediate: dst := op lhs, #imm ---
-        Instr::BinaryOpImm(d, op, l, imm) => {
-            write_dst(f, *d)?;
+        Instr::BinaryOpImm { dst, op, lhs, imm } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "{} {}, {}",
                 binary_op_name(op),
-                slot_name(*l),
+                slot_name(*lhs),
                 imm_value(imm)
             )
         },
 
         // --- Struct ---
-        Instr::Pack(d, ty, fields) => {
-            write_dst(f, *d)?;
+        Instr::Pack {
+            dst,
+            struct_ty,
+            srcs,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "pack ")?;
-            display_type(f, *ty)?;
-            write!(f, ", {}", slot_names(fields))
+            display_type(f, *struct_ty)?;
+            write!(f, ", {}", slot_names(srcs))
         },
-        Instr::Unpack(ds, ty, s) => {
-            write_dsts(f, ds)?;
+        Instr::Unpack {
+            dsts,
+            struct_ty,
+            src,
+        } => {
+            write_dsts(f, dsts)?;
             write!(f, "unpack ")?;
-            display_type(f, *ty)?;
-            write!(f, ", {}", slot_name(*s))
+            display_type(f, *struct_ty)?;
+            write!(f, ", {}", slot_name(*src))
         },
 
         // --- Variant ---
-        Instr::PackVariant(d, ty, variant, fields) => {
-            write_dst(f, *d)?;
+        Instr::PackVariant {
+            dst,
+            enum_ty,
+            variant,
+            srcs,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "pack_variant ")?;
-            display_type(f, *ty)?;
-            write!(f, "@{}, {}", variant, slot_names(fields))
+            display_type(f, *enum_ty)?;
+            write!(f, "@{}, {}", variant, slot_names(srcs))
         },
-        Instr::UnpackVariant(ds, ty, variant, s) => {
-            write_dsts(f, ds)?;
+        Instr::UnpackVariant {
+            dsts,
+            enum_ty,
+            variant,
+            src,
+        } => {
+            write_dsts(f, dsts)?;
             write!(f, "unpack_variant ")?;
-            display_type(f, *ty)?;
-            write!(f, "@{}, {}", variant, slot_name(*s))
+            display_type(f, *enum_ty)?;
+            write!(f, "@{}, {}", variant, slot_name(*src))
         },
-        Instr::TestVariant(d, ty, variant, s) => {
-            write_dst(f, *d)?;
+        Instr::TestVariant {
+            dst,
+            enum_ty,
+            variant,
+            src,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "test_variant ")?;
-            display_type(f, *ty)?;
-            write!(f, "@{}, {}", variant, slot_name(*s))
+            display_type(f, *enum_ty)?;
+            write!(f, "@{}, {}", variant, slot_name(*src))
         },
 
         // --- References ---
-        Instr::ImmBorrowLoc(d, s) => {
-            write_dst(f, *d)?;
-            write!(f, "imm_borrow_loc {}", slot_name(*s))
+        Instr::ImmBorrowLoc { dst, local } => {
+            write_dst(f, *dst)?;
+            write!(f, "imm_borrow_loc {}", slot_name(*local))
         },
-        Instr::MutBorrowLoc(d, s) => {
-            write_dst(f, *d)?;
-            write!(f, "mut_borrow_loc {}", slot_name(*s))
+        Instr::MutBorrowLoc { dst, local } => {
+            write_dst(f, *dst)?;
+            write!(f, "mut_borrow_loc {}", slot_name(*local))
         },
-        Instr::ImmBorrowField(d, _, idx, s) => {
-            write_dst(f, *d)?;
+        Instr::ImmBorrowField {
+            dst, field, src, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "imm_borrow_field {}, {}",
-                field_name(module, *idx),
-                slot_name(*s)
+                field_name(module, *field),
+                slot_name(*src)
             )
         },
-        Instr::MutBorrowField(d, _, idx, s) => {
-            write_dst(f, *d)?;
+        Instr::MutBorrowField {
+            dst, field, src, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "mut_borrow_field {}, {}",
-                field_name(module, *idx),
-                slot_name(*s)
+                field_name(module, *field),
+                slot_name(*src)
             )
         },
-        Instr::ImmBorrowVariantField(d, _, idx, s) => {
-            write_dst(f, *d)?;
+        Instr::ImmBorrowVariantField {
+            dst, field, src, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "imm_borrow_variant_field {}, {}",
-                variant_field_name(module, *idx),
-                slot_name(*s)
+                variant_field_name(module, *field),
+                slot_name(*src)
             )
         },
-        Instr::MutBorrowVariantField(d, _, idx, s) => {
-            write_dst(f, *d)?;
+        Instr::MutBorrowVariantField {
+            dst, field, src, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "mut_borrow_variant_field {}, {}",
-                variant_field_name(module, *idx),
-                slot_name(*s)
+                variant_field_name(module, *field),
+                slot_name(*src)
             )
         },
-        Instr::ReadRef(d, s) => {
-            write_dst(f, *d)?;
-            write!(f, "read_ref {}", slot_name(*s))
+        Instr::ReadRef { dst, src } => {
+            write_dst(f, *dst)?;
+            write!(f, "read_ref {}", slot_name(*src))
         },
         // WriteRef has no destination (side-effect only)
-        Instr::WriteRef(d, v) => write!(f, "write_ref {}, {}", slot_name(*d), slot_name(*v)),
+        Instr::WriteRef { dst_ref, val } => {
+            write!(f, "write_ref {}, {}", slot_name(*dst_ref), slot_name(*val))
+        },
 
         // --- Fused field access ---
-        Instr::ReadField(d, _, idx, s) => {
-            write_dst(f, *d)?;
+        Instr::ReadField {
+            dst, field, src, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "read_field {}, {}",
-                field_name(module, *idx),
-                slot_name(*s)
+                field_name(module, *field),
+                slot_name(*src)
             )
         },
-        Instr::WriteField(_, idx, d, v) => {
+        Instr::WriteField {
+            dst_ref,
+            field,
+            val,
+            ..
+        } => {
             write!(
                 f,
                 "write_field {}, {}, {}",
-                field_name(module, *idx),
-                slot_name(*d),
-                slot_name(*v)
+                field_name(module, *field),
+                slot_name(*dst_ref),
+                slot_name(*val)
             )
         },
-        Instr::ReadVariantField(d, _, idx, s) => {
-            write_dst(f, *d)?;
+        Instr::ReadVariantField {
+            dst, field, src, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "read_variant_field {}, {}",
-                variant_field_name(module, *idx),
-                slot_name(*s)
+                variant_field_name(module, *field),
+                slot_name(*src)
             )
         },
-        Instr::WriteVariantField(_, idx, d, v) => {
+        Instr::WriteVariantField {
+            dst_ref,
+            field,
+            val,
+            ..
+        } => {
             write!(
                 f,
                 "write_variant_field {}, {}, {}",
-                variant_field_name(module, *idx),
-                slot_name(*d),
-                slot_name(*v)
+                variant_field_name(module, *field),
+                slot_name(*dst_ref),
+                slot_name(*val)
             )
         },
 
         // --- Fused inline-struct field access ---
-        Instr::ImmBorrowLocField(d, _, idx, local) => {
-            write_dst(f, *d)?;
+        Instr::ImmBorrowLocField {
+            dst, field, local, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "imm_borrow_loc_field {}, {}",
-                field_name(module, *idx),
+                field_name(module, *field),
                 slot_name(*local)
             )
         },
-        Instr::MutBorrowLocField(d, _, idx, local) => {
-            write_dst(f, *d)?;
+        Instr::MutBorrowLocField {
+            dst, field, local, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "mut_borrow_loc_field {}, {}",
-                field_name(module, *idx),
+                field_name(module, *field),
                 slot_name(*local)
             )
         },
-        Instr::ReadLocalField(d, _, idx, local) => {
-            write_dst(f, *d)?;
+        Instr::ReadLocField {
+            dst, field, local, ..
+        } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
-                "read_local_field {}, {}",
-                field_name(module, *idx),
+                "read_loc_field {}, {}",
+                field_name(module, *field),
                 slot_name(*local)
             )
         },
-        Instr::WriteLocalField(_, idx, local, v) => {
+        Instr::WriteLocField {
+            local, field, val, ..
+        } => {
             write!(
                 f,
-                "write_local_field {}, {}, {}",
-                field_name(module, *idx),
+                "write_loc_field {}, {}, {}",
+                field_name(module, *field),
                 slot_name(*local),
-                slot_name(*v)
+                slot_name(*val)
             )
         },
 
         // --- Fused field chains ---
-        Instr::ReadFieldChain(d, path, s) => {
-            write_dst(f, *d)?;
+        Instr::ReadFieldChain { dst, path, src } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "read_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*s)
+                slot_name(*src)
             )
         },
-        Instr::WriteFieldChain(path, d, v) => {
+        Instr::WriteFieldChain { dst_ref, path, val } => {
             write!(
                 f,
                 "write_field_chain {}, {}, {}",
                 field_path_name(module, path),
-                slot_name(*d),
-                slot_name(*v)
+                slot_name(*dst_ref),
+                slot_name(*val)
             )
         },
-        Instr::ImmBorrowFieldChain(d, path, s) => {
-            write_dst(f, *d)?;
+        Instr::ImmBorrowFieldChain { dst, path, src } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "imm_borrow_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*s)
+                slot_name(*src)
             )
         },
-        Instr::MutBorrowFieldChain(d, path, s) => {
-            write_dst(f, *d)?;
+        Instr::MutBorrowFieldChain { dst, path, src } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
                 "mut_borrow_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*s)
+                slot_name(*src)
             )
         },
-        Instr::ReadLocalFieldChain(d, path, local) => {
-            write_dst(f, *d)?;
+        Instr::ReadLocFieldChain { dst, path, local } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
-                "read_local_field_chain {}, {}",
+                "read_loc_field_chain {}, {}",
                 field_path_name(module, path),
                 slot_name(*local)
             )
         },
-        Instr::WriteLocalFieldChain(path, local, v) => {
+        Instr::WriteLocFieldChain { local, path, val } => {
             write!(
                 f,
-                "write_local_field_chain {}, {}, {}",
+                "write_loc_field_chain {}, {}, {}",
                 field_path_name(module, path),
                 slot_name(*local),
-                slot_name(*v)
+                slot_name(*val)
             )
         },
-        Instr::ImmBorrowLocalFieldChain(d, path, local) => {
-            write_dst(f, *d)?;
+        Instr::ImmBorrowLocFieldChain { dst, path, local } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
-                "imm_borrow_local_field_chain {}, {}",
+                "imm_borrow_loc_field_chain {}, {}",
                 field_path_name(module, path),
                 slot_name(*local)
             )
         },
-        Instr::MutBorrowLocalFieldChain(d, path, local) => {
-            write_dst(f, *d)?;
+        Instr::MutBorrowLocFieldChain { dst, path, local } => {
+            write_dst(f, *dst)?;
             write!(
                 f,
-                "mut_borrow_local_field_chain {}, {}",
+                "mut_borrow_loc_field_chain {}, {}",
                 field_path_name(module, path),
                 slot_name(*local)
             )
         },
 
         // --- Globals ---
-        Instr::Exists(d, ty, a) => {
-            write_dst(f, *d)?;
+        Instr::Exists {
+            dst,
+            resource_ty,
+            addr,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "exists ")?;
-            display_type(f, *ty)?;
-            write!(f, ", {}", slot_name(*a))
+            display_type(f, *resource_ty)?;
+            write!(f, ", {}", slot_name(*addr))
         },
-        Instr::MoveFrom(d, ty, a) => {
-            write_dst(f, *d)?;
+        Instr::MoveFrom {
+            dst,
+            resource_ty,
+            addr,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "move_from ")?;
-            display_type(f, *ty)?;
-            write!(f, ", {}", slot_name(*a))
+            display_type(f, *resource_ty)?;
+            write!(f, ", {}", slot_name(*addr))
         },
         // MoveTo has no destination (side-effect)
-        Instr::MoveTo(ty, s, v) => {
+        Instr::MoveTo {
+            resource_ty,
+            signer,
+            val,
+        } => {
             write!(f, "move_to ")?;
-            display_type(f, *ty)?;
-            write!(f, ", {}, {}", slot_name(*s), slot_name(*v))
+            display_type(f, *resource_ty)?;
+            write!(f, ", {}, {}", slot_name(*signer), slot_name(*val))
         },
-        Instr::ImmBorrowGlobal(d, ty, a) => {
-            write_dst(f, *d)?;
+        Instr::ImmBorrowGlobal {
+            dst,
+            resource_ty,
+            addr,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "imm_borrow_global ")?;
-            display_type(f, *ty)?;
-            write!(f, ", {}", slot_name(*a))
+            display_type(f, *resource_ty)?;
+            write!(f, ", {}", slot_name(*addr))
         },
-        Instr::MutBorrowGlobal(d, ty, a) => {
-            write_dst(f, *d)?;
+        Instr::MutBorrowGlobal {
+            dst,
+            resource_ty,
+            addr,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "mut_borrow_global ")?;
-            display_type(f, *ty)?;
-            write!(f, ", {}", slot_name(*a))
+            display_type(f, *resource_ty)?;
+            write!(f, ", {}", slot_name(*addr))
         },
 
         // --- Calls ---
-        Instr::Call(data) => {
+        Instr::Call { data } => {
             write_dsts(f, &data.rets)?;
             write!(f, "call {}", func_name(module, data.function_handle))?;
             write_ty_args(f, data.ty_args)?;
@@ -514,7 +589,7 @@ fn display_instr(
         },
 
         // --- Closures ---
-        Instr::PackClosure(data) => {
+        Instr::PackClosure { data } => {
             write_dst(f, data.dst)?;
             write!(
                 f,
@@ -524,7 +599,7 @@ fn display_instr(
             write_ty_args(f, data.ty_args)?;
             write!(f, ", {}, {}", data.mask, slot_names(&data.captured))
         },
-        Instr::CallClosure(data) => {
+        Instr::CallClosure { data } => {
             write_dsts(f, &data.rets)?;
             write!(f, "call_closure ")?;
             write!(f, "[")?;
@@ -534,84 +609,125 @@ fn display_instr(
         },
 
         // --- Vector ---
-        Instr::VecPack(d, elem_ty, elems) => {
-            write_dst(f, *d)?;
+        Instr::VecPack { dst, elem_ty, srcs } => {
+            write_dst(f, *dst)?;
             write!(f, "vec_pack ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", elems.len(), slot_names(elems))
+            write!(f, ", {}, {}", srcs.len(), slot_names(srcs))
         },
-        Instr::VecLen(d, elem_ty, s) => {
-            write_dst(f, *d)?;
+        Instr::VecLen {
+            dst,
+            elem_ty,
+            vec_ref,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "vec_len ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}", slot_name(*s))
+            write!(f, ", {}", slot_name(*vec_ref))
         },
-        Instr::VecImmBorrow(d, elem_ty, v, i) => {
-            write_dst(f, *d)?;
+        Instr::VecImmBorrow {
+            dst,
+            elem_ty,
+            vec_ref,
+            idx,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "vec_imm_borrow ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", slot_name(*v), slot_name(*i))
+            write!(f, ", {}, {}", slot_name(*vec_ref), slot_name(*idx))
         },
-        Instr::VecMutBorrow(d, elem_ty, v, i) => {
-            write_dst(f, *d)?;
+        Instr::VecMutBorrow {
+            dst,
+            elem_ty,
+            vec_ref,
+            idx,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "vec_mut_borrow ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", slot_name(*v), slot_name(*i))
+            write!(f, ", {}, {}", slot_name(*vec_ref), slot_name(*idx))
         },
         // VecPushBack has no destination
-        Instr::VecPushBack(elem_ty, v, val) => {
+        Instr::VecPushBack {
+            vec_ref,
+            elem_ty,
+            val,
+        } => {
             write!(f, "vec_push_back ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", slot_name(*v), slot_name(*val))
+            write!(f, ", {}, {}", slot_name(*vec_ref), slot_name(*val))
         },
-        Instr::VecPopBack(d, elem_ty, s) => {
-            write_dst(f, *d)?;
+        Instr::VecPopBack {
+            dst,
+            elem_ty,
+            vec_ref,
+        } => {
+            write_dst(f, *dst)?;
             write!(f, "vec_pop_back ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}", slot_name(*s))
+            write!(f, ", {}", slot_name(*vec_ref))
         },
-        Instr::VecUnpack(ds, elem_ty, s) => {
-            write_dsts(f, ds)?;
+        Instr::VecUnpack { dsts, elem_ty, src } => {
+            write_dsts(f, dsts)?;
             write!(f, "vec_unpack ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", ds.len(), slot_name(*s))
+            write!(f, ", {}, {}", dsts.len(), slot_name(*src))
         },
         // VecSwap has no destination
-        Instr::VecSwap(elem_ty, v, i, j) => {
+        Instr::VecSwap {
+            vec_ref,
+            elem_ty,
+            idx_a,
+            idx_b,
+        } => {
             write!(f, "vec_swap ")?;
             display_type(f, *elem_ty)?;
             write!(
                 f,
                 ", {}, {}, {}",
-                slot_name(*v),
-                slot_name(*i),
-                slot_name(*j)
+                slot_name(*vec_ref),
+                slot_name(*idx_a),
+                slot_name(*idx_b)
             )
         },
 
         // --- Control flow (no destinations) ---
-        Instr::Branch(l) => write!(f, "branch L{}", l.0),
-        Instr::BrTrue(l, c) => write!(f, "br_true L{}, {}", l.0, slot_name(*c)),
-        Instr::BrFalse(l, c) => write!(f, "br_false L{}, {}", l.0, slot_name(*c)),
-        Instr::BrCmp(l, op, lhs, rhs) => write!(
+        Instr::Branch { target } => write!(f, "branch L{}", target.0),
+        Instr::BrTrue { target, cond } => write!(f, "br_true L{}, {}", target.0, slot_name(*cond)),
+        Instr::BrFalse { target, cond } => {
+            write!(f, "br_false L{}, {}", target.0, slot_name(*cond))
+        },
+        Instr::BrCmp {
+            target,
+            op,
+            lhs,
+            rhs,
+        } => write!(
             f,
             "br_{} L{}, {}, {}",
             cmp_op_name(op),
-            l.0,
+            target.0,
             slot_name(*lhs),
             slot_name(*rhs)
         ),
-        Instr::BrCmpImm(l, op, src, imm) => write!(
+        Instr::BrCmpImm {
+            target,
+            op,
+            lhs,
+            imm,
+        } => write!(
             f,
             "br_{} L{}, {}, {}",
             cmp_op_name(op),
-            l.0,
-            slot_name(*src),
+            target.0,
+            slot_name(*lhs),
             imm_value(imm)
         ),
-        Instr::Ret(rs) => write!(f, "ret {}", slot_names(rs)),
-        Instr::Abort(c) => write!(f, "abort {}", slot_name(*c)),
-        Instr::AbortMsg(c, m) => write!(f, "abort_msg {}, {}", slot_name(*c), slot_name(*m)),
+        Instr::Ret { srcs } => write!(f, "ret {}", slot_names(srcs)),
+        Instr::Abort { code } => write!(f, "abort {}", slot_name(*code)),
+        Instr::AbortMsg { code, msg } => {
+            write!(f, "abort_msg {}, {}", slot_name(*code), slot_name(*msg))
+        },
         Instr::ForceGC => write!(f, "force_gc"),
     }
 }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
@@ -122,68 +122,68 @@ pub(crate) fn remap_source_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> 
 #[inline]
 pub(crate) fn call_boundary_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[Slot])> {
     match instr {
-        Instr::Call(data) => Some((&data.rets, &data.args)),
-        Instr::CallClosure(data) => Some((&data.rets, &data.args)),
+        Instr::Call { data } => Some((&data.rets, &data.args)),
+        Instr::CallClosure { data } => Some((&data.rets, &data.args)),
 
         // Every other instruction: not a call boundary.
-        Instr::LdConst(..)
-        | Instr::LdImm(..)
-        | Instr::Copy(..)
-        | Instr::Move(..)
-        | Instr::UnaryOp(..)
-        | Instr::BinaryOp(..)
-        | Instr::BinaryOpImm(..)
-        | Instr::Pack(..)
-        | Instr::Unpack(..)
-        | Instr::PackVariant(..)
-        | Instr::UnpackVariant(..)
-        | Instr::TestVariant(..)
-        | Instr::ImmBorrowLoc(..)
-        | Instr::MutBorrowLoc(..)
-        | Instr::ImmBorrowField(..)
-        | Instr::MutBorrowField(..)
-        | Instr::ImmBorrowVariantField(..)
-        | Instr::MutBorrowVariantField(..)
-        | Instr::ReadRef(..)
-        | Instr::WriteRef(..)
-        | Instr::ReadField(..)
-        | Instr::WriteField(..)
-        | Instr::ReadVariantField(..)
-        | Instr::WriteVariantField(..)
-        | Instr::ImmBorrowLocField(..)
-        | Instr::MutBorrowLocField(..)
-        | Instr::ReadLocalField(..)
-        | Instr::WriteLocalField(..)
-        | Instr::ReadFieldChain(..)
-        | Instr::WriteFieldChain(..)
-        | Instr::ImmBorrowFieldChain(..)
-        | Instr::MutBorrowFieldChain(..)
-        | Instr::ReadLocalFieldChain(..)
-        | Instr::WriteLocalFieldChain(..)
-        | Instr::ImmBorrowLocalFieldChain(..)
-        | Instr::MutBorrowLocalFieldChain(..)
-        | Instr::Exists(..)
-        | Instr::MoveFrom(..)
-        | Instr::MoveTo(..)
-        | Instr::ImmBorrowGlobal(..)
-        | Instr::MutBorrowGlobal(..)
-        | Instr::PackClosure(..)
-        | Instr::VecPack(..)
-        | Instr::VecLen(..)
-        | Instr::VecImmBorrow(..)
-        | Instr::VecMutBorrow(..)
-        | Instr::VecPushBack(..)
-        | Instr::VecPopBack(..)
-        | Instr::VecUnpack(..)
-        | Instr::VecSwap(..)
-        | Instr::Branch(..)
-        | Instr::BrTrue(..)
-        | Instr::BrFalse(..)
-        | Instr::BrCmp(..)
-        | Instr::BrCmpImm(..)
-        | Instr::Ret(..)
-        | Instr::Abort(..)
-        | Instr::AbortMsg(..)
+        Instr::LdConst { .. }
+        | Instr::LdImm { .. }
+        | Instr::Copy { .. }
+        | Instr::Move { .. }
+        | Instr::UnaryOp { .. }
+        | Instr::BinaryOp { .. }
+        | Instr::BinaryOpImm { .. }
+        | Instr::Pack { .. }
+        | Instr::Unpack { .. }
+        | Instr::PackVariant { .. }
+        | Instr::UnpackVariant { .. }
+        | Instr::TestVariant { .. }
+        | Instr::ImmBorrowLoc { .. }
+        | Instr::MutBorrowLoc { .. }
+        | Instr::ImmBorrowField { .. }
+        | Instr::MutBorrowField { .. }
+        | Instr::ImmBorrowVariantField { .. }
+        | Instr::MutBorrowVariantField { .. }
+        | Instr::ReadRef { .. }
+        | Instr::WriteRef { .. }
+        | Instr::ReadField { .. }
+        | Instr::WriteField { .. }
+        | Instr::ReadVariantField { .. }
+        | Instr::WriteVariantField { .. }
+        | Instr::ImmBorrowLocField { .. }
+        | Instr::MutBorrowLocField { .. }
+        | Instr::ReadLocField { .. }
+        | Instr::WriteLocField { .. }
+        | Instr::ReadFieldChain { .. }
+        | Instr::WriteFieldChain { .. }
+        | Instr::ImmBorrowFieldChain { .. }
+        | Instr::MutBorrowFieldChain { .. }
+        | Instr::ReadLocFieldChain { .. }
+        | Instr::WriteLocFieldChain { .. }
+        | Instr::ImmBorrowLocFieldChain { .. }
+        | Instr::MutBorrowLocFieldChain { .. }
+        | Instr::Exists { .. }
+        | Instr::MoveFrom { .. }
+        | Instr::MoveTo { .. }
+        | Instr::ImmBorrowGlobal { .. }
+        | Instr::MutBorrowGlobal { .. }
+        | Instr::PackClosure { .. }
+        | Instr::VecPack { .. }
+        | Instr::VecLen { .. }
+        | Instr::VecImmBorrow { .. }
+        | Instr::VecMutBorrow { .. }
+        | Instr::VecPushBack { .. }
+        | Instr::VecPopBack { .. }
+        | Instr::VecUnpack { .. }
+        | Instr::VecSwap { .. }
+        | Instr::Branch { .. }
+        | Instr::BrTrue { .. }
+        | Instr::BrFalse { .. }
+        | Instr::BrCmp { .. }
+        | Instr::BrCmpImm { .. }
+        | Instr::Ret { .. }
+        | Instr::Abort { .. }
+        | Instr::AbortMsg { .. }
         | Instr::ForceGC => None,
     }
 }
@@ -201,68 +201,68 @@ pub(crate) fn clobbers_xfer(instr: &Instr) -> bool {
 pub(crate) fn mut_local_borrow_target(instr: &Instr) -> Option<Slot> {
     match instr {
         // Mutable borrows of a local's storage.
-        Instr::MutBorrowLoc(_, local)
-        | Instr::MutBorrowLocField(_, _, _, local)
-        | Instr::MutBorrowLocalFieldChain(_, _, local) => Some(*local),
+        Instr::MutBorrowLoc { local, .. }
+        | Instr::MutBorrowLocField { local, .. }
+        | Instr::MutBorrowLocFieldChain { local, .. } => Some(*local),
 
         // Every other instruction: no local storage is mutably borrowed.
-        Instr::Pack(..)
-        | Instr::Unpack(..)
-        | Instr::PackVariant(..)
-        | Instr::UnpackVariant(..)
-        | Instr::TestVariant(..)
-        | Instr::ImmBorrowField(..)
-        | Instr::MutBorrowField(..)
-        | Instr::ReadField(..)
-        | Instr::WriteField(..)
-        | Instr::ImmBorrowLocField(..)
-        | Instr::ReadLocalField(..)
-        | Instr::WriteLocalField(..)
-        | Instr::ReadFieldChain(..)
-        | Instr::WriteFieldChain(..)
-        | Instr::ImmBorrowFieldChain(..)
-        | Instr::MutBorrowFieldChain(..)
-        | Instr::ReadLocalFieldChain(..)
-        | Instr::WriteLocalFieldChain(..)
-        | Instr::ImmBorrowLocalFieldChain(..)
-        | Instr::ImmBorrowVariantField(..)
-        | Instr::MutBorrowVariantField(..)
-        | Instr::ReadVariantField(..)
-        | Instr::WriteVariantField(..)
-        | Instr::PackClosure(..)
-        | Instr::CallClosure(..)
-        | Instr::Exists(..)
-        | Instr::MoveFrom(..)
-        | Instr::MoveTo(..)
-        | Instr::ImmBorrowGlobal(..)
-        | Instr::MutBorrowGlobal(..)
-        | Instr::VecPack(..)
-        | Instr::VecLen(..)
-        | Instr::VecImmBorrow(..)
-        | Instr::VecMutBorrow(..)
-        | Instr::VecPushBack(..)
-        | Instr::VecPopBack(..)
-        | Instr::VecUnpack(..)
-        | Instr::VecSwap(..)
-        | Instr::LdConst(..)
-        | Instr::LdImm(..)
-        | Instr::Copy(..)
-        | Instr::Move(..)
-        | Instr::UnaryOp(..)
-        | Instr::BinaryOp(..)
-        | Instr::BinaryOpImm(..)
-        | Instr::ImmBorrowLoc(..)
-        | Instr::ReadRef(..)
-        | Instr::WriteRef(..)
-        | Instr::Call(..)
-        | Instr::Branch(..)
-        | Instr::BrTrue(..)
-        | Instr::BrFalse(..)
-        | Instr::BrCmp(..)
-        | Instr::BrCmpImm(..)
-        | Instr::Ret(..)
-        | Instr::Abort(..)
-        | Instr::AbortMsg(..)
+        Instr::Pack { .. }
+        | Instr::Unpack { .. }
+        | Instr::PackVariant { .. }
+        | Instr::UnpackVariant { .. }
+        | Instr::TestVariant { .. }
+        | Instr::ImmBorrowField { .. }
+        | Instr::MutBorrowField { .. }
+        | Instr::ReadField { .. }
+        | Instr::WriteField { .. }
+        | Instr::ImmBorrowLocField { .. }
+        | Instr::ReadLocField { .. }
+        | Instr::WriteLocField { .. }
+        | Instr::ReadFieldChain { .. }
+        | Instr::WriteFieldChain { .. }
+        | Instr::ImmBorrowFieldChain { .. }
+        | Instr::MutBorrowFieldChain { .. }
+        | Instr::ReadLocFieldChain { .. }
+        | Instr::WriteLocFieldChain { .. }
+        | Instr::ImmBorrowLocFieldChain { .. }
+        | Instr::ImmBorrowVariantField { .. }
+        | Instr::MutBorrowVariantField { .. }
+        | Instr::ReadVariantField { .. }
+        | Instr::WriteVariantField { .. }
+        | Instr::PackClosure { .. }
+        | Instr::CallClosure { .. }
+        | Instr::Exists { .. }
+        | Instr::MoveFrom { .. }
+        | Instr::MoveTo { .. }
+        | Instr::ImmBorrowGlobal { .. }
+        | Instr::MutBorrowGlobal { .. }
+        | Instr::VecPack { .. }
+        | Instr::VecLen { .. }
+        | Instr::VecImmBorrow { .. }
+        | Instr::VecMutBorrow { .. }
+        | Instr::VecPushBack { .. }
+        | Instr::VecPopBack { .. }
+        | Instr::VecUnpack { .. }
+        | Instr::VecSwap { .. }
+        | Instr::LdConst { .. }
+        | Instr::LdImm { .. }
+        | Instr::Copy { .. }
+        | Instr::Move { .. }
+        | Instr::UnaryOp { .. }
+        | Instr::BinaryOp { .. }
+        | Instr::BinaryOpImm { .. }
+        | Instr::ImmBorrowLoc { .. }
+        | Instr::ReadRef { .. }
+        | Instr::WriteRef { .. }
+        | Instr::Call { .. }
+        | Instr::Branch { .. }
+        | Instr::BrTrue { .. }
+        | Instr::BrFalse { .. }
+        | Instr::BrCmp { .. }
+        | Instr::BrCmpImm { .. }
+        | Instr::Ret { .. }
+        | Instr::Abort { .. }
+        | Instr::AbortMsg { .. }
         | Instr::ForceGC => None,
     }
 }
@@ -275,68 +275,68 @@ pub(crate) fn mut_local_borrow_target(instr: &Instr) -> Option<Slot> {
 pub(crate) fn resource_type_in_instr(instr: &Instr) -> Option<InternedType> {
     match instr {
         // Global-storage ops carry the resource nominal directly.
-        Instr::Exists(_, ty, _)
-        | Instr::MoveFrom(_, ty, _)
-        | Instr::MoveTo(ty, _, _)
-        | Instr::ImmBorrowGlobal(_, ty, _)
-        | Instr::MutBorrowGlobal(_, ty, _) => Some(*ty),
+        Instr::Exists { resource_ty, .. }
+        | Instr::MoveFrom { resource_ty, .. }
+        | Instr::MoveTo { resource_ty, .. }
+        | Instr::ImmBorrowGlobal { resource_ty, .. }
+        | Instr::MutBorrowGlobal { resource_ty, .. } => Some(*resource_ty),
 
         // Every other instruction: no resource type involved.
-        Instr::LdImm(..)
-        | Instr::Pack(..)
-        | Instr::Unpack(..)
-        | Instr::PackVariant(..)
-        | Instr::UnpackVariant(..)
-        | Instr::TestVariant(..)
-        | Instr::ImmBorrowField(..)
-        | Instr::MutBorrowField(..)
-        | Instr::ReadField(..)
-        | Instr::WriteField(..)
-        | Instr::ImmBorrowLocField(..)
-        | Instr::MutBorrowLocField(..)
-        | Instr::ReadLocalField(..)
-        | Instr::WriteLocalField(..)
-        | Instr::ReadFieldChain(..)
-        | Instr::WriteFieldChain(..)
-        | Instr::ImmBorrowFieldChain(..)
-        | Instr::MutBorrowFieldChain(..)
-        | Instr::ReadLocalFieldChain(..)
-        | Instr::WriteLocalFieldChain(..)
-        | Instr::ImmBorrowLocalFieldChain(..)
-        | Instr::MutBorrowLocalFieldChain(..)
-        | Instr::ImmBorrowVariantField(..)
-        | Instr::MutBorrowVariantField(..)
-        | Instr::ReadVariantField(..)
-        | Instr::WriteVariantField(..)
-        | Instr::PackClosure(..)
-        | Instr::CallClosure(..)
-        | Instr::VecPack(..)
-        | Instr::VecLen(..)
-        | Instr::VecImmBorrow(..)
-        | Instr::VecMutBorrow(..)
-        | Instr::VecPushBack(..)
-        | Instr::VecPopBack(..)
-        | Instr::VecUnpack(..)
-        | Instr::VecSwap(..)
-        | Instr::LdConst(..)
-        | Instr::Copy(..)
-        | Instr::Move(..)
-        | Instr::UnaryOp(..)
-        | Instr::BinaryOp(..)
-        | Instr::BinaryOpImm(..)
-        | Instr::ImmBorrowLoc(..)
-        | Instr::MutBorrowLoc(..)
-        | Instr::ReadRef(..)
-        | Instr::WriteRef(..)
-        | Instr::Call(..)
-        | Instr::Branch(..)
-        | Instr::BrTrue(..)
-        | Instr::BrFalse(..)
-        | Instr::BrCmp(..)
-        | Instr::BrCmpImm(..)
-        | Instr::Ret(..)
-        | Instr::Abort(..)
-        | Instr::AbortMsg(..)
+        Instr::LdImm { .. }
+        | Instr::Pack { .. }
+        | Instr::Unpack { .. }
+        | Instr::PackVariant { .. }
+        | Instr::UnpackVariant { .. }
+        | Instr::TestVariant { .. }
+        | Instr::ImmBorrowField { .. }
+        | Instr::MutBorrowField { .. }
+        | Instr::ReadField { .. }
+        | Instr::WriteField { .. }
+        | Instr::ImmBorrowLocField { .. }
+        | Instr::MutBorrowLocField { .. }
+        | Instr::ReadLocField { .. }
+        | Instr::WriteLocField { .. }
+        | Instr::ReadFieldChain { .. }
+        | Instr::WriteFieldChain { .. }
+        | Instr::ImmBorrowFieldChain { .. }
+        | Instr::MutBorrowFieldChain { .. }
+        | Instr::ReadLocFieldChain { .. }
+        | Instr::WriteLocFieldChain { .. }
+        | Instr::ImmBorrowLocFieldChain { .. }
+        | Instr::MutBorrowLocFieldChain { .. }
+        | Instr::ImmBorrowVariantField { .. }
+        | Instr::MutBorrowVariantField { .. }
+        | Instr::ReadVariantField { .. }
+        | Instr::WriteVariantField { .. }
+        | Instr::PackClosure { .. }
+        | Instr::CallClosure { .. }
+        | Instr::VecPack { .. }
+        | Instr::VecLen { .. }
+        | Instr::VecImmBorrow { .. }
+        | Instr::VecMutBorrow { .. }
+        | Instr::VecPushBack { .. }
+        | Instr::VecPopBack { .. }
+        | Instr::VecUnpack { .. }
+        | Instr::VecSwap { .. }
+        | Instr::LdConst { .. }
+        | Instr::Copy { .. }
+        | Instr::Move { .. }
+        | Instr::UnaryOp { .. }
+        | Instr::BinaryOp { .. }
+        | Instr::BinaryOpImm { .. }
+        | Instr::ImmBorrowLoc { .. }
+        | Instr::MutBorrowLoc { .. }
+        | Instr::ReadRef { .. }
+        | Instr::WriteRef { .. }
+        | Instr::Call { .. }
+        | Instr::Branch { .. }
+        | Instr::BrTrue { .. }
+        | Instr::BrFalse { .. }
+        | Instr::BrCmp { .. }
+        | Instr::BrCmpImm { .. }
+        | Instr::Ret { .. }
+        | Instr::Abort { .. }
+        | Instr::AbortMsg { .. }
         | Instr::ForceGC => None,
     }
 }
@@ -362,85 +362,87 @@ pub(crate) enum NominalKind {
 pub(crate) fn field_layout_nominal_in_instr(instr: &Instr) -> Option<(InternedType, NominalKind)> {
     match instr {
         // Carry the instantiated struct type directly.
-        Instr::Pack(_, ty, _) | Instr::Unpack(_, ty, _) => Some((*ty, NominalKind::Struct)),
+        Instr::Pack { struct_ty, .. } | Instr::Unpack { struct_ty, .. } => {
+            Some((*struct_ty, NominalKind::Struct))
+        },
 
         // Field ops carry the instantiated owner struct type.
-        Instr::ImmBorrowField(_, owner, _, _)
-        | Instr::MutBorrowField(_, owner, _, _)
-        | Instr::ReadField(_, owner, _, _)
-        | Instr::WriteField(owner, _, _, _)
-        | Instr::ImmBorrowLocField(_, owner, _, _)
-        | Instr::MutBorrowLocField(_, owner, _, _)
-        | Instr::ReadLocalField(_, owner, _, _)
-        | Instr::WriteLocalField(owner, _, _, _) => Some((*owner, NominalKind::Struct)),
+        Instr::ImmBorrowField { owner_ty, .. }
+        | Instr::MutBorrowField { owner_ty, .. }
+        | Instr::ReadField { owner_ty, .. }
+        | Instr::WriteField { owner_ty, .. }
+        | Instr::ImmBorrowLocField { owner_ty, .. }
+        | Instr::MutBorrowLocField { owner_ty, .. }
+        | Instr::ReadLocField { owner_ty, .. }
+        | Instr::WriteLocField { owner_ty, .. } => Some((*owner_ty, NominalKind::Struct)),
 
         // A struct chain's first owner contains every later owner as an inline
         // field (each later owner is the previous hop's field type), so
         // discovering it transitively lays out the whole path. The containment
         // invariant is debug-checked at the discovery site.
-        Instr::ReadFieldChain(_, path, _)
-        | Instr::WriteFieldChain(path, _, _)
-        | Instr::ImmBorrowFieldChain(_, path, _)
-        | Instr::MutBorrowFieldChain(_, path, _)
-        | Instr::ReadLocalFieldChain(_, path, _)
-        | Instr::WriteLocalFieldChain(path, _, _)
-        | Instr::ImmBorrowLocalFieldChain(_, path, _)
-        | Instr::MutBorrowLocalFieldChain(_, path, _) => {
+        Instr::ReadFieldChain { path, .. }
+        | Instr::WriteFieldChain { path, .. }
+        | Instr::ImmBorrowFieldChain { path, .. }
+        | Instr::MutBorrowFieldChain { path, .. }
+        | Instr::ReadLocFieldChain { path, .. }
+        | Instr::WriteLocFieldChain { path, .. }
+        | Instr::ImmBorrowLocFieldChain { path, .. }
+        | Instr::MutBorrowLocFieldChain { path, .. } => {
             path.first().map(|(owner, _)| (*owner, NominalKind::Struct))
         },
 
         // Variant ops carry the instantiated enum type directly.
-        Instr::PackVariant(_, ty, _, _)
-        | Instr::UnpackVariant(_, ty, _, _)
-        | Instr::TestVariant(_, ty, _, _) => Some((*ty, NominalKind::Enum)),
+        Instr::PackVariant { enum_ty, .. }
+        | Instr::UnpackVariant { enum_ty, .. }
+        | Instr::TestVariant { enum_ty, .. } => Some((*enum_ty, NominalKind::Enum)),
 
         // Variant-field ops carry the instantiated owner enum type.
-        Instr::ImmBorrowVariantField(_, owner, _, _)
-        | Instr::MutBorrowVariantField(_, owner, _, _)
-        | Instr::ReadVariantField(_, owner, _, _)
-        | Instr::WriteVariantField(owner, _, _, _) => Some((*owner, NominalKind::Enum)),
+        Instr::ImmBorrowVariantField { owner_ty, .. }
+        | Instr::MutBorrowVariantField { owner_ty, .. }
+        | Instr::ReadVariantField { owner_ty, .. }
+        | Instr::WriteVariantField { owner_ty, .. } => Some((*owner_ty, NominalKind::Enum)),
 
         // Global-resource ops surface their type via `resource_type_in_instr`
         // (they need whole-value size, not field offsets); vector ops need only
         // element stride and closure ops a capture-object layout, so none has a
         // field-layout nominal to report here.
-        Instr::Exists(..)
-        | Instr::MoveFrom(..)
-        | Instr::MoveTo(..)
-        | Instr::ImmBorrowGlobal(..)
-        | Instr::MutBorrowGlobal(..)
-        | Instr::PackClosure(..)
-        | Instr::CallClosure(..)
-        | Instr::VecPack(..)
-        | Instr::VecLen(..)
-        | Instr::VecImmBorrow(..)
-        | Instr::VecMutBorrow(..)
-        | Instr::VecPushBack(..)
-        | Instr::VecPopBack(..)
-        | Instr::VecUnpack(..)
-        | Instr::VecSwap(..) => None,
+        Instr::Exists { .. }
+        | Instr::MoveFrom { .. }
+        | Instr::MoveTo { .. }
+        | Instr::ImmBorrowGlobal { .. }
+        | Instr::MutBorrowGlobal { .. }
+        | Instr::PackClosure { .. }
+        | Instr::CallClosure { .. }
+        | Instr::VecPack { .. }
+        | Instr::VecLen { .. }
+        | Instr::VecImmBorrow { .. }
+        | Instr::VecMutBorrow { .. }
+        | Instr::VecPushBack { .. }
+        | Instr::VecPopBack { .. }
+        | Instr::VecUnpack { .. }
+        | Instr::VecSwap { .. } => None,
 
         // No struct type involved.
-        Instr::LdConst(..)
-        | Instr::LdImm(..)
-        | Instr::Copy(..)
-        | Instr::Move(..)
-        | Instr::UnaryOp(..)
-        | Instr::BinaryOp(..)
-        | Instr::BinaryOpImm(..)
-        | Instr::ImmBorrowLoc(..)
-        | Instr::MutBorrowLoc(..)
-        | Instr::ReadRef(..)
-        | Instr::WriteRef(..)
-        | Instr::Call(..)
-        | Instr::Branch(..)
-        | Instr::BrTrue(..)
-        | Instr::BrFalse(..)
-        | Instr::BrCmp(..)
-        | Instr::BrCmpImm(..)
-        | Instr::Ret(..)
-        | Instr::Abort(..)
-        | Instr::AbortMsg(..)
+        Instr::LdConst { .. }
+        | Instr::LdImm { .. }
+        | Instr::Copy { .. }
+        | Instr::Move { .. }
+        | Instr::UnaryOp { .. }
+        | Instr::BinaryOp { .. }
+        | Instr::BinaryOpImm { .. }
+        | Instr::ImmBorrowLoc { .. }
+        | Instr::MutBorrowLoc { .. }
+        | Instr::ReadRef { .. }
+        | Instr::WriteRef { .. }
+        | Instr::Call { .. }
+        | Instr::Branch { .. }
+        | Instr::BrTrue { .. }
+        | Instr::BrFalse { .. }
+        | Instr::BrCmp { .. }
+        | Instr::BrCmpImm { .. }
+        | Instr::Ret { .. }
+        | Instr::Abort { .. }
+        | Instr::AbortMsg { .. }
         | Instr::ForceGC => None,
     }
 }
@@ -448,68 +450,68 @@ pub(crate) fn field_layout_nominal_in_instr(instr: &Instr) -> Option<(InternedTy
 /// The fused-chain `FieldPath` carried by `instr`, if any.
 pub(crate) fn chain_field_path(instr: &Instr) -> Option<&FieldPath> {
     match instr {
-        Instr::ReadFieldChain(_, path, _)
-        | Instr::WriteFieldChain(path, _, _)
-        | Instr::ImmBorrowFieldChain(_, path, _)
-        | Instr::MutBorrowFieldChain(_, path, _)
-        | Instr::ReadLocalFieldChain(_, path, _)
-        | Instr::WriteLocalFieldChain(path, _, _)
-        | Instr::ImmBorrowLocalFieldChain(_, path, _)
-        | Instr::MutBorrowLocalFieldChain(_, path, _) => Some(path),
+        Instr::ReadFieldChain { path, .. }
+        | Instr::WriteFieldChain { path, .. }
+        | Instr::ImmBorrowFieldChain { path, .. }
+        | Instr::MutBorrowFieldChain { path, .. }
+        | Instr::ReadLocFieldChain { path, .. }
+        | Instr::WriteLocFieldChain { path, .. }
+        | Instr::ImmBorrowLocFieldChain { path, .. }
+        | Instr::MutBorrowLocFieldChain { path, .. } => Some(path),
 
         // Every other instruction: no fused chain.
-        Instr::Pack(..)
-        | Instr::Unpack(..)
-        | Instr::PackVariant(..)
-        | Instr::UnpackVariant(..)
-        | Instr::TestVariant(..)
-        | Instr::ImmBorrowField(..)
-        | Instr::MutBorrowField(..)
-        | Instr::ReadField(..)
-        | Instr::WriteField(..)
-        | Instr::ImmBorrowLocField(..)
-        | Instr::MutBorrowLocField(..)
-        | Instr::ReadLocalField(..)
-        | Instr::WriteLocalField(..)
-        | Instr::ImmBorrowVariantField(..)
-        | Instr::MutBorrowVariantField(..)
-        | Instr::ReadVariantField(..)
-        | Instr::WriteVariantField(..)
-        | Instr::PackClosure(..)
-        | Instr::CallClosure(..)
-        | Instr::Exists(..)
-        | Instr::MoveFrom(..)
-        | Instr::MoveTo(..)
-        | Instr::ImmBorrowGlobal(..)
-        | Instr::MutBorrowGlobal(..)
-        | Instr::VecPack(..)
-        | Instr::VecLen(..)
-        | Instr::VecImmBorrow(..)
-        | Instr::VecMutBorrow(..)
-        | Instr::VecPushBack(..)
-        | Instr::VecPopBack(..)
-        | Instr::VecUnpack(..)
-        | Instr::VecSwap(..)
-        | Instr::LdConst(..)
-        | Instr::LdImm(..)
-        | Instr::Copy(..)
-        | Instr::Move(..)
-        | Instr::UnaryOp(..)
-        | Instr::BinaryOp(..)
-        | Instr::BinaryOpImm(..)
-        | Instr::ImmBorrowLoc(..)
-        | Instr::MutBorrowLoc(..)
-        | Instr::ReadRef(..)
-        | Instr::WriteRef(..)
-        | Instr::Call(..)
-        | Instr::Branch(..)
-        | Instr::BrTrue(..)
-        | Instr::BrFalse(..)
-        | Instr::BrCmp(..)
-        | Instr::BrCmpImm(..)
-        | Instr::Ret(..)
-        | Instr::Abort(..)
-        | Instr::AbortMsg(..)
+        Instr::Pack { .. }
+        | Instr::Unpack { .. }
+        | Instr::PackVariant { .. }
+        | Instr::UnpackVariant { .. }
+        | Instr::TestVariant { .. }
+        | Instr::ImmBorrowField { .. }
+        | Instr::MutBorrowField { .. }
+        | Instr::ReadField { .. }
+        | Instr::WriteField { .. }
+        | Instr::ImmBorrowLocField { .. }
+        | Instr::MutBorrowLocField { .. }
+        | Instr::ReadLocField { .. }
+        | Instr::WriteLocField { .. }
+        | Instr::ImmBorrowVariantField { .. }
+        | Instr::MutBorrowVariantField { .. }
+        | Instr::ReadVariantField { .. }
+        | Instr::WriteVariantField { .. }
+        | Instr::PackClosure { .. }
+        | Instr::CallClosure { .. }
+        | Instr::Exists { .. }
+        | Instr::MoveFrom { .. }
+        | Instr::MoveTo { .. }
+        | Instr::ImmBorrowGlobal { .. }
+        | Instr::MutBorrowGlobal { .. }
+        | Instr::VecPack { .. }
+        | Instr::VecLen { .. }
+        | Instr::VecImmBorrow { .. }
+        | Instr::VecMutBorrow { .. }
+        | Instr::VecPushBack { .. }
+        | Instr::VecPopBack { .. }
+        | Instr::VecUnpack { .. }
+        | Instr::VecSwap { .. }
+        | Instr::LdConst { .. }
+        | Instr::LdImm { .. }
+        | Instr::Copy { .. }
+        | Instr::Move { .. }
+        | Instr::UnaryOp { .. }
+        | Instr::BinaryOp { .. }
+        | Instr::BinaryOpImm { .. }
+        | Instr::ImmBorrowLoc { .. }
+        | Instr::MutBorrowLoc { .. }
+        | Instr::ReadRef { .. }
+        | Instr::WriteRef { .. }
+        | Instr::Call { .. }
+        | Instr::Branch { .. }
+        | Instr::BrTrue { .. }
+        | Instr::BrFalse { .. }
+        | Instr::BrCmp { .. }
+        | Instr::BrCmpImm { .. }
+        | Instr::Ret { .. }
+        | Instr::Abort { .. }
+        | Instr::AbortMsg { .. }
         | Instr::ForceGC => None,
     }
 }
@@ -518,64 +520,67 @@ pub(crate) fn chain_field_path(instr: &Instr) -> Option<&FieldPath> {
 #[inline]
 pub(crate) fn is_fallthrough_terminator(instr: &Instr) -> bool {
     match instr {
-        Instr::BrTrue(..) | Instr::BrFalse(..) | Instr::BrCmp(..) | Instr::BrCmpImm(..) => true,
+        Instr::BrTrue { .. }
+        | Instr::BrFalse { .. }
+        | Instr::BrCmp { .. }
+        | Instr::BrCmpImm { .. } => true,
 
-        Instr::Branch(..)
-        | Instr::Ret(..)
-        | Instr::Abort(..)
-        | Instr::AbortMsg(..)
-        | Instr::LdConst(..)
-        | Instr::LdImm(..)
-        | Instr::Copy(..)
-        | Instr::Move(..)
-        | Instr::UnaryOp(..)
-        | Instr::BinaryOp(..)
-        | Instr::BinaryOpImm(..)
-        | Instr::Pack(..)
-        | Instr::Unpack(..)
-        | Instr::PackVariant(..)
-        | Instr::UnpackVariant(..)
-        | Instr::TestVariant(..)
-        | Instr::ImmBorrowLoc(..)
-        | Instr::MutBorrowLoc(..)
-        | Instr::ImmBorrowField(..)
-        | Instr::MutBorrowField(..)
-        | Instr::ImmBorrowVariantField(..)
-        | Instr::MutBorrowVariantField(..)
-        | Instr::ReadRef(..)
-        | Instr::WriteRef(..)
-        | Instr::ReadField(..)
-        | Instr::WriteField(..)
-        | Instr::ReadVariantField(..)
-        | Instr::WriteVariantField(..)
-        | Instr::ImmBorrowLocField(..)
-        | Instr::MutBorrowLocField(..)
-        | Instr::ReadLocalField(..)
-        | Instr::WriteLocalField(..)
-        | Instr::ReadFieldChain(..)
-        | Instr::WriteFieldChain(..)
-        | Instr::ImmBorrowFieldChain(..)
-        | Instr::MutBorrowFieldChain(..)
-        | Instr::ReadLocalFieldChain(..)
-        | Instr::WriteLocalFieldChain(..)
-        | Instr::ImmBorrowLocalFieldChain(..)
-        | Instr::MutBorrowLocalFieldChain(..)
-        | Instr::Exists(..)
-        | Instr::MoveFrom(..)
-        | Instr::MoveTo(..)
-        | Instr::ImmBorrowGlobal(..)
-        | Instr::MutBorrowGlobal(..)
-        | Instr::Call(..)
-        | Instr::PackClosure(..)
-        | Instr::CallClosure(..)
-        | Instr::VecPack(..)
-        | Instr::VecLen(..)
-        | Instr::VecImmBorrow(..)
-        | Instr::VecMutBorrow(..)
-        | Instr::VecPushBack(..)
-        | Instr::VecPopBack(..)
-        | Instr::VecUnpack(..)
-        | Instr::VecSwap(..)
+        Instr::Branch { .. }
+        | Instr::Ret { .. }
+        | Instr::Abort { .. }
+        | Instr::AbortMsg { .. }
+        | Instr::LdConst { .. }
+        | Instr::LdImm { .. }
+        | Instr::Copy { .. }
+        | Instr::Move { .. }
+        | Instr::UnaryOp { .. }
+        | Instr::BinaryOp { .. }
+        | Instr::BinaryOpImm { .. }
+        | Instr::Pack { .. }
+        | Instr::Unpack { .. }
+        | Instr::PackVariant { .. }
+        | Instr::UnpackVariant { .. }
+        | Instr::TestVariant { .. }
+        | Instr::ImmBorrowLoc { .. }
+        | Instr::MutBorrowLoc { .. }
+        | Instr::ImmBorrowField { .. }
+        | Instr::MutBorrowField { .. }
+        | Instr::ImmBorrowVariantField { .. }
+        | Instr::MutBorrowVariantField { .. }
+        | Instr::ReadRef { .. }
+        | Instr::WriteRef { .. }
+        | Instr::ReadField { .. }
+        | Instr::WriteField { .. }
+        | Instr::ReadVariantField { .. }
+        | Instr::WriteVariantField { .. }
+        | Instr::ImmBorrowLocField { .. }
+        | Instr::MutBorrowLocField { .. }
+        | Instr::ReadLocField { .. }
+        | Instr::WriteLocField { .. }
+        | Instr::ReadFieldChain { .. }
+        | Instr::WriteFieldChain { .. }
+        | Instr::ImmBorrowFieldChain { .. }
+        | Instr::MutBorrowFieldChain { .. }
+        | Instr::ReadLocFieldChain { .. }
+        | Instr::WriteLocFieldChain { .. }
+        | Instr::ImmBorrowLocFieldChain { .. }
+        | Instr::MutBorrowLocFieldChain { .. }
+        | Instr::Exists { .. }
+        | Instr::MoveFrom { .. }
+        | Instr::MoveTo { .. }
+        | Instr::ImmBorrowGlobal { .. }
+        | Instr::MutBorrowGlobal { .. }
+        | Instr::Call { .. }
+        | Instr::PackClosure { .. }
+        | Instr::CallClosure { .. }
+        | Instr::VecPack { .. }
+        | Instr::VecLen { .. }
+        | Instr::VecImmBorrow { .. }
+        | Instr::VecMutBorrow { .. }
+        | Instr::VecPushBack { .. }
+        | Instr::VecPopBack { .. }
+        | Instr::VecUnpack { .. }
+        | Instr::VecSwap { .. }
         | Instr::ForceGC => false,
     }
 }
@@ -653,154 +658,164 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
     mut f: impl FnMut(Slot, SlotRole),
 ) {
     match instr {
-        Instr::LdConst(dst, _) | Instr::LdImm(dst, _) => def::<DEFS>(*dst, &mut f),
+        Instr::LdConst { dst, .. } | Instr::LdImm { dst, .. } => def::<DEFS>(*dst, &mut f),
 
-        Instr::Copy(dst, src) | Instr::Move(dst, src) | Instr::UnaryOp(dst, _, src) => {
+        Instr::Copy { dst, src } | Instr::Move { dst, src } | Instr::UnaryOp { dst, src, .. } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*src, &mut f);
         },
-        Instr::BinaryOp(dst, _, lhs, rhs) => {
+        Instr::BinaryOp { dst, lhs, rhs, .. } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*lhs, &mut f);
             used::<USES>(*rhs, &mut f);
         },
-        Instr::BinaryOpImm(dst, _, lhs, _) => {
+        Instr::BinaryOpImm { dst, lhs, .. } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*lhs, &mut f);
         },
 
-        Instr::Pack(dst, _, fields) | Instr::PackVariant(dst, _, _, fields) => {
+        Instr::Pack { dst, srcs, .. } | Instr::PackVariant { dst, srcs, .. } => {
             def::<DEFS>(*dst, &mut f);
-            uses::<USES>(fields, &mut f);
+            uses::<USES>(srcs, &mut f);
         },
-        Instr::Unpack(dsts, _, src) | Instr::UnpackVariant(dsts, _, _, src) => {
+        Instr::Unpack { dsts, src, .. } | Instr::UnpackVariant { dsts, src, .. } => {
             defs::<DEFS>(dsts, &mut f);
             used::<USES>(*src, &mut f);
         },
-        Instr::TestVariant(dst, _, _, src) => {
+        Instr::TestVariant { dst, src, .. } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*src, &mut f);
         },
 
-        // `src` is a place use: the local's identity is
+        // `local` is a place use: the local's identity is
         // taken, its bytes are not consumed.
-        Instr::ImmBorrowLoc(dst, src) | Instr::MutBorrowLoc(dst, src) => {
+        Instr::ImmBorrowLoc { dst, local } | Instr::MutBorrowLoc { dst, local } => {
             def::<DEFS>(*dst, &mut f);
-            storage_use::<USES>(*src, &mut f);
+            storage_use::<USES>(*local, &mut f);
         },
         // Field chains share the slot shape of their single-field counterparts;
         // only the carried `path` differs.
-        Instr::ImmBorrowField(dst, _, _, src)
-        | Instr::MutBorrowField(dst, _, _, src)
-        | Instr::ImmBorrowVariantField(dst, _, _, src)
-        | Instr::MutBorrowVariantField(dst, _, _, src)
-        | Instr::ImmBorrowFieldChain(dst, _, src)
-        | Instr::MutBorrowFieldChain(dst, _, src)
-        | Instr::ReadRef(dst, src) => {
+        Instr::ImmBorrowField { dst, src, .. }
+        | Instr::MutBorrowField { dst, src, .. }
+        | Instr::ImmBorrowVariantField { dst, src, .. }
+        | Instr::MutBorrowVariantField { dst, src, .. }
+        | Instr::ImmBorrowFieldChain { dst, src, .. }
+        | Instr::MutBorrowFieldChain { dst, src, .. }
+        | Instr::ReadRef { dst, src } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*src, &mut f);
         },
-        Instr::WriteRef(ref_slot, val) => {
-            used::<USES>(*ref_slot, &mut f);
+        Instr::WriteRef { dst_ref, val } => {
+            used::<USES>(*dst_ref, &mut f);
             used::<USES>(*val, &mut f);
         },
 
-        Instr::ReadField(dst, _, _, src)
-        | Instr::ReadVariantField(dst, _, _, src)
-        | Instr::ReadFieldChain(dst, _, src) => {
+        Instr::ReadField { dst, src, .. }
+        | Instr::ReadVariantField { dst, src, .. }
+        | Instr::ReadFieldChain { dst, src, .. } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*src, &mut f);
         },
-        Instr::WriteField(_, _, ref_slot, val)
-        | Instr::WriteVariantField(_, _, ref_slot, val)
-        | Instr::WriteFieldChain(_, ref_slot, val) => {
-            used::<USES>(*ref_slot, &mut f);
+        Instr::WriteField { dst_ref, val, .. }
+        | Instr::WriteVariantField { dst_ref, val, .. }
+        | Instr::WriteFieldChain { dst_ref, val, .. } => {
+            used::<USES>(*dst_ref, &mut f);
             used::<USES>(*val, &mut f);
         },
 
         // `local` names the inline-struct frame slot, not a reference:
         // a place use.
-        Instr::ImmBorrowLocField(dst, _, _, local)
-        | Instr::MutBorrowLocField(dst, _, _, local)
-        | Instr::ReadLocalField(dst, _, _, local)
-        | Instr::ImmBorrowLocalFieldChain(dst, _, local)
-        | Instr::MutBorrowLocalFieldChain(dst, _, local)
-        | Instr::ReadLocalFieldChain(dst, _, local) => {
+        Instr::ImmBorrowLocField { dst, local, .. }
+        | Instr::MutBorrowLocField { dst, local, .. }
+        | Instr::ReadLocField { dst, local, .. }
+        | Instr::ImmBorrowLocFieldChain { dst, local, .. }
+        | Instr::MutBorrowLocFieldChain { dst, local, .. }
+        | Instr::ReadLocFieldChain { dst, local, .. } => {
             def::<DEFS>(*dst, &mut f);
             storage_use::<USES>(*local, &mut f);
         },
         // `local` is both a def (a field is written in-place) and a
         // place use (the other fields persist, so the slot
         // stays live with the same type after the write).
-        Instr::WriteLocalField(_, _, local, val) | Instr::WriteLocalFieldChain(_, local, val) => {
+        Instr::WriteLocField { local, val, .. } | Instr::WriteLocFieldChain { local, val, .. } => {
             def::<DEFS>(*local, &mut f);
             storage_use::<USES>(*local, &mut f);
             used::<USES>(*val, &mut f);
         },
 
-        Instr::Exists(dst, _, addr) | Instr::MoveFrom(dst, _, addr) => {
+        Instr::Exists { dst, addr, .. } | Instr::MoveFrom { dst, addr, .. } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*addr, &mut f);
         },
-        Instr::MoveTo(_, signer, val) => {
+        Instr::MoveTo { signer, val, .. } => {
             used::<USES>(*signer, &mut f);
             used::<USES>(*val, &mut f);
         },
-        Instr::ImmBorrowGlobal(dst, _, addr) | Instr::MutBorrowGlobal(dst, _, addr) => {
+        Instr::ImmBorrowGlobal { dst, addr, .. } | Instr::MutBorrowGlobal { dst, addr, .. } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*addr, &mut f);
         },
 
-        Instr::Call(data) => {
+        Instr::Call { data } => {
             defs::<DEFS>(&data.rets, &mut f);
             uses::<USES>(&data.args, &mut f);
         },
-        Instr::CallClosure(data) => {
+        Instr::CallClosure { data } => {
             defs::<DEFS>(&data.rets, &mut f);
             uses::<USES>(&data.args, &mut f);
         },
-        Instr::PackClosure(data) => {
+        Instr::PackClosure { data } => {
             def::<DEFS>(data.dst, &mut f);
             uses::<USES>(&data.captured, &mut f);
         },
 
-        Instr::VecPack(dst, _, elems) => {
+        Instr::VecPack { dst, srcs, .. } => {
             def::<DEFS>(*dst, &mut f);
-            uses::<USES>(elems, &mut f);
+            uses::<USES>(srcs, &mut f);
         },
-        Instr::VecLen(dst, _, src) | Instr::VecPopBack(dst, _, src) => {
+        Instr::VecLen { dst, vec_ref, .. } | Instr::VecPopBack { dst, vec_ref, .. } => {
             def::<DEFS>(*dst, &mut f);
-            used::<USES>(*src, &mut f);
+            used::<USES>(*vec_ref, &mut f);
         },
-        Instr::VecImmBorrow(dst, _, vec_ref, idx) | Instr::VecMutBorrow(dst, _, vec_ref, idx) => {
+        Instr::VecImmBorrow {
+            dst, vec_ref, idx, ..
+        }
+        | Instr::VecMutBorrow {
+            dst, vec_ref, idx, ..
+        } => {
             def::<DEFS>(*dst, &mut f);
             used::<USES>(*vec_ref, &mut f);
             used::<USES>(*idx, &mut f);
         },
-        Instr::VecPushBack(_, vec_ref, val) => {
+        Instr::VecPushBack { vec_ref, val, .. } => {
             used::<USES>(*vec_ref, &mut f);
             used::<USES>(*val, &mut f);
         },
-        Instr::VecUnpack(dsts, _, src) => {
+        Instr::VecUnpack { dsts, src, .. } => {
             defs::<DEFS>(dsts, &mut f);
             used::<USES>(*src, &mut f);
         },
-        Instr::VecSwap(_, vec_ref, idx_a, idx_b) => {
+        Instr::VecSwap {
+            vec_ref,
+            idx_a,
+            idx_b,
+            ..
+        } => {
             used::<USES>(*vec_ref, &mut f);
             used::<USES>(*idx_a, &mut f);
             used::<USES>(*idx_b, &mut f);
         },
 
-        Instr::Branch(_) => {},
-        Instr::BrTrue(_, cond) | Instr::BrFalse(_, cond) => used::<USES>(*cond, &mut f),
-        Instr::BrCmp(_, _, lhs, rhs) => {
+        Instr::Branch { .. } => {},
+        Instr::BrTrue { cond, .. } | Instr::BrFalse { cond, .. } => used::<USES>(*cond, &mut f),
+        Instr::BrCmp { lhs, rhs, .. } => {
             used::<USES>(*lhs, &mut f);
             used::<USES>(*rhs, &mut f);
         },
-        Instr::BrCmpImm(_, _, src, _) => used::<USES>(*src, &mut f),
-        Instr::Ret(rets) => uses::<USES>(rets, &mut f),
-        Instr::Abort(code) => used::<USES>(*code, &mut f),
-        Instr::AbortMsg(code, msg) => {
+        Instr::BrCmpImm { lhs, .. } => used::<USES>(*lhs, &mut f),
+        Instr::Ret { srcs } => uses::<USES>(srcs, &mut f),
+        Instr::Abort { code } => used::<USES>(*code, &mut f),
+        Instr::AbortMsg { code, msg } => {
             used::<USES>(*code, &mut f);
             used::<USES>(*msg, &mut f);
         },
@@ -838,13 +853,13 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
     mut f: impl FnMut(Slot) -> Slot,
 ) {
     match instr {
-        Instr::LdConst(dst, _) | Instr::LdImm(dst, _) => {
+        Instr::LdConst { dst, .. } | Instr::LdImm { dst, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
         },
 
-        Instr::Copy(dst, src) | Instr::Move(dst, src) | Instr::UnaryOp(dst, _, src) => {
+        Instr::Copy { dst, src } | Instr::Move { dst, src } | Instr::UnaryOp { dst, src, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -852,7 +867,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slot(src, &mut f);
             }
         },
-        Instr::BinaryOp(dst, _, lhs, rhs) => {
+        Instr::BinaryOp { dst, lhs, rhs, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -861,7 +876,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slot(rhs, &mut f);
             }
         },
-        Instr::BinaryOpImm(dst, _, lhs, _) => {
+        Instr::BinaryOpImm { dst, lhs, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -870,15 +885,15 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        Instr::Pack(dst, _, fields) | Instr::PackVariant(dst, _, _, fields) => {
+        Instr::Pack { dst, srcs, .. } | Instr::PackVariant { dst, srcs, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
             if USES {
-                rewrite_slots(fields, &mut f);
+                rewrite_slots(srcs, &mut f);
             }
         },
-        Instr::Unpack(dsts, _, src) | Instr::UnpackVariant(dsts, _, _, src) => {
+        Instr::Unpack { dsts, src, .. } | Instr::UnpackVariant { dsts, src, .. } => {
             if DEFS {
                 rewrite_slots(dsts, &mut f);
             }
@@ -886,7 +901,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slot(src, &mut f);
             }
         },
-        Instr::TestVariant(dst, _, _, src) => {
+        Instr::TestVariant { dst, src, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -895,64 +910,8 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        // `src` is a place use; skip it under SKIP_PLACE_USE.
-        Instr::ImmBorrowLoc(dst, src) | Instr::MutBorrowLoc(dst, src) => {
-            if DEFS {
-                rewrite_slot(dst, &mut f);
-            }
-            if USES && !SKIP_PLACE_USE {
-                rewrite_slot(src, &mut f);
-            }
-        },
-        // Field chains share the slot shape of their single-field counterparts.
-        Instr::ImmBorrowField(dst, _, _, src)
-        | Instr::MutBorrowField(dst, _, _, src)
-        | Instr::ImmBorrowVariantField(dst, _, _, src)
-        | Instr::MutBorrowVariantField(dst, _, _, src)
-        | Instr::ImmBorrowFieldChain(dst, _, src)
-        | Instr::MutBorrowFieldChain(dst, _, src)
-        | Instr::ReadRef(dst, src) => {
-            if DEFS {
-                rewrite_slot(dst, &mut f);
-            }
-            if USES {
-                rewrite_slot(src, &mut f);
-            }
-        },
-        Instr::WriteRef(ref_slot, val) => {
-            if USES {
-                rewrite_slot(ref_slot, &mut f);
-                rewrite_slot(val, &mut f);
-            }
-        },
-
-        Instr::ReadField(dst, _, _, src)
-        | Instr::ReadVariantField(dst, _, _, src)
-        | Instr::ReadFieldChain(dst, _, src) => {
-            if DEFS {
-                rewrite_slot(dst, &mut f);
-            }
-            if USES {
-                rewrite_slot(src, &mut f);
-            }
-        },
-        Instr::WriteField(_, _, ref_slot, val)
-        | Instr::WriteVariantField(_, _, ref_slot, val)
-        | Instr::WriteFieldChain(_, ref_slot, val) => {
-            if USES {
-                rewrite_slot(ref_slot, &mut f);
-                rewrite_slot(val, &mut f);
-            }
-        },
-
-        // `local` is a place use, so skip it under
-        // SKIP_PLACE_USE.
-        Instr::ImmBorrowLocField(dst, _, _, local)
-        | Instr::MutBorrowLocField(dst, _, _, local)
-        | Instr::ReadLocalField(dst, _, _, local)
-        | Instr::ImmBorrowLocalFieldChain(dst, _, local)
-        | Instr::MutBorrowLocalFieldChain(dst, _, local)
-        | Instr::ReadLocalFieldChain(dst, _, local) => {
+        // `local` is a place use; skip it under SKIP_PLACE_USE.
+        Instr::ImmBorrowLoc { dst, local } | Instr::MutBorrowLoc { dst, local } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -960,7 +919,63 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slot(local, &mut f);
             }
         },
-        Instr::WriteLocalField(_, _, local, val) | Instr::WriteLocalFieldChain(_, local, val) => {
+        // Field chains share the slot shape of their single-field counterparts.
+        Instr::ImmBorrowField { dst, src, .. }
+        | Instr::MutBorrowField { dst, src, .. }
+        | Instr::ImmBorrowVariantField { dst, src, .. }
+        | Instr::MutBorrowVariantField { dst, src, .. }
+        | Instr::ImmBorrowFieldChain { dst, src, .. }
+        | Instr::MutBorrowFieldChain { dst, src, .. }
+        | Instr::ReadRef { dst, src } => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
+        Instr::WriteRef { dst_ref, val } => {
+            if USES {
+                rewrite_slot(dst_ref, &mut f);
+                rewrite_slot(val, &mut f);
+            }
+        },
+
+        Instr::ReadField { dst, src, .. }
+        | Instr::ReadVariantField { dst, src, .. }
+        | Instr::ReadFieldChain { dst, src, .. } => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
+        Instr::WriteField { dst_ref, val, .. }
+        | Instr::WriteVariantField { dst_ref, val, .. }
+        | Instr::WriteFieldChain { dst_ref, val, .. } => {
+            if USES {
+                rewrite_slot(dst_ref, &mut f);
+                rewrite_slot(val, &mut f);
+            }
+        },
+
+        // `local` is a place use, so skip it under
+        // SKIP_PLACE_USE.
+        Instr::ImmBorrowLocField { dst, local, .. }
+        | Instr::MutBorrowLocField { dst, local, .. }
+        | Instr::ReadLocField { dst, local, .. }
+        | Instr::ImmBorrowLocFieldChain { dst, local, .. }
+        | Instr::MutBorrowLocFieldChain { dst, local, .. }
+        | Instr::ReadLocFieldChain { dst, local, .. } => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES && !SKIP_PLACE_USE {
+                rewrite_slot(local, &mut f);
+            }
+        },
+        Instr::WriteLocField { local, val, .. } | Instr::WriteLocFieldChain { local, val, .. } => {
             // `local` is both a def and a place use of one
             // operand: rewrite once when either role is active. Under
             // SKIP_PLACE_USE only the use side is suppressed.
@@ -972,7 +987,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        Instr::Exists(dst, _, addr) | Instr::MoveFrom(dst, _, addr) => {
+        Instr::Exists { dst, addr, .. } | Instr::MoveFrom { dst, addr, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -980,13 +995,13 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slot(addr, &mut f);
             }
         },
-        Instr::MoveTo(_, signer, val) => {
+        Instr::MoveTo { signer, val, .. } => {
             if USES {
                 rewrite_slot(signer, &mut f);
                 rewrite_slot(val, &mut f);
             }
         },
-        Instr::ImmBorrowGlobal(dst, _, addr) | Instr::MutBorrowGlobal(dst, _, addr) => {
+        Instr::ImmBorrowGlobal { dst, addr, .. } | Instr::MutBorrowGlobal { dst, addr, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -995,7 +1010,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        Instr::Call(data) => {
+        Instr::Call { data } => {
             if DEFS {
                 rewrite_slots(&mut data.rets, &mut f);
             }
@@ -1003,7 +1018,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slots(&mut data.args, &mut f);
             }
         },
-        Instr::CallClosure(data) => {
+        Instr::CallClosure { data } => {
             if DEFS {
                 rewrite_slots(&mut data.rets, &mut f);
             }
@@ -1011,7 +1026,7 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slots(&mut data.args, &mut f);
             }
         },
-        Instr::PackClosure(data) => {
+        Instr::PackClosure { data } => {
             if DEFS {
                 rewrite_slot(&mut data.dst, &mut f);
             }
@@ -1020,23 +1035,28 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        Instr::VecPack(dst, _, elems) => {
+        Instr::VecPack { dst, srcs, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
             if USES {
-                rewrite_slots(elems, &mut f);
+                rewrite_slots(srcs, &mut f);
             }
         },
-        Instr::VecLen(dst, _, src) | Instr::VecPopBack(dst, _, src) => {
+        Instr::VecLen { dst, vec_ref, .. } | Instr::VecPopBack { dst, vec_ref, .. } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
             if USES {
-                rewrite_slot(src, &mut f);
+                rewrite_slot(vec_ref, &mut f);
             }
         },
-        Instr::VecImmBorrow(dst, _, vec_ref, idx) | Instr::VecMutBorrow(dst, _, vec_ref, idx) => {
+        Instr::VecImmBorrow {
+            dst, vec_ref, idx, ..
+        }
+        | Instr::VecMutBorrow {
+            dst, vec_ref, idx, ..
+        } => {
             if DEFS {
                 rewrite_slot(dst, &mut f);
             }
@@ -1045,13 +1065,13 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slot(idx, &mut f);
             }
         },
-        Instr::VecPushBack(_, vec_ref, val) => {
+        Instr::VecPushBack { vec_ref, val, .. } => {
             if USES {
                 rewrite_slot(vec_ref, &mut f);
                 rewrite_slot(val, &mut f);
             }
         },
-        Instr::VecUnpack(dsts, _, src) => {
+        Instr::VecUnpack { dsts, src, .. } => {
             if DEFS {
                 rewrite_slots(dsts, &mut f);
             }
@@ -1059,7 +1079,12 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
                 rewrite_slot(src, &mut f);
             }
         },
-        Instr::VecSwap(_, vec_ref, idx_a, idx_b) => {
+        Instr::VecSwap {
+            vec_ref,
+            idx_a,
+            idx_b,
+            ..
+        } => {
             if USES {
                 rewrite_slot(vec_ref, &mut f);
                 rewrite_slot(idx_a, &mut f);
@@ -1067,34 +1092,34 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
             }
         },
 
-        Instr::Branch(_) => {},
-        Instr::BrTrue(_, cond) | Instr::BrFalse(_, cond) => {
+        Instr::Branch { .. } => {},
+        Instr::BrTrue { cond, .. } | Instr::BrFalse { cond, .. } => {
             if USES {
                 rewrite_slot(cond, &mut f);
             }
         },
-        Instr::BrCmp(_, _, lhs, rhs) => {
+        Instr::BrCmp { lhs, rhs, .. } => {
             if USES {
                 rewrite_slot(lhs, &mut f);
                 rewrite_slot(rhs, &mut f);
             }
         },
-        Instr::BrCmpImm(_, _, src, _) => {
+        Instr::BrCmpImm { lhs, .. } => {
             if USES {
-                rewrite_slot(src, &mut f);
+                rewrite_slot(lhs, &mut f);
             }
         },
-        Instr::Ret(rets) => {
+        Instr::Ret { srcs } => {
             if USES {
-                rewrite_slots(rets, &mut f);
+                rewrite_slots(srcs, &mut f);
             }
         },
-        Instr::Abort(code) => {
+        Instr::Abort { code } => {
             if USES {
                 rewrite_slot(code, &mut f);
             }
         },
-        Instr::AbortMsg(code, msg) => {
+        Instr::AbortMsg { code, msg } => {
             if USES {
                 rewrite_slot(code, &mut f);
                 rewrite_slot(msg, &mut f);

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -181,147 +181,442 @@ impl CallClosureData {
 
 /// A stackless IR instruction with explicit named-slot operands.
 ///
-/// TODO(cleanup):
-/// (1) convert variants to struct-style (named fields) so call sites read
-/// `Instr::Move { dst, src }` rather than positional tuples. Payloads that
-/// would push a variant past the size/align asserts below get a boxed
-/// named-field `*Data` struct instead (as the call-ish variants do).
-/// (2) add description for each instruction variant.
-/// (3) change uses of raw integers into newtypes/type-aliases.
+/// # Field order
+///
+/// Each variant declares its fields in three tiers:
+/// 1. Destinations: result slots (`dst`/`dsts`), the written-through reference
+///    (`dst_ref`; `vec_ref`), the in-place-written `local`, or the branch
+///    `target`.
+/// 2. Operation parameters: `op`, carried types (`struct_ty`, `enum_ty`,
+///    `owner_ty`, `resource_ty`, `elem_ty`), `field`, `variant`, `path`,
+///    `const_idx`.
+/// 3. Sources, in evaluation order: `src`/`srcs`, `lhs`/`rhs`, `local`, `addr`,
+///    `signer`, `val`, `vec_ref`, `idx`/`idx_a`/`idx_b`, `cond`, `code`, `msg`,
+///    and a trailing `imm`.
+///
+/// A role keeps one field name across all variants, so same-typed roles can
+/// be bound by or-patterns: `Instr::A { dst, src, .. } | Instr::B { dst, src }`
+///
+/// # Operand roles
+///
+/// Every slot operand is written (a def), read (a value use), or referenced
+/// by location (a place use):
+/// - `dst`/`dsts` are defs.
+/// - Sources are value uses: a `Vid` is consumed (single-use SSA before
+///   slot allocation); a `Home` slot stays valid unless moved out. A
+///   written-through reference is also a value use — its pointee is
+///   mutated, but the slot is not a def.
+/// - `local` is a place use: only the frame slot's location is taken; its
+///   bytes are unread and it stays live with the same type. In `WriteLoc*`,
+///   `local` is both a def and a place use (one field written, the rest
+///   persist).
+///
+/// # Type contract
+///
+/// `struct_ty`, `enum_ty`, `owner_ty`, `resource_ty`, and the owners in a
+/// `path` are instantiated nominals (type arguments already applied);
+/// `elem_ty` and `closure_ty` are arbitrary element/function types. Inside
+/// a generic function, carried types may still contain the enclosing
+/// function's `TypeParam`s.
+///
+/// # Control flow
+///
+/// `Branch`, `Ret`, `Abort`, and `AbortMsg` terminate a block; `BrTrue`,
+/// `BrFalse`, `BrCmp`, and `BrCmpImm` fall through when not taken. `Call`
+/// and `CallClosure` clobber all `Xfer` slots.
+///
+/// TODO(cleanup): change uses of raw integers into newtypes/type-aliases.
 #[derive(Clone)]
 pub enum Instr {
     // --- Loads ---
-    LdConst(Slot, ConstantPoolIndex),
+    /// `dst = const_pool[const_idx]` — load a constant, deserialized from
+    /// its BCS byte blob in the constant pool.
+    LdConst {
+        dst: Slot,
+        const_idx: ConstantPoolIndex,
+    },
     /// `dst = imm` — load a bool or integer literal.
-    LdImm(Slot, ImmValue),
+    LdImm { dst: Slot, imm: ImmValue },
 
     // --- Slot ops ---
     /// `dst = copy(src)`, source remains valid.
-    Copy(Slot, Slot),
+    Copy { dst: Slot, src: Slot },
     /// `dst = move(src)`, source invalidated.
-    Move(Slot, Slot),
+    Move { dst: Slot, src: Slot },
 
     // --- Unary / Binary ---
-    /// `dst = op(src)`
-    UnaryOp(Slot, UnaryOp, Slot),
-    /// `dst = op(lhs, rhs)`
-    BinaryOp(Slot, BinaryOp, Slot, Slot),
-    /// `dst = op(lhs_slot, immediate)` — binary op with immediate right operand
-    BinaryOpImm(Slot, BinaryOp, Slot, ImmValue),
+    /// `dst = op(src)`. `Cast` aborts when the value does not fit the
+    /// target integer type.
+    UnaryOp { dst: Slot, op: UnaryOp, src: Slot },
+    /// `dst = op(lhs, rhs)`. Arithmetic aborts on overflow and on
+    /// division/modulo by zero; shifts abort when the amount is at least
+    /// the operand width.
+    BinaryOp {
+        dst: Slot,
+        op: BinaryOp,
+        lhs: Slot,
+        rhs: Slot,
+    },
+    /// `dst = op(lhs, imm)` — [`Instr::BinaryOp`] with an immediate right
+    /// operand.
+    BinaryOpImm {
+        dst: Slot,
+        op: BinaryOp,
+        lhs: Slot,
+        imm: ImmValue,
+    },
 
-    // --- Struct (second field is the interned struct `Type`) ---
-    //
-    // Contract: the carried `InternedType` is the instantiated nominal, with
-    // the instantiation's type arguments already applied. Inside a generic
-    // function it may still contain the enclosing function's `TypeParam`s.
-    Pack(Slot, InternedType, Box<[Slot]>),
-    Unpack(Box<[Slot]>, InternedType, Slot),
+    // --- Struct ---
+    /// `dst = struct_ty { srcs }` — construct a struct from the field
+    /// values, in field declaration order.
+    Pack {
+        dst: Slot,
+        struct_ty: InternedType,
+        srcs: Box<[Slot]>,
+    },
+    /// `dsts = fields of src` — destructure a `struct_ty` value into its
+    /// field values, in field declaration order.
+    Unpack {
+        dsts: Box<[Slot]>,
+        struct_ty: InternedType,
+        src: Slot,
+    },
 
-    // --- Variant (enum type + variant ordinal; same type contract as
-    // `Pack`/`Unpack`) ---
-    PackVariant(Slot, InternedType, u16, Box<[Slot]>),
-    UnpackVariant(Box<[Slot]>, InternedType, u16, Slot),
-    TestVariant(Slot, InternedType, u16, Slot),
+    // --- Variant (enum type + variant ordinal) ---
+    /// `dst = enum_ty::variant { srcs }` — construct an enum value with tag
+    /// `variant` from the field values, in field declaration order.
+    PackVariant {
+        dst: Slot,
+        enum_ty: InternedType,
+        variant: u16,
+        srcs: Box<[Slot]>,
+    },
+    /// `dsts = fields of src` — destructure an `enum_ty` value; aborts when
+    /// the value's runtime tag is not `variant`.
+    UnpackVariant {
+        dsts: Box<[Slot]>,
+        enum_ty: InternedType,
+        variant: u16,
+        src: Slot,
+    },
+    /// `dst = (tag(*src) == variant)` — `src` holds a reference to an
+    /// `enum_ty` value.
+    TestVariant {
+        dst: Slot,
+        enum_ty: InternedType,
+        variant: u16,
+        src: Slot,
+    },
 
     // --- References ---
     //
-    // Field ops carry `(instantiated owner type, non-generic field handle)`:
-    // the handle gives the field position; the owner type has the same contract
-    // as `Pack`/`Unpack`.
-    ImmBorrowLoc(Slot, Slot),
-    MutBorrowLoc(Slot, Slot),
-    ImmBorrowField(Slot, InternedType, FieldHandleIndex, Slot),
-    MutBorrowField(Slot, InternedType, FieldHandleIndex, Slot),
-    ImmBorrowVariantField(Slot, InternedType, VariantFieldHandleIndex, Slot),
-    MutBorrowVariantField(Slot, InternedType, VariantFieldHandleIndex, Slot),
-    ReadRef(Slot, Slot),
-    /// `*dst_ref = src_val`
-    WriteRef(Slot, Slot),
+    /// `dst = &local`.
+    ImmBorrowLoc { dst: Slot, local: Slot },
+    /// `dst = &mut local`. A later write through `dst` mutates `local`
+    /// without a def at the write site (a hidden write).
+    MutBorrowLoc { dst: Slot, local: Slot },
+    // Field ops carry the instantiated owner type (`owner_ty`) and a
+    // non-generic field handle (`field`) giving the field position.
+    /// `dst = &(*src).field` — pure address computation, no abort.
+    ImmBorrowField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: FieldHandleIndex,
+        src: Slot,
+    },
+    /// `dst = &mut (*src).field` — pure address computation, no abort.
+    MutBorrowField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: FieldHandleIndex,
+        src: Slot,
+    },
+    /// `dst = &(*src).field` on an enum; aborts when the value's runtime
+    /// variant does not declare `field`.
+    ImmBorrowVariantField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: VariantFieldHandleIndex,
+        src: Slot,
+    },
+    /// `dst = &mut (*src).field` on an enum; aborts when the value's
+    /// runtime variant does not declare `field`.
+    MutBorrowVariantField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: VariantFieldHandleIndex,
+        src: Slot,
+    },
+    /// `dst = *src`.
+    ReadRef { dst: Slot, src: Slot },
+    /// `*dst_ref = val`
+    WriteRef { dst_ref: Slot, val: Slot },
 
     // --- Fused field access (borrow+read/write combined) ---
-    /// `dst = src_ref.field` (imm_borrow_field + read_ref)
-    ReadField(Slot, InternedType, FieldHandleIndex, Slot),
-    /// `dst_ref.field = val` (mut_borrow_field + write_ref)
-    WriteField(InternedType, FieldHandleIndex, Slot, Slot),
-    ReadVariantField(Slot, InternedType, VariantFieldHandleIndex, Slot),
-    WriteVariantField(InternedType, VariantFieldHandleIndex, Slot, Slot),
+    /// `dst = (*src).field` (imm_borrow_field + read_ref)
+    ReadField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: FieldHandleIndex,
+        src: Slot,
+    },
+    /// `(*dst_ref).field = val` (mut_borrow_field + write_ref)
+    WriteField {
+        dst_ref: Slot,
+        owner_ty: InternedType,
+        field: FieldHandleIndex,
+        val: Slot,
+    },
+    /// `dst = (*src).field` on an enum (imm_borrow_variant_field +
+    /// read_ref); aborts when the value's runtime variant does not declare
+    /// `field`.
+    ReadVariantField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: VariantFieldHandleIndex,
+        src: Slot,
+    },
+    /// `(*dst_ref).field = val` on an enum (mut_borrow_variant_field +
+    /// write_ref); aborts when the value's runtime variant does not declare
+    /// `field`.
+    WriteVariantField {
+        dst_ref: Slot,
+        owner_ty: InternedType,
+        field: VariantFieldHandleIndex,
+        val: Slot,
+    },
 
     // --- Fused inline-struct field access (borrow_loc + field op combined) ---
     /// `dst = &local.field` (imm_borrow_loc + imm_borrow_field on an inline struct local)
-    ImmBorrowLocField(Slot, InternedType, FieldHandleIndex, Slot),
-    /// `dst = &mut local.field`
-    MutBorrowLocField(Slot, InternedType, FieldHandleIndex, Slot),
+    ImmBorrowLocField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: FieldHandleIndex,
+        local: Slot,
+    },
+    /// `dst = &mut local.field`. Hidden-write hazard as in
+    /// [`Instr::MutBorrowLoc`].
+    MutBorrowLocField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: FieldHandleIndex,
+        local: Slot,
+    },
     /// `dst = local.field` (imm_borrow_loc + read_field on an inline struct local)
-    ReadLocalField(Slot, InternedType, FieldHandleIndex, Slot),
-    /// `local.field = src` (mut_borrow_loc + write_field on an inline struct local)
-    WriteLocalField(InternedType, FieldHandleIndex, Slot, Slot),
+    ReadLocField {
+        dst: Slot,
+        owner_ty: InternedType,
+        field: FieldHandleIndex,
+        local: Slot,
+    },
+    /// `local.field = val` (mut_borrow_loc + write_field on an inline
+    /// struct local).
+    WriteLocField {
+        local: Slot,
+        owner_ty: InternedType,
+        field: FieldHandleIndex,
+        val: Slot,
+    },
 
-    // --- Fused inline-struct field CHAINS (depth >= 2) ---
+    // --- Fused inline-struct field CHAINS ---
     //
-    // Collapse a run of `*BorrowField` selections (whose intermediate
-    // references are dead after the chain) into one micro-op. `path` is the
-    // non-empty list of `(owner, field)` steps; the deepest field's address is
-    // `base(root) + Σ offsets`. Borrow chains keep the `Imm`/`Mut` split of
-    // the single-field borrows, see [`Instr::MutBorrowLocalFieldChain`] why
-    // this is needed.
+    // A chain applies the field selections in `path` — `(owner, field)`
+    // steps in selection order, always depth >= 2 — to a root operand, and
+    // reads, writes, or borrows the field reached last. The root is a
+    // reference in the `*FieldChain` forms (`src` when read or borrowed,
+    // `dst_ref` when written through) and a by-value inline-struct `local`
+    // in the `*LocFieldChain` forms. Every step selects an inline-struct
+    // field, so the target's address is `base(root) + Σ offsets` and no
+    // step can abort.
     //
-    /// `dst = root_ref.path` (root is a reference).
-    ReadFieldChain(Slot, FieldPath, Slot),
-    /// `root_ref.path = val`.
-    WriteFieldChain(FieldPath, Slot, Slot),
-    /// `dst = &root_ref.path`.
-    ImmBorrowFieldChain(Slot, FieldPath, Slot),
-    /// `dst = &mut root_ref.path`.
-    MutBorrowFieldChain(Slot, FieldPath, Slot),
-    /// `dst = root_local.path` (root is a by-value inline-struct local).
-    ReadLocalFieldChain(Slot, FieldPath, Slot),
-    /// `root_local.path = val`.
-    WriteLocalFieldChain(FieldPath, Slot, Slot),
-    /// `dst = &root_local.path`.
-    ImmBorrowLocalFieldChain(Slot, FieldPath, Slot),
-    /// `dst = &mut root_local.path`. A later write through `dst` mutates the
-    /// local without a def at the write site, so passes that track the
-    /// local's value must recognize this variant — the reason borrow chains
-    /// keep the `Imm`/`Mut` split.
-    MutBorrowLocalFieldChain(Slot, FieldPath, Slot),
+    /// `dst = (*src).path`.
+    ReadFieldChain {
+        dst: Slot,
+        path: FieldPath,
+        src: Slot,
+    },
+    /// `(*dst_ref).path = val`.
+    WriteFieldChain {
+        dst_ref: Slot,
+        path: FieldPath,
+        val: Slot,
+    },
+    /// `dst = &(*src).path`.
+    ImmBorrowFieldChain {
+        dst: Slot,
+        path: FieldPath,
+        src: Slot,
+    },
+    /// `dst = &mut (*src).path`.
+    MutBorrowFieldChain {
+        dst: Slot,
+        path: FieldPath,
+        src: Slot,
+    },
+    /// `dst = local.path`.
+    ReadLocFieldChain {
+        dst: Slot,
+        path: FieldPath,
+        local: Slot,
+    },
+    /// `local.path = val`.
+    WriteLocFieldChain {
+        local: Slot,
+        path: FieldPath,
+        val: Slot,
+    },
+    /// `dst = &local.path`.
+    ImmBorrowLocFieldChain {
+        dst: Slot,
+        path: FieldPath,
+        local: Slot,
+    },
+    /// `dst = &mut local.path`. Hidden-write hazard as in
+    /// [`Instr::MutBorrowLoc`].
+    MutBorrowLocFieldChain {
+        dst: Slot,
+        path: FieldPath,
+        local: Slot,
+    },
 
-    // --- Globals (struct type is the interned `Type` for the named
-    // resource; same type contract as `Pack`/`Unpack`) ---
-    Exists(Slot, InternedType, Slot),
-    MoveFrom(Slot, InternedType, Slot),
-    /// `(struct_ty, signer, val)`
-    MoveTo(InternedType, Slot, Slot),
-    ImmBorrowGlobal(Slot, InternedType, Slot),
-    MutBorrowGlobal(Slot, InternedType, Slot),
+    // --- Globals (`resource_ty` names the resource in global storage) ---
+    /// `dst = exists<resource_ty>(addr)` — true iff global storage holds a
+    /// `resource_ty` at `addr`.
+    Exists {
+        dst: Slot,
+        resource_ty: InternedType,
+        addr: Slot,
+    },
+    /// `dst = move_from<resource_ty>(addr)` — remove the resource from
+    /// global storage; aborts when none exists at `addr`.
+    MoveFrom {
+        dst: Slot,
+        resource_ty: InternedType,
+        addr: Slot,
+    },
+    /// `move_to<resource_ty>(signer, val)` — publish `val` under the
+    /// signer's address; aborts when a resource of this type already exists
+    /// there.
+    MoveTo {
+        resource_ty: InternedType,
+        signer: Slot,
+        val: Slot,
+    },
+    /// `dst = &global<resource_ty>(addr)`; aborts when no resource exists
+    /// at `addr`.
+    ImmBorrowGlobal {
+        dst: Slot,
+        resource_ty: InternedType,
+        addr: Slot,
+    },
+    /// `dst = &mut global<resource_ty>(addr)`; aborts when no resource
+    /// exists at `addr`.
+    MutBorrowGlobal {
+        dst: Slot,
+        resource_ty: InternedType,
+        addr: Slot,
+    },
 
     // --- Calls (payload boxed to keep `Instr` small; see `CallData`) ---
-    Call(Box<CallData>),
+    /// `data.rets = data.function_handle<data.ty_args>(data.args)`.
+    Call { data: Box<CallData> },
 
     // --- Closures (payloads boxed; see `PackClosureData`/`CallClosureData`) ---
-    PackClosure(Box<PackClosureData>),
-    CallClosure(Box<CallClosureData>),
+    /// `data.dst` receives a closure over `data.function_handle<data.ty_args>`
+    /// in which the values of `data.captured` are pre-bound to the argument
+    /// positions marked in `data.mask`; the remaining positions are filled by
+    /// the arguments supplied when the closure is called.
+    PackClosure { data: Box<PackClosureData> },
+    /// `data.rets = closure(provided args)` — the closure operand is the
+    /// last element of `data.args` (see
+    /// [`CallClosureData::closure_and_provided`]).
+    CallClosure { data: Box<CallClosureData> },
 
-    // --- Vector (second field is the vector's element type) ---
-    VecPack(Slot, InternedType, Box<[Slot]>),
-    VecLen(Slot, InternedType, Slot),
-    VecImmBorrow(Slot, InternedType, Slot, Slot),
-    VecMutBorrow(Slot, InternedType, Slot, Slot),
-    VecPushBack(InternedType, Slot, Slot),
-    VecPopBack(Slot, InternedType, Slot),
-    VecUnpack(Box<[Slot]>, InternedType, Slot),
-    VecSwap(InternedType, Slot, Slot, Slot),
+    // --- Vector (`elem_ty` is the vector's element type) ---
+    /// `dst = vector[srcs]`.
+    VecPack {
+        dst: Slot,
+        elem_ty: InternedType,
+        srcs: Box<[Slot]>,
+    },
+    /// `dst = (*vec_ref).length()`.
+    VecLen {
+        dst: Slot,
+        elem_ty: InternedType,
+        vec_ref: Slot,
+    },
+    /// `dst = &(*vec_ref)[idx]`; aborts when `idx` is out of bounds.
+    VecImmBorrow {
+        dst: Slot,
+        elem_ty: InternedType,
+        vec_ref: Slot,
+        idx: Slot,
+    },
+    /// `dst = &mut (*vec_ref)[idx]`; aborts when `idx` is out of bounds.
+    VecMutBorrow {
+        dst: Slot,
+        elem_ty: InternedType,
+        vec_ref: Slot,
+        idx: Slot,
+    },
+    /// `(*vec_ref).push_back(val)`.
+    VecPushBack {
+        vec_ref: Slot,
+        elem_ty: InternedType,
+        val: Slot,
+    },
+    /// `dst = (*vec_ref).pop_back()`; aborts on an empty vector.
+    VecPopBack {
+        dst: Slot,
+        elem_ty: InternedType,
+        vec_ref: Slot,
+    },
+    /// `dsts = elements of src`; aborts unless the vector's length is
+    /// exactly `dsts.len()`.
+    VecUnpack {
+        dsts: Box<[Slot]>,
+        elem_ty: InternedType,
+        src: Slot,
+    },
+    /// `(*vec_ref).swap(idx_a, idx_b)`; aborts when either index is out of
+    /// bounds.
+    VecSwap {
+        vec_ref: Slot,
+        elem_ty: InternedType,
+        idx_a: Slot,
+        idx_b: Slot,
+    },
 
     // --- Control flow ---
-    Branch(Label),
-    BrTrue(Label, Slot),
-    BrFalse(Label, Slot),
-    /// `BrCmp(target, op, lhs, rhs)` — branch to `target` if `op(lhs, rhs)` is true.
-    BrCmp(Label, CmpKind, Slot, Slot),
-    /// `BrCmpImm(target, op, src, imm)` — branch to `target` if `op(src, imm)` is true.
-    BrCmpImm(Label, CmpKind, Slot, ImmValue),
-    Ret(Box<[Slot]>),
-    Abort(Slot),
-    AbortMsg(Slot, Slot),
+    /// Unconditional jump to `target`.
+    Branch { target: Label },
+    /// Jump to `target` when `cond` is true; otherwise fall through.
+    BrTrue { target: Label, cond: Slot },
+    /// Jump to `target` when `cond` is false; otherwise fall through.
+    BrFalse { target: Label, cond: Slot },
+    /// Jump to `target` when `op(lhs, rhs)` is true; otherwise fall through
+    /// (fused compare + conditional branch).
+    BrCmp {
+        target: Label,
+        op: CmpKind,
+        lhs: Slot,
+        rhs: Slot,
+    },
+    /// Jump to `target` when `op(lhs, imm)` is true; otherwise fall
+    /// through.
+    BrCmpImm {
+        target: Label,
+        op: CmpKind,
+        lhs: Slot,
+        imm: ImmValue,
+    },
+    /// Return `srcs` to the caller.
+    Ret { srcs: Box<[Slot]> },
+    /// Abort execution with the error code held in `code`.
+    Abort { code: Slot },
+    /// Abort execution with the error code in `code` and the message
+    /// payload in `msg`.
+    AbortMsg { code: Slot, msg: Slot },
 
     // --- Test intrinsics ---
     /// Triggers a garbage collection.
@@ -346,66 +641,66 @@ impl Instr {
     /// messages that don't need the full operand dump.
     pub fn opcode_name(&self) -> &'static str {
         match self {
-            Instr::LdConst(..) => "LdConst",
-            Instr::LdImm(..) => "LdImm",
-            Instr::Copy(..) => "Copy",
-            Instr::Move(..) => "Move",
-            Instr::UnaryOp(..) => "UnaryOp",
-            Instr::BinaryOp(..) => "BinaryOp",
-            Instr::BinaryOpImm(..) => "BinaryOpImm",
-            Instr::Pack(..) => "Pack",
-            Instr::Unpack(..) => "Unpack",
-            Instr::PackVariant(..) => "PackVariant",
-            Instr::UnpackVariant(..) => "UnpackVariant",
-            Instr::TestVariant(..) => "TestVariant",
-            Instr::ImmBorrowLoc(..) => "ImmBorrowLoc",
-            Instr::MutBorrowLoc(..) => "MutBorrowLoc",
-            Instr::ImmBorrowField(..) => "ImmBorrowField",
-            Instr::MutBorrowField(..) => "MutBorrowField",
-            Instr::ImmBorrowVariantField(..) => "ImmBorrowVariantField",
-            Instr::MutBorrowVariantField(..) => "MutBorrowVariantField",
-            Instr::ReadRef(..) => "ReadRef",
-            Instr::WriteRef(..) => "WriteRef",
-            Instr::ReadField(..) => "ReadField",
-            Instr::WriteField(..) => "WriteField",
-            Instr::ReadVariantField(..) => "ReadVariantField",
-            Instr::WriteVariantField(..) => "WriteVariantField",
-            Instr::ImmBorrowLocField(..) => "ImmBorrowLocField",
-            Instr::MutBorrowLocField(..) => "MutBorrowLocField",
-            Instr::ReadLocalField(..) => "ReadLocalField",
-            Instr::WriteLocalField(..) => "WriteLocalField",
-            Instr::ReadFieldChain(..) => "ReadFieldChain",
-            Instr::WriteFieldChain(..) => "WriteFieldChain",
-            Instr::ImmBorrowFieldChain(..) => "ImmBorrowFieldChain",
-            Instr::MutBorrowFieldChain(..) => "MutBorrowFieldChain",
-            Instr::ReadLocalFieldChain(..) => "ReadLocalFieldChain",
-            Instr::WriteLocalFieldChain(..) => "WriteLocalFieldChain",
-            Instr::ImmBorrowLocalFieldChain(..) => "ImmBorrowLocalFieldChain",
-            Instr::MutBorrowLocalFieldChain(..) => "MutBorrowLocalFieldChain",
-            Instr::Exists(..) => "Exists",
-            Instr::MoveFrom(..) => "MoveFrom",
-            Instr::MoveTo(..) => "MoveTo",
-            Instr::ImmBorrowGlobal(..) => "ImmBorrowGlobal",
-            Instr::MutBorrowGlobal(..) => "MutBorrowGlobal",
-            Instr::Call(..) => "Call",
-            Instr::PackClosure(..) => "PackClosure",
-            Instr::CallClosure(..) => "CallClosure",
-            Instr::VecPack(..) => "VecPack",
-            Instr::VecLen(..) => "VecLen",
-            Instr::VecImmBorrow(..) => "VecImmBorrow",
-            Instr::VecMutBorrow(..) => "VecMutBorrow",
-            Instr::VecPushBack(..) => "VecPushBack",
-            Instr::VecPopBack(..) => "VecPopBack",
-            Instr::VecUnpack(..) => "VecUnpack",
-            Instr::VecSwap(..) => "VecSwap",
-            Instr::Branch(..) => "Branch",
-            Instr::BrTrue(..) => "BrTrue",
-            Instr::BrFalse(..) => "BrFalse",
-            Instr::BrCmp(..) => "BrCmp",
-            Instr::BrCmpImm(..) => "BrCmpImm",
-            Instr::Ret(..) => "Ret",
-            Instr::Abort(..) => "Abort",
-            Instr::AbortMsg(..) => "AbortMsg",
+            Instr::LdConst { .. } => "LdConst",
+            Instr::LdImm { .. } => "LdImm",
+            Instr::Copy { .. } => "Copy",
+            Instr::Move { .. } => "Move",
+            Instr::UnaryOp { .. } => "UnaryOp",
+            Instr::BinaryOp { .. } => "BinaryOp",
+            Instr::BinaryOpImm { .. } => "BinaryOpImm",
+            Instr::Pack { .. } => "Pack",
+            Instr::Unpack { .. } => "Unpack",
+            Instr::PackVariant { .. } => "PackVariant",
+            Instr::UnpackVariant { .. } => "UnpackVariant",
+            Instr::TestVariant { .. } => "TestVariant",
+            Instr::ImmBorrowLoc { .. } => "ImmBorrowLoc",
+            Instr::MutBorrowLoc { .. } => "MutBorrowLoc",
+            Instr::ImmBorrowField { .. } => "ImmBorrowField",
+            Instr::MutBorrowField { .. } => "MutBorrowField",
+            Instr::ImmBorrowVariantField { .. } => "ImmBorrowVariantField",
+            Instr::MutBorrowVariantField { .. } => "MutBorrowVariantField",
+            Instr::ReadRef { .. } => "ReadRef",
+            Instr::WriteRef { .. } => "WriteRef",
+            Instr::ReadField { .. } => "ReadField",
+            Instr::WriteField { .. } => "WriteField",
+            Instr::ReadVariantField { .. } => "ReadVariantField",
+            Instr::WriteVariantField { .. } => "WriteVariantField",
+            Instr::ImmBorrowLocField { .. } => "ImmBorrowLocField",
+            Instr::MutBorrowLocField { .. } => "MutBorrowLocField",
+            Instr::ReadLocField { .. } => "ReadLocField",
+            Instr::WriteLocField { .. } => "WriteLocField",
+            Instr::ReadFieldChain { .. } => "ReadFieldChain",
+            Instr::WriteFieldChain { .. } => "WriteFieldChain",
+            Instr::ImmBorrowFieldChain { .. } => "ImmBorrowFieldChain",
+            Instr::MutBorrowFieldChain { .. } => "MutBorrowFieldChain",
+            Instr::ReadLocFieldChain { .. } => "ReadLocFieldChain",
+            Instr::WriteLocFieldChain { .. } => "WriteLocFieldChain",
+            Instr::ImmBorrowLocFieldChain { .. } => "ImmBorrowLocFieldChain",
+            Instr::MutBorrowLocFieldChain { .. } => "MutBorrowLocFieldChain",
+            Instr::Exists { .. } => "Exists",
+            Instr::MoveFrom { .. } => "MoveFrom",
+            Instr::MoveTo { .. } => "MoveTo",
+            Instr::ImmBorrowGlobal { .. } => "ImmBorrowGlobal",
+            Instr::MutBorrowGlobal { .. } => "MutBorrowGlobal",
+            Instr::Call { .. } => "Call",
+            Instr::PackClosure { .. } => "PackClosure",
+            Instr::CallClosure { .. } => "CallClosure",
+            Instr::VecPack { .. } => "VecPack",
+            Instr::VecLen { .. } => "VecLen",
+            Instr::VecImmBorrow { .. } => "VecImmBorrow",
+            Instr::VecMutBorrow { .. } => "VecMutBorrow",
+            Instr::VecPushBack { .. } => "VecPushBack",
+            Instr::VecPopBack { .. } => "VecPopBack",
+            Instr::VecUnpack { .. } => "VecUnpack",
+            Instr::VecSwap { .. } => "VecSwap",
+            Instr::Branch { .. } => "Branch",
+            Instr::BrTrue { .. } => "BrTrue",
+            Instr::BrFalse { .. } => "BrFalse",
+            Instr::BrCmp { .. } => "BrCmp",
+            Instr::BrCmpImm { .. } => "BrCmpImm",
+            Instr::Ret { .. } => "Ret",
+            Instr::Abort { .. } => "Abort",
+            Instr::AbortMsg { .. } => "AbortMsg",
             Instr::ForceGC => "ForceGC",
         }
     }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_struct_field.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_struct_field.exp
@@ -12,15 +12,15 @@ fun local_field_ops(r0, r1): u64 {
   code:
   L0:
     0: r2 := pack 0x42::generic_struct_field::Pair<u8, u64>, [r0, r1]
-    1: r3 := read_local_field Pair::second, r2
+    1: r3 := read_loc_field Pair::second, r2
     2: r3 := add r3, #1
-    3: write_local_field Pair::second, r2, r3
-    4: r4 := read_local_field Pair::first, r2
+    3: write_loc_field Pair::second, r2, r3
+    4: r4 := read_loc_field Pair::first, r2
     5: r4 := add r4, #1u8
-    6: write_local_field Pair::first, r2, r4
-    7: r4 := read_local_field Pair::first, r2
+    6: write_loc_field Pair::first, r2, r4
+    7: r4 := read_loc_field Pair::first, r2
     8: r3 := cast_u64 r4
-    9: r5 := read_local_field Pair::second, r2
+    9: r5 := read_loc_field Pair::second, r2
     10: r5 := add r3, r5
     11: ret [r5]
 }
@@ -82,9 +82,9 @@ fun write_via_mut_ref(r0, r1): u64 {
     2: r4 := read_field Pair::second, r3
     3: r4 := add r4, #10
     4: write_field Pair::second, r3, r4
-    5: r5 := read_local_field Pair::first, r2
+    5: r5 := read_loc_field Pair::first, r2
     6: r4 := cast_u64 r5
-    7: r6 := read_local_field Pair::second, r2
+    7: r6 := read_loc_field Pair::second, r2
     8: r6 := add r4, r6
     9: ret [r6]
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/field_ref_fusion.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/field_ref_fusion.exp
@@ -7,7 +7,7 @@ fun read_field_val(r0): u8 {
     r1: u8
   code:
   L0:
-    0: r1 := read_local_field S::_2, r0
+    0: r1 := read_loc_field S::_2, r0
     1: ret [r1]
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/chained_field_fusion.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/chained_field_fusion.exp
@@ -26,7 +26,7 @@ fun read_by_value(r0): u64 {
     r1: u64
   code:
   L0:
-    0: r1 := read_local_field_chain S::x.A::y.B::z, r0
+    0: r1 := read_loc_field_chain S::x.A::y.B::z, r0
     1: ret [r1]
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_chain_borrows.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_chain_borrows.exp
@@ -32,7 +32,7 @@ fun bump_via_deep_mut(r0): u64 {
     3: r3 := read_ref r2
     4: r3 := add r3, #1
     5: write_ref r2, r3
-    6: r3 := read_local_field_chain S::x.A::y.B::z, r1
+    6: r3 := read_loc_field_chain S::x.A::y.B::z, r1
     7: ret [r3]
 }
 
@@ -63,7 +63,7 @@ fun read_via_call(r0): u64 {
   code:
   L0:
     0: [r1] := call build, [r0]
-    1: x0 := imm_borrow_local_field_chain S::x.A::y.B::z, r1
+    1: x0 := imm_borrow_loc_field_chain S::x.A::y.B::z, r1
     2: [x0] := call read_ref, [x0]
     3: ret [x0]
 }
@@ -76,7 +76,7 @@ fun read_via_local_ref(r0): u64 {
   code:
   L0:
     0: [r1] := call build, [r0]
-    1: r2 := read_local_field_chain S::x.A::y.B::z, r1
+    1: r2 := read_loc_field_chain S::x.A::y.B::z, r1
     2: ret [r2]
 }
 
@@ -90,8 +90,8 @@ fun write_via_local(r0): u64 {
     0: x0 := ld_u64 0
     1: [r1] := call build, [x0]
     2: r2 := add r0, #1
-    3: write_local_field_chain S::x.A::y.B::z, r1, r2
-    4: r2 := read_local_field_chain S::x.A::y.B::z, r1
+    3: write_loc_field_chain S::x.A::y.B::z, r1, r2
+    4: r2 := read_loc_field_chain S::x.A::y.B::z, r1
     5: ret [r2]
 }
 === micro-ops ===

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_fusion.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_fusion.exp
@@ -16,8 +16,8 @@ fun add_two_fields(r0): u64 {
     r2: u64
   code:
   L0:
-    0: r1 := read_local_field Pair::_1, r0
-    1: r2 := read_local_field Pair::_2, r0
+    0: r1 := read_loc_field Pair::_1, r0
+    1: r2 := read_loc_field Pair::_2, r0
     2: r2 := add r1, r2
     3: ret [r2]
 }
@@ -27,7 +27,7 @@ fun field_to_call(r0): u64 {
     r0: 0x66::field_fusion::Pair
   code:
   L0:
-    0: x0 := read_local_field Pair::_1, r0
+    0: x0 := read_loc_field Pair::_1, r0
     1: [x0] := call identity, [x0]
     2: ret [x0]
 }
@@ -40,8 +40,8 @@ fun two_fields_to_call(r0, r1): u64 {
     r3: u64
   code:
   L0:
-    0: r2 := read_local_field Pair::_1, r0
-    1: r3 := read_local_field Pair::_2, r1
+    0: r2 := read_loc_field Pair::_1, r0
+    1: r3 := read_loc_field Pair::_2, r1
     2: x0 := add r2, r3
     3: [x0] := call identity, [x0]
     4: ret [x0]
@@ -53,7 +53,7 @@ fun field_plus_constant(r0): u64 {
     r1: u64
   code:
   L0:
-    0: r1 := read_local_field Pair::_1, r0
+    0: r1 := read_loc_field Pair::_1, r0
     1: r1 := add r1, #42
     2: ret [r1]
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/mut_local_field_chain.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/mut_local_field_chain.exp
@@ -27,11 +27,11 @@ fun bump(r0): u64 {
   code:
   L0:
     0: [r1] := call build, [r0]
-    1: r2 := mut_borrow_local_field_chain S::x.A::y.B::z, r1
+    1: r2 := mut_borrow_loc_field_chain S::x.A::y.B::z, r1
     2: r3 := read_ref r2
     3: r3 := add r3, #1
     4: write_ref r2, r3
-    5: r3 := read_local_field_chain S::x.A::y.B::z, r1
+    5: r3 := read_loc_field_chain S::x.A::y.B::z, r1
     6: ret [r3]
 }
 === micro-ops ===

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/pack_overlap_safety.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/pack_overlap_safety.exp
@@ -8,9 +8,9 @@ fun consume(r0): u64 {
     r2: u64
   code:
   L0:
-    0: r1 := read_local_field Pair::a, r0
+    0: r1 := read_loc_field Pair::a, r0
     1: r1 := mul r1, #1000
-    2: r2 := read_local_field Pair::b, r0
+    2: r2 := read_loc_field Pair::b, r0
     3: r2 := add r1, r2
     4: ret [r2]
 }


### PR DESCRIPTION
# `Instr` Named-Fields Refactor

Convert the stackless execution IR's `Instr` enum (61 variants, `specializer` crate) from positional tuple variants to struct-style variants with named fields, with a documented field-order convention, uniform variant naming, and per-variant semantics docs.

## Variant renames

Six variants adopt the bytecode-style `Loc` spelling already used by `ImmBorrowLoc`/`ImmBorrowLocField`, making it uniform across the enum:

- `ReadLocalField` → `ReadLocField`, `WriteLocalField` → `WriteLocField`
- `ReadLocalFieldChain` → `ReadLocFieldChain`, `WriteLocalFieldChain` → `WriteLocFieldChain`
- `ImmBorrowLocalFieldChain` → `ImmBorrowLocFieldChain`, `MutBorrowLocalFieldChain` → `MutBorrowLocFieldChain`

The six display mnemonics (`read_local_field` → `read_loc_field`, …) and `opcode_name()` strings change in lockstep; the affected golden `.exp` baselines are regenerated (mnemonic tokens only).

## Named fields under a documented convention

Every variant now declares its fields in three tiers:

1. **Destinations** — `dst`/`dsts`, the written-through reference (`dst_ref`; `vec_ref` in the `dst`-less mutating vector ops), the in-place-written `local` (`WriteLoc*`), or the branch `target`.
2. **Operation parameters** — `op`, carried types (`struct_ty`, `enum_ty`, `owner_ty`, `resource_ty`, `elem_ty`), `field`, `variant`, `path`, `const_idx`.
3. **Sources**, in evaluation order — `src`/`srcs`, `lhs`/`rhs`, `addr`, `signer`, `val`, `idx`, `cond`, `code`, `msg`, a trailing `imm`, ….

A role keeps the same field name in every variant that has it, so or-patterns bind across variants (`Instr::A { dst, src, .. } | Instr::B { dst, src }`) — this preserves every grouped match in `instr_utils.rs`, `gas.rs`, and the fusion passes. Seven variants change declaration order so the written-through ref/local leads (`WriteField`, `WriteVariantField`, `WriteLocField`, `WriteFieldChain`, `WriteLocFieldChain`, `VecPushBack`, `VecSwap`); `BrCmpImm`'s slot operand is renamed `src` → `lhs` to parallel `BrCmp`/`BinaryOpImm`. The call-ish variants become `Call { data: Box<CallData> }` (likewise `PackClosure`/`CallClosure`). All ~700 construction and match sites across the crate are converted, with old positional bindings replaced by field shorthand.

## Documentation

- **Enum-level doc** on `Instr`: the field-order tiers and vocabulary, operand roles (def vs value use vs place use, including the write family's not-a-def through-reference and `WriteLoc*`'s dual-role `local`), the instantiated-nominal type contract, and terminator/Xfer-clobber classification.
- **Per-variant docs**: `dst = …` semantics for each instruction plus preconditions, invariants, and abort conditions (division/overflow, variant-tag mismatch, missing/existing resources, vector bounds, the mut-borrow hidden-write hazard, chain `path` invariants).
- The enum's `TODO(cleanup)` items for struct-style variants and per-variant descriptions are resolved and removed.

Behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large mechanical sweep across the specializer pipeline (allocation, fusion, gas, lowering); mistakes in pattern matches could alter codegen, though the change is intended to be behavior-preserving.
> 
> **Overview**
> Refactors the stackless **`Instr`** IR from positional tuple variants to **struct-style variants** with named fields (`dst`/`src`, `lhs`/`rhs`, `resource_ty`, etc.), following a documented def → params → sources field order so grouped `match` arms stay ergonomic.
> 
> **Call-like instructions** are now `Call { data: Box<CallData> }` (and the same for `PackClosure` / `CallClosure`). Six local-field variants and their display mnemonics are renamed from `*Local*` to `*Loc*` (e.g. `ReadLocField`, `read_loc_field`). A few variants reorder fields so the written-through ref/local leads (`WriteField`, `VecPushBack`, …); `BrCmpImm` uses `lhs` like `BrCmp`.
> 
> All construction sites and matches across **destack** (SSA conversion, analysis, optimize, fusion), **gas**, **lowering**, and **display** are updated; comments reference the new shapes. **Semantics are unchanged** — this is an IR representation and naming cleanup aligned with the PR’s enum-level and per-variant docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b808541e3a601fbb6b072773e61f055915069f79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->