### PR TITLE
[block-stm] Remove before materialization guard

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -273,7 +273,6 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .collect()
     }
 
-    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn for_each_module_write(
         &self,
         callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>,
@@ -288,7 +287,6 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         Ok(())
     }
 
-    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>> {
         self.vm_output.delayed_field_change_set().clone()
     }
@@ -325,7 +323,6 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .collect()
     }
 
-    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn get_events(&self) -> Vec<(ContractEvent, Option<MoveTypeLayout>)> {
         self.vm_output.events().to_vec()
     }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -8,10 +8,7 @@ use aptos_aggregator::delayed_change::DelayedChange;
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManager,
     executor::BlockExecutor,
-    task::{
-        BeforeMaterializationOutput, ExecutorTask,
-        TransactionOutput as BlockExecutorTransactionOutput,
-    },
+    task::{ExecutorTask, TransactionOutput as BlockExecutorTransactionOutput},
     txn_commit_hook::TransactionCommitHook,
     txn_provider::TxnProvider,
     types::InputOutputKey,
@@ -58,7 +55,7 @@ use vm_wrapper::AptosExecutorTask;
 /// transformed into TransactionOutput type on materialization.
 #[derive(Debug)]
 pub struct AptosTransactionOutput {
-    vm_output: Option<VMOutput>,
+    vm_output: VMOutput,
     /// State keys read by the VM during the execution (incarnation) that produced this output.
     ///
     /// TODO(HotState): also consider recording the read kind (exists/metadata/value) and the
@@ -73,25 +70,28 @@ impl AptosTransactionOutput {
 
     pub fn new_with_read_set(output: VMOutput, read_set: UnorderedReadSet) -> Self {
         Self {
-            vm_output: Some(output),
+            vm_output: output,
             read_set,
         }
     }
 }
 
-/// Before materialization guard wrapper that holds a read lock.
-pub struct BeforeMaterializationGuard<'a> {
-    guard: &'a VMOutput,
-    read_set: &'a UnorderedReadSet,
-}
+impl BlockExecutorTransactionOutput for AptosTransactionOutput {
+    type CommittedOutput = TransactionOutput;
+    type Txn = SignatureVerifiedTransaction;
 
-impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMaterializationGuard<'_> {
+    /// Execution output for transactions that comes after SkipRest signal or when there was a
+    /// problem creating the output (e.g. group serialization issue).
+    fn skip_output() -> Self {
+        Self::new(VMOutput::empty_with_status(TransactionStatus::Retry))
+    }
+
     fn fee_statement(&self) -> FeeStatement {
-        *self.guard.fee_statement()
+        *self.vm_output.fee_statement()
     }
 
     fn has_new_epoch_event(&self) -> bool {
-        self.guard
+        self.vm_output
             .events()
             .iter()
             .map(|(event, _)| event)
@@ -99,13 +99,13 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
     }
 
     fn output_approx_size(&self) -> u64 {
-        self.guard.materialized_size()
+        self.vm_output.materialized_size()
     }
 
     fn get_write_summary(&self) -> HashSet<InputOutputKey<StateKey, StructTag>> {
         let mut writes = HashSet::new();
 
-        for (state_key, write) in self.guard.resource_write_set() {
+        for (state_key, write) in self.vm_output.resource_write_set() {
             match write {
                 AbstractResourceWriteOp::Write(..)
                 | AbstractResourceWriteOp::WriteWithDelayedFields(_) => {
@@ -125,7 +125,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
             }
         }
 
-        for identifier in self.guard.delayed_field_change_set().keys() {
+        for identifier in self.vm_output.delayed_field_change_set().keys() {
             writes.insert(InputOutputKey::DelayedField(*identifier));
         }
 
@@ -142,10 +142,10 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
         // get_write_summary (conflict detection), this includes in-place delayed field
         // rewrites and module writes. The accumulator dedups, so the chained keys need not
         // be unique.
-        self.guard
+        self.vm_output
             .resource_write_set()
             .keys()
-            .chain(self.guard.module_write_set().keys())
+            .chain(self.vm_output.module_write_set().keys())
     }
 
     // TODO: get rid of the cloning data-structures in the following APIs.
@@ -159,7 +159,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
             BTreeMap<StructTag, ValueWithLayout<WriteOp>>,
         ),
     > {
-        self.guard
+        self.vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| {
@@ -201,7 +201,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
         callback: &mut dyn FnMut(&StateKey) -> Result<(), PanicError>,
     ) -> Result<(), PanicError> {
         for key in self
-            .guard
+            .vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| match write {
@@ -220,7 +220,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
         callback: &mut dyn FnMut(&StateKey, HashSet<&StructTag>) -> Result<(), PanicError>,
     ) -> Result<(), PanicError> {
         for (key, tags) in self
-            .guard
+            .vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| {
@@ -239,7 +239,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
 
     /// More efficient implementation to avoid unnecessarily cloning inner_ops.
     fn resource_group_metadata_ops(&self) -> Vec<(StateKey, WriteOp)> {
-        self.guard
+        self.vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| {
@@ -253,7 +253,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
     }
 
     fn resource_write_set(&self) -> HashMap<StateKey, ValueWithLayout<WriteOp>> {
-        self.guard
+        self.vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| match write {
@@ -278,7 +278,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
         &self,
         callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>,
     ) -> Result<(), PanicError> {
-        for write in self.guard.module_write_set().values() {
+        for write in self.vm_output.module_write_set().values() {
             let state_value = write
                 .write_op()
                 .as_state_value()
@@ -290,13 +290,13 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
 
     /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>> {
-        self.guard.delayed_field_change_set().clone()
+        self.vm_output.delayed_field_change_set().clone()
     }
 
     fn reads_needing_delayed_field_exchange(
         &self,
     ) -> Vec<(StateKey, StateValueMetadata, TriompheArc<MoveTypeLayout>)> {
-        self.guard
+        self.vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| {
@@ -310,7 +310,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
     }
 
     fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(StateKey, StateValueMetadata)> {
-        self.guard
+        self.vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| {
@@ -327,7 +327,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
 
     /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn get_events(&self) -> Vec<(ContractEvent, Option<MoveTypeLayout>)> {
-        self.guard.events().to_vec()
+        self.vm_output.events().to_vec()
     }
 
     // For legacy interfaces, there are more efficient alternatives in BlockSTMv2.
@@ -337,7 +337,7 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
     //
     // Internally clones and also allocates a new vector. Used for BlockSTMv1 only.
     fn legacy_v1_resource_group_tags(&self) -> Vec<(StateKey, HashSet<StructTag>)> {
-        self.guard
+        self.vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| {
@@ -352,39 +352,14 @@ impl BeforeMaterializationOutput<SignatureVerifiedTransaction> for BeforeMateria
             })
             .collect()
     }
-}
-
-impl BlockExecutorTransactionOutput for AptosTransactionOutput {
-    type BeforeMaterializationGuard<'a> = BeforeMaterializationGuard<'a>;
-    type CommittedOutput = TransactionOutput;
-    type Txn = SignatureVerifiedTransaction;
-
-    /// Execution output for transactions that comes after SkipRest signal or when there was a
-    /// problem creating the output (e.g. group serialization issue).
-    fn skip_output() -> Self {
-        Self::new(VMOutput::empty_with_status(TransactionStatus::Retry))
-    }
-
-    fn before_materialization<'a>(&'a self) -> Result<BeforeMaterializationGuard<'a>, PanicError> {
-        Ok(BeforeMaterializationGuard {
-            guard: self
-                .vm_output
-                .as_ref()
-                .ok_or_else(|| code_invariant_error("Output must be set but not materialized"))?,
-            read_set: &self.read_set,
-        })
-    }
 
     fn incorporate_materialized_txn_output(
-        mut self,
+        self,
         materialized_resource_write_set: Vec<(StateKey, WriteOp)>,
         materialized_events: Vec<ContractEvent>,
     ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
         // Before creating the output, extract the trace for replay.
-        let mut vm_output = self
-            .vm_output
-            .take()
-            .expect("Output must be set to incorporate materialized data");
+        let mut vm_output = self.vm_output;
         let trace = vm_output.take_trace();
 
         let committed_output = vm_output.into_transaction_output_with_materialized_write_set(

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -6,7 +6,7 @@ use crate::{
         DeltaTestKind, GroupSizeOrMetadata, MockIncarnation, MockTransaction, ValueType,
         RESERVED_TAG,
     },
-    task::{BeforeMaterializationOutput, ExecutionStatus, ExecutorTask, TransactionOutput},
+    task::{ExecutionStatus, ExecutorTask, TransactionOutput},
     types::delayed_field_mock_serialization::{
         deserialize_to_delayed_field_id, serialize_from_delayed_field_id,
     },
@@ -690,16 +690,11 @@ where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
-    type BeforeMaterializationGuard<'a> = &'a Self;
     type CommittedOutput = MockOutput<K, E>;
     type Txn = MockTransaction<K, E>;
 
     fn skip_output() -> Self {
         Self::skipped_output(None)
-    }
-
-    fn before_materialization(&self) -> Result<Self::BeforeMaterializationGuard<'_>, PanicError> {
-        Ok(self)
     }
 
     fn incorporate_materialized_txn_output(
@@ -716,13 +711,7 @@ where
         // and patched writes the baseline verifies.
         Ok((self, Trace::empty()))
     }
-}
 
-impl<K, E> BeforeMaterializationOutput<MockTransaction<K, E>> for &MockOutput<K, E>
-where
-    K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
-    E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
-{
     fn resource_write_set(&self) -> HashMap<K, ValueWithLayout<ValueType>> {
         self.writes
             .iter()

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -18,7 +18,7 @@ use crate::{
     scheduler::{DependencyStatus, ExecutionTaskType, Scheduler, SchedulerTask, Wave},
     scheduler_v2::{AbortManager, CommitResult, SchedulerV2, TaskKind},
     scheduler_wrapper::SchedulerWrapper,
-    task::{BeforeMaterializationOutput, ExecutionStatus, ExecutorTask, TransactionOutput},
+    task::{ExecutionStatus, ExecutorTask, TransactionOutput},
     txn_commit_hook::TransactionCommitHook,
     txn_last_input_output::TxnLastInputOutput,
     txn_provider::TxnProvider,
@@ -148,8 +148,7 @@ where
             )
         })?;
 
-        let output_before_guard = output.before_materialization()?;
-        let resource_write_set = output_before_guard.resource_write_set();
+        let resource_write_set = output.resource_write_set();
 
         for (key, _) in pre_write_entries {
             if !resource_write_set.contains_key(&key) {
@@ -172,11 +171,8 @@ where
         // The order is reversed in BlockSTMv2 as opposed to V1, avoiding the necessity
         // to clone the previous keys.
 
-        let mut resource_write_set = maybe_output.map_or(Ok(HashMap::new()), |output| {
-            output
-                .before_materialization()
-                .map(|inner| inner.resource_write_set())
-        })?;
+        let mut resource_write_set =
+            maybe_output.map_or_else(HashMap::new, |output| output.resource_write_set());
 
         last_input_output.for_each_resource_key_no_aggregator_v1(
             idx_to_execute,
@@ -232,11 +228,8 @@ where
         // in BlockSTMv2 as opposed to V1, which avoids the necessity to clone group keys and
         // previous tags.
 
-        let mut resource_group_write_set = maybe_output.map_or(Ok(HashMap::new()), |output| {
-            output
-                .before_materialization()
-                .map(|inner| inner.resource_group_write_set())
-        })?;
+        let mut resource_group_write_set =
+            maybe_output.map_or_else(HashMap::new, |output| output.resource_group_write_set());
 
         last_input_output.for_each_resource_group_key_and_tags(
             idx_to_execute,
@@ -338,8 +331,7 @@ where
         // }
 
         if let Some(output) = maybe_output {
-            let output_before_guard = output.before_materialization()?;
-            for (id, change) in output_before_guard.delayed_field_change_set().into_iter() {
+            for (id, change) in output.delayed_field_change_set().into_iter() {
                 prev_modified_delayed_fields.remove(&id);
 
                 let entry = change.into_entry_no_additional_history();
@@ -599,9 +591,8 @@ where
         // (since those resource group validations rely on estimates).
         let mut needs_suffix_validation = false;
         let mut apply_updates = |output: &E::Output| -> Result<(), PanicError> {
-            let output_before_guard = output.before_materialization()?;
             for (group_key, (group_metadata_op, group_size, group_ops)) in
-                output_before_guard.resource_group_write_set().into_iter()
+                output.resource_group_write_set().into_iter()
             {
                 let prev_tags = prev_modified_group_keys
                     .remove(&group_key)
@@ -632,7 +623,7 @@ where
                 }
             }
 
-            let resource_write_set = output_before_guard.resource_write_set();
+            let resource_write_set = output.resource_write_set();
 
             // Then, process resource writes (aggregator v1 writes are part of this set).
             for (k, v) in resource_write_set.into_iter() {
@@ -2029,7 +2020,7 @@ where
             AptosModuleExtension,
         >,
         unsync_map: &UnsyncMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
-        output_before_guard: &<E::Output as TransactionOutput>::BeforeMaterializationGuard<'_>,
+        output: &E::Output,
         resource_write_set: HashMap<T::Key, ValueWithLayout<T::Value>>,
     ) -> Result<(), SequentialBlockExecutionError> {
         for (key, value) in resource_write_set.into_iter() {
@@ -2037,13 +2028,13 @@ where
         }
 
         for (group_key, (metadata_op, group_size, group_ops)) in
-            output_before_guard.resource_group_write_set().into_iter()
+            output.resource_group_write_set().into_iter()
         {
             unsync_map.insert_group_ops(&group_key, group_ops, group_size)?;
             unsync_map.write(group_key, metadata_op);
         }
 
-        output_before_guard.for_each_module_write(&mut |module_id, state_value| {
+        output.for_each_module_write(&mut |module_id, state_value| {
             add_module_write_to_module_cache(
                 module_id,
                 state_value,
@@ -2056,7 +2047,7 @@ where
 
         let mut second_phase = Vec::new();
         let mut updates = HashMap::new();
-        for (id, change) in output_before_guard.delayed_field_change_set().into_iter() {
+        for (id, change) in output.delayed_field_change_set().into_iter() {
             match change {
                 DelayedChange::Create(value) => {
                     assert_none!(
@@ -2188,7 +2179,6 @@ where
                     )));
                 },
                 ExecutionStatus::Executed { output, skips_rest } => {
-                    let output_before_guard = output.before_materialization()?;
                     // Calculating the accumulated gas costs of the committed txns.
 
                     let approx_output_size = self
@@ -2197,7 +2187,7 @@ where
                         .block_gas_limit_type
                         .block_output_limit()
                         .map(|_| {
-                            output_before_guard.output_approx_size()
+                            output.output_approx_size()
                                 + if self
                                     .config
                                     .onchain
@@ -2219,12 +2209,12 @@ where
                         .map(|_| {
                             ReadWriteSummary::new(
                                 sequential_reads.get_read_summary(),
-                                output_before_guard.get_write_summary(),
+                                output.get_write_summary(),
                             )
                         });
 
                     block_limit_processor.accumulate_fee_statement(
-                        output_before_guard.fee_statement(),
+                        output.fee_statement(),
                         read_write_summary,
                         approx_output_size,
                     );
@@ -2259,7 +2249,7 @@ where
                         };
 
                         // The IDs are not exchanged but it doesn't change the types (Bytes) or size.
-                        let serialization_error = output_before_guard
+                        let serialization_error = output
                             .group_reads_needing_delayed_field_exchange()
                             .iter()
                             .any(|(group_key, _)| {
@@ -2276,10 +2266,8 @@ where
                                     Err(_) => true,
                                 }
                             })
-                            || output_before_guard
-                                .resource_group_write_set()
-                                .into_iter()
-                                .any(|(group_key, (_, output_group_size, group_ops))| {
+                            || output.resource_group_write_set().into_iter().any(
+                                |(group_key, (_, output_group_size, group_ops))| {
                                     fail_point!("fail-point-resource-group-serialization", |_| {
                                         true
                                     });
@@ -2308,7 +2296,8 @@ where
                                         },
                                         Err(_) => true,
                                     }
-                                });
+                                },
+                            );
 
                         if serialization_error {
                             // The corresponding error / alert must already be triggered, the goal in sequential
@@ -2327,8 +2316,8 @@ where
                     // carry empty read/write sets.
                     if block_limit_processor.is_hot_state_accumulation_enabled() {
                         block_limit_processor.accumulate_hot_state_rw(
-                            output_before_guard.storage_keys_written(),
-                            output_before_guard.storage_keys_read(),
+                            output.storage_keys_written(),
+                            output.storage_keys_read(),
                         );
                     }
 
@@ -2338,13 +2327,9 @@ where
                         runtime_environment,
                         module_cache_manager_guard.module_cache(),
                         &unsync_map,
-                        &output_before_guard,
-                        output_before_guard.resource_write_set(),
+                        &output,
+                        output.resource_write_set(),
                     )?;
-
-                    // The guard borrows the output immutably; drop it before
-                    // materialization, which consumes the output by value.
-                    drop(output_before_guard);
 
                     // If dynamic change set materialization part (indented for clarity/variable scope):
                     let committed_output = {

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -2021,9 +2021,8 @@ where
         >,
         unsync_map: &UnsyncMap<T::Key, T::Tag, ValueWithLayout<T::Value>, DelayedFieldID>,
         output: &E::Output,
-        resource_write_set: HashMap<T::Key, ValueWithLayout<T::Value>>,
     ) -> Result<(), SequentialBlockExecutionError> {
-        for (key, value) in resource_write_set.into_iter() {
+        for (key, value) in output.resource_write_set().into_iter() {
             unsync_map.write(key, value);
         }
 
@@ -2328,7 +2327,6 @@ where
                         module_cache_manager_guard.module_cache(),
                         &unsync_map,
                         &output,
-                        output.resource_write_set(),
                     )?;
 
                     // If dynamic change set materialization part (indented for clarity/variable scope):

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -180,7 +180,6 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> Materializer<T>
 /// finalizes and serializes resource group updates, replaces delayed field
 /// identifiers with values in resource writes and events, and incorporates the
 /// results into the output.
-/// !!! [CAUTION] !!!: May not be concurrent with any other accesses to the output.
 pub(crate) fn materialize_output<T, O, M>(
     output: O,
     materializer: &M,

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -5,7 +5,7 @@ use crate::{
     captured_reads::{CapturedReads, DataRead, ReadKind},
     counters,
     errors::ResourceGroupSerializationError,
-    task::{BeforeMaterializationOutput, ExecutorTask, TransactionOutput},
+    task::{ExecutorTask, TransactionOutput},
     txn_last_input_output::TxnLastInputOutput,
     view::{LatestView, ViewState},
 };
@@ -190,22 +190,11 @@ where
     O: TransactionOutput<Txn = T>,
     M: Materializer<T>,
 {
-    let (
-        group_metadata_ops,
-        group_reads_needing_exchange,
-        resource_write_set,
-        reads_needing_exchange,
-        events,
-    ) = {
-        let guard = output.before_materialization()?;
-        (
-            guard.resource_group_metadata_ops(),
-            guard.group_reads_needing_delayed_field_exchange(),
-            guard.resource_write_set(),
-            guard.reads_needing_delayed_field_exchange(),
-            guard.get_events(),
-        )
-    };
+    let group_metadata_ops = output.resource_group_metadata_ops();
+    let group_reads_needing_exchange = output.group_reads_needing_delayed_field_exchange();
+    let resource_write_set = output.resource_write_set();
+    let reads_needing_exchange = output.reads_needing_delayed_field_exchange();
+    let events = output.get_events();
 
     let finalized_groups = group_metadata_ops
         .into_iter()

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -110,45 +110,67 @@ pub trait ExecutorTask {
     }
 }
 
-/// Traits for execution result of a single transaction.
-pub trait BeforeMaterializationOutput<Txn: Transaction> {
+/// The output of executing a single transaction.
+pub trait TransactionOutput: Send + Debug {
+    /// Type of transaction and its associated key and value.
+    type Txn: Transaction;
+    /// The materialized output produced from this (speculative) output.
+    type CommittedOutput: CommittedTransactionOutput;
+
+    /// Execution output for transactions that comes after SkipRest signal.
+    fn skip_output() -> Self;
+
     /// Get the writes of a transaction from its output, separately for resources
-    /// and modules. Aggregator V1 writes are ordinary entries of the resource write set.
-    fn resource_write_set(&self) -> HashMap<Txn::Key, ValueWithLayout<Txn::Value>>;
+    /// and modules.
+    fn resource_write_set(
+        &self,
+    ) -> HashMap<<Self::Txn as Transaction>::Key, ValueWithLayout<<Self::Txn as Transaction>::Value>>;
 
     /// Get the delayed field changes of a transaction from its output.
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>>;
 
     fn reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(Txn::Key, StateValueMetadata, TriompheArc<MoveTypeLayout>)>;
+    ) -> Vec<(
+        <Self::Txn as Transaction>::Key,
+        StateValueMetadata,
+        TriompheArc<MoveTypeLayout>,
+    )>;
 
-    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(Txn::Key, StateValueMetadata)>;
+    fn group_reads_needing_delayed_field_exchange(
+        &self,
+    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata)>;
 
     /// Get the events of a transaction from its output.
-    fn get_events(&self) -> Vec<(Txn::Event, Option<MoveTypeLayout>)>;
+    fn get_events(&self) -> Vec<(<Self::Txn as Transaction>::Event, Option<MoveTypeLayout>)>;
 
     fn resource_group_write_set(
         &self,
     ) -> HashMap<
-        Txn::Key,
+        <Self::Txn as Transaction>::Key,
         (
-            ValueWithLayout<Txn::Value>,
+            ValueWithLayout<<Self::Txn as Transaction>::Value>,
             ResourceGroupSize,
-            BTreeMap<Txn::Tag, ValueWithLayout<Txn::Value>>,
+            BTreeMap<
+                <Self::Txn as Transaction>::Tag,
+                ValueWithLayout<<Self::Txn as Transaction>::Value>,
+            >,
         ),
     >;
 
     fn for_each_resource_key(
         &self,
-        callback: &mut dyn FnMut(&Txn::Key) -> Result<(), PanicError>,
+        callback: &mut dyn FnMut(&<Self::Txn as Transaction>::Key) -> Result<(), PanicError>,
     ) -> Result<(), PanicError>;
 
     fn for_each_resource_group_key_and_tags(
         &self,
         // This is &mut dyn and not Impl to sidestep an internal compiler error:
         // https://github.com/rust-lang/rust/issues/145188.
-        callback: &mut dyn FnMut(&Txn::Key, HashSet<&Txn::Tag>) -> Result<(), PanicError>,
+        callback: &mut dyn FnMut(
+            &<Self::Txn as Transaction>::Key,
+            HashSet<&<Self::Txn as Transaction>::Tag>,
+        ) -> Result<(), PanicError>,
     ) -> Result<(), PanicError>;
 
     /// Invokes the callback for each module published by this transaction.
@@ -161,14 +183,24 @@ pub trait BeforeMaterializationOutput<Txn: Transaction> {
     // For now, the below interfaces for keys and metada and keys and tags are provided
     // to avoid unnecessarily cloning the whole resource group write set.
     // TODO: get rid of these interfaces when we can have zero-copy access to the output.
-    fn resource_group_metadata_ops(&self) -> Vec<(Txn::Key, Txn::Value)> {
+    fn resource_group_metadata_ops(
+        &self,
+    ) -> Vec<(
+        <Self::Txn as Transaction>::Key,
+        <Self::Txn as Transaction>::Value,
+    )> {
         self.resource_group_write_set()
             .into_iter()
             .map(|(key, (op, _, _))| (key, op.extract_value().clone()))
             .collect()
     }
 
-    fn legacy_v1_resource_group_tags(&self) -> Vec<(Txn::Key, HashSet<Txn::Tag>)> {
+    fn legacy_v1_resource_group_tags(
+        &self,
+    ) -> Vec<(
+        <Self::Txn as Transaction>::Key,
+        HashSet<<Self::Txn as Transaction>::Tag>,
+    )> {
         self.resource_group_write_set()
             .into_iter()
             .map(|(key, (_, _, group_ops))| (key, group_ops.keys().cloned().collect()))
@@ -186,46 +218,20 @@ pub trait BeforeMaterializationOutput<Txn: Transaction> {
     /// Sum of all sizes of writes (keys + write_ops) and events.
     fn output_approx_size(&self) -> u64;
 
-    fn get_write_summary(&self) -> HashSet<InputOutputKey<Txn::Key, Txn::Tag>>;
+    fn get_write_summary(
+        &self,
+    ) -> HashSet<InputOutputKey<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Tag>>;
 
     /// State keys read by the VM during the execution that produced this output.
-    fn storage_keys_read(&self) -> impl Iterator<Item = &Txn::Key>;
+    fn storage_keys_read(&self) -> impl Iterator<Item = &<Self::Txn as Transaction>::Key>;
 
     /// Keys written when this output commits.
-    fn storage_keys_written(&self) -> impl Iterator<Item = &Txn::Key>;
-}
-
-pub trait TransactionOutput: Send + Debug {
-    /// Type of transaction and its associated key and value.
-    type Txn: Transaction;
-    /// The materialized output produced from this (speculative) output.
-    type CommittedOutput: CommittedTransactionOutput;
-
-    type BeforeMaterializationGuard<'a>: BeforeMaterializationOutput<Self::Txn> + 'a
-    where
-        Self: 'a;
-
-    /// Execution output for transactions that comes after SkipRest signal.
-    fn skip_output() -> Self;
-
-    // Materialization transforms the stored txn output, and may require the
-    // TransactionOutput implementation to have different processing for
-    // extracting data from the output. Hence, it is important to make the
-    // caller aware via the guard types and the chaining pattern in order to
-    // ensure the appropriate methods are called.
-    fn before_materialization<'a>(
-        &'a self,
-    ) -> Result<Self::BeforeMaterializationGuard<'a>, PanicError>;
-
-    // Below methods perform various types of materialization. These may modify
-    // the stored output representation and hence must be carefully implemented
-    // to avoid data races with the accessor methods.
+    fn storage_keys_written(&self) -> impl Iterator<Item = &<Self::Txn as Transaction>::Key>;
 
     /// Will be called once per transaction when the output is ready to be committed.
     /// Ensures that any writes corresponding to materialized delayed fields and group
-    /// updates (recorded in output separately) are incorporated into the transaction output.
-    /// !!! [CAUTION] !!!: This method must be called in quiescence, i.e. may not be
-    /// concurrent with any other method that accesses the output.
+    /// updates (recorded in output separately) are incorporated into the transaction
+    /// output. Consumes the output, so the accessors above cannot be called afterwards.
     fn incorporate_materialized_txn_output(
         self,
         patched_resource_write_set: Vec<(

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -9,7 +9,7 @@ use crate::{
     explicit_sync_wrapper::ExplicitSyncWrapper,
     limit_processor::BlockGasLimitProcessor,
     scheduler_wrapper::SchedulerWrapper,
-    task::{BeforeMaterializationOutput, ExecutionStatus, TransactionOutput},
+    task::{ExecutionStatus, TransactionOutput},
     types::ReadWriteSummary,
 };
 use aptos_logger::error;
@@ -66,10 +66,9 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
         // Summaries are only meaningful for an executed output.
         let (maybe_approx_output_size, maybe_read_write_summary) = match &output {
             ExecutionStatus::Executed { output, .. } => {
-                let output_before_guard = output.before_materialization()?;
                 let maybe_approx_output_size =
                     block_gas_limit_type.block_output_limit().map(|_| {
-                        output_before_guard.output_approx_size()
+                        output.output_approx_size()
                             + if block_gas_limit_type.include_user_txn_size_in_block_output() {
                                 user_txn_bytes_len
                             } else {
@@ -80,7 +79,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
                     block_gas_limit_type.conflict_penalty_window().map(|_| {
                         ReadWriteSummary::new(
                             read_set.get_read_summary(),
-                            output_before_guard.get_write_summary(),
+                            output.get_write_summary(),
                         )
                     });
                 (maybe_approx_output_size, maybe_read_write_summary)
@@ -201,9 +200,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         };
 
         // Read the output facts before flipping the disjoint skips_rest flag.
-        let output_before_guard = output.before_materialization()?;
-        let has_new_epoch_event = output_before_guard.has_new_epoch_event();
-        let fee_statement = output_before_guard.fee_statement();
+        let has_new_epoch_event = output.has_new_epoch_event();
+        let fee_statement = output.fee_statement();
 
         // For committed txns, calculate the accumulated gas costs.
         block_limit_processor.accumulate_fee_statement(
@@ -212,12 +210,9 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
             maybe_approx_output_size,
         );
         if block_limit_processor.is_hot_state_accumulation_enabled() {
-            block_limit_processor.accumulate_hot_state_rw(
-                output_before_guard.storage_keys_written(),
-                output_before_guard.storage_keys_read(),
-            );
+            block_limit_processor
+                .accumulate_hot_state_rw(output.storage_keys_written(), output.storage_keys_read());
         }
-        drop(output_before_guard);
 
         let mut must_create_epilogue_txn = if *skips_rest_flag {
             !has_new_epoch_event
@@ -277,9 +272,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     ) -> Result<(), PanicError> {
         let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
         if let Some(output) = output_wrapper.get_output() {
-            output
-                .before_materialization()?
-                .for_each_resource_key(&mut callback)?;
+            output.for_each_resource_key(&mut callback)?;
         }
 
         Ok(())
@@ -293,9 +286,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     ) -> Result<(), PanicError> {
         let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
         if let Some(output) = output_wrapper.get_output() {
-            output
-                .before_materialization()?
-                .for_each_resource_group_key_and_tags(&mut callback)?;
+            output.for_each_resource_group_key_and_tags(&mut callback)?;
         }
 
         Ok(())
@@ -307,10 +298,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     ) -> Vec<(T::Key, HashSet<T::Tag>)> {
         let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
         match output_wrapper.get_output() {
-            Some(output) => output
-                .before_materialization()
-                .expect("Output must be set")
-                .legacy_v1_resource_group_tags(),
+            Some(output) => output.legacy_v1_resource_group_tags(),
             None => vec![],
         }
     }
@@ -323,13 +311,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     ) -> Option<impl Iterator<Item = T::Key>> {
         let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
         let output = output_wrapper.get_output()?;
-        Some(
-            output
-                .before_materialization()
-                .expect("Output must be set")
-                .resource_write_set()
-                .into_keys(),
-        )
+        Some(output.resource_write_set().into_keys())
     }
 
     // The output must be an executed output, o.w. an invariant error is returned.
@@ -353,11 +335,10 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
                 txn_idx
             ))
         })?;
-        let output_before_guard = output.before_materialization()?;
 
         let mut published = false;
         let mut module_ids_for_v2 = BTreeSet::new();
-        output_before_guard.for_each_module_write(&mut |module_id, state_value| {
+        output.for_each_module_write(&mut |module_id, state_value| {
             published = true;
             if scheduler.is_v2() {
                 module_ids_for_v2.insert(module_id.clone());
@@ -384,13 +365,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     ) -> Option<impl Iterator<Item = DelayedFieldID>> {
         let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
         let output = output_wrapper.get_output()?;
-        Some(
-            output
-                .before_materialization()
-                .expect("Output must be set")
-                .delayed_field_change_set()
-                .into_keys(),
-        )
+        Some(output.delayed_field_change_set().into_keys())
     }
 
     // Called when a transaction is committed to materialize its recorded output:

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -62,7 +62,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
         read_set: &TxnInput<T>,
         block_gas_limit_type: &BlockGasLimitType,
         user_txn_bytes_len: u64,
-    ) -> Result<Self, PanicError> {
+    ) -> Self {
         // Summaries are only meaningful for an executed output.
         let (maybe_approx_output_size, maybe_read_write_summary) = match &output {
             ExecutionStatus::Executed { output, .. } => {
@@ -87,11 +87,11 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
             ExecutionStatus::Aborted(_) | ExecutionStatus::SpeculativeFailure => (None, None),
         };
 
-        Ok(Self {
+        Self {
             output: Some(output),
             maybe_read_write_summary,
             maybe_approx_output_size,
-        })
+        }
     }
 }
 
@@ -135,7 +135,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
             &input,
             block_gas_limit_type,
             user_txn_bytes_len,
-        )?;
+        );
         *self.inputs[txn_idx as usize].lock() = Some(Arc::new(input));
 
         Ok(())
@@ -371,10 +371,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     // Called when a transaction is committed to materialize its recorded output:
     // resource group updates are finalized and serialized, and delayed field
     // identifiers are replaced with committed values in resource writes and events.
-    //
-    // !!! [CAUTION] !!!: This finalizes the output and may not be concurrent with
-    // any other accesses to the output (e.g. querying the write-set, events, etc),
-    // as these read accesses are not synchronized and assumed to have terminated.
     pub(crate) fn materialize<M: Materializer<T>>(
         &self,
         txn_idx: TxnIndex,

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -14,7 +14,7 @@ use aptos_aggregator::{
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManagerGuard,
     executor::BlockExecutor,
-    task::{BeforeMaterializationOutput, ExecutionStatus, ExecutorTask, TransactionOutput},
+    task::{ExecutionStatus, ExecutorTask, TransactionOutput},
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::default::DefaultTxnProvider,
     types::InputOutputKey,
@@ -159,16 +159,11 @@ impl BlockExecutableTransaction for TestTransaction {
 struct TestOutput;
 
 impl TransactionOutput for TestOutput {
-    type BeforeMaterializationGuard<'a> = &'a Self;
     type CommittedOutput = aptos_types::transaction::TransactionOutput;
     type Txn = TestTransaction;
 
     fn skip_output() -> Self {
         Self
-    }
-
-    fn before_materialization(&self) -> Result<Self::BeforeMaterializationGuard<'_>, PanicError> {
-        Ok(self)
     }
 
     fn incorporate_materialized_txn_output(
@@ -181,9 +176,7 @@ impl TransactionOutput for TestOutput {
             Trace::empty(),
         ))
     }
-}
 
-impl BeforeMaterializationOutput<TestTransaction> for &TestOutput {
     fn resource_write_set(&self) -> HashMap<StateKey, ValueWithLayout<WriteOp>> {
         HashMap::new()
     }


### PR DESCRIPTION
## Description

Stacked on #20257 (`[block-stm] Refactor recorded outputs`).

Removes the `before_materialization` guard by folding `BeforeMaterializationOutput`
into `TransactionOutput`. The trait is now a plain output data type: `skip_output`,
a set of `&self` read accessors, and a single consuming
`incorporate_materialized_txn_output(self)`.

- Drop the `before_materialization` method and the `BeforeMaterializationGuard`
  associated type; delete the standalone `BeforeMaterializationOutput` trait.
- Every `output.before_materialization()?.foo()` call site becomes `output.foo()`
  (executor, executor_utilities, txn_last_input_output). `apply_output_sequential`
  takes `&E::Output` instead of the guard type; `materialize_output` reads the
  output directly.
- `AptosTransactionOutput::vm_output` becomes non-`Option`. The `Option` (and the
  fallible `before_materialization`) only existed to detect the "already
  materialized" state; now that materialization consumes the output by value,
  ownership enforces that no accessor runs afterwards, so the runtime check is
  gone.
- Merge the mock's / test's `impl BeforeMaterializationOutput for &Self` into their
  `TransactionOutput` impls.

Enabler for driving a second VM (MonoMove) through Block-STM: the output becomes a
VM-neutral, ownership-based data trait that a VM implements directly, with no
guard type or fallible re-entry, and the executor's output read path is generic
over the output type.

No functional change intended — a trait-shape refactor.

## How Has This Been Tested?

- `cargo nextest run -p aptos-block-executor` — 265/265 pass.
- `cargo check` (all targets) on `aptos-block-executor`, `aptos-vm`,
  `aptos-executor-benchmark`, and `e2e-move-tests`.

## Key Areas to Review

- `task.rs`: the merged `TransactionOutput` trait and the updated
  `incorporate_materialized_txn_output` contract (consumes `self`).
- `aptos-vm/.../mod.rs`: `AptosTransactionOutput` accessors moved off the guard,
  `vm_output` non-`Option`, `incorporate` no longer `.take().expect()`s.
- `txn_last_input_output.rs` `commit`: reads output facts directly (disjoint
  `output` / `skips_rest` borrow), no guard.

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core parallel/sequential Block-STM commit and materialization path across executor and VM output types; behavior should be unchanged but regressions would affect block execution correctness.
> 
> **Overview**
> **Block-STM output API refactor** — removes the `before_materialization` guard pattern and treats speculative execution output as a single trait type VMs can implement directly.
> 
> The standalone **`BeforeMaterializationOutput`** trait and **`BeforeMaterializationGuard`** associated type are deleted; their accessors move onto **`TransactionOutput`** as plain **`&self`** methods, with **`incorporate_materialized_txn_output(self, …)`** as the only consuming step. Executor paths (`executor`, `executor_utilities`, `txn_last_input_output`, sequential `apply_output_sequential`) call **`output.foo()`** instead of **`output.before_materialization()?.foo()`**, and **`OutputWrapper::from_execution_status`** no longer returns **`Result`** from guard setup.
> 
> **`AptosTransactionOutput`** stores **`vm_output`** as non-optional **`VMOutput`**; the old **`Option`** / fallible guard existed only to catch use-after-materialize, which **Rust ownership** now enforces when materialization takes **`self`**. Mock and e2e test outputs follow the same merged trait shape.
> 
> No intended execution semantics change — trait-shape cleanup to support VM-neutral Block-STM outputs (e.g. MonoMove).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cebe4a2e6aad44e69200400af24a4538f99c1f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->