### PR TITLE
[mono-move] Typed Slot Forms in the Stackless IR

### DIFF
--- a/third_party/move/mono-move/orchestrator/src/bin/mseir-compiler.rs
+++ b/third_party/move/mono-move/orchestrator/src/bin/mseir-compiler.rs
@@ -82,14 +82,14 @@ fn print_stats(module_ir: &specializer::stackless_exec_ir::ModuleIR) {
         let num_temps = func_ir
             .num_home_slots
             .saturating_sub(func_ir.num_params + func_ir.num_locals);
-        let total_slots = func_ir.num_home_slots + func_ir.num_xfer_positions;
+        let total_slots = func_ir.num_home_slots + func_ir.num_transfer_positions;
 
         eprintln!(
             "{mod_prefix}::{func_name}  \
              bytecode: {bc_instrs} instrs, {bc_locals} locals  |  \
              IR: {ir_instrs} instrs, {total_slots} slots \
-             (= {} params + {} locals + {num_temps} temps + {} xfer)",
-            func_ir.num_params, func_ir.num_locals, func_ir.num_xfer_positions,
+             (= {} params + {} locals + {num_temps} temps + {} transfer)",
+            func_ir.num_params, func_ir.num_locals, func_ir.num_transfer_positions,
         );
     }
 }

--- a/third_party/move/mono-move/specializer/src/destack/analysis.rs
+++ b/third_party/move/mono-move/specializer/src/destack/analysis.rs
@@ -3,56 +3,56 @@
 
 //! Per-basic-block analysis feeding the slot allocator. From a single
 //! intra-block SSA slice it produces a [`BlockAnalysis`] — liveness
-//! plus three "color this Vid into that slot" hint maps the allocator
+//! plus three "color this ValueId into that slot" hint maps the allocator
 //! uses to elide copies. See the [`BlockAnalysis`] field docs for the
 //! precise semantics of each entry.
 //!
-//! # Xfer slot invariants
+//! # Transfer slot invariants
 //!
-//! `analyze` establishes several invariants on the resulting `xfer_precolor`
-//! map. The slot allocator follows the precolor map verbatim: every Vid in it
-//! lands at the named Xfer slot, and no other Vid lands at any Xfer slot. So
+//! `analyze` establishes several invariants on the resulting `transfer_precolor`
+//! map. The slot allocator follows the precolor map verbatim: every ValueId in it
+//! lands at the named Transfer slot, and no other ValueId lands at any Transfer slot. So
 //! these are equivalently invariants on each call's args/rets in the
-//! xfer-slot-allocated IR.
+//! transfer-slot-allocated IR.
 //!
-//! 1. Block-local lifetime. Every Xfer-bound Vid has its def and last use
+//! 1. Block-local lifetime. Every Transfer-bound ValueId has its def and last use
 //!    within the same basic block. Block or function exit ends the slot's
 //!    lifetime.
-//! 2. Arg positionality. For any call, if `args[j]` is precolored to `Xfer(i)`,
+//! 2. Arg positionality. For any call, if `args[j]` is precolored to `Transfer(i)`,
 //!    then `i == j`.
-//! 3. Return monotonicity. For any call, if `rets[k1] == Xfer(i1)` and
-//!    `rets[k2] == Xfer(i2)` with `k1 < k2`, then `i1 < i2`.
+//! 3. Return monotonicity. For any call, if `rets[k1] == Transfer(i1)` and
+//!    `rets[k2] == Transfer(i2)` with `k1 < k2`, then `i1 < i2`.
 //! 4. Pass-through contiguity. For any pair of consecutive calls in the same
-//!    block A then B, the positions in `B.args` whose Vids are defined at A and
-//!    Xfer-bound form one contiguous interval.
-//! 5. Return Xfer prefix. Within any call's `rets` list, all Xfer-bound entries
+//!    block A then B, the positions in `B.args` whose ValueIds are defined at A and
+//!    Transfer-bound form one contiguous interval.
+//! 5. Return Transfer prefix. Within any call's `rets` list, all Transfer-bound entries
 //!    precede all Home-bound entries.
-//! 6. Each Xfer-bound Vid is read exactly once at or before the call-like
+//! 6. Each Transfer-bound ValueId is read exactly once at or before the call-like
 //!    instruction immediately following its def.
-//! 7. Not live across calls. No Xfer-bound Vid's lifetime spans across (defined
+//! 7. Not live across calls. No Transfer-bound ValueId's lifetime spans across (defined
 //!    before and used after) call-like instruction.
 //!
 //! Notes:
 //!
-//! a. Return xfers don't have positionality. A `ret(k)` may be precolored to
-//!   `Xfer(j)` with `j ≠ k` when the same Vid is also `B.args[j]` of the
+//! a. Return transfers do not have positionality. A `ret(k)` may be precolored to
+//!   `Transfer(j)` with `j ≠ k` when the same ValueId is also `B.args[j]` of the
 //!   immediately-following call (the pass-through case).
-//! b. No duplicate Xfer indices within a call's args or rets. Arg
-//!    positionality forces `args[j] = Xfer(j)` for distinct `j`; return
-//!    monotonicity forces rets to take strictly-increasing Xfer indices.
+//! b. No duplicate Transfer indices within a call's args or rets. Arg
+//!    positionality forces `args[j] = Transfer(j)` for distinct `j`; return
+//!    monotonicity forces rets to take strictly-increasing Transfer indices.
 //! c. No cycle detection needed at lowering. Arg positionality and return
 //!    monotonicity together make reverse-order emit provably safe by
 //!    structural reasoning, with no appeal to bytecode stack semantics or
 //!    runtime cycle detection.
 //!
-//! [`assert_xfer_invariants`] checks all seven invariants at the end of
+//! [`assert_transfer_invariants`] checks all seven invariants at the end of
 //! `analyze` in debug builds.
 //!
 //! # Why `coalesce_to_local` aliasing is safe
 //!
-//! In SSA, a Vid is defined once and read-only thereafter — coalescing
-//! never introduces Vid-side writes to the source local's slot. The
-//! Vid's intended value at any read site `t` equals the local's value
+//! In SSA, a ValueId is defined once and read-only thereafter — coalescing
+//! never introduces ValueId-side writes to the source local's slot. The
+//! ValueId's intended value at any read site `t` equals the local's value
 //! at the def site, so it equals the local's value at `t` *iff the
 //! local's slot has not been mutated in between*. Two channels can
 //! mutate it:
@@ -63,16 +63,16 @@
 //!    a mutable ref, and a subsequent `WriteRef` (or a callee writing
 //!    through the ref) mutates `x`'s slot. Move's borrow checker
 //!    forbids accessing `x` *under the name `x`* while `&mut x` is
-//!    live, but the coalesced Vid is, at the IR level, an independent
+//!    live, but the coalesced ValueId is, at the IR level, an independent
 //!    stack value — the borrow checker does not see the aliasing.
 //!    Tracked by `home_mut_borrow_pos`; checked via `home_mut_borrowed`.
 //!    `MutBorrowLocField` is tracked under the same channel.
 //!
-//! With both channels clear over `[def_pos(vid)+1, live_end(vid))`, the
-//! Vid's snapshot equals the local's slot at every read site and they
+//! With both channels clear over `[def_pos(value_id)+1, live_end(value_id))`, the
+//! ValueId's snapshot equals the local's slot at every read site and they
 //! can share storage with no copy. `MutBorrowField` /
 //! `MutBorrowVariantField` / `MutBorrowGlobal` need no tracking here:
-//! their `src` is a ref Vid (or address), never a local, so any
+//! their `src` is a ref ValueId (or address), never a local, so any
 //! local-storage mutation they cascade into was already gated on an
 //! upstream `MutBorrowLoc` (or `MutBorrowLocField`). (Field-level
 //! coalescing, if ever added, would need to revisit this.)
@@ -81,10 +81,10 @@
 use crate::stackless_exec_ir::instr_utils::for_each_value_use;
 use crate::stackless_exec_ir::{
     instr_utils::{
-        call_boundary_rets_and_args, clobbers_xfer, for_each_def, for_each_use,
+        call_boundary_rets_and_args, clobbers_transfer, for_each_def, for_each_use,
         mut_local_borrow_target,
     },
-    Instr, Slot,
+    HomeIndex, Instr, NamedSlot, SsaSlot, TransferPosition,
 };
 #[cfg(debug_assertions)]
 use mono_move_core::{ExecutionErrorKind, IntoExecutionError, VMInternalError, VMResult};
@@ -97,177 +97,176 @@ use thiserror::Error;
 
 #[cfg(debug_assertions)]
 #[derive(Debug, Error)]
-enum XferVerifierError {
-    #[error("post-optimize Xfer verifier: block {block}, instr {instr}: {inner}")]
-    XferCallStructural {
+enum TransferVerifierError {
+    #[error("post-optimize Transfer verifier: block {block}, instr {instr}: {inner}")]
+    TransferCallStructural {
         block: usize,
         instr: usize,
-        inner: Box<XferVerifierError>,
+        inner: Box<TransferVerifierError>,
     },
 
     #[error(
-        "arg positionality: args[{arg_idx}] resolves to Xfer({got}), expected Xfer({arg_idx})"
+        "arg positionality: args[{arg_idx}] resolves to Transfer({got}), expected Transfer({arg_idx})"
     )]
-    XferArgPositionality { arg_idx: usize, got: u16 },
+    TransferArgPositionality { arg_idx: usize, got: u16 },
 
-    #[error("return Xfer prefix: rets[{ret_idx}] resolves to Xfer({got}) after a non-Xfer ret")]
-    XferReturnPrefix { ret_idx: usize, got: u16 },
+    #[error(
+        "return Transfer prefix: rets[{ret_idx}] resolves to Transfer({got}) after a non-Transfer ret"
+    )]
+    TransferReturnPrefix { ret_idx: usize, got: u16 },
 
-    #[error("return monotonicity: rets[{ret_idx}] = Xfer({got}) <= prev Xfer({prev})")]
-    XferReturnNotMonotonic { ret_idx: usize, got: u16, prev: u16 },
+    #[error("return monotonicity: rets[{ret_idx}] = Transfer({got}) <= prev Transfer({prev})")]
+    TransferReturnNotMonotonic { ret_idx: usize, got: u16, prev: u16 },
 
-    #[error("post-optimize Xfer verifier: block {block}, instr {instr}: use of Xfer({xfer}) with no live def earlier in this block")]
-    XferUseWithoutLiveDef {
+    #[error("post-optimize Transfer verifier: block {block}, instr {instr}: use of Transfer({transfer}) with no live def earlier in this block")]
+    TransferUseWithoutLiveDef {
         block: usize,
         instr: usize,
-        xfer: u16,
+        transfer: u16,
     },
 
-    #[error("post-optimize Xfer verifier: block {block}, instr {instr}: Xfer({xfer}) bound at call boundary but not consumed as args[{xfer}]")]
-    XferBoundNotConsumed {
+    #[error("post-optimize Transfer verifier: block {block}, instr {instr}: Transfer({transfer}) bound at call boundary but not consumed as args[{transfer}]")]
+    TransferBoundNotConsumed {
         block: usize,
         instr: usize,
-        xfer: u16,
+        transfer: u16,
     },
 
-    #[error("post-optimize Xfer verifier: block {block}: Xfer({xfer}) bound at block end (Xfer lifetimes must be block-local)")]
-    XferBoundAtBlockEnd { block: usize, xfer: u16 },
+    #[error("post-optimize Transfer verifier: block {block}: Transfer({transfer}) bound at block end (Transfer lifetimes must be block-local)")]
+    TransferBoundAtBlockEnd { block: usize, transfer: u16 },
 }
 
 #[cfg(debug_assertions)]
-impl IntoExecutionError for XferVerifierError {
+impl IntoExecutionError for TransferVerifierError {
     fn kind(&self) -> ExecutionErrorKind {
-        use XferVerifierError::*;
+        use TransferVerifierError::*;
         match self {
-            XferCallStructural { .. }
-            | XferArgPositionality { .. }
-            | XferReturnPrefix { .. }
-            | XferReturnNotMonotonic { .. }
-            | XferUseWithoutLiveDef { .. }
-            | XferBoundNotConsumed { .. }
-            | XferBoundAtBlockEnd { .. } => ExecutionErrorKind::InvariantViolation,
+            TransferCallStructural { .. }
+            | TransferArgPositionality { .. }
+            | TransferReturnPrefix { .. }
+            | TransferReturnNotMonotonic { .. }
+            | TransferUseWithoutLiveDef { .. }
+            | TransferBoundNotConsumed { .. }
+            | TransferBoundAtBlockEnd { .. } => ExecutionErrorKind::InvariantViolation,
         }
     }
 }
 
-/// Analysis results for a single basic block. All map keys are `Vid`s.
+/// Analysis results for a single basic block. All map keys are `ValueId`s.
 pub(crate) struct BlockAnalysis {
-    /// End of the `Vid`'s live range — the last instruction index where it
-    /// is referenced (def or use). For a Vid that is defined but never
+    /// End of the `ValueId`'s live range — the last instruction index where it
+    /// is referenced (def or use). For a ValueId that is defined but never
     /// used, equals its `def_pos`, marking the live range as collapsed to
     /// the def site. Used downstream as the "kill point" beyond which the
-    /// Vid's slot can be reused.
-    pub live_end: UnorderedMap<Slot, usize>,
-    /// `Vid` → Home slot, when the Vid will later be moved into the Home
-    /// slot (`Move { dst: Home, src: vid }`, the `st_loc` shape produced by destack)
-    /// and the Home slot is not accessed between the Vid's def and the
+    /// ValueId's slot can be reused.
+    pub live_end: UnorderedMap<SsaSlot, usize>,
+    /// `ValueId` → Home slot index it will later be moved into
+    /// (`Move { dst: Home, src: value_id }`, the `st_loc` shape produced by destack),
+    /// when the Home slot is not accessed between the ValueId's def and the
     /// store. Sound because destack emits this shape only for `StLoc`,
-    /// where the Vid is popped — the move is its last use, so coloring
-    /// the Vid into the Home slot makes the store a self-move that elides.
-    pub stloc_targets: UnorderedMap<Slot, Slot>,
-    /// `Vid` → local it was copied/moved out of, when the local is
-    /// neither redefined nor mut-borrowed during the `Vid`'s live range.
-    pub coalesce_to_local: UnorderedMap<Slot, Slot>,
-    /// `Vid` → `Xfer` slot, for call args or rets whose live range
-    /// doesn't cross any other call. See the file-header section
-    /// "Xfer slot invariants" for the different properties this map
+    /// where the ValueId is popped — the move is its last use, so coloring
+    /// the ValueId into the Home slot makes the store a self-move that elides.
+    pub stloc_targets: UnorderedMap<SsaSlot, HomeIndex>,
+    /// `ValueId` → Home slot index of the local it was copied/moved out of,
+    /// when the local is neither redefined nor mut-borrowed during the
+    /// `ValueId`'s live range.
+    pub coalesce_to_local: UnorderedMap<SsaSlot, HomeIndex>,
+    /// `ValueId` → `Transfer` position, for call args or rets whose live
+    /// range doesn't cross any other call. See the file-header section
+    /// "Transfer slot invariants" for the different properties this map
     /// satisfies.
-    pub xfer_precolor: UnorderedMap<Slot, Slot>,
+    pub transfer_precolor: UnorderedMap<SsaSlot, TransferPosition>,
     /// Largest `max(args.len(), rets.len())` across all calls in the
-    /// block — i.e., the number of distinct `Xfer(j)` positions any
+    /// block — i.e., the number of distinct `Transfer(j)` positions any
     /// call uses.
-    pub max_xfer_positions: u16,
+    pub max_transfer_positions: u16,
 }
 
 impl BlockAnalysis {
     /// Analyze a basic block and produce hint maps for slot allocation.
     ///
-    /// Pre: `instrs` is one basic block's SSA slice; each `Vid` is
+    /// Pre: `instrs` is one basic block's SSA slice; each `ValueId` is
     /// defined exactly once.
     ///
     /// Post: each entry's soundness condition is enforced before insert,
     /// and the three hint maps (`stloc_targets`, `coalesce_to_local`,
-    /// `xfer_precolor`) are pairwise disjoint — `coalesce_to_local`
-    /// skips Vids already in `stloc_targets`, and `xfer_precolor` skips
-    /// Vids already in either earlier map. (`coalesce_to_local` ∩ call
-    /// rets is empty by SSA: a Vid defined by a `Call` is never the
-    /// `dst` of `Copy`/`Move { dst: vid, src: Home }`.)
-    pub(crate) fn analyze(instrs: &[Instr]) -> Self {
-        // Forward scan: build per-`Vid` and per-`Home` position indices.
-        // `Vid` -> last instruction index where it appears as def or use.
-        let mut live_end: UnorderedMap<Slot, usize> = UnorderedMap::new();
-        // `Vid` -> instruction index where it is defined.
-        let mut def_pos: UnorderedMap<Slot, usize> = UnorderedMap::new();
+    /// `transfer_precolor`) are pairwise disjoint — `coalesce_to_local`
+    /// skips ValueIds already in `stloc_targets`, and `transfer_precolor` skips
+    /// ValueIds already in either earlier map. (`coalesce_to_local` ∩ call
+    /// rets is empty by SSA: a ValueId defined by a `Call` is never the
+    /// `dst` of `Copy`/`Move { dst: value_id, src: Home }`.)
+    pub(crate) fn analyze(instrs: &[Instr<SsaSlot>]) -> Self {
+        // Forward scan: build per-`ValueId` and per-`Home` position indices.
+        // `ValueId` -> last instruction index where it appears as def or use.
+        let mut live_end: UnorderedMap<SsaSlot, usize> = UnorderedMap::new();
+        // `ValueId` -> instruction index where it is defined.
+        let mut def_pos: UnorderedMap<SsaSlot, usize> = UnorderedMap::new();
         // `Home` -> sorted positions where the Home slot appears as def or use.
         // Used only for range-existence queries, so any duplicate `i` (from a
         // single instr touching the same Home as both def and use — destack
         // doesn't currently emit such shapes) would be harmless.
-        let mut home_touch_pos: UnorderedMap<Slot, Vec<usize>> = UnorderedMap::new();
+        let mut home_touch_pos: UnorderedMap<SsaSlot, Vec<usize>> = UnorderedMap::new();
         // `Home` -> sorted positions where the Home slot appears as def only.
-        let mut home_def_pos: UnorderedMap<Slot, Vec<usize>> = UnorderedMap::new();
+        let mut home_def_pos: UnorderedMap<SsaSlot, Vec<usize>> = UnorderedMap::new();
         // `Home` -> sorted positions of `MutBorrowLoc` whose source is the
         // Home slot (see file header for why `coalesce_to_local` treats these
         // as conflicts).
-        let mut home_mut_borrow_pos: UnorderedMap<Slot, Vec<usize>> = UnorderedMap::new();
+        let mut home_mut_borrow_pos: UnorderedMap<SsaSlot, Vec<usize>> = UnorderedMap::new();
 
         // TODO(perf): we can reduce the number of passes over instructions.
         for (i, instr) in instrs.iter().enumerate() {
             for_each_use(instr, |slot| match slot {
-                Slot::Vid(_) => {
+                SsaSlot::ValueId(_) => {
                     live_end.insert(slot, i);
                 },
-                Slot::Home(_) => {
+                SsaSlot::Home(_) => {
                     home_touch_pos.entry(slot).or_default().push(i);
-                },
-                Slot::Xfer(_) => {
-                    // cannot appear
                 },
             });
             for_each_def(instr, |slot| match slot {
-                Slot::Vid(_) => {
+                SsaSlot::ValueId(_) => {
                     live_end.entry(slot).or_insert(i);
                     def_pos.entry(slot).or_insert(i);
                 },
-                Slot::Home(_) => {
+                SsaSlot::Home(_) => {
                     home_touch_pos.entry(slot).or_default().push(i);
                     home_def_pos.entry(slot).or_default().push(i);
-                },
-                Slot::Xfer(_) => {
-                    // cannot appear
                 },
             });
             // A `&mut` into a home local's storage can defer a write through
             // the returned reference, conflicting with coalescing.
-            if let Some(local @ Slot::Home(_)) = mut_local_borrow_target(instr) {
+            if let Some(local @ SsaSlot::Home(_)) = mut_local_borrow_target(instr) {
                 home_mut_borrow_pos.entry(local).or_default().push(i);
             }
         }
 
-        // Call positions — any instruction that clobbers xfer slots.
+        // Call positions — any instruction that clobbers transfer slots.
         // Already sorted since we iterate in order.
         let call_positions: Vec<usize> = instrs
             .iter()
             .enumerate()
-            .filter(|(_, ins)| clobbers_xfer(ins))
+            .filter(|(_, ins)| clobbers_transfer(ins))
             .map(|(i, _)| i)
             .collect();
 
-        // StLoc look-ahead: map `Vid` → Home slot when the `Vid` is produced
+        // StLoc look-ahead: map `ValueId` → Home slot when the `ValueId` is produced
         // and later stored to that Home slot, with the Home slot not accessed
         // in between. Check uses binary search on home_touch_pos: O(log n)
         // per candidate.
-        let mut stloc_targets: UnorderedMap<Slot, Slot> = UnorderedMap::new();
+        let mut stloc_targets: UnorderedMap<SsaSlot, HomeIndex> = UnorderedMap::new();
         for (i, instr) in instrs.iter().enumerate() {
-            if let Instr::Move { dst, src } = instr
-                && dst.is_home()
-                && src.is_vid()
+            if let Instr::Move {
+                dst: dst @ SsaSlot::Home(home_idx),
+                src,
+            } = instr
+                && src.is_value_id()
                 && !stloc_targets.contains_key(src)
             {
                 let dp = def_pos.get(src).copied().unwrap_or(0);
                 let touches = home_touch_pos.get(dst).map(|v| v.as_slice()).unwrap_or(&[]);
                 let home_touched = has_any_in_range(touches, dp + 1, i);
                 if !home_touched {
-                    stloc_targets.insert(*src, *dst);
+                    stloc_targets.insert(*src, *home_idx);
                 }
             }
         }
@@ -275,16 +274,16 @@ impl BlockAnalysis {
         // `CopyLoc` / `MoveLoc` coalescing. Range checks on
         // `home_def_pos` and `home_mut_borrow_pos` are O(log n) each
         // via binary search.
-        let mut coalesce_to_local: UnorderedMap<Slot, Slot> = UnorderedMap::new();
+        let mut coalesce_to_local: UnorderedMap<SsaSlot, HomeIndex> = UnorderedMap::new();
         for (i, instr) in instrs.iter().enumerate() {
             if let Instr::Copy { dst, src } | Instr::Move { dst, src } = instr
-                && dst.is_vid()
-                && src.is_home()
+                && dst.is_value_id()
+                && let SsaSlot::Home(home_idx) = src
             {
-                let vid = *dst;
-                if let Some(&lu) = live_end.get(&vid)
+                let value_id = *dst;
+                if let Some(&lu) = live_end.get(&value_id)
                     && lu > i
-                    && !stloc_targets.contains_key(&vid)
+                    && !stloc_targets.contains_key(&value_id)
                 {
                     let local = *src;
                     let defs = home_def_pos
@@ -300,16 +299,16 @@ impl BlockAnalysis {
                         .unwrap_or(&[]);
                     let home_mut_borrowed = has_any_in_range(borrows, i + 1, lu);
                     if !home_redefined && !home_mut_borrowed {
-                        coalesce_to_local.insert(vid, local);
+                        coalesce_to_local.insert(value_id, *home_idx);
                     }
                 }
             }
         }
 
-        // Xfer slot precoloring.
+        // Transfer slot precoloring.
         //
-        // Establishes the seven Xfer invariants documented in the file
-        // header. See `assert_xfer_invariants` for the debug-build
+        // Establishes the seven Transfer invariants documented in the file
+        // header. See `assert_transfer_invariants` for the debug-build
         // checks that verify them post-precoloring.
         //
         // Three-walk flow:
@@ -317,69 +316,69 @@ impl BlockAnalysis {
         //     collision checks downstream).
         //   - Rets walk visits each call's rets in order. Each ret's
         //     decision folds in two cascade rules:
-        //       * return Xfer prefix: once a ret resolves to Home, all
+        //       * return Transfer prefix: once a ret resolves to Home, all
         //         later rets in this call's list cascade to Home too.
-        //       * return monotonicity: a candidate `Xfer(i)` is accepted
-        //         only if `i` strictly exceeds the previous Xfer index
+        //       * return monotonicity: a candidate `Transfer(i)` is accepted
+        //         only if `i` strictly exceeds the previous Transfer index
         //         in this list; non-strict candidates cascade to Home.
         //     A separate per-ret collision check (lifetime overlap vs.
         //     the next call's args claim) covers the cross-call
         //     same-slot case that return monotonicity alone cannot see.
         //   - Args walk fills in remaining args-side precolors for
-        //     Vids not handled by the rets walk (params, locals,
+        //     ValueIds not handled by the rets walk (params, locals,
         //     computed values).
 
-        // `Vid` -> `Xfer(j)` for the call arg/ret that this Vid will be
-        // bound to. Every value is a `Slot::Xfer(_)`; absence means the
-        // Vid is not Xfer-eligible and will get a Home slot.
-        let mut xfer_precolor: UnorderedMap<Slot, Slot> = UnorderedMap::new();
-        let mut max_xfer_positions: u16 = 0;
+        // `ValueId` -> Transfer position `j` for the call arg/ret that this
+        // ValueId will be bound to; absence means the ValueId is not
+        // Transfer-eligible and will get a Home slot.
+        let mut transfer_precolor: UnorderedMap<SsaSlot, TransferPosition> = UnorderedMap::new();
+        let mut max_transfer_positions: u16 = 0;
 
-        let args_walk_eligible = |vid: &Slot, call_pos: usize| -> bool {
-            if !vid.is_vid() {
+        let args_walk_eligible = |value_id: &SsaSlot, call_pos: usize| -> bool {
+            if !value_id.is_value_id() {
                 return false;
             }
-            if stloc_targets.contains_key(vid) || coalesce_to_local.contains_key(vid) {
+            if stloc_targets.contains_key(value_id) || coalesce_to_local.contains_key(value_id) {
                 return false;
             }
-            let Some(&dp) = def_pos.get(vid) else {
+            let Some(&dp) = def_pos.get(value_id) else {
                 return false;
             };
-            // Live range crosses an earlier call — xfer slot would be clobbered.
+            // Live range crosses an earlier call — transfer slot would be clobbered.
             if has_any_in_range(&call_positions, dp + 1, call_pos) {
                 return false;
             }
-            // Vid must end its life at this call (used as one of its args).
-            live_end.get(vid) == Some(&call_pos)
+            // ValueId must end its life at this call (used as one of its args).
+            live_end.get(value_id) == Some(&call_pos)
         };
 
-        let rets_walk_eligible = |vid: &Slot, call_pos: usize, next_call: usize| -> bool {
-            if !vid.is_vid() {
+        let rets_walk_eligible = |value_id: &SsaSlot, call_pos: usize, next_call: usize| -> bool {
+            if !value_id.is_value_id() {
                 return false;
             }
-            // Caller passes ret Vids of `call_pos`; SSA single-def then
+            // Caller passes ret ValueIds of `call_pos`; SSA single-def then
             // implies they're absent from `coalesce_to_local` and have
             // entries in both `def_pos` and `live_end`. Make those
             // implicit preconditions load-bearing so a future SSA
             // regression trips here instead of producing wrong precolors.
             debug_assert!(
-                !coalesce_to_local.contains_key(vid),
-                "ret Vid {:?} is in coalesce_to_local, violates SSA single-def",
-                vid
+                !coalesce_to_local.contains_key(value_id),
+                "ret ValueId {:?} is in coalesce_to_local, violates SSA single-def",
+                value_id
             );
             debug_assert!(
-                live_end.contains_key(vid),
-                "ret Vid {:?} missing from live_end",
-                vid
+                live_end.contains_key(value_id),
+                "ret ValueId {:?} missing from live_end",
+                value_id
             );
-            if stloc_targets.contains_key(vid) {
+            if stloc_targets.contains_key(value_id) {
                 return false;
             }
             // Dead-on-arrival rets must go to Home.
-            if live_end.get(vid) == Some(&call_pos) {
+            if live_end.get(value_id) == Some(&call_pos) {
                 return false;
             }
-            if let Some(&lu) = live_end.get(vid)
+            if let Some(&lu) = live_end.get(value_id)
                 && lu >= next_call
             {
                 return false;
@@ -398,10 +397,10 @@ impl BlockAnalysis {
                 continue;
             };
             let call_width = std::cmp::max(args.len(), rets.len()) as u16;
-            max_xfer_positions = max_xfer_positions.max(call_width);
+            max_transfer_positions = max_transfer_positions.max(call_width);
             let mut bits = SmallBitVec::from_elem(args.len(), false);
-            for (j, vid) in args.iter().enumerate() {
-                if args_walk_eligible(vid, call_pos) {
+            for (j, value_id) in args.iter().enumerate() {
+                if args_walk_eligible(value_id, call_pos) {
                     bits.set(j, true);
                 }
             }
@@ -410,12 +409,12 @@ impl BlockAnalysis {
 
         // Rets walk — per-call rets visit.
         //
-        // `handled_rets` records every ret Vid we visit. The args
-        // walk uses this to skip Vids that are rets of a prev call:
-        // cascaded rets are *not* in `xfer_precolor` after the rets
+        // `handled_rets` records every ret ValueId we visit. The args
+        // walk uses this to skip ValueIds that are rets of a prev call:
+        // cascaded rets are *not* in `transfer_precolor` after the rets
         // walk, but the args walk must still skip them (else it would
         // re-insert an args-side precolor and undo the cascade).
-        let mut handled_rets: UnorderedSet<Slot> = UnorderedSet::new();
+        let mut handled_rets: UnorderedSet<SsaSlot> = UnorderedSet::new();
         for (call_idx, &call_pos) in call_positions.iter().enumerate() {
             let Some((rets, _)) = direct_call_rets_and_args(&instrs[call_pos]) else {
                 continue;
@@ -427,53 +426,53 @@ impl BlockAnalysis {
             let next_args_claim = args_claim.get(call_idx + 1);
 
             let mut found_home = false;
-            // Tracks the highest Xfer index inserted so far in this
+            // Tracks the highest Transfer index inserted so far in this
             // call's rets list. Anchors the return-monotonicity
             // cascade: subsequent rets must take strictly larger
             // indices, else they cascade to Home.
-            let mut last_xfer_index: i32 = -1;
-            for (k, &vid) in rets.iter().enumerate() {
-                handled_rets.insert(vid);
-                if found_home || !vid.is_vid() {
+            let mut last_transfer_index: i32 = -1;
+            for (k, &value_id) in rets.iter().enumerate() {
+                handled_rets.insert(value_id);
+                if found_home || !value_id.is_value_id() {
                     continue;
                 }
                 let k = k as u16;
 
-                // Decide vid's slot. Three cases, in priority order:
-                // (a) Pass-through: vid is also at next call's args[j],
-                //     args-walk-eligible there. Land at Xfer(j) and let
+                // Decide value_id's slot. Three cases, in priority order:
+                // (a) Pass-through: value_id is also at next call's args[j],
+                //     args-walk-eligible there. Land at Transfer(j) and let
                 //     args walk skip it via `handled_rets`.
-                // (b) Rets-walk precolor at Xfer(k), unless next call's
+                // (b) Rets-walk precolor at Transfer(k), unless next call's
                 //     args[k] would claim the same slot AND lifetimes
                 //     overlap. Slot reuse is fine when the next-call
-                //     arg's def_pos > vid's live_end.
+                //     arg's def_pos > value_id's live_end.
                 // (c) Otherwise Home, which trips the cascade flag.
                 //
                 // `bit(next_args_claim, j)` is the cached
                 // `args_walk_eligible(next_args[j], next_call_pos)`
                 // result from the prep walk; no need to recompute
                 // the predicate here.
-                let target: Option<Slot> = if let Some(args) = next_args
-                    && let Some(j) = args.iter().position(|a| *a == vid)
+                let target: Option<TransferPosition> = if let Some(args) = next_args
+                    && let Some(j) = args.iter().position(|a| *a == value_id)
                     && bit(next_args_claim, j)
                 {
-                    Some(Slot::Xfer(j as u16))
-                } else if rets_walk_eligible(&vid, call_pos, next_call) {
+                    Some(TransferPosition(j as u16))
+                } else if rets_walk_eligible(&value_id, call_pos, next_call) {
                     let collides = bit(next_args_claim, k as usize)
-                        && next_arg_lifetime_overlaps(vid, k, next_args, &def_pos, &live_end);
-                    (!collides).then_some(Slot::Xfer(k))
+                        && next_arg_lifetime_overlaps(value_id, k, next_args, &def_pos, &live_end);
+                    (!collides).then_some(TransferPosition(k))
                 } else {
                     None
                 };
 
-                // Enforce return monotonicity: accept Xfer(i) only if
-                // i > last_xfer_index. Non-strict candidates cascade
+                // Enforce return monotonicity: accept Transfer(i) only if
+                // i > last_transfer_index. Non-strict candidates cascade
                 // to Home.
-                if let Some(Slot::Xfer(i)) = target
-                    && (i as i32) > last_xfer_index
+                if let Some(i) = target
+                    && (i.0 as i32) > last_transfer_index
                 {
-                    xfer_precolor.insert(vid, Slot::Xfer(i));
-                    last_xfer_index = i as i32;
+                    transfer_precolor.insert(value_id, i);
+                    last_transfer_index = i.0 as i32;
                 } else {
                     found_home = true;
                 }
@@ -486,29 +485,35 @@ impl BlockAnalysis {
                 continue;
             };
             let claim = &args_claim[call_idx];
-            for (j, &vid) in args.iter().enumerate() {
+            for (j, &value_id) in args.iter().enumerate() {
                 if !claim
                     .get(j)
                     .expect("args_claim sized to args.len() in prep walk")
                 {
                     continue;
                 }
-                if handled_rets.contains(&vid) {
+                if handled_rets.contains(&value_id) {
                     continue;
                 }
-                xfer_precolor.insert(vid, Slot::Xfer(j as u16));
+                transfer_precolor.insert(value_id, TransferPosition(j as u16));
             }
         }
 
         #[cfg(debug_assertions)]
-        assert_xfer_invariants(instrs, &call_positions, &xfer_precolor, &def_pos, &live_end);
+        assert_transfer_invariants(
+            instrs,
+            &call_positions,
+            &transfer_precolor,
+            &def_pos,
+            &live_end,
+        );
 
         Self {
             live_end,
             stloc_targets,
             coalesce_to_local,
-            xfer_precolor,
-            max_xfer_positions,
+            transfer_precolor,
+            max_transfer_positions,
         }
     }
 }
@@ -520,7 +525,7 @@ fn bit(bv: Option<&SmallBitVec>, j: usize) -> bool {
     bv.and_then(|b| b.get(j)).unwrap_or(false)
 }
 
-/// True iff `vid`'s lifetime overlaps the lifetime of the Vid at
+/// True iff `value_id`'s lifetime overlaps the lifetime of the ValueId at
 /// `next_args[k]` (if any).
 ///
 /// `a_lu == b_def` is treated as disjoint: at a single instruction,
@@ -529,90 +534,90 @@ fn bit(bv: Option<&SmallBitVec>, j: usize) -> bool {
 ///
 /// Precondition: callers gate this with the next-call's args-claim
 /// bit, which only fires for next-args[k] satisfying
-/// `args_walk_eligible` — that means `next_args[k]` is a Vid present
-/// in `def_pos` and `live_end`. `vid` is a ret of the current call,
+/// `args_walk_eligible` — that means `next_args[k]` is a ValueId present
+/// in `def_pos` and `live_end`. `value_id` is a ret of the current call,
 /// so the same SSA invariant applies. Both lookups must hit.
 fn next_arg_lifetime_overlaps(
-    vid: Slot,
+    value_id: SsaSlot,
     k: u16,
-    next_args: Option<&[Slot]>,
-    def_pos: &UnorderedMap<Slot, usize>,
-    live_end: &UnorderedMap<Slot, usize>,
+    next_args: Option<&[SsaSlot]>,
+    def_pos: &UnorderedMap<SsaSlot, usize>,
+    live_end: &UnorderedMap<SsaSlot, usize>,
 ) -> bool {
     let Some(other) = next_args.and_then(|a| a.get(k as usize).copied()) else {
         return false;
     };
     let a_def = *def_pos
-        .get(&vid)
-        .expect("Vid in xfer_precolor missing from def_pos");
+        .get(&value_id)
+        .expect("ValueId in transfer_precolor missing from def_pos");
     let a_lu = *live_end
-        .get(&vid)
-        .expect("Vid in xfer_precolor missing from live_end");
+        .get(&value_id)
+        .expect("ValueId in transfer_precolor missing from live_end");
     let b_def = *def_pos
         .get(&other)
-        .expect("next-call arg-walk-eligible Vid missing from def_pos");
+        .expect("next-call arg-walk-eligible ValueId missing from def_pos");
     let b_lu = *live_end
         .get(&other)
-        .expect("next-call arg-walk-eligible Vid missing from live_end");
+        .expect("next-call arg-walk-eligible ValueId missing from live_end");
     !(a_lu <= b_def || b_lu <= a_def)
 }
 
-/// Check the per-call structural Xfer invariants:
+/// Check the per-call structural Transfer invariants:
 ///
 /// - **Arg positionality** (invariant 2): if `args[j]` resolves to
-///   `Xfer(i)`, then `i == j`.
-/// - **Return Xfer prefix** (invariant 5): the rets list is a
-///   (possibly empty) Xfer-resolved prefix followed by a non-Xfer
+///   `Transfer(i)`, then `i == j`.
+/// - **Return Transfer prefix** (invariant 5): the rets list is a
+///   (possibly empty) Transfer-resolved prefix followed by a non-Transfer
 ///   suffix.
-/// - **Return monotonicity** (invariant 3): within the Xfer prefix,
-///   resolved Xfer indices strictly increase.
+/// - **Return monotonicity** (invariant 3): within the Transfer prefix,
+///   resolved Transfer indices strictly increase.
 #[cfg(debug_assertions)]
-fn check_call_structural_invariants<F>(
-    args: &[Slot],
-    rets: &[Slot],
-    xfer_pos: F,
-) -> Result<(), XferVerifierError>
+fn check_call_structural_invariants<SlotForm, F>(
+    args: &[SlotForm],
+    rets: &[SlotForm],
+    transfer_pos: F,
+) -> Result<(), TransferVerifierError>
 where
-    F: Fn(&Slot) -> Option<u16>,
+    F: Fn(&SlotForm) -> Option<u16>,
 {
     for (j, slot) in args.iter().enumerate() {
-        if let Some(i) = xfer_pos(slot)
+        if let Some(i) = transfer_pos(slot)
             && i as usize != j
         {
-            return Err(XferVerifierError::XferArgPositionality { arg_idx: j, got: i });
+            return Err(TransferVerifierError::TransferArgPositionality { arg_idx: j, got: i });
         }
     }
 
-    let mut seen_non_xfer = false;
-    let mut last_xfer: Option<u16> = None;
+    let mut seen_non_transfer = false;
+    let mut last_transfer: Option<u16> = None;
     for (k, slot) in rets.iter().enumerate() {
-        match xfer_pos(slot) {
+        match transfer_pos(slot) {
             Some(i) => {
-                if seen_non_xfer {
-                    return Err(XferVerifierError::XferReturnPrefix { ret_idx: k, got: i });
+                if seen_non_transfer {
+                    return Err(TransferVerifierError::TransferReturnPrefix { ret_idx: k, got: i });
                 }
-                if let Some(prev) = last_xfer
+                if let Some(prev) = last_transfer
                     && i <= prev
                 {
-                    return Err(XferVerifierError::XferReturnNotMonotonic {
+                    return Err(TransferVerifierError::TransferReturnNotMonotonic {
                         ret_idx: k,
                         got: i,
                         prev,
                     });
                 }
-                last_xfer = Some(i);
+                last_transfer = Some(i);
             },
-            None => seen_non_xfer = true,
+            None => seen_non_transfer = true,
         }
     }
 
     Ok(())
 }
 
-/// Verifies the seven Xfer invariants from the file header on the
-/// just-built `xfer_precolor` map. Per-call invariants (arg
+/// Verifies the seven Transfer invariants from the file header on the
+/// just-built `transfer_precolor` map. Per-call invariants (arg
 /// positionality, return monotonicity, pass-through contiguity, return
-/// Xfer prefix, and the per-Vid lifetime checks for block-local
+/// Transfer prefix, and the per-ValueId lifetime checks for block-local
 /// lifetime, single use, not live across calls) are checked in a
 /// single forward pass over `call_positions`. A final cross-call pass
 /// checks slot-sharing — the no-overlapping-lifetimes property is
@@ -620,21 +625,21 @@ where
 /// not live across calls but checked directly to localize any upstream
 /// regression that violates it.
 #[cfg(debug_assertions)]
-fn assert_xfer_invariants(
-    instrs: &[Instr],
+fn assert_transfer_invariants(
+    instrs: &[Instr<SsaSlot>],
     call_positions: &[usize],
-    xfer_precolor: &UnorderedMap<Slot, Slot>,
-    def_pos: &UnorderedMap<Slot, usize>,
-    live_end: &UnorderedMap<Slot, usize>,
+    transfer_precolor: &UnorderedMap<SsaSlot, TransferPosition>,
+    def_pos: &UnorderedMap<SsaSlot, usize>,
+    live_end: &UnorderedMap<SsaSlot, usize>,
 ) {
-    let is_xfer = |vid: &Slot| matches!(xfer_precolor.get(vid), Some(Slot::Xfer(_)));
-    let lifetime_of = |vid: &Slot| -> (usize, usize) {
+    let is_transfer = |value_id: &SsaSlot| transfer_precolor.contains_key(value_id);
+    let lifetime_of = |value_id: &SsaSlot| -> (usize, usize) {
         let dp = *def_pos
-            .get(vid)
-            .expect("[block-local lifetime] Xfer-bound Vid missing from def_pos");
+            .get(value_id)
+            .expect("[block-local lifetime] Transfer-bound ValueId missing from def_pos");
         let lu = *live_end
-            .get(vid)
-            .expect("[block-local lifetime] Xfer-bound Vid missing from live_end");
+            .get(value_id)
+            .expect("[block-local lifetime] Transfer-bound ValueId missing from live_end");
         (dp, lu)
     };
 
@@ -648,21 +653,21 @@ fn assert_xfer_invariants(
             .copied()
             .unwrap_or(instrs.len());
 
-        // Structural invariants (arg positionality, return Xfer prefix, return
+        // Structural invariants (arg positionality, return Transfer prefix, return
         // monotonicity).
         check_call_structural_invariants(args, rets, |slot| {
-            if !slot.is_vid() {
+            if !slot.is_value_id() {
                 return None;
             }
-            match xfer_precolor.get(slot) {
-                Some(&Slot::Xfer(i)) => Some(i),
-                _ => None,
-            }
+            transfer_precolor
+                .get(slot)
+                .copied()
+                .map(|position| position.0)
         })
-        .unwrap_or_else(|e| panic!("[xfer structural invariant] {e}"));
+        .unwrap_or_else(|e| panic!("[transfer structural invariant] {e}"));
 
         // Pass-through contiguity: among args of `call_pos` defined at the
-        // immediately-preceding call and bound to Xfer, the positions form
+        // immediately-preceding call and bound to Transfer, the positions form
         // a contiguous interval. (Move's stack discipline only allows a
         // prefix of A's rets to feed B at consecutive positions of B.args
         // — see file header.)
@@ -670,7 +675,11 @@ fn assert_xfer_invariants(
             let from_prev: Vec<usize> = args
                 .iter()
                 .enumerate()
-                .filter(|(_, vid)| vid.is_vid() && def_pos.get(vid) == Some(&prev) && is_xfer(vid))
+                .filter(|(_, value_id)| {
+                    value_id.is_value_id()
+                        && def_pos.get(value_id) == Some(&prev)
+                        && is_transfer(value_id)
+                })
                 .map(|(j, _)| j)
                 .collect();
             for w in from_prev.windows(2) {
@@ -685,48 +694,48 @@ fn assert_xfer_invariants(
             }
         }
 
-        // For Xfer-bound args: def_pos and live_end exist (block-local
+        // For Transfer-bound args: def_pos and live_end exist (block-local
         // lifetime), live_end lands at this call (single use), and no
         // call sits strictly between def and live_end (not live across
         // calls).
-        for vid in args {
-            if !vid.is_vid() || !is_xfer(vid) {
+        for value_id in args {
+            if !value_id.is_value_id() || !is_transfer(value_id) {
                 continue;
             }
-            let (dp, lu) = lifetime_of(vid);
+            let (dp, lu) = lifetime_of(value_id);
             assert_eq!(
                 lu, call_pos,
-                "[single use] Xfer-bound arg Vid {:?} live_end {} != call {}",
-                vid, lu, call_pos
+                "[single use] Transfer-bound arg ValueId {:?} live_end {} != call {}",
+                value_id, lu, call_pos
             );
             assert!(
                 !has_any_in_range(call_positions, dp + 1, lu),
-                "[not live across calls] Xfer-bound arg Vid {:?} live across a call (def {}, lu {})",
-                vid,
+                "[not live across calls] Transfer-bound arg ValueId {:?} live across a call (def {}, lu {})",
+                value_id,
                 dp,
                 lu,
             );
         }
 
-        // For Xfer-bound rets: def at `call_pos` (block-local lifetime),
+        // For Transfer-bound rets: def at `call_pos` (block-local lifetime),
         // live_end strictly after `call_pos` and at or before the next call
         // (single use; block end if no next call). The strict lower bound
         // rules out dead-on-arrival rets (def == lu == call_pos, zero uses),
         // which upstream eligibility checks already reject.
-        for vid in rets {
-            if !vid.is_vid() || !is_xfer(vid) {
+        for value_id in rets {
+            if !value_id.is_value_id() || !is_transfer(value_id) {
                 continue;
             }
-            let (dp, lu) = lifetime_of(vid);
+            let (dp, lu) = lifetime_of(value_id);
             assert_eq!(
                 dp, call_pos,
-                "[block-local lifetime] Xfer-bound ret Vid {:?} def {} != call {}",
-                vid, dp, call_pos
+                "[block-local lifetime] Transfer-bound ret ValueId {:?} def {} != call {}",
+                value_id, dp, call_pos
             );
             assert!(
                 call_pos < lu && lu <= next_call,
-                "[single use] Xfer-bound ret Vid {:?} live_end {} not in (call {}, next call {}]",
-                vid,
+                "[single use] Transfer-bound ret ValueId {:?} live_end {} not in (call {}, next call {}]",
+                value_id,
                 lu,
                 call_pos,
                 next_call,
@@ -736,8 +745,8 @@ fn assert_xfer_invariants(
             // boundary, not strictly inside.
             assert!(
                 !has_any_in_range(call_positions, dp + 1, lu),
-                "[not live across calls] Xfer-bound ret Vid {:?} live across a call (def {}, lu {})",
-                vid,
+                "[not live across calls] Transfer-bound ret ValueId {:?} live across a call (def {}, lu {})",
+                value_id,
                 dp,
                 lu,
             );
@@ -745,55 +754,53 @@ fn assert_xfer_invariants(
     }
 
     // Cross-check (implied by arg positionality, return monotonicity,
-    // single use, not live across calls): no two Xfer-bound Vids
-    // with overlapping lifetimes share an Xfer slot. Cross-call reuse
+    // single use, not live across calls): no two Transfer-bound ValueIds
+    // with overlapping lifetimes share an Transfer slot. Cross-call reuse
     // with disjoint lifetimes is fine (the ld→call pattern around
-    // Xfer(0) is the canonical example).
+    // Transfer(0) is the canonical example).
     //
-    // Walks the IR rather than iterating `xfer_precolor` (UnorderedMap
-    // doesn't expose iter()): every entry in `xfer_precolor` is either
+    // Walks the IR rather than iterating `transfer_precolor` (UnorderedMap
+    // doesn't expose iter()): every entry in `transfer_precolor` is either
     // a ret or an arg of some call, so this finds them all. A
-    // pass-through Vid that appears as both ret(k) of call A and
-    // args[j] of call B is deduplicated via `seen_vids`. `BTreeMap`
-    // for `by_slot` keeps the failing-assertion error message
+    // pass-through ValueId that appears as both ret(k) of call A and
+    // args[j] of call B is deduplicated via `seen_value_ids`. `BTreeMap`
+    // for `by_position` keeps the failing-assertion error message
     // deterministic.
-    let mut by_slot: BTreeMap<Slot, Vec<Slot>> = BTreeMap::new();
-    let mut seen_vids: UnorderedSet<Slot> = UnorderedSet::new();
+    let mut by_position: BTreeMap<TransferPosition, Vec<SsaSlot>> = BTreeMap::new();
+    let mut seen_value_ids: UnorderedSet<SsaSlot> = UnorderedSet::new();
     for &call_pos in call_positions {
         let Some((rets, args)) = direct_call_rets_and_args(&instrs[call_pos]) else {
             continue;
         };
-        for vid in rets.iter().chain(args.iter()) {
-            if !seen_vids.insert(*vid) {
+        for value_id in rets.iter().chain(args.iter()) {
+            if !seen_value_ids.insert(*value_id) {
                 continue;
             }
-            if let Some(&slot) = xfer_precolor.get(vid)
-                && matches!(slot, Slot::Xfer(_))
-            {
-                by_slot.entry(slot).or_default().push(*vid);
+            if let Some(&position) = transfer_precolor.get(value_id) {
+                by_position.entry(position).or_default().push(*value_id);
             }
         }
     }
-    for (slot, vids) in by_slot {
-        for i in 0..vids.len() {
-            for j in (i + 1)..vids.len() {
-                let a = vids[i];
-                let b = vids[j];
+    for (position, value_ids) in by_position {
+        for i in 0..value_ids.len() {
+            for j in (i + 1)..value_ids.len() {
+                let a = value_ids[i];
+                let b = value_ids[j];
                 let (a_def, a_lu) = lifetime_of(&a);
                 let (b_def, b_lu) = lifetime_of(&b);
                 // `a_lu == b_def` is disjoint — within an instruction,
                 // uses read before defs write.
                 assert!(
                     a_lu <= b_def || b_lu <= a_def,
-                    "Xfer slot reuse with overlapping lifetimes: {:?} \
-                     (live [{}, {}]) and {:?} (live [{}, {}]) at {:?}",
+                    "Transfer slot reuse with overlapping lifetimes: {:?} \
+                     (live [{}, {}]) and {:?} (live [{}, {}]) at Transfer({})",
                     a,
                     a_def,
                     a_lu,
                     b,
                     b_def,
                     b_lu,
-                    slot,
+                    position.0,
                 );
             }
         }
@@ -801,12 +808,12 @@ fn assert_xfer_invariants(
 }
 
 /// Returns `(rets, args)` for `Call`. `CallClosure` is
-/// intentionally excluded: Xfer precoloring leaves closure calls alone
-/// (they still count as call boundaries via `clobbers_xfer`, just not
+/// intentionally excluded: Transfer precoloring leaves closure calls alone
+/// (they still count as call boundaries via `clobbers_transfer`, just not
 /// destructured for slot inspection). For the boundary-wide counterpart
 /// covering both variants, see `instr_utils::call_boundary_rets_and_args`.
 #[inline]
-fn direct_call_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[Slot])> {
+fn direct_call_rets_and_args(instr: &Instr<SsaSlot>) -> Option<(&[SsaSlot], &[SsaSlot])> {
     if let Instr::Call { data } = instr {
         Some((&data.rets, &data.args))
     } else {
@@ -825,85 +832,86 @@ fn has_any_in_range(sorted: &[usize], lo: usize, hi: usize) -> bool {
 }
 
 /// Verify that the post-optimize, slot-allocated IR satisfies the
-/// Xfer-slot invariants the lowering depends on.
+/// Transfer-slot invariants the lowering depends on.
 ///
 /// The seven invariants at the top of this file are established by
-/// `BlockAnalysis::analyze` on pre-allocation Vid IR but are not
+/// `BlockAnalysis::analyze` on the SSA-form IR, before slot allocation, but are not
 /// re-checked through `optimize_module`. This walk re-checks the
 /// subset that survives slot allocation:
 ///
-/// 1. Every use of `Xfer(j)` is preceded by a def in the same block.
-/// 2. At a call boundary, every bound Xfer slot is consumed by the
+/// 1. Every use of `Transfer(j)` is preceded by a def in the same block.
+/// 2. At a call boundary, every bound Transfer slot is consumed by the
 ///    call's args (orphans signal an upstream regression).
-/// 3. Calls clobber every Xfer slot; ret defs re-bind on the same
+/// 3. Calls clobber every Transfer slot; ret defs re-bind on the same
 ///    instruction.
-/// 4. No Xfer binding leaks across a block boundary.
+/// 4. No Transfer binding leaks across a block boundary.
 /// 5. Per-call structural invariants — arg positionality, return
-///    Xfer prefix, return monotonicity — via
+///    Transfer prefix, return monotonicity — via
 ///    `check_call_structural_invariants`, the same helper
-///    `assert_xfer_invariants` uses on the Vid-level maps.
+///    `assert_transfer_invariants` uses on the ValueId-level maps.
 ///
 /// Pass-through contiguity (invariant 4 in the header) is not
 /// checked here: it requires distinguishing bound positions that
 /// came from the previous call's rets from positions defined by
 /// intermediate non-call instrs, which this walk doesn't track.
 #[cfg(debug_assertions)]
-pub(crate) fn assert_xfer_invariants_on_final_ir(
+pub(crate) fn assert_transfer_invariants_on_final_ir(
     func: &crate::stackless_exec_ir::FunctionIR,
 ) -> VMResult<()> {
-    let num_xfer = func.num_xfer_positions as usize;
-    let mut bound: Vec<bool> = vec![false; num_xfer];
+    let num_transfer = func.num_transfer_positions as usize;
+    let mut bound: Vec<bool> = vec![false; num_transfer];
     for (b_idx, block) in func.blocks.iter().enumerate() {
         // Block-local lifetime: a fresh state at every block.
         bound.iter_mut().for_each(|b| *b = false);
         for (i, instr) in block.instrs.iter().enumerate() {
-            // (1) every Xfer value use must be live.
+            // (1) every Transfer value use must be live.
             let mut unbound: Option<u16> = None;
             for_each_value_use(instr, |s| {
-                if let Slot::Xfer(j) = s
-                    && !bound[j as usize]
+                if let NamedSlot::Transfer(j) = s
+                    && !bound[j.0 as usize]
                     && unbound.is_none()
                 {
-                    unbound = Some(j);
+                    unbound = Some(j.0);
                 }
             });
             if let Some(j) = unbound {
                 return Err(VMInternalError::new(
-                    XferVerifierError::XferUseWithoutLiveDef {
+                    TransferVerifierError::TransferUseWithoutLiveDef {
                         block: b_idx,
                         instr: i,
-                        xfer: j,
+                        transfer: j,
                     },
                 ));
             }
 
-            // (2) at a call boundary, every bound Xfer slot must
-            // be consumed by this call's args as args[j] = Xfer(j)
+            // (2) at a call boundary, every bound Transfer slot must
+            // be consumed by this call's args as args[j] = Transfer(j)
             // (arg positionality).
             if let Some((rets, args)) = call_boundary_rets_and_args(instr) {
-                // Structural invariants (arg positionality, return Xfer prefix,
+                // Structural invariants (arg positionality, return Transfer prefix,
                 // return monotonicity).
                 check_call_structural_invariants(args, rets, |s| match s {
-                    Slot::Xfer(i) => Some(*i),
-                    _ => None,
+                    NamedSlot::Transfer(i) => Some(i.0),
+                    NamedSlot::Home(_) => None,
                 })
-                .map_err(|e| XferVerifierError::XferCallStructural {
+                .map_err(|e| TransferVerifierError::TransferCallStructural {
                     block: b_idx,
                     instr: i,
                     inner: Box::new(e),
                 })?;
                 // Orphan check: every bound slot must be consumed
                 // by this call's args. A bound position not in args
-                // signals a dead Xfer def from earlier in the block.
+                // signals a dead Transfer def from earlier in the block.
                 for (j, &b) in bound.iter().enumerate() {
                     if b {
-                        let consumed_here = j < args.len() && args[j] == Slot::Xfer(j as u16);
+                        let consumed_here = j < args.len()
+                            && args[j] == NamedSlot::Transfer(TransferPosition(j as u16));
                         if !consumed_here {
                             return Err(VMInternalError::new(
-                                XferVerifierError::XferBoundNotConsumed {
+                                TransferVerifierError::TransferBoundNotConsumed {
                                     block: b_idx,
                                     instr: i,
-                                    xfer: j as u16,
+                                    transfer: j as u16,
                                 },
                             ));
                         }
@@ -916,27 +924,27 @@ pub(crate) fn assert_xfer_invariants_on_final_ir(
             } else {
                 // Non-call: value uses release their bindings (single-use).
                 for_each_value_use(instr, |s| {
-                    if let Slot::Xfer(j) = s {
-                        bound[j as usize] = false;
+                    if let NamedSlot::Transfer(j) = s {
+                        bound[j.0 as usize] = false;
                     }
                 });
             }
-            // Defs bind: ret-Xfers for calls, Move/Copy dst (etc.)
+            // Defs bind: ret-Transfers for calls, Move/Copy dst (etc.)
             // for non-calls.
             for_each_def(instr, |s| {
-                if let Slot::Xfer(j) = s {
-                    bound[j as usize] = true;
+                if let NamedSlot::Transfer(j) = s {
+                    bound[j.0 as usize] = true;
                 }
             });
         }
 
-        // (3) no Xfer binding may survive past the end of a block.
+        // (3) no Transfer binding may survive past the end of a block.
         for (j, &b) in bound.iter().enumerate() {
             if b {
                 return Err(VMInternalError::new(
-                    XferVerifierError::XferBoundAtBlockEnd {
+                    TransferVerifierError::TransferBoundAtBlockEnd {
                         block: b_idx,
-                        xfer: j as u16,
+                        transfer: j as u16,
                     },
                 ));
             }
@@ -957,7 +965,7 @@ mod tests {
     #[test]
     fn analyze_handles_wide_call_signatures() {
         // 200 args exercises `SmallBitVec`'s heap-allocated path.
-        let args: Box<[Slot]> = (0..200).map(Slot::Vid).collect();
+        let args: Box<[SsaSlot]> = (0..200).map(SsaSlot::ValueId).collect();
         let instrs = vec![Instr::Call {
             data: Box::new(CallData {
                 rets: Box::new([]),
@@ -967,6 +975,6 @@ mod tests {
             }),
         }];
         let analysis = BlockAnalysis::analyze(&instrs);
-        assert_eq!(analysis.max_xfer_positions, 200);
+        assert_eq!(analysis.max_transfer_positions, 200);
     }
 }

--- a/third_party/move/mono-move/specializer/src/destack/mod.rs
+++ b/third_party/move/mono-move/specializer/src/destack/mod.rs
@@ -42,10 +42,10 @@ pub fn destack(module: CompiledModule, interner: &impl Interner) -> VMResult<Mod
     // over-approximating (charging for instructions that optimization removes).
     gas::instrument(&mut module_ir, interner)?;
 
-    // Debug-mode failsafe: verify xfer invariants hold after optimization.
+    // Debug-mode failsafe: verify transfer invariants hold after optimization.
     #[cfg(debug_assertions)]
     for func in module_ir.functions.iter().flatten() {
-        analysis::assert_xfer_invariants_on_final_ir(func)?;
+        analysis::assert_transfer_invariants_on_final_ir(func)?;
     }
     Ok(module_ir)
 }

--- a/third_party/move/mono-move/specializer/src/destack/optimize.rs
+++ b/third_party/move/mono-move/specializer/src/destack/optimize.rs
@@ -13,12 +13,12 @@ use crate::stackless_exec_ir::{
         for_each_def, for_each_slot, for_each_use, mut_local_borrow_target, remap_all_slots_with,
         remap_source_slots_with,
     },
-    FunctionIR, Instr, ModuleIR, Slot,
+    FunctionIR, HomeIndex, Instr, ModuleIR, NamedSlot,
 };
 use shared_dsa::{UnorderedMap, UnorderedSet};
 
 /// Optimize all functions in a module IR.
-/// Pre: slot allocation complete — no `Vid`s remain.
+/// Operates on the slot-allocated (named-slot) IR.
 pub fn optimize_module(module_ir: &mut ModuleIR) {
     for func in module_ir.functions.iter_mut().flatten() {
         eliminate_identity_moves(func);
@@ -31,7 +31,7 @@ pub fn optimize_module(module_ir: &mut ModuleIR) {
 
 /// Pass: Forward copy propagation within each basic block.
 ///
-/// Pre: allocated instruction stream (real slots).
+/// Pre: allocated instruction stream (named slots).
 /// Post: Copy/Move sources propagated to downstream uses; no instructions removed.
 ///
 /// # Correctness
@@ -71,7 +71,7 @@ fn copy_propagation(func: &mut FunctionIR) {
         // TODO(perf): `retain` scans all entries to kill by value, making each kill O(|subst|).
         // For typical small blocks this is fine, but if subst grows large, consider a
         // reverse index (value → keys) for O(1) value-based kills.
-        let mut subst: UnorderedMap<Slot, Slot> = UnorderedMap::new();
+        let mut subst: UnorderedMap<NamedSlot, NamedSlot> = UnorderedMap::new();
 
         for instr in &mut block.instrs {
             remap_source_slots_with(instr, |s| *subst.get(&s).unwrap_or(&s));
@@ -99,9 +99,9 @@ fn copy_propagation(func: &mut FunctionIR) {
 
             match instr {
                 Instr::Copy { dst, src } | Instr::Move { dst, src } => {
-                    // Xfer slot values don't survive a call boundary,
+                    // Transfer slot values don't survive a call boundary,
                     // so don't copy propagate from them.
-                    if !matches!(src, Slot::Xfer(_)) {
+                    if !matches!(src, NamedSlot::Transfer(_)) {
                         subst.insert(*dst, *src);
                     }
                 },
@@ -131,9 +131,9 @@ fn eliminate_identity_moves(func: &mut FunctionIR) {
 /// removal — their liveness cannot be determined by block-local analysis.
 fn dead_instruction_elimination(func: &mut FunctionIR) {
     // Pre-scan: identify Home slots that appear in more than one block.
-    // (Vid and Xfer slots are intra-block and never cross block boundaries.)
-    let mut slot_block: UnorderedMap<Slot, usize> = UnorderedMap::new();
-    let mut cross_block_slots: UnorderedSet<Slot> = UnorderedSet::new();
+    // (Transfer slots are intra-block and never cross block boundaries.)
+    let mut slot_block: UnorderedMap<NamedSlot, usize> = UnorderedMap::new();
+    let mut cross_block_slots: UnorderedSet<NamedSlot> = UnorderedSet::new();
     for (block_id, block) in func.blocks.iter().enumerate() {
         for instr in &block.instrs {
             for_each_slot(instr, |r| match slot_block.get(&r) {
@@ -149,7 +149,7 @@ fn dead_instruction_elimination(func: &mut FunctionIR) {
     }
 
     for block in &mut func.blocks {
-        let mut live: UnorderedSet<Slot> = UnorderedSet::new();
+        let mut live: UnorderedSet<NamedSlot> = UnorderedSet::new();
         let mut dead_indices: UnorderedSet<usize> = UnorderedSet::new();
 
         for (i, instr) in block.instrs.iter().enumerate().rev() {
@@ -202,8 +202,8 @@ fn renumber_slots(func: &mut FunctionIR) {
     let mut used = vec![false; old_num_home as usize];
     for instr in func.instrs() {
         for_each_slot(instr, |r| {
-            if let Slot::Home(i) = r {
-                used[i as usize] = true;
+            if let NamedSlot::Home(i) = r {
+                used[i.0 as usize] = true;
             }
         });
     }
@@ -230,7 +230,9 @@ fn renumber_slots(func: &mut FunctionIR) {
     for instr in func.instrs_mut() {
         let remap_ref = &remap;
         remap_all_slots_with(instr, |slot| match slot {
-            Slot::Home(i) => remap_ref[i as usize].map(Slot::Home).unwrap_or(slot),
+            NamedSlot::Home(i) => remap_ref[i.0 as usize]
+                .map(|new_idx| NamedSlot::Home(HomeIndex(new_idx)))
+                .unwrap_or(slot),
             other => other,
         });
     }

--- a/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
+++ b/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
@@ -3,13 +3,15 @@
 
 //! Greedy slot allocation.
 //!
-//! Consumes `BlockAnalysis` from `analysis` and maps SSA temp `Vid`s to
-//! real `Home`/`Xfer` slots using liveness-driven type-keyed reuse.
+//! Consumes `BlockAnalysis` from `analysis` and maps SSA `ValueId`s to
+//! `Home`/`Transfer` slots using liveness-driven type-keyed reuse.
+//! This is the pipeline's only conversion from `Instr<SsaSlot>` to
+//! `Instr<NamedSlot>`.
 
 use super::{analysis::BlockAnalysis, ssa_function::SSAFunction};
 use crate::stackless_exec_ir::{
-    instr_utils::{collect_defs_and_uses, remap_all_slots_with},
-    BasicBlock, Instr, Slot,
+    instr_utils::{collect_defs_and_uses, try_map_slots},
+    BasicBlock, HomeIndex, NamedSlot, SsaSlot,
 };
 use mono_move_core::{
     types::InternedType, ExecutionErrorKind, IntoExecutionError, VMInternalError, VMResult,
@@ -19,155 +21,200 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 enum SlotAllocError {
-    #[error("VID type not found during SSA allocation")]
-    VidTypeNotFound,
+    #[error("ValueId type not found during SSA allocation")]
+    ValueIdTypeNotFound,
 
-    #[error("vid_type called on a non-Vid slot")]
-    VidTypeOnNonVidSlot,
+    #[error("ValueId {value_id} has no binding at its use site")]
+    UnboundValueId { value_id: u16 },
 }
 
 impl IntoExecutionError for SlotAllocError {
     fn kind(&self) -> ExecutionErrorKind {
         use SlotAllocError::*;
         match self {
-            VidTypeNotFound | VidTypeOnNonVidSlot => ExecutionErrorKind::InvariantViolation,
+            ValueIdTypeNotFound | UnboundValueId { .. } => ExecutionErrorKind::InvariantViolation,
         }
     }
 }
 
 /// Output of slot allocation for a single function.
 pub(crate) struct AllocatedFunction {
-    pub blocks: Vec<BasicBlock>,
+    pub blocks: Vec<BasicBlock<NamedSlot>>,
     pub num_home_slots: u16,
-    pub num_xfer_positions: u16,
+    pub num_transfer_positions: u16,
     pub home_slot_types: Vec<InternedType>,
 }
 
-/// SSA `Vid` → real slot mapping with per-slot type tracking.
+/// SSA `ValueId` → named-slot mapping with per-slot type tracking.
 ///
 /// Backed by two dense vectors indexed by ordinal:
-///   - `real_slot_types[i]` — type of `Slot::Home(i)`.
-///   - `vid_to_real[i]` — binding of `Slot::Vid(i)` (`None` if unbound).
+///   - `home_slot_types[i]` — type of `NamedSlot::Home(i)`.
+///   - `value_id_bindings[i]` — binding of `SsaSlot::ValueId(i)` (`None` if
+///     unbound). Preallocated to the function's value-id count and never
+///     cleared: value ids are globally unique and block-local, so each
+///     index is written at most once and stale bindings are never read
+///     (debug-asserted via `block_floor`).
 ///
 /// Invariant: every Home slot has a recorded type. Enforced by
 /// [`Self::mint_fresh`] being the only slot-introduction path. Pinned-local
-/// identity (`Home(i) → Home(i)` for `i < num_pinned`) is inferred, not stored.
+/// identity (`Home(i) → Home(i)`, always with `i < num_pinned`) is inferred,
+/// not stored.
 struct SlotTable {
-    /// Pinned local count. Occupies `0..num_pinned` in `real_slot_types`.
+    /// Pinned local count. Occupies `0..num_pinned` in `home_slot_types`.
     num_pinned: u16,
     /// Type per Home slot, indexed by ordinal. Grows only via `mint_fresh`.
-    real_slot_types: Vec<InternedType>,
-    /// Binding per Vid, indexed by ordinal. Cleared per block.
-    vid_to_real: Vec<Option<Slot>>,
+    home_slot_types: Vec<InternedType>,
+    /// Binding per ValueId, indexed by ordinal.
+    value_id_bindings: Vec<Option<NamedSlot>>,
+    /// Lowest value id admissible in the current block. Value ids are
+    /// allocated monotonically across blocks, so a cross-block id — which
+    /// would otherwise silently resolve to a stale binding — trips the
+    /// debug assertions in [`Self::bind`] and [`Self::resolve`].
+    #[cfg(debug_assertions)]
+    block_floor: u16,
+    /// What `block_floor` becomes at the next block boundary: one past the
+    /// highest value id bound so far.
+    #[cfg(debug_assertions)]
+    next_block_floor: u16,
 }
 
 impl SlotTable {
-    fn new(local_types: &[InternedType]) -> Self {
+    fn new(local_types: &[InternedType], num_value_ids: usize) -> Self {
         Self {
             num_pinned: local_types.len() as u16,
-            real_slot_types: local_types.to_vec(),
-            vid_to_real: Vec::new(),
+            home_slot_types: local_types.to_vec(),
+            value_id_bindings: vec![None; num_value_ids],
+            #[cfg(debug_assertions)]
+            block_floor: 0,
+            #[cfg(debug_assertions)]
+            next_block_floor: 0,
         }
     }
 
-    /// Resets per-block state.
+    /// Marks a block boundary for the block-locality tripwire; bindings
+    /// themselves persist (see the struct doc).
     fn start_block(&mut self) {
-        self.vid_to_real.clear();
-    }
-
-    /// Mints a fresh Home slot with the given type and binds `vid` to it.
-    /// The only path that introduces a new real slot.
-    fn mint_fresh(&mut self, vid: Slot, ty: InternedType) -> Slot {
-        let real = Slot::Home(self.real_slot_types.len() as u16);
-        self.real_slot_types.push(ty);
-        self.bind(vid, real);
-        real
-    }
-
-    /// Binds `vid` to an existing real slot. No-op for non-Vid keys
-    /// (pinned identity is implicit; Xfer slots pass through).
-    fn bind(&mut self, vid: Slot, real: Slot) {
-        if let Slot::Vid(i) = vid {
-            let i = i as usize;
-            if self.vid_to_real.len() <= i {
-                self.vid_to_real.resize(i + 1, None);
-            }
-            self.vid_to_real[i] = Some(real);
+        #[cfg(debug_assertions)]
+        {
+            self.block_floor = self.next_block_floor;
         }
     }
 
-    /// Returns `(real_slot, type)` for a vid bound to a Home slot, or
-    /// `None` if unbound or bound to an Xfer slot. Returning both pieces
+    /// Mints a fresh Home slot with the given type and binds `value_id` to it.
+    /// The only path that introduces a new Home slot.
+    fn mint_fresh(&mut self, value_id: u16, ty: InternedType) -> NamedSlot {
+        let named_slot = NamedSlot::Home(HomeIndex(self.home_slot_types.len() as u16));
+        self.home_slot_types.push(ty);
+        self.bind(value_id, named_slot);
+        named_slot
+    }
+
+    /// Binds `value_id` to an existing named slot.
+    fn bind(&mut self, value_id: u16, named_slot: NamedSlot) {
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                value_id >= self.block_floor,
+                "value id {value_id} crosses a block boundary (block floor {})",
+                self.block_floor
+            );
+            self.next_block_floor = self.next_block_floor.max(value_id.saturating_add(1));
+        }
+        // An id beyond the preallocated range cannot come out of SSA
+        // conversion; leaving it unbound surfaces as `UnboundValueId`
+        // at `resolve`.
+        if let Some(binding) = self.value_id_bindings.get_mut(value_id as usize) {
+            *binding = Some(named_slot);
+        }
+    }
+
+    /// Returns `(named_slot, type)` for a value ID bound to a Home slot, or
+    /// `None` if unbound or bound to a Transfer slot. Returning both pieces
     /// atomically prevents callers from observing a slot without its type.
-    fn lookup(&self, vid: Slot) -> Option<(Slot, InternedType)> {
-        let real = self.real_of_opt(vid)?;
-        let Slot::Home(i) = real else { return None };
-        let ty = *self.real_slot_types.get(i as usize)?;
-        Some((real, ty))
+    fn lookup(&self, value_id: u16) -> Option<(NamedSlot, InternedType)> {
+        let named_slot = self.binding_of(value_id)?;
+        let NamedSlot::Home(i) = named_slot else {
+            return None;
+        };
+        let ty = *self.home_slot_types.get(i.0 as usize)?;
+        Some((named_slot, ty))
     }
 
-    /// Whether `vid` is bound (pinned identity counts).
-    fn contains(&self, vid: &Slot) -> bool {
-        self.real_of_opt(*vid).is_some()
+    /// Whether `value_id` is bound.
+    fn contains(&self, value_id: u16) -> bool {
+        self.binding_of(value_id).is_some()
     }
 
-    /// Returns the real slot for `vid`, or `vid` unchanged if unbound.
-    fn real_of(&self, vid: Slot) -> Slot {
-        self.real_of_opt(vid).unwrap_or(vid)
+    /// Resolves an SSA slot to its named slot: pinned identity for `Home`,
+    /// the recorded binding for `ValueId`. An unbound `ValueId` is a hard
+    /// error — SSA is intra-block, so every use is bound by its earlier def.
+    fn resolve(&self, slot: SsaSlot) -> VMResult<NamedSlot> {
+        match slot {
+            SsaSlot::Home(i) => {
+                debug_assert!(i.0 < self.num_pinned, "SSA Home slot beyond pinned locals");
+                Ok(NamedSlot::Home(i))
+            },
+            SsaSlot::ValueId(i) => {
+                #[cfg(debug_assertions)]
+                debug_assert!(
+                    i >= self.block_floor,
+                    "value id {i} crosses a block boundary (block floor {})",
+                    self.block_floor
+                );
+                self.binding_of(i).ok_or_else(|| {
+                    VMInternalError::new(SlotAllocError::UnboundValueId { value_id: i })
+                })
+            },
+        }
     }
 
-    /// Whether `real` is poolable — a non-pinned Home slot.
-    fn is_poolable(&self, real: Slot) -> bool {
-        matches!(real, Slot::Home(i) if i >= self.num_pinned)
+    /// Whether `named_slot` is poolable — a non-pinned Home slot.
+    fn is_poolable(&self, named_slot: NamedSlot) -> bool {
+        matches!(named_slot, NamedSlot::Home(i) if i.0 >= self.num_pinned)
     }
 
     fn next_slot(&self) -> u16 {
-        self.real_slot_types.len() as u16
+        self.home_slot_types.len() as u16
     }
 
     /// Consumes the table and returns the per-Home-slot type vector
     /// indexed by ordinal.
     fn into_home_slot_types(self) -> Vec<InternedType> {
-        self.real_slot_types
+        self.home_slot_types
     }
 
-    fn real_of_opt(&self, vid: Slot) -> Option<Slot> {
-        match vid {
-            // Pinned locals are identity-mapped without an explicit entry.
-            Slot::Home(i) if i < self.num_pinned => Some(vid),
-            Slot::Vid(i) => self.vid_to_real.get(i as usize).copied().flatten(),
-            _ => None,
-        }
+    fn binding_of(&self, value_id: u16) -> Option<NamedSlot> {
+        self.value_id_bindings
+            .get(value_id as usize)
+            .copied()
+            .flatten()
     }
 }
 
-/// Map SSA `Vid`s to real slots across all blocks.
+/// Map SSA `ValueId`s to named slots across all blocks.
 ///
-/// Consumes the SSAFunction and remaps instructions in-place.
+/// Consumes the SSAFunction and produces named-slot blocks.
 ///
-/// Pre: SSA blocks after fusion passes; vid_types maps each `Vid(i)`
-///      to its type at index `i`.
-/// Post: all `Vid`s replaced with real `Home`/`Xfer` slots.
+/// Pre: SSA blocks after fusion passes; value_id_types maps each
+///      `ValueId(i)` to its type at index `i`.
+/// Post: all `ValueId`s replaced with `Home`/`Transfer` slots
+///       (guaranteed by the output type).
 pub(crate) fn allocate_slots(ssa: SSAFunction) -> VMResult<AllocatedFunction> {
-    let mut table = SlotTable::new(&ssa.local_types);
+    let mut table = SlotTable::new(&ssa.local_types, ssa.value_id_types.len());
     let mut result_blocks = Vec::with_capacity(ssa.blocks.len());
-    let mut global_num_xfer_positions: u16 = 0;
-    let mut free_pool: UnorderedMap<InternedType, Vec<Slot>> = UnorderedMap::new();
+    let mut num_transfer_positions: u16 = 0;
+    let mut free_pool: UnorderedMap<InternedType, Vec<NamedSlot>> = UnorderedMap::new();
 
-    for mut block in ssa.blocks {
+    for block in ssa.blocks {
         let analysis = BlockAnalysis::analyze(&block.instrs);
-        let (block_xfer_positions, returned_pool) = allocate_block_in_place(
-            &mut block.instrs,
+        num_transfer_positions = num_transfer_positions.max(analysis.max_transfer_positions);
+        result_blocks.push(allocate_block(
+            block,
             &mut table,
-            free_pool,
-            &ssa.vid_types,
+            &mut free_pool,
+            &ssa.value_id_types,
             &analysis,
-        )?;
-        free_pool = returned_pool;
-        if block_xfer_positions > global_num_xfer_positions {
-            global_num_xfer_positions = block_xfer_positions;
-        }
-        result_blocks.push(block);
+        )?);
     }
 
     let num_home_slots = table.next_slot();
@@ -176,93 +223,104 @@ pub(crate) fn allocate_slots(ssa: SSAFunction) -> VMResult<AllocatedFunction> {
     Ok(AllocatedFunction {
         blocks: result_blocks,
         num_home_slots,
-        num_xfer_positions: global_num_xfer_positions,
+        num_transfer_positions,
         home_slot_types,
     })
 }
 
-fn vid_type(vid: Slot, vid_types: &[InternedType]) -> VMResult<InternedType> {
-    match vid {
-        Slot::Vid(i) => vid_types
-            .get(i as usize)
-            .copied()
-            .ok_or_else(|| VMInternalError::new(SlotAllocError::VidTypeNotFound)),
-        _ => Err(VMInternalError::new(SlotAllocError::VidTypeOnNonVidSlot)),
-    }
+fn value_id_type(value_id: u16, value_id_types: &[InternedType]) -> VMResult<InternedType> {
+    value_id_types
+        .get(value_id as usize)
+        .copied()
+        .ok_or_else(|| VMInternalError::new(SlotAllocError::ValueIdTypeNotFound))
 }
 
-/// Allocate real slots for a single basic block, remapping instructions in-place.
+/// Allocate named slots for a single basic block, consuming its SSA
+/// instructions and producing their named-slot counterparts.
 ///
-/// For each instruction, in order: free last-use sources, allocate defs, remap, free dead defs.
-/// Allocation priority: xfer_precolor > stloc_targets > coalesce_to_local > type-keyed reuse > fresh.
-///
-/// Returns (xfer width, updated free pool).
-fn allocate_block_in_place(
-    instrs: &mut [Instr],
+/// For each instruction, in order: free last-use sources, allocate defs, map
+/// to the named-slot form, free dead defs.
+/// Allocation priority: transfer_precolor > stloc_targets > coalesce_to_local
+/// > type-keyed reuse > fresh.
+fn allocate_block(
+    block: BasicBlock<SsaSlot>,
     table: &mut SlotTable,
-    carry_pool: UnorderedMap<InternedType, Vec<Slot>>,
-    vid_types: &[InternedType],
+    free_pool: &mut UnorderedMap<InternedType, Vec<NamedSlot>>,
+    value_id_types: &[InternedType],
     analysis: &BlockAnalysis,
-) -> VMResult<(u16, UnorderedMap<InternedType, Vec<Slot>>)> {
-    if instrs.is_empty() {
-        return Ok((0, carry_pool));
-    }
+) -> VMResult<BasicBlock<NamedSlot>> {
     table.start_block();
-    let mut free_pool = carry_pool;
 
-    for (i, instr) in instrs.iter_mut().enumerate() {
-        let (defs, uses) = collect_defs_and_uses(instr);
+    let instrs = block
+        .instrs
+        .into_iter()
+        .enumerate()
+        .map(|(i, instr)| {
+            let (defs, uses) = collect_defs_and_uses(&instr);
 
-        // Phase 1: Free use-slots whose last use is this instruction.
-        // Done BEFORE def allocation so the freed slot can be immediately reused.
-        // Safe because sources are read before destinations are written.
-        for r in &uses {
-            if r.is_vid()
-                && analysis.live_end.get(r) == Some(&i)
-                && !defs.contains(r)
-                && let Some((real, ty)) = table.lookup(*r)
-                && table.is_poolable(real)
-            {
-                free_pool.entry(ty).or_default().push(real);
+            // Phase 1: Free use-slots whose last use is this instruction.
+            // Done BEFORE def allocation so the freed slot can be immediately
+            // reused. Safe because sources are read before destinations are
+            // written.
+            for use_slot in &uses {
+                if let SsaSlot::ValueId(id) = use_slot
+                    && analysis.live_end.get(use_slot) == Some(&i)
+                    && !defs.contains(use_slot)
+                    && let Some((named_slot, ty)) = table.lookup(*id)
+                    && table.is_poolable(named_slot)
+                {
+                    free_pool.entry(ty).or_default().push(named_slot);
+                }
             }
-        }
 
-        // Phase 2: Allocate real slots for destination `Vid`s.
-        for d in &defs {
-            if d.is_vid() && !table.contains(d) {
-                if let Some(&xfer_r) = analysis.xfer_precolor.get(d) {
-                    table.bind(*d, xfer_r);
-                } else if let Some(&local_r) = analysis.stloc_targets.get(d) {
-                    table.bind(*d, local_r);
-                } else if let Some(&local_r) = analysis.coalesce_to_local.get(d) {
-                    table.bind(*d, local_r);
-                } else {
-                    // General case: reuse a same-typed slot from the pool, or mint a fresh one.
-                    let ty = vid_type(*d, vid_types)?;
-                    if let Some(real) = free_pool.get_mut(&ty).and_then(|slots| slots.pop()) {
-                        table.bind(*d, real);
+            // Phase 2: Allocate named slots for destination `ValueId`s.
+            for def_slot in &defs {
+                if let SsaSlot::ValueId(id) = def_slot
+                    && !table.contains(*id)
+                {
+                    if let Some(&position) = analysis.transfer_precolor.get(def_slot) {
+                        table.bind(*id, NamedSlot::Transfer(position));
+                    } else if let Some(&home_idx) = analysis.stloc_targets.get(def_slot) {
+                        table.bind(*id, NamedSlot::Home(home_idx));
+                    } else if let Some(&home_idx) = analysis.coalesce_to_local.get(def_slot) {
+                        table.bind(*id, NamedSlot::Home(home_idx));
                     } else {
-                        table.mint_fresh(*d, ty);
+                        // General case: reuse a same-typed slot from the pool,
+                        // or mint a fresh one.
+                        let ty = value_id_type(*id, value_id_types)?;
+                        if let Some(named_slot) =
+                            free_pool.get_mut(&ty).and_then(|slots| slots.pop())
+                        {
+                            table.bind(*id, named_slot);
+                        } else {
+                            table.mint_fresh(*id, ty);
+                        }
                     }
                 }
             }
-        }
 
-        // Phase 3: Rewrite the instruction with real slots — in-place.
-        remap_all_slots_with(instr, |s| table.real_of(s));
+            // Phase 3: Convert the instruction into the named-slot form.
+            let converted = try_map_slots(instr, |slot| table.resolve(slot))?;
 
-        // Phase 4: Free slots for defs that are never used (live_end == def site).
-        for d in &defs {
-            if d.is_vid()
-                && analysis.live_end.get(d) == Some(&i)
-                && !uses.contains(d)
-                && let Some((real, ty)) = table.lookup(*d)
-                && table.is_poolable(real)
-            {
-                free_pool.entry(ty).or_default().push(real);
+            // Phase 4: Free slots for defs that are never used
+            // (live_end == def site).
+            for def_slot in &defs {
+                if let SsaSlot::ValueId(id) = def_slot
+                    && analysis.live_end.get(def_slot) == Some(&i)
+                    && !uses.contains(def_slot)
+                    && let Some((named_slot, ty)) = table.lookup(*id)
+                    && table.is_poolable(named_slot)
+                {
+                    free_pool.entry(ty).or_default().push(named_slot);
+                }
             }
-        }
-    }
 
-    Ok((analysis.max_xfer_positions, free_pool))
+            Ok(converted)
+        })
+        .collect::<VMResult<Vec<_>>>()?;
+
+    Ok(BasicBlock {
+        label: block.label,
+        instrs,
+    })
 }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -9,8 +9,8 @@
 
 use super::ssa_function::SSAFunction;
 use crate::stackless_exec_ir::{
-    BasicBlock, BinaryOp, CallClosureData, CallData, CmpKind, ImmValue, Instr, Label,
-    PackClosureData, Slot, UnaryOp,
+    BasicBlock, BinaryOp, CallClosureData, CallData, CmpKind, HomeIndex, ImmValue, Instr, Label,
+    PackClosureData, SsaSlot, UnaryOp,
 };
 use mono_move_core::{
     convert_mut_to_immut_ref, strip_ref,
@@ -34,7 +34,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 enum SsaConversionError {
     // TODO(security): consider verifying this at publish time?
-    #[error("too many SSA values (Vid u16 overflow)")]
+    #[error("too many SSA values (ValueId u16 overflow)")]
     TooManySsaValues,
 
     #[error("verified bytecode must end with a terminator")]
@@ -43,11 +43,11 @@ enum SsaConversionError {
     #[error("operand stack underflow")]
     StackUnderflow,
 
-    #[error("Vid id {vid} out of range")]
-    VidOutOfRange { vid: u16 },
+    #[error("ValueId {value_id} out of range")]
+    ValueIdOutOfRange { value_id: u16 },
 
-    #[error("expected a Vid slot on the operand stack")]
-    ExpectedVidOnStack,
+    #[error("expected a ValueId slot on the operand stack")]
+    ExpectedValueIdOnStack,
 
     #[error("operand stack must be empty at a block boundary")]
     StackNotEmptyAtBlockBoundary,
@@ -78,8 +78,8 @@ impl IntoExecutionError for SsaConversionError {
             TooManySsaValues => ExecutionErrorKind::RuntimeLimitExceeded,
             MissingTerminator
             | StackUnderflow
-            | VidOutOfRange { .. }
-            | ExpectedVidOnStack
+            | ValueIdOutOfRange { .. }
+            | ExpectedValueIdOnStack
             | StackNotEmptyAtBlockBoundary
             | ExpectedStructType
             | ExpectedEnumType
@@ -135,19 +135,19 @@ fn split_bytecode_into_blocks(
 
 pub(crate) struct SsaConverter<'a, I: Interner> {
     /// Next value ID number (0-based, monotonically increasing across blocks).
-    next_vid: u16,
+    next_value_id: u16,
     /// Simulated operand stack.
-    stack: Vec<Slot>,
+    stack: Vec<SsaSlot>,
     /// Types of all locals (params ++ declared locals).
     local_types: Vec<InternedType>,
     /// Types of value IDs, indexed directly by value ID number.
-    vid_types: Vec<InternedType>,
+    value_id_types: Vec<InternedType>,
     /// Interner for composite type construction.
     interner: &'a I,
     /// Completed basic blocks.
-    blocks: Vec<BasicBlock>,
+    blocks: Vec<BasicBlock<SsaSlot>>,
     /// Instructions for the current block being built.
-    current_block_instrs: Vec<Instr>,
+    current_block_instrs: Vec<Instr<SsaSlot>>,
     /// Label for the current block being built. `None` before the first block starts.
     current_block_label: Option<Label>,
     /// Map from bytecode offset to label
@@ -159,10 +159,10 @@ pub(crate) struct SsaConverter<'a, I: Interner> {
 impl<'a, I: Interner> SsaConverter<'a, I> {
     pub(crate) fn new(local_types: Vec<InternedType>, interner: &'a I) -> Self {
         Self {
-            next_vid: 0,
+            next_value_id: 0,
             stack: Vec::new(),
             local_types,
-            vid_types: Vec::new(),
+            value_id_types: Vec::new(),
             interner,
             blocks: Vec::new(),
             current_block_instrs: Vec::new(),
@@ -172,28 +172,31 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
         }
     }
 
-    fn alloc_vid(&mut self, ty: InternedType) -> VMResult<Slot> {
-        let vid = Slot::Vid(self.next_vid);
-        self.next_vid = self
-            .next_vid
+    fn alloc_value_id(&mut self, ty: InternedType) -> VMResult<SsaSlot> {
+        let value_id = SsaSlot::ValueId(self.next_value_id);
+        self.next_value_id = self
+            .next_value_id
             .checked_add(1)
             .ok_or(SsaConversionError::TooManySsaValues)?;
-        self.vid_types.push(ty);
-        Ok(vid)
+        self.value_id_types.push(ty);
+        Ok(value_id)
     }
 
-    fn push_slot(&mut self, r: Slot) {
-        debug_assert!(r.is_vid(), "only Vid slots belong on the operand stack");
+    fn push_slot(&mut self, r: SsaSlot) {
+        debug_assert!(
+            r.is_value_id(),
+            "only ValueId slots belong on the operand stack"
+        );
         self.stack.push(r);
     }
 
-    fn pop_slot(&mut self) -> VMResult<Slot> {
+    fn pop_slot(&mut self) -> VMResult<SsaSlot> {
         self.stack
             .pop()
             .ok_or_else(|| VMInternalError::new(SsaConversionError::StackUnderflow))
     }
 
-    fn pop_n_reverse(&mut self, n: usize) -> VMResult<Box<[Slot]>> {
+    fn pop_n_reverse(&mut self, n: usize) -> VMResult<Box<[SsaSlot]>> {
         if self.stack.len() < n {
             return Err(VMInternalError::new(SsaConversionError::StackUnderflow));
         }
@@ -203,7 +206,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
     /// Freeze a result-slot list, push each result onto the simulated stack,
     /// and return the frozen list for the emitted instruction's operand.
-    fn push_results(&mut self, results: Vec<Slot>) -> Box<[Slot]> {
+    fn push_results(&mut self, results: Vec<SsaSlot>) -> Box<[SsaSlot]> {
         let results = results.into_boxed_slice();
         for &slot in &results {
             self.push_slot(slot);
@@ -211,19 +214,21 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
         results
     }
 
-    /// Returns the type of a Vid slot by looking it up in `vid_types`.
-    /// Invariant: only Vid slots appear on the operand stack.
-    fn vid_type(&self, slot: Slot) -> VMResult<InternedType> {
+    /// Returns the type of a ValueId slot by looking it up in `value_id_types`.
+    /// Invariant: only ValueId slots appear on the operand stack.
+    fn value_id_type(&self, slot: SsaSlot) -> VMResult<InternedType> {
         match slot {
-            Slot::Vid(id) => {
-                self.vid_types.get(id as usize).copied().ok_or_else(|| {
-                    VMInternalError::new(SsaConversionError::VidOutOfRange { vid: id })
-                })
+            SsaSlot::ValueId(id) => {
+                self.value_id_types
+                    .get(id as usize)
+                    .copied()
+                    .ok_or_else(|| {
+                        VMInternalError::new(SsaConversionError::ValueIdOutOfRange { value_id: id })
+                    })
             },
-            other => {
-                let _ = other;
-                Err(VMInternalError::new(SsaConversionError::ExpectedVidOnStack))
-            },
+            SsaSlot::Home(_) => Err(VMInternalError::new(
+                SsaConversionError::ExpectedValueIdOnStack,
+            )),
         }
     }
 
@@ -396,7 +401,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
         Ok(SSAFunction {
             blocks: self.blocks,
-            vid_types: self.vid_types,
+            value_id_types: self.value_id_types,
             local_types: self.local_types,
         })
     }
@@ -427,7 +432,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::LdFalse => self.convert_load(ty::BOOL_TY, ImmValue::Bool(false))?,
             B::LdConst(idx) => {
                 let ty = module.interned_constant_type_at(*idx);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::LdConst {
                     dst,
                     const_idx: *idx,
@@ -437,22 +442,22 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
             // --- Locals ---
             B::CopyLoc(idx) => {
-                let src = Slot::Home(*idx as u16);
+                let src = SsaSlot::Home(HomeIndex(*idx as u16));
                 let ty = self.local_types[*idx as usize];
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::Copy { dst, src });
                 self.push_slot(dst);
             },
             B::MoveLoc(idx) => {
-                let src = Slot::Home(*idx as u16);
+                let src = SsaSlot::Home(HomeIndex(*idx as u16));
                 let ty = self.local_types[*idx as usize];
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::Move { dst, src });
                 self.push_slot(dst);
             },
             B::StLoc(idx) => {
                 let src = self.pop_slot()?;
-                let dst = Slot::Home(*idx as u16);
+                let dst = SsaSlot::Home(HomeIndex(*idx as u16));
                 self.current_block_instrs.push(Instr::Move { dst, src });
             },
 
@@ -498,7 +503,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::Not => self.convert_unop(UnaryOp::Not, ty::BOOL_TY)?,
             // --- Unary ops (result type derived from operand) ---
             B::Negate => {
-                let src_ty = self.vid_type(
+                let src_ty = self.value_id_type(
                     *self
                         .stack
                         .last()
@@ -507,7 +512,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 self.convert_unop(UnaryOp::Negate, src_ty)?;
             },
             B::FreezeRef => {
-                let src_ty = self.vid_type(
+                let src_ty = self.value_id_type(
                     *self
                         .stack
                         .last()
@@ -524,7 +529,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let n = struct_field_count(module, *idx);
                 let srcs = self.pop_n_reverse(n)?;
                 let struct_ty = module.interned_nominal_def_type_at(*idx);
-                let dst = self.alloc_vid(struct_ty)?;
+                let dst = self.alloc_value_id(struct_ty)?;
                 self.current_block_instrs.push(Instr::Pack {
                     dst,
                     struct_ty,
@@ -537,7 +542,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let n = struct_field_count(module, inst.def);
                 let srcs = self.pop_n_reverse(n)?;
                 let struct_ty = self.struct_inst_ty(module, *idx)?;
-                let dst = self.alloc_vid(struct_ty)?;
+                let dst = self.alloc_value_id(struct_ty)?;
                 self.current_block_instrs.push(Instr::Pack {
                     dst,
                     struct_ty,
@@ -552,7 +557,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     .ok_or(SsaConversionError::ExpectedStructType)?;
                 let mut dsts = Vec::with_capacity(ftypes.len());
                 for &fty in ftypes {
-                    dsts.push(self.alloc_vid(fty)?);
+                    dsts.push(self.alloc_value_id(fty)?);
                 }
                 let dsts = self.push_results(dsts);
                 let struct_ty = module.interned_nominal_def_type_at(*idx);
@@ -575,7 +580,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let mut dsts = Vec::with_capacity(fields.len());
                 for &fty in fields {
                     let fty = self.interner.subst_type(fty, ty_args)?;
-                    dsts.push(self.alloc_vid(fty)?);
+                    dsts.push(self.alloc_value_id(fty)?);
                 }
                 let dsts = self.push_results(dsts);
                 self.current_block_instrs.push(Instr::Unpack {
@@ -592,7 +597,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let n = variant_field_count(module, handle.struct_index, variant);
                 let srcs = self.pop_n_reverse(n)?;
                 let enum_ty = module.interned_nominal_def_type_at(handle.struct_index);
-                let dst = self.alloc_vid(enum_ty)?;
+                let dst = self.alloc_value_id(enum_ty)?;
                 self.current_block_instrs.push(Instr::PackVariant {
                     dst,
                     enum_ty,
@@ -608,7 +613,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let n = variant_field_count(module, handle.struct_index, variant);
                 let srcs = self.pop_n_reverse(n)?;
                 let (enum_ty, variant_ord, _) = self.variant_inst_parts(module, *idx)?;
-                let dst = self.alloc_vid(enum_ty)?;
+                let dst = self.alloc_value_id(enum_ty)?;
                 self.current_block_instrs.push(Instr::PackVariant {
                     dst,
                     enum_ty,
@@ -626,7 +631,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     .ok_or(SsaConversionError::ExpectedEnumType)?;
                 let mut dsts = Vec::with_capacity(ftypes.len());
                 for &fty in ftypes {
-                    dsts.push(self.alloc_vid(fty)?);
+                    dsts.push(self.alloc_value_id(fty)?);
                 }
                 let dsts = self.push_results(dsts);
                 let enum_ty = module.interned_nominal_def_type_at(handle.struct_index);
@@ -649,7 +654,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let mut dsts = Vec::with_capacity(fields.len());
                 for &fty in fields {
                     let fty = self.interner.subst_type(fty, ty_args)?;
-                    dsts.push(self.alloc_vid(fty)?);
+                    dsts.push(self.alloc_value_id(fty)?);
                 }
                 let dsts = self.push_results(dsts);
                 self.current_block_instrs.push(Instr::UnpackVariant {
@@ -664,7 +669,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let handle = &module.struct_variant_handles[idx.0 as usize];
                 let variant = handle.variant;
                 let enum_ty = module.interned_nominal_def_type_at(handle.struct_index);
-                let dst = self.alloc_vid(ty::BOOL_TY)?;
+                let dst = self.alloc_value_id(ty::BOOL_TY)?;
                 self.current_block_instrs.push(Instr::TestVariant {
                     dst,
                     enum_ty,
@@ -676,7 +681,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::TestVariantGeneric(idx) => {
                 let src = self.pop_slot()?;
                 let (enum_ty, variant, _) = self.variant_inst_parts(module, *idx)?;
-                let dst = self.alloc_vid(ty::BOOL_TY)?;
+                let dst = self.alloc_value_id(ty::BOOL_TY)?;
                 self.current_block_instrs.push(Instr::TestVariant {
                     dst,
                     enum_ty,
@@ -688,19 +693,19 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
             // --- References ---
             B::ImmBorrowLoc(idx) => {
-                let local = Slot::Home(*idx as u16);
+                let local = SsaSlot::Home(HomeIndex(*idx as u16));
                 let inner = self.local_types[*idx as usize];
                 let ty = self.interner.immut_ref_of(inner);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs
                     .push(Instr::ImmBorrowLoc { dst, local });
                 self.push_slot(dst);
             },
             B::MutBorrowLoc(idx) => {
-                let local = Slot::Home(*idx as u16);
+                let local = SsaSlot::Home(HomeIndex(*idx as u16));
                 let inner = self.local_types[*idx as usize];
                 let ty = self.interner.mut_ref_of(inner);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs
                     .push(Instr::MutBorrowLoc { dst, local });
                 self.push_slot(dst);
@@ -711,7 +716,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let owner_ty = module.interned_nominal_def_type_at(owner_idx);
                 let fty = module.interned_field_type_at(*idx);
                 let ty = self.interner.immut_ref_of(fty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::ImmBorrowField {
                     dst,
                     owner_ty,
@@ -726,7 +731,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let owner_ty = module.interned_nominal_def_type_at(owner_idx);
                 let fty = module.interned_field_type_at(*idx);
                 let ty = self.interner.mut_ref_of(fty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::MutBorrowField {
                     dst,
                     owner_ty,
@@ -739,7 +744,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let src = self.pop_slot()?;
                 let (field, owner_ty, fty) = self.field_inst_parts(module, *idx)?;
                 let ty = self.interner.immut_ref_of(fty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::ImmBorrowField {
                     dst,
                     owner_ty,
@@ -752,7 +757,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let src = self.pop_slot()?;
                 let (field, owner_ty, fty) = self.field_inst_parts(module, *idx)?;
                 let ty = self.interner.mut_ref_of(fty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::MutBorrowField {
                     dst,
                     owner_ty,
@@ -767,7 +772,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let owner_ty = module.interned_nominal_def_type_at(owner_idx);
                 let fty = module.interned_variant_field_type_at(*idx);
                 let ty = self.interner.immut_ref_of(fty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs
                     .push(Instr::ImmBorrowVariantField {
                         dst,
@@ -783,7 +788,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let owner_ty = module.interned_nominal_def_type_at(owner_idx);
                 let fty = module.interned_variant_field_type_at(*idx);
                 let ty = self.interner.mut_ref_of(fty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs
                     .push(Instr::MutBorrowVariantField {
                         dst,
@@ -797,7 +802,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let src = self.pop_slot()?;
                 let (field, owner_ty, fty) = self.variant_field_inst_parts(module, *idx)?;
                 let ty = self.interner.immut_ref_of(fty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs
                     .push(Instr::ImmBorrowVariantField {
                         dst,
@@ -811,7 +816,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let src = self.pop_slot()?;
                 let (field, owner_ty, fty) = self.variant_field_inst_parts(module, *idx)?;
                 let ty = self.interner.mut_ref_of(fty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs
                     .push(Instr::MutBorrowVariantField {
                         dst,
@@ -823,10 +828,10 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             },
             B::ReadRef => {
                 let src = self.pop_slot()?;
-                let src_ty = self.vid_type(src)?;
+                let src_ty = self.value_id_type(src)?;
                 // The bytecode verifier guarantees the operand is `&T` or `&mut T`.
                 let ty = strip_ref(src_ty).ok_or(SsaConversionError::ExpectedReferenceType)?;
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::ReadRef { dst, src });
                 self.push_slot(dst);
             },
@@ -841,7 +846,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::Exists(idx) => {
                 let addr = self.pop_slot()?;
                 let resource_ty = module.interned_nominal_def_type_at(*idx);
-                let dst = self.alloc_vid(ty::BOOL_TY)?;
+                let dst = self.alloc_value_id(ty::BOOL_TY)?;
                 self.current_block_instrs.push(Instr::Exists {
                     dst,
                     resource_ty,
@@ -852,7 +857,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::ExistsGeneric(idx) => {
                 let addr = self.pop_slot()?;
                 let resource_ty = self.struct_inst_ty(module, *idx)?;
-                let dst = self.alloc_vid(ty::BOOL_TY)?;
+                let dst = self.alloc_value_id(ty::BOOL_TY)?;
                 self.current_block_instrs.push(Instr::Exists {
                     dst,
                     resource_ty,
@@ -863,7 +868,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::MoveFrom(idx) => {
                 let addr = self.pop_slot()?;
                 let resource_ty = module.interned_nominal_def_type_at(*idx);
-                let dst = self.alloc_vid(resource_ty)?;
+                let dst = self.alloc_value_id(resource_ty)?;
                 self.current_block_instrs.push(Instr::MoveFrom {
                     dst,
                     resource_ty,
@@ -874,7 +879,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::MoveFromGeneric(idx) => {
                 let addr = self.pop_slot()?;
                 let resource_ty = self.struct_inst_ty(module, *idx)?;
-                let dst = self.alloc_vid(resource_ty)?;
+                let dst = self.alloc_value_id(resource_ty)?;
                 self.current_block_instrs.push(Instr::MoveFrom {
                     dst,
                     resource_ty,
@@ -906,7 +911,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let addr = self.pop_slot()?;
                 let resource_ty = module.interned_nominal_def_type_at(*idx);
                 let ty = self.interner.immut_ref_of(resource_ty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::ImmBorrowGlobal {
                     dst,
                     resource_ty,
@@ -918,7 +923,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let addr = self.pop_slot()?;
                 let resource_ty = self.struct_inst_ty(module, *idx)?;
                 let ty = self.interner.immut_ref_of(resource_ty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::ImmBorrowGlobal {
                     dst,
                     resource_ty,
@@ -930,7 +935,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let addr = self.pop_slot()?;
                 let resource_ty = module.interned_nominal_def_type_at(*idx);
                 let ty = self.interner.mut_ref_of(resource_ty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::MutBorrowGlobal {
                     dst,
                     resource_ty,
@@ -942,7 +947,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let addr = self.pop_slot()?;
                 let resource_ty = self.struct_inst_ty(module, *idx)?;
                 let ty = self.interner.mut_ref_of(resource_ty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::MutBorrowGlobal {
                     dst,
                     resource_ty,
@@ -960,7 +965,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let args = self.pop_n_reverse(num_args)?;
                 let mut rets = Vec::with_capacity(ret_types.len());
                 for &rty in ret_types {
-                    rets.push(self.alloc_vid(rty)?);
+                    rets.push(self.alloc_value_id(rty)?);
                 }
                 let rets = self.push_results(rets);
                 self.current_block_instrs.push(Instr::Call {
@@ -982,7 +987,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let mut rets = Vec::with_capacity(ret_types.len());
                 for &rty in ret_types {
                     let rty = self.interner.subst_type(rty, ty_args)?;
-                    rets.push(self.alloc_vid(rty)?);
+                    rets.push(self.alloc_value_id(rty)?);
                 }
                 let rets = self.push_results(rets);
                 self.current_block_instrs.push(Instr::Call {
@@ -1011,7 +1016,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     returns,
                     move_core_types::ability::AbilitySet::EMPTY,
                 );
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::PackClosure {
                     data: Box::new(PackClosureData {
                         dst,
@@ -1042,7 +1047,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     returns,
                     move_core_types::ability::AbilitySet::EMPTY,
                 );
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::PackClosure {
                     data: Box::new(PackClosureData {
                         dst,
@@ -1074,7 +1079,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let all_args = self.pop_n_reverse(num_args + 1)?;
                 let mut rets = Vec::with_capacity(ret_types.len());
                 for &rty in ret_types {
-                    rets.push(self.alloc_vid(rty)?);
+                    rets.push(self.alloc_value_id(rty)?);
                 }
                 let rets = self.push_results(rets);
                 self.current_block_instrs.push(Instr::CallClosure {
@@ -1089,7 +1094,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let srcs = self.pop_n_reverse(count as usize)?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let ty = self.interner.vector_of(elem_ty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs
                     .push(Instr::VecPack { dst, elem_ty, srcs });
                 self.push_slot(dst);
@@ -1097,7 +1102,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::VecLen(sig_idx) => {
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
-                let dst = self.alloc_vid(ty::U64_TY)?;
+                let dst = self.alloc_value_id(ty::U64_TY)?;
                 self.current_block_instrs.push(Instr::VecLen {
                     dst,
                     elem_ty,
@@ -1110,7 +1115,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let ty = self.interner.immut_ref_of(elem_ty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::VecImmBorrow {
                     dst,
                     elem_ty,
@@ -1124,7 +1129,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let ty = self.interner.mut_ref_of(elem_ty);
-                let dst = self.alloc_vid(ty)?;
+                let dst = self.alloc_value_id(ty)?;
                 self.current_block_instrs.push(Instr::VecMutBorrow {
                     dst,
                     elem_ty,
@@ -1146,7 +1151,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::VecPopBack(sig_idx) => {
                 let vec_ref = self.pop_slot()?;
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
-                let dst = self.alloc_vid(elem_ty)?;
+                let dst = self.alloc_value_id(elem_ty)?;
                 self.current_block_instrs.push(Instr::VecPopBack {
                     dst,
                     elem_ty,
@@ -1161,7 +1166,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let elem_ty = module.interned_types_at(*sig_idx)[0];
                 let mut dsts = Vec::with_capacity(count as usize);
                 for _ in 0..count {
-                    dsts.push(self.alloc_vid(elem_ty)?);
+                    dsts.push(self.alloc_value_id(elem_ty)?);
                 }
                 let dsts = self.push_results(dsts);
                 self.current_block_instrs
@@ -1198,7 +1203,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                     .push(Instr::BrFalse { target, cond });
             },
             B::Ret => {
-                let srcs: Box<[Slot]> = self.stack.drain(..).collect();
+                let srcs: Box<[SsaSlot]> = self.stack.drain(..).collect();
                 self.current_block_instrs.push(Instr::Ret { srcs });
             },
             B::Abort => {
@@ -1218,7 +1223,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
     }
 
     fn convert_load(&mut self, result_ty: InternedType, imm: ImmValue) -> VMResult<()> {
-        let dst = self.alloc_vid(result_ty)?;
+        let dst = self.alloc_value_id(result_ty)?;
         self.current_block_instrs.push(Instr::LdImm { dst, imm });
         self.push_slot(dst);
         Ok(())
@@ -1230,9 +1235,9 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
         let result_ty = if result_is_bool {
             ty::BOOL_TY
         } else {
-            self.vid_type(lhs)?
+            self.value_id_type(lhs)?
         };
-        let dst = self.alloc_vid(result_ty)?;
+        let dst = self.alloc_value_id(result_ty)?;
         self.current_block_instrs
             .push(Instr::BinaryOp { dst, op, lhs, rhs });
         self.push_slot(dst);
@@ -1241,7 +1246,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
     fn convert_unop(&mut self, op: UnaryOp, result_ty: InternedType) -> VMResult<()> {
         let src = self.pop_slot()?;
-        let dst = self.alloc_vid(result_ty)?;
+        let dst = self.alloc_value_id(result_ty)?;
         self.current_block_instrs
             .push(Instr::UnaryOp { dst, op, src });
         self.push_slot(dst);

--- a/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
@@ -10,7 +10,7 @@
 
 use crate::stackless_exec_ir::{
     instr_utils::{for_each_value_use, is_commutative},
-    BasicBlock, BinaryOp, FieldPath, Instr, Slot,
+    BasicBlock, BinaryOp, FieldPath, Instr, SsaSlot,
 };
 use mono_move_core::types::InternedType;
 use shared_dsa::UnorderedMap;
@@ -18,9 +18,9 @@ use shared_dsa::UnorderedMap;
 /// Intermediate SSA representation of a single function, before slot allocation.
 pub(crate) struct SSAFunction {
     /// Basic blocks in SSA form.
-    pub blocks: Vec<BasicBlock>,
+    pub blocks: Vec<BasicBlock<SsaSlot>>,
     /// Type of each value ID, indexed directly by the value ID number.
-    pub vid_types: Vec<InternedType>,
+    pub value_id_types: Vec<InternedType>,
     /// Types of all locals (params ++ declared locals).
     pub local_types: Vec<InternedType>,
 }
@@ -53,7 +53,10 @@ impl SSAFunction {
 /// For each position, calls `try_fuse(&instrs[r], &instrs[r+1])`. If it returns
 /// `Some(fused)`, the pair is replaced by the single fused instruction. Otherwise
 /// the instruction is kept as-is. Uses a write-cursor so no allocation is needed.
-fn fuse_pairs(instrs: &mut Vec<Instr>, try_fuse: fn(&Instr, &Instr) -> Option<Instr>) {
+fn fuse_pairs(
+    instrs: &mut Vec<Instr<SsaSlot>>,
+    try_fuse: fn(&Instr<SsaSlot>, &Instr<SsaSlot>) -> Option<Instr<SsaSlot>>,
+) {
     let mut write = 0;
     let mut read = 0;
     while read < instrs.len() {
@@ -79,7 +82,10 @@ fn fuse_pairs(instrs: &mut Vec<Instr>, try_fuse: fn(&Instr, &Instr) -> Option<In
 }
 
 /// Try to fuse a borrow+deref pair into a combined field access instruction.
-fn try_fuse_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
+fn try_fuse_field_access(
+    first: &Instr<SsaSlot>,
+    second: &Instr<SsaSlot>,
+) -> Option<Instr<SsaSlot>> {
     match (first, second) {
         (
             Instr::ImmBorrowField {
@@ -149,7 +155,10 @@ fn try_fuse_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
 
 /// Try to fuse a `borrow_loc` followed by a field op on its result into a
 /// single local-field op, eliding the intermediate fat pointer.
-fn try_fuse_local_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
+fn try_fuse_local_field_access(
+    first: &Instr<SsaSlot>,
+    second: &Instr<SsaSlot>,
+) -> Option<Instr<SsaSlot>> {
     match (first, second) {
         (
             Instr::ImmBorrowLoc { dst: ref_r, local },
@@ -214,7 +223,10 @@ fn try_fuse_local_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
 /// Try to fuse a comparison + conditional branch pair into a single `BrCmp`/`BrCmpImm`.
 ///
 /// Handles both `BrTrue` (keeps the comparison operator) and `BrFalse` (negates it).
-fn try_fuse_compare_branch(first: &Instr, second: &Instr) -> Option<Instr> {
+fn try_fuse_compare_branch(
+    first: &Instr<SsaSlot>,
+    second: &Instr<SsaSlot>,
+) -> Option<Instr<SsaSlot>> {
     match (first, second) {
         (
             Instr::BinaryOp {
@@ -279,29 +291,29 @@ fn try_fuse_compare_branch(first: &Instr, second: &Instr) -> Option<Instr> {
 /// Where a fused field chain is rooted.
 enum ChainRoot {
     /// A by-value inline-struct local (the `*BorrowLoc` is absorbed).
-    Local(Slot),
+    Local(SsaSlot),
     /// A reference (any non-chain ref value).
-    Ref(Slot),
+    Ref(SsaSlot),
 }
 
 /// How a chain ends.
 enum ChainTerminal {
     /// `ReadRef` of the deepest reference — a by-value field read. `dst` is
     /// the `ReadRef`'s destination, receiving the field's bytes.
-    Read { dst: Slot },
+    Read { dst: SsaSlot },
     /// `WriteRef` through the deepest reference — a field write. `val` is the
     /// `WriteRef`'s value operand, whose bytes are stored into the field.
-    Write { val: Slot },
+    Write { val: SsaSlot },
     /// The deepest reference escapes (returned, passed, frozen, ...) — a
     /// borrow. `dst` is that reference itself, which the fused instruction
     /// takes over defining; its consumers stay unchanged.
-    Borrow { dst: Slot },
+    Borrow { dst: SsaSlot },
 }
 
 /// A fused chain and how it rewrites the instruction stream.
 struct FusedChain {
     /// The fused instruction.
-    instr: Instr,
+    instr: Instr<SsaSlot>,
     /// The single position that survives the rewrite: `instr` overwrites the
     /// original instruction here (the terminal read/write, or the last borrow
     /// for a borrow chain); every other absorbed position is deleted.
@@ -329,7 +341,7 @@ const MIN_CHAIN_DEPTH: usize = 2;
 /// that terminal is sound because a reference is an address compute
 /// (`base + offset`), not a value snapshot, and Move forbids modifying the root
 /// while it stays borrowed. Depth-1 runs are left to the pairwise passes.
-fn fuse_field_chains(instrs: &mut Vec<Instr>) {
+fn fuse_field_chains(instrs: &mut Vec<Instr<SsaSlot>>) {
     // Every fusable chain contains at least `MIN_CHAIN_DEPTH` struct field
     // borrows; skip the analysis allocations for blocks that cannot hold one
     // (the common case).
@@ -353,7 +365,7 @@ fn fuse_field_chains(instrs: &mut Vec<Instr>) {
     // the compaction loop below: `placed[pos]` replaces the instruction at
     // `pos` with the fused one, `removed[pos]` deletes it. `placed` stays
     // empty when nothing fuses.
-    let mut placed: Vec<Option<Instr>> = Vec::new();
+    let mut placed: Vec<Option<Instr<SsaSlot>>> = Vec::new();
     let mut removed: Vec<bool> = Vec::new();
 
     let mut start = 0;
@@ -405,14 +417,14 @@ fn fuse_field_chains(instrs: &mut Vec<Instr>) {
     instrs.truncate(write);
 }
 
-/// For each `Vid`, the `(use count, last consumer position)` pair. A reference
-/// `Vid` is linkable into a chain only when its use count is exactly 1, in which
+/// For each `ValueId`, the `(use count, last consumer position)` pair. A reference
+/// `ValueId` is linkable into a chain only when its use count is exactly 1, in which
 /// case the recorded position is that sole consumer's.
-fn value_use_info(instrs: &[Instr]) -> UnorderedMap<Slot, (u32, usize)> {
-    let mut info: UnorderedMap<Slot, (u32, usize)> = UnorderedMap::new();
+fn value_use_info(instrs: &[Instr<SsaSlot>]) -> UnorderedMap<SsaSlot, (u32, usize)> {
+    let mut info: UnorderedMap<SsaSlot, (u32, usize)> = UnorderedMap::new();
     for (pos, instr) in instrs.iter().enumerate() {
         for_each_value_use(instr, |slot| {
-            if slot.is_vid() {
+            if slot.is_value_id() {
                 let entry = info.entry(slot).or_insert((0, pos));
                 entry.0 += 1;
                 entry.1 = pos;
@@ -424,11 +436,12 @@ fn value_use_info(instrs: &[Instr]) -> UnorderedMap<Slot, (u32, usize)> {
 
 /// Try to build a fused field chain rooted at `instrs[start]`.
 fn try_build_chain(
-    instrs: &[Instr],
+    instrs: &[Instr<SsaSlot>],
     start: usize,
-    use_info: &UnorderedMap<Slot, (u32, usize)>,
+    use_info: &UnorderedMap<SsaSlot, (u32, usize)>,
 ) -> Option<FusedChain> {
-    let linkable = |slot: Slot| slot.is_vid() && matches!(use_info.get(&slot), Some(&(1, _)));
+    let linkable =
+        |slot: SsaSlot| slot.is_value_id() && matches!(use_info.get(&slot), Some(&(1, _)));
 
     // Identify the head: the root, the reference the next struct field-borrow
     // must consume, the next index, and the path so far. The borrow kind (`Imm`
@@ -506,7 +519,7 @@ fn try_build_chain(
     // escapes (returned, passed, frozen, used more than once) and ends a borrow.
     // Field borrows are pure address computes (no abort), so the terminal may
     // sink past intervening instructions freely.
-    let sole_use_pos = if cur_ref.is_vid() {
+    let sole_use_pos = if cur_ref.is_value_id() {
         use_info
             .get(&cur_ref)
             .and_then(|&(count, pos)| (count == 1).then_some(pos))
@@ -545,7 +558,7 @@ fn build_chain_instr(
     is_mut: bool,
     path: FieldPath,
     terminal: ChainTerminal,
-) -> Instr {
+) -> Instr<SsaSlot> {
     match root {
         ChainRoot::Local(local) => match terminal {
             ChainTerminal::Read { dst } => Instr::ReadLocFieldChain { dst, path, local },
@@ -571,7 +584,10 @@ fn build_chain_instr(
 }
 
 /// Try to fuse a `LdImm` + `BinaryOp` pair into a `BinaryOpImm` instruction.
-fn try_fuse_immediate_binop(first: &Instr, second: &Instr) -> Option<Instr> {
+fn try_fuse_immediate_binop(
+    first: &Instr<SsaSlot>,
+    second: &Instr<SsaSlot>,
+) -> Option<Instr<SsaSlot>> {
     match (first, second) {
         (Instr::LdImm { dst: tmp, imm }, Instr::BinaryOp { dst, op, lhs, rhs }) if *tmp == *rhs => {
             Some(Instr::BinaryOpImm {

--- a/third_party/move/mono-move/specializer/src/destack/test_utils.rs
+++ b/third_party/move/mono-move/specializer/src/destack/test_utils.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Maps certain calls to VM intrinsics (special instructions). This runs before
-//! slot allocation so the original call does not clobber xfer slots or cause
+//! slot allocation so the original call does not clobber transfer slots or cause
 //! other side effects.
 
 use super::ssa_function::SSAFunction;

--- a/third_party/move/mono-move/specializer/src/destack/translate.rs
+++ b/third_party/move/mono-move/specializer/src/destack/translate.rs
@@ -64,7 +64,7 @@ pub fn translate_module(module: PreparedModule, interner: &impl Interner) -> VMR
                 .with_fusion_passes()
                 .with_test_utils_passes(&module)?;
 
-            // Pass: Greedy Slot Allocation (consumes SSA, remaps in-place)
+            // Pass: Greedy Slot Allocation (consumes SSA, produces named-slot IR)
             let alloc = super::slot_alloc::allocate_slots(ssa)?;
 
             Ok(Some(FunctionIR {
@@ -73,7 +73,7 @@ pub fn translate_module(module: PreparedModule, interner: &impl Interner) -> VMR
                 num_params,
                 num_locals,
                 num_home_slots: alloc.num_home_slots,
-                num_xfer_positions: alloc.num_xfer_positions,
+                num_transfer_positions: alloc.num_transfer_positions,
                 blocks: alloc.blocks,
                 home_slot_types: alloc.home_slot_types,
                 // Populated by the gas instrumentation pass.

--- a/third_party/move/mono-move/specializer/src/gas.rs
+++ b/third_party/move/mono-move/specializer/src/gas.rs
@@ -26,8 +26,8 @@
 use crate::{
     lower::context::concrete_type_size,
     stackless_exec_ir::{
-        instr_utils::{clobbers_xfer, for_each_value_use},
-        BasicBlock, Instr, ModuleIR, Slot,
+        instr_utils::{clobbers_transfer, for_each_value_use},
+        BasicBlock, Instr, ModuleIR, NamedSlot,
     },
 };
 use mono_move_core::{
@@ -44,14 +44,11 @@ enum GasInstrumentationError {
     #[error("expected a reference type")]
     ExpectedReferenceType,
 
-    #[error("Xfer({xfer}) read without a prior call-return binding")]
-    XferReadWithoutBinding { xfer: u16 },
+    #[error("Transfer({transfer}) read without a prior call-return binding")]
+    TransferReadWithoutBinding { transfer: u16 },
 
     #[error("empty field chain")]
     EmptyFieldChain,
-
-    #[error("Vid slot in post-allocation IR")]
-    VidInPostAllocationIr,
 
     #[error("field owner is not a struct type")]
     FieldOwnerNotStruct,
@@ -77,9 +74,8 @@ impl IntoExecutionError for GasInstrumentationError {
         use GasInstrumentationError::*;
         match self {
             ExpectedReferenceType
-            | XferReadWithoutBinding { .. }
+            | TransferReadWithoutBinding { .. }
             | EmptyFieldChain
-            | VidInPostAllocationIr
             | FieldOwnerNotStruct
             | VariantOwnerNotEnum
             | EnumDefinitionNotFound
@@ -183,7 +179,7 @@ pub(crate) fn instrument<I: Interner>(module_ir: &mut ModuleIR, interner: &I) ->
             module,
             interner,
             home_slot_types: &func.home_slot_types,
-            xfer_ret_types: vec![None; func.num_xfer_positions as usize],
+            transfer_ret_types: vec![None; func.num_transfer_positions as usize],
         };
         // Indexed by block label (dense `0..blocks.len()`).
         let mut costs = vec![BlockCost::zero(); func.blocks.len()];
@@ -195,35 +191,34 @@ pub(crate) fn instrument<I: Interner>(module_ir: &mut ModuleIR, interner: &I) ->
     Ok(())
 }
 
-/// Builds cost formulas by walking the IR. Xfer slots carry no type in the IR,
+/// Builds cost formulas by walking the IR. Transfer slots carry no type in the IR,
 /// so the emitter tracks the type flowing through each one.
 struct Emitter<'a, I: Interner> {
     module: &'a PreparedModule,
     interner: &'a I,
     /// Type of each Home slot, indexed by Home slot id.
     home_slot_types: &'a [InternedType],
-    /// Type bound to each Xfer position by the most recent call's returns.
+    /// Type bound to each Transfer position by the most recent call's returns.
     /// Block-local: reset per block and clobbered by every call.
-    xfer_ret_types: Vec<Option<InternedType>>,
+    transfer_ret_types: Vec<Option<InternedType>>,
 }
 
 impl<I: Interner> Emitter<'_, I> {
-    /// Type of the value in `slot`. An Xfer slot read here always holds a prior
+    /// Type of the value in `slot`. A Transfer slot read here always holds a prior
     /// call's return (call arguments are costed from the callee signature).
-    fn slot_ty(&self, slot: Slot) -> VMResult<InternedType> {
+    fn slot_ty(&self, slot: NamedSlot) -> VMResult<InternedType> {
         match slot {
-            Slot::Home(i) => Ok(self.home_slot_types[i as usize]),
-            Slot::Xfer(j) => self.xfer_ret_types[j as usize].ok_or_else(|| {
-                VMInternalError::new(GasInstrumentationError::XferReadWithoutBinding { xfer: j })
+            NamedSlot::Home(i) => Ok(self.home_slot_types[i.0 as usize]),
+            NamedSlot::Transfer(j) => self.transfer_ret_types[j.0 as usize].ok_or_else(|| {
+                VMInternalError::new(GasInstrumentationError::TransferReadWithoutBinding {
+                    transfer: j.0,
+                })
             }),
-            Slot::Vid(_) => Err(VMInternalError::new(
-                GasInstrumentationError::VidInPostAllocationIr,
-            )),
         }
     }
 
     /// Pointee type of a reference slot (`ReadRef`/`WriteRef` touch the pointee).
-    fn pointee_ty(&self, ref_slot: Slot) -> VMResult<InternedType> {
+    fn pointee_ty(&self, ref_slot: NamedSlot) -> VMResult<InternedType> {
         strip_ref(self.slot_ty(ref_slot)?)
             .ok_or_else(|| VMInternalError::new(GasInstrumentationError::ExpectedReferenceType))
     }
@@ -279,33 +274,33 @@ impl<I: Interner> Emitter<'_, I> {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    /// Cost of the formula for one block, resetting Xfer tracking at its start.
-    fn block_cost(&mut self, block: &BasicBlock) -> VMResult<BlockCost> {
-        // Xfer slots are block-local.
-        self.xfer_ret_types.fill(None);
+    /// Cost of the formula for one block, resetting Transfer tracking at its start.
+    fn block_cost(&mut self, block: &BasicBlock<NamedSlot>) -> VMResult<BlockCost> {
+        // Transfer slots are block-local.
+        self.transfer_ret_types.fill(None);
         let mut b = BlockCost::zero();
         for instr in &block.instrs {
             self.instr_cost(&mut b, instr)?;
-            self.advance_xfer_tracking(instr);
+            self.advance_transfer_tracking(instr);
         }
         Ok(b)
     }
 
-    /// After costing `instr`, drop the Xfer slots it consumed. Calls manage
+    /// After costing `instr`, drop the Transfer slots it consumed. Calls manage
     /// their own return bindings in [`Self::call_cost`].
-    fn advance_xfer_tracking(&mut self, instr: &Instr) {
-        if clobbers_xfer(instr) {
+    fn advance_transfer_tracking(&mut self, instr: &Instr<NamedSlot>) {
+        if clobbers_transfer(instr) {
             return;
         }
         for_each_value_use(instr, |s| {
-            if let Slot::Xfer(j) = s {
-                self.xfer_ret_types[j as usize] = None;
+            if let NamedSlot::Transfer(j) = s {
+                self.transfer_ret_types[j.0 as usize] = None;
             }
         });
     }
 
     /// Emit the cost of `instr` into `b`.
-    fn instr_cost(&mut self, b: &mut BlockCost, instr: &Instr) -> VMResult<()> {
+    fn instr_cost(&mut self, b: &mut BlockCost, instr: &Instr<NamedSlot>) -> VMResult<()> {
         match instr {
             // --- Loads ---
             Instr::LdConst { .. } | Instr::LdImm { .. } => b.add_constant(LD),
@@ -474,12 +469,12 @@ impl<I: Interner> Emitter<'_, I> {
     }
 
     /// Dispatch, a move per argument (sized from the callee signature), and a
-    /// move per Home-slot return. Also binds the call's Xfer returns.
+    /// move per Home-slot return. Also binds the call's Transfer returns.
     fn call_cost(
         &mut self,
         b: &mut BlockCost,
         param_types: InternedTypeList,
-        ret_slots: &[Slot],
+        ret_slots: &[NamedSlot],
         ret_types: InternedTypeList,
     ) -> VMResult<()> {
         b.add_constant(CALL);
@@ -488,16 +483,11 @@ impl<I: Interner> Emitter<'_, I> {
         }
         for ret in ret_slots {
             match *ret {
-                Slot::Xfer(_) => {
+                NamedSlot::Transfer(_) => {
                     // Placed without a copy.
                 },
-                Slot::Home(i) => {
-                    b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.home_slot_types[i as usize])
-                },
-                Slot::Vid(_) => {
-                    return Err(VMInternalError::new(
-                        GasInstrumentationError::VidInPostAllocationIr,
-                    ))
+                NamedSlot::Home(i) => {
+                    b.add_sized(MOVE_BASE, MOVE_PER_BYTE, self.home_slot_types[i.0 as usize])
                 },
             }
         }
@@ -505,20 +495,20 @@ impl<I: Interner> Emitter<'_, I> {
         Ok(())
     }
 
-    /// Clobber all Xfer slots, then bind each Xfer return to its callee type.
+    /// Clobber all Transfer slots, then bind each Transfer return to its callee type.
     fn bind_call_returns(
         &mut self,
-        ret_slots: &[Slot],
+        ret_slots: &[NamedSlot],
         ret_types: InternedTypeList,
     ) -> VMResult<()> {
-        self.xfer_ret_types.fill(None);
+        self.transfer_ret_types.fill(None);
         let ret_types = view_type_list(ret_types);
         for (k, ret) in ret_slots.iter().enumerate() {
-            if let Slot::Xfer(j) = *ret {
+            if let NamedSlot::Transfer(j) = *ret {
                 let ty = *ret_types
                     .get(k)
                     .ok_or(GasInstrumentationError::CallReturnNoSignatureType { ret_idx: k })?;
-                self.xfer_ret_types[j as usize] = Some(ty);
+                self.transfer_ret_types[j.0 as usize] = Some(ty);
             }
         }
         Ok(())

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -314,7 +314,7 @@ pub struct LoweringContext<'a> {
     /// Where `Instr::Ret` writes before the `Return` micro-op. Laid out
     /// from offset 0 so addresses match the caller's `ret_slots`.
     pub return_slots: Vec<SizedSlot>,
-    pub num_xfer_positions: u16,
+    pub num_transfer_positions: u16,
     /// TODO(cleanup): we should consider unifying the various scratch slots below,
     /// even though they are used for different purposes, only one is ever
     /// live at a time, and they have the same GC invariant.
@@ -751,7 +751,7 @@ pub fn try_build_context<'a>(
         frame_data_size,
         call_sites,
         return_slots,
-        num_xfer_positions: func_ir.num_xfer_positions,
+        num_transfer_positions: func_ir.num_transfer_positions,
         scratch,
         resource_box_slot,
         enum_ptr_scratch,
@@ -1326,10 +1326,10 @@ fn try_build_inline_value_layout(
 /// Invariant behind first-owner-only chain discovery: each later `path` owner
 /// must be the previous hop's field type, so the transitive walk of the first
 /// owner reaches every later one. Trivially true for non-chain instructions.
-fn chain_path_is_inline_contained(
+fn chain_path_is_inline_contained<SlotForm>(
     interner: &impl Interner,
     module: &PreparedModule,
-    instr: &Instr,
+    instr: &Instr<SlotForm>,
 ) -> bool {
     let Some(path) = chain_field_path(instr) else {
         return true;

--- a/third_party/move/mono-move/specializer/src/lower/mod.rs
+++ b/third_party/move/mono-move/specializer/src/lower/mod.rs
@@ -27,8 +27,8 @@ enum LoweringError {
     ClosureSignatureNotFunction,
 
     // ---- post-allocation IR sanity ----
-    #[error("Vid slot in post-allocation IR")]
-    VidInPostAllocationIr,
+    #[error("Transfer({transfer}) read without a prior def in this block")]
+    TransferReadWithoutDef { transfer: u16 },
 
     #[error("scratch slot required when emitting 2+ parallel copies")]
     ScratchSlotRequiredForParallelCopy,
@@ -179,9 +179,6 @@ enum LoweringError {
 
     #[error("field chain offset overflow")]
     FieldChainOffsetOverflow,
-
-    #[error("Xfer({xfer}) read without a prior def in this block")]
-    XferReadWithoutDef { xfer: u16 },
 }
 
 impl IntoExecutionError for LoweringError {
@@ -191,7 +188,7 @@ impl IntoExecutionError for LoweringError {
             NativeAbi(e) => e.kind(),
             ExpectedReferenceType
             | ClosureSignatureNotFunction
-            | VidInPostAllocationIr
+            | TransferReadWithoutDef { .. }
             | ScratchSlotRequiredForParallelCopy
             | LayoutNotPopulated
             | TypeParamReachedGcLayout
@@ -233,8 +230,7 @@ impl IntoExecutionError for LoweringError {
             | VariantOrdinalOutOfRange { .. }
             | EnumPtrScratchMissing { .. }
             | EmptyFieldChain
-            | FieldChainOffsetOverflow
-            | XferReadWithoutDef { .. } => ExecutionErrorKind::InvariantViolation,
+            | FieldChainOffsetOverflow => ExecutionErrorKind::InvariantViolation,
         }
     }
 }

--- a/third_party/move/mono-move/specializer/src/lower/parallel_copy.rs
+++ b/third_party/move/mono-move/specializer/src/lower/parallel_copy.rs
@@ -17,7 +17,7 @@
 //! `lower_call`'s arg-setup path inlines reverse-order emission directly
 //! and uses [`reverse_emit_is_safe`] as a debug assertion. Soundness
 //! rests on arg positionality + return monotonicity (see
-//! `BlockAnalysis::analyze`): pass-through Xfer args land at
+//! `BlockAnalysis::analyze`): pass-through Transfer args land at
 //! `arg_offset(j) ≥ ret_offset(k_j)` everywhere, so the dependency graph
 //! is forward-only. Home args' sources live in the home region (offsets
 //! `< frame_data_size`), disjoint from the arg region. No cycles, so no

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -15,8 +15,8 @@ use super::{
 use crate::{
     gas::{self, CostResolver},
     stackless_exec_ir::{
-        instr_utils::{clobbers_xfer, for_each_value_use, is_fallthrough_terminator},
-        BinaryOp, FunctionIR, ImmValue, Instr, Label, Slot, UnaryOp,
+        instr_utils::{clobbers_transfer, for_each_value_use, is_fallthrough_terminator},
+        BinaryOp, FunctionIR, ImmValue, Instr, Label, NamedSlot, TransferPosition, UnaryOp,
     },
 };
 use mono_move_core::{
@@ -68,23 +68,23 @@ pub(super) fn lower_function(
 ) -> VMResult<LoweredFunction> {
     let mut state = LoweringState::new(func_ir, ctx);
     for (block_idx, block) in func_ir.blocks.iter().enumerate() {
-        // Xfer slots are block-local.
+        // Transfer slots are block-local.
         debug_assert!(
-            state.xfer_bindings.iter().all(Option::is_none),
-            "xfer_bindings not fully cleared at block boundary",
+            state.transfer_bindings.iter().all(Option::is_none),
+            "transfer_bindings not fully cleared at block boundary",
         );
         debug_assert!(
             state.pending_def_binds.is_empty(),
             "pending_def_binds not committed at block boundary",
         );
-        state.xfer_bindings.fill(None);
+        state.transfer_bindings.fill(None);
         state.label_map[block.label.0 as usize] = Some(state.out_buf.len() as u32);
         // Resolve this block's cost formula to concrete gas for this instantiation.
         state.block_costs[block.label.0 as usize] =
             state.resolve_block_cost(&func_ir.block_costs[block.label.0 as usize])?;
         for instr in &block.instrs {
             state.lower_instr(func_ir, instr)?;
-            state.commit_xfer_bindings_after(instr);
+            state.commit_transfer_bindings_after(instr);
         }
         // Record a conditional branch's fallthrough block (the next in emission
         // order) on its fixup, so `fixup_branches` can write that block's cost
@@ -156,14 +156,14 @@ struct LoweringState<'a> {
     /// Types of the function IR's home (frame-resident) slots with the
     /// instantiation's type arguments substituted, indexed by Home slot id.
     home_slot_types: &'a [InternedType],
-    /// `Some(TypedSlot)` while `Slot::Xfer(j)` holds a fully-written
+    /// `Some(TypedSlot)` while `NamedSlot::Transfer(j)` holds a fully-written
     /// live value visible to the GC; `None` otherwise. Length
-    /// `ctx.num_xfer_positions`.
-    xfer_bindings: Vec<Option<TypedSlot>>,
-    /// Xfer bindings staged by the current IR instruction's defs and
-    /// committed by `commit_xfer_bindings_after`. Each tuple is
-    /// `(j, typed_slot)`: the Xfer position `j` and the value bound there.
-    pending_def_binds: Vec<(u16, TypedSlot)>,
+    /// `ctx.num_transfer_positions`.
+    transfer_bindings: Vec<Option<TypedSlot>>,
+    /// Transfer bindings staged by the current IR instruction's defs and
+    /// committed by `commit_transfer_bindings_after`. Each tuple is
+    /// `(j, typed_slot)`: the Transfer position `j` and the value bound there.
+    pending_def_binds: Vec<(TransferPosition, TypedSlot)>,
     /// Safe-point entries in code-offset order. Populated by `emit`
     /// when `op.is_allocating()`.
     pending_safe_points: Vec<SafePointEntry>,
@@ -181,7 +181,7 @@ impl gas::CostResolver for LoweringState<'_> {
 
 impl<'a> LoweringState<'a> {
     fn new(func_ir: &'a FunctionIR, ctx: &'a LoweringContext<'a>) -> Self {
-        let num_xfer_positions = ctx.num_xfer_positions as usize;
+        let num_transfer_positions = ctx.num_transfer_positions as usize;
         LoweringState {
             ctx,
             out_buf: Vec::new(),
@@ -192,7 +192,7 @@ impl<'a> LoweringState<'a> {
             closure_pack_cursor: 0,
             closure_call_cursor: 0,
             home_slot_types: view_type_list(ctx.home_types),
-            xfer_bindings: vec![None; num_xfer_positions],
+            transfer_bindings: vec![None; num_transfer_positions],
             pending_def_binds: Vec::new(),
             pending_safe_points: Vec::new(),
         }
@@ -301,8 +301,8 @@ impl<'a> LoweringState<'a> {
     fn lower_local_field_borrow(
         &mut self,
         field_offset: u32,
-        local: Slot,
-        dst: Slot,
+        local: NamedSlot,
+        dst: NamedSlot,
     ) -> VMResult<()> {
         let local_info = self.slot(local)?;
         let dst_info = self.def_slot(dst)?;
@@ -317,8 +317,8 @@ impl<'a> LoweringState<'a> {
     fn lower_local_field_read(
         &mut self,
         field: (u32, u32),
-        local: Slot,
-        dst: Slot,
+        local: NamedSlot,
+        dst: NamedSlot,
     ) -> VMResult<()> {
         let (field_offset, field_size) = field;
         let local_info = self.slot(local)?;
@@ -336,8 +336,8 @@ impl<'a> LoweringState<'a> {
     fn lower_local_field_write(
         &mut self,
         field: (u32, u32),
-        local: Slot,
-        val: Slot,
+        local: NamedSlot,
+        val: NamedSlot,
     ) -> VMResult<()> {
         let (field_offset, field_size) = field;
         let local_info = self.slot(local)?;
@@ -352,7 +352,12 @@ impl<'a> LoweringState<'a> {
 
     /// Borrow of a field through a reference: fold the field offset into the
     /// address compute in a single dispatch.
-    fn lower_ref_field_borrow(&mut self, field_offset: u32, src: Slot, dst: Slot) -> VMResult<()> {
+    fn lower_ref_field_borrow(
+        &mut self,
+        field_offset: u32,
+        src: NamedSlot,
+        dst: NamedSlot,
+    ) -> VMResult<()> {
         let src_info = self.slot(src)?;
         let dst_info = self.def_slot(dst)?;
         self.emit(MicroOp::DeriveRefOffsetImm {
@@ -364,7 +369,12 @@ impl<'a> LoweringState<'a> {
 
     /// By-value read of a field through a reference, plus a deep copy when
     /// the field is heap-backed.
-    fn lower_ref_field_read(&mut self, field: (u32, u32), src: Slot, dst: Slot) -> VMResult<()> {
+    fn lower_ref_field_read(
+        &mut self,
+        field: (u32, u32),
+        src: NamedSlot,
+        dst: NamedSlot,
+    ) -> VMResult<()> {
         let (field_offset, field_size) = field;
         let src_info = self.slot(src)?;
         let dst_info = self.def_typed_slot(dst)?;
@@ -381,8 +391,8 @@ impl<'a> LoweringState<'a> {
     fn lower_ref_field_write(
         &mut self,
         field: (u32, u32),
-        dst_ref: Slot,
-        val: Slot,
+        dst_ref: NamedSlot,
+        val: NamedSlot,
     ) -> VMResult<()> {
         let (field_offset, field_size) = field;
         let ref_info = self.slot(dst_ref)?;
@@ -405,65 +415,63 @@ impl<'a> LoweringState<'a> {
         resolve_variant_field_access(self.ctx.module, &self.ctx.enum_layouts, enum_ty, vfh)
     }
 
-    fn xfer_binding(&self, j: u16) -> VMResult<TypedSlot> {
-        self.xfer_bindings[j as usize]
-            .ok_or_else(|| VMInternalError::new(LoweringError::XferReadWithoutDef { xfer: j }))
+    fn transfer_binding(&self, position: TransferPosition) -> VMResult<TypedSlot> {
+        self.transfer_bindings[position.0 as usize].ok_or_else(|| {
+            VMInternalError::new(LoweringError::TransferReadWithoutDef {
+                transfer: position.0,
+            })
+        })
     }
 
-    fn slot(&self, slot: Slot) -> VMResult<SizedSlot> {
+    fn slot(&self, slot: NamedSlot) -> VMResult<SizedSlot> {
         Ok(match slot {
-            Slot::Home(i) => self.ctx.home_slots[i as usize],
-            Slot::Xfer(j) => self.xfer_binding(j)?.slot,
-            Slot::Vid(_) => return Err(VMInternalError::new(LoweringError::VidInPostAllocationIr)),
+            NamedSlot::Home(i) => self.ctx.home_slots[i.0 as usize],
+            NamedSlot::Transfer(j) => self.transfer_binding(j)?.slot,
         })
     }
 
     /// Returns sized layout info for a destination slot.
-    fn def_slot(&mut self, slot: Slot) -> VMResult<SizedSlot> {
+    fn def_slot(&mut self, slot: NamedSlot) -> VMResult<SizedSlot> {
         Ok(self.def_typed_slot(slot)?.slot)
     }
 
     /// Resolves a destination slot to its sized layout and value type. For
-    /// `Slot::Xfer(j)`, stages a pending binding to arg position `j` of the
-    /// upcoming call. Errors for `Slot::Vid`.
-    fn def_typed_slot(&mut self, slot: Slot) -> VMResult<TypedSlot> {
+    /// `NamedSlot::Transfer(j)`, stages a pending binding to arg position `j` of the
+    /// upcoming call.
+    fn def_typed_slot(&mut self, slot: NamedSlot) -> VMResult<TypedSlot> {
         Ok(match slot {
-            Slot::Home(i) => TypedSlot {
-                slot: self.ctx.home_slots[i as usize],
-                ty: self.home_slot_types[i as usize],
+            NamedSlot::Home(i) => TypedSlot {
+                slot: self.ctx.home_slots[i.0 as usize],
+                ty: self.home_slot_types[i.0 as usize],
             },
-            Slot::Xfer(j) => {
+            NamedSlot::Transfer(j) => {
                 let call_site = &self.ctx.call_sites[self.call_site_cursor];
-                let typed_slot = call_site.arg_slots[j as usize];
+                let typed_slot = call_site.arg_slots[j.0 as usize];
                 self.pending_def_binds.push((j, typed_slot));
                 typed_slot
             },
-            Slot::Vid(_) => return Err(VMInternalError::new(LoweringError::VidInPostAllocationIr)),
         })
     }
 
     /// Resolves each `slot` to its [`SizedSlot`] frame layout.
-    fn slots_to_sized_slots(&self, slots: &[Slot]) -> VMResult<Vec<SizedSlot>> {
+    fn slots_to_sized_slots(&self, slots: &[NamedSlot]) -> VMResult<Vec<SizedSlot>> {
         slots.iter().map(|slot| self.slot(*slot)).collect()
     }
 
     /// Place a call's return values; `ret_slots` are their caller-frame
-    /// locations. The call clobbers the whole callee region, so clear all Xfer
-    /// bindings, then re-bind each `Xfer` ret (for GC) and copy each `Home` in.
-    fn bind_call_returns(&mut self, rets: &[Slot], ret_slots: &[TypedSlot]) -> VMResult<()> {
-        self.xfer_bindings.fill(None);
+    /// locations. The call clobbers the whole callee region, so clear all Transfer
+    /// bindings, then re-bind each `Transfer` ret (for GC) and copy each `Home` in.
+    fn bind_call_returns(&mut self, rets: &[NamedSlot], ret_slots: &[TypedSlot]) -> VMResult<()> {
+        self.transfer_bindings.fill(None);
         for (k, ret_slot) in rets.iter().enumerate() {
             match *ret_slot {
-                Slot::Xfer(j) => {
-                    self.xfer_bindings[j as usize] = Some(ret_slots[k]);
+                NamedSlot::Transfer(j) => {
+                    self.transfer_bindings[j.0 as usize] = Some(ret_slots[k]);
                 },
-                Slot::Home(i) => {
+                NamedSlot::Home(i) => {
                     let src = ret_slots[k].slot;
-                    let dst = self.ctx.home_slots[i as usize];
+                    let dst = self.ctx.home_slots[i.0 as usize];
                     self.emit_single_move(dst.offset, src)?;
-                },
-                Slot::Vid(_) => {
-                    return Err(VMInternalError::new(LoweringError::VidInPostAllocationIr))
                 },
             }
         }
@@ -473,12 +481,12 @@ impl<'a> LoweringState<'a> {
     /// Append `op` to the output buffer. For allocating `op`s,
     /// also emit a paired `SafePointEntry` whose `code_offset` is
     /// `op`'s index in the buffer and whose `heap_ptr_offsets`
-    /// are derived from the current `xfer_bindings`.
+    /// are derived from the current `transfer_bindings`.
     fn emit(&mut self, op: MicroOp) -> VMResult<()> {
         if op.is_allocating() {
             let code_offset = CodeOffset(self.out_buf.len() as u32);
-            let mut heap_ptr_offsets = Vec::with_capacity(self.xfer_bindings.len());
-            for ts in self.xfer_bindings.iter().flatten() {
+            let mut heap_ptr_offsets = Vec::with_capacity(self.transfer_bindings.len());
+            for ts in self.transfer_bindings.iter().flatten() {
                 let rels = type_pointer_offsets(self.ctx.layouts, ts.ty)?;
                 heap_ptr_offsets
                     .extend(rels.into_iter().map(|r| FrameOffset(ts.slot.offset.0 + r)));
@@ -568,17 +576,16 @@ impl<'a> LoweringState<'a> {
     }
 
     /// Interned-type corresponding to `slot`.
-    fn slot_interned_type(&self, slot: Slot) -> VMResult<InternedType> {
+    fn slot_interned_type(&self, slot: NamedSlot) -> VMResult<InternedType> {
         Ok(match slot {
-            Slot::Home(i) => self.home_slot_types[i as usize],
-            Slot::Xfer(j) => self.xfer_binding(j)?.ty,
-            Slot::Vid(_) => return Err(VMInternalError::new(LoweringError::VidInPostAllocationIr)),
+            NamedSlot::Home(i) => self.home_slot_types[i.0 as usize],
+            NamedSlot::Transfer(j) => self.transfer_binding(j)?.ty,
         })
     }
 
     /// Canonical [`Type`] variant of `slot`. Use [`Self::slot_interned_type`]
     /// when an interned pointer is needed instead.
-    fn slot_type(&self, slot: Slot) -> VMResult<&'static Type> {
+    fn slot_type(&self, slot: NamedSlot) -> VMResult<&'static Type> {
         Ok(view_type(self.slot_interned_type(slot)?))
     }
 
@@ -609,7 +616,7 @@ impl<'a> LoweringState<'a> {
 
     /// Emit an `IntCast` to `to` from `src` into `dst`. The source type comes
     /// from `src`'s slot type and the `to` type is supplied by the caller.
-    fn lower_cast(&mut self, dst: Slot, src: Slot, to: IntTy) -> VMResult<()> {
+    fn lower_cast(&mut self, dst: NamedSlot, src: NamedSlot, to: IntTy) -> VMResult<()> {
         let from =
             IntTy::from_type(self.slot_type(src)?).ok_or(LoweringError::CastSourceNotInteger)?;
         let src_info = self.slot(src)?;
@@ -623,7 +630,7 @@ impl<'a> LoweringState<'a> {
     }
 
     /// Size in bytes of `ref_slot`'s pointee.
-    fn ref_pointee_size(&self, ref_slot: Slot) -> VMResult<u32> {
+    fn ref_pointee_size(&self, ref_slot: NamedSlot) -> VMResult<u32> {
         super::context::ref_pointee_size(self.ctx.layouts, self.slot_interned_type(ref_slot)?)
     }
 
@@ -687,7 +694,7 @@ impl<'a> LoweringState<'a> {
     }
 
     /// Lower one IR instruction.
-    fn lower_instr(&mut self, func_ir: &FunctionIR, instr: &Instr) -> VMResult<()> {
+    fn lower_instr(&mut self, func_ir: &FunctionIR, instr: &Instr<NamedSlot>) -> VMResult<()> {
         match instr {
             // --- Loads ---
             // TODO(correctness): audit every integer-width use across the
@@ -1925,7 +1932,7 @@ impl<'a> LoweringState<'a> {
                     }));
                 }
                 let descriptor_id = layout.descriptor_id;
-                // GC-safe ordering: `def_slot` only stages the dst's Xfer bind,
+                // GC-safe ordering: `def_slot` only stages the dst's Transfer bind,
                 // so the dst is not a safe-point root at the allocating
                 // `EnumNew`; the live field args are. `EnumNew` fuses the
                 // allocation and the tag store.
@@ -1935,7 +1942,7 @@ impl<'a> LoweringState<'a> {
                 let arg_slots = self.slots_to_sized_slots(srcs)?;
                 // `EnumNew` writes the heap pointer to its target slot BEFORE the
                 // field stores read the args. The slot allocator may thread the
-                // enum dst and a field arg through one Xfer position (its
+                // enum dst and a field arg through one Transfer position (its
                 // read-before-write contract assumes an instruction reads all
                 // sources before writing dst), so if `dst`'s pointer slot aliases
                 // any arg slot, writing the pointer to `dst` would clobber that
@@ -2010,7 +2017,7 @@ impl<'a> LoweringState<'a> {
                 }
                 // Each field load rereads the enum pointer from its source slot.
                 // The slot allocator may thread the consumed enum and a field
-                // output through one Xfer position (its read-before-write contract
+                // output through one Transfer position (its read-before-write contract
                 // assumes sources are read before dsts are written), so if a dst
                 // slot aliases `src`, the load that writes that dst corrupts the
                 // pointer and the next load dereferences garbage (memory-unsafe).
@@ -2168,20 +2175,20 @@ impl<'a> LoweringState<'a> {
         Ok(())
     }
 
-    /// Advance the Xfer state machine after `instr` has been lowered.
-    fn commit_xfer_bindings_after(&mut self, instr: &Instr) {
-        // Calls manage their own Xfer state in `lower_call`.
-        if !clobbers_xfer(instr) {
-            // Release Xfer bindings consumed by this instr's value uses.
+    /// Advance the Transfer state machine after `instr` has been lowered.
+    fn commit_transfer_bindings_after(&mut self, instr: &Instr<NamedSlot>) {
+        // Calls manage their own Transfer state in `lower_call`.
+        if !clobbers_transfer(instr) {
+            // Release Transfer bindings consumed by this instr's value uses.
             // Place uses leave the slot live, so their binding
             // must persist for the GC to scan at the next safe point.
             for_each_value_use(instr, |s| {
-                if let Slot::Xfer(j) = s {
-                    self.xfer_bindings[j as usize] = None;
+                if let NamedSlot::Transfer(j) = s {
+                    self.transfer_bindings[j.0 as usize] = None;
                 }
             });
             // Clear-then-commit so an instr that uses and re-defs the
-            // same `Xfer(j)` ends with the new value visible.
+            // same `Transfer(j)` ends with the new value visible.
             // Precolor guarantees distinct `j` per instr; assert it,
             // since a duplicate would drop a `TypedSlot` and corrupt
             // the safe-point heap-pointer map.
@@ -2191,18 +2198,18 @@ impl<'a> LoweringState<'a> {
                 for (j, _) in &self.pending_def_binds {
                     debug_assert!(
                         seen.insert(*j),
-                        "duplicate Xfer({}) staged for one IR instr",
-                        j,
+                        "duplicate Transfer({}) staged for one IR instr",
+                        j.0,
                     );
                 }
             }
             for (j, ts) in self.pending_def_binds.drain(..) {
-                self.xfer_bindings[j as usize] = Some(ts);
+                self.transfer_bindings[j.0 as usize] = Some(ts);
             }
         } else {
             debug_assert!(
                 self.pending_def_binds.is_empty(),
-                "calls must not leave a pending Xfer def bind",
+                "calls must not leave a pending Transfer def bind",
             );
         }
     }
@@ -2242,20 +2249,25 @@ impl<'a> LoweringState<'a> {
     /// + return monotonicity (see `BlockAnalysis::analyze`), which
     /// guarantee a forward-only dependency graph between arg copies.
     ///
-    /// Rets are placed lazily in `xfer_bindings` (Xfer rets) or copied
+    /// Rets are placed lazily in `transfer_bindings` (Transfer rets) or copied
     /// to Home (Home rets), with no eager hoist into the next call's
-    /// arg region. Lazy Xfer placement is sound because: (1) Home
-    /// writes target a disjoint region; (2) `xfer_precolor`'s
-    /// per-position uniqueness keeps intermediate Xfer dsts off the
+    /// arg region. Lazy Transfer placement is sound because: (1) Home
+    /// writes target a disjoint region; (2) `transfer_precolor`'s
+    /// per-position uniqueness keeps intermediate Transfer dsts off the
     /// live ret slot; and (3) the single-use invariant bounds the
     /// bound value's last read to at or before the next call, so the
     /// callee_base region is free to be reused past that point.
-    fn lower_call(&mut self, _func_ir: &FunctionIR, args: &[Slot], rets: &[Slot]) -> VMResult<()> {
+    fn lower_call(
+        &mut self,
+        _func_ir: &FunctionIR,
+        args: &[NamedSlot],
+        rets: &[NamedSlot],
+    ) -> VMResult<()> {
         let cs = &self.ctx.call_sites[self.call_site_cursor];
 
         // Debug: assert the byte-overlap precondition that makes
         // reverse-order emit sound. The upstream invariants on
-        // `xfer_precolor` should always satisfy it; this guard catches
+        // `transfer_precolor` should always satisfy it; this guard catches
         // a layer-skipping regression at the lowering site.
         #[cfg(debug_assertions)]
         {
@@ -2327,7 +2339,7 @@ impl<'a> LoweringState<'a> {
         }
         self.call_site_cursor += 1;
 
-        // Place each ret (Xfer rets are already written by `CallIndirect`).
+        // Place each ret (Transfer rets are already written by `CallIndirect`).
         self.bind_call_returns(rets, &cs.ret_slots)?;
         Ok(())
     }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -4,7 +4,10 @@
 //! Display for the stackless IR. Types render from their interned form;
 //! entity handles (functions, fields, variants) resolve via `CompiledModule`.
 
-use super::{BinaryOp, CmpKind, FunctionIR, ImmValue, Instr, ModuleIR, Slot, UnaryOp};
+use super::{
+    BinaryOp, CmpKind, FunctionIR, HomeIndex, ImmValue, Instr, ModuleIR, NamedSlot, SsaSlot,
+    UnaryOp,
+};
 use mono_move_core::types::{display_type, display_type_list, InternedTypeList};
 use move_binary_format::{
     access::ModuleAccess,
@@ -12,6 +15,24 @@ use move_binary_format::{
     CompiledModule,
 };
 use std::fmt;
+
+impl fmt::Display for SsaSlot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SsaSlot::Home(i) => write!(f, "r{}", i.0),
+            SsaSlot::ValueId(i) => write!(f, "v{}", i),
+        }
+    }
+}
+
+impl fmt::Display for NamedSlot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NamedSlot::Home(i) => write!(f, "r{}", i.0),
+            NamedSlot::Transfer(i) => write!(f, "x{}", i.0),
+        }
+    }
+}
 
 impl fmt::Display for ModuleIR {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -46,7 +67,7 @@ fn display_function(
         if i > 0 {
             write!(f, ", ")?;
         }
-        write!(f, "{}", slot_name(Slot::Home(i as u16)))?;
+        write!(f, "{}", NamedSlot::Home(HomeIndex(i as u16)))?;
     }
     write!(f, ")")?;
     if !returns.is_empty() {
@@ -60,11 +81,11 @@ fn display_function(
     }
     writeln!(f, " {{")?;
     let num_temps = func.num_home_slots - func.num_params - func.num_locals;
-    if func.num_xfer_positions > 0 {
+    if func.num_transfer_positions > 0 {
         writeln!(
             f,
-            "  slots: params({}), locals({}), temps({}), xfer({})",
-            func.num_params, func.num_locals, num_temps, func.num_xfer_positions
+            "  slots: params({}), locals({}), temps({}), transfer({})",
+            func.num_params, func.num_locals, num_temps, func.num_transfer_positions
         )?;
     } else {
         writeln!(
@@ -99,26 +120,18 @@ fn display_function(
     Ok(())
 }
 
-fn slot_name(s: Slot) -> String {
-    match s {
-        Slot::Home(i) => format!("r{}", i),
-        Slot::Xfer(i) => format!("x{}", i),
-        Slot::Vid(i) => format!("v{}", i),
-    }
-}
-
-fn slot_names(ss: &[Slot]) -> String {
-    let parts: Vec<String> = ss.iter().map(|s| slot_name(*s)).collect();
+fn slot_names<SlotForm: fmt::Display>(ss: &[SlotForm]) -> String {
+    let parts: Vec<String> = ss.iter().map(|s| s.to_string()).collect();
     format!("[{}]", parts.join(", "))
 }
 
 /// Write `dest := ` prefix for a single destination slot.
-fn write_dst(f: &mut fmt::Formatter<'_>, d: Slot) -> fmt::Result {
-    write!(f, "{} := ", slot_name(d))
+fn write_dst<SlotForm: fmt::Display>(f: &mut fmt::Formatter<'_>, d: SlotForm) -> fmt::Result {
+    write!(f, "{} := ", d)
 }
 
 /// Write `[dests] := ` prefix for multiple destination slots.
-fn write_dsts(f: &mut fmt::Formatter<'_>, ds: &[Slot]) -> fmt::Result {
+fn write_dsts<SlotForm: fmt::Display>(f: &mut fmt::Formatter<'_>, ds: &[SlotForm]) -> fmt::Result {
     write!(f, "{} := ", slot_names(ds))
 }
 
@@ -182,10 +195,10 @@ fn field_path_name(module: &CompiledModule, path: &super::FieldPath) -> String {
         .join(".")
 }
 
-fn display_instr(
+fn display_instr<SlotForm: Copy + fmt::Display>(
     f: &mut fmt::Formatter<'_>,
     module: &CompiledModule,
-    instr: &Instr,
+    instr: &Instr<SlotForm>,
 ) -> fmt::Result {
     match instr {
         // --- Loads: dst := instr literal ---
@@ -201,40 +214,28 @@ fn display_instr(
         // --- Slot ops: dst := copy/move src ---
         Instr::Copy { dst, src } => {
             write_dst(f, *dst)?;
-            write!(f, "copy {}", slot_name(*src))
+            write!(f, "copy {}", src)
         },
         Instr::Move { dst, src } => {
             write_dst(f, *dst)?;
-            write!(f, "move {}", slot_name(*src))
+            write!(f, "move {}", src)
         },
 
         // --- Unary: dst := op src ---
         Instr::UnaryOp { dst, op, src } => {
             write_dst(f, *dst)?;
             write_unary_op(f, op)?;
-            write!(f, " {}", slot_name(*src))
+            write!(f, " {}", src)
         },
         // --- Binary: dst := op lhs, rhs ---
         Instr::BinaryOp { dst, op, lhs, rhs } => {
             write_dst(f, *dst)?;
-            write!(
-                f,
-                "{} {}, {}",
-                binary_op_name(op),
-                slot_name(*lhs),
-                slot_name(*rhs)
-            )
+            write!(f, "{} {}, {}", binary_op_name(op), lhs, rhs)
         },
         // --- Binary immediate: dst := op lhs, #imm ---
         Instr::BinaryOpImm { dst, op, lhs, imm } => {
             write_dst(f, *dst)?;
-            write!(
-                f,
-                "{} {}, {}",
-                binary_op_name(op),
-                slot_name(*lhs),
-                imm_value(imm)
-            )
+            write!(f, "{} {}, {}", binary_op_name(op), lhs, imm_value(imm))
         },
 
         // --- Struct ---
@@ -256,7 +257,7 @@ fn display_instr(
             write_dsts(f, dsts)?;
             write!(f, "unpack ")?;
             display_type(f, *struct_ty)?;
-            write!(f, ", {}", slot_name(*src))
+            write!(f, ", {}", src)
         },
 
         // --- Variant ---
@@ -280,7 +281,7 @@ fn display_instr(
             write_dsts(f, dsts)?;
             write!(f, "unpack_variant ")?;
             display_type(f, *enum_ty)?;
-            write!(f, "@{}, {}", variant, slot_name(*src))
+            write!(f, "@{}, {}", variant, src)
         },
         Instr::TestVariant {
             dst,
@@ -291,17 +292,17 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "test_variant ")?;
             display_type(f, *enum_ty)?;
-            write!(f, "@{}, {}", variant, slot_name(*src))
+            write!(f, "@{}, {}", variant, src)
         },
 
         // --- References ---
         Instr::ImmBorrowLoc { dst, local } => {
             write_dst(f, *dst)?;
-            write!(f, "imm_borrow_loc {}", slot_name(*local))
+            write!(f, "imm_borrow_loc {}", local)
         },
         Instr::MutBorrowLoc { dst, local } => {
             write_dst(f, *dst)?;
-            write!(f, "mut_borrow_loc {}", slot_name(*local))
+            write!(f, "mut_borrow_loc {}", local)
         },
         Instr::ImmBorrowField {
             dst, field, src, ..
@@ -311,7 +312,7 @@ fn display_instr(
                 f,
                 "imm_borrow_field {}, {}",
                 field_name(module, *field),
-                slot_name(*src)
+                src
             )
         },
         Instr::MutBorrowField {
@@ -322,7 +323,7 @@ fn display_instr(
                 f,
                 "mut_borrow_field {}, {}",
                 field_name(module, *field),
-                slot_name(*src)
+                src
             )
         },
         Instr::ImmBorrowVariantField {
@@ -333,7 +334,7 @@ fn display_instr(
                 f,
                 "imm_borrow_variant_field {}, {}",
                 variant_field_name(module, *field),
-                slot_name(*src)
+                src
             )
         },
         Instr::MutBorrowVariantField {
@@ -344,16 +345,16 @@ fn display_instr(
                 f,
                 "mut_borrow_variant_field {}, {}",
                 variant_field_name(module, *field),
-                slot_name(*src)
+                src
             )
         },
         Instr::ReadRef { dst, src } => {
             write_dst(f, *dst)?;
-            write!(f, "read_ref {}", slot_name(*src))
+            write!(f, "read_ref {}", src)
         },
         // WriteRef has no destination (side-effect only)
         Instr::WriteRef { dst_ref, val } => {
-            write!(f, "write_ref {}, {}", slot_name(*dst_ref), slot_name(*val))
+            write!(f, "write_ref {}, {}", dst_ref, val)
         },
 
         // --- Fused field access ---
@@ -361,12 +362,7 @@ fn display_instr(
             dst, field, src, ..
         } => {
             write_dst(f, *dst)?;
-            write!(
-                f,
-                "read_field {}, {}",
-                field_name(module, *field),
-                slot_name(*src)
-            )
+            write!(f, "read_field {}, {}", field_name(module, *field), src)
         },
         Instr::WriteField {
             dst_ref,
@@ -378,8 +374,8 @@ fn display_instr(
                 f,
                 "write_field {}, {}, {}",
                 field_name(module, *field),
-                slot_name(*dst_ref),
-                slot_name(*val)
+                dst_ref,
+                val
             )
         },
         Instr::ReadVariantField {
@@ -390,7 +386,7 @@ fn display_instr(
                 f,
                 "read_variant_field {}, {}",
                 variant_field_name(module, *field),
-                slot_name(*src)
+                src
             )
         },
         Instr::WriteVariantField {
@@ -403,8 +399,8 @@ fn display_instr(
                 f,
                 "write_variant_field {}, {}, {}",
                 variant_field_name(module, *field),
-                slot_name(*dst_ref),
-                slot_name(*val)
+                dst_ref,
+                val
             )
         },
 
@@ -417,7 +413,7 @@ fn display_instr(
                 f,
                 "imm_borrow_loc_field {}, {}",
                 field_name(module, *field),
-                slot_name(*local)
+                local
             )
         },
         Instr::MutBorrowLocField {
@@ -428,7 +424,7 @@ fn display_instr(
                 f,
                 "mut_borrow_loc_field {}, {}",
                 field_name(module, *field),
-                slot_name(*local)
+                local
             )
         },
         Instr::ReadLocField {
@@ -439,7 +435,7 @@ fn display_instr(
                 f,
                 "read_loc_field {}, {}",
                 field_name(module, *field),
-                slot_name(*local)
+                local
             )
         },
         Instr::WriteLocField {
@@ -449,8 +445,8 @@ fn display_instr(
                 f,
                 "write_loc_field {}, {}, {}",
                 field_name(module, *field),
-                slot_name(*local),
-                slot_name(*val)
+                local,
+                val
             )
         },
 
@@ -461,7 +457,7 @@ fn display_instr(
                 f,
                 "read_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*src)
+                src
             )
         },
         Instr::WriteFieldChain { dst_ref, path, val } => {
@@ -469,8 +465,8 @@ fn display_instr(
                 f,
                 "write_field_chain {}, {}, {}",
                 field_path_name(module, path),
-                slot_name(*dst_ref),
-                slot_name(*val)
+                dst_ref,
+                val
             )
         },
         Instr::ImmBorrowFieldChain { dst, path, src } => {
@@ -479,7 +475,7 @@ fn display_instr(
                 f,
                 "imm_borrow_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*src)
+                src
             )
         },
         Instr::MutBorrowFieldChain { dst, path, src } => {
@@ -488,7 +484,7 @@ fn display_instr(
                 f,
                 "mut_borrow_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*src)
+                src
             )
         },
         Instr::ReadLocFieldChain { dst, path, local } => {
@@ -497,7 +493,7 @@ fn display_instr(
                 f,
                 "read_loc_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*local)
+                local
             )
         },
         Instr::WriteLocFieldChain { local, path, val } => {
@@ -505,8 +501,8 @@ fn display_instr(
                 f,
                 "write_loc_field_chain {}, {}, {}",
                 field_path_name(module, path),
-                slot_name(*local),
-                slot_name(*val)
+                local,
+                val
             )
         },
         Instr::ImmBorrowLocFieldChain { dst, path, local } => {
@@ -515,7 +511,7 @@ fn display_instr(
                 f,
                 "imm_borrow_loc_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*local)
+                local
             )
         },
         Instr::MutBorrowLocFieldChain { dst, path, local } => {
@@ -524,7 +520,7 @@ fn display_instr(
                 f,
                 "mut_borrow_loc_field_chain {}, {}",
                 field_path_name(module, path),
-                slot_name(*local)
+                local
             )
         },
 
@@ -537,7 +533,7 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "exists ")?;
             display_type(f, *resource_ty)?;
-            write!(f, ", {}", slot_name(*addr))
+            write!(f, ", {}", addr)
         },
         Instr::MoveFrom {
             dst,
@@ -547,7 +543,7 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "move_from ")?;
             display_type(f, *resource_ty)?;
-            write!(f, ", {}", slot_name(*addr))
+            write!(f, ", {}", addr)
         },
         // MoveTo has no destination (side-effect)
         Instr::MoveTo {
@@ -557,7 +553,7 @@ fn display_instr(
         } => {
             write!(f, "move_to ")?;
             display_type(f, *resource_ty)?;
-            write!(f, ", {}, {}", slot_name(*signer), slot_name(*val))
+            write!(f, ", {}, {}", signer, val)
         },
         Instr::ImmBorrowGlobal {
             dst,
@@ -567,7 +563,7 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "imm_borrow_global ")?;
             display_type(f, *resource_ty)?;
-            write!(f, ", {}", slot_name(*addr))
+            write!(f, ", {}", addr)
         },
         Instr::MutBorrowGlobal {
             dst,
@@ -577,7 +573,7 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "mut_borrow_global ")?;
             display_type(f, *resource_ty)?;
-            write!(f, ", {}", slot_name(*addr))
+            write!(f, ", {}", addr)
         },
 
         // --- Calls ---
@@ -623,7 +619,7 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "vec_len ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}", slot_name(*vec_ref))
+            write!(f, ", {}", vec_ref)
         },
         Instr::VecImmBorrow {
             dst,
@@ -634,7 +630,7 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "vec_imm_borrow ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", slot_name(*vec_ref), slot_name(*idx))
+            write!(f, ", {}, {}", vec_ref, idx)
         },
         Instr::VecMutBorrow {
             dst,
@@ -645,7 +641,7 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "vec_mut_borrow ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", slot_name(*vec_ref), slot_name(*idx))
+            write!(f, ", {}, {}", vec_ref, idx)
         },
         // VecPushBack has no destination
         Instr::VecPushBack {
@@ -655,7 +651,7 @@ fn display_instr(
         } => {
             write!(f, "vec_push_back ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", slot_name(*vec_ref), slot_name(*val))
+            write!(f, ", {}, {}", vec_ref, val)
         },
         Instr::VecPopBack {
             dst,
@@ -665,13 +661,13 @@ fn display_instr(
             write_dst(f, *dst)?;
             write!(f, "vec_pop_back ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}", slot_name(*vec_ref))
+            write!(f, ", {}", vec_ref)
         },
         Instr::VecUnpack { dsts, elem_ty, src } => {
             write_dsts(f, dsts)?;
             write!(f, "vec_unpack ")?;
             display_type(f, *elem_ty)?;
-            write!(f, ", {}, {}", dsts.len(), slot_name(*src))
+            write!(f, ", {}, {}", dsts.len(), src)
         },
         // VecSwap has no destination
         Instr::VecSwap {
@@ -682,34 +678,21 @@ fn display_instr(
         } => {
             write!(f, "vec_swap ")?;
             display_type(f, *elem_ty)?;
-            write!(
-                f,
-                ", {}, {}, {}",
-                slot_name(*vec_ref),
-                slot_name(*idx_a),
-                slot_name(*idx_b)
-            )
+            write!(f, ", {}, {}, {}", vec_ref, idx_a, idx_b)
         },
 
         // --- Control flow (no destinations) ---
         Instr::Branch { target } => write!(f, "branch L{}", target.0),
-        Instr::BrTrue { target, cond } => write!(f, "br_true L{}, {}", target.0, slot_name(*cond)),
+        Instr::BrTrue { target, cond } => write!(f, "br_true L{}, {}", target.0, cond),
         Instr::BrFalse { target, cond } => {
-            write!(f, "br_false L{}, {}", target.0, slot_name(*cond))
+            write!(f, "br_false L{}, {}", target.0, cond)
         },
         Instr::BrCmp {
             target,
             op,
             lhs,
             rhs,
-        } => write!(
-            f,
-            "br_{} L{}, {}, {}",
-            cmp_op_name(op),
-            target.0,
-            slot_name(*lhs),
-            slot_name(*rhs)
-        ),
+        } => write!(f, "br_{} L{}, {}, {}", cmp_op_name(op), target.0, lhs, rhs),
         Instr::BrCmpImm {
             target,
             op,
@@ -720,13 +703,13 @@ fn display_instr(
             "br_{} L{}, {}, {}",
             cmp_op_name(op),
             target.0,
-            slot_name(*lhs),
+            lhs,
             imm_value(imm)
         ),
         Instr::Ret { srcs } => write!(f, "ret {}", slot_names(srcs)),
-        Instr::Abort { code } => write!(f, "abort {}", slot_name(*code)),
+        Instr::Abort { code } => write!(f, "abort {}", code),
         Instr::AbortMsg { code, msg } => {
-            write!(f, "abort_msg {}, {}", slot_name(*code), slot_name(*msg))
+            write!(f, "abort_msg {}, {}", code, msg)
         },
         Instr::ForceGC => write!(f, "force_gc"),
     }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
@@ -5,15 +5,18 @@
 //!
 //! Provides read-only slot visitors (`for_each_def`, `for_each_use`,
 //! `for_each_slot`, `collect_defs_and_uses`), in-place slot rewriters
-//! (`remap_all_slots_with`, `remap_source_slots_with`), and miscellaneous
-//! instruction helpers (`call_boundary_rets_and_args`, `is_commutative`).
+//! (`remap_all_slots_with`, `remap_source_slots_with`), the consuming
+//! slot-form converter (`try_map_slots`), and miscellaneous instruction
+//! helpers (`call_boundary_rets_and_args`, `is_commutative`). Everything is
+//! generic over the slot form `SlotForm` of `Instr<SlotForm>`.
 //!
 //! # Architecture
 //!
-//! All slot traversal is built on two const-generic core functions
-//! (`visit_slots` for reading, `rewrite_instr_slots` for mutation) so that
-//! adding a new `Instr` variant requires updating exactly two match blocks.
-//! Public functions are thin wrappers that select const-generic parameters.
+//! All slot traversal is built on three core functions (`visit_slots` for
+//! reading, `rewrite_instr_slots` for in-place mutation, `try_map_slots` for
+//! consuming form conversion) so that adding a new `Instr` variant
+//! requires updating exactly three match blocks. Public functions are thin
+//! wrappers that select const-generic parameters.
 //!
 //! # Performance
 //!
@@ -30,12 +33,12 @@
 //!   caller-provided closures (`impl FnMut`) are monomorphized and inlined
 //!   at each call site.
 
-use super::{BinaryOp, FieldPath, Instr, Slot};
+use super::{BinaryOp, CallClosureData, CallData, FieldPath, Instr, PackClosureData};
 use mono_move_core::types::InternedType;
 use smallvec::SmallVec;
 
 /// Most instructions have at most 4 defs or uses.
-pub(crate) type SlotList = SmallVec<[Slot; 4]>;
+pub(crate) type SlotList<SlotForm> = SmallVec<[SlotForm; 4]>;
 
 /// Whether a visited slot is a def (written) or a use (read).
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -56,21 +59,24 @@ enum SlotRole {
 // =============================================================================
 
 /// Apply `f` to each slot defined (written) by an instruction.
-pub(crate) fn for_each_def(instr: &Instr, mut f: impl FnMut(Slot)) {
-    visit_slots::<true, false>(instr, |slot, _| f(slot));
+pub(crate) fn for_each_def<SlotForm: Copy>(instr: &Instr<SlotForm>, mut f: impl FnMut(SlotForm)) {
+    visit_slots::<true, false, SlotForm>(instr, |slot, _| f(slot));
 }
 
 /// Apply `f` to each slot used (read) by an instruction. Includes
 /// both value uses and place uses — the full union of
 /// read-side operands.
-pub(crate) fn for_each_use(instr: &Instr, mut f: impl FnMut(Slot)) {
-    visit_slots::<false, true>(instr, |slot, _| f(slot));
+pub(crate) fn for_each_use<SlotForm: Copy>(instr: &Instr<SlotForm>, mut f: impl FnMut(SlotForm)) {
+    visit_slots::<false, true, SlotForm>(instr, |slot, _| f(slot));
 }
 
 /// Apply `f` to each slot whose value an instruction consumes,
 /// skipping place uses.
-pub(crate) fn for_each_value_use(instr: &Instr, mut f: impl FnMut(Slot)) {
-    visit_slots::<false, true>(instr, |slot, role| {
+pub(crate) fn for_each_value_use<SlotForm: Copy>(
+    instr: &Instr<SlotForm>,
+    mut f: impl FnMut(SlotForm),
+) {
+    visit_slots::<false, true, SlotForm>(instr, |slot, role| {
         if role == SlotRole::ValueUse {
             f(slot);
         }
@@ -78,16 +84,18 @@ pub(crate) fn for_each_value_use(instr: &Instr, mut f: impl FnMut(Slot)) {
 }
 
 /// Apply `f` to every slot (defs and uses) in an instruction.
-pub(crate) fn for_each_slot(instr: &Instr, mut f: impl FnMut(Slot)) {
-    visit_slots::<true, true>(instr, |slot, _| f(slot));
+pub(crate) fn for_each_slot<SlotForm: Copy>(instr: &Instr<SlotForm>, mut f: impl FnMut(SlotForm)) {
+    visit_slots::<true, true, SlotForm>(instr, |slot, _| f(slot));
 }
 
 /// Collect defs and uses into separate lists in a single pass.
 /// Place uses are grouped with value uses.
-pub(crate) fn collect_defs_and_uses(instr: &Instr) -> (SlotList, SlotList) {
+pub(crate) fn collect_defs_and_uses<SlotForm: Copy>(
+    instr: &Instr<SlotForm>,
+) -> (SlotList<SlotForm>, SlotList<SlotForm>) {
     let mut defs = SlotList::new();
     let mut uses = SlotList::new();
-    visit_slots::<true, true>(instr, |slot, role| match role {
+    visit_slots::<true, true, SlotForm>(instr, |slot, role| match role {
         SlotRole::Def => defs.push(slot),
         SlotRole::ValueUse | SlotRole::PlaceUse => uses.push(slot),
     });
@@ -101,16 +109,22 @@ pub(crate) fn collect_defs_and_uses(instr: &Instr) -> (SlotList, SlotList) {
 /// Rewrite all slot operands of an instruction by applying `f`.
 ///
 /// Each slot is rewritten exactly once — `f` is not applied transitively.
-pub(crate) fn remap_all_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> Slot) {
-    rewrite_instr_slots::<true, true, false>(instr, f);
+pub(crate) fn remap_all_slots_with<SlotForm: Copy>(
+    instr: &mut Instr<SlotForm>,
+    f: impl FnMut(SlotForm) -> SlotForm,
+) {
+    rewrite_instr_slots::<true, true, false, SlotForm>(instr, f);
 }
 
 /// Rewrite source (use) operands of an instruction by applying `f`,
 /// skipping defs and BorrowLoc sources.
 ///
 /// Each slot is rewritten exactly once — `f` is not applied transitively.
-pub(crate) fn remap_source_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> Slot) {
-    rewrite_instr_slots::<false, true, true>(instr, f);
+pub(crate) fn remap_source_slots_with<SlotForm: Copy>(
+    instr: &mut Instr<SlotForm>,
+    f: impl FnMut(SlotForm) -> SlotForm,
+) {
+    rewrite_instr_slots::<false, true, true, SlotForm>(instr, f);
 }
 
 // =============================================================================
@@ -120,7 +134,9 @@ pub(crate) fn remap_source_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> 
 /// `(rets, args)` of a call-boundary instruction (`Call`, `CallClosure`),
 /// `None` for everything else.
 #[inline]
-pub(crate) fn call_boundary_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[Slot])> {
+pub(crate) fn call_boundary_rets_and_args<SlotForm>(
+    instr: &Instr<SlotForm>,
+) -> Option<(&[SlotForm], &[SlotForm])> {
     match instr {
         Instr::Call { data } => Some((&data.rets, &data.args)),
         Instr::CallClosure { data } => Some((&data.rets, &data.args)),
@@ -188,9 +204,10 @@ pub(crate) fn call_boundary_rets_and_args(instr: &Instr) -> Option<(&[Slot], &[S
     }
 }
 
-/// Call-like instructions (`Call`, `CallClosure`) that clobber Xfer slots.
+/// Call-like instructions (`Call`, `CallClosure`) that clobber Transfer
+/// slots.
 #[inline]
-pub(crate) fn clobbers_xfer(instr: &Instr) -> bool {
+pub(crate) fn clobbers_transfer<SlotForm>(instr: &Instr<SlotForm>) -> bool {
     call_boundary_rets_and_args(instr).is_some()
 }
 
@@ -198,7 +215,7 @@ pub(crate) fn clobbers_xfer(instr: &Instr) -> bool {
 /// through that borrow mutates the local without a def at the write site (a
 /// hidden write), so coalescing and copy propagation both derive their
 /// guards from this single predicate.
-pub(crate) fn mut_local_borrow_target(instr: &Instr) -> Option<Slot> {
+pub(crate) fn mut_local_borrow_target<SlotForm: Copy>(instr: &Instr<SlotForm>) -> Option<SlotForm> {
     match instr {
         // Mutable borrows of a local's storage.
         Instr::MutBorrowLoc { local, .. }
@@ -272,7 +289,7 @@ pub(crate) fn mut_local_borrow_target(instr: &Instr) -> Option<Slot> {
 /// is the interned resource nominal embedded in the instruction; it may still
 /// contain type parameters that the caller substitutes with the function's
 /// type arguments.
-pub(crate) fn resource_type_in_instr(instr: &Instr) -> Option<InternedType> {
+pub(crate) fn resource_type_in_instr<SlotForm>(instr: &Instr<SlotForm>) -> Option<InternedType> {
     match instr {
         // Global-storage ops carry the resource nominal directly.
         Instr::Exists { resource_ty, .. }
@@ -359,7 +376,9 @@ pub(crate) enum NominalKind {
 /// and captured-data discovery.
 ///
 /// TODO(cleanup): reconcile various type-in-instr discovery methods.
-pub(crate) fn field_layout_nominal_in_instr(instr: &Instr) -> Option<(InternedType, NominalKind)> {
+pub(crate) fn field_layout_nominal_in_instr<SlotForm>(
+    instr: &Instr<SlotForm>,
+) -> Option<(InternedType, NominalKind)> {
     match instr {
         // Carry the instantiated struct type directly.
         Instr::Pack { struct_ty, .. } | Instr::Unpack { struct_ty, .. } => {
@@ -448,7 +467,7 @@ pub(crate) fn field_layout_nominal_in_instr(instr: &Instr) -> Option<(InternedTy
 }
 
 /// The fused-chain `FieldPath` carried by `instr`, if any.
-pub(crate) fn chain_field_path(instr: &Instr) -> Option<&FieldPath> {
+pub(crate) fn chain_field_path<SlotForm>(instr: &Instr<SlotForm>) -> Option<&FieldPath> {
     match instr {
         Instr::ReadFieldChain { path, .. }
         | Instr::WriteFieldChain { path, .. }
@@ -518,7 +537,7 @@ pub(crate) fn chain_field_path(instr: &Instr) -> Option<&FieldPath> {
 
 /// Whether `instr` is a terminator that falls through to the next block.
 #[inline]
-pub(crate) fn is_fallthrough_terminator(instr: &Instr) -> bool {
+pub(crate) fn is_fallthrough_terminator<SlotForm>(instr: &Instr<SlotForm>) -> bool {
     match instr {
         Instr::BrTrue { .. }
         | Instr::BrFalse { .. }
@@ -610,7 +629,7 @@ pub(crate) fn is_commutative(op: &BinaryOp) -> bool {
 
 /// Emit a def slot if `ACTIVE` is true.
 #[inline]
-fn def<const ACTIVE: bool>(slot: Slot, f: &mut impl FnMut(Slot, SlotRole)) {
+fn def<const ACTIVE: bool, SlotForm>(slot: SlotForm, f: &mut impl FnMut(SlotForm, SlotRole)) {
     if ACTIVE {
         f(slot, SlotRole::Def);
     }
@@ -618,7 +637,7 @@ fn def<const ACTIVE: bool>(slot: Slot, f: &mut impl FnMut(Slot, SlotRole)) {
 
 /// Emit a use slot if `ACTIVE` is true.
 #[inline]
-fn used<const ACTIVE: bool>(slot: Slot, f: &mut impl FnMut(Slot, SlotRole)) {
+fn used<const ACTIVE: bool, SlotForm>(slot: SlotForm, f: &mut impl FnMut(SlotForm, SlotRole)) {
     if ACTIVE {
         f(slot, SlotRole::ValueUse);
     }
@@ -627,7 +646,10 @@ fn used<const ACTIVE: bool>(slot: Slot, f: &mut impl FnMut(Slot, SlotRole)) {
 /// Emit a place use slot if `ACTIVE` is true. The slot's
 /// identity matters but its bytes are NOT consumed by the instruction.
 #[inline]
-fn storage_use<const ACTIVE: bool>(slot: Slot, f: &mut impl FnMut(Slot, SlotRole)) {
+fn storage_use<const ACTIVE: bool, SlotForm>(
+    slot: SlotForm,
+    f: &mut impl FnMut(SlotForm, SlotRole),
+) {
     if ACTIVE {
         f(slot, SlotRole::PlaceUse);
     }
@@ -635,7 +657,10 @@ fn storage_use<const ACTIVE: bool>(slot: Slot, f: &mut impl FnMut(Slot, SlotRole
 
 /// Emit each slot in a slice as defs if `ACTIVE` is true.
 #[inline]
-fn defs<const ACTIVE: bool>(slots: &[Slot], f: &mut impl FnMut(Slot, SlotRole)) {
+fn defs<const ACTIVE: bool, SlotForm: Copy>(
+    slots: &[SlotForm],
+    f: &mut impl FnMut(SlotForm, SlotRole),
+) {
     if ACTIVE {
         slots.iter().for_each(|slot| f(*slot, SlotRole::Def));
     }
@@ -643,7 +668,10 @@ fn defs<const ACTIVE: bool>(slots: &[Slot], f: &mut impl FnMut(Slot, SlotRole)) 
 
 /// Emit each slot in a slice as uses if `ACTIVE` is true.
 #[inline]
-fn uses<const ACTIVE: bool>(slots: &[Slot], f: &mut impl FnMut(Slot, SlotRole)) {
+fn uses<const ACTIVE: bool, SlotForm: Copy>(
+    slots: &[SlotForm],
+    f: &mut impl FnMut(SlotForm, SlotRole),
+) {
     if ACTIVE {
         slots.iter().for_each(|slot| f(*slot, SlotRole::ValueUse));
     }
@@ -653,45 +681,45 @@ fn uses<const ACTIVE: bool>(slots: &[Slot], f: &mut impl FnMut(Slot, SlotRole)) 
 ///
 /// `DEFS`/`USES` select which slots to visit. The `def`/`used`/`defs`/`uses`
 /// helpers pair the role tag with the const generic by convention.
-fn visit_slots<const DEFS: bool, const USES: bool>(
-    instr: &Instr,
-    mut f: impl FnMut(Slot, SlotRole),
+fn visit_slots<const DEFS: bool, const USES: bool, SlotForm: Copy>(
+    instr: &Instr<SlotForm>,
+    mut f: impl FnMut(SlotForm, SlotRole),
 ) {
     match instr {
-        Instr::LdConst { dst, .. } | Instr::LdImm { dst, .. } => def::<DEFS>(*dst, &mut f),
+        Instr::LdConst { dst, .. } | Instr::LdImm { dst, .. } => def::<DEFS, _>(*dst, &mut f),
 
         Instr::Copy { dst, src } | Instr::Move { dst, src } | Instr::UnaryOp { dst, src, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*src, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*src, &mut f);
         },
         Instr::BinaryOp { dst, lhs, rhs, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*lhs, &mut f);
-            used::<USES>(*rhs, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*lhs, &mut f);
+            used::<USES, _>(*rhs, &mut f);
         },
         Instr::BinaryOpImm { dst, lhs, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*lhs, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*lhs, &mut f);
         },
 
         Instr::Pack { dst, srcs, .. } | Instr::PackVariant { dst, srcs, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            uses::<USES>(srcs, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            uses::<USES, _>(srcs, &mut f);
         },
         Instr::Unpack { dsts, src, .. } | Instr::UnpackVariant { dsts, src, .. } => {
-            defs::<DEFS>(dsts, &mut f);
-            used::<USES>(*src, &mut f);
+            defs::<DEFS, _>(dsts, &mut f);
+            used::<USES, _>(*src, &mut f);
         },
         Instr::TestVariant { dst, src, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*src, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*src, &mut f);
         },
 
         // `local` is a place use: the local's identity is
         // taken, its bytes are not consumed.
         Instr::ImmBorrowLoc { dst, local } | Instr::MutBorrowLoc { dst, local } => {
-            def::<DEFS>(*dst, &mut f);
-            storage_use::<USES>(*local, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            storage_use::<USES, _>(*local, &mut f);
         },
         // Field chains share the slot shape of their single-field counterparts;
         // only the carried `path` differs.
@@ -702,25 +730,25 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
         | Instr::ImmBorrowFieldChain { dst, src, .. }
         | Instr::MutBorrowFieldChain { dst, src, .. }
         | Instr::ReadRef { dst, src } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*src, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*src, &mut f);
         },
         Instr::WriteRef { dst_ref, val } => {
-            used::<USES>(*dst_ref, &mut f);
-            used::<USES>(*val, &mut f);
+            used::<USES, _>(*dst_ref, &mut f);
+            used::<USES, _>(*val, &mut f);
         },
 
         Instr::ReadField { dst, src, .. }
         | Instr::ReadVariantField { dst, src, .. }
         | Instr::ReadFieldChain { dst, src, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*src, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*src, &mut f);
         },
         Instr::WriteField { dst_ref, val, .. }
         | Instr::WriteVariantField { dst_ref, val, .. }
         | Instr::WriteFieldChain { dst_ref, val, .. } => {
-            used::<USES>(*dst_ref, &mut f);
-            used::<USES>(*val, &mut f);
+            used::<USES, _>(*dst_ref, &mut f);
+            used::<USES, _>(*val, &mut f);
         },
 
         // `local` names the inline-struct frame slot, not a reference:
@@ -731,51 +759,51 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
         | Instr::ImmBorrowLocFieldChain { dst, local, .. }
         | Instr::MutBorrowLocFieldChain { dst, local, .. }
         | Instr::ReadLocFieldChain { dst, local, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            storage_use::<USES>(*local, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            storage_use::<USES, _>(*local, &mut f);
         },
         // `local` is both a def (a field is written in-place) and a
         // place use (the other fields persist, so the slot
         // stays live with the same type after the write).
         Instr::WriteLocField { local, val, .. } | Instr::WriteLocFieldChain { local, val, .. } => {
-            def::<DEFS>(*local, &mut f);
-            storage_use::<USES>(*local, &mut f);
-            used::<USES>(*val, &mut f);
+            def::<DEFS, _>(*local, &mut f);
+            storage_use::<USES, _>(*local, &mut f);
+            used::<USES, _>(*val, &mut f);
         },
 
         Instr::Exists { dst, addr, .. } | Instr::MoveFrom { dst, addr, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*addr, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*addr, &mut f);
         },
         Instr::MoveTo { signer, val, .. } => {
-            used::<USES>(*signer, &mut f);
-            used::<USES>(*val, &mut f);
+            used::<USES, _>(*signer, &mut f);
+            used::<USES, _>(*val, &mut f);
         },
         Instr::ImmBorrowGlobal { dst, addr, .. } | Instr::MutBorrowGlobal { dst, addr, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*addr, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*addr, &mut f);
         },
 
         Instr::Call { data } => {
-            defs::<DEFS>(&data.rets, &mut f);
-            uses::<USES>(&data.args, &mut f);
+            defs::<DEFS, _>(&data.rets, &mut f);
+            uses::<USES, _>(&data.args, &mut f);
         },
         Instr::CallClosure { data } => {
-            defs::<DEFS>(&data.rets, &mut f);
-            uses::<USES>(&data.args, &mut f);
+            defs::<DEFS, _>(&data.rets, &mut f);
+            uses::<USES, _>(&data.args, &mut f);
         },
         Instr::PackClosure { data } => {
-            def::<DEFS>(data.dst, &mut f);
-            uses::<USES>(&data.captured, &mut f);
+            def::<DEFS, _>(data.dst, &mut f);
+            uses::<USES, _>(&data.captured, &mut f);
         },
 
         Instr::VecPack { dst, srcs, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            uses::<USES>(srcs, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            uses::<USES, _>(srcs, &mut f);
         },
         Instr::VecLen { dst, vec_ref, .. } | Instr::VecPopBack { dst, vec_ref, .. } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*vec_ref, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*vec_ref, &mut f);
         },
         Instr::VecImmBorrow {
             dst, vec_ref, idx, ..
@@ -783,17 +811,17 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
         | Instr::VecMutBorrow {
             dst, vec_ref, idx, ..
         } => {
-            def::<DEFS>(*dst, &mut f);
-            used::<USES>(*vec_ref, &mut f);
-            used::<USES>(*idx, &mut f);
+            def::<DEFS, _>(*dst, &mut f);
+            used::<USES, _>(*vec_ref, &mut f);
+            used::<USES, _>(*idx, &mut f);
         },
         Instr::VecPushBack { vec_ref, val, .. } => {
-            used::<USES>(*vec_ref, &mut f);
-            used::<USES>(*val, &mut f);
+            used::<USES, _>(*vec_ref, &mut f);
+            used::<USES, _>(*val, &mut f);
         },
         Instr::VecUnpack { dsts, src, .. } => {
-            defs::<DEFS>(dsts, &mut f);
-            used::<USES>(*src, &mut f);
+            defs::<DEFS, _>(dsts, &mut f);
+            used::<USES, _>(*src, &mut f);
         },
         Instr::VecSwap {
             vec_ref,
@@ -801,23 +829,23 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
             idx_b,
             ..
         } => {
-            used::<USES>(*vec_ref, &mut f);
-            used::<USES>(*idx_a, &mut f);
-            used::<USES>(*idx_b, &mut f);
+            used::<USES, _>(*vec_ref, &mut f);
+            used::<USES, _>(*idx_a, &mut f);
+            used::<USES, _>(*idx_b, &mut f);
         },
 
         Instr::Branch { .. } => {},
-        Instr::BrTrue { cond, .. } | Instr::BrFalse { cond, .. } => used::<USES>(*cond, &mut f),
+        Instr::BrTrue { cond, .. } | Instr::BrFalse { cond, .. } => used::<USES, _>(*cond, &mut f),
         Instr::BrCmp { lhs, rhs, .. } => {
-            used::<USES>(*lhs, &mut f);
-            used::<USES>(*rhs, &mut f);
+            used::<USES, _>(*lhs, &mut f);
+            used::<USES, _>(*rhs, &mut f);
         },
-        Instr::BrCmpImm { lhs, .. } => used::<USES>(*lhs, &mut f),
-        Instr::Ret { srcs } => uses::<USES>(srcs, &mut f),
-        Instr::Abort { code } => used::<USES>(*code, &mut f),
+        Instr::BrCmpImm { lhs, .. } => used::<USES, _>(*lhs, &mut f),
+        Instr::Ret { srcs } => uses::<USES, _>(srcs, &mut f),
+        Instr::Abort { code } => used::<USES, _>(*code, &mut f),
         Instr::AbortMsg { code, msg } => {
-            used::<USES>(*code, &mut f);
-            used::<USES>(*msg, &mut f);
+            used::<USES, _>(*code, &mut f);
+            used::<USES, _>(*msg, &mut f);
         },
 
         // No slot operands.
@@ -831,13 +859,13 @@ fn visit_slots<const DEFS: bool, const USES: bool>(
 
 /// Rewrite a slot in-place by applying `f`.
 #[inline]
-fn rewrite_slot(slot: &mut Slot, f: &mut impl FnMut(Slot) -> Slot) {
+fn rewrite_slot<SlotForm: Copy>(slot: &mut SlotForm, f: &mut impl FnMut(SlotForm) -> SlotForm) {
     *slot = f(*slot);
 }
 
 /// Rewrite each slot in a slice by applying `f`.
 #[inline]
-fn rewrite_slots(slots: &mut [Slot], f: &mut impl FnMut(Slot) -> Slot) {
+fn rewrite_slots<SlotForm: Copy>(slots: &mut [SlotForm], f: &mut impl FnMut(SlotForm) -> SlotForm) {
     for slot in slots.iter_mut() {
         rewrite_slot(slot, f);
     }
@@ -848,9 +876,14 @@ fn rewrite_slots(slots: &mut [Slot], f: &mut impl FnMut(Slot) -> Slot) {
 /// - `DEFS` / `USES`: select which slots to rewrite (compile-time).
 /// - `SKIP_PLACE_USE`: when true, place uses are not
 ///   rewritten.
-fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE: bool>(
-    instr: &mut Instr,
-    mut f: impl FnMut(Slot) -> Slot,
+fn rewrite_instr_slots<
+    const DEFS: bool,
+    const USES: bool,
+    const SKIP_PLACE_USE: bool,
+    SlotForm: Copy,
+>(
+    instr: &mut Instr<SlotForm>,
+    mut f: impl FnMut(SlotForm) -> SlotForm,
 ) {
     match instr {
         Instr::LdConst { dst, .. } | Instr::LdImm { dst, .. } => {
@@ -1129,4 +1162,512 @@ fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_PLACE_USE:
         // No slot operands.
         Instr::ForceGC => {},
     }
+}
+
+// =============================================================================
+// Consuming slot-form conversion
+// =============================================================================
+
+/// Map a boxed slot slice through `f`, preserving order.
+fn try_map_slot_box<FromForm, ToForm, E>(
+    slots: Box<[FromForm]>,
+    f: &mut impl FnMut(FromForm) -> Result<ToForm, E>,
+) -> Result<Box<[ToForm]>, E> {
+    slots.into_vec().into_iter().map(f).collect()
+}
+
+/// Consume `instr`, converting every slot operand from form `FromForm` to
+/// form `ToForm` through `f`. The sole conversion path between slot forms;
+/// the output type guarantees no operand escapes unconverted.
+pub(crate) fn try_map_slots<FromForm, ToForm, E>(
+    instr: Instr<FromForm>,
+    mut f: impl FnMut(FromForm) -> Result<ToForm, E>,
+) -> Result<Instr<ToForm>, E> {
+    Ok(match instr {
+        Instr::LdConst { dst, const_idx } => Instr::LdConst {
+            dst: f(dst)?,
+            const_idx,
+        },
+        Instr::LdImm { dst, imm } => Instr::LdImm { dst: f(dst)?, imm },
+
+        Instr::Copy { dst, src } => Instr::Copy {
+            dst: f(dst)?,
+            src: f(src)?,
+        },
+        Instr::Move { dst, src } => Instr::Move {
+            dst: f(dst)?,
+            src: f(src)?,
+        },
+
+        Instr::UnaryOp { dst, op, src } => Instr::UnaryOp {
+            dst: f(dst)?,
+            op,
+            src: f(src)?,
+        },
+        Instr::BinaryOp { dst, op, lhs, rhs } => Instr::BinaryOp {
+            dst: f(dst)?,
+            op,
+            lhs: f(lhs)?,
+            rhs: f(rhs)?,
+        },
+        Instr::BinaryOpImm { dst, op, lhs, imm } => Instr::BinaryOpImm {
+            dst: f(dst)?,
+            op,
+            lhs: f(lhs)?,
+            imm,
+        },
+
+        Instr::Pack {
+            dst,
+            struct_ty,
+            srcs,
+        } => Instr::Pack {
+            dst: f(dst)?,
+            struct_ty,
+            srcs: try_map_slot_box(srcs, &mut f)?,
+        },
+        Instr::Unpack {
+            dsts,
+            struct_ty,
+            src,
+        } => Instr::Unpack {
+            dsts: try_map_slot_box(dsts, &mut f)?,
+            struct_ty,
+            src: f(src)?,
+        },
+
+        Instr::PackVariant {
+            dst,
+            enum_ty,
+            variant,
+            srcs,
+        } => Instr::PackVariant {
+            dst: f(dst)?,
+            enum_ty,
+            variant,
+            srcs: try_map_slot_box(srcs, &mut f)?,
+        },
+        Instr::UnpackVariant {
+            dsts,
+            enum_ty,
+            variant,
+            src,
+        } => Instr::UnpackVariant {
+            dsts: try_map_slot_box(dsts, &mut f)?,
+            enum_ty,
+            variant,
+            src: f(src)?,
+        },
+        Instr::TestVariant {
+            dst,
+            enum_ty,
+            variant,
+            src,
+        } => Instr::TestVariant {
+            dst: f(dst)?,
+            enum_ty,
+            variant,
+            src: f(src)?,
+        },
+
+        Instr::ImmBorrowLoc { dst, local } => Instr::ImmBorrowLoc {
+            dst: f(dst)?,
+            local: f(local)?,
+        },
+        Instr::MutBorrowLoc { dst, local } => Instr::MutBorrowLoc {
+            dst: f(dst)?,
+            local: f(local)?,
+        },
+        Instr::ImmBorrowField {
+            dst,
+            owner_ty,
+            field,
+            src,
+        } => Instr::ImmBorrowField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            src: f(src)?,
+        },
+        Instr::MutBorrowField {
+            dst,
+            owner_ty,
+            field,
+            src,
+        } => Instr::MutBorrowField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            src: f(src)?,
+        },
+        Instr::ImmBorrowVariantField {
+            dst,
+            owner_ty,
+            field,
+            src,
+        } => Instr::ImmBorrowVariantField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            src: f(src)?,
+        },
+        Instr::MutBorrowVariantField {
+            dst,
+            owner_ty,
+            field,
+            src,
+        } => Instr::MutBorrowVariantField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            src: f(src)?,
+        },
+        Instr::ReadRef { dst, src } => Instr::ReadRef {
+            dst: f(dst)?,
+            src: f(src)?,
+        },
+        Instr::WriteRef { dst_ref, val } => Instr::WriteRef {
+            dst_ref: f(dst_ref)?,
+            val: f(val)?,
+        },
+
+        Instr::ReadField {
+            dst,
+            owner_ty,
+            field,
+            src,
+        } => Instr::ReadField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            src: f(src)?,
+        },
+        Instr::WriteField {
+            dst_ref,
+            owner_ty,
+            field,
+            val,
+        } => Instr::WriteField {
+            dst_ref: f(dst_ref)?,
+            owner_ty,
+            field,
+            val: f(val)?,
+        },
+        Instr::ReadVariantField {
+            dst,
+            owner_ty,
+            field,
+            src,
+        } => Instr::ReadVariantField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            src: f(src)?,
+        },
+        Instr::WriteVariantField {
+            dst_ref,
+            owner_ty,
+            field,
+            val,
+        } => Instr::WriteVariantField {
+            dst_ref: f(dst_ref)?,
+            owner_ty,
+            field,
+            val: f(val)?,
+        },
+
+        Instr::ImmBorrowLocField {
+            dst,
+            owner_ty,
+            field,
+            local,
+        } => Instr::ImmBorrowLocField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            local: f(local)?,
+        },
+        Instr::MutBorrowLocField {
+            dst,
+            owner_ty,
+            field,
+            local,
+        } => Instr::MutBorrowLocField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            local: f(local)?,
+        },
+        Instr::ReadLocField {
+            dst,
+            owner_ty,
+            field,
+            local,
+        } => Instr::ReadLocField {
+            dst: f(dst)?,
+            owner_ty,
+            field,
+            local: f(local)?,
+        },
+        Instr::WriteLocField {
+            local,
+            owner_ty,
+            field,
+            val,
+        } => Instr::WriteLocField {
+            local: f(local)?,
+            owner_ty,
+            field,
+            val: f(val)?,
+        },
+
+        Instr::ReadFieldChain { dst, path, src } => Instr::ReadFieldChain {
+            dst: f(dst)?,
+            path,
+            src: f(src)?,
+        },
+        Instr::WriteFieldChain { dst_ref, path, val } => Instr::WriteFieldChain {
+            dst_ref: f(dst_ref)?,
+            path,
+            val: f(val)?,
+        },
+        Instr::ImmBorrowFieldChain { dst, path, src } => Instr::ImmBorrowFieldChain {
+            dst: f(dst)?,
+            path,
+            src: f(src)?,
+        },
+        Instr::MutBorrowFieldChain { dst, path, src } => Instr::MutBorrowFieldChain {
+            dst: f(dst)?,
+            path,
+            src: f(src)?,
+        },
+        Instr::ReadLocFieldChain { dst, path, local } => Instr::ReadLocFieldChain {
+            dst: f(dst)?,
+            path,
+            local: f(local)?,
+        },
+        Instr::WriteLocFieldChain { local, path, val } => Instr::WriteLocFieldChain {
+            local: f(local)?,
+            path,
+            val: f(val)?,
+        },
+        Instr::ImmBorrowLocFieldChain { dst, path, local } => Instr::ImmBorrowLocFieldChain {
+            dst: f(dst)?,
+            path,
+            local: f(local)?,
+        },
+        Instr::MutBorrowLocFieldChain { dst, path, local } => Instr::MutBorrowLocFieldChain {
+            dst: f(dst)?,
+            path,
+            local: f(local)?,
+        },
+
+        Instr::Exists {
+            dst,
+            resource_ty,
+            addr,
+        } => Instr::Exists {
+            dst: f(dst)?,
+            resource_ty,
+            addr: f(addr)?,
+        },
+        Instr::MoveFrom {
+            dst,
+            resource_ty,
+            addr,
+        } => Instr::MoveFrom {
+            dst: f(dst)?,
+            resource_ty,
+            addr: f(addr)?,
+        },
+        Instr::MoveTo {
+            resource_ty,
+            signer,
+            val,
+        } => Instr::MoveTo {
+            resource_ty,
+            signer: f(signer)?,
+            val: f(val)?,
+        },
+        Instr::ImmBorrowGlobal {
+            dst,
+            resource_ty,
+            addr,
+        } => Instr::ImmBorrowGlobal {
+            dst: f(dst)?,
+            resource_ty,
+            addr: f(addr)?,
+        },
+        Instr::MutBorrowGlobal {
+            dst,
+            resource_ty,
+            addr,
+        } => Instr::MutBorrowGlobal {
+            dst: f(dst)?,
+            resource_ty,
+            addr: f(addr)?,
+        },
+
+        Instr::Call { data } => {
+            let CallData {
+                rets,
+                function_handle,
+                ty_args,
+                args,
+            } = *data;
+            Instr::Call {
+                data: Box::new(CallData {
+                    rets: try_map_slot_box(rets, &mut f)?,
+                    function_handle,
+                    ty_args,
+                    args: try_map_slot_box(args, &mut f)?,
+                }),
+            }
+        },
+        Instr::PackClosure { data } => {
+            let PackClosureData {
+                dst,
+                function_handle,
+                ty_args,
+                mask,
+                captured,
+            } = *data;
+            Instr::PackClosure {
+                data: Box::new(PackClosureData {
+                    dst: f(dst)?,
+                    function_handle,
+                    ty_args,
+                    mask,
+                    captured: try_map_slot_box(captured, &mut f)?,
+                }),
+            }
+        },
+        Instr::CallClosure { data } => {
+            let CallClosureData {
+                rets,
+                closure_ty,
+                args,
+            } = *data;
+            Instr::CallClosure {
+                data: Box::new(CallClosureData::new(
+                    try_map_slot_box(rets, &mut f)?,
+                    closure_ty,
+                    try_map_slot_box(args, &mut f)?,
+                )),
+            }
+        },
+
+        Instr::VecPack { dst, elem_ty, srcs } => Instr::VecPack {
+            dst: f(dst)?,
+            elem_ty,
+            srcs: try_map_slot_box(srcs, &mut f)?,
+        },
+        Instr::VecLen {
+            dst,
+            elem_ty,
+            vec_ref,
+        } => Instr::VecLen {
+            dst: f(dst)?,
+            elem_ty,
+            vec_ref: f(vec_ref)?,
+        },
+        Instr::VecImmBorrow {
+            dst,
+            elem_ty,
+            vec_ref,
+            idx,
+        } => Instr::VecImmBorrow {
+            dst: f(dst)?,
+            elem_ty,
+            vec_ref: f(vec_ref)?,
+            idx: f(idx)?,
+        },
+        Instr::VecMutBorrow {
+            dst,
+            elem_ty,
+            vec_ref,
+            idx,
+        } => Instr::VecMutBorrow {
+            dst: f(dst)?,
+            elem_ty,
+            vec_ref: f(vec_ref)?,
+            idx: f(idx)?,
+        },
+        Instr::VecPushBack {
+            vec_ref,
+            elem_ty,
+            val,
+        } => Instr::VecPushBack {
+            vec_ref: f(vec_ref)?,
+            elem_ty,
+            val: f(val)?,
+        },
+        Instr::VecPopBack {
+            dst,
+            elem_ty,
+            vec_ref,
+        } => Instr::VecPopBack {
+            dst: f(dst)?,
+            elem_ty,
+            vec_ref: f(vec_ref)?,
+        },
+        Instr::VecUnpack { dsts, elem_ty, src } => Instr::VecUnpack {
+            dsts: try_map_slot_box(dsts, &mut f)?,
+            elem_ty,
+            src: f(src)?,
+        },
+        Instr::VecSwap {
+            vec_ref,
+            elem_ty,
+            idx_a,
+            idx_b,
+        } => Instr::VecSwap {
+            vec_ref: f(vec_ref)?,
+            elem_ty,
+            idx_a: f(idx_a)?,
+            idx_b: f(idx_b)?,
+        },
+
+        Instr::Branch { target } => Instr::Branch { target },
+        Instr::BrTrue { target, cond } => Instr::BrTrue {
+            target,
+            cond: f(cond)?,
+        },
+        Instr::BrFalse { target, cond } => Instr::BrFalse {
+            target,
+            cond: f(cond)?,
+        },
+        Instr::BrCmp {
+            target,
+            op,
+            lhs,
+            rhs,
+        } => Instr::BrCmp {
+            target,
+            op,
+            lhs: f(lhs)?,
+            rhs: f(rhs)?,
+        },
+        Instr::BrCmpImm {
+            target,
+            op,
+            lhs,
+            imm,
+        } => Instr::BrCmpImm {
+            target,
+            op,
+            lhs: f(lhs)?,
+            imm,
+        },
+        Instr::Ret { srcs } => Instr::Ret {
+            srcs: try_map_slot_box(srcs, &mut f)?,
+        },
+        Instr::Abort { code } => Instr::Abort { code: f(code)? },
+        Instr::AbortMsg { code, msg } => Instr::AbortMsg {
+            code: f(code)?,
+            msg: f(msg)?,
+        },
+
+        Instr::ForceGC => Instr::ForceGC,
+    })
 }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -24,40 +24,50 @@ use move_core_types::{
     int256::{I256, U256},
 };
 
-/// Named slot operand.
-/// TODO(cleanup): consider renaming this enum to `NamedSlot`, to contrast with `SizedSlot`.
-///
-/// - `Home` — frame-local storage: parameters, declared locals, and temporaries
-///   due to destackification. These map 1:1 to frame slots.
-///
-/// - `Xfer` — transfer slots used for both  passing arguments to a callee
-///   (before the call) and receiving return values (after the call).
-///   `Xfer` overlaps with the callee's  parameter/return area, so values
-///   produced directly into a `Xfer` slot avoid a copy at the call site.
-///
-/// - `Vid` — SSA value ID, a 0-based temporary that exists only in the
-///   pre-allocation IR. Slot allocation replaces every `Vid` with a real
-///   `Home` or `Xfer` slot.
+/// Index of a `Home` slot within the frame's local area. Shared by
+/// [`SsaSlot::Home`] and [`NamedSlot::Home`]: slot allocation maps pinned
+/// locals across the two forms index-preservingly.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Slot {
-    /// Params, locals, and temporaries — displayed as `r0, r1, ...`
-    Home(u16),
-    /// Call-interface slots — displayed as `x0, x1, ...`
-    Xfer(u16),
-    /// SSA value ID (pre-allocation only) — displayed as `v0, v1, ...`
-    Vid(u16),
+pub struct HomeIndex(pub u16);
+
+/// Position within the frame's transfer area.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TransferPosition(pub u16);
+
+/// Instruction operand used while a function is in SSA form, before slot
+/// allocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SsaSlot {
+    /// Frame-local storage for parameters and declared locals. These map
+    /// 1:1 to frame slots and stay mutable across blocks. Displayed as
+    /// `r0, r1, ...`.
+    Home(HomeIndex),
+    /// SSA value ID, a temporary defined exactly once within its block.
+    /// Displayed as `v0, v1, ...`.
+    ValueId(u16),
 }
 
-impl Slot {
-    /// Returns `true` if this is a Vid slot (SSA value ID).
-    pub fn is_vid(self) -> bool {
-        matches!(self, Slot::Vid(_))
+impl SsaSlot {
+    /// Returns `true` if this is a `ValueId` slot (SSA value ID).
+    pub fn is_value_id(self) -> bool {
+        matches!(self, SsaSlot::ValueId(_))
     }
+}
 
-    /// Returns `true` if this is a Home slot (pinned local).
-    pub fn is_home(self) -> bool {
-        matches!(self, Slot::Home(_))
-    }
+/// Instruction operand after slot allocation: a concrete named position in
+/// the runtime frame. Contrast with the lowering layer's `SizedSlot`, which
+/// adds layout (offset and size) to the name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NamedSlot {
+    /// Frame-local storage: parameters, declared locals, and temporaries
+    /// due to destackification. Displayed as `r0, r1, ...`.
+    Home(HomeIndex),
+    /// Call-interface slots, used for both passing arguments to a callee
+    /// (before the call) and receiving return values (after the call).
+    /// `Transfer` overlaps with the callee's parameter/return area, so
+    /// values produced directly into a `Transfer` slot avoid a copy at the
+    /// call site. Displayed as `x0, x1, ...`.
+    Transfer(TransferPosition),
 }
 
 /// Label for branch targets.
@@ -126,38 +136,42 @@ pub type FieldPath = Box<[(InternedType, FieldHandleIndex)]>;
 /// non-generic call. Inside a generic function `ty_args` may still
 /// contain the enclosing function's `TypeParam`s.
 #[derive(Clone)]
-pub struct CallData {
-    pub rets: Box<[Slot]>,
+pub struct CallData<SlotForm> {
+    pub rets: Box<[SlotForm]>,
     pub function_handle: FunctionHandleIndex,
     pub ty_args: InternedTypeList,
-    pub args: Box<[Slot]>,
+    pub args: Box<[SlotForm]>,
 }
 
 /// Payload of [`Instr::PackClosure`] (same `(function_handle, ty_args)`
 /// contract as [`CallData`]).
 #[derive(Clone)]
-pub struct PackClosureData {
-    pub dst: Slot,
+pub struct PackClosureData<SlotForm> {
+    pub dst: SlotForm,
     pub function_handle: FunctionHandleIndex,
     pub ty_args: InternedTypeList,
     pub mask: ClosureMask,
-    pub captured: Box<[Slot]>,
+    pub captured: Box<[SlotForm]>,
 }
 
 /// Payload of [`Instr::CallClosure`].
 #[derive(Clone)]
-pub struct CallClosureData {
-    pub rets: Box<[Slot]>,
+pub struct CallClosureData<SlotForm> {
+    pub rets: Box<[SlotForm]>,
     /// The closure's type; always a `Type::Function`.
     pub closure_ty: InternedType,
     /// The arguments provided to the closure, followed by the closure
     /// itself as the last element. Never empty; enforced by [`Self::new`].
-    args: Box<[Slot]>,
+    args: Box<[SlotForm]>,
 }
 
-impl CallClosureData {
+impl<SlotForm> CallClosureData<SlotForm> {
     /// `args` must end with the closure operand (hence be non-empty).
-    pub(crate) fn new(rets: Box<[Slot]>, closure_ty: InternedType, args: Box<[Slot]>) -> Self {
+    pub(crate) fn new(
+        rets: Box<[SlotForm]>,
+        closure_ty: InternedType,
+        args: Box<[SlotForm]>,
+    ) -> Self {
         debug_assert!(
             !args.is_empty(),
             "CallClosure args must include the closure"
@@ -170,7 +184,10 @@ impl CallClosureData {
     }
 
     /// Splits `args` into `(closure, provided arguments)`.
-    pub fn closure_and_provided(&self) -> (Slot, &[Slot]) {
+    pub fn closure_and_provided(&self) -> (SlotForm, &[SlotForm])
+    where
+        SlotForm: Copy,
+    {
         let (closure, provided) = self
             .args
             .split_last()
@@ -179,7 +196,11 @@ impl CallClosureData {
     }
 }
 
-/// A stackless IR instruction with explicit named-slot operands.
+/// A stackless IR instruction with explicit slot operands.
+///
+/// Generic over the slot form `SlotForm`: [`SsaSlot`] before slot allocation,
+/// [`NamedSlot`] after. Slot allocation is the only conversion between the
+/// two (see `destack::slot_alloc`).
 ///
 /// # Field order
 ///
@@ -202,7 +223,7 @@ impl CallClosureData {
 /// Every slot operand is written (a def), read (a value use), or referenced
 /// by location (a place use):
 /// - `dst`/`dsts` are defs.
-/// - Sources are value uses: a `Vid` is consumed (single-use SSA before
+/// - Sources are value uses: a `ValueId` is consumed (single-use SSA before
 ///   slot allocation); a `Home` slot stays valid unless moved out. A
 ///   written-through reference is also a value use — its pointee is
 ///   mutated, but the slot is not a def.
@@ -223,46 +244,50 @@ impl CallClosureData {
 ///
 /// `Branch`, `Ret`, `Abort`, and `AbortMsg` terminate a block; `BrTrue`,
 /// `BrFalse`, `BrCmp`, and `BrCmpImm` fall through when not taken. `Call`
-/// and `CallClosure` clobber all `Xfer` slots.
+/// and `CallClosure` clobber all `Transfer` slots.
 ///
 /// TODO(cleanup): change uses of raw integers into newtypes/type-aliases.
 #[derive(Clone)]
-pub enum Instr {
+pub enum Instr<SlotForm> {
     // --- Loads ---
     /// `dst = const_pool[const_idx]` — load a constant, deserialized from
     /// its BCS byte blob in the constant pool.
     LdConst {
-        dst: Slot,
+        dst: SlotForm,
         const_idx: ConstantPoolIndex,
     },
     /// `dst = imm` — load a bool or integer literal.
-    LdImm { dst: Slot, imm: ImmValue },
+    LdImm { dst: SlotForm, imm: ImmValue },
 
     // --- Slot ops ---
     /// `dst = copy(src)`, source remains valid.
-    Copy { dst: Slot, src: Slot },
+    Copy { dst: SlotForm, src: SlotForm },
     /// `dst = move(src)`, source invalidated.
-    Move { dst: Slot, src: Slot },
+    Move { dst: SlotForm, src: SlotForm },
 
     // --- Unary / Binary ---
     /// `dst = op(src)`. `Cast` aborts when the value does not fit the
     /// target integer type.
-    UnaryOp { dst: Slot, op: UnaryOp, src: Slot },
+    UnaryOp {
+        dst: SlotForm,
+        op: UnaryOp,
+        src: SlotForm,
+    },
     /// `dst = op(lhs, rhs)`. Arithmetic aborts on overflow and on
     /// division/modulo by zero; shifts abort when the amount is at least
     /// the operand width.
     BinaryOp {
-        dst: Slot,
+        dst: SlotForm,
         op: BinaryOp,
-        lhs: Slot,
-        rhs: Slot,
+        lhs: SlotForm,
+        rhs: SlotForm,
     },
     /// `dst = op(lhs, imm)` — [`Instr::BinaryOp`] with an immediate right
     /// operand.
     BinaryOpImm {
-        dst: Slot,
+        dst: SlotForm,
         op: BinaryOp,
-        lhs: Slot,
+        lhs: SlotForm,
         imm: ImmValue,
     },
 
@@ -270,152 +295,152 @@ pub enum Instr {
     /// `dst = struct_ty { srcs }` — construct a struct from the field
     /// values, in field declaration order.
     Pack {
-        dst: Slot,
+        dst: SlotForm,
         struct_ty: InternedType,
-        srcs: Box<[Slot]>,
+        srcs: Box<[SlotForm]>,
     },
     /// `dsts = fields of src` — destructure a `struct_ty` value into its
     /// field values, in field declaration order.
     Unpack {
-        dsts: Box<[Slot]>,
+        dsts: Box<[SlotForm]>,
         struct_ty: InternedType,
-        src: Slot,
+        src: SlotForm,
     },
 
     // --- Variant (enum type + variant ordinal) ---
     /// `dst = enum_ty::variant { srcs }` — construct an enum value with tag
     /// `variant` from the field values, in field declaration order.
     PackVariant {
-        dst: Slot,
+        dst: SlotForm,
         enum_ty: InternedType,
         variant: u16,
-        srcs: Box<[Slot]>,
+        srcs: Box<[SlotForm]>,
     },
     /// `dsts = fields of src` — destructure an `enum_ty` value; aborts when
     /// the value's runtime tag is not `variant`.
     UnpackVariant {
-        dsts: Box<[Slot]>,
+        dsts: Box<[SlotForm]>,
         enum_ty: InternedType,
         variant: u16,
-        src: Slot,
+        src: SlotForm,
     },
     /// `dst = (tag(*src) == variant)` — `src` holds a reference to an
     /// `enum_ty` value.
     TestVariant {
-        dst: Slot,
+        dst: SlotForm,
         enum_ty: InternedType,
         variant: u16,
-        src: Slot,
+        src: SlotForm,
     },
 
     // --- References ---
     //
     /// `dst = &local`.
-    ImmBorrowLoc { dst: Slot, local: Slot },
+    ImmBorrowLoc { dst: SlotForm, local: SlotForm },
     /// `dst = &mut local`. A later write through `dst` mutates `local`
     /// without a def at the write site (a hidden write).
-    MutBorrowLoc { dst: Slot, local: Slot },
+    MutBorrowLoc { dst: SlotForm, local: SlotForm },
     // Field ops carry the instantiated owner type (`owner_ty`) and a
     // non-generic field handle (`field`) giving the field position.
     /// `dst = &(*src).field` — pure address computation, no abort.
     ImmBorrowField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: FieldHandleIndex,
-        src: Slot,
+        src: SlotForm,
     },
     /// `dst = &mut (*src).field` — pure address computation, no abort.
     MutBorrowField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: FieldHandleIndex,
-        src: Slot,
+        src: SlotForm,
     },
     /// `dst = &(*src).field` on an enum; aborts when the value's runtime
     /// variant does not declare `field`.
     ImmBorrowVariantField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: VariantFieldHandleIndex,
-        src: Slot,
+        src: SlotForm,
     },
     /// `dst = &mut (*src).field` on an enum; aborts when the value's
     /// runtime variant does not declare `field`.
     MutBorrowVariantField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: VariantFieldHandleIndex,
-        src: Slot,
+        src: SlotForm,
     },
     /// `dst = *src`.
-    ReadRef { dst: Slot, src: Slot },
+    ReadRef { dst: SlotForm, src: SlotForm },
     /// `*dst_ref = val`
-    WriteRef { dst_ref: Slot, val: Slot },
+    WriteRef { dst_ref: SlotForm, val: SlotForm },
 
     // --- Fused field access (borrow+read/write combined) ---
     /// `dst = (*src).field` (imm_borrow_field + read_ref)
     ReadField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: FieldHandleIndex,
-        src: Slot,
+        src: SlotForm,
     },
     /// `(*dst_ref).field = val` (mut_borrow_field + write_ref)
     WriteField {
-        dst_ref: Slot,
+        dst_ref: SlotForm,
         owner_ty: InternedType,
         field: FieldHandleIndex,
-        val: Slot,
+        val: SlotForm,
     },
     /// `dst = (*src).field` on an enum (imm_borrow_variant_field +
     /// read_ref); aborts when the value's runtime variant does not declare
     /// `field`.
     ReadVariantField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: VariantFieldHandleIndex,
-        src: Slot,
+        src: SlotForm,
     },
     /// `(*dst_ref).field = val` on an enum (mut_borrow_variant_field +
     /// write_ref); aborts when the value's runtime variant does not declare
     /// `field`.
     WriteVariantField {
-        dst_ref: Slot,
+        dst_ref: SlotForm,
         owner_ty: InternedType,
         field: VariantFieldHandleIndex,
-        val: Slot,
+        val: SlotForm,
     },
 
     // --- Fused inline-struct field access (borrow_loc + field op combined) ---
     /// `dst = &local.field` (imm_borrow_loc + imm_borrow_field on an inline struct local)
     ImmBorrowLocField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: FieldHandleIndex,
-        local: Slot,
+        local: SlotForm,
     },
     /// `dst = &mut local.field`. Hidden-write hazard as in
     /// [`Instr::MutBorrowLoc`].
     MutBorrowLocField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: FieldHandleIndex,
-        local: Slot,
+        local: SlotForm,
     },
     /// `dst = local.field` (imm_borrow_loc + read_field on an inline struct local)
     ReadLocField {
-        dst: Slot,
+        dst: SlotForm,
         owner_ty: InternedType,
         field: FieldHandleIndex,
-        local: Slot,
+        local: SlotForm,
     },
     /// `local.field = val` (mut_borrow_loc + write_field on an inline
     /// struct local).
     WriteLocField {
-        local: Slot,
+        local: SlotForm,
         owner_ty: InternedType,
         field: FieldHandleIndex,
-        val: Slot,
+        val: SlotForm,
     },
 
     // --- Fused inline-struct field CHAINS ---
@@ -431,212 +456,218 @@ pub enum Instr {
     //
     /// `dst = (*src).path`.
     ReadFieldChain {
-        dst: Slot,
+        dst: SlotForm,
         path: FieldPath,
-        src: Slot,
+        src: SlotForm,
     },
     /// `(*dst_ref).path = val`.
     WriteFieldChain {
-        dst_ref: Slot,
+        dst_ref: SlotForm,
         path: FieldPath,
-        val: Slot,
+        val: SlotForm,
     },
     /// `dst = &(*src).path`.
     ImmBorrowFieldChain {
-        dst: Slot,
+        dst: SlotForm,
         path: FieldPath,
-        src: Slot,
+        src: SlotForm,
     },
     /// `dst = &mut (*src).path`.
     MutBorrowFieldChain {
-        dst: Slot,
+        dst: SlotForm,
         path: FieldPath,
-        src: Slot,
+        src: SlotForm,
     },
     /// `dst = local.path`.
     ReadLocFieldChain {
-        dst: Slot,
+        dst: SlotForm,
         path: FieldPath,
-        local: Slot,
+        local: SlotForm,
     },
     /// `local.path = val`.
     WriteLocFieldChain {
-        local: Slot,
+        local: SlotForm,
         path: FieldPath,
-        val: Slot,
+        val: SlotForm,
     },
     /// `dst = &local.path`.
     ImmBorrowLocFieldChain {
-        dst: Slot,
+        dst: SlotForm,
         path: FieldPath,
-        local: Slot,
+        local: SlotForm,
     },
     /// `dst = &mut local.path`. Hidden-write hazard as in
     /// [`Instr::MutBorrowLoc`].
     MutBorrowLocFieldChain {
-        dst: Slot,
+        dst: SlotForm,
         path: FieldPath,
-        local: Slot,
+        local: SlotForm,
     },
 
     // --- Globals (`resource_ty` names the resource in global storage) ---
     /// `dst = exists<resource_ty>(addr)` — true iff global storage holds a
     /// `resource_ty` at `addr`.
     Exists {
-        dst: Slot,
+        dst: SlotForm,
         resource_ty: InternedType,
-        addr: Slot,
+        addr: SlotForm,
     },
     /// `dst = move_from<resource_ty>(addr)` — remove the resource from
     /// global storage; aborts when none exists at `addr`.
     MoveFrom {
-        dst: Slot,
+        dst: SlotForm,
         resource_ty: InternedType,
-        addr: Slot,
+        addr: SlotForm,
     },
     /// `move_to<resource_ty>(signer, val)` — publish `val` under the
     /// signer's address; aborts when a resource of this type already exists
     /// there.
     MoveTo {
         resource_ty: InternedType,
-        signer: Slot,
-        val: Slot,
+        signer: SlotForm,
+        val: SlotForm,
     },
     /// `dst = &global<resource_ty>(addr)`; aborts when no resource exists
     /// at `addr`.
     ImmBorrowGlobal {
-        dst: Slot,
+        dst: SlotForm,
         resource_ty: InternedType,
-        addr: Slot,
+        addr: SlotForm,
     },
     /// `dst = &mut global<resource_ty>(addr)`; aborts when no resource
     /// exists at `addr`.
     MutBorrowGlobal {
-        dst: Slot,
+        dst: SlotForm,
         resource_ty: InternedType,
-        addr: Slot,
+        addr: SlotForm,
     },
 
     // --- Calls (payload boxed to keep `Instr` small; see `CallData`) ---
     /// `data.rets = data.function_handle<data.ty_args>(data.args)`.
-    Call { data: Box<CallData> },
+    Call { data: Box<CallData<SlotForm>> },
 
     // --- Closures (payloads boxed; see `PackClosureData`/`CallClosureData`) ---
     /// `data.dst` receives a closure over `data.function_handle<data.ty_args>`
     /// in which the values of `data.captured` are pre-bound to the argument
     /// positions marked in `data.mask`; the remaining positions are filled by
     /// the arguments supplied when the closure is called.
-    PackClosure { data: Box<PackClosureData> },
+    PackClosure {
+        data: Box<PackClosureData<SlotForm>>,
+    },
     /// `data.rets = closure(provided args)` — the closure operand is the
     /// last element of `data.args` (see
     /// [`CallClosureData::closure_and_provided`]).
-    CallClosure { data: Box<CallClosureData> },
+    CallClosure {
+        data: Box<CallClosureData<SlotForm>>,
+    },
 
     // --- Vector (`elem_ty` is the vector's element type) ---
     /// `dst = vector[srcs]`.
     VecPack {
-        dst: Slot,
+        dst: SlotForm,
         elem_ty: InternedType,
-        srcs: Box<[Slot]>,
+        srcs: Box<[SlotForm]>,
     },
     /// `dst = (*vec_ref).length()`.
     VecLen {
-        dst: Slot,
+        dst: SlotForm,
         elem_ty: InternedType,
-        vec_ref: Slot,
+        vec_ref: SlotForm,
     },
     /// `dst = &(*vec_ref)[idx]`; aborts when `idx` is out of bounds.
     VecImmBorrow {
-        dst: Slot,
+        dst: SlotForm,
         elem_ty: InternedType,
-        vec_ref: Slot,
-        idx: Slot,
+        vec_ref: SlotForm,
+        idx: SlotForm,
     },
     /// `dst = &mut (*vec_ref)[idx]`; aborts when `idx` is out of bounds.
     VecMutBorrow {
-        dst: Slot,
+        dst: SlotForm,
         elem_ty: InternedType,
-        vec_ref: Slot,
-        idx: Slot,
+        vec_ref: SlotForm,
+        idx: SlotForm,
     },
     /// `(*vec_ref).push_back(val)`.
     VecPushBack {
-        vec_ref: Slot,
+        vec_ref: SlotForm,
         elem_ty: InternedType,
-        val: Slot,
+        val: SlotForm,
     },
     /// `dst = (*vec_ref).pop_back()`; aborts on an empty vector.
     VecPopBack {
-        dst: Slot,
+        dst: SlotForm,
         elem_ty: InternedType,
-        vec_ref: Slot,
+        vec_ref: SlotForm,
     },
     /// `dsts = elements of src`; aborts unless the vector's length is
     /// exactly `dsts.len()`.
     VecUnpack {
-        dsts: Box<[Slot]>,
+        dsts: Box<[SlotForm]>,
         elem_ty: InternedType,
-        src: Slot,
+        src: SlotForm,
     },
     /// `(*vec_ref).swap(idx_a, idx_b)`; aborts when either index is out of
     /// bounds.
     VecSwap {
-        vec_ref: Slot,
+        vec_ref: SlotForm,
         elem_ty: InternedType,
-        idx_a: Slot,
-        idx_b: Slot,
+        idx_a: SlotForm,
+        idx_b: SlotForm,
     },
 
     // --- Control flow ---
     /// Unconditional jump to `target`.
     Branch { target: Label },
     /// Jump to `target` when `cond` is true; otherwise fall through.
-    BrTrue { target: Label, cond: Slot },
+    BrTrue { target: Label, cond: SlotForm },
     /// Jump to `target` when `cond` is false; otherwise fall through.
-    BrFalse { target: Label, cond: Slot },
+    BrFalse { target: Label, cond: SlotForm },
     /// Jump to `target` when `op(lhs, rhs)` is true; otherwise fall through
     /// (fused compare + conditional branch).
     BrCmp {
         target: Label,
         op: CmpKind,
-        lhs: Slot,
-        rhs: Slot,
+        lhs: SlotForm,
+        rhs: SlotForm,
     },
     /// Jump to `target` when `op(lhs, imm)` is true; otherwise fall
     /// through.
     BrCmpImm {
         target: Label,
         op: CmpKind,
-        lhs: Slot,
+        lhs: SlotForm,
         imm: ImmValue,
     },
     /// Return `srcs` to the caller.
-    Ret { srcs: Box<[Slot]> },
+    Ret { srcs: Box<[SlotForm]> },
     /// Abort execution with the error code held in `code`.
-    Abort { code: Slot },
+    Abort { code: SlotForm },
     /// Abort execution with the error code in `code` and the message
     /// payload in `msg`.
-    AbortMsg { code: Slot, msg: Slot },
+    AbortMsg { code: SlotForm, msg: SlotForm },
 
     // --- Test intrinsics ---
     /// Triggers a garbage collection.
     ForceGC,
 }
 
+// Both slot forms are 4 bytes (tag + u16), so both instantiations share
+// the 32-byte pin.
 const _: () = assert!(
-    std::mem::size_of::<Instr>() == 32,
+    std::mem::size_of::<Instr<SsaSlot>>() == 32 && std::mem::size_of::<Instr<NamedSlot>>() == 32,
     "Instr is no longer 32 bytes; if it grew, box the offending variant's \
     payload — if the widest variant shrank, re-pin this constant"
 );
 // The align assert matters on its own: a raw `u128`-family payload could keep
 // the size at 32 while bumping the alignment (and allocator padding) to 16.
 const _: () = assert!(
-    std::mem::align_of::<Instr>() == 8,
+    std::mem::align_of::<Instr<SsaSlot>>() == 8 && std::mem::align_of::<Instr<NamedSlot>>() == 8,
     "Instr alignment is no longer 8; if it grew, box the align-16 \
      (u128-family) payload — if it shrank, re-pin this constant"
 );
 
-impl Instr {
+impl<SlotForm> Instr<SlotForm> {
     /// Returns the variant tag as a static string. Useful for terse error
     /// messages that don't need the full operand dump.
     pub fn opcode_name(&self) -> &'static str {
@@ -706,18 +737,19 @@ impl Instr {
     }
 }
 
-/// A basic block of instructions.
+/// A basic block of instructions, generic over the slot form like
+/// [`Instr`].
 ///
 /// Every block has a label. The last instruction is a terminator.
 /// (`Branch`, `BrTrue`, `BrFalse`, `Ret`, `Abort`, `AbortMsg`).
-pub struct BasicBlock {
+pub struct BasicBlock<SlotForm> {
     /// Label identifying this block.
     pub label: Label,
     /// Instructions in this block.
-    pub instrs: Vec<Instr>,
+    pub instrs: Vec<Instr<SlotForm>>,
 }
 
-/// IR for a single function.
+/// IR for a single function, after slot allocation (named-slot form).
 pub struct FunctionIR {
     /// Function name in identifier pool.
     pub name_idx: IdentifierIndex,
@@ -729,13 +761,14 @@ pub struct FunctionIR {
     pub num_locals: u16,
     /// Total Home slots used (params + locals + temps).
     pub num_home_slots: u16,
-    /// Number of distinct `Xfer(j)` positions used across all calls in this
-    /// function.
-    pub num_xfer_positions: u16,
+    /// Number of distinct `Transfer(j)` positions used across all calls in
+    /// this function.
+    pub num_transfer_positions: u16,
     /// Basic blocks of the function.
-    pub blocks: Vec<BasicBlock>,
+    pub blocks: Vec<BasicBlock<NamedSlot>>,
     /// Type of each Home slot (indexed by Home slot index, 0..num_home_slots-1).
-    /// Xfer slots have no entry here — their types are inferred from call signatures.
+    /// Transfer slots have no entry here — their types are inferred from call
+    /// signatures.
     pub home_slot_types: Vec<InternedType>,
     /// Gas cost of each block as an unresolved formula, indexed by block label.
     pub(crate) block_costs: Vec<BlockCost>,
@@ -743,12 +776,12 @@ pub struct FunctionIR {
 
 impl FunctionIR {
     /// Iterate over all instructions across all blocks.
-    pub fn instrs(&self) -> impl Iterator<Item = &Instr> {
+    pub fn instrs(&self) -> impl Iterator<Item = &Instr<NamedSlot>> {
         self.blocks.iter().flat_map(|b| b.instrs.iter())
     }
 
     /// Iterate mutably over all instructions across all blocks.
-    pub fn instrs_mut(&mut self) -> impl Iterator<Item = &mut Instr> {
+    pub fn instrs_mut(&mut self) -> impl Iterator<Item = &mut Instr<NamedSlot>> {
         self.blocks.iter_mut().flat_map(|b| b.instrs.iter_mut())
     }
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/bool/eq_compare.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/bool/eq_compare.exp
@@ -24,7 +24,7 @@ fun eq(l0: u64, l1: u64): bool
 // module 0x1::test
 
 fun compare(r0, r1): u64 {
-  slots: params(2), locals(0), temps(1), xfer(2)
+  slots: params(2), locals(0), temps(1), transfer(2)
     r0: u64
     r1: u64
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/arg_regs.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/arg_regs.exp
@@ -43,7 +43,7 @@ fun three_args(r0, r1, r2): u64 {
 }
 
 fun simple_promotion(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(1)
+  slots: params(0), locals(0), temps(0), transfer(1)
   code:
   L0:
     0: x0 := ld_u64 42
@@ -52,7 +52,7 @@ fun simple_promotion(): u64 {
 }
 
 fun multi_arg(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(2)
+  slots: params(0), locals(0), temps(0), transfer(2)
   code:
   L0:
     0: x0 := ld_u64 1
@@ -62,7 +62,7 @@ fun multi_arg(): u64 {
 }
 
 fun nested_fg(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(1)
+  slots: params(0), locals(0), temps(0), transfer(1)
   code:
   L0:
     0: x0 := ld_u64 7
@@ -72,7 +72,7 @@ fun nested_fg(): u64 {
 }
 
 fun two_inner_calls(): u64 {
-  slots: params(0), locals(0), temps(1), xfer(2)
+  slots: params(0), locals(0), temps(1), transfer(2)
     r0: u64
   code:
   L0:
@@ -85,7 +85,7 @@ fun two_inner_calls(): u64 {
 }
 
 fun computed_arg(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L0:
@@ -95,7 +95,7 @@ fun computed_arg(r0): u64 {
 }
 
 fun partial_promotion(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(2)
+  slots: params(1), locals(0), temps(0), transfer(2)
     r0: u64
   code:
   L0:
@@ -105,7 +105,7 @@ fun partial_promotion(r0): u64 {
 }
 
 fun call_with_param(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L0:
@@ -114,7 +114,7 @@ fun call_with_param(r0): u64 {
 }
 
 fun arg_live_after_call(r0): u64 {
-  slots: params(1), locals(1), temps(1), xfer(1)
+  slots: params(1), locals(1), temps(1), transfer(1)
     r0: u64
     r1: u64
     r2: u64
@@ -126,7 +126,7 @@ fun arg_live_after_call(r0): u64 {
 }
 
 fun ret_used_past_next_call(): u64 {
-  slots: params(0), locals(1), temps(1), xfer(1)
+  slots: params(0), locals(1), temps(1), transfer(1)
     r0: u64
     r1: u64
   code:
@@ -140,7 +140,7 @@ fun ret_used_past_next_call(): u64 {
 }
 
 fun multi_ret(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(2)
+  slots: params(0), locals(0), temps(0), transfer(2)
   code:
   L0:
     0: x0 := ld_u64 3
@@ -151,7 +151,7 @@ fun multi_ret(): u64 {
 }
 
 fun width_from_max(): u64 {
-  slots: params(0), locals(0), temps(1), xfer(3)
+  slots: params(0), locals(0), temps(1), transfer(3)
     r0: u64
   code:
   L0:
@@ -166,7 +166,7 @@ fun width_from_max(): u64 {
 }
 
 fun call_in_loop(r0): u64 {
-  slots: params(1), locals(1), temps(0), xfer(1)
+  slots: params(1), locals(1), temps(0), transfer(1)
     r0: u64
     r1: u64
   code:
@@ -184,7 +184,7 @@ fun call_in_loop(r0): u64 {
 }
 
 fun mixed_at_callsite(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(3)
+  slots: params(1), locals(0), temps(0), transfer(3)
     r0: u64
   code:
   L0:
@@ -195,7 +195,7 @@ fun mixed_at_callsite(r0): u64 {
 }
 
 fun mixed_intervening_call(): u64 {
-  slots: params(0), locals(0), temps(1), xfer(3)
+  slots: params(0), locals(0), temps(1), transfer(3)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/calls.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/calls.exp
@@ -10,7 +10,7 @@ fun identity(r0): u64 {
 }
 
 fun caller(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(1)
+  slots: params(0), locals(0), temps(0), transfer(1)
   code:
   L0:
     0: x0 := ld_u64 10

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_func.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_func.exp
@@ -29,7 +29,7 @@ fun double(r0): u64 {
 }
 
 fun quad(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_ret_cross_position.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_ret_cross_position.exp
@@ -25,7 +25,7 @@ fun sink(r0, r1, r2) {
 }
 
 fun caller(r0) {
-  slots: params(1), locals(0), temps(1), xfer(3)
+  slots: params(1), locals(0), temps(1), transfer(3)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_ret_flow.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_ret_flow.exp
@@ -39,7 +39,7 @@ fun two_rets(): (u64, u64)
 // module 0xc0ffee::multi_ret_flow
 
 fun trigger(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(2)
+  slots: params(0), locals(0), temps(0), transfer(2)
   code:
   L0:
     0: [x0, x1] := call two_rets, []
@@ -48,7 +48,7 @@ fun trigger(): u64 {
 }
 
 fun trigger_swap(): u64 {
-  slots: params(0), locals(2), temps(0), xfer(2)
+  slots: params(0), locals(2), temps(0), transfer(2)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_ret_mixed_size.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_ret_mixed_size.exp
@@ -21,7 +21,7 @@ fun other_call(r0, r1) {
 }
 
 fun caller(r0) {
-  slots: params(1), locals(0), temps(1), xfer(2)
+  slots: params(1), locals(0), temps(1), transfer(2)
     r0: &mut u64
     r1: u64
   code:
@@ -35,7 +35,7 @@ fun caller(r0) {
 }
 
 fun trigger(): u64 {
-  slots: params(0), locals(1), temps(0), xfer(1)
+  slots: params(0), locals(1), temps(0), transfer(1)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_ret_single_xfer.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/multi_ret_single_xfer.exp
@@ -25,7 +25,7 @@ fun three_args(r0, r1, r2) {
 }
 
 fun caller(r0) {
-  slots: params(1), locals(2), temps(1), xfer(3)
+  slots: params(1), locals(2), temps(1), transfer(3)
     r0: &mut u64
     r1: u64
     r2: u64
@@ -39,7 +39,7 @@ fun caller(r0) {
 }
 
 fun trigger(): u64 {
-  slots: params(0), locals(1), temps(0), xfer(1)
+  slots: params(0), locals(1), temps(0), transfer(1)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/padded_param_abi.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/padded_param_abi.exp
@@ -30,7 +30,7 @@ l0: mut_borrow_loc l2
 // module 0x66::padded_param
 
 fun driver(r0, r1): u64 {
-  slots: params(2), locals(0), temps(0), xfer(2)
+  slots: params(2), locals(0), temps(0), transfer(2)
     r0: bool
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/ret_non_monotonic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/ret_non_monotonic.exp
@@ -25,7 +25,7 @@ fun B(r0, r1, r2): u64 {
 }
 
 fun caller(r0, r1): u64 {
-  slots: params(2), locals(0), temps(1), xfer(3)
+  slots: params(2), locals(0), temps(1), transfer(3)
     r0: u64
     r1: u64
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/ret_swap.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/ret_swap.exp
@@ -45,7 +45,7 @@ fun swap_back(l0: u64, l1: u64): (u64, u64)
 // module 0xc0ffee::ret_swap
 
 fun first(): u64 {
-  slots: params(0), locals(0), temps(1), xfer(2)
+  slots: params(0), locals(0), temps(1), transfer(2)
     r0: u64
   code:
   L0:
@@ -56,7 +56,7 @@ fun first(): u64 {
 }
 
 fun second(): u64 {
-  slots: params(0), locals(1), temps(1), xfer(2)
+  slots: params(0), locals(1), temps(1), transfer(2)
     r0: u64
     r1: u64
   code:
@@ -68,7 +68,7 @@ fun second(): u64 {
 }
 
 fun second_offset(): u64 {
-  slots: params(0), locals(1), temps(2), xfer(2)
+  slots: params(0), locals(1), temps(2), transfer(2)
     r0: u64
     r1: u64
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/v2_leftovers.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/v2_leftovers.exp
@@ -21,7 +21,7 @@ fun add_two(r0, r1): u64 {
 }
 
 fun copy_to_call(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L0:
@@ -30,7 +30,7 @@ fun copy_to_call(r0): u64 {
 }
 
 fun move_to_call(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L0:
@@ -50,7 +50,7 @@ fun multi_use_local_alias(r0): u64 {
 }
 
 fun copy_call_then_use(r0): u64 {
-  slots: params(1), locals(0), temps(1), xfer(1)
+  slots: params(1), locals(0), temps(1), transfer(1)
     r0: u64
     r1: u64
   code:
@@ -61,7 +61,7 @@ fun copy_call_then_use(r0): u64 {
 }
 
 fun two_copies_to_call(r0, r1): u64 {
-  slots: params(2), locals(0), temps(0), xfer(2)
+  slots: params(2), locals(0), temps(0), transfer(2)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/xfer_collision.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/xfer_collision.exp
@@ -28,7 +28,7 @@ fun three_args(r0, r1, r2): u64 {
 }
 
 fun caller(r0): u64 {
-  slots: params(1), locals(0), temps(1), xfer(3)
+  slots: params(1), locals(0), temps(1), transfer(3)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/xfer_propagation_safety.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/xfer_propagation_safety.exp
@@ -18,7 +18,7 @@ fun void_no_arg() {
 }
 
 fun trigger(): u64 {
-  slots: params(0), locals(1), temps(0), xfer(1)
+  slots: params(0), locals(1), temps(0), transfer(1)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/xfer_ret_order.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/calls/xfer_ret_order.exp
@@ -26,7 +26,7 @@ fun two_args(r0, r1): u64 {
 }
 
 fun caller(): u64 {
-  slots: params(0), locals(0), temps(3), xfer(3)
+  slots: params(0), locals(0), temps(3), transfer(3)
     r0: u64
     r1: u64
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_middle_interleave.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_middle_interleave.exp
@@ -31,7 +31,7 @@ fun g(r0, r1, r2): u64 {
 }
 
 fun caller(): u64 {
-  slots: params(0), locals(1), temps(3), xfer(3)
+  slots: params(0), locals(1), temps(3), transfer(3)
     r0: |u64, u64|u64
     r1: u64
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capturing.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capturing.exp
@@ -213,7 +213,7 @@ fun make_adder(r0): |u64|u64 {
 }
 
 fun use_adder(r0, r1): u64 {
-  slots: params(2), locals(1), temps(1), xfer(1)
+  slots: params(2), locals(1), temps(1), transfer(1)
     r0: u64
     r1: u64
     r2: |u64|u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_as_arg.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_as_arg.exp
@@ -49,7 +49,7 @@ fun apply(r0, r1): u64 {
 }
 
 fun run(r0, r1): u64 {
-  slots: params(2), locals(0), temps(0), xfer(2)
+  slots: params(2), locals(0), temps(0), transfer(2)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/cross_block_calls.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/cross_block_calls.exp
@@ -21,7 +21,7 @@ fun consume(r0): u64 {
 }
 
 fun trigger(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L2:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/fibonacci.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/fibonacci.exp
@@ -27,7 +27,7 @@ l0: copy_loc l0
 // module 0x1::test
 
 fun fib(r0): u64 {
-  slots: params(1), locals(0), temps(1), xfer(1)
+  slots: params(1), locals(0), temps(1), transfer(1)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/chain_abort_order.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/chain_abort_order.exp
@@ -26,7 +26,7 @@ fun read_after_call(r0): u64 {
 }
 
 fun run(): u64 {
-  slots: params(0), locals(1), temps(1), xfer(1)
+  slots: params(0), locals(1), temps(1), transfer(1)
     r0: 0x55::chain_abort_order::E
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/chained_variant_field_fusion.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/chained_variant_field_fusion.exp
@@ -86,7 +86,7 @@ fun read_u(r0): u8 {
 }
 
 fun run_read_e(r0, r1): u8 {
-  slots: params(2), locals(1), temps(0), xfer(2)
+  slots: params(2), locals(1), temps(0), transfer(2)
     r0: u64
     r1: u8
     r2: 0x99::chained_variant_field_fusion::E
@@ -99,7 +99,7 @@ fun run_read_e(r0, r1): u8 {
 }
 
 fun run_read_f(r0): u8 {
-  slots: params(1), locals(1), temps(4), xfer(1)
+  slots: params(1), locals(1), temps(4), transfer(1)
     r0: u64
     r1: 0x99::chained_variant_field_fusion::F
     r2: u8
@@ -126,7 +126,7 @@ fun run_read_f(r0): u8 {
 }
 
 fun run_read_u(r0, r1): u8 {
-  slots: params(2), locals(1), temps(0), xfer(2)
+  slots: params(2), locals(1), temps(0), transfer(2)
     r0: u64
     r1: u8
     r2: 0x99::chained_variant_field_fusion::U
@@ -139,7 +139,7 @@ fun run_read_u(r0, r1): u8 {
 }
 
 fun run_write_e(r0, r1): u8 {
-  slots: params(2), locals(1), temps(0), xfer(2)
+  slots: params(2), locals(1), temps(0), transfer(2)
     r0: u64
     r1: u8
     r2: 0x99::chained_variant_field_fusion::E

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/variant_field_tail_borrows.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/variant_field_tail_borrows.exp
@@ -2,7 +2,7 @@
 // module 0x77::variant_field_tail_borrows
 
 fun bump_via_mut_ref(r0, r1): u8 {
-  slots: params(2), locals(2), temps(1), xfer(2)
+  slots: params(2), locals(2), temps(1), transfer(2)
     r0: u64
     r1: u8
     r2: 0x77::variant_field_tail_borrows::E
@@ -71,7 +71,7 @@ fun mut_ref(r0): &mut u8 {
 }
 
 fun read_via_imm_ref(r0, r1): u8 {
-  slots: params(2), locals(1), temps(1), xfer(2)
+  slots: params(2), locals(1), temps(1), transfer(2)
     r0: u64
     r1: u8
     r2: 0x77::variant_field_tail_borrows::E

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/call_generic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/call_generic.exp
@@ -10,7 +10,7 @@ fun identity(r0): _0 {
 }
 
 fun call_u64(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(1)
+  slots: params(0), locals(0), temps(0), transfer(1)
   code:
   L0:
     0: x0 := ld_u64 10
@@ -19,7 +19,7 @@ fun call_u64(): u64 {
 }
 
 fun call_bool(): bool {
-  slots: params(0), locals(0), temps(0), xfer(1)
+  slots: params(0), locals(0), temps(0), transfer(1)
   code:
   L0:
     0: x0 := ld_true

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/chained_field_fusion_generic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/chained_field_fusion_generic.exp
@@ -27,7 +27,7 @@ fun read_chain(r0): _0 {
 }
 
 fun run_u64(r0): u64 {
-  slots: params(1), locals(1), temps(0), xfer(2)
+  slots: params(1), locals(1), temps(0), transfer(2)
     r0: u64
     r1: 0x77::chained_field_fusion_generic::S<u64>
   code:
@@ -40,7 +40,7 @@ fun run_u64(r0): u64 {
 }
 
 fun run_u8(r0): u8 {
-  slots: params(1), locals(1), temps(0), xfer(2)
+  slots: params(1), locals(1), temps(0), transfer(2)
     r0: u8
     r1: 0x77::chained_field_fusion_generic::S<u8>
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_call.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_call.exp
@@ -22,7 +22,7 @@ fun identity<T0>(l0: T0): T0
 // module 0x42::generic_call
 
 fun call_bool(): bool {
-  slots: params(0), locals(0), temps(0), xfer(1)
+  slots: params(0), locals(0), temps(0), transfer(1)
   code:
   L0:
     0: x0 := ld_true
@@ -31,7 +31,7 @@ fun call_bool(): bool {
 }
 
 fun call_u64(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(1)
+  slots: params(0), locals(0), temps(0), transfer(1)
   code:
   L0:
     0: x0 := ld_u64 7

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_closure_pack.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_closure_pack.exp
@@ -14,7 +14,7 @@ fun call_identity(r0): u64 {
 }
 
 fun call_pick(r0): u64 {
-  slots: params(1), locals(2), temps(3), xfer(1)
+  slots: params(1), locals(2), temps(3), transfer(1)
     r0: u64
     r1: |u64, bool|u64
     r2: |u64, bool|u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_identity.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_identity.exp
@@ -16,7 +16,7 @@ fun identity<T0>(l0: T0): T0
 // module 0x1::test
 
 fun call_identity_u64(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_multi_param.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_multi_param.exp
@@ -17,7 +17,7 @@ fun pick_first<T0: drop, T1: drop>(l0: T0, l1: T1): T0
 // module 0x1::test
 
 fun entry(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(2)
+  slots: params(1), locals(0), temps(0), transfer(2)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_nested.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_nested.exp
@@ -28,7 +28,7 @@ fun outer<T0: drop>(l0: T0): T0
 // module 0x1::test
 
 fun entry(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L0:
@@ -45,7 +45,7 @@ fun innermost(r0): _0 {
 }
 
 fun middle(r0): _0 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: _0
   code:
   L0:
@@ -54,7 +54,7 @@ fun middle(r0): _0 {
 }
 
 fun outer(r0): _0 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: _0
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_partial_inst.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_partial_inst.exp
@@ -24,7 +24,7 @@ fun identity<T0: drop, T1: drop>(l0: T0, l1: T1): T0
 // module 0x1::test
 
 fun caller(r0, r1): u64 {
-  slots: params(2), locals(0), temps(0), xfer(2)
+  slots: params(2), locals(0), temps(0), transfer(2)
     r0: u64
     r1: _0
   code:
@@ -34,7 +34,7 @@ fun caller(r0, r1): u64 {
 }
 
 fun entry(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(2)
+  slots: params(1), locals(0), temps(0), transfer(2)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_repeated_call.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_repeated_call.exp
@@ -29,7 +29,7 @@ fun identity<T0: drop>(l0: T0): T0
 // module 0x1::test
 
 fun entry(): u64 {
-  slots: params(0), locals(1), temps(2), xfer(1)
+  slots: params(0), locals(1), temps(2), transfer(1)
     r0: u64
     r1: u64
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_swapped_args.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_swapped_args.exp
@@ -17,7 +17,7 @@ fun pick_second<T0: drop, T1: drop>(l0: T0, l1: T1): T1
 // module 0x1::test
 
 fun entry(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(2)
+  slots: params(1), locals(0), temps(0), transfer(2)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/field_ref_fusion.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/field_ref_fusion.exp
@@ -38,7 +38,7 @@ fun read_field_ref_twice(r0): u64 {
 }
 
 fun test_read_and_add(r0): u64 {
-  slots: params(1), locals(1), temps(0), xfer(1)
+  slots: params(1), locals(1), temps(0), transfer(1)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/freeze_ref.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/freeze_ref.exp
@@ -2,7 +2,7 @@
 // module 0x1::test
 
 fun frozen_read(r0): u64 {
-  slots: params(1), locals(1), temps(1), xfer(1)
+  slots: params(1), locals(1), temps(1), transfer(1)
     r0: u64
     r1: u64
     r2: &mut u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/simple_refs.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/simple_refs.exp
@@ -22,7 +22,7 @@ fun add_refs(l0: &u64, l1: &u64): u64
 // module 0xc0ffee::refs
 
 fun add(r0, r1): u64 {
-  slots: params(2), locals(0), temps(0), xfer(2)
+  slots: params(2), locals(0), temps(0), transfer(2)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/basic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/basic.exp
@@ -75,7 +75,7 @@ fun get_x(r0): u64 {
 }
 
 fun get_x_of(r0, r1): u64 {
-  slots: params(2), locals(1), temps(0), xfer(2)
+  slots: params(2), locals(1), temps(0), transfer(2)
     r0: u64
     r1: u64
     r2: 0x42::basic::Point

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/chained_field_fusion.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/chained_field_fusion.exp
@@ -61,7 +61,7 @@ fun borrow_chain(r0): &u64 {
 }
 
 fun use_borrow_chain(r0): u64 {
-  slots: params(1), locals(0), temps(1), xfer(1)
+  slots: params(1), locals(0), temps(1), transfer(1)
     r0: &0x66::chained_field_fusion::S
     r1: u64
   code:
@@ -87,7 +87,7 @@ fun read_shared(r0): u64 {
 }
 
 fun test_read_by_value(r0): u64 {
-  slots: params(1), locals(1), temps(0), xfer(2)
+  slots: params(1), locals(1), temps(0), transfer(2)
     r0: u64
     r1: 0x66::chained_field_fusion::S
   code:
@@ -99,7 +99,7 @@ fun test_read_by_value(r0): u64 {
 }
 
 fun test_read_by_ref(r0): u64 {
-  slots: params(1), locals(1), temps(0), xfer(2)
+  slots: params(1), locals(1), temps(0), transfer(2)
     r0: u64
     r1: 0x66::chained_field_fusion::S
   code:
@@ -112,7 +112,7 @@ fun test_read_by_ref(r0): u64 {
 }
 
 fun test_write_by_ref(r0, r1): u64 {
-  slots: params(2), locals(1), temps(0), xfer(2)
+  slots: params(2), locals(1), temps(0), transfer(2)
     r0: u64
     r1: u64
     r2: 0x66::chained_field_fusion::S
@@ -127,7 +127,7 @@ fun test_write_by_ref(r0, r1): u64 {
 }
 
 fun test_borrow_chain(r0): u64 {
-  slots: params(1), locals(1), temps(0), xfer(2)
+  slots: params(1), locals(1), temps(0), transfer(2)
     r0: u64
     r1: 0x66::chained_field_fusion::S
   code:
@@ -140,7 +140,7 @@ fun test_borrow_chain(r0): u64 {
 }
 
 fun test_read_shared(r0, r1): u64 {
-  slots: params(2), locals(1), temps(0), xfer(2)
+  slots: params(2), locals(1), temps(0), transfer(2)
     r0: u64
     r1: u64
     r2: 0x66::chained_field_fusion::S

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_chain_borrows.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_chain_borrows.exp
@@ -19,7 +19,7 @@ fun build(r0): S {
 }
 
 fun bump_via_deep_mut(r0): u64 {
-  slots: params(1), locals(2), temps(1), xfer(1)
+  slots: params(1), locals(2), temps(1), transfer(1)
     r0: u64
     r1: 0x88::field_chain_borrows::S
     r2: &mut u64
@@ -57,7 +57,7 @@ fun read_ref(r0): u64 {
 }
 
 fun read_via_call(r0): u64 {
-  slots: params(1), locals(1), temps(0), xfer(1)
+  slots: params(1), locals(1), temps(0), transfer(1)
     r0: u64
     r1: 0x88::field_chain_borrows::S
   code:
@@ -69,7 +69,7 @@ fun read_via_call(r0): u64 {
 }
 
 fun read_via_local_ref(r0): u64 {
-  slots: params(1), locals(1), temps(1), xfer(1)
+  slots: params(1), locals(1), temps(1), transfer(1)
     r0: u64
     r1: 0x88::field_chain_borrows::S
     r2: u64
@@ -81,7 +81,7 @@ fun read_via_local_ref(r0): u64 {
 }
 
 fun write_via_local(r0): u64 {
-  slots: params(1), locals(1), temps(1), xfer(1)
+  slots: params(1), locals(1), temps(1), transfer(1)
     r0: u64
     r1: 0x88::field_chain_borrows::S
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_chain_gap_terminal.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_chain_gap_terminal.exp
@@ -44,7 +44,7 @@ fun write_gap(r0, r1) {
 }
 
 fun test_read_gap(r0): u64 {
-  slots: params(1), locals(1), temps(0), xfer(1)
+  slots: params(1), locals(1), temps(0), transfer(1)
     r0: u64
     r1: 0x67::field_chain_gap_terminal::S
   code:
@@ -56,7 +56,7 @@ fun test_read_gap(r0): u64 {
 }
 
 fun test_write_gap(r0, r1): u64 {
-  slots: params(2), locals(1), temps(0), xfer(2)
+  slots: params(2), locals(1), temps(0), transfer(2)
     r0: u64
     r1: u64
     r2: 0x67::field_chain_gap_terminal::S

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_fusion.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/field_fusion.exp
@@ -23,7 +23,7 @@ fun add_two_fields(r0): u64 {
 }
 
 fun field_to_call(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: 0x66::field_fusion::Pair
   code:
   L0:
@@ -33,7 +33,7 @@ fun field_to_call(r0): u64 {
 }
 
 fun two_fields_to_call(r0, r1): u64 {
-  slots: params(2), locals(0), temps(2), xfer(1)
+  slots: params(2), locals(0), temps(2), transfer(1)
     r0: 0x66::field_fusion::Pair
     r1: 0x66::field_fusion::Pair
     r2: u64
@@ -71,7 +71,7 @@ fun increment_field(r0) {
 }
 
 fun test_add_two_fields(r0, r1): u64 {
-  slots: params(2), locals(1), temps(0), xfer(1)
+  slots: params(2), locals(1), temps(0), transfer(1)
     r0: u64
     r1: u64
     r2: 0x66::field_fusion::Pair
@@ -83,7 +83,7 @@ fun test_add_two_fields(r0, r1): u64 {
 }
 
 fun test_field_to_call(r0, r1): u64 {
-  slots: params(2), locals(1), temps(0), xfer(1)
+  slots: params(2), locals(1), temps(0), transfer(1)
     r0: u64
     r1: u64
     r2: 0x66::field_fusion::Pair
@@ -95,7 +95,7 @@ fun test_field_to_call(r0, r1): u64 {
 }
 
 fun test_two_fields_to_call(r0, r1, r2, r3): u64 {
-  slots: params(4), locals(2), temps(0), xfer(2)
+  slots: params(4), locals(2), temps(0), transfer(2)
     r0: u64
     r1: u64
     r2: u64
@@ -111,7 +111,7 @@ fun test_two_fields_to_call(r0, r1, r2, r3): u64 {
 }
 
 fun test_field_plus_constant(r0, r1): u64 {
-  slots: params(2), locals(1), temps(0), xfer(1)
+  slots: params(2), locals(1), temps(0), transfer(1)
     r0: u64
     r1: u64
     r2: 0x66::field_fusion::Pair
@@ -123,7 +123,7 @@ fun test_field_plus_constant(r0, r1): u64 {
 }
 
 fun test_increment_field(r0, r1): u64 {
-  slots: params(2), locals(1), temps(2), xfer(1)
+  slots: params(2), locals(1), temps(2), transfer(1)
     r0: u64
     r1: u64
     r2: 0x66::field_fusion::Pair

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/mut_local_field_chain.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/mut_local_field_chain.exp
@@ -19,7 +19,7 @@ fun build(r0): S {
 }
 
 fun bump(r0): u64 {
-  slots: params(1), locals(2), temps(1), xfer(1)
+  slots: params(1), locals(2), temps(1), transfer(1)
     r0: u64
     r1: 0x88::mut_local_field_chain::S
     r2: &mut u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/pack_overlap_safety.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/pack_overlap_safety.exp
@@ -28,7 +28,7 @@ fun consume_two(r0, r1): u64 {
 }
 
 fun pack_natural(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(2)
+  slots: params(0), locals(0), temps(0), transfer(2)
   code:
   L0:
     0: [x0, x1] := call split, []
@@ -38,7 +38,7 @@ fun pack_natural(): u64 {
 }
 
 fun pack_reordered(): u64 {
-  slots: params(0), locals(2), temps(0), xfer(2)
+  slots: params(0), locals(2), temps(0), transfer(2)
     r0: u64
     r1: u64
   code:
@@ -74,7 +74,7 @@ fun split(): u64 * u64 {
 }
 
 fun unpack_natural(): u64 {
-  slots: params(0), locals(0), temps(0), xfer(2)
+  slots: params(0), locals(0), temps(0), transfer(2)
   code:
   L0:
     0: [x0] := call pair_provider, []
@@ -84,7 +84,7 @@ fun unpack_natural(): u64 {
 }
 
 fun unpack_reordered(): u64 {
-  slots: params(0), locals(2), temps(0), xfer(2)
+  slots: params(0), locals(2), temps(0), transfer(2)
     r0: u64
     r1: u64
   code:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/pack_xfer_overlap_probe.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/pack_xfer_overlap_probe.exp
@@ -27,7 +27,7 @@ fun consume_two(r0, r1): u64 {
 }
 
 fun trigger(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(2)
+  slots: params(1), locals(0), temps(0), transfer(2)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_nested_eq.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_nested_eq.exp
@@ -140,7 +140,7 @@ fun pts_neq(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u
 // module 0x1::test
 
 fun bag_eq(r0, r1, r2, r3, r4, r5): bool {
-  slots: params(6), locals(0), temps(2), xfer(3)
+  slots: params(6), locals(0), temps(2), transfer(3)
     r0: u64
     r1: u64
     r2: u64
@@ -158,7 +158,7 @@ fun bag_eq(r0, r1, r2, r3, r4, r5): bool {
 }
 
 fun bag_eq_len(r0, r1, r2, r3, r4): bool {
-  slots: params(5), locals(0), temps(2), xfer(3)
+  slots: params(5), locals(0), temps(2), transfer(3)
     r0: u64
     r1: u64
     r2: u64
@@ -175,7 +175,7 @@ fun bag_eq_len(r0, r1, r2, r3, r4): bool {
 }
 
 fun bag_neq(r0, r1, r2, r3, r4, r5): bool {
-  slots: params(6), locals(0), temps(2), xfer(3)
+  slots: params(6), locals(0), temps(2), transfer(3)
     r0: u64
     r1: u64
     r2: u64
@@ -249,7 +249,7 @@ fun mk_points(r0, r1, r2, r3): vector<Point> {
 }
 
 fun pts_eq(r0, r1, r2, r3, r4, r5, r6, r7): bool {
-  slots: params(8), locals(0), temps(2), xfer(4)
+  slots: params(8), locals(0), temps(2), transfer(4)
     r0: u64
     r1: u64
     r2: u64
@@ -269,7 +269,7 @@ fun pts_eq(r0, r1, r2, r3, r4, r5, r6, r7): bool {
 }
 
 fun pts_neq(r0, r1, r2, r3, r4, r5, r6, r7): bool {
-  slots: params(8), locals(0), temps(2), xfer(4)
+  slots: params(8), locals(0), temps(2), transfer(4)
     r0: u64
     r1: u64
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/unpack_partial_xfer_probe.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/unpack_partial_xfer_probe.exp
@@ -23,7 +23,7 @@ fun id(r0): u64 {
 }
 
 fun trigger(): u64 {
-  slots: params(0), locals(0), temps(1), xfer(1)
+  slots: params(0), locals(0), temps(1), transfer(1)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/unpack_xfer_overlap_probe.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/unpack_xfer_overlap_probe.exp
@@ -28,7 +28,7 @@ fun consume(r0, r1, r2): u64 {
 }
 
 fun trigger(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(3)
+  slots: params(1), locals(0), temps(0), transfer(3)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/cross_module_vec_sum.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/cross_module_vec_sum.exp
@@ -131,7 +131,7 @@ use 0xc0ffee::foo
 // module 0xc0ffee::bar
 
 fun sum_first_n(r0): u64 {
-  slots: params(1), locals(0), temps(0), xfer(1)
+  slots: params(1), locals(0), temps(0), transfer(1)
     r0: u64
   code:
   L0:

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.exp
@@ -104,7 +104,7 @@ fun neq_ref(l0: u64, l1: u64, l2: u64, l3: u64): bool
 // module 0x1::test
 
 fun cmp(r0, r1, r2, r3): u64 {
-  slots: params(4), locals(0), temps(2), xfer(2)
+  slots: params(4), locals(0), temps(2), transfer(2)
     r0: u64
     r1: u64
     r2: u64
@@ -141,7 +141,7 @@ fun build(r0, r1): vector<u64> {
 }
 
 fun eq(r0, r1, r2, r3): bool {
-  slots: params(4), locals(0), temps(2), xfer(2)
+  slots: params(4), locals(0), temps(2), transfer(2)
     r0: u64
     r1: u64
     r2: u64
@@ -157,7 +157,7 @@ fun eq(r0, r1, r2, r3): bool {
 }
 
 fun eq_len(r0, r1, r2): bool {
-  slots: params(3), locals(1), temps(2), xfer(2)
+  slots: params(3), locals(1), temps(2), transfer(2)
     r0: u64
     r1: u64
     r2: u64
@@ -175,7 +175,7 @@ fun eq_len(r0, r1, r2): bool {
 }
 
 fun eq_ref(r0, r1, r2, r3): bool {
-  slots: params(4), locals(2), temps(3), xfer(2)
+  slots: params(4), locals(2), temps(3), transfer(2)
     r0: u64
     r1: u64
     r2: u64
@@ -196,7 +196,7 @@ fun eq_ref(r0, r1, r2, r3): bool {
 }
 
 fun neq_ref(r0, r1, r2, r3): bool {
-  slots: params(4), locals(2), temps(3), xfer(2)
+  slots: params(4), locals(2), temps(3), transfer(2)
     r0: u64
     r1: u64
     r2: u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_pushback_safe_point.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_pushback_safe_point.exp
@@ -29,7 +29,7 @@ fun take(l0: vector<u8>)
 // module 0x66::vec_pushback_safe_point
 
 fun caller(r0): u64 {
-  slots: params(1), locals(1), temps(2), xfer(1)
+  slots: params(1), locals(1), temps(2), transfer(1)
     r0: u64
     r1: vector<u64>
     r2: &mut vector<u64>


### PR DESCRIPTION
## Description

This pull request encodes an important phase invariant of the intermediate representation directly in the type system.

### Motivation

Previously, operands were represented by a single enum with three variants. However, no stage of the pipeline could legally use all three variants:

* Before slot allocation, only two variants were valid.
* After slot allocation, a different pair of variants was valid.

This invariant was enforced through comments and runtime checks rather than through the type system.

### What changed

The operand type is now split into two phase-specific forms:

* An SSA operand used before slot allocation
* A slot-allocated operand used after slot allocation

The instruction representation is generic over the operand form it contains.

Slot allocation is now the single, explicit conversion point between these representations. It consumes the SSA-form instructions and produces slot-allocated instructions, ensuring through the output type that no operand can escape without being converted.

### Benefits

This change moves failures closer to their source:

* A missed conversion previously passed silently through two additional pipeline stages before triggering a runtime check.
* It now produces either a compile-time error or a hard error at the exact point where the invariant is established.
* Seven families of runtime “this can’t happen” error paths were removed because the invalid states they guarded are now unrepresentable.

The change has no runtime cost:

* The new operand forms retain the previous memory layout.
* The generic instruction representation is eliminated through monomorphization.
* The existing size pin on the instruction type continues to hold.

### Additional changes

This pull request also:

* Standardizes some terminology throughout the specializer.
* Replaces some raw integer values with typed equivalents.
* Fixes a subtle worst-case quadratic refill pattern by performing a one-time preallocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the full destack→lower compiler path and call/transfer-slot invariants, but behavior is intended to be equivalent with failures moved earlier via types rather than new algorithms.
> 
> **Overview**
> **Phase-specific operand types** replace the old single `Slot` enum: pre-allocation IR uses `Instr<SsaSlot>` (`Home` + `ValueId`); post-allocation IR uses `Instr<NamedSlot>` (`Home` + `Transfer`). Downstream passes (optimize, gas, lowering) only see named slots, so invalid “Vid still in IR” states are no longer representable and related invariant errors are dropped.
> 
> **Slot allocation** is no longer in-place remapping on one instruction type. It consumes SSA blocks, binds `ValueId`s via an updated `SlotTable` (pre-sized bindings, optional block-floor debug checks), and emits new instructions through `try_map_slots` / `resolve`. Analysis hints (`transfer_precolor`, `max_transfer_positions`, etc.) and debug verifiers are renamed and retargeted to the new types.
> 
> **Naming cleanup** standardizes **Xfer → Transfer**, **Vid → ValueId**, and wraps indices in **`HomeIndex`** / **`TransferPosition`**. The `mseir-compiler` verbose stats and `FunctionIR` fields follow (`num_transfer_positions`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6024c2b2d179816121a7aac75a89dd110df528e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->