### PR TITLE
Fix data invariant enforcement for mutable loop targets

### DIFF
--- a/third_party/move/move-model/bytecode/src/function_target.rs
+++ b/third_party/move/move-model/bytecode/src/function_target.rs
@@ -74,6 +74,9 @@ pub struct FunctionData {
     pub loop_unrolling: BTreeMap<AttrId, usize>,
     /// The set of inline asserts that represent loop invariants
     pub loop_invariants: BTreeSet<AttrId>,
+    /// Well-formed assumptions for mutable references after loop-target havoc. These assumptions
+    /// describe only type validity and must not be strengthened with data invariants.
+    pub shallow_wellformed_assumes: BTreeSet<AttrId>,
     /// The map from loop invariants (represented by the AttrId of the first invariant) to corresponding borrow information
     /// Used to instrument write-back actions for borrowed values
     pub loop_invariant_write_back_map: BTreeMap<AttrId, (BorrowInfo, BTreeSet<BorrowNode>)>,
@@ -536,6 +539,7 @@ impl FunctionData {
             loop_unrolling,
             loop_invariant_write_back_map: Default::default(),
             loop_invariants,
+            shallow_wellformed_assumes: Default::default(),
             debug_comments: Default::default(),
             vc_infos: Default::default(),
             annotations: Default::default(),

--- a/third_party/move/move-prover/bytecode-pipeline/src/data_invariant_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/data_invariant_instrumentation.rs
@@ -140,24 +140,28 @@ impl<'a> Instrumenter<'a> {
             // We leave the old WellFormed check for the backend to process any type related
             // assumptions.
             Prop(id, PropKind::Assume, exp) => {
-                let mut rewriter = |e: Exp| {
-                    if let ExpData::Call(_, ast::Operation::WellFormed, args) = e.as_ref() {
-                        let inv = self.builder.mk_join_bool(
-                            ast::Operation::And,
-                            self.translate_invariant(true, args[0].clone())
-                                .into_iter()
-                                .map(|(_, e)| e),
-                        );
-                        let e = self
-                            .builder
-                            .mk_join_opt_bool(ast::Operation::And, Some(e), inv)
-                            .unwrap();
-                        RewriteResult::Rewritten(e)
-                    } else {
-                        RewriteResult::Unchanged(e)
-                    }
+                let exp = if self.builder.data.shallow_wellformed_assumes.contains(&id) {
+                    exp
+                } else {
+                    let mut rewriter = |e: Exp| {
+                        if let ExpData::Call(_, ast::Operation::WellFormed, args) = e.as_ref() {
+                            let inv = self.builder.mk_join_bool(
+                                ast::Operation::And,
+                                self.translate_invariant(true, args[0].clone())
+                                    .into_iter()
+                                    .map(|(_, e)| e),
+                            );
+                            let e = self
+                                .builder
+                                .mk_join_opt_bool(ast::Operation::And, Some(e), inv)
+                                .unwrap();
+                            RewriteResult::Rewritten(e)
+                        } else {
+                            RewriteResult::Unchanged(e)
+                        }
+                    };
+                    ExpData::rewrite(exp, &mut rewriter)
                 };
-                let exp = ExpData::rewrite(exp, &mut rewriter);
                 self.builder.emit(Prop(id, PropKind::Assume, exp));
             },
             _ => self.builder.emit(bc),

--- a/third_party/move/move-prover/bytecode-pipeline/src/loop_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/loop_analysis.rs
@@ -172,7 +172,9 @@ impl LoopAnalysisProcessor {
                                 ast::Operation::WellFormed,
                                 vec![builder.mk_temporary(*idx)],
                             );
-                            builder.emit_with(move |id| Bytecode::Prop(id, PropKind::Assume, exp));
+                            let id = builder.new_attr();
+                            builder.emit(Bytecode::Prop(id, PropKind::Assume, exp));
+                            builder.data.shallow_wellformed_assumes.insert(id);
                         }
 
                         // trace implicitly reassigned variables after havocking

--- a/third_party/move/move-prover/tests/sources/functional/data_invariant_loop_havoc.exp
+++ b/third_party/move/move-prover/tests/sources/functional/data_invariant_loop_havoc.exp
@@ -1,0 +1,33 @@
+Move prover returns: exiting with verification errors
+error: data invariant does not hold
+  ┌─ tests/sources/functional/data_invariant_loop_havoc.move:7:9
+  │
+7 │         invariant x > 0;
+  │         ^^^^^^^^^^^^^^^^
+  │
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:14: bad_loop
+  =         r = <redacted>
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:15: bad_loop
+  =         i = <redacted>
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:16: bad_loop
+  =     enter loop, variable(s) r, i havocked and reassigned
+  =         r = <redacted>
+  =         i = <redacted>
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:16: bad_loop
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:14: bad_loop
+  =         r = <redacted>
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:7
+
+error: data invariant does not hold
+  ┌─ tests/sources/functional/data_invariant_loop_havoc.move:7:9
+  │
+7 │         invariant x > 0;
+  │         ^^^^^^^^^^^^^^^^
+  │
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:10: bad_straight
+  =         r = <redacted>
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:11: bad_straight
+  =         r = <redacted>
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:10: bad_straight
+  =         r = <redacted>
+  =     at tests/sources/functional/data_invariant_loop_havoc.move:7

--- a/third_party/move/move-prover/tests/sources/functional/data_invariant_loop_havoc.move
+++ b/third_party/move/move-prover/tests/sources/functional/data_invariant_loop_havoc.move
@@ -1,0 +1,21 @@
+module 0x42::data_invariant_loop_havoc {
+    struct R {
+        x: u64,
+    }
+
+    spec R {
+        invariant x > 0;
+    }
+
+    fun bad_straight(r: &mut R) {
+        r.x = 0;
+    }
+
+    fun bad_loop(r: &mut R) {
+        let i = 0;
+        while (i < 1) {
+            r.x = 0;
+            i = i + 1;
+        };
+    }
+}


### PR DESCRIPTION
## Description

Closes #20217.

Move Prover loop analysis havocs variables that can change across a loop iteration. For a mutable reference target, it then emits a `WellFormed` assumption so the backend can continue to rely on the reference having a valid type representation.

Data invariant instrumentation previously strengthened every `WellFormed` assumption with the referenced value's data invariant. That strengthening is not valid for a live mutable reference because its referent may temporarily violate a data invariant. The invariant is required when the reference is written back, where `PackRefDeep` already emits the corresponding assertion. Assuming the invariant immediately after loop havoc pruned real counterexamples and allowed an invalid loop body to verify.

This change:

- adds `FunctionData::shallow_wellformed_assumes` to record the exact assumption attributes that must remain type-only checks
- marks the `WellFormed` assumptions emitted after havoc of mutable loop targets as shallow
- leaves data invariant augmentation unchanged for value loop targets, function entry assumptions, and opaque call assumptions
- preserves the existing deep data invariant assertion at mutable reference write-back
- adds a regression proving that a violation inside a loop is rejected just like the equivalent straight-line violation

The result restores the intended proof obligation. If a loop needs facts about the data invariant of a live mutable referent, those facts must now be carried by explicit loop invariants instead of being introduced by an unjustified assumption.

## How Has This Been Tested?

- `cargo +nightly fmt --all -- --check`
- `cargo check -p move-prover-bytecode-pipeline`
- `cargo test -p move-prover-bytecode-pipeline`
  - 31 passed
- focused Move Prover regression for `data_invariant_loop_havoc.move`
  - verifies the expected diagnostics for both the loop and straight-line cases
- full Move Prover test suite with Boogie 3.5.6 and Z3 4.13.0
  - 279 passed

I also ran the Aptos standard library prover as a diagnostic. It now exposes the latent loop specification gaps called out in #20217, including `big_vector` and `smart_vector`, instead of silently discharging them through the unsound assumption. Those framework specification updates are separate from the bytecode-pipeline soundness fix.

## Key Areas to Review

- The new attribute set is deliberately narrow. Only assumptions emitted for mutable loop targets are marked shallow.
- The data invariant processor still strengthens every other `WellFormed` assumption as before.
- Write-back enforcement is unchanged. `PackRefDeep` remains the point where the deep data invariant is asserted.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other: Move Prover

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Move Prover verification soundness in loop + data-invariant interaction; may surface previously hidden proof failures in framework specs.
> 
> **Overview**
> Fixes an unsoundness where **data invariant instrumentation** strengthened every `WellFormed` **assume** with the referent’s data invariant. After loop analysis **havocs** a mutable reference loop target, that strengthening wrongly assumed the invariant still held on the live referent, so invalid loop bodies could verify.
> 
> The PR adds **`FunctionData::shallow_wellformed_assumes`** and tags only the `WellFormed` assumes emitted for **mutable** loop targets in `loop_analysis`. **Data invariant instrumentation** skips augmentation for those attrs; value loop targets, entry, and other assumes behave as before. **`PackRefDeep`** still asserts the deep data invariant at write-back.
> 
> A regression test expects **data invariant does not hold** for both straight-line and loop mutations that set `x` to 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f608960aa9d7eb98204987e48ad6163949d663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->