### PR TITLE
[block-stm] Refactor bcs group fallback into its method

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -6,12 +6,14 @@ pub(crate) mod vm_wrapper;
 use crate::counters::{BLOCK_EXECUTOR_CONCURRENCY, BLOCK_EXECUTOR_EXECUTE_BLOCK_SECONDS};
 use aptos_aggregator::delayed_change::DelayedChange;
 use aptos_block_executor::{
+    check_resource_group_serialization,
     code_cache_global_manager::AptosModuleCacheManager,
     executor::BlockExecutor,
     task::{ExecutorTask, TransactionOutput as BlockExecutorTransactionOutput},
     txn_commit_hook::TransactionCommitHook,
     txn_provider::TxnProvider,
     types::InputOutputKey,
+    Materializer,
 };
 use aptos_types::{
     block_executor::{
@@ -84,6 +86,10 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
     /// problem creating the output (e.g. group serialization issue).
     fn skip_output() -> Self {
         Self::new(VMOutput::empty_with_status(TransactionStatus::Retry))
+    }
+
+    fn check_materialization(&self, materializer: &impl Materializer<Self::Txn>) -> bool {
+        check_resource_group_serialization(self, materializer)
     }
 
     fn fee_statement(&self) -> FeeStatement {

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
+    check_resource_group_serialization,
     combinatorial_tests::types::{
         DeltaTestKind, GroupSizeOrMetadata, MockIncarnation, MockTransaction, ValueType,
         RESERVED_TAG,
@@ -10,6 +11,7 @@ use crate::{
     types::delayed_field_mock_serialization::{
         deserialize_to_delayed_field_id, serialize_from_delayed_field_id,
     },
+    Materializer,
 };
 use aptos_aggregator::{
     bounded_math::SignedU128,
@@ -695,6 +697,10 @@ where
 
     fn skip_output() -> Self {
         Self::skipped_output(None)
+    }
+
+    fn check_materialization(&self, materializer: &impl Materializer<Self::Txn>) -> bool {
+        check_resource_group_serialization(self, materializer)
     }
 
     fn incorporate_materialized_txn_output(

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -38,10 +38,8 @@ use aptos_mvhashmap::{
 };
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorConfig,
-        output::CommittedTransactionOutput,
-        transaction_slice_metadata::TransactionSliceMetadata,
-        value::{SpeculativeValue, ValueWithLayout},
+        config::BlockExecutorConfig, output::CommittedTransactionOutput,
+        transaction_slice_metadata::TransactionSliceMetadata, value::ValueWithLayout,
     },
     error::{code_invariant_error, expect_ok, PanicError, PanicOr},
     on_chain_config::Features,
@@ -51,14 +49,11 @@ use aptos_types::{
         BlockExecutableTransaction, BlockExecutionResult, BlockOutput, FeeDistribution,
     },
     vm::modules::AptosModuleExtension,
-    write_set::TransactionWrite,
 };
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_logging::{alert, init_speculative_logs, prelude::*};
-use aptos_vm_types::resolver::ResourceGroupSize;
 use claims::assert_none;
 use core::panic;
-use fail::fail_point;
 use move_binary_format::CompiledModule;
 use move_core_types::{language_storage::ModuleId, vm_status::StatusCode};
 use move_vm_runtime::{Module, RuntimeEnvironment, TypeChecker, WithRuntimeEnvironment};
@@ -2229,76 +2224,8 @@ where
                         // Dynamic change set optimizations are enabled, and resource group serialization
                         // previously failed in bcs serialization for preparing final transaction outputs.
                         // TODO: remove this fallback when txn errors can be created from block executor.
-
-                        let finalize = |group_key| -> (BTreeMap<_, _>, ResourceGroupSize) {
-                            let (group, size) = unsync_map.finalize_group(&group_key);
-
-                            (
-                                group
-                                    .map(|(resource_tag, value_with_layout)| {
-                                        let bytes = value_with_layout
-                                            .extract_value()
-                                            .extract_raw_bytes()
-                                            .expect("Deletions should already be applied");
-                                        (resource_tag, bytes)
-                                    })
-                                    .collect(),
-                                size,
-                            )
-                        };
-
-                        // The IDs are not exchanged but it doesn't change the types (Bytes) or size.
-                        let serialization_error = output
-                            .group_reads_needing_delayed_field_exchange()
-                            .iter()
-                            .any(|(group_key, _)| {
-                                fail_point!("fail-point-resource-group-serialization", |_| {
-                                    true
-                                });
-
-                                let (finalized_group, group_size) = finalize(group_key.clone());
-                                match bcs::to_bytes(&finalized_group) {
-                                    Ok(group) => {
-                                        (!finalized_group.is_empty() || group_size.get() != 0)
-                                            && group.len() as u64 != group_size.get()
-                                    },
-                                    Err(_) => true,
-                                }
-                            })
-                            || output.resource_group_write_set().into_iter().any(
-                                |(group_key, (_, output_group_size, group_ops))| {
-                                    fail_point!("fail-point-resource-group-serialization", |_| {
-                                        true
-                                    });
-
-                                    let (mut finalized_group, group_size) = finalize(group_key);
-                                    if output_group_size.get() != group_size.get() {
-                                        return false;
-                                    }
-                                    for (value_tag, group_op) in group_ops {
-                                        if group_op.is_deletion() {
-                                            finalized_group.remove(&value_tag);
-                                        } else {
-                                            finalized_group.insert(
-                                                value_tag,
-                                                group_op
-                                                    .extract_value()
-                                                    .extract_raw_bytes()
-                                                    .expect("Not a deletion"),
-                                            );
-                                        }
-                                    }
-                                    match bcs::to_bytes(&finalized_group) {
-                                        Ok(group) => {
-                                            (!finalized_group.is_empty() || group_size.get() != 0)
-                                                && group.len() as u64 != group_size.get()
-                                        },
-                                        Err(_) => true,
-                                    }
-                                },
-                            );
-
-                        if serialization_error {
+                        let materializer = SequentialMaterializer::new(&latest_view);
+                        if !output.check_materialization(&materializer) {
                             // The corresponding error / alert must already be triggered, the goal in sequential
                             // fallback is to just skip any transactions that would cause such serialization errors.
                             alert!("Discarding transaction because serialization failed in bcs fallback");

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -35,7 +35,7 @@ use triomphe::Arc as TriompheArc;
 /// Block executor state access required to materialize a transaction output at
 /// commit time: finalizing resource groups and exchanging delayed field
 /// identifiers back to values.
-pub(crate) trait Materializer<T: Transaction> {
+pub trait Materializer<T: Transaction> {
     /// Returns the committed contents of a resource group and its size.
     fn finalize_group(
         &self,
@@ -262,6 +262,78 @@ where
             .collect(),
         materialized_events,
     )?)
+}
+
+/// Checks that every resource group this transaction finalizes BCS-serializes to
+/// its recorded size, merging the transaction's own group ops onto the group's
+/// committed contents. Returns false if any group's size does not match, so the
+/// caller can discard the transaction.
+pub fn check_resource_group_serialization<T, O, M>(output: &O, materializer: &M) -> bool
+where
+    T: Transaction,
+    O: TransactionOutput<Txn = T>,
+    M: Materializer<T>,
+{
+    let serializes =
+        |group: &BTreeMap<T::Tag, Bytes>, size: ResourceGroupSize| match bcs::to_bytes(group) {
+            Ok(bytes) => {
+                !((!group.is_empty() || size.get() != 0) && bytes.len() as u64 != size.get())
+            },
+            Err(_) => false,
+        };
+    let raw_bytes = |value: ValueWithLayout<T::Value>| {
+        value
+            .extract_value()
+            .extract_raw_bytes()
+            .expect("Deletions should already be applied")
+    };
+
+    // Groups only read but rewritten due to delayed-field changes: the finalized
+    // contents are exactly the group already in the map.
+    for (group_key, _) in output.group_reads_needing_delayed_field_exchange() {
+        fail_point!("fail-point-resource-group-serialization", |_| false);
+        let (finalized, size) = match materializer.finalize_group(&group_key) {
+            Ok(finalized) => finalized,
+            // finalize_group only errors outside sequential execution, where this
+            // check does not run; treat as non-materializable defensively.
+            Err(_) => return false,
+        };
+        let group = finalized
+            .into_iter()
+            .map(|(tag, value)| (tag, raw_bytes(value)))
+            .collect();
+        if !serializes(&group, size) {
+            return false;
+        }
+    }
+
+    // Groups written: merge this transaction's ops onto the prior contents.
+    for (group_key, (_, output_size, group_ops)) in output.resource_group_write_set() {
+        fail_point!("fail-point-resource-group-serialization", |_| false);
+        let (finalized, size) = match materializer.finalize_group(&group_key) {
+            Ok(finalized) => finalized,
+            Err(_) => return false,
+        };
+        if output_size.get() != size.get() {
+            continue;
+        }
+        let mut group: BTreeMap<_, _> = finalized
+            .into_iter()
+            .map(|(tag, value)| (tag, raw_bytes(value)))
+            .collect();
+        for (tag, op) in group_ops {
+            if op.is_deletion() {
+                group.remove(&tag);
+            } else {
+                group.insert(tag, raw_bytes(op));
+            }
+        }
+        if !serializes(&group, size) {
+            return false;
+        }
+    }
+
+    true
 }
 
 /// Given a state value, performs deserialization-serialization round-trip to

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -264,10 +264,11 @@ where
     )?)
 }
 
-/// Checks that every resource group this transaction finalizes BCS-serializes to
-/// its recorded size, merging the transaction's own group ops onto the group's
-/// committed contents. Returns false if any group's size does not match, so the
-/// caller can discard the transaction.
+/// Checks that every resource group this transaction finalizes will
+/// BCS-serialize to its recorded size, merging the transaction's own group ops
+/// onto the group's committed contents. Returns false if a finalized group
+/// fails to serialize to its recorded size, so the caller can discard the
+/// transaction.
 pub fn check_resource_group_serialization<T, O, M>(output: &O, materializer: &M) -> bool
 where
     T: Transaction,
@@ -314,6 +315,9 @@ where
             Ok(finalized) => finalized,
             Err(_) => return false,
         };
+        // The finalized size and the output's recorded size come from the same
+        // output, so they are expected to be equal; this guard is defensive and
+        // skips the group in the unexpected case that they diverge.
         if output_size.get() != size.get() {
             continue;
         }
@@ -325,7 +329,12 @@ where
             if op.is_deletion() {
                 group.remove(&tag);
             } else {
-                group.insert(tag, raw_bytes(op));
+                group.insert(
+                    tag,
+                    op.extract_value()
+                        .extract_raw_bytes()
+                        .expect("Non-deletion op must have raw bytes"),
+                );
             }
         }
         if !serializes(&group, size) {

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -145,6 +145,7 @@ pub mod counters;
 pub mod errors;
 pub mod executor;
 mod executor_utilities;
+pub use executor_utilities::{check_resource_group_serialization, Materializer};
 pub mod explicit_sync_wrapper;
 pub mod hot_state_op_accumulator;
 mod limit_processor;

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::types::InputOutputKey;
+use crate::{executor_utilities::Materializer, types::InputOutputKey};
 use aptos_aggregator::delayed_change::DelayedChange;
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
@@ -227,6 +227,12 @@ pub trait TransactionOutput: Send + Debug {
 
     /// Keys written when this output commits.
     fn storage_keys_written(&self) -> impl Iterator<Item = &<Self::Txn as Transaction>::Key>;
+
+    /// Verifies that this transaction's output can be materialized (e.g., outputs
+    /// BCS-serialized into storage representation).
+    ///
+    /// Only invoked during the resource-group serialization fallback.
+    fn check_materialization(&self, materializer: &impl Materializer<Self::Txn>) -> bool;
 
     /// Will be called once per transaction when the output is ready to be committed.
     /// Ensures that any writes corresponding to materialized delayed fields and group

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -18,6 +18,7 @@ use aptos_block_executor::{
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::default::DefaultTxnProvider,
     types::InputOutputKey,
+    Materializer,
 };
 use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
 use aptos_mvhashmap::types::TxnIndex;
@@ -164,6 +165,10 @@ impl TransactionOutput for TestOutput {
 
     fn skip_output() -> Self {
         Self
+    }
+
+    fn check_materialization(&self, _materializer: &impl Materializer<Self::Txn>) -> bool {
+        true
     }
 
     fn incorporate_materialized_txn_output(


### PR DESCRIPTION
## Description

Pure refactor, no behavior change. It moves the sequential resource-group serialization fallback pre-check out of the block executor loop and behind the output's own interface.

Previously `execute_transactions_sequential` contained an inline closure that, in the `resource_group_bcs_fallback` pass, finalized each resource group, bcs-serialized it, and compared against the recorded `ResourceGroupSize` to decide whether to discard the transaction. That closure operated on legacy `ValueWithLayout` write ops directly in the generic loop.

This PR:
- Adds a required method `TransactionOutput::check_materialization(&self, &impl Materializer<Self::Txn>) -> bool`. The sequential fallback now calls `output.check_materialization(&materializer)` and discards the transaction on `false`.
- Extracts the finalize + serialize + size-check body (including its `fail_point`) into a shared helper `executor_utilities::check_resource_group_serialization`.
- Makes `Materializer` public and re-exports it (and the helper) from the crate root so output impls in other crates can name it.
- `AptosTransactionOutput` and `MockOutput` delegate to the helper; `TestOutput` returns `true` (its test only runs the parallel path and never reaches the fallback).

Motivation: preparatory work for a VM-neutral Block-STM execution abstraction. Keeping the value-specific bcs logic behind the output's method, rather than inline in the generic loop, lets each VM supply its own materialization check.

## How Has This Been Tested?

Behavior is unchanged, so existing coverage applies:
- The `aptos-block-executor` `unit_tests` failpoint test drives the two-pass fallback through `check_materialization`: it sets `fail-point-resource-group-serialization`, runs `execute_transactions_sequential(..., true)`, and expects the offending transaction discarded.
- The combinatorial `group_tests` / `resource_tests` exercise resource groups and the sequential path.
- `cargo check` on `aptos-block-executor`, `aptos-vm`, and `e2e-move-tests`.

## Key Areas to Review

- `TransactionOutput::check_materialization` (`task.rs`) and its delegation in the three impls.
- `executor_utilities::check_resource_group_serialization` — the old inline closure moved over verbatim, including the `fail_point`, so the discard behavior is identical.
- `Materializer` visibility change (`pub`) and the crate-root re-exports in `lib.rs`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor on the sequential fallback discard path; discard rules and failpoints are intended to be unchanged.
> 
> **Overview**
> Moves the sequential **resource-group BCS fallback** pre-check out of the generic block executor loop and behind each output’s **`TransactionOutput::check_materialization`**.
> 
> The executor now builds a **`SequentialMaterializer`** and calls **`output.check_materialization(&materializer)`** instead of an inline finalize + BCS + size-check closure. That logic lives in the shared **`check_resource_group_serialization`** helper (including the **`fail-point-resource-group-serialization`** behavior). **`Materializer`** is **`pub`** and re-exported from **`aptos-block-executor`** so **`AptosTransactionOutput`**, **`MockOutput`**, and test stubs can implement the trait method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f3ea3f478b3066e2bb2b8a956c039df21c2ad90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->