### PR TITLE
[block-stm] Split TransactionOutput into base and LegacyTxnOutput

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -9,7 +9,10 @@ use aptos_block_executor::{
     check_resource_group_serialization,
     code_cache_global_manager::AptosModuleCacheManager,
     executor::BlockExecutor,
-    task::{ExecutorTask, TransactionOutput as BlockExecutorTransactionOutput},
+    task::{
+        ExecutorTask, LegacyTxnOutput as BlockExecutorLegacyTxnOutput,
+        TransactionOutput as BlockExecutorTransactionOutput,
+    },
     txn_commit_hook::TransactionCommitHook,
     txn_provider::TxnProvider,
     types::InputOutputKey,
@@ -80,7 +83,10 @@ impl AptosTransactionOutput {
 
 impl BlockExecutorTransactionOutput for AptosTransactionOutput {
     type CommittedOutput = TransactionOutput;
+    type Key = StateKey;
+    type Tag = StructTag;
     type Txn = SignatureVerifiedTransaction;
+    type Value = ValueWithLayout<WriteOp>;
 
     /// Execution output for transactions that comes after SkipRest signal or when there was a
     /// problem creating the output (e.g. group serialization issue).
@@ -243,21 +249,6 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         Ok(())
     }
 
-    /// More efficient implementation to avoid unnecessarily cloning inner_ops.
-    fn resource_group_metadata_ops(&self) -> Vec<(StateKey, WriteOp)> {
-        self.vm_output
-            .resource_write_set()
-            .iter()
-            .flat_map(|(key, write)| {
-                if let AbstractResourceWriteOp::WriteResourceGroup(group_write) = write {
-                    Some((key.clone(), group_write.metadata_op().clone()))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
     fn resource_write_set(&self) -> HashMap<StateKey, ValueWithLayout<WriteOp>> {
         self.vm_output
             .resource_write_set()
@@ -297,6 +288,32 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output.delayed_field_change_set().clone()
     }
 
+    // For legacy interfaces, there are more efficient alternatives in BlockSTMv2.
+    // For now we do get the benefits of comparing different implementations.
+    // TODO: consider adjusting sequential execution and BlockSTMv1 to use the superior
+    // patterns and remove these legacy interfaces (needs to be done carefully).
+    //
+    // Internally clones and also allocates a new vector. Used for BlockSTMv1 only.
+    fn legacy_v1_resource_group_tags(&self) -> Vec<(StateKey, HashSet<StructTag>)> {
+        self.vm_output
+            .resource_write_set()
+            .iter()
+            .flat_map(|(key, write)| {
+                if let AbstractResourceWriteOp::WriteResourceGroup(group_write) = write {
+                    Some((
+                        key.clone(),
+                        group_write.inner_ops().keys().cloned().collect(),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+}
+
+impl BlockExecutorLegacyTxnOutput for AptosTransactionOutput {
     fn reads_needing_delayed_field_exchange(
         &self,
     ) -> Vec<(StateKey, StateValueMetadata, TriompheArc<MoveTypeLayout>)> {
@@ -333,22 +350,14 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output.events().to_vec()
     }
 
-    // For legacy interfaces, there are more efficient alternatives in BlockSTMv2.
-    // For now we do get the benefits of comparing different implementations.
-    // TODO: consider adjusting sequential execution and BlockSTMv1 to use the superior
-    // patterns and remove these legacy interfaces (needs to be done carefully).
-    //
-    // Internally clones and also allocates a new vector. Used for BlockSTMv1 only.
-    fn legacy_v1_resource_group_tags(&self) -> Vec<(StateKey, HashSet<StructTag>)> {
+    /// More efficient implementation to avoid unnecessarily cloning inner_ops.
+    fn resource_group_metadata_ops(&self) -> Vec<(StateKey, WriteOp)> {
         self.vm_output
             .resource_write_set()
             .iter()
             .flat_map(|(key, write)| {
                 if let AbstractResourceWriteOp::WriteResourceGroup(group_write) = write {
-                    Some((
-                        key.clone(),
-                        group_write.inner_ops().keys().cloned().collect(),
-                    ))
+                    Some((key.clone(), group_write.metadata_op().clone()))
                 } else {
                     None
                 }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -349,7 +349,8 @@ impl BlockExecutorLegacyTxnOutput for AptosTransactionOutput {
         self.vm_output.events().to_vec()
     }
 
-    /// More efficient implementation to avoid unnecessarily cloning inner_ops.
+    /// Extracts only the metadata write ops of each resource group, without
+    /// cloning the group's inner_ops.
     fn resource_group_metadata_ops(&self) -> Vec<(StateKey, WriteOp)> {
         self.vm_output
             .resource_write_set()

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -310,7 +310,6 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             })
             .collect()
     }
-
 }
 
 impl BlockExecutorLegacyTxnOutput for AptosTransactionOutput {

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -21,7 +21,7 @@ use aptos_mvhashmap::{
     versioned_group_data::VersionedGroupData,
 };
 use aptos_types::{
-    block_executor::value::ValueWithLayout,
+    block_executor::value::{SpeculativeValue, ValueWithLayout},
     error::{code_invariant_error, PanicError, PanicOr},
     executable::ModulePath,
     state_store::{state_value::StateValueMetadata, TStateView},
@@ -520,7 +520,7 @@ pub enum CacheRead<T> {
 /// resolution from MVHashMap/storage should be captured. This enforces an invariant that
 /// 'capture_read' will never be called with a read that can be resolved from the already
 /// captured variant (e.g. Size, Metadata, or exists if SizeAndMetadata is already captured).
-pub(crate) struct CapturedReads<T: Transaction, K, DC, VC, S> {
+pub struct CapturedReads<T: Transaction, K, DC, VC, S> {
     data_reads: HashMap<T::Key, DataRead<T::Value>>,
     group_reads: HashMap<T::Key, GroupRead<T>>,
     delayed_field_reads: HashMap<DelayedFieldID, DelayedFieldRead>,
@@ -1150,7 +1150,7 @@ where
 
 #[derive(Derivative)]
 #[derivative(Default(bound = "", new = "true"))]
-pub(crate) struct UnsyncReadSet<T: Transaction, K> {
+pub struct UnsyncReadSet<T: Transaction, K> {
     pub(crate) resource_reads: HashSet<T::Key>,
     pub(crate) group_reads: HashMap<T::Key, HashSet<T::Tag>>,
     pub(crate) delayed_field_reads: HashSet<DelayedFieldID>,
@@ -1190,6 +1190,260 @@ where
         }
 
         ret
+    }
+}
+
+/// A transaction's read set, validated against the multi-version data structures
+/// to decide whether the transaction must re-execute. Abstracts the concrete
+/// read-set representation so the executor does not depend on a specific VM's form.
+pub trait TxnInput: Send + Sync {
+    type Key;
+    type Tag;
+    type Value: SpeculativeValue;
+
+    fn validate_data_reads(
+        &self,
+        data_map: &VersionedData<Self::Key, Self::Value>,
+        idx_to_validate: TxnIndex,
+    ) -> bool;
+
+    fn validate_group_reads(
+        &self,
+        group_map: &VersionedGroupData<Self::Key, Self::Tag, Self::Value>,
+        idx_to_validate: TxnIndex,
+    ) -> bool;
+
+    fn validate_delayed_field_reads(
+        &self,
+        delayed_fields: &dyn TVersionedDelayedFieldView<DelayedFieldID>,
+        idx_to_validate: TxnIndex,
+    ) -> Result<bool, PanicError>;
+
+    // SEAM: typed against the legacy Move VM code cache; a VM with its own code
+    // caching generalizes this method when it lands.
+    fn validate_module_reads(
+        &self,
+        global_module_cache: &GlobalModuleCache<
+            ModuleId,
+            CompiledModule,
+            Module,
+            AptosModuleExtension,
+        >,
+        per_block_module_cache: &SyncModuleCache<
+            ModuleId,
+            CompiledModule,
+            Module,
+            AptosModuleExtension,
+            Option<TxnIndex>,
+        >,
+        maybe_updated_module_keys: Option<&BTreeSet<ModuleId>>,
+    ) -> bool;
+
+    /// Records a delayed-field delta application failure so re-validation fails and
+    /// the transaction re-executes.
+    fn record_delayed_field_application_failure(&mut self);
+
+    /// The incarnation whose reads were captured, used for BlockSTMv2 module validation.
+    fn incarnation(&self) -> Option<Incarnation>;
+
+    fn is_incorrect_use(&self) -> bool;
+
+    fn get_read_summary(&self) -> HashSet<InputOutputKey<Self::Key, Self::Tag>>;
+}
+
+/// The read set produced by the legacy Move VM path (captured via `LatestView`).
+pub type CapturedReadSet<T> =
+    CapturedReads<T, ModuleId, CompiledModule, Module, AptosModuleExtension>;
+
+impl<T: Transaction> TxnInput for CapturedReadSet<T> {
+    type Key = T::Key;
+    type Tag = T::Tag;
+    type Value = ValueWithLayout<T::Value>;
+
+    fn validate_data_reads(
+        &self,
+        data_map: &VersionedData<T::Key, ValueWithLayout<T::Value>>,
+        idx_to_validate: TxnIndex,
+    ) -> bool {
+        CapturedReads::validate_data_reads(self, data_map, idx_to_validate)
+    }
+
+    fn validate_group_reads(
+        &self,
+        group_map: &VersionedGroupData<T::Key, T::Tag, ValueWithLayout<T::Value>>,
+        idx_to_validate: TxnIndex,
+    ) -> bool {
+        CapturedReads::validate_group_reads(self, group_map, idx_to_validate)
+    }
+
+    fn validate_delayed_field_reads(
+        &self,
+        delayed_fields: &dyn TVersionedDelayedFieldView<DelayedFieldID>,
+        idx_to_validate: TxnIndex,
+    ) -> Result<bool, PanicError> {
+        CapturedReads::validate_delayed_field_reads(self, delayed_fields, idx_to_validate)
+    }
+
+    fn validate_module_reads(
+        &self,
+        global_module_cache: &GlobalModuleCache<
+            ModuleId,
+            CompiledModule,
+            Module,
+            AptosModuleExtension,
+        >,
+        per_block_module_cache: &SyncModuleCache<
+            ModuleId,
+            CompiledModule,
+            Module,
+            AptosModuleExtension,
+            Option<TxnIndex>,
+        >,
+        maybe_updated_module_keys: Option<&BTreeSet<ModuleId>>,
+    ) -> bool {
+        CapturedReads::validate_module_reads(
+            self,
+            global_module_cache,
+            per_block_module_cache,
+            maybe_updated_module_keys,
+        )
+    }
+
+    fn record_delayed_field_application_failure(&mut self) {
+        self.capture_delayed_field_read_error(&PanicOr::Or(
+            MVDelayedFieldsError::DeltaApplicationFailure,
+        ));
+    }
+
+    fn incarnation(&self) -> Option<Incarnation> {
+        self.blockstm_v2_incarnation()
+    }
+
+    fn is_incorrect_use(&self) -> bool {
+        CapturedReads::is_incorrect_use(self)
+    }
+
+    fn get_read_summary(&self) -> HashSet<InputOutputKey<T::Key, T::Tag>> {
+        CapturedReads::get_read_summary(self)
+    }
+}
+
+/// The legacy Move VM's read set: BlockSTM (parallel) captures `CapturedReads`,
+/// sequential execution captures an `UnsyncReadSet`. Adapts both behind one type
+/// so the executor stores a single read-set type. The `validate_*` methods are
+/// only reached for the parallel variant.
+pub enum LegacyReads<T: Transaction> {
+    Parallel(CapturedReadSet<T>),
+    Sequential(UnsyncReadSet<T, ModuleId>),
+}
+
+impl<T: Transaction> TxnInput for LegacyReads<T> {
+    type Key = T::Key;
+    type Tag = T::Tag;
+    type Value = ValueWithLayout<T::Value>;
+
+    fn validate_data_reads(
+        &self,
+        data_map: &VersionedData<T::Key, ValueWithLayout<T::Value>>,
+        idx_to_validate: TxnIndex,
+    ) -> bool {
+        match self {
+            LegacyReads::Parallel(reads) => reads.validate_data_reads(data_map, idx_to_validate),
+            LegacyReads::Sequential(_) => {
+                unreachable!("Sequential execution does not validate reads")
+            },
+        }
+    }
+
+    fn validate_group_reads(
+        &self,
+        group_map: &VersionedGroupData<T::Key, T::Tag, ValueWithLayout<T::Value>>,
+        idx_to_validate: TxnIndex,
+    ) -> bool {
+        match self {
+            LegacyReads::Parallel(reads) => reads.validate_group_reads(group_map, idx_to_validate),
+            LegacyReads::Sequential(_) => {
+                unreachable!("Sequential execution does not validate reads")
+            },
+        }
+    }
+
+    fn validate_delayed_field_reads(
+        &self,
+        delayed_fields: &dyn TVersionedDelayedFieldView<DelayedFieldID>,
+        idx_to_validate: TxnIndex,
+    ) -> Result<bool, PanicError> {
+        match self {
+            LegacyReads::Parallel(reads) => {
+                reads.validate_delayed_field_reads(delayed_fields, idx_to_validate)
+            },
+            LegacyReads::Sequential(_) => {
+                unreachable!("Sequential execution does not validate reads")
+            },
+        }
+    }
+
+    fn validate_module_reads(
+        &self,
+        global_module_cache: &GlobalModuleCache<
+            ModuleId,
+            CompiledModule,
+            Module,
+            AptosModuleExtension,
+        >,
+        per_block_module_cache: &SyncModuleCache<
+            ModuleId,
+            CompiledModule,
+            Module,
+            AptosModuleExtension,
+            Option<TxnIndex>,
+        >,
+        maybe_updated_module_keys: Option<&BTreeSet<ModuleId>>,
+    ) -> bool {
+        match self {
+            LegacyReads::Parallel(reads) => reads.validate_module_reads(
+                global_module_cache,
+                per_block_module_cache,
+                maybe_updated_module_keys,
+            ),
+            LegacyReads::Sequential(_) => {
+                unreachable!("Sequential execution does not validate reads")
+            },
+        }
+    }
+
+    fn record_delayed_field_application_failure(&mut self) {
+        match self {
+            LegacyReads::Parallel(reads) => reads.capture_delayed_field_read_error(&PanicOr::Or(
+                MVDelayedFieldsError::DeltaApplicationFailure,
+            )),
+            LegacyReads::Sequential(_) => {
+                unreachable!(
+                    "Sequential execution does not apply delayed field changes speculatively"
+                )
+            },
+        }
+    }
+
+    fn incarnation(&self) -> Option<Incarnation> {
+        match self {
+            LegacyReads::Parallel(reads) => reads.blockstm_v2_incarnation(),
+            LegacyReads::Sequential(_) => None,
+        }
+    }
+
+    fn is_incorrect_use(&self) -> bool {
+        match self {
+            LegacyReads::Parallel(reads) => reads.is_incorrect_use(),
+            LegacyReads::Sequential(reads) => reads.incorrect_use,
+        }
+    }
+
+    fn get_read_summary(&self) -> HashSet<InputOutputKey<T::Key, T::Tag>> {
+        match self {
+            LegacyReads::Parallel(reads) => reads.get_read_summary(),
+            LegacyReads::Sequential(reads) => reads.get_read_summary(),
+        }
     }
 }
 

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1201,27 +1201,34 @@ pub trait TxnInput: Send + Sync {
     type Tag;
     type Value: SpeculativeValue;
 
+    /// Returns true if the data reads are still consistent with the multi-version
+    /// data map at the given validation index.
     fn validate_data_reads(
         &self,
         data_map: &VersionedData<Self::Key, Self::Value>,
         idx_to_validate: TxnIndex,
     ) -> bool;
 
+    /// Returns true if the resource group reads are still consistent with the
+    /// multi-version group data map at the given validation index.
     fn validate_group_reads(
         &self,
         group_map: &VersionedGroupData<Self::Key, Self::Tag, Self::Value>,
         idx_to_validate: TxnIndex,
     ) -> bool;
 
+    /// Returns true if the delayed-field reads are still consistent with the
+    /// versioned delayed fields at the given validation index.
     fn validate_delayed_field_reads(
         &self,
         delayed_fields: &dyn TVersionedDelayedFieldView<DelayedFieldID>,
         idx_to_validate: TxnIndex,
     ) -> Result<bool, PanicError>;
 
-    // SEAM: typed against the legacy Move VM code cache; a VM with its own code
-    // caching generalizes this method when it lands.
-    fn validate_module_reads(
+    /// Returns true if the module reads are still consistent with the code caches.
+    /// Used for the legacy publishing flow when modules may have been upgraded
+    /// concurrently within the block.
+    fn legacy_validate_module_reads(
         &self,
         global_module_cache: &GlobalModuleCache<
             ModuleId,
@@ -1246,8 +1253,11 @@ pub trait TxnInput: Send + Sync {
     /// The incarnation whose reads were captured, used for BlockSTMv2 module validation.
     fn incarnation(&self) -> Option<Incarnation>;
 
+    /// Returns true if capturing the read set hit a code-invariant violation.
+    /// Such a read set is invalid and must be handled by the caller.
     fn is_incorrect_use(&self) -> bool;
 
+    /// Keys read by this transaction.
     fn get_read_summary(&self) -> HashSet<InputOutputKey<Self::Key, Self::Tag>>;
 }
 
@@ -1284,7 +1294,7 @@ impl<T: Transaction> TxnInput for CapturedReadSet<T> {
         CapturedReads::validate_delayed_field_reads(self, delayed_fields, idx_to_validate)
     }
 
-    fn validate_module_reads(
+    fn legacy_validate_module_reads(
         &self,
         global_module_cache: &GlobalModuleCache<
             ModuleId,
@@ -1377,13 +1387,13 @@ impl<T: Transaction> TxnInput for LegacyReads<T> {
             LegacyReads::Parallel(reads) => {
                 reads.validate_delayed_field_reads(delayed_fields, idx_to_validate)
             },
-            LegacyReads::Sequential(_) => {
-                unreachable!("Sequential execution does not validate reads")
-            },
+            LegacyReads::Sequential(_) => Err(code_invariant_error(
+                "Sequential execution does not validate reads",
+            )),
         }
     }
 
-    fn validate_module_reads(
+    fn legacy_validate_module_reads(
         &self,
         global_module_cache: &GlobalModuleCache<
             ModuleId,

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -7,7 +7,7 @@ use crate::{
         DeltaTestKind, GroupSizeOrMetadata, MockIncarnation, MockTransaction, ValueType,
         RESERVED_TAG,
     },
-    task::{ExecutionStatus, ExecutorTask, TransactionOutput},
+    task::{ExecutionStatus, ExecutorTask, LegacyTxnOutput, TransactionOutput},
     types::delayed_field_mock_serialization::{
         deserialize_to_delayed_field_id, serialize_from_delayed_field_id,
     },
@@ -693,7 +693,10 @@ where
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
     type CommittedOutput = MockOutput<K, E>;
+    type Key = K;
+    type Tag = u32;
     type Txn = MockTransaction<K, E>;
+    type Value = ValueWithLayout<ValueType>;
 
     fn skip_output() -> Self {
         Self::skipped_output(None)
@@ -701,21 +704,6 @@ where
 
     fn check_materialization(&self, materializer: &impl Materializer<Self::Txn>) -> bool {
         check_resource_group_serialization(self, materializer)
-    }
-
-    fn incorporate_materialized_txn_output(
-        self,
-        patched_resource_write_set: Vec<(K, ValueType)>,
-        _patched_events: Vec<E>,
-    ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
-        assert_ok!(self
-            .patched_resource_write_set
-            .set(patched_resource_write_set.into_iter().collect()));
-        // TODO: Also test patched events
-
-        // The mock's committed output is a snapshot of itself, carrying the reads
-        // and patched writes the baseline verifies.
-        Ok((self, Trace::empty()))
     }
 
     fn resource_write_set(&self) -> HashMap<K, ValueWithLayout<ValueType>> {
@@ -768,22 +756,6 @@ where
         } else {
             BTreeMap::new()
         }
-    }
-
-    fn reads_needing_delayed_field_exchange(
-        &self,
-    ) -> Vec<(K, StateValueMetadata, TriompheArc<MoveTypeLayout>)> {
-        self.reads_needing_exchange
-            .iter()
-            .map(|(key, (metadata, layout))| (key.clone(), metadata.clone(), layout.clone()))
-            .collect()
-    }
-
-    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(K, StateValueMetadata)> {
-        self.group_reads_needing_exchange
-            .iter()
-            .map(|(key, metadata)| (key.clone(), metadata.clone()))
-            .collect()
     }
 
     fn resource_group_write_set(
@@ -859,10 +831,6 @@ where
         std::iter::empty()
     }
 
-    fn get_events(&self) -> Vec<(E, Option<MoveTypeLayout>)> {
-        self.events.iter().map(|e| (e.clone(), None)).collect()
-    }
-
     fn fee_statement(&self) -> FeeStatement {
         mock_fee_statement(self.total_gas)
     }
@@ -870,6 +838,54 @@ where
     fn has_new_epoch_event(&self) -> bool {
         // For tests, it is ok to return false.
         false
+    }
+}
+
+impl<K, E> LegacyTxnOutput for MockOutput<K, E>
+where
+    K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
+    E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
+{
+    fn reads_needing_delayed_field_exchange(
+        &self,
+    ) -> Vec<(K, StateValueMetadata, TriompheArc<MoveTypeLayout>)> {
+        self.reads_needing_exchange
+            .iter()
+            .map(|(key, (metadata, layout))| (key.clone(), metadata.clone(), layout.clone()))
+            .collect()
+    }
+
+    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(K, StateValueMetadata)> {
+        self.group_reads_needing_exchange
+            .iter()
+            .map(|(key, metadata)| (key.clone(), metadata.clone()))
+            .collect()
+    }
+
+    fn get_events(&self) -> Vec<(E, Option<MoveTypeLayout>)> {
+        self.events.iter().map(|e| (e.clone(), None)).collect()
+    }
+
+    fn resource_group_metadata_ops(&self) -> Vec<(K, ValueType)> {
+        self.resource_group_write_set()
+            .into_iter()
+            .map(|(key, (op, _, _))| (key, op.extract_value().clone()))
+            .collect()
+    }
+
+    fn incorporate_materialized_txn_output(
+        self,
+        patched_resource_write_set: Vec<(K, ValueType)>,
+        _patched_events: Vec<E>,
+    ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
+        assert_ok!(self
+            .patched_resource_write_set
+            .set(patched_resource_write_set.into_iter().collect()));
+        // TODO: Also test patched events
+
+        // The mock's committed output is a snapshot of itself, carrying the reads
+        // and patched writes the baseline verifies.
+        Ok((self, Trace::empty()))
     }
 }
 

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -5,7 +5,7 @@ use crate::{
     captured_reads::{CapturedReads, DataRead, ReadKind},
     counters,
     errors::ResourceGroupSerializationError,
-    task::{ExecutorTask, TransactionOutput},
+    task::{ExecutorTask, LegacyTxnOutput},
     txn_last_input_output::TxnLastInputOutput,
     view::{LatestView, ViewState},
 };
@@ -186,7 +186,7 @@ pub(crate) fn materialize_output<T, O, M>(
 ) -> Result<(O::CommittedOutput, Trace), PanicOr<ResourceGroupSerializationError>>
 where
     T: Transaction,
-    O: TransactionOutput<Txn = T>,
+    O: LegacyTxnOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>,
     M: Materializer<T>,
 {
     let group_metadata_ops = output.resource_group_metadata_ops();
@@ -272,7 +272,7 @@ where
 pub fn check_resource_group_serialization<T, O, M>(output: &O, materializer: &M) -> bool
 where
     T: Transaction,
-    O: TransactionOutput<Txn = T>,
+    O: LegacyTxnOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>,
     M: Materializer<T>,
 {
     let serializes =

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -136,6 +136,7 @@ due to the ESTIMATE markers on memory locations, instead of waiting for a
 subsequent incarnation to finish.
 **/
 mod captured_reads;
+pub use captured_reads::{CapturedReadSet, LegacyReads, TxnInput};
 mod code_cache;
 pub mod code_cache_global;
 pub mod code_cache_global_manager;

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -142,7 +142,14 @@ pub trait TransactionOutput: Send + Debug {
 
     fn resource_group_write_set(
         &self,
-    ) -> HashMap<Self::Key, (Self::Value, ResourceGroupSize, BTreeMap<Self::Tag, Self::Value>)>;
+    ) -> HashMap<
+        Self::Key,
+        (
+            Self::Value,
+            ResourceGroupSize,
+            BTreeMap<Self::Tag, Self::Value>,
+        ),
+    >;
 
     fn for_each_resource_key(
         &self,
@@ -204,18 +211,14 @@ pub trait LegacyTxnOutput: TransactionOutput {
         &self,
     ) -> Vec<(Self::Key, StateValueMetadata, TriompheArc<MoveTypeLayout>)>;
 
-    fn group_reads_needing_delayed_field_exchange(
-        &self,
-    ) -> Vec<(Self::Key, StateValueMetadata)>;
+    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(Self::Key, StateValueMetadata)>;
 
     /// Get the events of a transaction from its output.
     fn get_events(&self) -> Vec<(<Self::Txn as Transaction>::Event, Option<MoveTypeLayout>)>;
 
     /// Group metadata write ops, kept separate to avoid cloning the whole resource
     /// group write set.
-    fn resource_group_metadata_ops(
-        &self,
-    ) -> Vec<(Self::Key, <Self::Txn as Transaction>::Value)>;
+    fn resource_group_metadata_ops(&self) -> Vec<(Self::Key, <Self::Txn as Transaction>::Value)>;
 
     /// Will be called once per transaction when the output is ready to be committed.
     /// Ensures that any writes corresponding to materialized delayed fields and group

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -5,7 +5,10 @@ use crate::{executor_utilities::Materializer, types::InputOutputKey};
 use aptos_aggregator::delayed_change::DelayedChange;
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    block_executor::{output::CommittedTransactionOutput, value::ValueWithLayout},
+    block_executor::{
+        output::CommittedTransactionOutput,
+        value::{SpeculativeValue, ValueWithLayout},
+    },
     error::PanicError,
     fee_statement::FeeStatement,
     state_store::{
@@ -29,6 +32,7 @@ use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
+    hash::Hash,
 };
 use triomphe::Arc as TriompheArc;
 
@@ -68,7 +72,12 @@ pub trait ExecutorTask {
     type AuxiliaryInfo: AuxiliaryInfoTrait;
 
     /// The output of a transaction. This should contain the side effect of this transaction.
-    type Output: TransactionOutput<Txn = Self::Txn> + 'static;
+    type Output: LegacyTxnOutput<
+            Txn = Self::Txn,
+            Key = <Self::Txn as Transaction>::Key,
+            Tag = <Self::Txn as Transaction>::Tag,
+            Value = ValueWithLayout<<Self::Txn as Transaction>::Value>,
+        > + 'static;
 
     /// Create an instance of the transaction executor.
     fn init(
@@ -110,10 +119,14 @@ pub trait ExecutorTask {
     }
 }
 
-/// The output of executing a single transaction.
+/// The output of executing a single transaction. The associated `Key`, `Tag`, and
+/// `Value` are the multi-version map's types (the writes applied to and validated
+/// against the map); `Txn` provides the storage-side key/value/event types.
 pub trait TransactionOutput: Send + Debug {
-    /// Type of transaction and its associated key and value.
     type Txn: Transaction;
+    type Key;
+    type Tag: Clone + Eq + Hash;
+    type Value: SpeculativeValue;
     /// The materialized output produced from this (speculative) output.
     type CommittedOutput: CommittedTransactionOutput;
 
@@ -122,55 +135,25 @@ pub trait TransactionOutput: Send + Debug {
 
     /// Get the writes of a transaction from its output, separately for resources
     /// and modules.
-    fn resource_write_set(
-        &self,
-    ) -> HashMap<<Self::Txn as Transaction>::Key, ValueWithLayout<<Self::Txn as Transaction>::Value>>;
+    fn resource_write_set(&self) -> HashMap<Self::Key, Self::Value>;
 
     /// Get the delayed field changes of a transaction from its output.
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>>;
 
-    fn reads_needing_delayed_field_exchange(
-        &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        StateValueMetadata,
-        TriompheArc<MoveTypeLayout>,
-    )>;
-
-    fn group_reads_needing_delayed_field_exchange(
-        &self,
-    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata)>;
-
-    /// Get the events of a transaction from its output.
-    fn get_events(&self) -> Vec<(<Self::Txn as Transaction>::Event, Option<MoveTypeLayout>)>;
-
     fn resource_group_write_set(
         &self,
-    ) -> HashMap<
-        <Self::Txn as Transaction>::Key,
-        (
-            ValueWithLayout<<Self::Txn as Transaction>::Value>,
-            ResourceGroupSize,
-            BTreeMap<
-                <Self::Txn as Transaction>::Tag,
-                ValueWithLayout<<Self::Txn as Transaction>::Value>,
-            >,
-        ),
-    >;
+    ) -> HashMap<Self::Key, (Self::Value, ResourceGroupSize, BTreeMap<Self::Tag, Self::Value>)>;
 
     fn for_each_resource_key(
         &self,
-        callback: &mut dyn FnMut(&<Self::Txn as Transaction>::Key) -> Result<(), PanicError>,
+        callback: &mut dyn FnMut(&Self::Key) -> Result<(), PanicError>,
     ) -> Result<(), PanicError>;
 
     fn for_each_resource_group_key_and_tags(
         &self,
         // This is &mut dyn and not Impl to sidestep an internal compiler error:
         // https://github.com/rust-lang/rust/issues/145188.
-        callback: &mut dyn FnMut(
-            &<Self::Txn as Transaction>::Key,
-            HashSet<&<Self::Txn as Transaction>::Tag>,
-        ) -> Result<(), PanicError>,
+        callback: &mut dyn FnMut(&Self::Key, HashSet<&Self::Tag>) -> Result<(), PanicError>,
     ) -> Result<(), PanicError>;
 
     /// Invokes the callback for each module published by this transaction.
@@ -180,27 +163,7 @@ pub trait TransactionOutput: Send + Debug {
         callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>,
     ) -> Result<(), PanicError>;
 
-    // For now, the below interfaces for keys and metada and keys and tags are provided
-    // to avoid unnecessarily cloning the whole resource group write set.
-    // TODO: get rid of these interfaces when we can have zero-copy access to the output.
-    fn resource_group_metadata_ops(
-        &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        <Self::Txn as Transaction>::Value,
-    )> {
-        self.resource_group_write_set()
-            .into_iter()
-            .map(|(key, (op, _, _))| (key, op.extract_value().clone()))
-            .collect()
-    }
-
-    fn legacy_v1_resource_group_tags(
-        &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        HashSet<<Self::Txn as Transaction>::Tag>,
-    )> {
+    fn legacy_v1_resource_group_tags(&self) -> Vec<(Self::Key, HashSet<Self::Tag>)> {
         self.resource_group_write_set()
             .into_iter()
             .map(|(key, (_, _, group_ops))| (key, group_ops.keys().cloned().collect()))
@@ -218,21 +181,41 @@ pub trait TransactionOutput: Send + Debug {
     /// Sum of all sizes of writes (keys + write_ops) and events.
     fn output_approx_size(&self) -> u64;
 
-    fn get_write_summary(
-        &self,
-    ) -> HashSet<InputOutputKey<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Tag>>;
+    fn get_write_summary(&self) -> HashSet<InputOutputKey<Self::Key, Self::Tag>>;
 
     /// State keys read by the VM during the execution that produced this output.
-    fn storage_keys_read(&self) -> impl Iterator<Item = &<Self::Txn as Transaction>::Key>;
+    fn storage_keys_read(&self) -> impl Iterator<Item = &Self::Key>;
 
     /// Keys written when this output commits.
-    fn storage_keys_written(&self) -> impl Iterator<Item = &<Self::Txn as Transaction>::Key>;
+    fn storage_keys_written(&self) -> impl Iterator<Item = &Self::Key>;
 
     /// Verifies that this transaction's output can be materialized (e.g., outputs
     /// BCS-serialized into storage representation).
     ///
     /// Only invoked during the resource-group serialization fallback.
     fn check_materialization(&self, materializer: &impl Materializer<Self::Txn>) -> bool;
+}
+
+/// Output accessors used only by the legacy Move VM's materialization
+/// (`executor_utilities::materialize_output`); a VM that materializes its own
+/// output does not implement this.
+pub trait LegacyTxnOutput: TransactionOutput {
+    fn reads_needing_delayed_field_exchange(
+        &self,
+    ) -> Vec<(Self::Key, StateValueMetadata, TriompheArc<MoveTypeLayout>)>;
+
+    fn group_reads_needing_delayed_field_exchange(
+        &self,
+    ) -> Vec<(Self::Key, StateValueMetadata)>;
+
+    /// Get the events of a transaction from its output.
+    fn get_events(&self) -> Vec<(<Self::Txn as Transaction>::Event, Option<MoveTypeLayout>)>;
+
+    /// Group metadata write ops, kept separate to avoid cloning the whole resource
+    /// group write set.
+    fn resource_group_metadata_ops(
+        &self,
+    ) -> Vec<(Self::Key, <Self::Txn as Transaction>::Value)>;
 
     /// Will be called once per transaction when the output is ready to be committed.
     /// Ensures that any writes corresponding to materialized delayed fields and group

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -170,6 +170,8 @@ pub trait TransactionOutput: Send + Debug {
         callback: &mut dyn FnMut(&ModuleId, StateValue) -> Result<(), PanicError>,
     ) -> Result<(), PanicError>;
 
+    /// Returns the key and member tags for each resource group modified. Only
+    /// used by Block-STM v1.
     fn legacy_v1_resource_group_tags(&self) -> Vec<(Self::Key, HashSet<Self::Tag>)> {
         self.resource_group_write_set()
             .into_iter()
@@ -188,6 +190,7 @@ pub trait TransactionOutput: Send + Debug {
     /// Sum of all sizes of writes (keys + write_ops) and events.
     fn output_approx_size(&self) -> u64;
 
+    /// Keys written by transaction.
     fn get_write_summary(&self) -> HashSet<InputOutputKey<Self::Key, Self::Tag>>;
 
     /// State keys read by the VM during the execution that produced this output.
@@ -203,9 +206,8 @@ pub trait TransactionOutput: Send + Debug {
     fn check_materialization(&self, materializer: &impl Materializer<Self::Txn>) -> bool;
 }
 
-/// Output accessors used only by the legacy Move VM's materialization
-/// (`executor_utilities::materialize_output`); a VM that materializes its own
-/// output does not implement this.
+/// Output accessors used only by the legacy Move VM's materialization; a VM that
+/// materializes its own output does not implement this.
 pub trait LegacyTxnOutput: TransactionOutput {
     fn reads_needing_delayed_field_exchange(
         &self,

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -9,7 +9,7 @@ use crate::{
     explicit_sync_wrapper::ExplicitSyncWrapper,
     limit_processor::BlockGasLimitProcessor,
     scheduler_wrapper::SchedulerWrapper,
-    task::{ExecutionStatus, TransactionOutput},
+    task::{ExecutionStatus, LegacyTxnOutput, TransactionOutput},
     types::ReadWriteSummary,
 };
 use aptos_logger::error;
@@ -38,13 +38,13 @@ use std::{
 
 type TxnInput<T> = CapturedReads<T, ModuleId, CompiledModule, Module, AptosModuleExtension>;
 
-struct OutputWrapper<T: Transaction, O: TransactionOutput<Txn = T>> {
+struct OutputWrapper<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>> {
     output: Option<ExecutionStatus<O>>,
     maybe_read_write_summary: Option<ReadWriteSummary<T>>,
     maybe_approx_output_size: Option<u64>,
 }
 
-impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
+impl<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>> OutputWrapper<T, O> {
     fn empty() -> Self {
         Self {
             output: None,
@@ -95,7 +95,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
     }
 }
 
-pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>> {
+pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>> {
     inputs: Vec<CachePadded<Mutex<Option<Arc<TxnInput<T>>>>>>, // txn_idx -> input (read set).
 
     output_wrappers: Vec<CachePadded<Mutex<OutputWrapper<T, O>>>>,
@@ -104,7 +104,7 @@ pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>> {
     speculative_failures: Vec<CachePadded<AtomicBool>>,
 }
 
-impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
+impl<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>> TxnLastInputOutput<T, O> {
     /// num_txns passed here is typically larger than the number of txns in the block,
     /// currently by 1 to account for the block epilogue txn.
     pub fn new(num_txns: TxnIndex) -> Self {
@@ -375,7 +375,10 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         &self,
         txn_idx: TxnIndex,
         materializer: &M,
-    ) -> Result<(O::CommittedOutput, Trace), PanicOr<ResourceGroupSerializationError>> {
+    ) -> Result<(O::CommittedOutput, Trace), PanicOr<ResourceGroupSerializationError>>
+    where
+        O: LegacyTxnOutput,
+    {
         let output = self.output_wrappers[txn_idx as usize].lock().output.take();
         match output {
             Some(ExecutionStatus::Executed { output, .. }) => {

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -38,13 +38,20 @@ use std::{
 
 type TxnInput<T> = CapturedReads<T, ModuleId, CompiledModule, Module, AptosModuleExtension>;
 
-struct OutputWrapper<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>> {
+struct OutputWrapper<
+    T: Transaction,
+    O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>,
+> {
     output: Option<ExecutionStatus<O>>,
     maybe_read_write_summary: Option<ReadWriteSummary<T>>,
     maybe_approx_output_size: Option<u64>,
 }
 
-impl<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>> OutputWrapper<T, O> {
+impl<
+        T: Transaction,
+        O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>,
+    > OutputWrapper<T, O>
+{
     fn empty() -> Self {
         Self {
             output: None,
@@ -95,7 +102,10 @@ impl<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, V
     }
 }
 
-pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>> {
+pub struct TxnLastInputOutput<
+    T: Transaction,
+    O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>,
+> {
     inputs: Vec<CachePadded<Mutex<Option<Arc<TxnInput<T>>>>>>, // txn_idx -> input (read set).
 
     output_wrappers: Vec<CachePadded<Mutex<OutputWrapper<T, O>>>>,
@@ -104,7 +114,11 @@ pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T, Key 
     speculative_failures: Vec<CachePadded<AtomicBool>>,
 }
 
-impl<T: Transaction, O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>> TxnLastInputOutput<T, O> {
+impl<
+        T: Transaction,
+        O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>,
+    > TxnLastInputOutput<T, O>
+{
     /// num_txns passed here is typically larger than the number of txns in the block,
     /// currently by 1 to account for the block epilogue txn.
     pub fn new(num_txns: TxnIndex) -> Self {

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    captured_reads::CapturedReads,
+    captured_reads::CapturedReadSet,
     code_cache_global::{add_module_write_to_module_cache, GlobalModuleCache},
     errors::{ParallelBlockExecutionError, ResourceGroupSerializationError},
     executor_utilities::{materialize_output, Materializer},
@@ -36,8 +36,6 @@ use std::{
     },
 };
 
-type TxnInput<T> = CapturedReads<T, ModuleId, CompiledModule, Module, AptosModuleExtension>;
-
 struct OutputWrapper<
     T: Transaction,
     O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>,
@@ -66,7 +64,7 @@ impl<
 
     fn from_execution_status(
         output: ExecutionStatus<O>,
-        read_set: &TxnInput<T>,
+        read_set: &CapturedReadSet<T>,
         block_gas_limit_type: &BlockGasLimitType,
         user_txn_bytes_len: u64,
     ) -> Self {
@@ -106,7 +104,7 @@ pub struct TxnLastInputOutput<
     T: Transaction,
     O: TransactionOutput<Txn = T, Key = T::Key, Tag = T::Tag, Value = ValueWithLayout<T::Value>>,
 > {
-    inputs: Vec<CachePadded<Mutex<Option<Arc<TxnInput<T>>>>>>, // txn_idx -> input (read set).
+    inputs: Vec<CachePadded<Mutex<Option<Arc<CapturedReadSet<T>>>>>>, // txn_idx -> input (read set).
 
     output_wrappers: Vec<CachePadded<Mutex<OutputWrapper<T, O>>>>,
     // Used to record if the latest incarnation of a txn was a failure due to the
@@ -138,7 +136,7 @@ impl<
     pub(crate) fn record(
         &self,
         txn_idx: TxnIndex,
-        input: TxnInput<T>,
+        input: CapturedReadSet<T>,
         output: ExecutionStatus<O>,
         block_gas_limit_type: &BlockGasLimitType,
         user_txn_bytes_len: u64,
@@ -163,7 +161,7 @@ impl<
         self.speculative_failures[txn_idx as usize].load(Ordering::Relaxed)
     }
 
-    pub(crate) fn read_set(&self, txn_idx: TxnIndex) -> Option<Arc<TxnInput<T>>> {
+    pub(crate) fn read_set(&self, txn_idx: TxnIndex) -> Option<Arc<CapturedReadSet<T>>> {
         Some(Arc::clone(self.inputs[txn_idx as usize].lock().as_ref()?))
     }
 

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -14,7 +14,7 @@ use aptos_aggregator::{
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManagerGuard,
     executor::BlockExecutor,
-    task::{ExecutionStatus, ExecutorTask, TransactionOutput},
+    task::{ExecutionStatus, ExecutorTask, LegacyTxnOutput, TransactionOutput},
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::default::DefaultTxnProvider,
     types::InputOutputKey,
@@ -161,7 +161,10 @@ struct TestOutput;
 
 impl TransactionOutput for TestOutput {
     type CommittedOutput = aptos_types::transaction::TransactionOutput;
+    type Key = StateKey;
+    type Tag = StructTag;
     type Txn = TestTransaction;
+    type Value = ValueWithLayout<WriteOp>;
 
     fn skip_output() -> Self {
         Self
@@ -169,17 +172,6 @@ impl TransactionOutput for TestOutput {
 
     fn check_materialization(&self, _materializer: &impl Materializer<Self::Txn>) -> bool {
         true
-    }
-
-    fn incorporate_materialized_txn_output(
-        self,
-        _patched_resource_write_set: Vec<(StateKey, WriteOp)>,
-        _patched_events: Vec<ContractEvent>,
-    ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
-        Ok((
-            aptos_types::transaction::TransactionOutput::new_empty_success(),
-            Trace::empty(),
-        ))
     }
 
     fn resource_write_set(&self) -> HashMap<StateKey, ValueWithLayout<WriteOp>> {
@@ -195,20 +187,6 @@ impl TransactionOutput for TestOutput {
 
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>> {
         BTreeMap::new()
-    }
-
-    fn reads_needing_delayed_field_exchange(
-        &self,
-    ) -> Vec<(StateKey, StateValueMetadata, TriompheArc<MoveTypeLayout>)> {
-        vec![]
-    }
-
-    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(StateKey, StateValueMetadata)> {
-        vec![]
-    }
-
-    fn get_events(&self) -> Vec<(ContractEvent, Option<MoveTypeLayout>)> {
-        vec![]
     }
 
     fn resource_group_write_set(
@@ -260,6 +238,37 @@ impl TransactionOutput for TestOutput {
 
     fn storage_keys_written(&self) -> impl Iterator<Item = &StateKey> {
         std::iter::empty()
+    }
+}
+
+impl LegacyTxnOutput for TestOutput {
+    fn reads_needing_delayed_field_exchange(
+        &self,
+    ) -> Vec<(StateKey, StateValueMetadata, TriompheArc<MoveTypeLayout>)> {
+        vec![]
+    }
+
+    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(StateKey, StateValueMetadata)> {
+        vec![]
+    }
+
+    fn get_events(&self) -> Vec<(ContractEvent, Option<MoveTypeLayout>)> {
+        vec![]
+    }
+
+    fn resource_group_metadata_ops(&self) -> Vec<(StateKey, WriteOp)> {
+        vec![]
+    }
+
+    fn incorporate_materialized_txn_output(
+        self,
+        _patched_resource_write_set: Vec<(StateKey, WriteOp)>,
+        _patched_events: Vec<ContractEvent>,
+    ) -> Result<(Self::CommittedOutput, Trace), PanicError> {
+        Ok((
+            aptos_types::transaction::TransactionOutput::new_empty_success(),
+            Trace::empty(),
+        ))
     }
 }
 


### PR DESCRIPTION
## Description

Preparatory refactors for a VM-neutral Block-STM execution abstraction (a future `SingleTransactionExecutor`, landing in a follow-up). Two commits, both behavior-preserving:

**1. Split `TransactionOutput` into base + `LegacyTxnOutput`.**
- Add multi-version-map associated types to `TransactionOutput`: `type Key`, `type Tag`, `type Value: SpeculativeValue`. The map-side accessors (`resource_write_set`, `resource_group_write_set`, `for_each_resource_*`, `get_write_summary`, `legacy_v1_resource_group_tags`, `storage_keys_read/written`) are retyped to `Self::Key/Tag/Value`, so a VM can carry its own value type instead of being fixed to the legacy `ValueWithLayout<WriteOp>`.
- Move the legacy Move VM's materialization-only accessors into a new `LegacyTxnOutput: TransactionOutput` supertrait: `get_events`, `resource_group_metadata_ops`, `reads_needing_delayed_field_exchange`, `group_reads_needing_delayed_field_exchange`, `incorporate_materialized_txn_output`. These are consumed only by `executor_utilities::materialize_output`, so a VM that materializes its own output won't implement them.
- `ExecutorTask::Output` and `materialize_output` / `check_resource_group_serialization` are bounded on `LegacyTxnOutput` with the map value pinned to `ValueWithLayout<T::Value>` for the legacy path. The three output impls (`AptosTransactionOutput`, `MockOutput`, `TestOutput`) gain the associated types and split their legacy accessors into a `LegacyTxnOutput` impl.

**2. Add `TxnInput` read-set abstraction.**
- Add a `TxnInput` trait (`captured_reads.rs`) abstracting the read set the executor validates against the multi-version map: `validate_data_reads` / `validate_group_reads` / `validate_delayed_field_reads` / `validate_module_reads`, plus `record_delayed_field_application_failure`, `incarnation`, `is_incorrect_use`, and `get_read_summary`.
- The legacy Move VM's read sets implement it: `CapturedReadSet<T>` (parallel) and a `LegacyReads<T>` enum (parallel `CapturedReads` or sequential `UnsyncReadSet`). The `CapturedReads`/`UnsyncReadSet` structs are made `pub` so these types can be exposed.
- `validate_module_reads` stays typed against the legacy Move VM code cache (`GlobalModuleCache`/`SyncModuleCache`), marked as a known non-neutral seam to be generalized when a VM supplies its own code caching.
- Unused until the executor is wired to `SingleTransactionExecutor` (follow-up commit).

## How Has This Been Tested?

Both changes are behavior-preserving — commit 1 is a pure trait reshuffle (method bodies unchanged), and commit 2 adds an as-yet-unused trait + impls. So existing coverage applies:
- `cargo check` passes for `aptos-block-executor`, `aptos-vm`, `e2e-move-tests`, and `aptos-executor-benchmark`.
- `RUST_MIN_STACK=1073741824 cargo nextest run -p aptos-block-executor` — the `unit_tests` (incl. the resource-group serialization fallback failpoint test) and combinatorial `group_tests`/`resource_tests` pass, exercising the `TransactionOutput`/`LegacyTxnOutput` accessors through the parallel and sequential paths.

## Key Areas to Review

- `task.rs` — the base `TransactionOutput` vs `LegacyTxnOutput` split and the associated-type bounds (`type Tag: Clone + Eq + Hash`, `type Value: SpeculativeValue`); `ExecutorTask::Output` bound.
- `captured_reads.rs` — the `TxnInput` trait, its `CapturedReadSet`/`LegacyReads` impls (sequential arms are `unreachable!` — parallel-only validation), and the `validate_module_reads` seam.
- `executor_utilities.rs` — `materialize_output` / `check_resource_group_serialization` bounds moving to `LegacyTxnOutput`.
- The three output impls splitting their legacy accessors into `LegacyTxnOutput`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Block-STM trait boundaries and parallel validation/materialization paths; changes are intended to be behavior-preserving but errors in trait splits could affect execution or commit-time materialization.
> 
> **Overview**
> Prepares Block-STM for VM-neutral execution by reshaping output and read-set traits without changing runtime behavior.
> 
> **`TransactionOutput` is slimmed down** with associated types `Key`, `Tag`, and `Value: SpeculativeValue`, and map-facing accessors are typed on those instead of always using the transaction’s storage types. **Legacy Move VM materialization** (`get_events`, delayed-field exchange reads, `resource_group_metadata_ops`, `incorporate_materialized_txn_output`) moves to a new **`LegacyTxnOutput`** supertrait. `ExecutorTask::Output`, `materialize_output`, and `check_resource_group_serialization` are bounded on `LegacyTxnOutput`; `AptosTransactionOutput`, mocks, and e2e test outputs split their impls accordingly (e.g. `resource_group_metadata_ops` only on the legacy impl).
> 
> **Read sets get a `TxnInput` trait** so validation against the MV map is not tied to one VM shape: `validate_*` for data, groups, delayed fields, and modules, plus helpers like `get_read_summary` and `incarnation`. **`CapturedReadSet`** and **`LegacyReads`** (parallel `CapturedReads` vs sequential `UnsyncReadSet`) implement it; `CapturedReads` / `UnsyncReadSet` are **`pub`** and re-exported. Module validation on `TxnInput` still uses the legacy Move code-cache types (`legacy_validate_module_reads`) as an explicit seam. **`TxnLastInputOutput` still stores `CapturedReadSet` directly**—the new trait is API for a follow-up executor wiring change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a220a2b3027e1765bcb4e8441bb8a8fed91dc1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->