### PR TITLE
[consensus] Don't log cancelled self-share derive as error

### DIFF
--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -61,6 +61,20 @@ impl Display for TaskError {
     }
 }
 
+impl TaskError {
+    /// Returns true if this error is (or propagates from) a cancelled task —
+    /// i.e. expected pipeline teardown (the block was dropped or a
+    /// buffer_manager reset aborted the pipeline) rather than a genuine
+    /// failure. A panicked `JoinError` is a real failure and returns false.
+    pub fn is_cancellation(&self) -> bool {
+        match self {
+            TaskError::JoinError(e) => e.is_cancelled(),
+            TaskError::PropagatedError(inner) => inner.is_cancellation(),
+            TaskError::InternalError(_) => false,
+        }
+    }
+}
+
 impl From<Error> for TaskError {
     fn from(value: Error) -> Self {
         Self::InternalError(Arc::new(value))
@@ -247,6 +261,31 @@ mod tests {
 
         drop(block);
         assert_eq!(ordered_blocks.pipelined_blocks().unwrap_err(), block_id);
+    }
+
+    #[tokio::test]
+    async fn task_error_is_cancellation() {
+        // An aborted task yields a cancelled JoinError — expected pipeline
+        // teardown — and must be classified as a cancellation, including when
+        // it propagates in from an upstream stage.
+        let handle = tokio::spawn(std::future::pending::<()>());
+        handle.abort();
+        let cancelled = handle.await.expect_err("aborted task should not complete");
+        assert!(cancelled.is_cancelled());
+        let cancelled = TaskError::JoinError(Arc::new(cancelled));
+        assert!(cancelled.is_cancellation());
+        assert!(TaskError::PropagatedError(Box::new(cancelled)).is_cancellation());
+
+        // A panicked task is a genuine failure, not a cancellation.
+        let handle = tokio::spawn(async { panic!("boom") });
+        let panicked = handle.await.expect_err("panicked task should not complete");
+        assert!(panicked.is_panic());
+        let panicked = TaskError::JoinError(Arc::new(panicked));
+        assert!(!panicked.is_cancellation());
+        assert!(!TaskError::PropagatedError(Box::new(panicked)).is_cancellation());
+
+        // A genuine internal error is never a cancellation.
+        assert!(!TaskError::from(anyhow::anyhow!("boom")).is_cancellation());
     }
 }
 

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -23,7 +23,7 @@ use aptos_consensus_types::{
     pipelined_block::{PipelinedBlock, SecretShareResult, TaskResult},
 };
 use aptos_infallible::Mutex;
-use aptos_logger::{error, info, spawn_named, warn};
+use aptos_logger::{debug, error, info, spawn_named, warn};
 use aptos_network::{protocols::network::RpcError, ProtocolId};
 use aptos_reliable_broadcast::{DropGuard, ReliableBroadcast};
 use aptos_time_service::TimeService;
@@ -167,6 +167,13 @@ impl SecretShareManager {
                     item.resolve_round_without_key(round);
                 }
                 self.secret_share_store.lock().mark_round_skipped(round);
+                return;
+            },
+            Err(e) if e.is_cancellation() => {
+                // Expected teardown: the block was dropped or a buffer_manager
+                // reset aborted the pipeline, cancelling the derive future. Not
+                // a failure, so log at debug and don't surface it as an error.
+                debug!(round = round, "Self-share derive cancelled: {:?}", e);
                 return;
             },
             Err(e) => {


### PR DESCRIPTION
## Problem

A devnet-validator alert (filter: `level = error`, `container = validator`, `pod = /^devnet/`) was firing on this line:

```
consensus/src/rand/secret_sharing/secret_share_manager.rs:173
  error!  "Self-share derive failed: JoinError(JoinError::Cancelled(Id(...)))"
```

`process_completed_derive` awaits the block's `secret_sharing_derive_self_fut` (a pipeline `TaskFuture`). When a block is dropped or a `buffer_manager` reset aborts the pipeline (normal teardown — frequent on fullnodes re-rooting, and also seen on validators during state-sync / epoch boundaries / abandoned forks), that future resolves to a cancelled `JoinError`. Logging it at `error!` turned expected teardown into alert-firing noise.

Over 24h this was the *only* error-level line matching the alert on devnet validators — every occurrence was `JoinError::Cancelled`, **zero panics** — confirming it is 100% benign.

## Fix

- Add `TaskError::is_cancellation()` — returns `true` for a cancelled `JoinError` (including when wrapped in `PropagatedError` from an upstream stage) and `false` for `InternalError` and *panicked* `JoinError`s.
- Route cancelled derives to `debug!` in `process_completed_derive`; keep `error!` for genuine `InternalError`/panic failures.

No behavioral change — log level only. Real derive failures are still surfaced as errors.

## Test

- New `#[tokio::test] task_error_is_cancellation` in `consensus-types` constructs real cancelled/panicked `JoinError`s and asserts classification across all three variants plus the propagated case.
- `cargo check -p aptos-consensus` clean; `cargo +nightly fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)