### PR TITLE
Re-resolve memoized closures when defining module changes

### DIFF
--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -309,6 +309,8 @@ pub fn aptos_prod_vm_config(
         check_depth_on_type_counts: gas_feature_version >= RELEASE_V1_41,
         enable_public_struct_args: features.is_enabled(FeatureFlag::PUBLIC_STRUCT_ENUM_ARGS),
         include_closure_mask_in_cmp: gas_feature_version >= RELEASE_V1_45,
+        revalidate_resolved_closures: timed_features
+            .is_enabled(TimedFeatureFlag::RevalidateResolvedClosures),
     };
 
     // Note: if max_value_nest_depth changed, make sure the constant is in-sync. Do not remove this

--- a/aptos-move/e2e-move-tests/src/tests/closure_stale_generic_ability.rs
+++ b/aptos-move/e2e-move-tests/src/tests/closure_stale_generic_ability.rs
@@ -1,0 +1,408 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{assert_abort, assert_vm_status, tests::common, MoveHarness};
+use aptos_cached_packages::aptos_stdlib;
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_language_e2e_tests::account::Account;
+use aptos_package_builder::PackageBuilder;
+use aptos_types::{
+    account_address::AccountAddress,
+    move_utils::MemberId,
+    on_chain_config::TimedFeatureFlag,
+    transaction::{EntryFunction, ExecutionStatus, TransactionPayload, TransactionStatus},
+};
+use aptos_vm_environment::prod_configs::{set_async_runtime_checks, set_paranoid_type_checks};
+use move_core_types::vm_status::StatusCode;
+
+const ADDRESS: &str = "0xca14";
+const FEE_PAYER_ADDRESS: &str = "0xca15";
+const SUPPLY_HOLDER_ADDRESS: &str = "0xca16";
+const OCTAS_PER_APT: u64 = 100_000_000;
+const INITIAL_BALANCE_APT: u64 = 1_000_000;
+const INITIAL_BALANCE: u64 = INITIAL_BALANCE_APT * OCTAS_PER_APT;
+const FEE_PAYER_BALANCE: u64 = 100 * OCTAS_PER_APT;
+
+const V1: &str = r#"
+module 0xca14::provider {
+    use aptos_std::copyable_any::Any;
+
+    package fun pack<X: store>(value: X): Any {
+        let _ = value;
+        abort 1401
+    }
+}
+
+module 0xca14::caller {
+    use std::signer;
+    use aptos_std::copyable_any;
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin::{Self, Coin};
+    use 0xca14::provider;
+
+    const AMOUNT: u64 = 100000000000000;
+
+    struct Single has key {
+        coin: Coin<AptosCoin>,
+    }
+
+    struct Doubled has key {
+        left: Coin<AptosCoin>,
+        right: Coin<AptosCoin>,
+    }
+
+    struct SupplyReserve has key {
+        coin: Coin<AptosCoin>,
+    }
+
+    public entry fun create_supply_reserve(owner: &signer) {
+        move_to(owner, SupplyReserve { coin: coin::withdraw<AptosCoin>(owner, AMOUNT) })
+    }
+
+    public entry fun create(owner: &signer) {
+        assert!(coin::balance<AptosCoin>(signer::address_of(owner)) == AMOUNT, 1401);
+        let coin = coin::withdraw<AptosCoin>(owner, AMOUNT);
+        assert!(coin::value(&coin) == AMOUNT, 1402);
+        move_to(owner, Single { coin })
+    }
+
+    #[persistent]
+    public fun closure_target(owner: &signer, input: u64): u64 {
+        if (input == 0) {
+            return 10
+        };
+
+        let Single { coin } = move_from<Single>(signer::address_of(owner));
+        assert!(coin::value(&coin) == AMOUNT, 1403);
+
+        let packed = provider::pack<Coin<AptosCoin>>(coin);
+
+        let packed_copy = copy packed;
+        let left = copyable_any::unpack<Coin<AptosCoin>>(packed);
+        let right = copyable_any::unpack<Coin<AptosCoin>>(packed_copy);
+
+        assert!(coin::value(&left) == AMOUNT, 1404);
+        assert!(coin::value(&right) == AMOUNT, 1405);
+        move_to(owner, Doubled { left, right });
+        99
+    }
+
+    public fun assert_doubled(addr: address) acquires Doubled {
+        let doubled = borrow_global<Doubled>(addr);
+        assert!(coin::value(&doubled.left) == AMOUNT, 1406);
+        assert!(coin::value(&doubled.right) == AMOUNT, 1407)
+    }
+
+    public entry fun redeem(owner: &signer) acquires Doubled {
+        let addr = signer::address_of(owner);
+        let balance_before = coin::balance<AptosCoin>(addr);
+        assert!(balance_before == 0, 1408);
+        let Doubled { left, right } = move_from<Doubled>(addr);
+        assert!(coin::value(&left) == AMOUNT, 1409);
+        assert!(coin::value(&right) == AMOUNT, 1410);
+        coin::deposit<AptosCoin>(addr, left);
+        coin::deposit<AptosCoin>(addr, right);
+        assert!(coin::balance<AptosCoin>(addr) == 2 * AMOUNT, 1411)
+    }
+}
+
+module 0xca14::keeper {
+    use 0xca14::caller;
+
+    struct Holder has key {
+        f: |&signer, u64|u64 has copy + drop + store,
+    }
+
+    public entry fun create(owner: &signer) {
+        move_to(owner, Holder { f: caller::closure_target })
+    }
+
+    public fun invoke(owner: &signer, input: u64): u64 {
+        let f = borrow_global<Holder>(std::signer::address_of(owner)).f;
+        f(owner, input)
+    }
+}
+
+module 0xca14::upgrade_driver {
+    use aptos_framework::code;
+    use 0xca14::keeper;
+
+    public entry fun upgrade(
+        owner: &signer,
+        metadata: vector<u8>,
+        code: vector<vector<u8>>,
+    ) {
+        assert!(keeper::invoke(owner, 0) == 10, 1411);
+        code::publish_package_txn(owner, metadata, code)
+    }
+}
+"#;
+
+const V2: &str = r#"
+module 0xca14::provider {
+    use aptos_std::copyable_any::{Self, Any};
+
+    public fun pack<X: copy + drop + store>(value: X): Any {
+        copyable_any::pack<X>(value)
+    }
+}
+
+module 0xca14::caller {
+    use std::signer;
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin::{Self, Coin};
+
+    const AMOUNT: u64 = 100000000000000;
+
+    struct Single has key {
+        coin: Coin<AptosCoin>,
+    }
+
+    struct Doubled has key {
+        left: Coin<AptosCoin>,
+        right: Coin<AptosCoin>,
+    }
+
+    struct SupplyReserve has key {
+        coin: Coin<AptosCoin>,
+    }
+
+    public entry fun create_supply_reserve(owner: &signer) {
+        move_to(owner, SupplyReserve { coin: coin::withdraw<AptosCoin>(owner, AMOUNT) })
+    }
+
+    public entry fun create(owner: &signer) {
+        assert!(coin::balance<AptosCoin>(signer::address_of(owner)) == AMOUNT, 1401);
+        let coin = coin::withdraw<AptosCoin>(owner, AMOUNT);
+        assert!(coin::value(&coin) == AMOUNT, 1402);
+        move_to(owner, Single { coin })
+    }
+
+    #[persistent]
+    public fun closure_target(_owner: &signer, _input: u64): u64 { 777 }
+
+    public fun assert_doubled(addr: address) acquires Doubled {
+        let doubled = borrow_global<Doubled>(addr);
+        assert!(coin::value(&doubled.left) == AMOUNT, 1406);
+        assert!(coin::value(&doubled.right) == AMOUNT, 1407)
+    }
+
+    public entry fun redeem(owner: &signer) acquires Doubled {
+        let addr = signer::address_of(owner);
+        let balance_before = coin::balance<AptosCoin>(addr);
+        assert!(balance_before == 0, 1408);
+        let Doubled { left, right } = move_from<Doubled>(addr);
+        assert!(coin::value(&left) == AMOUNT, 1409);
+        assert!(coin::value(&right) == AMOUNT, 1410);
+        coin::deposit<AptosCoin>(addr, left);
+        coin::deposit<AptosCoin>(addr, right);
+        assert!(coin::balance<AptosCoin>(addr) == 2 * AMOUNT, 1411)
+    }
+}
+
+module 0xca14::keeper {
+    use 0xca14::caller;
+
+    struct Holder has key {
+        f: |&signer, u64|u64 has copy + drop + store,
+    }
+
+    public entry fun create(owner: &signer) {
+        move_to(owner, Holder { f: caller::closure_target })
+    }
+
+    public fun invoke(owner: &signer, input: u64): u64 {
+        let f = borrow_global<Holder>(std::signer::address_of(owner)).f;
+        f(owner, input)
+    }
+}
+
+module 0xca14::upgrade_driver {
+    use aptos_framework::code;
+    use 0xca14::keeper;
+
+    public entry fun upgrade(
+        owner: &signer,
+        metadata: vector<u8>,
+        code: vector<vector<u8>>,
+    ) {
+        assert!(keeper::invoke(owner, 0) == 777, 1411);
+        code::publish_package_txn(owner, metadata, code)
+    }
+}
+
+module 0xca14::trigger {
+    use std::signer;
+    use 0xca14::caller;
+    use 0xca14::keeper;
+
+    fun init_module(owner: &signer) {
+        assert!(keeper::invoke(owner, 1) == 99, 1412);
+        caller::assert_doubled(signer::address_of(owner))
+    }
+}
+"#;
+
+fn package_builder(source: &str) -> PackageBuilder {
+    let mut builder = PackageBuilder::new("StagedGenericAbilityCopyableAnyAptosCoinClone");
+    builder.add_source("coin_clone.move", source);
+    for (name, path) in [
+        ("MoveStdlib", "move-stdlib"),
+        ("AptosStdlib", "aptos-stdlib"),
+        ("AptosFramework", "aptos-framework"),
+    ] {
+        builder.add_local_dep(name, &common::framework_dir_path(path).to_string_lossy());
+    }
+    builder
+}
+
+fn expect_success(label: &str, status: TransactionStatus) {
+    println!("{label}: {status:?}");
+    assert_eq!(status, TransactionStatus::Keep(ExecutionStatus::Success));
+}
+
+fn entry_function_payload(function: &str, args: Vec<Vec<u8>>) -> TransactionPayload {
+    let MemberId {
+        module_id,
+        member_id,
+    } = function.parse().expect("valid entry-function member id");
+    TransactionPayload::EntryFunction(EntryFunction::new(module_id, member_id, vec![], args))
+}
+
+fn publish_payload(package: &BuiltPackage) -> TransactionPayload {
+    let metadata = package.extract_metadata().expect("package metadata");
+    aptos_stdlib::code_publish_package_txn(
+        bcs::to_bytes(&metadata).expect("serialize package metadata"),
+        package.extract_code(),
+    )
+}
+
+fn run_with_fee_payer(
+    harness: &mut MoveHarness,
+    sender: &Account,
+    fee_payer: &Account,
+    payload: TransactionPayload,
+) -> TransactionStatus {
+    let txn = harness
+        .create_transaction_without_sign(sender, payload)
+        .fee_payer(fee_payer.clone())
+        .sign_fee_payer();
+    harness.run(txn)
+}
+
+/// A stored closure over `caller::closure_target` is resolved before `caller` is upgraded, then
+/// re-invoked (via a new module's `init_module`) within the same upgrade transaction. Two
+/// independent defenses stop the stale closure from duplicating a coin:
+///   - with revalidation enabled, the closure is re-resolved to the upgraded `closure_target`
+///     (which returns 777), so `init_module` aborts with 1412;
+///   - with revalidation disabled, the stale body runs but its cross-module call into the upgraded
+///     `provider::pack` fails the type-argument ability recheck (`CONSTRAINT_NOT_SATISFIED`).
+/// Either way the upgrade is discarded and the coin is never duplicated.
+fn run_coin_duplication_scenario(revalidation_enabled: bool) {
+    set_paranoid_type_checks(true);
+    set_async_runtime_checks(true);
+
+    let mut harness = MoveHarness::new_testnet();
+    harness.set_timed_feature(
+        TimedFeatureFlag::RevalidateResolvedClosures,
+        revalidation_enabled,
+    );
+    let account = harness.new_account_with_balance_at(
+        AccountAddress::from_hex_literal(ADDRESS).unwrap(),
+        INITIAL_BALANCE,
+    );
+    let fee_payer = harness.new_account_with_balance_at(
+        AccountAddress::from_hex_literal(FEE_PAYER_ADDRESS).unwrap(),
+        FEE_PAYER_BALANCE,
+    );
+    let supply_holder = harness.new_account_with_balance_at(
+        AccountAddress::from_hex_literal(SUPPLY_HOLDER_ADDRESS).unwrap(),
+        INITIAL_BALANCE,
+    );
+    assert_eq!(
+        harness.read_aptos_balance(account.address()),
+        INITIAL_BALANCE
+    );
+
+    let v1 = package_builder(V1).write_to_temp().expect("write v1");
+    let built_v1 =
+        BuiltPackage::build(v1.path().to_path_buf(), BuildOptions::move_2()).expect("build v1");
+    expect_success(
+        "publish v1",
+        run_with_fee_payer(
+            &mut harness,
+            &account,
+            &fee_payer,
+            publish_payload(&built_v1),
+        ),
+    );
+    assert_eq!(
+        harness.read_aptos_balance(account.address()),
+        INITIAL_BALANCE
+    );
+
+    expect_success(
+        "caller::create_supply_reserve",
+        run_with_fee_payer(
+            &mut harness,
+            &supply_holder,
+            &fee_payer,
+            entry_function_payload(&format!("{ADDRESS}::caller::create_supply_reserve"), vec![]),
+        ),
+    );
+
+    for function in ["caller::create", "keeper::create"] {
+        expect_success(
+            function,
+            run_with_fee_payer(
+                &mut harness,
+                &account,
+                &fee_payer,
+                entry_function_payload(&format!("{ADDRESS}::{function}"), vec![]),
+            ),
+        );
+    }
+    assert_eq!(harness.read_aptos_balance(account.address()), 0);
+
+    let v2 = package_builder(V2).write_to_temp().expect("write v2");
+    let built =
+        BuiltPackage::build(v2.path().to_path_buf(), BuildOptions::move_2()).expect("build v2");
+    let metadata = bcs::to_bytes(&built.extract_metadata().expect("metadata")).unwrap();
+    let code = built.extract_code();
+
+    let upgrade_status = run_with_fee_payer(
+        &mut harness,
+        &account,
+        &fee_payer,
+        entry_function_payload(&format!("{ADDRESS}::upgrade_driver::upgrade"), vec![
+            bcs::to_bytes(&metadata).unwrap(),
+            bcs::to_bytes(&code).unwrap(),
+        ]),
+    );
+    println!("upgrade (revalidation_enabled={revalidation_enabled}): {upgrade_status:?}");
+
+    if revalidation_enabled {
+        assert_abort!(upgrade_status, 1412);
+        assert_eq!(harness.read_aptos_balance(account.address()), 0);
+        return;
+    }
+
+    // Closure revalidation is disabled, so the stale closure still executes the pre-upgrade
+    // `closure_target`. But when that body invokes the upgraded `provider::pack` through a
+    // cross-module generic call, the runtime re-checks the type-argument abilities against the
+    // resolved callee. The upgraded `pack` requires `copy + drop + store`, which `Coin<AptosCoin>`
+    // does not satisfy, so the call is rejected and the upgrade transaction is discarded. The coin
+    // is therefore never duplicated.
+    assert_vm_status!(upgrade_status, StatusCode::CONSTRAINT_NOT_SATISFIED);
+    assert_eq!(harness.read_aptos_balance(account.address()), 0);
+}
+
+#[test]
+fn coin_duplication_prevented_by_ability_recheck_when_revalidation_disabled() {
+    run_coin_duplication_scenario(false);
+}
+
+#[test]
+fn coin_duplication_prevented_when_revalidation_enabled() {
+    run_coin_duplication_scenario(true);
+}

--- a/aptos-move/e2e-move-tests/src/tests/init_module_closure_store.rs
+++ b/aptos-move/e2e-move-tests/src/tests/init_module_closure_store.rs
@@ -15,14 +15,19 @@
 //! The test ensures that it is NOT possible to load **old** version
 //! of the function in A that is private.
 
-use crate::{assert_success, tests::common, MoveHarness};
-use aptos_framework::BuildOptions;
+use crate::{assert_abort, assert_success, tests::common, MoveHarness};
+use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_language_e2e_tests::{
     account::Account,
     executor::{ExecutorMode, FakeExecutor},
 };
 use aptos_package_builder::PackageBuilder;
-use aptos_types::{account_address::AccountAddress, transaction::SignedTransaction};
+use aptos_types::{
+    account_address::AccountAddress,
+    on_chain_config::{FeatureFlag, TimedFeatureFlag},
+    transaction::{SignedTransaction, TransactionStatus},
+};
+use test_case::test_case;
 
 fn build_publish_a(h: &mut MoveHarness, acc: &Account) -> SignedTransaction {
     let source = r#"
@@ -132,4 +137,173 @@ fn poc_type_confusion_module_upgrade_parallel() {
             assert_success!(result.status().clone());
         }
     }
+}
+
+/// Module with a stored closure over the public (persistent) function `foo`. `INCREMENT` is
+/// substituted to distinguish versions: v1 adds 1, v2 adds 1000.
+const MODULE_A_TEMPLATE: &str = r#"
+    module 0xcafe::a {
+        use aptos_framework::code;
+        use std::signer;
+
+        struct Res has key { f: |u64|u64 has copy + store }
+
+        public fun foo(x: u64): u64 {
+            x + INCREMENT
+        }
+
+        public entry fun store(s: &signer) {
+            let f: |u64|u64 has copy + drop + store = |x| foo(x);
+            move_to(s, Res { f });
+        }
+
+        public fun call_stored(addr: address): u64 acquires Res {
+            let r = borrow_global<Res>(addr);
+            (r.f)(41)
+        }
+
+        public entry fun check(addr: address, expected: u64) acquires Res {
+            assert!(call_stored(addr) == expected, 200);
+        }
+
+        public entry fun call_then_upgrade(
+            owner: &signer,
+            metadata: vector<u8>,
+            code: vector<vector<u8>>,
+        ) acquires Res {
+            // Resolves (and memoizes) the stored closure under the pre-upgrade module version.
+            assert!(call_stored(signer::address_of(owner)) == 42, 100);
+            code::publish_package_txn(owner, metadata, code);
+        }
+    }
+"#;
+
+/// New module published together with the upgraded `a`. Its `init_module` runs inside the
+/// publishing transaction and re-invokes the closure that was already resolved against the
+/// pre-upgrade version of `a` earlier in the same transaction.
+const MODULE_B: &str = r#"
+    module 0xcafe::b {
+        fun init_module(_s: &signer) {
+            assert!(0xcafe::a::call_stored(@0xcafe) == 1041, 777);
+        }
+    }
+"#;
+
+// Returns BCS-serialized package metadata and module code, ready to be passed to
+// `code::publish_package_txn`.
+fn build_package_a(sources: Vec<(&str, String)>) -> (Vec<u8>, Vec<Vec<u8>>) {
+    let mut builder = PackageBuilder::new("package_a");
+    for (name, source) in sources {
+        builder.add_source(name, &source);
+    }
+    builder.add_local_dep(
+        "AptosFramework",
+        &common::framework_dir_path("aptos-framework").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+    let package = BuiltPackage::build(path.path().to_path_buf(), BuildOptions::move_2()).unwrap();
+    let code = package.extract_code();
+    let metadata = bcs::to_bytes(&package.extract_metadata().unwrap()).unwrap();
+    (metadata, code)
+}
+
+/// Publishes `a` v1 and stores a closure over `a::foo` (v1: returns `x + 1`).
+fn publish_a_v1_and_store_closure(h: &mut MoveHarness, acc: &Account) {
+    let mut builder = PackageBuilder::new("package_a");
+    builder.add_source("a.move", &MODULE_A_TEMPLATE.replace("INCREMENT", "1"));
+    builder.add_local_dep(
+        "AptosFramework",
+        &common::framework_dir_path("aptos-framework").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+    let txn = h.create_publish_package(acc, path.path(), Some(BuildOptions::move_2()), |_| {});
+    assert_success!(h.run(txn));
+
+    assert_success!(h.run_entry_function(
+        acc,
+        str::parse("0xcafe::a::store").unwrap(),
+        vec![],
+        vec![],
+    ));
+}
+
+/// Runs a single transaction which calls the stored closure (memoizing its resolution) and then
+/// upgrades `a` (v2: `foo` returns `x + 1000`) together with the new module `b`, whose
+/// `init_module` asserts the closure result. Returns the transaction status.
+fn run_call_then_upgrade(h: &mut MoveHarness, acc: &Account) -> TransactionStatus {
+    let (metadata, code) = build_package_a(vec![
+        ("a.move", MODULE_A_TEMPLATE.replace("INCREMENT", "1000")),
+        ("b.move", MODULE_B.to_string()),
+    ]);
+
+    let txn = h.create_entry_function(
+        acc,
+        str::parse("0xcafe::a::call_then_upgrade").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(&metadata).unwrap(),
+            bcs::to_bytes(&code).unwrap(),
+        ],
+    );
+    h.run(txn)
+}
+
+fn check_stored_closure_result(h: &mut MoveHarness, acc: &Account, expected: u64) {
+    assert_success!(h.run_entry_function(
+        acc,
+        str::parse("0xcafe::a::check").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(acc.address()).unwrap(),
+            bcs::to_bytes(&expected).unwrap(),
+        ],
+    ));
+}
+
+/// A closure resolved earlier in a transaction must be re-resolved when its defining module is
+/// republished within the same transaction, so that `init_module` of a newly published module
+/// observes the upgraded code (`foo` returns 1041, not the stale 42). Exercised under both lazy
+/// and eager loading, which use different `unmetered_get_module_hash_and_size` implementations.
+///
+/// Uses a testnet harness so the `RevalidateResolvedClosures` timed feature has a real activation
+/// date, then advances past it to enable the fix.
+#[test_case(true; "lazy_loading")]
+#[test_case(false; "eager_loading")]
+fn stale_closure_memo_re_resolved_after_same_txn_upgrade(enable_lazy_loading: bool) {
+    let mut h = MoveHarness::new_testnet();
+    if enable_lazy_loading {
+        h.enable_features(vec![FeatureFlag::ENABLE_LAZY_LOADING], vec![]);
+    } else {
+        h.enable_features(vec![], vec![FeatureFlag::ENABLE_LAZY_LOADING]);
+    }
+    h.set_timed_feature(TimedFeatureFlag::RevalidateResolvedClosures, true);
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    publish_a_v1_and_store_closure(&mut h, &acc);
+    check_stored_closure_result(&mut h, &acc, 42);
+
+    let status = run_call_then_upgrade(&mut h, &acc);
+    assert_success!(status);
+
+    // After the upgrade is committed, the closure binds to v2 for later transactions as well.
+    check_stored_closure_result(&mut h, &acc, 1041);
+}
+
+/// Before the `RevalidateResolvedClosures` timed feature activates, the memoized resolution is not
+/// revalidated: the closure keeps executing the pre-upgrade code within the publishing
+/// transaction, so `init_module` of module `b` aborts and the upgrade is rolled back.
+#[test]
+fn stale_closure_memo_kept_when_timed_feature_disabled() {
+    let mut h = MoveHarness::new_testnet();
+    h.set_timed_feature(TimedFeatureFlag::RevalidateResolvedClosures, false);
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    publish_a_v1_and_store_closure(&mut h, &acc);
+    check_stored_closure_result(&mut h, &acc, 42);
+
+    let status = run_call_then_upgrade(&mut h, &acc);
+    assert_abort!(status, 777);
+
+    // The upgrade was rolled back, so the stored closure still binds to v1.
+    check_stored_closure_result(&mut h, &acc, 42);
 }

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod any;
 mod attributes;
 mod bcs;
 mod chain_id;
+mod closure_stale_generic_ability;
 mod code_publishing;
 mod common;
 mod confidential_asset;

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -80,6 +80,10 @@ pub struct VMConfig {
     /// Without this, two closures over the same function with different masks but identical
     /// captured values are incorrectly treated as equal.
     pub include_closure_mask_in_cmp: bool,
+    /// When enabled, a resolved closure is validated against the current
+    /// version (hash) of its defining module before use, and re-resolved if the
+    /// module was republished since the resolution.
+    pub revalidate_resolved_closures: bool,
 }
 
 impl Default for VMConfig {
@@ -113,6 +117,7 @@ impl Default for VMConfig {
             check_depth_on_type_counts: true,
             enable_public_struct_args: true,
             include_closure_mask_in_cmp: true,
+            revalidate_resolved_closures: true,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -604,6 +604,11 @@ impl Frame {
         let (module, function) = loader
             .load_function_definition(gas_meter, traversal_context, module_id, function_name)
             .map_err(|err| err.to_partial())?;
+
+        // Lazy loading resolves the callee dynamically, so re-validate the caller's type
+        // arguments against the callee actually resolved here.
+        Type::verify_ty_arg_abilities(function.ty_param_abilities(), &verified_ty_args)?;
+
         Ok(LoadedFunction {
             owner: LoadedFunctionOwner::Module(module),
             ty_args: verified_ty_args,

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -266,6 +266,12 @@ pub(crate) enum LazyLoadedFunctionState {
         // closures at construction time. Non-storable closures just have None as they will not be
         // serialized anyway.
         captured_layouts: Option<Vec<MoveTypeLayout>>,
+        // Hash of the defining module when resolved; a mismatch with the module's current hash
+        // triggers re-resolution so a stored closure never binds to pre-upgrade code. Recorded
+        // only for persistent functions (the only closures that are storable and can thus observe
+        // a republish); [None] otherwise (including scripts, which cannot be captured), which
+        // forces one re-resolution on the next call.
+        module_hash: Option<[u8; 32]>,
     },
 }
 
@@ -315,12 +321,27 @@ impl LazyLoadedFunction {
             })
             .transpose()?;
 
+        // Record the version (hash) of the defining module so that later calls can detect if the
+        // module was republished within the same transaction, and re-resolve. Only needed for
+        // persistent functions: non-persistent closures always keep their pack-time binding.
+        let module_hash = match fun.module_id() {
+            Some(module_id)
+                if fun.function.is_persistent()
+                    && runtime_environment.vm_config().revalidate_resolved_closures =>
+            {
+                let (hash, _) = layout_converter.unmetered_get_module_hash_and_size(module_id)?;
+                Some(hash)
+            },
+            _ => None,
+        };
+
         Ok(Self {
             state: Rc::new(RefCell::new(LazyLoadedFunctionState::Resolved {
                 fun,
                 ty_args,
                 mask,
                 captured_layouts,
+                module_hash,
             })),
         })
     }
@@ -328,6 +349,9 @@ impl LazyLoadedFunction {
     pub(crate) fn new_resolved_not_capturing(
         runtime_environment: &RuntimeEnvironment,
         fun: Rc<LoadedFunction>,
+        // Hash of the defining module at resolution time, or [None] if the caller could not
+        // compute it (which forces one re-resolution on the first call).
+        module_hash: Option<[u8; 32]>,
     ) -> PartialVMResult<Self> {
         let ty_args = fun
             .ty_args
@@ -340,6 +364,7 @@ impl LazyLoadedFunction {
                 ty_args,
                 mask: ClosureMask::empty(),
                 captured_layouts: Some(vec![]),
+                module_hash,
             })),
         })
     }
@@ -421,7 +446,9 @@ impl LazyLoadedFunction {
     }
 
     /// If the function hasn't been resolved (loaded) yet, loads it. The gas is also charged for
-    /// function loading and any other module accesses.
+    /// function loading and any other module accesses. If the function has been resolved before,
+    /// but its defining module was republished since (i.e., upgraded within the same transaction),
+    /// it is re-resolved so that it binds to the module version currently visible to the loader.
     pub(crate) fn as_resolved(
         &self,
         loader: &impl Loader,
@@ -429,58 +456,128 @@ impl LazyLoadedFunction {
         traversal_context: &mut TraversalContext,
     ) -> PartialVMResult<Rc<LoadedFunction>> {
         let mut state = self.state.borrow_mut();
-        Ok(match &mut *state {
-            LazyLoadedFunctionState::Resolved { fun, .. } => fun.clone(),
-            LazyLoadedFunctionState::Unresolved {
-                data:
-                    SerializedFunctionData {
-                        format_version: _,
-                        module_id,
-                        fun_id,
-                        ty_args,
-                        mask,
-                        captured_layouts,
+
+        if let LazyLoadedFunctionState::Resolved {
+            fun, module_hash, ..
+        } = &*state
+        {
+            // The memoized resolution is stale if the defining module was republished since the
+            // function was resolved. Only persistent functions are revalidated:
+            //   - closures over non-persistent functions are not storable,
+            //   - script-owned functions cannot be republished.
+            let is_stale = loader
+                .runtime_environment()
+                .vm_config()
+                .revalidate_resolved_closures
+                && fun.function.is_persistent()
+                && match (fun.module_id(), module_hash) {
+                    (None, _) => false,
+                    // Resolution version unknown: re-resolve to be safe.
+                    (Some(_), None) => true,
+                    (Some(module_id), Some(resolved_hash)) => {
+                        let (current_hash, _) = loader
+                            .unmetered_get_module_hash_and_size(
+                                module_id.address(),
+                                module_id.name(),
+                            )
+                            .map_err(|err| err.to_partial())?;
+                        &current_hash != resolved_hash
                     },
-            } => {
-                let fun = loader.load_closure(
-                    gas_meter,
-                    traversal_context,
-                    module_id,
-                    fun_id,
-                    ty_args,
-                )?;
-
-                // A closure can only be stored if its function is persistent (public
-                // or has #[persistent] attribute). Persistent functions have their
-                // signatures frozen by the upgrade compatibility check, so captured
-                // argument types are guaranteed to match across different upgraded
-                // module versions.
-                // Here, we check that loaded function is indeed persistent. It might not
-                // be the case for `init_module` that stores a closure:
-                //   1. Function `foo` is private in original module A.
-                //   2. Module B is published which calls now public `foo`.
-                // As a result, there is a speculative resource write which resolves
-                // to older (still private) function because Block-STM makes module
-                // upgrades visible only at commit. Such behavior should be caught
-                // immediately because private function can change signature, so there
-                // is some room for type confusion via captured arguments.
-                if !fun.function.is_persistent() {
-                    return Err(PartialVMError::new_invariant_violation(format!(
-                        "Stored closure references non-persistent function `{}::{}`",
-                        module_id.short_str_lossless(),
-                        fun_id
-                    )));
-                }
-
-                *state = LazyLoadedFunctionState::Resolved {
-                    fun: fun.clone(),
-                    ty_args: mem::take(ty_args),
-                    mask: *mask,
-                    captured_layouts: Some(mem::take(captured_layouts)),
                 };
-                fun
-            },
-        })
+            if !is_stale {
+                return Ok(fun.clone());
+            }
+        }
+
+        // First resolution, or the memoized resolution is stale: load the function from the
+        // module version currently visible to the loader. Note that the state is not modified
+        // until all fallible operations have succeeded.
+        let (fun, module_hash) = {
+            let (module_id, fun_id, ty_args) = match &*state {
+                LazyLoadedFunctionState::Unresolved { data } => (
+                    &data.module_id,
+                    data.fun_id.as_ident_str(),
+                    data.ty_args.as_slice(),
+                ),
+                LazyLoadedFunctionState::Resolved { fun, ty_args, .. } => {
+                    let module_id = fun.module_id().ok_or_else(|| {
+                        PartialVMError::new_invariant_violation(
+                            "Script functions cannot be re-resolved",
+                        )
+                    })?;
+                    (module_id, fun.name_id(), ty_args.as_slice())
+                },
+            };
+
+            let fun =
+                loader.load_closure(gas_meter, traversal_context, module_id, fun_id, ty_args)?;
+
+            // A closure can only be stored if its function is persistent (public
+            // or has #[persistent] attribute). Persistent functions have their
+            // signatures frozen by the upgrade compatibility check, so captured
+            // argument types are guaranteed to match across different upgraded
+            // module versions.
+            // Here, we check that loaded function is indeed persistent. It might not
+            // be the case for `init_module` that stores a closure:
+            //   1. Function `foo` is private in original module A.
+            //   2. Module B is published which calls now public `foo`.
+            // As a result, there is a speculative resource write which resolves
+            // to older (still private) function because Block-STM makes module
+            // upgrades visible only at commit. Such behavior should be caught
+            // immediately because private function can change signature, so there
+            // is some room for type confusion via captured arguments.
+            if !fun.function.is_persistent() {
+                return Err(PartialVMError::new_invariant_violation(format!(
+                    "Stored closure references non-persistent function `{}::{}`",
+                    module_id.short_str_lossless(),
+                    fun_id
+                )));
+            }
+
+            let module_hash = if loader
+                .runtime_environment()
+                .vm_config()
+                .revalidate_resolved_closures
+            {
+                let (hash, _) = loader
+                    .unmetered_get_module_hash_and_size(module_id.address(), module_id.name())
+                    .map_err(|err| err.to_partial())?;
+                Some(hash)
+            } else {
+                None
+            };
+            (fun, module_hash)
+        };
+
+        let (ty_args, mask, captured_layouts) = match &mut *state {
+            LazyLoadedFunctionState::Unresolved { data } => (
+                mem::take(&mut data.ty_args),
+                data.mask,
+                Some(mem::take(&mut data.captured_layouts)),
+            ),
+            LazyLoadedFunctionState::Resolved {
+                ty_args,
+                mask,
+                captured_layouts,
+                ..
+            } => (
+                mem::take(ty_args),
+                *mask,
+                // Persistent function signatures are frozen by the upgrade compatibility check, so
+                // the captured-argument layouts stay compatible with the values they hold across
+                // upgrades. They may be out of date (e.g. missing enum variants added later) but
+                // remain valid for the already-captured data, so reusing them is sound.
+                captured_layouts.take(),
+            ),
+        };
+        *state = LazyLoadedFunctionState::Resolved {
+            fun: fun.clone(),
+            ty_args,
+            mask,
+            captured_layouts,
+            module_hash,
+        };
+        Ok(fun)
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -472,6 +472,20 @@ impl<'a, 'b> LoaderContext<'a, 'b> {
         // Construct result.
         let env = self.module_storage.runtime_environment();
         let ty_args_id = env.ty_pool().intern_ty_args(&ty_args);
+
+        // Record the version (hash) of the defining module so that the resolved function does not
+        // need to be re-resolved on its first call just to learn its version. The module was just
+        // loaded here, so this lookup is a cache hit.
+        let module_hash = if env.vm_config().revalidate_resolved_closures {
+            let module_id = module.self_id();
+            self.module_storage
+                .unmetered_get_module_hash_and_size(module_id.address(), module_id.name())
+                .map_err(|err| err.to_partial())?
+                .map(|(hash, _)| hash)
+        } else {
+            None
+        };
+
         let loaded_fun = Rc::new(LoadedFunction {
             owner: LoadedFunctionOwner::Module(module),
             ty_args,
@@ -479,7 +493,7 @@ impl<'a, 'b> LoaderContext<'a, 'b> {
             function: func,
         });
         Ok(Ok(Box::new(
-            LazyLoadedFunction::new_resolved_not_capturing(env, loaded_fun)?,
+            LazyLoadedFunction::new_resolved_not_capturing(env, loaded_fun, module_hash)?,
         )))
     }
 }

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -584,6 +584,8 @@ impl FunctionValueExtension for FunctionValueExtensionAdapter<'_> {
                 mask,
                 ty_args,
                 captured_layouts,
+                // Serialization stays name-based: the resolved module version is not stored.
+                module_hash: _,
             } => {
                 // If there are no captured layouts, then this closure is non-storable, i.e., the
                 // function is not persistent (not public or not private with #[persistent]

--- a/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
@@ -17,7 +17,7 @@ use move_core_types::{
     ident_str,
     identifier::Identifier,
     int256,
-    language_storage::LEGACY_OPTION_VEC,
+    language_storage::{ModuleId, LEGACY_OPTION_VEC},
     value::{IdentifierMappingKind, MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
     vm_status::StatusCode,
 };
@@ -238,6 +238,16 @@ where
     /// Returns the runtime environment used in the system.
     pub(crate) fn runtime_environment(&self) -> &RuntimeEnvironment {
         self.struct_definition_loader.runtime_environment()
+    }
+
+    /// Returns the hash and size of the specified module, without charging gas.
+    pub(crate) fn unmetered_get_module_hash_and_size(
+        &self,
+        module_id: &ModuleId,
+    ) -> PartialVMResult<([u8; 32], usize)> {
+        self.struct_definition_loader
+            .unmetered_get_module_hash_and_size(module_id.address(), module_id.name())
+            .map_err(|err| err.to_partial())
     }
 
     /// Returns the struct name for the specified index.

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -54,6 +54,11 @@ pub enum TimedFeatureFlag {
     /// Reject publishing of v5 module bytecode. Publishing only; already-published modules keep
     /// loading and executing at any version.
     RejectV5ModulePublishing,
+
+    /// If enabled, re-resolve a memoized closure when its defining module is
+    /// republished within the same transaction, so it binds to the current
+    /// module version instead of executing stale pre-upgrade code.
+    RevalidateResolvedClosures,
 }
 
 /// Representation of features that are gated by the block timestamps.
@@ -101,7 +106,8 @@ impl TimedFeatureOverride {
                 | EnableStrictBoundsInProdConfig
                 | RevisedBoundsInProdConfig
                 | ConstantSerializedSizeLocalCache
-                | RejectV5ModulePublishing,
+                | RejectV5ModulePublishing
+                | RevalidateResolvedClosures,
             ) => None,
         }
     }
@@ -247,6 +253,15 @@ impl TimedFeatureFlag {
                 .with_timezone(&Utc),
             (RejectV5ModulePublishing, MAINNET) => Los_Angeles
                 .with_ymd_and_hms(2026, 7, 29, 12, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            (RevalidateResolvedClosures, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 7, 22, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (RevalidateResolvedClosures, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 7, 24, 10, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 


### PR DESCRIPTION
## Description

Minor correctness improvements to how the Move VM resolves closures and loaded functions under lazy loading.

Closures memoize the function they resolve to. When a function's defining module is upgraded within the same transaction, this change makes the VM re-check the memoized resolution against the module's current version and re-resolve if it has changed, so a closure always runs against the module version currently visible to the loader rather than a previously cached one. The check keys off the defining module's hash and only applies to persistent (storable) functions.

It also adds a type-argument ability re-check on the lazily-resolved call path in `frame.rs`, so a caller's type arguments are validated against the callee that was actually resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core VM closure resolution and generic call validation during package upgrades; incorrect behavior could affect fund safety or break legitimate upgrade flows, though rollout is timed-feature gated.
> 
> **Overview**
> **Hardens Move VM behavior when stored closures are invoked across in-transaction module upgrades**, closing paths where memoized closure resolution could run pre-upgrade bytecode (e.g. coin duplication via `init_module`).
> 
> Adds **`revalidate_resolved_closures`** on `VMConfig`, wired from production config via timed feature **`RevalidateResolvedClosures`** (testnet/mainnet activation dates). When enabled, `LazyLoadedFunction::as_resolved` stores the defining module hash at resolution and **re-loads the closure** if the module hash changed—only for persistent (storable) functions.
> 
> **Lazy-loaded cross-module calls** in `frame.rs` now run **`Type::verify_ty_arg_abilities`** against the callee actually resolved, so upgraded generics with stricter ability bounds can fail with `CONSTRAINT_NOT_SATISFIED` even if closure revalidation is off.
> 
> New/extended e2e tests cover same-txn upgrade + stored closure (`init_module_closure_store`), and a coin-clone attack scenario (`closure_stale_generic_ability`) under both revalidation on and off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27ab40f8c54b75d84e9283e4bfd3e0a360a6ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->