### PR TITLE
[cli] Add unauthenticated Move simulation modes

### DIFF
--- a/aptos-move/cli/src/commands.rs
+++ b/aptos-move/cli/src/commands.rs
@@ -2294,7 +2294,17 @@ impl CliCommand<TransactionSummary> for RunFunction {
 /// BETA: subject to change
 ///
 /// This allows you to simulate and see the output from any function or Move script all in one command.
-/// It additionally lets you simulate for any account
+///
+/// By default, simulation is performed by the remote fullnode. With private or public
+/// key material, remote simulation uses a zero Ed25519 signature and validates the
+/// authentication key. Without key material, supply `--sender-account` (or configure
+/// a profile account); it uses an unauthenticated simulation transaction and skips
+/// authentication-key validation, so the result does not establish submit authorization.
+///
+/// `--local` preserves normal local execution semantics: it needs a private key,
+/// creates a real signature, and runs the normal VM without submitting the transaction.
+/// `--local-simulation` runs the local simulation VM with the same unauthenticated
+/// simulation behavior as remote simulation, and is intended for local debugging.
 ///
 #[derive(Parser)]
 pub struct Simulate {
@@ -2304,8 +2314,14 @@ pub struct Simulate {
     #[clap(flatten)]
     entry_function_args: EntryFunctionArguments,
 
-    #[clap(long)]
+    /// Execute locally with a real signature using the normal VM path. Requires a private key.
+    #[clap(long, conflicts_with = "local_simulation")]
     local: bool,
+
+    /// Execute locally in VM simulation mode. Without key material, authentication-key validation
+    /// is skipped; use this mode for debugging, not to establish submit authorization.
+    #[clap(long, conflicts_with = "local")]
+    local_simulation: bool,
 
     /// Include simulated events and state changes in the output.
     #[clap(long)]
@@ -2332,6 +2348,10 @@ impl CliCommand<TransactionSummary> for Simulate {
         if self.local {
             self.txn_options
                 .simulate_locally(payload, &self.env, self.show_details)
+                .await
+        } else if self.local_simulation {
+            self.txn_options
+                .simulate_locally_simulation(payload, &self.env, self.show_details)
                 .await
         } else {
             let mut rng = rand::rngs::StdRng::from_entropy();
@@ -2373,6 +2393,8 @@ mod simulate_flag_tests {
             "u64:1",
         ]);
         assert!(!simulate.show_details);
+        assert!(!simulate.local);
+        assert!(!simulate.local_simulation);
     }
 
     #[test]
@@ -2387,6 +2409,22 @@ mod simulate_flag_tests {
             "--show-details",
         ]);
         assert!(simulate.show_details);
+    }
+
+    #[test]
+    fn local_modes_conflict() {
+        let result = TestCli::try_parse_from([
+            "test",
+            "simulate",
+            "--local",
+            "--local-simulation",
+            "--function-id",
+            "0x1::aptos_account::transfer",
+            "--args",
+            "address:0x1",
+            "u64:1",
+        ]);
+        assert!(result.is_err());
     }
 }
 

--- a/aptos-move/cli/src/commands.rs
+++ b/aptos-move/cli/src/commands.rs
@@ -2300,6 +2300,8 @@ impl CliCommand<TransactionSummary> for RunFunction {
 /// authentication key. Without key material, supply `--sender-account` (or configure
 /// a profile account); it uses an unauthenticated simulation transaction and skips
 /// authentication-key validation, so the result does not establish submit authorization.
+/// A selected profile with private or public key material continues to use authenticated
+/// zero-signature simulation, even when `--sender-account` overrides the sender address.
 ///
 /// `--local` preserves normal local execution semantics: it needs a private key,
 /// creates a real signature, and runs the normal VM without submitting the transaction.

--- a/aptos-move/cli/src/local_simulation.rs
+++ b/aptos-move/cli/src/local_simulation.rs
@@ -5,9 +5,11 @@ use crate::MoveDebugger;
 use aptos_cli_common::{CliError, CliTypedResult};
 use aptos_crypto::HashValue;
 use aptos_gas_profiling::FrameName;
-use aptos_types::transaction::{AuxiliaryInfo, PersistedAuxiliaryInfo, SignedTransaction};
+use aptos_types::transaction::{
+    AuxiliaryInfo, PersistedAuxiliaryInfo, SignedTransaction, TransactionOutput,
+};
 use aptos_validator_interface::LocalModuleOverrides;
-use aptos_vm::{data_cache::AsMoveResolver, AptosVM};
+use aptos_vm::{data_cache::AsMoveResolver, AptosSimulationVM, AptosVM};
 use aptos_vm_environment::{environment::AptosEnvironment, prod_configs};
 use aptos_vm_logging::log_schema::AdapterLogSchema;
 use aptos_vm_types::{
@@ -45,6 +47,22 @@ pub fn run_transaction_using_debugger(
     );
 
     Ok((vm_status, vm_output))
+}
+
+/// Simulates a transaction locally without checking its authenticator.
+///
+/// This mirrors the fullnode simulation endpoint: the VM runs in simulation
+/// mode, so a [`NoAccountAuthenticator`](aptos_types::transaction::authenticator::AccountAuthenticator::NoAccountAuthenticator)
+/// can be used to simulate any sender without a private or public key.
+pub fn simulate_transaction_using_debugger(
+    debugger: &dyn MoveDebugger,
+    version: u64,
+    transaction: SignedTransaction,
+) -> CliTypedResult<(VMStatus, TransactionOutput)> {
+    prod_configs::set_debugging_enabled(true);
+
+    let state_view = debugger.state_view_at_version(version);
+    Ok(AptosSimulationVM::create_vm_and_simulate_signed_transaction(&transaction, &state_view))
 }
 
 /// Replay a transaction with local module overrides and an optional source

--- a/aptos-move/cli/src/transactions.rs
+++ b/aptos-move/cli/src/transactions.rs
@@ -7,9 +7,10 @@ use crate::{local_simulation, MoveEnv};
 // Re-export from aptos-cli-common to eliminate the duplicate definition.
 pub use aptos_cli_common::ReplayProtectionType;
 use aptos_cli_common::{
-    format_txn_status, get_account_with_state, CliError, CliTypedResult, EncodingOptions,
-    GasOptions, PrivateKeyInputOptions, ProfileOptions, PromptOptions, RestOptions,
-    TransactionSummary, ACCEPTED_CLOCK_SKEW_US, US_IN_SECS,
+    account_address_from_public_key, format_txn_status, get_account_with_state, CliError,
+    CliTypedResult, EncodingOptions, GasOptions, PrivateKeyInputOptions, ProfileConfig,
+    ProfileOptions, PromptOptions, RestOptions, TransactionSummary, ACCEPTED_CLOCK_SKEW_US,
+    US_IN_SECS,
 };
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519Signature},
@@ -270,6 +271,14 @@ impl TxnOptions {
     /// compatibility fallback for callers that have not yet stored an account
     /// address.
     fn get_simulation_address(&self) -> CliTypedResult<AccountAddress> {
+        let profile = self.profile_options.profile().ok();
+        self.get_simulation_address_with_profile(profile.as_ref())
+    }
+
+    fn get_simulation_address_with_profile(
+        &self,
+        profile: Option<&ProfileConfig>,
+    ) -> CliTypedResult<AccountAddress> {
         if let Some(sender) = self.sender_account {
             return Ok(sender);
         }
@@ -278,7 +287,7 @@ impl TxnOptions {
             return self.get_address();
         }
 
-        if let Ok(profile) = self.profile_options.profile() {
+        if let Some(profile) = profile {
             if let Some(account) = profile.account {
                 return Ok(account);
             }
@@ -301,13 +310,15 @@ impl TxnOptions {
     fn simulation_sender_and_authenticator(
         &self,
     ) -> CliTypedResult<(AccountAddress, AccountAuthenticator, bool)> {
-        let has_profile_private_key = self
-            .profile_options
-            .profile()
-            .ok()
-            .and_then(|profile| profile.private_key)
-            .is_some();
-        if self.private_key_options.has_key_or_file() || has_profile_private_key {
+        let profile = self.profile_options.profile().ok();
+        self.simulation_sender_and_authenticator_with_profile(profile.as_ref())
+    }
+
+    fn simulation_sender_and_authenticator_with_profile(
+        &self,
+        profile: Option<&ProfileConfig>,
+    ) -> CliTypedResult<(AccountAddress, AccountAuthenticator, bool)> {
+        if self.private_key_options.has_key_or_file() {
             let (private_key, sender) = self.private_key_options.extract_private_key_and_address(
                 self.encoding_options.encoding,
                 &self.profile_options,
@@ -323,18 +334,30 @@ impl TxnOptions {
             ));
         }
 
-        if let Ok((public_key, sender)) = self
-            .private_key_options
-            .extract_ed25519_public_key_and_address(
-                self.encoding_options.encoding,
-                &self.profile_options,
-                self.sender_account,
-            )
-        {
+        if let Some(private_key) = profile.and_then(|profile| profile.private_key.as_ref()) {
+            let sender = self
+                .sender_account
+                .or(profile.and_then(|profile| profile.account))
+                .unwrap_or_else(|| account_address_from_public_key(&private_key.public_key()));
             return Ok((
                 sender,
                 AccountAuthenticator::ed25519(
-                    public_key,
+                    private_key.public_key(),
+                    Ed25519Signature::try_from([0u8; 64].as_ref()).unwrap(),
+                ),
+                false,
+            ));
+        }
+
+        if let Some(public_key) = profile.and_then(|profile| profile.public_key.as_ref()) {
+            let sender = self
+                .sender_account
+                .or(profile.and_then(|profile| profile.account))
+                .unwrap_or_else(|| account_address_from_public_key(public_key));
+            return Ok((
+                sender,
+                AccountAuthenticator::ed25519(
+                    public_key.clone(),
                     Ed25519Signature::try_from([0u8; 64].as_ref()).unwrap(),
                 ),
                 false,
@@ -342,7 +365,7 @@ impl TxnOptions {
         }
 
         Ok((
-            self.get_simulation_address()?,
+            self.get_simulation_address_with_profile(profile)?,
             AccountAuthenticator::NoAccountAuthenticator,
             true,
         ))
@@ -390,7 +413,7 @@ impl TxnOptions {
         // Warn local user that clock is skewed behind the blockchain.
         // There will always be a little lag from real time to blockchain time
         if now_usecs < state.timestamp_usecs - ACCEPTED_CLOCK_SKEW_US {
-            eprintln!("Local clock is is skewed from blockchain clock.  Clock is more than {} seconds behind the blockchain {}", ACCEPTED_CLOCK_SKEW_US, state.timestamp_usecs / US_IN_SECS );
+            eprintln!("Local clock is skewed from blockchain clock. Clock is more than {} seconds behind the blockchain {}", ACCEPTED_CLOCK_SKEW_US, state.timestamp_usecs / US_IN_SECS );
         }
         let expiration_time_secs = now + self.gas_options.expiration_secs;
 
@@ -559,7 +582,7 @@ impl TxnOptions {
         show_details: bool,
     ) -> CliTypedResult<TransactionSummary> {
         println!();
-        println!("Simulating transaction locally...");
+        println!("Executing transaction locally...");
 
         let client = self.rest_client()?;
         const DEFAULT_GAS_UNIT_PRICE: u64 = 100;
@@ -659,7 +682,8 @@ impl TxnOptions {
 mod tests {
     use super::{local_events_to_json, local_write_set_to_json, serialize_as_json, TxnOptions};
     use aptos_cli_common::{
-        account_address_from_public_key, PrivateKeyInputOptions, ProfileOptions, TransactionSummary,
+        account_address_from_public_key, PrivateKeyInputOptions, ProfileConfig, ProfileOptions,
+        TransactionSummary,
     };
     use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
     use aptos_sdk::transaction_builder::TransactionFactory;
@@ -768,6 +792,70 @@ mod tests {
         let (sender, authenticator, skips_auth_key_check) =
             options.simulation_sender_and_authenticator().unwrap();
         assert_eq!(sender, expected_address);
+        assert!(!skips_auth_key_check);
+        assert!(matches!(
+            authenticator,
+            AccountAuthenticator::Ed25519 { .. }
+        ));
+    }
+
+    #[test]
+    fn simulation_sender_uses_profile_account_without_key_material() {
+        let profile = ProfileConfig {
+            account: Some(AccountAddress::ONE),
+            ..Default::default()
+        };
+        let options = TxnOptions::default();
+
+        let (sender, authenticator, skips_auth_key_check) = options
+            .simulation_sender_and_authenticator_with_profile(Some(&profile))
+            .unwrap();
+        assert_eq!(sender, AccountAddress::ONE);
+        assert!(skips_auth_key_check);
+        assert!(matches!(
+            authenticator,
+            AccountAuthenticator::NoAccountAuthenticator
+        ));
+    }
+
+    #[test]
+    fn simulation_sender_uses_profile_public_key() {
+        let private_key = Ed25519PrivateKey::generate(&mut rand::rngs::OsRng);
+        let profile = ProfileConfig {
+            account: Some(AccountAddress::ONE),
+            public_key: Some(private_key.public_key()),
+            ..Default::default()
+        };
+        let options = TxnOptions::default();
+
+        let (sender, authenticator, skips_auth_key_check) = options
+            .simulation_sender_and_authenticator_with_profile(Some(&profile))
+            .unwrap();
+        assert_eq!(sender, AccountAddress::ONE);
+        assert!(!skips_auth_key_check);
+        assert!(matches!(
+            authenticator,
+            AccountAuthenticator::Ed25519 { .. }
+        ));
+    }
+
+    #[test]
+    fn simulation_sender_allows_sender_account_to_override_profile_private_key_address() {
+        let private_key = Ed25519PrivateKey::generate(&mut rand::rngs::OsRng);
+        let profile = ProfileConfig {
+            account: Some(AccountAddress::ONE),
+            private_key: Some(private_key),
+            ..Default::default()
+        };
+        let options = TxnOptions {
+            sender_account: Some(AccountAddress::TWO),
+            ..Default::default()
+        };
+
+        let (sender, authenticator, skips_auth_key_check) = options
+            .simulation_sender_and_authenticator_with_profile(Some(&profile))
+            .unwrap();
+        assert_eq!(sender, AccountAddress::TWO);
         assert!(!skips_auth_key_check);
         assert!(matches!(
             authenticator,

--- a/aptos-move/cli/src/transactions.rs
+++ b/aptos-move/cli/src/transactions.rs
@@ -3,7 +3,7 @@
 
 //! Transaction options and local simulation support for the `aptos move simulate` command.
 
-use crate::{local_simulation, MoveDebugger, MoveEnv};
+use crate::{local_simulation, MoveEnv};
 // Re-export from aptos-cli-common to eliminate the duplicate definition.
 pub use aptos_cli_common::ReplayProtectionType;
 use aptos_cli_common::{
@@ -26,17 +26,14 @@ use aptos_types::{
     contract_event::ContractEvent,
     state_store::state_key::inner::StateKeyInner,
     transaction::{
-        PersistedAuxiliaryInfo, ReplayProtector, SignedTransaction, TransactionOutput,
-        TransactionPayload, TransactionStatus,
+        authenticator::AccountAuthenticator, PersistedAuxiliaryInfo, ReplayProtector,
+        SignedTransaction, TransactionOutput, TransactionPayload, TransactionStatus,
     },
     write_set::WriteSet,
 };
-use aptos_vm::data_cache::AsMoveResolver;
-use aptos_vm_types::output::VMOutput;
 use clap::Parser;
 #[cfg(test)]
 use move_core_types::value::MoveTypeLayout;
-use move_core_types::vm_status::VMStatus;
 use serde::Serialize;
 use std::{
     collections::BTreeMap,
@@ -45,6 +42,18 @@ use std::{
 
 fn serialize_as_json<T: Serialize>(value: &T) -> CliTypedResult<serde_json::Value> {
     serde_json::to_value(value).map_err(|err| CliError::UnexpectedError(err.to_string()))
+}
+
+fn local_materialize_output(
+    state_view: &impl aptos_types::state_store::StateView,
+    vm_output: aptos_vm_types::output::VMOutput,
+) -> CliTypedResult<TransactionOutput> {
+    use aptos_vm::data_cache::AsMoveResolver;
+
+    let resolver = state_view.as_move_resolver();
+    vm_output
+        .try_materialize_into_transaction_output(&resolver)
+        .map_err(|err| CliError::UnexpectedError(err.to_string()))
 }
 
 #[cfg(test)]
@@ -196,16 +205,6 @@ fn local_write_set_to_json(
     serialize_as_json(&changes)
 }
 
-fn local_materialize_output(
-    state_view: &impl aptos_types::state_store::StateView,
-    vm_output: VMOutput,
-) -> CliTypedResult<TransactionOutput> {
-    let resolver = state_view.as_move_resolver();
-    vm_output
-        .try_materialize_into_transaction_output(&resolver)
-        .map_err(|err| CliError::UnexpectedError(err.to_string()))
-}
-
 /// Transaction options for the `Simulate` and `Replay` commands.
 ///
 /// A lighter-weight alternative to `TransactionOptions` that provides local
@@ -213,10 +212,9 @@ fn local_materialize_output(
 /// directly, without routing through `AptosContext`.
 #[derive(Debug, Default, Parser)]
 pub(crate) struct TxnOptions {
-    /// Sender account address
-    ///
-    /// This allows you to override the account address from the derived account address
-    /// in the event that the authentication key was rotated or for a resource account
+    /// Sender account address. This overrides the address derived from key material
+    /// or configured in the selected profile. Key requirements depend on the
+    /// selected simulation mode.
     #[clap(long, value_parser = aptos_cli_common::load_account_arg)]
     pub(crate) sender_account: Option<AccountAddress>,
 
@@ -247,8 +245,15 @@ impl TxnOptions {
         self.rest_options.client(&self.profile_options)
     }
 
-    /// Retrieves the private key and the associated address
-    /// TODO: Cache this information
+    pub fn get_address(&self) -> CliTypedResult<AccountAddress> {
+        self.private_key_options.extract_address(
+            self.encoding_options.encoding,
+            &self.profile_options,
+            self.sender_account,
+        )
+    }
+
+    /// Retrieves the private key and associated address for authenticated local execution.
     pub fn get_key_and_address(&self) -> CliTypedResult<(Ed25519PrivateKey, AccountAddress)> {
         self.private_key_options.extract_private_key_and_address(
             self.encoding_options.encoding,
@@ -257,12 +262,97 @@ impl TxnOptions {
         )
     }
 
-    pub fn get_address(&self) -> CliTypedResult<AccountAddress> {
-        self.private_key_options.extract_address(
-            self.encoding_options.encoding,
-            &self.profile_options,
-            self.sender_account,
-        )
+    /// Resolves the sender for a simulation that has no authentication material.
+    ///
+    /// Prefer an explicit sender, then derive the address from an explicitly
+    /// supplied private key. If neither is supplied, use an account address
+    /// stored in the profile. The legacy public-key resolution remains as a
+    /// compatibility fallback for callers that have not yet stored an account
+    /// address.
+    fn get_simulation_address(&self) -> CliTypedResult<AccountAddress> {
+        if let Some(sender) = self.sender_account {
+            return Ok(sender);
+        }
+
+        if self.private_key_options.has_key_or_file() {
+            return self.get_address();
+        }
+
+        if let Ok(profile) = self.profile_options.profile() {
+            if let Some(account) = profile.account {
+                return Ok(account);
+            }
+        }
+
+        self.get_address().map_err(|_| {
+            CliError::CommandArgumentError(
+                "Simulation requires --sender-account or an account address in the selected profile"
+                    .to_string(),
+            )
+        })
+    }
+
+    /// Builds the authenticator used for simulation without ever signing.
+    ///
+    /// Preserve the legacy zero-signature Ed25519 form when a private key or
+    /// public key is available. This keeps its authentication-key validation
+    /// semantics. Fall back to NoAccountAuthenticator only when no key material
+    /// is configured, allowing simulation for an arbitrary sender address.
+    fn simulation_sender_and_authenticator(
+        &self,
+    ) -> CliTypedResult<(AccountAddress, AccountAuthenticator, bool)> {
+        let has_profile_private_key = self
+            .profile_options
+            .profile()
+            .ok()
+            .and_then(|profile| profile.private_key)
+            .is_some();
+        if self.private_key_options.has_key_or_file() || has_profile_private_key {
+            let (private_key, sender) = self.private_key_options.extract_private_key_and_address(
+                self.encoding_options.encoding,
+                &self.profile_options,
+                self.sender_account,
+            )?;
+            return Ok((
+                sender,
+                AccountAuthenticator::ed25519(
+                    private_key.public_key(),
+                    Ed25519Signature::try_from([0u8; 64].as_ref()).unwrap(),
+                ),
+                false,
+            ));
+        }
+
+        if let Ok((public_key, sender)) = self
+            .private_key_options
+            .extract_ed25519_public_key_and_address(
+                self.encoding_options.encoding,
+                &self.profile_options,
+                self.sender_account,
+            )
+        {
+            return Ok((
+                sender,
+                AccountAuthenticator::ed25519(
+                    public_key,
+                    Ed25519Signature::try_from([0u8; 64].as_ref()).unwrap(),
+                ),
+                false,
+            ));
+        }
+
+        Ok((
+            self.get_simulation_address()?,
+            AccountAuthenticator::NoAccountAuthenticator,
+            true,
+        ))
+    }
+
+    fn simulation_transaction(
+        raw_transaction: aptos_types::transaction::RawTransaction,
+        authenticator: AccountAuthenticator,
+    ) -> SignedTransaction {
+        SignedTransaction::new_single_sender(raw_transaction, authenticator)
     }
 
     pub async fn simulate_remotely(
@@ -272,9 +362,13 @@ impl TxnOptions {
         show_details: bool,
     ) -> CliTypedResult<TransactionSummary> {
         let client = self.rest_client()?;
-        let sender_address = self.get_address()?;
-        let (sender_private_key, _) = self.get_key_and_address()?;
-        let sender_public_key = sender_private_key.public_key();
+        let (sender_address, authenticator, skips_auth_key_check) =
+            self.simulation_sender_and_authenticator()?;
+        if skips_auth_key_check {
+            eprintln!(
+                "Warning: authentication-key validation was skipped; this simulation does not establish authorization to submit the transaction."
+            );
+        }
 
         let gas_unit_price = if let Some(gas_unit_price) = self.gas_options.gas_unit_price {
             gas_unit_price
@@ -315,71 +409,53 @@ impl TxnOptions {
         }
         let unsigned_transaction = txn_builder.build();
 
-        let signed_transaction = SignedTransaction::new(
-            unsigned_transaction,
-            sender_public_key,
-            Ed25519Signature::try_from([0u8; 64].as_ref()).unwrap(),
-        );
+        let signed_transaction = Self::simulation_transaction(unsigned_transaction, authenticator);
 
+        // Use BCS for the response as well as the request. Fullnodes currently
+        // serialize a NoAccountAuthenticator as an incomplete JSON signature,
+        // which prevents the JSON UserTransaction type from deserializing.
         let simulated_txn = client
-            .simulate_with_gas_estimation(&signed_transaction, true, false)
+            .simulate_bcs_with_gas_estimation(&signed_transaction, true, false)
             .await?
-            .into_inner()
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                CliError::UnexpectedError(
-                    "Simulation returned an empty transaction list".to_string(),
-                )
-            })?;
+            .into_inner();
 
-        let replay_protector = simulated_txn.request.replay_protector();
+        let replay_protector = signed_transaction.replay_protector();
         let sequence_number = match &replay_protector {
             ReplayProtector::SequenceNumber(sequence_number) => Some(*sequence_number),
             _ => None,
         };
 
         let mut summary = TransactionSummary {
-            transaction_hash: simulated_txn.info.hash,
-            gas_used: Some(simulated_txn.info.gas_used.0),
-            gas_unit_price: Some(simulated_txn.request.gas_unit_price.0),
+            transaction_hash: simulated_txn.info.transaction_hash().into(),
+            gas_used: Some(simulated_txn.info.gas_used()),
+            gas_unit_price: Some(signed_transaction.gas_unit_price()),
             pending: None,
-            sender: Some(*simulated_txn.request.sender.inner()),
+            sender: Some(sender_address),
             replay_protector: Some(replay_protector),
             sequence_number,
-            success: Some(simulated_txn.info.success),
+            success: Some(simulated_txn.info.status().is_success()),
             timestamp_us: None,
-            version: Some(simulated_txn.info.version.0),
-            vm_status: Some(simulated_txn.info.vm_status.clone()),
+            version: Some(simulated_txn.version),
+            vm_status: Some(format!("{:?}", simulated_txn.info.status())),
             deployed_object_address: None,
             events: None,
             changes: None,
         };
         if show_details {
             summary.events = Some(serialize_as_json(&simulated_txn.events)?);
-            summary.changes = Some(serialize_as_json(&simulated_txn.info.changes)?);
+            summary.changes = Some(serialize_as_json(&simulated_txn.changes)?);
         }
 
         Ok(summary)
     }
 
-    /// Simulates a transaction locally, using the debugger to fetch required data from remote.
-    async fn simulate_using_debugger<F>(
+    /// Simulates a transaction locally in simulation mode, using remote state.
+    async fn simulate_using_simulation_vm(
         &self,
         payload: TransactionPayload,
         env: &MoveEnv,
         show_details: bool,
-        execute: F,
-    ) -> CliTypedResult<TransactionSummary>
-    where
-        F: FnOnce(
-            &dyn MoveDebugger,
-            u64,
-            SignedTransaction,
-            aptos_crypto::HashValue,
-            PersistedAuxiliaryInfo,
-        ) -> CliTypedResult<(VMStatus, VMOutput)>,
-    {
+    ) -> CliTypedResult<TransactionSummary> {
         let client = self.rest_client()?;
 
         // Fetch the chain states required for the simulation
@@ -387,7 +463,13 @@ impl TxnOptions {
         const DEFAULT_GAS_UNIT_PRICE: u64 = 100;
         const DEFAULT_MAX_GAS: u64 = 2_000_000;
 
-        let (sender_key, sender_address) = self.get_key_and_address()?;
+        let (sender_address, authenticator, skips_auth_key_check) =
+            self.simulation_sender_and_authenticator()?;
+        if skips_auth_key_check {
+            eprintln!(
+                "Warning: authentication-key validation was skipped; this simulation does not establish authorization to submit the transaction."
+            );
+        }
         let gas_unit_price = self
             .gas_options
             .gas_unit_price
@@ -415,28 +497,32 @@ impl TxnOptions {
             .with_gas_unit_price(gas_unit_price)
             .with_max_gas_amount(max_gas)
             .with_transaction_expiration_time(self.gas_options.expiration_secs);
-        let sender_account = &mut LocalAccount::new(sender_address, sender_key, sequence_number);
-        let transaction =
-            sender_account.sign_with_transaction_builder(transaction_factory.payload(payload));
+        let transaction = Self::simulation_transaction(
+            transaction_factory
+                .payload(payload)
+                .sender(sender_address)
+                .sequence_number(sequence_number)
+                .build(),
+            authenticator,
+        );
         let hash = transaction.committed_hash();
 
         let debugger = env.create_move_debugger(client)?;
-        let (vm_status, vm_output) = execute(
-            &*debugger,
-            version,
-            transaction,
-            hash,
-            PersistedAuxiliaryInfo::None,
-        )?;
+        let (vm_status, transaction_output) =
+            local_simulation::simulate_transaction_using_debugger(
+                &*debugger,
+                version,
+                transaction,
+            )?;
 
-        let success = match vm_output.status() {
+        let success = match transaction_output.status() {
             TransactionStatus::Keep(exec_status) => Some(exec_status.is_success()),
             TransactionStatus::Discard(_) | TransactionStatus::Retry => None,
         };
 
         let mut summary = TransactionSummary {
             transaction_hash: hash.into(),
-            gas_used: Some(vm_output.gas_used()),
+            gas_used: Some(transaction_output.gas_used()),
             gas_unit_price: Some(gas_unit_price),
             pending: None,
             sender: Some(sender_address),
@@ -445,6 +531,94 @@ impl TxnOptions {
             success,
             timestamp_us: None,
             version: Some(version), // The transaction is not committed so there is no new version.
+            vm_status: Some(format_txn_status(transaction_output.status(), &vm_status)),
+            deployed_object_address: None,
+            events: None,
+            changes: None,
+        };
+        if show_details {
+            let state_view = debugger.state_view_at_version(version);
+            summary.events = Some(local_contract_events_to_json(
+                &state_view,
+                transaction_output.events(),
+            )?);
+            summary.changes = Some(local_write_set_to_json(
+                &state_view,
+                transaction_output.write_set(),
+            )?);
+        }
+
+        Ok(summary)
+    }
+
+    /// Executes a transaction locally using a real signature and the normal VM path.
+    pub async fn simulate_locally(
+        &self,
+        payload: TransactionPayload,
+        env: &MoveEnv,
+        show_details: bool,
+    ) -> CliTypedResult<TransactionSummary> {
+        println!();
+        println!("Simulating transaction locally...");
+
+        let client = self.rest_client()?;
+        const DEFAULT_GAS_UNIT_PRICE: u64 = 100;
+        const DEFAULT_MAX_GAS: u64 = 2_000_000;
+
+        let (sender_key, sender_address) = self.get_key_and_address()?;
+        let gas_unit_price = self
+            .gas_options
+            .gas_unit_price
+            .unwrap_or(DEFAULT_GAS_UNIT_PRICE);
+        let (account, state) = get_account_with_state(&client, sender_address).await?;
+        let version = state.version;
+        let chain_id = ChainId::new(state.chain_id);
+        let sequence_number = account.sequence_number;
+
+        let balance = client
+            .view_apt_account_balance_at_version(sender_address, version)
+            .await
+            .map_err(|err| CliError::ApiError(err.to_string()))?
+            .into_inner();
+        let max_gas = self.gas_options.max_gas.unwrap_or_else(|| {
+            if gas_unit_price == 0 {
+                DEFAULT_MAX_GAS
+            } else {
+                std::cmp::min(balance / gas_unit_price, DEFAULT_MAX_GAS)
+            }
+        });
+
+        let transaction_factory = TransactionFactory::new(chain_id)
+            .with_gas_unit_price(gas_unit_price)
+            .with_max_gas_amount(max_gas)
+            .with_transaction_expiration_time(self.gas_options.expiration_secs);
+        let transaction = LocalAccount::new(sender_address, sender_key, sequence_number)
+            .sign_with_transaction_builder(transaction_factory.payload(payload));
+        let hash = transaction.committed_hash();
+
+        let debugger = env.create_move_debugger(client)?;
+        let (vm_status, vm_output) = local_simulation::run_transaction_using_debugger(
+            &*debugger,
+            version,
+            transaction,
+            hash,
+            PersistedAuxiliaryInfo::None,
+        )?;
+        let success = match vm_output.status() {
+            TransactionStatus::Keep(exec_status) => Some(exec_status.is_success()),
+            TransactionStatus::Discard(_) | TransactionStatus::Retry => None,
+        };
+        let mut summary = TransactionSummary {
+            transaction_hash: hash.into(),
+            gas_used: Some(vm_output.gas_used()),
+            gas_unit_price: Some(gas_unit_price),
+            pending: None,
+            sender: Some(sender_address),
+            sequence_number: None,
+            replay_protector: None,
+            success,
+            timestamp_us: None,
+            version: Some(version),
             vm_status: Some(format_txn_status(vm_output.status(), &vm_status)),
             deployed_object_address: None,
             events: None,
@@ -466,36 +640,39 @@ impl TxnOptions {
         Ok(summary)
     }
 
-    /// Simulates a transaction locally.
-    pub async fn simulate_locally(
+    /// Executes a transaction locally in VM simulation mode.
+    pub async fn simulate_locally_simulation(
         &self,
         payload: TransactionPayload,
         env: &MoveEnv,
         show_details: bool,
     ) -> CliTypedResult<TransactionSummary> {
         println!();
-        println!("Simulating transaction locally...");
+        println!("Simulating transaction locally in simulation mode...");
 
-        self.simulate_using_debugger(
-            payload,
-            env,
-            show_details,
-            local_simulation::run_transaction_using_debugger,
-        )
-        .await
+        self.simulate_using_simulation_vm(payload, env, show_details)
+            .await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{local_events_to_json, local_write_set_to_json, serialize_as_json};
-    use aptos_cli_common::TransactionSummary;
-    use aptos_crypto::HashValue;
+    use super::{local_events_to_json, local_write_set_to_json, serialize_as_json, TxnOptions};
+    use aptos_cli_common::{
+        account_address_from_public_key, PrivateKeyInputOptions, ProfileOptions, TransactionSummary,
+    };
+    use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+    use aptos_sdk::transaction_builder::TransactionFactory;
     use aptos_transaction_simulation::EmptyStateView;
     use aptos_types::{
         account_address::AccountAddress,
+        chain_id::ChainId,
         event::EventKey,
         state_store::{state_key::StateKey, table::TableHandle},
+        transaction::{
+            authenticator::{AccountAuthenticator, TransactionAuthenticator},
+            Script, TransactionPayload,
+        },
         write_set::{WriteOp, WriteSet},
     };
     use move_core_types::{ident_str, language_storage::TypeTag};
@@ -552,6 +729,90 @@ mod tests {
         let value = serde_json::to_value(with_changes).unwrap();
         assert!(value.get("events").is_none());
         assert!(value.get("changes").is_some());
+    }
+
+    #[test]
+    fn simulation_sender_uses_explicit_address_without_a_key() {
+        let options = TxnOptions {
+            sender_account: Some(AccountAddress::ONE),
+            profile_options: ProfileOptions {
+                profile: Some("missing-simulation-profile".to_string()),
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(
+            options.get_simulation_address().unwrap(),
+            AccountAddress::ONE
+        );
+        let (sender, authenticator, skips_auth_key_check) =
+            options.simulation_sender_and_authenticator().unwrap();
+        assert_eq!(sender, AccountAddress::ONE);
+        assert!(skips_auth_key_check);
+        assert!(matches!(
+            authenticator,
+            AccountAuthenticator::NoAccountAuthenticator
+        ));
+    }
+
+    #[test]
+    fn simulation_sender_derives_address_from_explicit_private_key() {
+        let private_key = Ed25519PrivateKey::generate(&mut rand::rngs::OsRng);
+        let expected_address = account_address_from_public_key(&private_key.public_key());
+        let options = TxnOptions {
+            private_key_options: PrivateKeyInputOptions::from_private_key(&private_key).unwrap(),
+            ..Default::default()
+        };
+
+        assert_eq!(options.get_simulation_address().unwrap(), expected_address);
+        let (sender, authenticator, skips_auth_key_check) =
+            options.simulation_sender_and_authenticator().unwrap();
+        assert_eq!(sender, expected_address);
+        assert!(!skips_auth_key_check);
+        assert!(matches!(
+            authenticator,
+            AccountAuthenticator::Ed25519 { .. }
+        ));
+    }
+
+    #[test]
+    fn simulation_sender_requires_an_address_when_no_profile_or_key_is_available() {
+        let options = TxnOptions {
+            profile_options: ProfileOptions {
+                profile: Some("missing-simulation-profile".to_string()),
+            },
+            ..Default::default()
+        };
+        let error = options.get_simulation_address().unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Simulation requires --sender-account or an account address"));
+    }
+
+    #[test]
+    fn simulation_transaction_has_no_account_authenticator() {
+        let raw_transaction = TransactionFactory::new(ChainId::test())
+            .payload(TransactionPayload::Script(Script::new(
+                vec![],
+                vec![],
+                vec![],
+            )))
+            .sender(AccountAddress::ONE)
+            .sequence_number(0)
+            .build();
+        let transaction = TxnOptions::simulation_transaction(
+            raw_transaction,
+            AccountAuthenticator::NoAccountAuthenticator,
+        );
+
+        assert!(matches!(
+            transaction.authenticator_ref(),
+            TransactionAuthenticator::SingleSender {
+                sender: AccountAuthenticator::NoAccountAuthenticator
+            }
+        ));
+        assert!(transaction.verify_signature().is_err());
     }
 
     #[test]

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+- `aptos move simulate` now supports unauthenticated remote simulation with `--sender-account` or a profile `account`, and adds `--local-simulation` for unauthenticated local Simulation VM debugging. `--local` continues to require a private key and executes a real signature through the normal VM path.
+
 ## [9.5.0]
 - Compiler now uses receiver style calls for macro-generated code.
 - Point `aptos update movefmt` at the new `aptos-labs/movefmt` repo and bump default movefmt version to 1.5.3.

--- a/third_party/move/documentation/book/src/cli-run.md
+++ b/third_party/move/documentation/book/src/cli-run.md
@@ -64,20 +64,40 @@ Simulate a transaction without committing it. Useful for estimating gas, checkin
 
 ```shellscript filename="Terminal"
 aptos move simulate \
+  --sender-account 0xABC \
   --function-id 0x42::counter::increment \
   --args address:0xABC u64:1 \
   --profile devnet
 
 aptos move simulate \
+  --local \
+  --private-key <PRIVATE_KEY> \
   --function-id 0x42::counter::increment \
-  --args address:0xABC u64:1 \
-  --local                                # local VM instead of remote simulation
+  --args address:0xABC u64:1
+
+aptos move simulate \
+  --local-simulation \
+  --sender-account 0xABC \
+  --function-id 0x42::counter::increment \
+  --args address:0xABC u64:1
 ```
 
 | Flag | Meaning |
 |---|---|
-| `--local` | Simulate in a local VM (using the latest state pulled from the network), instead of asking the fullnode to simulate. |
+| Default | Requests remote fullnode simulation. With no key material, supply `--sender-account` or configure the profile account; authentication-key validation is skipped. |
+| `--local` | Execute locally with a real transaction signature and the normal VM path. Requires a private key. The transaction is not submitted. |
+| `--local-simulation` | Execute locally in simulation mode. Without key material, supply `--sender-account`; authentication-key validation is skipped, so the result does not establish submit authorization. |
+| `--sender-account <ADDR>` | Override the sender address. Key requirements depend on the selected mode. |
 | Plus the same `--function-id` / `--type-args` / `--args` shape as `run`. | |
+
+For best-effort VM failure diagnostics in either local mode, set `MOVE_TRACE_EXEC=vm_error`:
+
+```shellscript filename="Terminal"
+MOVE_TRACE_EXEC=vm_error aptos move simulate --local-simulation --sender-account 0xABC \
+  --function-id 0x42::counter::increment --args address:0xABC u64:1
+```
+
+This is a developer trace of VM internals; its format and source mapping are not a stable CLI interface.
 
 ## `aptos move replay`
 

--- a/third_party/move/documentation/book/src/cli-run.md
+++ b/third_party/move/documentation/book/src/cli-run.md
@@ -84,7 +84,7 @@ aptos move simulate \
 
 | Flag | Meaning |
 |---|---|
-| Default | Requests remote fullnode simulation. With no key material, supply `--sender-account` or configure the profile account; authentication-key validation is skipped. |
+| Default | Requests remote fullnode simulation. With no key material, supply `--sender-account` or configure the profile account; authentication-key validation is skipped. A profile with a private or public key uses zero-signature Ed25519 simulation instead, even with `--sender-account`. To use unauthenticated simulation, select a profile without key material. |
 | `--local` | Execute locally with a real transaction signature and the normal VM path. Requires a private key. The transaction is not submitted. |
 | `--local-simulation` | Execute locally in simulation mode. Without key material, supply `--sender-account`; authentication-key validation is skipped, so the result does not establish submit authorization. |
 | `--sender-account <ADDR>` | Override the sender address. Key requirements depend on the selected mode. |


### PR DESCRIPTION
## Summary
- Add unauthenticated remote simulation with `NoAccountAuthenticator` when no key material is available.
- Restore `--local` as real-signature execution on the normal Aptos VM.
- Add `--local-simulation` for unauthenticated local Simulation VM debugging, and document all three modes.
- Clarify that profiles with private or public key material use authenticated zero-signature simulation, even with `--sender-account`.

## Why
Simulation should support arbitrary sender addresses without requiring private keys while keeping the existing authenticated local execution path unambiguous.

## Validation
- `cargo test -p aptos-move-cli --lib`
- `cargo check -p aptos-move-cli -p aptos`
- Manual Testnet verification:
  ```sh
  aptos move simulate --sender-account 0x1 --url https://fullnode.testnet.aptoslabs.com/v1 --function-id 0x1::aptos_account::transfer --args address:0x1 u64:1
  aptos move simulate --local-simulation --sender-account 0x1 --url https://fullnode.testnet.aptoslabs.com/v1 --function-id 0x1::aptos_account::transfer --args address:0x1 u64:1
  ```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction authentication and simulation client behavior for a core CLI command; mistakes could mislead users about submit authorization or break remote simulation responses, but scope is CLI-only with extensive tests and explicit warnings for unauthenticated mode.
> 
> **Overview**
> **`aptos move simulate`** now supports simulating arbitrary senders without a private key, and separates three execution paths with clearer semantics.
> 
> **Remote (default):** Sender resolution no longer always requires a key. With profile/explicit key material it still uses zero-signature Ed25519 and auth-key validation; without keys it uses `--sender-account` or profile `account` with `NoAccountAuthenticator`, skips auth-key validation (with a stderr warning), and calls **`simulate_bcs_with_gas_estimation`** so responses deserialize correctly when the authenticator is unauthenticated.
> 
> **`--local`:** Restored/clarified as **real signature + normal `AptosVM`** via `run_transaction_using_debugger` (private key required).
> 
> **`--local-simulation` (new):** Local **`AptosSimulationVM`** path (`simulate_transaction_using_debugger`) mirroring fullnode simulation, including unauthenticated senders; mutually exclusive with `--local`.
> 
> Docs and changelog describe the three modes; unit tests cover sender/authenticator selection and CLI flag conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d5c33d6c03c0515e3525f3f1683e1c1509ebf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->