### PR TITLE
[prover] Support `&mut` captures in closures

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/closure_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/closure_checker.rs
@@ -7,9 +7,10 @@
 //! - The closure satisfies the ability requirements of it's inferred type. For the
 //!   definition of closure abilities, see
 //!   [AIP-112](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-112.md).
-//! - The closure does not capture mutable references, and captures immutable
-//!   references only as a direct argument of a retained inline-opaque call in
-//!   verify mode (where the prover models the captured location).
+//! - The closure captures references only as a direct argument of a retained
+//!   inline-opaque call in verify mode (where the prover models the captured
+//!   location: immutable captures as read-only snapshots, mutable captures as
+//!   mutations carried by the closure value and written back after the call).
 //! - In a script, the closure cannot have a lambda lifted function.
 //! ```
 
@@ -133,44 +134,43 @@ pub fn check_closures(env: &GlobalEnv) {
                         for captured in args {
                             let captured_ty = env.get_node_type(captured.node_id());
                             if captured_ty.is_reference() {
-                                // In verify mode, an immutable reference capture is
-                                // admitted for a closure passed directly as an argument
-                                // of a retained inline-opaque call: the bytecode is never
-                                // executed but only translated for the prover (the VM
-                                // rejects reference captures), and the prover models the
-                                // captured location at that call site as a read-only
-                                // snapshot. A mutable reference can never be captured:
-                                // since a function type `|T|R` is opaque about whether
-                                // its closure captured a `&mut`, the prover cannot model
-                                // writes through such a capture.
-                                let admitted = ref_capture_allowed.contains(id)
-                                    && !captured_ty.is_mutable_reference();
-                                if !admitted {
-                                    let msg = if ref_capture_allowed.contains(id) {
-                                        // Direct argument of a retained call, so the only
-                                        // problem is the mutability of the reference.
-                                        format!(
-                                            "captured value cannot be a mutable reference, but \
-                                             has type `{}`{}; in verification, lambdas may \
-                                             capture only immutable references",
-                                            captured_ty.display(&fun_env.get_type_display_ctx()),
+                                // In verify mode, a reference capture is admitted for a
+                                // closure passed directly as an argument of a retained
+                                // inline-opaque call: the bytecode is never executed but
+                                // only translated for the prover (the VM rejects
+                                // reference captures). The prover models an immutable
+                                // capture at that call site as a read-only snapshot, and
+                                // a mutable capture as a mutation carried by the closure
+                                // value, havoced across the call and written back to its
+                                // source location when the closure dies. A mutable
+                                // capture makes the closure value linear: copying it
+                                // would duplicate the carried mutation.
+                                if captured_ty.is_mutable_reference()
+                                    && required_abilities.has_ability(Ability::Copy)
+                                {
+                                    env.error_with_notes(
+                                        &env.get_node_loc(captured.node_id()),
+                                        "cannot capture a mutable reference in a closure \
+                                         requiring the `copy` ability",
+                                        vec![format!(
+                                            "expected function type: `{}`{}",
+                                            context_ty.display(&fun_env.get_type_display_ctx()),
                                             wrapper_msg()
-                                        )
-                                    } else {
-                                        let mut msg = format!(
-                                            "captured value cannot be a reference, but has type \
-                                             `{}`{}",
-                                            captured_ty.display(&fun_env.get_type_display_ctx()),
-                                            wrapper_msg()
-                                        );
-                                        if env.is_verify_mode() {
-                                            msg += "; in verification, lambdas may capture only \
-                                                    immutable references, and only as direct \
-                                                    arguments of calls to inline functions with \
-                                                    `pragma opaque`";
-                                        }
-                                        msg
-                                    };
+                                        )],
+                                    );
+                                }
+                                if !ref_capture_allowed.contains(id) {
+                                    let mut msg = format!(
+                                        "captured value cannot be a reference, but has type \
+                                         `{}`{}",
+                                        captured_ty.display(&fun_env.get_type_display_ctx()),
+                                        wrapper_msg()
+                                    );
+                                    if env.is_verify_mode() {
+                                        msg += "; in verification, lambdas may capture \
+                                                references only as direct arguments of calls \
+                                                to inline functions with `pragma opaque`";
+                                    }
                                     env.error(&env.get_node_loc(captured.node_id()), &msg)
                                 }
                             }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/lambda_lifter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/lambda_lifter.rs
@@ -4,8 +4,12 @@
 //! This module implements lambda lifting, rewriting function definitions
 //! in the global environment.
 //!
-//! Lambda lifting is currently restricted to only lift lambdas which do
-//! not modify free variables.
+//! Lambda lifting is restricted to lambdas which do not modify free
+//! variables, except in verify mode, where a modified free variable is
+//! converted into a `&mut` capture: the lifted function takes a `&mut`
+//! parameter, reads become dereferences, and mutations go through the
+//! parameter, so `let n = 0; v.count(|| n += 1)` is lifted as if written
+//! `let rn = &mut n; v.count(|| *rn += 1)`.
 //!
 //! Lambda lifting rewrites lambda expressions into construction
 //! of *closures* using the `Closure` operation. A closure refers to a function and contains a list
@@ -211,6 +215,236 @@ impl ClosureFunction {
     }
 }
 
+/// Captured variables which are modified by a lambda and therefore converted into
+/// `&mut` captures (verify mode only).
+#[derive(Default)]
+struct MutCaptures {
+    /// Converted captured locals, by symbol.
+    locals: BTreeSet<Symbol>,
+    /// Converted captured parameters of the enclosing function, by original index.
+    temps: BTreeSet<TempIndex>,
+}
+
+impl MutCaptures {
+    fn is_empty(&self) -> bool {
+        self.locals.is_empty() && self.temps.is_empty()
+    }
+}
+
+/// Rewrites the body of a lifted lambda for captured variables which are modified
+/// and have been converted into `&mut` parameters:
+/// - reads `x` become dereferences `*x`
+/// - assignments `x = e` become mutations `*x = e`
+/// - mutable borrows `&mut x` become the parameter `x` itself
+/// - immutable borrows `&x` become `freeze(x)`
+struct MutCaptureRewriter<'a> {
+    env: &'a GlobalEnv,
+    captures: &'a MutCaptures,
+    /// Names of converted parameters of the enclosing function, by symbol.
+    /// Assignments reference parameters by symbol rather than by index.
+    param_temps: BTreeMap<Symbol, TempIndex>,
+    /// Local name scopes for shadowing detection.
+    scopes: Vec<BTreeSet<Symbol>>,
+}
+
+impl<'a> MutCaptureRewriter<'a> {
+    fn new(env: &'a GlobalEnv, fun_env: &FunctionEnv, captures: &'a MutCaptures) -> Self {
+        let param_temps = fun_env
+            .get_parameters()
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| captures.temps.contains(idx))
+            .map(|(idx, p)| (p.0, idx))
+            .collect();
+        Self {
+            env,
+            captures,
+            param_temps,
+            scopes: vec![],
+        }
+    }
+
+    fn is_shadowed(&self, sym: &Symbol) -> bool {
+        self.scopes.iter().any(|scope| scope.contains(sym))
+    }
+
+    /// Creates a reference-typed node for the LHS of a converted assignment.
+    fn assign_lhs_node(&self, pat: &Pattern) -> NodeId {
+        let lhs_ty = Type::Reference(
+            ReferenceKind::Mutable,
+            Box::new(self.env.get_node_type(pat.node_id())),
+        );
+        self.env
+            .new_node(self.env.get_node_loc(pat.node_id()), lhs_ty)
+    }
+
+    /// Returns true if this is an unshadowed reference to a converted variable.
+    fn is_converted_var(&self, exp: &ExpData) -> bool {
+        match exp {
+            ExpData::LocalVar(_, sym) => {
+                self.captures.locals.contains(sym) && !self.is_shadowed(sym)
+            },
+            ExpData::Temporary(_, idx) => self.captures.temps.contains(idx),
+            _ => false,
+        }
+    }
+
+    /// Creates a reference to the `&mut` parameter replacing the converted variable.
+    /// `var_id` is the node of the original variable reference (typed with the value
+    /// type), `ref_id` an optional node to reuse for the reference-typed expression.
+    fn make_param_ref(&self, var_exp: &ExpData, ref_id: Option<NodeId>) -> Exp {
+        let var_id = var_exp.node_id();
+        let id = ref_id.unwrap_or_else(|| {
+            let ty = Type::Reference(
+                ReferenceKind::Mutable,
+                Box::new(self.env.get_node_type(var_id)),
+            );
+            self.env.new_node(self.env.get_node_loc(var_id), ty)
+        });
+        match var_exp {
+            ExpData::LocalVar(_, sym) => ExpData::LocalVar(id, *sym).into_exp(),
+            ExpData::Temporary(_, idx) => ExpData::Temporary(id, *idx).into_exp(),
+            _ => unreachable!("expected variable"),
+        }
+    }
+
+    /// Returns true if the root of a selection chain (field selections, index
+    /// operations) is an unshadowed converted variable.
+    fn chain_root_is_converted(&self, exp: &Exp) -> bool {
+        self.is_converted_var(exp.as_ref().selection_chain_root(false))
+    }
+
+    /// Rewrites a mutation target (the lhs of `Mutate` or the operand of `&mut`)
+    /// whose selection chain is rooted in a converted variable: the variable is
+    /// replaced by the `&mut` parameter itself, so the mutation goes through the
+    /// reference. The default read rewrite (`x` to `*x`) must not be used here,
+    /// since it would mutate a dereferenced copy instead of the captured location.
+    fn rewrite_mutation_target(&mut self, exp: &Exp) -> Exp {
+        if self.is_converted_var(exp.as_ref()) {
+            return self.make_param_ref(exp.as_ref(), None);
+        }
+        match exp.as_ref() {
+            ExpData::Call(id, oper, args)
+                if matches!(
+                    oper,
+                    Operation::Select(..) | Operation::SelectVariants(..) | Operation::Index
+                ) =>
+            {
+                let mut new_args = vec![self.rewrite_mutation_target(&args[0])];
+                for arg in &args[1..] {
+                    new_args.push(self.rewrite_exp(arg.clone()));
+                }
+                ExpData::Call(*id, oper.clone(), new_args).into_exp()
+            },
+            _ => self.rewrite_exp(exp.clone()),
+        }
+    }
+}
+
+impl ExpRewriterFunctions for MutCaptureRewriter<'_> {
+    fn rewrite_exp(&mut self, exp: Exp) -> Exp {
+        match exp.as_ref() {
+            ExpData::Mutate(id, lhs, rhs) if self.chain_root_is_converted(lhs) => {
+                // E.g. `s.x = e` for converted `s`: mutate through the parameter.
+                let new_lhs = self.rewrite_mutation_target(lhs);
+                let new_rhs = self.rewrite_exp(rhs.clone());
+                ExpData::Mutate(*id, new_lhs, new_rhs).into_exp()
+            },
+            ExpData::Assign(id, pat, rhs) => {
+                if let Pattern::Var(_, sym) = pat {
+                    if !self.is_shadowed(sym) {
+                        // `x = e` becomes `*x = e`. Assignments reference converted
+                        // parameters of the enclosing function by symbol.
+                        let lhs = if self.captures.locals.contains(sym) {
+                            Some(ExpData::LocalVar(self.assign_lhs_node(pat), *sym).into_exp())
+                        } else {
+                            self.param_temps.get(sym).map(|idx| {
+                                ExpData::Temporary(self.assign_lhs_node(pat), *idx).into_exp()
+                            })
+                        };
+                        if let Some(lhs) = lhs {
+                            let rhs = self.rewrite_exp(rhs.clone());
+                            return ExpData::Mutate(*id, lhs, rhs).into_exp();
+                        }
+                    }
+                } else if pat.vars().iter().any(|(_, sym)| {
+                    (self.captures.locals.contains(sym) || self.param_temps.contains_key(sym))
+                        && !self.is_shadowed(sym)
+                }) {
+                    self.env.error(
+                        &self.env.get_node_loc(*id),
+                        "modified captured variables are not yet supported in tuple or \
+                         struct assignments inside of a lambda",
+                    );
+                    return exp;
+                }
+                self.rewrite_exp_descent(exp)
+            },
+            ExpData::Call(id, Operation::Borrow(kind), args)
+                if args.len() == 1 && self.is_converted_var(args[0].as_ref()) =>
+            {
+                match kind {
+                    ReferenceKind::Mutable => {
+                        // `&mut x` becomes the parameter `x` itself; the borrow
+                        // node already has the right reference type.
+                        self.make_param_ref(args[0].as_ref(), Some(*id))
+                    },
+                    ReferenceKind::Immutable => {
+                        // `&x` becomes `freeze(x)`; the borrow node already has
+                        // the immutable reference type.
+                        let param_ref = self.make_param_ref(args[0].as_ref(), None);
+                        ExpData::Call(*id, Operation::Freeze(false), vec![param_ref]).into_exp()
+                    },
+                }
+            },
+            ExpData::Call(id, Operation::Borrow(ReferenceKind::Mutable), args)
+                if args.len() == 1 && self.chain_root_is_converted(&args[0]) =>
+            {
+                // E.g. `&mut s.x` for converted `s`: borrow through the parameter.
+                let new_target = self.rewrite_mutation_target(&args[0]);
+                ExpData::Call(*id, Operation::Borrow(ReferenceKind::Mutable), vec![
+                    new_target,
+                ])
+                .into_exp()
+            },
+            _ => self.rewrite_exp_descent(exp),
+        }
+    }
+
+    fn rewrite_enter_scope<'b>(
+        &mut self,
+        _id: NodeId,
+        vars: impl Iterator<Item = &'b (NodeId, Symbol)>,
+    ) {
+        self.scopes
+            .push(vars.map(|(_, sym)| sym).cloned().collect())
+    }
+
+    fn rewrite_exit_scope(&mut self, _id: NodeId) {
+        self.scopes.pop().expect("stack balanced");
+    }
+
+    fn rewrite_local_var(&mut self, node_id: NodeId, sym: Symbol) -> Option<Exp> {
+        if self.captures.locals.contains(&sym) && !self.is_shadowed(&sym) {
+            // Read `x` becomes `*x`.
+            let param_ref = self.make_param_ref(&ExpData::LocalVar(node_id, sym), None);
+            Some(ExpData::Call(node_id, Operation::Deref, vec![param_ref]).into_exp())
+        } else {
+            None
+        }
+    }
+
+    fn rewrite_temporary(&mut self, node_id: NodeId, idx: TempIndex) -> Option<Exp> {
+        if self.captures.temps.contains(&idx) {
+            // Read `x` becomes `*x`.
+            let param_ref = self.make_param_ref(&ExpData::Temporary(node_id, idx), None);
+            Some(ExpData::Call(node_id, Operation::Deref, vec![param_ref]).into_exp())
+        } else {
+            None
+        }
+    }
+}
+
 impl<'a> LambdaLifter<'a> {
     pub fn new(
         options: &'a LambdaLiftingOptions,
@@ -277,14 +511,22 @@ impl<'a> LambdaLifter<'a> {
         }
     }
 
-    /// For the current state, calculate: (params, closure_args, param_index_mapping), where
+    /// For the current state, calculate: (params, closure_args, param_index_mapping, mut_captures),
+    /// where
     /// - `params` = new Parameter for each free var to represent it in the lifted function
     /// - `closure_args` = corresponding expressions to provide as actual arg for each param
     /// - `param_index_mapping` = for each free var which is a Parameter from the enclosing function,
     ///    a mapping from index there to index in the params list
+    /// - `mut_captures` = captured variables which are modified by the lambda and therefore
+    ///    converted into `&mut` captures (verify mode only)
     fn get_params_for_freevars(
         &mut self,
-    ) -> Option<(Vec<Parameter>, Vec<Exp>, BTreeMap<usize, usize>)> {
+    ) -> Option<(
+        Vec<Parameter>,
+        Vec<Exp>,
+        BTreeMap<usize, usize>,
+        MutCaptures,
+    )> {
         let env = self.fun_env.module_env.env;
         let mut closure_args = vec![];
 
@@ -293,14 +535,23 @@ impl<'a> LambdaLifter<'a> {
         // functions (courtesy of #12317)
         let mut param_index_mapping = BTreeMap::new();
         let mut params = vec![];
+        let mut mut_captures = MutCaptures::default();
         let mut saw_error = false;
+
+        // In verify mode, captured variables which are modified by the lambda are
+        // converted into `&mut` captures: the lifted function takes a mutable
+        // reference and the closure captures a borrow of the variable. The body
+        // is rewritten accordingly (see `MutCaptureRewriter`). Outside of verify
+        // mode this is not supported, since the VM does not allow closures to
+        // capture references.
+        let allow_mutating_captures = env.is_verify_mode();
 
         for (used_param_count, (param, var_info)) in self.free_params.iter().enumerate() {
             let name = self.fun_env.get_local_name(*param);
             let var_node_id = var_info.node_id;
             let ty = env.get_node_type(var_node_id);
             let loc = env.get_node_loc(var_node_id);
-            if var_info.modified {
+            if var_info.modified && !allow_mutating_captures {
                 env.error(
                     &loc,
                     &format!(
@@ -310,12 +561,29 @@ impl<'a> LambdaLifter<'a> {
                 );
                 saw_error = true;
             }
-            params.push(Parameter(name, ty.clone(), loc.clone()));
-            let new_id = env.new_node(loc, ty);
-            if let Some(inst) = env.get_node_instantiation_opt(var_node_id) {
-                env.set_node_instantiation(new_id, inst);
+            if var_info.modified && allow_mutating_captures {
+                let ref_ty = Type::Reference(ReferenceKind::Mutable, Box::new(ty.clone()));
+                params.push(Parameter(name, ref_ty.clone(), loc.clone()));
+                let var_id = env.new_node(loc.clone(), ty);
+                if let Some(inst) = env.get_node_instantiation_opt(var_node_id) {
+                    env.set_node_instantiation(var_id, inst);
+                }
+                let borrow_id = env.new_node(loc, ref_ty);
+                closure_args.push(
+                    ExpData::Call(borrow_id, Operation::Borrow(ReferenceKind::Mutable), vec![
+                        ExpData::Temporary(var_id, *param).into_exp(),
+                    ])
+                    .into_exp(),
+                );
+                mut_captures.temps.insert(*param);
+            } else {
+                params.push(Parameter(name, ty.clone(), loc.clone()));
+                let new_id = env.new_node(loc, ty);
+                if let Some(inst) = env.get_node_instantiation_opt(var_node_id) {
+                    env.set_node_instantiation(new_id, inst);
+                }
+                closure_args.push(ExpData::Temporary(new_id, *param).into_exp());
             }
-            closure_args.push(ExpData::Temporary(new_id, *param).into_exp());
             param_index_mapping.insert(*param, used_param_count);
         }
 
@@ -324,7 +592,7 @@ impl<'a> LambdaLifter<'a> {
             let var_info_id = var_info.node_id;
             let ty = env.get_node_type(var_info_id);
             let loc = env.get_node_loc(var_info_id);
-            if var_info.modified {
+            if var_info.modified && !allow_mutating_captures {
                 env.error(
                     &loc,
                     &format!(
@@ -334,16 +602,33 @@ impl<'a> LambdaLifter<'a> {
                 );
                 saw_error = true;
             }
-            params.push(Parameter(*name, ty.clone(), loc.clone()));
-            let new_id = env.new_node(loc, ty);
-            if let Some(inst) = env.get_node_instantiation_opt(var_info_id) {
-                env.set_node_instantiation(new_id, inst);
+            if var_info.modified && allow_mutating_captures {
+                let ref_ty = Type::Reference(ReferenceKind::Mutable, Box::new(ty.clone()));
+                params.push(Parameter(*name, ref_ty.clone(), loc.clone()));
+                let var_id = env.new_node(loc.clone(), ty);
+                if let Some(inst) = env.get_node_instantiation_opt(var_info_id) {
+                    env.set_node_instantiation(var_id, inst);
+                }
+                let borrow_id = env.new_node(loc, ref_ty);
+                closure_args.push(
+                    ExpData::Call(borrow_id, Operation::Borrow(ReferenceKind::Mutable), vec![
+                        ExpData::LocalVar(var_id, *name).into_exp(),
+                    ])
+                    .into_exp(),
+                );
+                mut_captures.locals.insert(*name);
+            } else {
+                params.push(Parameter(*name, ty.clone(), loc.clone()));
+                let new_id = env.new_node(loc, ty);
+                if let Some(inst) = env.get_node_instantiation_opt(var_info_id) {
+                    env.set_node_instantiation(new_id, inst);
+                }
+                closure_args.push(ExpData::LocalVar(new_id, *name).into_exp())
             }
-            closure_args.push(ExpData::LocalVar(new_id, *name).into_exp())
         }
 
         if !saw_error {
-            Some((params, closure_args, param_index_mapping))
+            Some((params, closure_args, param_index_mapping, mut_captures))
         } else {
             None
         }
@@ -469,6 +754,31 @@ impl<'a> LambdaLifter<'a> {
         self.scopes.iter().any(|scope| scope.contains(sym))
     }
 
+    /// Marks the root variable of a mutation target as modified, peeling field
+    /// selections, index operations, and dereferences (e.g. for `s.x = e` or
+    /// `v[i] = e`, the root is `s` resp. `v`). A reference-typed root is not
+    /// marked: there, the mutation goes through the reference and does not
+    /// modify the captured binding itself.
+    fn mark_mutation_root_modified(&mut self, target: &Exp) {
+        let env = self.fun_env.module_env.env;
+        let root = target.as_ref().selection_chain_root(true);
+        match root {
+            ExpData::LocalVar(node_id, name) if !env.get_node_type(*node_id).is_reference() => {
+                self.try_insert_free_local(*name, VarInfo {
+                    node_id: *node_id,
+                    modified: true,
+                });
+            },
+            ExpData::Temporary(node_id, param) if !env.get_node_type(*node_id).is_reference() => {
+                self.free_params.insert(*param, VarInfo {
+                    node_id: *node_id,
+                    modified: true,
+                });
+            },
+            _ => {},
+        }
+    }
+
     /// Insert `sym` as a free local variable, if it is not already in scope.
     fn try_insert_free_local(&mut self, sym: Symbol, var_info: VarInfo) {
         if !self.is_symbol_in_scope(&sym) {
@@ -478,6 +788,30 @@ impl<'a> LambdaLifter<'a> {
             } else {
                 self.free_locals.entry(sym).or_insert(var_info);
             }
+        }
+    }
+
+    /// Marks a variable assigned to by a pattern as a modified free variable.
+    /// Assignments reference variables by symbol; a symbol naming a parameter of
+    /// the enclosing function is resolved to the parameter (locals shadowing a
+    /// parameter are renamed by the model builder, so the name is unambiguous).
+    fn insert_assigned_var(&mut self, sym: Symbol, node_id: NodeId) {
+        if self.is_symbol_in_scope(&sym) {
+            return;
+        }
+        let var_info = VarInfo {
+            node_id,
+            modified: true,
+        };
+        if let Some(idx) = self
+            .fun_env
+            .get_parameters()
+            .iter()
+            .position(|p| p.0 == sym)
+        {
+            self.free_params.insert(idx, var_info);
+        } else {
+            self.free_locals.insert(sym, var_info);
         }
     }
 
@@ -532,6 +866,11 @@ impl ExpRewriterFunctions for LambdaLifter<'_> {
                 }
             }
         }
+        // Detect modification of captured variables through mutation targets like
+        // `s.x = e` or `v[i] = e` (`Mutate` has no dedicated rewriter hook).
+        if let ExpData::Mutate(_, lhs, _) = exp.as_ref() {
+            self.mark_mutation_root_modified(lhs);
+        }
         // Also if this is a lambda, before descent, clear any usages from siblings in the
         // context, so we get the isolated usage information for the lambda's body.
         if matches!(exp.as_ref(), ExpData::Lambda(..)) {
@@ -574,10 +913,7 @@ impl ExpRewriterFunctions for LambdaLifter<'_> {
 
     fn rewrite_assign(&mut self, _node_id: NodeId, lhs: &Pattern, _rhs: &Exp) -> Option<Exp> {
         for (node_id, name) in lhs.vars() {
-            self.try_insert_free_local(name, VarInfo {
-                node_id,
-                modified: true,
-            });
+            self.insert_assigned_var(name, node_id);
         }
         None
     }
@@ -597,7 +933,11 @@ impl ExpRewriterFunctions for LambdaLifter<'_> {
                         modified: true,
                     });
                 },
-                _ => {},
+                _ => {
+                    // Mutable borrow through a selection chain, e.g. `&mut s.x`:
+                    // the root variable is modified.
+                    self.mark_mutation_root_modified(&args[0]);
+                },
             }
         }
         None
@@ -639,7 +979,10 @@ impl ExpRewriterFunctions for LambdaLifter<'_> {
         // param_index_mapping = for each free var which is a Parameter from the enclosing function,
         //      a mapping from index there to index in the params list; other free vars are
         //      substituted automatically by using the same symbol for the param
-        let (mut params, closure_args, param_index_mapping) = self.get_params_for_freevars()?;
+        // mut_captures = captured variables converted to `&mut` because the lambda
+        //      modifies them (verify mode only)
+        let (mut params, closure_args, param_index_mapping, mut_captures) =
+            self.get_params_for_freevars()?;
 
         if closure_args.len() > ClosureMask::MAX_ARGS {
             env.error(
@@ -673,8 +1016,10 @@ impl ExpRewriterFunctions for LambdaLifter<'_> {
             }
         }
 
-        // Try to rewrite a lambda directly into a curry expression
-        if bindings.is_empty() {
+        // Try to rewrite a lambda directly into a curry expression. This is not
+        // possible with converted `&mut` captures, which require a lifted function
+        // with a rewritten body.
+        if bindings.is_empty() && mut_captures.is_empty() {
             let possible_curry_exp = self.try_to_reduce_lambda_to_curry(id, &lambda_params, body);
             if possible_curry_exp.is_some() {
                 return possible_curry_exp;
@@ -701,6 +1046,14 @@ impl ExpRewriterFunctions for LambdaLifter<'_> {
             _ => Type::Error, // type error reported
         };
 
+        // Rewrite accesses to converted `&mut` captures in the body (reads become
+        // dereferences, assignments become mutations, borrows use the parameter).
+        let body = if mut_captures.is_empty() {
+            body.clone()
+        } else {
+            MutCaptureRewriter::new(env, self.fun_env, &mut_captures).rewrite_exp(body.clone())
+        };
+
         // Rewrite references to Temporary in the new functions body (#12317)
         let mut replacer = |id: NodeId, target: RewriteTarget| {
             if let RewriteTarget::Temporary(temp) = target {
@@ -709,16 +1062,30 @@ impl ExpRewriterFunctions for LambdaLifter<'_> {
             }
             None
         };
-        let body = ExpRewriter::new(env, &mut replacer).rewrite_exp(body.clone());
+        let body = ExpRewriter::new(env, &mut replacer).rewrite_exp(body);
         let fun_id = FunId::new(fun_name);
-        // Spec rewriter needs to map parameters to temporary indices in the spec
+        // Spec rewriter needs to map parameters to temporary indices in the spec.
+        // For converted `&mut` captures, the node must get the parameter's reference
+        // type so the spec correctly depends on state (e.g. for `old(..)`).
+        let param_typed_node = |id: NodeId, param: &Parameter| {
+            if env.get_node_type(id) != param.1 {
+                env.new_node(env.get_node_loc(id), param.1.clone())
+            } else {
+                id
+            }
+        };
         let mut spec_replacer = |id: NodeId, target: RewriteTarget| {
             if let RewriteTarget::Temporary(temp) = target {
                 let new_temp = param_index_mapping.get(&temp).cloned().unwrap_or(temp);
+                let id = params
+                    .get(new_temp)
+                    .map(|par| param_typed_node(id, par))
+                    .unwrap_or(id);
                 return Some(ExpData::Temporary(id, new_temp).into_exp());
             } else if let RewriteTarget::LocalVar(sym) = target {
                 for (i, par) in params.iter().enumerate() {
                     if sym == par.0 {
+                        let id = param_typed_node(id, par);
                         return Some(ExpData::Temporary(id, i).into_exp());
                     }
                 }

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.exp
@@ -1,5 +1,12 @@
 // -- Model dump before first bytecode pipeline
 module 0x42::retained_mut_capture {
+    struct S {
+        x: u64,
+        y: u64,
+    }
+    struct V {
+        items: vector<u64>,
+    }
     private inline fun call_once(f: |u64|) {
         (f)(1)
     }
@@ -24,10 +31,100 @@ module 0x42::retained_mut_capture {
       ensures Eq<u64>(result0(), 1);
     }
 
+    private inline fun count(self: &V,f: |u64|) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t1, 1);
+    }
+
+    private fun field_caller(): u64 {
+        {
+          let s: S = pack retained_mut_capture::S(1, 7);
+          {
+            let (): ();
+            {
+              let (i: u64): (u64) = Tuple(1);
+              select retained_mut_capture::S.x<S>(s) = Add<u64>(select retained_mut_capture::S.x<S>(s), i)
+            }
+          };
+          Add<u64>(select retained_mut_capture::S.x<S>(s), select retained_mut_capture::S.y<S>(s))
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 9);
+    }
+
+    private fun freeze_caller(): u64 {
+        {
+          let x: u64 = 1;
+          {
+            let (): ();
+            {
+              let (i: u64): (u64) = Tuple(1);
+              x: u64 = Add<u64>(Add<u64>(x, retained_mut_capture::read(Borrow(Immutable)(x))), i)
+            }
+          };
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 3);
+    }
+
+    private fun param_caller(x: u64): u64 {
+        {
+          let (): ();
+          {
+            let (i: u64): (u64) = Tuple(1);
+            x: u64 = Add<u64>(x, i)
+          }
+        };
+        x
+    }
+    spec {
+      requires Lt($t0, 1000);
+      ensures Eq<u64>(result0(), Add($t0, 1));
+    }
+
+    private fun read(r: &u64): u64 {
+        Deref(r)
+    }
+    spec {
+      ensures Eq<u64>(result0(), $t0);
+    }
+
+    private fun receiver_caller(v: &V): u64 {
+        {
+          let n: u64 = 0;
+          {
+            let (self: &V): (&V) = Tuple(v);
+            {
+              let (_x: u64): (u64) = Tuple(1);
+              {
+                let $t: u64 = 1;
+                n: u64 = Add<u64>(n, $t)
+              }
+            }
+          };
+          n
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
 } // end 0x42::retained_mut_capture
 
 // -- Sourcified model before first bytecode pipeline
 module 0x42::retained_mut_capture {
+    struct S has copy, drop {
+        x: u64,
+        y: u64,
+    }
+    struct V has drop {
+        items: vector<u64>,
+    }
     inline fun call_once(f: |u64|) {
         f(1)
     }
@@ -51,10 +148,91 @@ module 0x42::retained_mut_capture {
         ensures result == 1;
     }
 
+    inline fun count(self: &V, f: |u64|) {
+        f(1)
+    }
+
+    spec count(self: &V, f: |u64|) {
+        pragma opaque = true;
+        ensures ensures_of<f>(1);
+    }
+
+    fun field_caller(): u64 {
+        let s = S{x: 1, y: 7};
+        {
+            let ();
+            let i = 1;
+            s.x = s.x + i
+        };
+        s.x + s.y
+    }
+
+    spec field_caller(): u64 {
+        ensures result == 9;
+    }
+
+    fun freeze_caller(): u64 {
+        let x = 1;
+        {
+            let ();
+            let i = 1;
+            x = x + read(&x) + i
+        };
+        x
+    }
+
+    spec freeze_caller(): u64 {
+        ensures result == 3;
+    }
+
+    fun param_caller(x: u64): u64 {
+        {
+            let ();
+            let i = 1;
+            x = x + i
+        };
+        x
+    }
+
+    spec param_caller(x: u64): u64 {
+        requires x < 1000;
+        ensures result == x + 1;
+    }
+
+    fun read(r: &u64): u64 {
+        *r
+    }
+
+    spec read(r: &u64): u64 {
+        ensures result == r;
+    }
+
+    fun receiver_caller(v: &V): u64 {
+        let n = 0;
+        {
+            let self = v;
+            let _x = 1;
+            let _t = 1;
+            n = n + _t
+        };
+        n
+    }
+
+    spec receiver_caller(v: &V): u64 {
+        ensures result == 1;
+    }
+
 }
 
 // -- Model dump before second bytecode pipeline
 module 0x42::retained_mut_capture {
+    struct S {
+        x: u64,
+        y: u64,
+    }
+    struct V {
+        items: vector<u64>,
+    }
     private inline fun call_once(f: |u64|) {
         (f)(1)
     }
@@ -73,17 +251,147 @@ module 0x42::retained_mut_capture {
       ensures Eq<u64>(result0(), 1);
     }
 
+    private inline fun count(self: &V,f: |u64|) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t1, 1);
+    }
+
+    private fun field_caller(): u64 {
+        {
+          let s: S = pack retained_mut_capture::S(1, 7);
+          select retained_mut_capture::S.x<S>(s) = Add<u64>(select retained_mut_capture::S.x<S>(s), 1);
+          Add<u64>(select retained_mut_capture::S.x<S>(s), select retained_mut_capture::S.y<S>(s))
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 9);
+    }
+
+    private fun freeze_caller(): u64 {
+        {
+          let x: u64 = 1;
+          x: u64 = Add<u64>(Add<u64>(x, retained_mut_capture::read(Borrow(Immutable)(x))), 1);
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 3);
+    }
+
+    private fun param_caller(x: u64): u64 {
+        x: u64 = Add<u64>(x, 1);
+        x
+    }
+    spec {
+      requires Lt($t0, 1000);
+      ensures Eq<u64>(result0(), Add($t0, 1));
+    }
+
+    private fun read(r: &u64): u64 {
+        Deref(r)
+    }
+    spec {
+      ensures Eq<u64>(result0(), $t0);
+    }
+
+    private fun receiver_caller(v: &V): u64 {
+        {
+          let n: u64 = 0;
+          {
+            let (self: &V): (&V) = Tuple(v);
+            n: u64 = Add<u64>(n, 1)
+          };
+          n
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
 } // end 0x42::retained_mut_capture
 
 
 ============ disassembled file-format ==================
 // Bytecode version v10
 module 0x42::retained_mut_capture
+struct S has copy + drop
+  x: u64
+  y: u64
+
+struct V has drop
+  items: vector<u64>
+
 // Function definition at index 0
 fun caller(): u64
     ld_u64 0
     ld_u64 1
     add
+    ret
+
+// Function definition at index 1
+fun field_caller(): u64
+    local l0: S
+    ld_u64 1
+    ld_u64 7
+    pack S
+    st_loc l0
+    borrow_loc l0
+    // @5
+    borrow_field S, x
+    read_ref
+    ld_u64 1
+    add
+    mut_borrow_loc l0
+    // @10
+    mut_borrow_field S, x
+    write_ref
+    borrow_loc l0
+    borrow_field S, x
+    read_ref
+    // @15
+    borrow_loc l0
+    borrow_field S, y
+    read_ref
+    add
+    ret
+
+// Function definition at index 2
+fun freeze_caller(): u64
+    local l0: u64
+    ld_u64 1
+    st_loc l0
+    copy_loc l0
+    borrow_loc l0
+    call read
+    // @5
+    add
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 3
+fun param_caller(l0: u64): u64
+    move_loc l0
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 4
+fun read(l0: &u64): u64
+    move_loc l0
+    read_ref
+    ret
+
+// Function definition at index 5
+fun receiver_caller(l0: &V): u64
+    ld_u64 0
+    move_loc l0
+    pop
+    ld_u64 1
+    add
+    // @5
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.move
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.move
@@ -1,8 +1,7 @@
-// In verify mode, a lambda passed to a retained inline-opaque function may not
-// modify a captured variable: the lambda lifter rejects it (a captured variable
-// is passed by value, so a modification could not be observed by the caller). In
-// normal compilation the inline function is expanded, so the lambda is never
-// lifted and no error arises.
+// In verify mode, lambdas passed to retained inline-opaque functions may modify
+// captured variables. The lambda lifter converts such captures into `&mut`
+// parameters: `|i| x = x + i` becomes a closure capturing `&mut x` over a lifted
+// function with body `*x = *x + i`. In normal compilation mode this is an error.
 module 0x42::retained_mut_capture {
 
     inline fun call_once(f: |u64|) {
@@ -20,5 +19,74 @@ module 0x42::retained_mut_capture {
     }
     spec caller {
         ensures result == 1;
+    }
+
+    struct S has copy, drop {
+        x: u64,
+        y: u64,
+    }
+
+    fun field_caller(): u64 {
+        let s = S { x: 1, y: 7 };
+        call_once(|i| s.x = s.x + i spec {
+            ensures s.x == old(s).x + i;
+            ensures s.y == old(s).y;
+        });
+        s.x + s.y
+    }
+    spec field_caller {
+        ensures result == 9;
+    }
+
+    struct V has drop {
+        items: vector<u64>,
+    }
+
+    inline fun count(self: &V, f: |u64|) {
+        f(1)
+    }
+    spec count {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    /// The motivating shape: receiver-style call with compound assignment on a
+    /// context local.
+    fun receiver_caller(v: &V): u64 {
+        let n = 0;
+        v.count(|_x| n += 1 spec { ensures n == old(n) + 1; });
+        n
+    }
+    spec receiver_caller {
+        ensures result == 1;
+    }
+
+    /// Modification of a captured parameter of the enclosing function; behaves
+    /// like a local.
+    fun param_caller(x: u64): u64 {
+        call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec param_caller {
+        requires x < 1000;
+        ensures result == x + 1;
+    }
+
+    /// A converted variable that is also read through an immutable borrow
+    /// (rewritten to a freeze of the `&mut` parameter).
+    fun freeze_caller(): u64 {
+        let x = 1;
+        call_once(|i| x = x + read(&x) + i spec { ensures x == old(x) * 2 + i; });
+        x
+    }
+    spec freeze_caller {
+        ensures result == 3;
+    }
+
+    fun read(r: &u64): u64 {
+        *r
+    }
+    spec read {
+        ensures result == r;
     }
 }

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.verify.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.verify.exp
@@ -1,7 +1,558 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::retained_mut_capture {
+    struct S {
+        x: u64,
+        y: u64,
+    }
+    struct V {
+        items: vector<u64>,
+    }
+    private inline fun call_once(f: |u64|) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t0, 1);
+    }
 
-Diagnostics:
-error: captured variable `x` cannot be modified inside of a lambda
-   ┌─ tests/inline-opaque/retained_mut_capture.move:18:23
-   │
-18 │         call_once(|i| x = x + i spec { ensures x == old(x) + i; });
-   │                       ^
+    private fun caller(): u64 {
+        {
+          let x: u64 = 0;
+          retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__caller(Borrow(Mutable)(x)));
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
+    private inline fun count(self: &V,f: |u64|) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t1, 1);
+    }
+
+    private fun field_caller(): u64 {
+        {
+          let s: S = pack retained_mut_capture::S(1, 7);
+          retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__field_caller(Borrow(Mutable)(s)));
+          Add<u64>(select retained_mut_capture::S.x<S>(s), select retained_mut_capture::S.y<S>(s))
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 9);
+    }
+
+    private fun freeze_caller(): u64 {
+        {
+          let x: u64 = 1;
+          retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__freeze_caller(Borrow(Mutable)(x)));
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 3);
+    }
+
+    private fun param_caller(x: u64): u64 {
+        retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__param_caller(Borrow(Mutable)(x)));
+        x
+    }
+    spec {
+      requires Lt($t0, 1000);
+      ensures Eq<u64>(result0(), Add($t0, 1));
+    }
+
+    private fun read(r: &u64): u64 {
+        Deref(r)
+    }
+    spec {
+      ensures Eq<u64>(result0(), $t0);
+    }
+
+    private fun receiver_caller(v: &V): u64 {
+        {
+          let n: u64 = 0;
+          retained_mut_capture::count(v, closure#1retained_mut_capture::__lambda__1__receiver_caller(Borrow(Mutable)(n)));
+          n
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
+    private fun __lambda__1__caller(x: &mut u64,i: u64) {
+        x = Add<u64>(Deref(x), i)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Old<u64>($t0), $t1));
+    }
+
+    private fun __lambda__1__field_caller(s: &mut S,i: u64) {
+        select retained_mut_capture::S.x<S>(s) = Add<u64>(select retained_mut_capture::S.x<S>(Deref(s)), i)
+    }
+    spec {
+      ensures Eq<u64>(select retained_mut_capture::S.x<0x42::retained_mut_capture::S>($t0), Add(select retained_mut_capture::S.x<0x42::retained_mut_capture::S>(Old<0x42::retained_mut_capture::S>($t0)), $t1));
+      ensures Eq<u64>(select retained_mut_capture::S.y<0x42::retained_mut_capture::S>($t0), select retained_mut_capture::S.y<0x42::retained_mut_capture::S>(Old<0x42::retained_mut_capture::S>($t0)));
+    }
+
+    private fun __lambda__1__freeze_caller(x: &mut u64,i: u64) {
+        x = Add<u64>(Add<u64>(Deref(x), retained_mut_capture::read(Freeze(false)(x))), i)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Mul(Old<u64>($t0), 2), $t1));
+    }
+
+    private fun __lambda__1__param_caller(x: &mut u64,i: u64) {
+        x = Add<u64>(Deref(x), i)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Old<u64>($t0), $t1));
+    }
+
+    private fun __lambda__1__receiver_caller(n: &mut u64,_x: u64) {
+        {
+          let $t: u64 = 1;
+          n = Add<u64>(Deref(n), $t)
+        }
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Old<u64>($t0), 1));
+    }
+
+} // end 0x42::retained_mut_capture
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::retained_mut_capture {
+    struct S has copy, drop {
+        x: u64,
+        y: u64,
+    }
+    struct V has drop {
+        items: vector<u64>,
+    }
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+
+    spec call_once(f: |u64|) {
+        pragma opaque = true;
+        ensures ensures_of<f>(1);
+    }
+
+    fun caller(): u64 {
+        let x = 0;
+        call_once({
+            let a = &mut x;
+            |x_1| lambda__1__caller(a, x_1)
+        });
+        x
+    }
+
+    spec caller(): u64 {
+        ensures result == 1;
+    }
+
+    inline fun count(self: &V, f: |u64|) {
+        f(1)
+    }
+
+    spec count(self: &V, f: |u64|) {
+        pragma opaque = true;
+        ensures ensures_of<f>(1);
+    }
+
+    fun field_caller(): u64 {
+        let s = S{x: 1, y: 7};
+        call_once({
+            let a = &mut s;
+            |x| lambda__1__field_caller(a, x)
+        });
+        s.x + s.y
+    }
+
+    spec field_caller(): u64 {
+        ensures result == 9;
+    }
+
+    fun freeze_caller(): u64 {
+        let x = 1;
+        call_once({
+            let a = &mut x;
+            |x_1| lambda__1__freeze_caller(a, x_1)
+        });
+        x
+    }
+
+    spec freeze_caller(): u64 {
+        ensures result == 3;
+    }
+
+    fun param_caller(x: u64): u64 {
+        call_once({
+            let a = &mut x;
+            |x_1| lambda__1__param_caller(a, x_1)
+        });
+        x
+    }
+
+    spec param_caller(x: u64): u64 {
+        requires x < 1000;
+        ensures result == x + 1;
+    }
+
+    fun read(r: &u64): u64 {
+        *r
+    }
+
+    spec read(r: &u64): u64 {
+        ensures result == r;
+    }
+
+    fun receiver_caller(v: &V): u64 {
+        let n = 0;
+        count(v, {
+            let a = &mut n;
+            |x| lambda__1__receiver_caller(a, x)
+        });
+        n
+    }
+
+    spec receiver_caller(v: &V): u64 {
+        ensures result == 1;
+    }
+
+    fun lambda__1__caller(x: &mut u64, i: u64) {
+        *x = *x + i
+    }
+
+    spec lambda__1__caller(x: &mut u64, i: u64) {
+        ensures x == old(x) + i;
+    }
+
+    fun lambda__1__field_caller(s: &mut S, i: u64) {
+        s.x = (*s).x + i
+    }
+
+    spec lambda__1__field_caller(s: &mut S, i: u64) {
+        ensures s.x == old(s).x + i;
+        ensures s.y == old(s).y;
+    }
+
+    fun lambda__1__freeze_caller(x: &mut u64, i: u64) {
+        *x = *x + read(x) + i
+    }
+
+    spec lambda__1__freeze_caller(x: &mut u64, i: u64) {
+        ensures x == old(x) * 2 + i;
+    }
+
+    fun lambda__1__param_caller(x: &mut u64, i: u64) {
+        *x = *x + i
+    }
+
+    spec lambda__1__param_caller(x: &mut u64, i: u64) {
+        ensures x == old(x) + i;
+    }
+
+    fun lambda__1__receiver_caller(n: &mut u64, _x: u64) {
+        let _t = 1;
+        *n = *n + _t
+    }
+
+    spec lambda__1__receiver_caller(n: &mut u64, _x: u64) {
+        ensures n == old(n) + 1;
+    }
+
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::retained_mut_capture {
+    struct S {
+        x: u64,
+        y: u64,
+    }
+    struct V {
+        items: vector<u64>,
+    }
+    private inline fun call_once(f: |u64|) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t0, 1);
+    }
+
+    private fun caller(): u64 {
+        {
+          let x: u64 = 0;
+          retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__caller(Borrow(Mutable)(x)));
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
+    private inline fun count(self: &V,f: |u64|) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t1, 1);
+    }
+
+    private fun field_caller(): u64 {
+        {
+          let s: S = pack retained_mut_capture::S(1, 7);
+          retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__field_caller(Borrow(Mutable)(s)));
+          Add<u64>(select retained_mut_capture::S.x<S>(s), select retained_mut_capture::S.y<S>(s))
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 9);
+    }
+
+    private fun freeze_caller(): u64 {
+        {
+          let x: u64 = 1;
+          retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__freeze_caller(Borrow(Mutable)(x)));
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 3);
+    }
+
+    private fun param_caller(x: u64): u64 {
+        retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__param_caller(Borrow(Mutable)(x)));
+        x
+    }
+    spec {
+      requires Lt($t0, 1000);
+      ensures Eq<u64>(result0(), Add($t0, 1));
+    }
+
+    private fun read(r: &u64): u64 {
+        Deref(r)
+    }
+    spec {
+      ensures Eq<u64>(result0(), $t0);
+    }
+
+    private fun receiver_caller(v: &V): u64 {
+        {
+          let n: u64 = 0;
+          retained_mut_capture::count(v, closure#1retained_mut_capture::__lambda__1__receiver_caller(Borrow(Mutable)(n)));
+          n
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
+    private fun __lambda__1__caller(x: &mut u64,i: u64) {
+        x = Add<u64>(Deref(x), i)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Old<u64>($t0), $t1));
+    }
+
+    private fun __lambda__1__field_caller(s: &mut S,i: u64) {
+        select retained_mut_capture::S.x<S>(s) = Add<u64>(select retained_mut_capture::S.x<S>(Deref(s)), i)
+    }
+    spec {
+      ensures Eq<u64>(select retained_mut_capture::S.x<0x42::retained_mut_capture::S>($t0), Add(select retained_mut_capture::S.x<0x42::retained_mut_capture::S>(Old<0x42::retained_mut_capture::S>($t0)), $t1));
+      ensures Eq<u64>(select retained_mut_capture::S.y<0x42::retained_mut_capture::S>($t0), select retained_mut_capture::S.y<0x42::retained_mut_capture::S>(Old<0x42::retained_mut_capture::S>($t0)));
+    }
+
+    private fun __lambda__1__freeze_caller(x: &mut u64,i: u64) {
+        x = Add<u64>(Add<u64>(Deref(x), retained_mut_capture::read(Freeze(false)(x))), i)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Mul(Old<u64>($t0), 2), $t1));
+    }
+
+    private fun __lambda__1__param_caller(x: &mut u64,i: u64) {
+        x = Add<u64>(Deref(x), i)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Old<u64>($t0), $t1));
+    }
+
+    private fun __lambda__1__receiver_caller(n: &mut u64,_x: u64) {
+        n = Add<u64>(Deref(n), 1)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Old<u64>($t0), 1));
+    }
+
+} // end 0x42::retained_mut_capture
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x42::retained_mut_capture
+struct S has copy + drop
+  x: u64
+  y: u64
+
+struct V has drop
+  items: vector<u64>
+
+// Function definition at index 0
+fun call_once(l0: |u64|)
+    ld_u64 1
+    move_loc l0
+    call_closure <|u64|>
+    ret
+
+// Function definition at index 1
+fun caller(): u64
+    local l0: u64
+    ld_u64 0
+    st_loc l0
+    mut_borrow_loc l0
+    pack_closure __lambda__1__caller, 1
+    call call_once
+    // @5
+    move_loc l0
+    ret
+
+// Function definition at index 2
+fun count(l0: &V, l1: |u64|)
+    ld_u64 1
+    move_loc l0
+    pop
+    move_loc l1
+    call_closure <|u64|>
+    // @5
+    ret
+
+// Function definition at index 3
+fun field_caller(): u64
+    local l0: S
+    ld_u64 1
+    ld_u64 7
+    pack S
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    pack_closure __lambda__1__field_caller, 1
+    call call_once
+    borrow_loc l0
+    borrow_field S, x
+    read_ref
+    // @10
+    borrow_loc l0
+    borrow_field S, y
+    read_ref
+    add
+    ret
+
+// Function definition at index 4
+fun freeze_caller(): u64
+    local l0: u64
+    ld_u64 1
+    st_loc l0
+    mut_borrow_loc l0
+    pack_closure __lambda__1__freeze_caller, 1
+    call call_once
+    // @5
+    move_loc l0
+    ret
+
+// Function definition at index 5
+fun param_caller(l0: u64): u64
+    mut_borrow_loc l0
+    pack_closure __lambda__1__param_caller, 1
+    call call_once
+    move_loc l0
+    ret
+
+// Function definition at index 6
+fun read(l0: &u64): u64
+    move_loc l0
+    read_ref
+    ret
+
+// Function definition at index 7
+fun receiver_caller(l0: &V): u64
+    local l1: u64
+    ld_u64 0
+    st_loc l1
+    move_loc l0
+    mut_borrow_loc l1
+    pack_closure __lambda__1__receiver_caller, 1
+    // @5
+    call count
+    move_loc l1
+    ret
+
+// Function definition at index 8
+fun __lambda__1__caller(l0: &mut u64, l1: u64)
+    copy_loc l0
+    read_ref
+    move_loc l1
+    add
+    move_loc l0
+    // @5
+    write_ref
+    ret
+
+// Function definition at index 9
+fun __lambda__1__field_caller(l0: &mut S, l1: u64)
+    local l2: S
+    copy_loc l0
+    read_ref
+    st_loc l2
+    borrow_loc l2
+    borrow_field S, x
+    // @5
+    read_ref
+    move_loc l1
+    add
+    move_loc l0
+    mut_borrow_field S, x
+    // @10
+    write_ref
+    ret
+
+// Function definition at index 10
+fun __lambda__1__freeze_caller(l0: &mut u64, l1: u64)
+    copy_loc l0
+    read_ref
+    copy_loc l0
+    freeze_ref
+    call read
+    // @5
+    add
+    move_loc l1
+    add
+    move_loc l0
+    write_ref
+    // @10
+    ret
+
+// Function definition at index 11
+fun __lambda__1__param_caller(l0: &mut u64, l1: u64)
+    copy_loc l0
+    read_ref
+    move_loc l1
+    add
+    move_loc l0
+    // @5
+    write_ref
+    ret
+
+// Function definition at index 12
+fun __lambda__1__receiver_caller(l0: &mut u64, l1: u64)
+    copy_loc l0
+    read_ref
+    ld_u64 1
+    add
+    move_loc l0
+    // @5
+    write_ref
+    ret
+
+
+============ bytecode verification skipped (verify mode) ====

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.exp
@@ -1,0 +1,100 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::retained_mut_capture_err {
+    private inline fun call_once(f: |u64|) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t0, 1);
+    }
+
+    private fun tuple_caller(): u64 {
+        {
+          let x: u64 = 0;
+          {
+            let y: u64 = 0;
+            {
+              let (): ();
+              {
+                let (i: u64): (u64) = Tuple(1);
+                (x: u64, y: u64): (u64, u64) = Tuple(i, i)
+              }
+            };
+            Add<u64>(x, y)
+          }
+        }
+    }
+} // end 0x42::retained_mut_capture_err
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::retained_mut_capture_err {
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+
+    spec call_once(f: |u64|) {
+        pragma opaque = true;
+        ensures ensures_of<f>(1);
+    }
+
+    fun tuple_caller(): u64 {
+        let x = 0;
+        let y = 0;
+        {
+            let ();
+            let i = 1;
+            (x,y) = (i, i)
+        };
+        x + y
+    }
+}
+
+
+Diagnostics:
+warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
+   ┌─ tests/inline-opaque/retained_mut_capture_err.move:17:17
+   │
+17 │         let x = 0;
+   │                 ^
+
+warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+   ┌─ tests/inline-opaque/retained_mut_capture_err.move:18:17
+   │
+18 │         let y = 0;
+   │                 ^
+
+// -- Model dump before second bytecode pipeline
+module 0x42::retained_mut_capture_err {
+    private inline fun call_once(f: |u64|) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t0, 1);
+    }
+
+    private fun tuple_caller(): u64 {
+        {
+          let x: u64 = 0;
+          {
+            let y: u64 = 0;
+            (x: u64, y: u64): (u64, u64) = Tuple(1, 1);
+            Add<u64>(x, y)
+          }
+        }
+    }
+} // end 0x42::retained_mut_capture_err
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x42::retained_mut_capture_err
+// Function definition at index 0
+fun tuple_caller(): u64
+    local l0: u64
+    local l1: u64
+    ld_u64 1
+    ld_u64 1
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.move
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.move
@@ -1,0 +1,22 @@
+// Restrictions on modifying captured variables in lambdas passed to retained
+// inline-opaque functions: converted variables cannot appear in tuple
+// assignments. (A mutating lambda for a `copy`-requiring function parameter is
+// rejected by the closure checker; see the prover test suite.)
+module 0x42::retained_mut_capture_err {
+
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Rejected: converted variable in a tuple assignment.
+    fun tuple_caller(): u64 {
+        let x = 0;
+        let y = 0;
+        call_once(|i| (x, y) = (i, i));
+        x + y
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.verify.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.verify.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: modified captured variables are not yet supported in tuple or struct assignments inside of a lambda
+   ┌─ tests/inline-opaque/retained_mut_capture_err.move:19:23
+   │
+19 │         call_once(|i| (x, y) = (i, i));
+   │                       ^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.exp
@@ -1,5 +1,8 @@
 // -- Model dump before first bytecode pipeline
 module 0x42::retained_mut_ref_capture {
+    struct R {
+        value: u64,
+    }
     private inline fun apply(f: |u64|u64,x: u64): u64 {
         (f)(x)
     }
@@ -7,19 +10,72 @@ module 0x42::retained_mut_ref_capture {
       ensures ensures_of($t0, $t1, result0());
     }
 
+    private inline fun apply_copy(f: |u64|u64 has copy,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures ensures_of($t0, $t1, result0());
+    }
+
+    private inline fun apply_ref(f: |u64|&mut u64,x: u64): u64 {
+        Deref((f)(x))
+    }
+    spec {
+    }
+
+    private fun copy_mut_capture(r: &mut u64): u64 {
+        {
+          let (x: u64): (u64) = Tuple(5);
+          {
+            let (y: u64): (u64) = Tuple(x);
+            r = Add<u64>(Deref(r), y);
+            Deref(r)
+          }
+        }
+    }
+    private fun deref_helper(r: &mut u64,y: u64): &mut u64 {
+        r = Add<u64>(Deref(r), y);
+        r
+    }
     private fun direct_mut_capture(r: &mut u64): u64 {
         {
           let (x: u64): (u64) = Tuple(5);
           {
             let (y: u64): (u64) = Tuple(x);
-            Add<u64>(y, Deref(r))
+            r = Add<u64>(Deref(r), y);
+            Deref(r)
           }
+        }
+    }
+    private fun global_rooted_capture(a: address): u64 {
+        {
+          let r: &mut u64 = Borrow(Mutable)(select retained_mut_ref_capture::R.value<R>(BorrowGlobal(Mutable)<R>(a)));
+          {
+            let (x: u64): (u64) = Tuple(5);
+            {
+              let (y: u64): (u64) = Tuple(x);
+              r = Add<u64>(Deref(r), y);
+              Deref(r)
+            }
+          }
+        }
+    }
+    private fun ret_mut_capture(r: &mut u64): u64 {
+        {
+          let (x: u64): (u64) = Tuple(5);
+          Deref({
+            let (y: u64): (u64) = Tuple(x);
+            retained_mut_ref_capture::deref_helper(r, y)
+          })
         }
     }
 } // end 0x42::retained_mut_ref_capture
 
 // -- Sourcified model before first bytecode pipeline
 module 0x42::retained_mut_ref_capture {
+    struct R has key {
+        value: u64,
+    }
     inline fun apply(f: |u64|u64, x: u64): u64 {
         f(x)
     }
@@ -29,15 +85,60 @@ module 0x42::retained_mut_ref_capture {
         ensures ensures_of<f>(x, result);
     }
 
+    inline fun apply_copy(f: |u64|u64 has copy, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_copy(f: |u64|u64 has copy, x: u64): u64 {
+        pragma opaque = true;
+        ensures ensures_of<f>(x, result);
+    }
+
+    inline fun apply_ref(f: |u64|&mut u64, x: u64): u64 {
+        *f(x)
+    }
+
+    spec apply_ref(f: |u64|&mut u64, x: u64): u64 {
+        pragma opaque = true;
+    }
+
+    fun copy_mut_capture(r: &mut u64): u64 {
+        let x = 5;
+        let y = x;
+        *r = *r + y;
+        *r
+    }
+    fun deref_helper(r: &mut u64, y: u64): &mut u64 {
+        *r = *r + y;
+        r
+    }
     fun direct_mut_capture(r: &mut u64): u64 {
         let x = 5;
         let y = x;
-        y + *r
+        *r = *r + y;
+        *r
+    }
+    fun global_rooted_capture(a: address): u64 {
+        let r = &mut borrow_global_mut<R>(a).value;
+        let x = 5;
+        let y = x;
+        *r = *r + y;
+        *r
+    }
+    fun ret_mut_capture(r: &mut u64): u64 {
+        let x = 5;
+        *{
+            let y = x;
+            deref_helper(r, y)
+        }
     }
 }
 
 // -- Model dump before second bytecode pipeline
 module 0x42::retained_mut_ref_capture {
+    struct R {
+        value: u64,
+    }
     private inline fun apply(f: |u64|u64,x: u64): u64 {
         (f)(x)
     }
@@ -45,8 +146,40 @@ module 0x42::retained_mut_ref_capture {
       ensures ensures_of($t0, $t1, result0());
     }
 
+    private inline fun apply_copy(f: |u64|u64 has copy,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures ensures_of($t0, $t1, result0());
+    }
+
+    private inline fun apply_ref(f: |u64|&mut u64,x: u64): u64 {
+        Deref((f)(x))
+    }
+    spec {
+    }
+
+    private fun copy_mut_capture(r: &mut u64): u64 {
+        r = Add<u64>(Deref(r), 5);
+        Deref(r)
+    }
+    private fun deref_helper(r: &mut u64,y: u64): &mut u64 {
+        r = Add<u64>(Deref(r), y);
+        r
+    }
     private fun direct_mut_capture(r: &mut u64): u64 {
-        Add<u64>(5, Deref(r))
+        r = Add<u64>(Deref(r), 5);
+        Deref(r)
+    }
+    private fun global_rooted_capture(a: address): u64 {
+        {
+          let r: &mut u64 = Borrow(Mutable)(select retained_mut_ref_capture::R.value<R>(BorrowGlobal(Mutable)<R>(a)));
+          r = Add<u64>(Deref(r), 5);
+          Deref(r)
+        }
+    }
+    private fun ret_mut_capture(r: &mut u64): u64 {
+        Deref(retained_mut_ref_capture::deref_helper(r, 5))
     }
 } // end 0x42::retained_mut_ref_capture
 
@@ -54,12 +187,72 @@ module 0x42::retained_mut_ref_capture {
 ============ disassembled file-format ==================
 // Bytecode version v10
 module 0x42::retained_mut_ref_capture
+struct R has key
+  value: u64
+
 // Function definition at index 0
-fun direct_mut_capture(l0: &mut u64): u64
+fun copy_mut_capture(l0: &mut u64): u64
+    copy_loc l0
+    read_ref
     ld_u64 5
+    add
+    copy_loc l0
+    // @5
+    write_ref
     move_loc l0
     read_ref
+    ret
+
+// Function definition at index 1
+fun deref_helper(l0: &mut u64, l1: u64): &mut u64
+    copy_loc l0
+    read_ref
+    move_loc l1
     add
+    copy_loc l0
+    // @5
+    write_ref
+    move_loc l0
+    ret
+
+// Function definition at index 2
+fun direct_mut_capture(l0: &mut u64): u64
+    copy_loc l0
+    read_ref
+    ld_u64 5
+    add
+    copy_loc l0
+    // @5
+    write_ref
+    move_loc l0
+    read_ref
+    ret
+
+// Function definition at index 3
+fun global_rooted_capture(l0: address): u64 acquires R
+    local l1: &mut u64
+    move_loc l0
+    mut_borrow_global R
+    mut_borrow_field R, value
+    st_loc l1
+    copy_loc l1
+    // @5
+    read_ref
+    ld_u64 5
+    add
+    copy_loc l1
+    write_ref
+    // @10
+    move_loc l1
+    read_ref
+    ret
+
+// Function definition at index 4
+fun ret_mut_capture(l0: &mut u64): u64
+    move_loc l0
+    ld_u64 5
+    call deref_helper
+    read_ref
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.move
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.move
@@ -1,9 +1,15 @@
 // In verify mode, a lambda passed to a retained inline-opaque function may capture
-// only immutable references; capturing a `&mut` is rejected by the closure checker,
-// since the prover cannot model writes through a captured mutable reference. In
-// normal compilation the inline function is expanded, so the lambda is never lifted
-// into a closure and no capture arises.
+// mutable references rooted anywhere (locals, parameters, or global storage). The
+// closure must not require the `copy` ability (a mutable capture makes the value
+// linear). An inline function with a `&mut`-returning function parameter does not
+// get the retained treatment at all — its opaque spec is not honored and calls are
+// expanded, so no lambda is lifted. In normal compilation every inline function is
+// expanded, so no capture arises anywhere.
 module 0x42::retained_mut_ref_capture {
+
+    struct R has key {
+        value: u64,
+    }
 
     inline fun apply(f: |u64| u64, x: u64): u64 {
         f(x)
@@ -13,7 +19,46 @@ module 0x42::retained_mut_ref_capture {
         ensures ensures_of<f>(x, result);
     }
 
+    inline fun apply_copy(f: |u64| u64 has copy, x: u64): u64 {
+        f(x)
+    }
+    spec apply_copy {
+        pragma opaque;
+        ensures ensures_of<f>(x, result);
+    }
+
+    inline fun apply_ref(f: |u64| &mut u64, x: u64): u64 {
+        *f(x)
+    }
+    spec apply_ref {
+        pragma opaque;
+    }
+
+    /// Admitted: capture of a `&mut` parameter in the retained direct-argument position.
     fun direct_mut_capture(r: &mut u64): u64 {
-        apply(|y| y + *r, 5)
+        apply(|y| { *r = *r + y; *r }, 5)
+    }
+
+    /// Admitted: capture rooted in global storage.
+    fun global_rooted_capture(a: address): u64 {
+        let r = &mut R[a].value;
+        apply(|y| { *r = *r + y; *r }, 5)
+    }
+
+    /// Rejected: closure requiring the `copy` ability.
+    fun copy_mut_capture(r: &mut u64): u64 {
+        apply_copy(|y| { *r = *r + y; *r }, 5)
+    }
+
+    fun deref_helper(r: &mut u64, y: u64): &mut u64 {
+        *r = *r + y;
+        r
+    }
+
+    /// Admitted via expansion: `apply_ref` has a `&mut`-returning function
+    /// parameter, so it is not retained; the call is expanded and the lambda
+    /// inlined instead of lifted.
+    fun ret_mut_capture(r: &mut u64): u64 {
+        apply_ref(|y| deref_helper(r, y), 5)
     }
 }

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.verify.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.verify.exp
@@ -1,7 +1,9 @@
 
 Diagnostics:
-error: captured value cannot be a mutable reference, but has type `&mut u64`; in verification, lambdas may capture only immutable references
-   ┌─ tests/inline-opaque/retained_mut_ref_capture.move:17:24
+error: cannot capture a mutable reference in a closure requiring the `copy` ability
+   ┌─ tests/inline-opaque/retained_mut_ref_capture.move:50:32
    │
-17 │         apply(|y| y + *r, 5)
-   │                        ^
+50 │         apply_copy(|y| { *r = *r + y; *r }, 5)
+   │                                ^
+   │
+   = expected function type: `|u64|u64 has copy`

--- a/third_party/move/move-model/bytecode/src/borrow_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/borrow_analysis.rs
@@ -24,7 +24,11 @@ use move_model::{
     ty::Type,
     well_known::VECTOR_BORROW_MUT,
 };
-use std::{borrow::BorrowMut, collections::BTreeMap, fmt};
+use std::{
+    borrow::BorrowMut,
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
 
 #[derive(AbstractDomain, Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Default)]
 pub struct BorrowInfo {
@@ -590,6 +594,10 @@ struct BorrowAnalysis<'a> {
     livevar_annotation: &'a LiveVarAnnotation,
     targets: &'a FunctionTargetsHolder,
     borrow_natives: &'a Vec<String>,
+    /// Temps holding closure values which capture mutable references. Such a value
+    /// carries the captured mutations and enters the borrow graph as a
+    /// `BorrowNode::Reference` although its type is a function type.
+    carrying_temps: BTreeSet<TempIndex>,
 }
 
 impl<'a> BorrowAnalysis<'a> {
@@ -608,6 +616,7 @@ impl<'a> BorrowAnalysis<'a> {
             livevar_annotation,
             targets,
             borrow_natives,
+            carrying_temps: mut_capture_carrying_temps(func_target, func_target.get_bytecode()),
         }
     }
 
@@ -655,6 +664,40 @@ impl<'a> BorrowAnalysis<'a> {
     }
 }
 
+/// Computes the temps which hold closure values capturing mutable references,
+/// closed under assignment propagation. The code is passed separately since some
+/// callers process it detached from the function data.
+pub fn mut_capture_carrying_temps(
+    func_target: &FunctionTarget,
+    code: &[Bytecode],
+) -> BTreeSet<TempIndex> {
+    let mut result = BTreeSet::new();
+    loop {
+        let count = result.len();
+        for bc in code {
+            match bc {
+                Bytecode::Call(_, dests, Operation::Closure(..), srcs, _) => {
+                    if srcs
+                        .iter()
+                        .any(|src| func_target.get_local_type(*src).is_mutable_reference())
+                    {
+                        result.insert(dests[0]);
+                    }
+                },
+                Bytecode::Assign(_, dest, src, _) => {
+                    if result.contains(src) {
+                        result.insert(*dest);
+                    }
+                },
+                _ => {},
+            }
+        }
+        if result.len() == count {
+            return result;
+        }
+    }
+}
+
 impl TransferFunctions for BorrowAnalysis<'_> {
     type State = BorrowInfo;
 
@@ -668,6 +711,19 @@ impl TransferFunctions for BorrowAnalysis<'_> {
             .expect("livevar annotation");
 
         match instr {
+            Assign(_, dest, src, kind) if self.carrying_temps.contains(src) => {
+                // Assignment of a closure value carrying captured mutations: the
+                // mutations move with the value. Model as a direct borrow edge so
+                // write-backs chain through the new temp. Copies are excluded
+                // since they would duplicate live mutations.
+                assert!(
+                    !matches!(kind, AssignKind::Copy),
+                    "copy of a closure value carrying captured mutations"
+                );
+                let dest_node = BorrowNode::Reference(*dest);
+                state.add_node(dest_node.clone());
+                state.add_edge(BorrowNode::Reference(*src), dest_node, BorrowEdge::Direct);
+            },
             Assign(_, dest, src, kind) => {
                 let dest_node = self.borrow_node(*dest);
                 state.add_node(dest_node.clone());
@@ -793,6 +849,34 @@ impl TransferFunctions for BorrowAnalysis<'_> {
                             dests,
                         );
                     },
+                    Closure(mid, fid, targs, mask)
+                        if livevar_annotation_at.after.contains(&dests[0])
+                            && srcs.iter().any(|src| {
+                                self.func_target.get_local_type(*src).is_mutable_reference()
+                            }) =>
+                    {
+                        // A closure capturing mutable references becomes a carrier of
+                        // the mutations: the closure temp enters the borrow graph
+                        // borrowing from each captured reference via a `Capture` edge,
+                        // so the mutations are written back when the closure dies.
+                        // The srcs are exactly the captured operands in mask order, so
+                        // the src position is the capture slot index.
+                        let dest_node = BorrowNode::Reference(dests[0]);
+                        state.add_node(dest_node.clone());
+                        for (slot, src) in srcs.iter().enumerate() {
+                            if self.func_target.get_local_type(*src).is_mutable_reference() {
+                                state.add_edge(
+                                    BorrowNode::Reference(*src),
+                                    dest_node.clone(),
+                                    BorrowEdge::Capture(
+                                        mid.qualified_inst(*fid, targs.clone()),
+                                        *mask,
+                                        slot,
+                                    ),
+                                );
+                            }
+                        }
+                    },
                     Invoke => {
                         // For Invoke, we have no function summaries and do not know the
                         // borrow relation. Directly draw the `Invoke` edges. We only need to
@@ -842,6 +926,10 @@ impl TransferFunctions for BorrowAnalysis<'_> {
             if self.func_target.get_local_type(*idx).is_reference() {
                 let node = self.borrow_node(*idx);
                 state.del_node(&node);
+            } else if self.carrying_temps.contains(idx) {
+                // Carrying closure temps live in the graph as `Reference` nodes
+                // although their type is a function type.
+                state.del_node(&BorrowNode::Reference(*idx));
             }
         }
     }

--- a/third_party/move/move-model/bytecode/src/livevar_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/livevar_analysis.rs
@@ -7,6 +7,7 @@
 // computation of new Destroy instructions.
 
 use crate::{
+    borrow_analysis::mut_capture_carrying_temps,
     dataflow_analysis::{DataflowAnalysis, TransferFunctions},
     dataflow_domains::{AbstractDomain, JoinResult},
     function_target::{FunctionData, FunctionTarget},
@@ -190,6 +191,10 @@ struct LiveVarAnalysis<'a> {
     func_target: &'a FunctionTarget<'a>,
     next_label_id: usize,
     next_attr_id: usize,
+    /// Temps holding closure values which capture mutable references. Like plain
+    /// references, they must be dropped explicitly along branch edges so that the
+    /// captured mutations are written back (set by `transform_code`).
+    carrying_temps: BTreeSet<TempIndex>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
@@ -221,6 +226,7 @@ impl<'a> LiveVarAnalysis<'a> {
             func_target,
             next_label_id,
             next_attr_id,
+            carrying_temps: BTreeSet::new(),
         }
     }
 
@@ -229,6 +235,7 @@ impl<'a> LiveVarAnalysis<'a> {
         annotations: &BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset>,
         mut code: Vec<Bytecode>,
     ) -> Vec<Bytecode> {
+        self.carrying_temps = mut_capture_carrying_temps(self.func_target, &code);
         let label_to_code_offset = Bytecode::label_offsets(&code);
         let mut transformed_code = vec![];
         let mut new_bytecodes = vec![];
@@ -392,7 +399,8 @@ impl<'a> LiveVarAnalysis<'a> {
             .after
             .iter()
             .filter(|x| {
-                self.func_target.get_local_type(**x).is_reference()
+                (self.func_target.get_local_type(**x).is_reference()
+                    || self.carrying_temps.contains(x))
                     && !annotations[&dest_code_offset].before.contains(x)
             })
             .copied()

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -97,6 +97,9 @@ pub enum HavocKind {
     MutationValue,
     /// Havoc everything in a mutation
     MutationAll,
+    /// Havoc the value parts of all mutations captured in a closure value, keeping
+    /// their pointers and all other captured values unchanged
+    CaptureValues,
 }
 
 /// A constant value.
@@ -453,6 +456,11 @@ pub enum BorrowEdge {
     Index(IndexEdgeKind),
     /// Borrow via a function value, unknown structure
     Invoke,
+    /// Mutation held in a capture slot of a closure value constructed from the given
+    /// function with the given mask. The index identifies the slot among the captured
+    /// operands. The mutation is moved into the slot when the closure is packed and
+    /// moved back out by the write-back when the closure dies.
+    Capture(QualifiedInstId<FunId>, ClosureMask, usize),
     /// Composed sequence of edges.
     Hyper(Vec<BorrowEdge>),
 }
@@ -470,6 +478,9 @@ impl BorrowEdge {
         match self {
             Self::Field(qid, variant, offset) => {
                 Self::Field(qid.instantiate_ref(params), variant.clone(), *offset)
+            },
+            Self::Capture(qid, mask, slot) => {
+                Self::Capture(qid.instantiate_ref(params), *mask, *slot)
             },
             Self::Hyper(edges) => {
                 let new_edges = edges.iter().map(|e| e.instantiate(params)).collect();
@@ -1432,6 +1443,7 @@ impl fmt::Display for OperationDisplay<'_> {
                     HavocKind::Value => "val",
                     HavocKind::MutationValue => "mut",
                     HavocKind::MutationAll => "mut_all",
+                    HavocKind::CaptureValues => "captures",
                 })?;
             },
             HavocGlobal(mid, sid, targs) => {
@@ -1638,6 +1650,10 @@ impl std::fmt::Display for BorrowEdgeDisplay<'_> {
             Index(_) => write!(f, "[]"),
             Direct => write!(f, "@"),
             Invoke => write!(f, ">"),
+            Capture(qid, _, slot) => {
+                let fun_env = self.env.get_function(qid.to_qualified_id());
+                write!(f, "capture[{}]({})", slot, fun_env.get_full_name_str())
+            },
             Hyper(es) => {
                 write!(
                     f,

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -5546,8 +5546,30 @@ impl<'env> FunctionEnv<'env> {
     /// sites) because the model is built for verification and the function is opaque.
     /// Such functions act like regular opaque functions in the prover: their spec is used
     /// at call sites instead of their body.
+    ///
+    /// The opaque spec is not honored — and the function expanded like any inline
+    /// function — if a function-typed parameter returns a mutable reference.
+    /// TODO(#20268): the retained treatment does not support `&mut`-returning function
+    /// parameters when lambdas capture mutable references (e.g. the accessor pattern
+    /// `|i| &mut v[i]` capturing `&mut v`): an invocation could hand back a reference
+    /// rooting inside a capture slot, which the carried-mutation model cannot express
+    /// yet. Expansion gives such calls precise verification instead. See the issue
+    /// for a layered plan to support this in the retained treatment.
     pub fn is_inline_opaque_retained(&self) -> bool {
-        self.module_env.env.is_verify_mode() && self.is_inline() && self.is_opaque()
+        self.module_env.env.is_verify_mode()
+            && self.is_inline()
+            && self.is_opaque()
+            && !self.get_parameter_types().iter().any(|ty| {
+                if let Type::Fun(_, result, _) = ty {
+                    result
+                        .clone()
+                        .flatten()
+                        .iter()
+                        .any(|t| t.is_mutable_reference())
+                } else {
+                    false
+                }
+            })
     }
 
     /// Return true if this is a lemma function (synthesized from a lemma declaration).

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -62,6 +62,19 @@ pub struct SpecTranslator<'a, 'b, T: ExpGenerator<'a>> {
     /// (function entry), so all saved memories can share one label. Using a single label
     /// avoids conflicts when multiple invariants/conditions reference overlapping memory types.
     shared_old_label: Option<MemoryLabel>,
+    /// Node ids of temporaries which must not be routed through `save_param` in
+    /// post-state context. Used for the live post-state clones of function values
+    /// appended to behavioral predicates (see `wrap_mut_ref_bp_inputs`).
+    no_save_nodes: BTreeSet<NodeId>,
+    /// Whether we are translating the right-hand side of an `update` clause.
+    in_update: bool,
+    /// Suppress appending live fun-value clones to behavioral predicates in
+    /// `wrap_mut_ref_bp_inputs`. The clone is an artifact of the verification
+    /// translation (the Boogie backend consumes it as the trailing `f_post`
+    /// slot); in spec-inference translations the canonical user-facing form
+    /// must stay clone-free, since translated expressions can end up in
+    /// inferred specs which are sourcified as ordinary Move code.
+    omit_fun_clones: bool,
 }
 
 /// A flattened proof action produced by translating a structured `Proof` tree.
@@ -314,6 +327,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     pub fn translate_fun_spec(
         auto_trace: bool,
         for_call: bool,
+        omit_fun_clones: bool,
         builder: &'b mut T,
         fun_env: &'b FunctionEnv<'a>,
         type_args: &[Type],
@@ -333,6 +347,9 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             let_locals: Default::default(),
             in_old: false,
             shared_old_label: None,
+            no_save_nodes: BTreeSet::new(),
+            in_update: false,
+            omit_fun_clones,
         };
         translator.translate_spec(for_call);
         translator.result
@@ -359,6 +376,9 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             let_locals: Default::default(),
             in_old: false,
             shared_old_label: None,
+            no_save_nodes: BTreeSet::new(),
+            in_update: false,
+            omit_fun_clones: false,
         };
         // Clone invariants so `inst` lives for the entire loop
         let invariants = invariants.collect_vec();
@@ -378,6 +398,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     pub fn translate_inline_property(
         loc: &Loc,
         auto_trace: bool,
+        omit_fun_clones: bool,
         builder: &'b mut T,
         prop: &Exp,
     ) -> (TranslatedSpec, Exp) {
@@ -395,6 +416,9 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             let_locals: Default::default(),
             in_old: false,
             shared_old_label: None,
+            no_save_nodes: BTreeSet::new(),
+            in_update: false,
+            omit_fun_clones,
         };
 
         // Handle updating of global spec variables
@@ -480,7 +504,9 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             self.in_post_state = false;
             let lhs =
                 self.translate_exp(&self.auto_trace(&cond.loc, &cond.additional_exps[0]), false);
+            self.in_update = true;
             let rhs = self.translate_exp(&self.auto_trace(&cond.loc, &cond.exp), false);
+            self.in_update = false;
             self.result.updates.push((cond.loc.clone(), lhs, rhs));
         }
 
@@ -1015,8 +1041,17 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     /// `Old(...)`-wrapped (triggering `save_param` for the captured pre-state
     /// temp). For `EnsuresOf` and `ResultOf`, a live post-state clone of each
     /// wrapped `&mut T` arg is appended after the existing user-provided
-    /// trailing args (the result slot, if any). Idempotent.
-    fn wrap_mut_ref_bp_inputs(&self, exp: &Exp) -> Exp {
+    /// trailing args (the result slot, if any).
+    ///
+    /// For a stateful function value, a live clone is appended as the final
+    /// trailing arg of `EnsuresOf`/`ResultOf`, exempted from post-state
+    /// saving (the fun input slot itself is routed through the pre-state
+    /// save by the regular post-state handling of value-typed temporaries).
+    /// The Boogie backend emits that clone as the updated fun value for
+    /// function types carrying mutations (mutable reference captures) and
+    /// drops it otherwise, so this is done uniformly for all function
+    /// values. Idempotent.
+    fn wrap_mut_ref_bp_inputs(&mut self, exp: &Exp) -> Exp {
         let env = self.builder.global_env();
         let ExpData::Call(node_id, Operation::Behavior(kind, range), args) = exp.as_ref() else {
             return exp.clone();
@@ -1049,7 +1084,20 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             })
             .collect();
         let post_state_slot_count = wrap_mask.iter().filter(|b| **b).count();
-        if post_state_slot_count == 0 {
+        // The underlying temporary when the fun exp is stateful (possibly
+        // already `Old`-wrapped by a prior pass).
+        let fun_stateful_temp = match fun_exp.as_ref() {
+            ExpData::Temporary(_, idx) => Some(*idx),
+            ExpData::Call(_, Operation::Old, inner) if inner.len() == 1 => {
+                if let ExpData::Temporary(_, idx) = inner[0].as_ref() {
+                    Some(*idx)
+                } else {
+                    None
+                }
+            },
+            _ => None,
+        };
+        if post_state_slot_count == 0 && fun_stateful_temp.is_none() {
             return exp.clone();
         }
 
@@ -1061,14 +1109,26 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
         } else {
             0
         };
-        let augmented_arity = 1
+        let fun_clone_slots =
+            if has_post_slots && fun_stateful_temp.is_some() && !self.omit_fun_clones {
+                1
+            } else {
+                0
+            };
+        // The canonical arity without the fun clone; the user may write this
+        // form explicitly (with post-state slots), so the presence of the
+        // `&mut` post-state clones and of the fun clone is detected
+        // separately by arity.
+        let canonical_arity = 1
             + num_inputs
             + if has_post_slots {
                 result_slots + post_state_slot_count
             } else {
                 0
             };
-        let needs_post_state = has_post_slots && args.len() < augmented_arity;
+        let augmented_arity = canonical_arity + fun_clone_slots;
+        let needs_post_state = has_post_slots && args.len() < canonical_arity;
+        let needs_fun_clone = fun_clone_slots > 0 && args.len() < augmented_arity;
 
         // Idempotent short-circuit when canonical form is already present.
         let all_wrapped = wrap_mask.iter().enumerate().all(|(k, needs_wrap)| {
@@ -1080,7 +1140,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                 Some(ExpData::Call(_, Operation::Old, _))
             )
         });
-        if all_wrapped && !needs_post_state {
+        if all_wrapped && !needs_post_state && !needs_fun_clone {
             return exp.clone();
         }
 
@@ -1114,7 +1174,20 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             for arg in args.iter().skip(1 + num_inputs) {
                 new_args.push(arg.clone());
             }
-            new_args.extend(post_state_clones);
+            if needs_post_state {
+                new_args.extend(post_state_clones);
+            }
+            if needs_fun_clone {
+                if let Some(idx) = fun_stateful_temp {
+                    // Live clone of the fun value, exempted from post-state
+                    // saving so it reads the current (updated) value.
+                    let fun_loc = env.get_node_loc(fun_exp.node_id());
+                    let fun_ty = env.get_node_type(fun_exp.node_id());
+                    let clone_id = env.new_node(fun_loc, fun_ty);
+                    self.no_save_nodes.insert(clone_id);
+                    new_args.push(ExpData::Temporary(clone_id, idx).into_exp());
+                }
+            }
         }
         ExpData::Call(
             *node_id,
@@ -1316,7 +1389,17 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
         // Compute the effective index.
         let mut effective_idx = self.apply_param_substitution(idx);
         let local_type = self.builder.get_local_type(effective_idx);
-        if self.in_old || (self.in_post_state && !local_type.is_mutable_reference()) {
+        // In `update` clauses (translated in pre-state but placed after the call
+        // resp. body), function-typed values are routed through the pre-state save:
+        // a bare reference to a function value means the value as passed. This
+        // matters for values carrying mutable reference captures, whose temp is
+        // updated across calls; the updated value is accessible only through the
+        // trailing clone synthesized by `wrap_mut_ref_bp_inputs`.
+        if (self.in_old
+            || (self.in_post_state && !local_type.is_mutable_reference())
+            || (self.in_update && local_type.is_function()))
+            && !self.no_save_nodes.contains(&id)
+        {
             // We access a param inside of old context, or a value which might have been
             // mutated as we are in the post state. We need to create a temporary
             // to save their value at function entry, and deliver this temporary here.

--- a/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -23,8 +23,10 @@ use move_model::{
     symbol::Symbol,
     ty::{PrimitiveType, ReferenceKind, Type},
 };
-use move_prover_bytecode_pipeline::number_operation::{
-    GlobalNumberOperationState, NumOperation::Bitwise,
+use move_prover_bytecode_pipeline::{
+    mono_analysis,
+    mono_analysis::ClosureInfo,
+    number_operation::{GlobalNumberOperationState, NumOperation::Bitwise},
 };
 use move_stackless_bytecode::{function_target::FunctionTarget, stackless_bytecode::Constant};
 use num::BigUint;
@@ -1258,6 +1260,49 @@ pub fn boogie_closure_pack_name(
     format!("$closure'{}'_{}", fun_name, mask)
 }
 
+/// Return the closure variant infos generated for the datatype of the given function
+/// type, in variant order. The type is matched against MonoInfo via its Boogie name,
+/// so it does not need to be in normalized form.
+pub fn boogie_closure_infos(env: &GlobalEnv, fun_ty: &Type) -> Vec<ClosureInfo> {
+    let mono_info = mono_analysis::get_info(env);
+    let boogie_name = boogie_type(env, fun_ty, false);
+    for (ty, infos) in &mono_info.fun_infos {
+        if boogie_type(env, ty, false) == boogie_name {
+            return infos.iter().cloned().collect();
+        }
+    }
+    vec![]
+}
+
+/// Return the variant index of the closure constructed from `fun` with `mask` within
+/// the datatype generated for the given function type.
+pub fn boogie_closure_variant_index(
+    env: &GlobalEnv,
+    fun_ty: &Type,
+    fun: &QualifiedInstId<FunId>,
+    mask: ClosureMask,
+) -> usize {
+    boogie_closure_infos(env, fun_ty)
+        .iter()
+        .position(|info| &info.fun == fun && info.mask == mask)
+        .expect("closure variant registered in mono info")
+}
+
+/// Return name of the field selector for a capture slot of a closure variant.
+/// `variant_idx` is the position of the variant within the closure infos generated
+/// for the function type's datatype.
+pub fn boogie_closure_capture_field(pos: usize, variant_idx: usize) -> String {
+    format!("p{}_v{}", pos, variant_idx)
+}
+
+/// Returns true if values of the given function type may carry mutations, i.e. the
+/// type has closure variants capturing mutable references.
+pub fn boogie_fun_ty_carries_mutations(env: &GlobalEnv, fun_ty: &Type) -> bool {
+    boogie_closure_infos(env, fun_ty)
+        .iter()
+        .any(|info| !info.mut_capture_slots(env).is_empty())
+}
+
 /// Return name of the datatype constructor for a function parameter variant.
 /// These variants represent function-typed parameters of verification targets.
 pub fn boogie_fun_param_name(
@@ -1456,8 +1501,6 @@ pub fn compute_evaluator_memory_union(
     BTreeSet<QualifiedInstId<StructId>>,
     BTreeSet<QualifiedInstId<StructId>>,
 ) {
-    use move_prover_bytecode_pipeline::mono_analysis;
-
     let mono_info = mono_analysis::get_info(env);
     let boogie_name = boogie_type(env, fun_type, false);
 

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -10,19 +10,21 @@ use crate::{
         boogie_address, boogie_address_blob, boogie_behavioral_eval_fun_name,
         boogie_behavioral_fun_result_name, boogie_behavioral_fun_spec_name,
         boogie_behavioral_result_fun_name, boogie_behavioral_spec_fun_name, boogie_byte_blob,
-        boogie_closure_pack_name, boogie_constant_blob, boogie_debug_track_abort,
+        boogie_closure_capture_field, boogie_closure_infos, boogie_closure_pack_name,
+        boogie_closure_variant_index, boogie_constant_blob, boogie_debug_track_abort,
         boogie_debug_track_local, boogie_debug_track_return, boogie_equality_for_type,
         boogie_field_sel, boogie_field_update, boogie_fun_apply_name, boogie_fun_param_name,
-        boogie_function_name, boogie_int_suffix, boogie_make_vec_from_strings,
-        boogie_modifies_memory_name, boogie_native_spec_fun_name, boogie_num_literal,
-        boogie_num_type_base, boogie_reflection_type_info, boogie_reflection_type_name,
-        boogie_resource_memory_name, boogie_spec_fun_name, boogie_struct_field_name,
-        boogie_struct_field_result_fun_name, boogie_struct_field_spec_fun_name, boogie_struct_name,
-        boogie_struct_variant_name, boogie_temp, boogie_temp_from_suffix, boogie_type,
-        boogie_type_for_struct_field, boogie_type_param, boogie_type_suffix,
-        boogie_type_suffix_for_struct, boogie_type_suffix_for_struct_variant,
-        boogie_variant_field_update, boogie_well_formed_check, boogie_well_formed_expr,
-        compute_evaluator_memory_union, field_bv_flag_global_state, TypeIdentToken,
+        boogie_fun_ty_carries_mutations, boogie_function_name, boogie_int_suffix,
+        boogie_make_vec_from_strings, boogie_modifies_memory_name, boogie_native_spec_fun_name,
+        boogie_num_literal, boogie_num_type_base, boogie_reflection_type_info,
+        boogie_reflection_type_name, boogie_resource_memory_name, boogie_spec_fun_name,
+        boogie_struct_field_name, boogie_struct_field_result_fun_name,
+        boogie_struct_field_spec_fun_name, boogie_struct_name, boogie_struct_variant_name,
+        boogie_temp, boogie_temp_from_suffix, boogie_type, boogie_type_for_struct_field,
+        boogie_type_param, boogie_type_suffix, boogie_type_suffix_for_struct,
+        boogie_type_suffix_for_struct_variant, boogie_variant_field_update,
+        boogie_well_formed_check, boogie_well_formed_expr, compute_evaluator_memory_union,
+        field_bv_flag_global_state, TypeIdentToken,
     },
     options::BoogieOptions,
     spec_translator::{LabelInfo, SpecTranslator},
@@ -98,6 +100,24 @@ enum ApplyFrameAccess {
     WritesAll,
     /// Resource may be written at specific Boogie address expressions only
     WritesAt(Vec<String>),
+}
+
+/// Output layout for a closure variant capturing mutable references in the apply
+/// procedure. The result Skolem of the variant's target carries post-state slots for
+/// all of the target's `&mut` parameters, captured ones included; this struct maps
+/// them onto apply outputs and describes the repack of the closure value.
+struct CaptureOutputs {
+    /// In target `&mut` parameter order: `Some(field)` if the parameter is captured,
+    /// with `field` the Boogie access of its capture slot (a `$Mutation`); `None` if
+    /// non-captured (consuming the next apply result local).
+    mut_slots: Vec<Option<String>>,
+    /// The constructor for repacking the closure value.
+    ctor_name: String,
+    /// Per capture slot in slot order: the Boogie access of the slot and, for
+    /// mutation slots, the index of its post value in the result Skolem tuple.
+    capture_fields: Vec<(String, Option<usize>)>,
+    /// Name of the apply output variable receiving the repacked value.
+    fun_out: String,
 }
 
 pub struct BoogieTranslator<'env> {
@@ -728,9 +748,8 @@ impl<'env> BoogieTranslator<'env> {
                 };
                 emit!(
                     self.writer,
-                    "p{}_v{}: {}",
-                    pos,
-                    idx,
+                    "{}: {}",
+                    boogie_closure_capture_field(pos, idx),
                     boogie_type(self.env, captured_ty, false)
                 )
             }
@@ -905,6 +924,18 @@ impl<'env> BoogieTranslator<'env> {
             );
             result_locals.push(local_name)
         }
+        // If closure variants of this type capture mutable references, the fun value
+        // carries mutations and is threaded in-out: the apply procedure returns the
+        // updated value as trailing output.
+        let carries_mutations = closure_infos
+            .iter()
+            .any(|info| !info.mut_capture_slots(self.env).is_empty());
+        if carries_mutations {
+            if !result_locals.is_empty() {
+                emit!(self.writer, ",");
+            }
+            emit!(self.writer, "fun_out: {}", fun_ty_boogie_name);
+        }
         emitln!(self.writer, ") {");
         self.writer.indent();
         let result_str = result_locals.iter().cloned().join(", ");
@@ -963,6 +994,24 @@ impl<'env> BoogieTranslator<'env> {
                 emitln!(self.writer, "var {}_$pre: {};", mem_name, mem_type);
             }
         }
+        // Declare locals receiving the updated captured mutations in the inline path
+        // of mut-capturing closure variants.
+        for (idx, info) in closure_infos.iter().enumerate() {
+            for (pos, target_ty) in info.mut_capture_slots(self.env) {
+                emitln!(
+                    self.writer,
+                    "var $$cap_upd{}_{}: $Mutation ({});",
+                    idx,
+                    pos,
+                    boogie_type(self.env, &target_ty, false)
+                );
+            }
+        }
+        if carries_mutations {
+            // Default: the fun value is unchanged; mut-capturing variants overwrite
+            // this with a repacked value carrying the updated mutations.
+            emitln!(self.writer, "fun_out := fun;");
+        }
 
         // Generate branches for all variants. Since the datatype is closed,
         // the last variant uses `else` without an explicit check (unless it's the only variant,
@@ -992,7 +1041,7 @@ impl<'env> BoogieTranslator<'env> {
             // Captured slots are not necessarily a prefix of the callee's
             // parameters.
             let captured_args: Vec<String> = (0..info.mask.captured_count())
-                .map(|pos| format!("fun->p{}_v{}", pos, idx))
+                .map(|pos| format!("fun->{}", boogie_closure_capture_field(pos as usize, idx)))
                 .collect();
             let non_captured_args: Vec<String> =
                 (0..params.len()).map(|pos| format!("p{}", pos)).collect();
@@ -1011,6 +1060,7 @@ impl<'env> BoogieTranslator<'env> {
                 .get(&(info.fun.to_qualified_id(), FunctionVariant::Baseline))
                 .map(|insts| !insts.is_empty())
                 .unwrap_or(false);
+            let mut_capture_slots = info.mut_capture_slots(self.env);
             if fun_env.is_opaque() || !has_inline {
                 self.emit_opaque_closure_body(
                     info,
@@ -1021,8 +1071,53 @@ impl<'env> BoogieTranslator<'env> {
                     &result_locals,
                     memory,
                 );
-            } else {
+            } else if mut_capture_slots.is_empty() {
                 emitln!(self.writer, "call {}{}({});", call_prefix, fun_name, args);
+            } else {
+                // The target returns updated mutations for all its `&mut` parameters,
+                // captured ones included, interleaved in parameter order. Collect the
+                // captured ones and repack the closure value into `fun_out`.
+                let param_tys =
+                    Type::instantiate_vec(fun_env.get_parameter_types(), &info.fun.inst);
+                let explicit_count = results.clone().flatten().len();
+                let mut call_outs: Vec<String> = result_locals[0..explicit_count].to_vec();
+                let mut apply_mut_pos = explicit_count;
+                let mut capture_slot = 0;
+                for (i, ty) in param_tys.iter().enumerate() {
+                    let captured = info.mask.is_captured(i);
+                    if ty.is_mutable_reference() {
+                        if captured {
+                            call_outs.push(format!("$$cap_upd{}_{}", idx, capture_slot));
+                        } else {
+                            call_outs.push(result_locals[apply_mut_pos].clone());
+                            apply_mut_pos += 1;
+                        }
+                    }
+                    if captured {
+                        capture_slot += 1;
+                    }
+                }
+                emitln!(
+                    self.writer,
+                    "call {} := {}({});",
+                    call_outs.iter().join(", "),
+                    fun_name,
+                    args
+                );
+                let repack_args = param_tys
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| info.mask.is_captured(*i))
+                    .enumerate()
+                    .map(|(slot, (_, ty))| {
+                        if ty.is_mutable_reference() {
+                            format!("$$cap_upd{}_{}", idx, slot)
+                        } else {
+                            format!("fun->{}", boogie_closure_capture_field(slot, idx))
+                        }
+                    })
+                    .join(", ");
+                emitln!(self.writer, "fun_out := {}({});", ctor_name, repack_args);
             }
             if is_only {
                 // Single variant: no closing needed
@@ -1119,6 +1214,7 @@ impl<'env> BoogieTranslator<'env> {
                 &params,
                 memory,
                 &frame_access,
+                None,
             );
             if is_only {
                 // Single variant: no outer block to close
@@ -1216,6 +1312,7 @@ impl<'env> BoogieTranslator<'env> {
                 &params,
                 memory,
                 &frame_access,
+                None,
             );
             if is_only {
                 // Single variant: no outer block to close
@@ -1286,11 +1383,23 @@ impl<'env> BoogieTranslator<'env> {
         memory: &[(QualifiedInstId<StructId>, String)],
     ) {
         // Build args for ALL callee params by interleaving captured and non-captured
-        // using ClosureMask::compose.
-        let captured_args: Vec<String> = (0..info.mask.captured_count())
-            .map(|pos| format!("fun->p{}_v{}", pos, variant_idx))
-            .collect();
+        // using ClosureMask::compose. Mutation-carrying capture slots contribute their
+        // value component, since behavioral predicates reason over plain values.
         let callee_param_tys = fun_env.get_parameter_types();
+        let captured_args: Vec<String> = info
+            .mask
+            .extract(&callee_param_tys, true)
+            .into_iter()
+            .enumerate()
+            .map(|(pos, ty)| {
+                let field = format!("fun->{}", boogie_closure_capture_field(pos, variant_idx));
+                if ty.is_mutable_reference() {
+                    format!("{}->v", field)
+                } else {
+                    field
+                }
+            })
+            .collect();
         let non_captured_args: Vec<String> = callee_param_tys
             .iter()
             .enumerate()
@@ -1343,6 +1452,50 @@ impl<'env> BoogieTranslator<'env> {
             .map(|m| m.clone().instantiate(&info.fun.inst))
             .collect();
 
+        // For a variant capturing mutable references, describe the target's `&mut`
+        // output layout (the result Skolem carries post-state slots for all of the
+        // target's `&mut` params, captured ones included) and the repack of the
+        // closure value.
+        let capture_outputs = if info.mut_capture_slots(self.env).is_empty() {
+            None
+        } else {
+            let explicit_count = explicit_results.len();
+            let mut mut_slots = vec![];
+            let mut capture_fields = vec![];
+            let mut slot = 0;
+            let mut mut_pos = 0;
+            for (i, ty) in callee_param_tys.iter().enumerate() {
+                let captured = info.mask.is_captured(i);
+                let is_mut = ty.is_mutable_reference();
+                if captured {
+                    let field = format!("fun->{}", boogie_closure_capture_field(slot, variant_idx));
+                    capture_fields.push((
+                        field.clone(),
+                        if is_mut {
+                            Some(explicit_count + mut_pos)
+                        } else {
+                            None
+                        },
+                    ));
+                    if is_mut {
+                        mut_slots.push(Some(field));
+                    }
+                    slot += 1;
+                } else if is_mut {
+                    mut_slots.push(None);
+                }
+                if is_mut {
+                    mut_pos += 1;
+                }
+            }
+            Some(CaptureOutputs {
+                mut_slots,
+                ctor_name: boogie_closure_pack_name(self.env, &info.fun, info.mask),
+                capture_fields,
+                fun_out: "fun_out".to_string(),
+            })
+        };
+
         self.emit_behavioral_predicate_body(
             &aborts_name,
             &ensures_name,
@@ -1357,6 +1510,7 @@ impl<'env> BoogieTranslator<'env> {
             params,
             memory,
             &frame_access,
+            capture_outputs.as_ref(),
         );
     }
 
@@ -1464,6 +1618,7 @@ impl<'env> BoogieTranslator<'env> {
         params: &[Type],
         memory: &[(QualifiedInstId<StructId>, String)],
         frame_access: &BTreeMap<QualifiedInstId<StructId>, ApplyFrameAccess>,
+        capture_outputs: Option<&CaptureOutputs>,
     ) {
         let env = self.env;
         let explicit_result_count = explicit_results.len();
@@ -1474,6 +1629,12 @@ impl<'env> BoogieTranslator<'env> {
             .map(|(idx, _)| idx)
             .collect();
         let first_mut_ref_param = mut_ref_param_indices.first().copied();
+        // The `&mut` output count of the result Skolem: for a mut-capturing closure
+        // variant this is determined by the target's `&mut` parameters (captured ones
+        // included); otherwise by the function type's `&mut` parameters.
+        let mut_output_count =
+            capture_outputs.map_or(mut_ref_param_indices.len(), |c| c.mut_slots.len());
+        let total_outputs = explicit_result_count + mut_output_count;
 
         // Compute which memory names are covered by frame_access
         let covered_by_frame: BTreeSet<String> = frame_access
@@ -1596,97 +1757,93 @@ impl<'env> BoogieTranslator<'env> {
         );
         let result_bp_args = post_mem_args.iter().chain(data_args.iter()).join(", ");
 
-        // Assign results using result_of function (now using post-state args)
-        if !result_locals.is_empty() {
-            if result_locals.len() == 1 {
-                let result_local = &result_locals[0];
-                if explicit_result_count == 1 {
-                    if explicit_results[0].is_mutable_reference() {
-                        let base_param = first_mut_ref_param.unwrap_or(0);
-                        emitln!(
-                            self.writer,
-                            "{} := $ChildMutation(p{}, -1, {}({}));",
-                            result_local,
-                            base_param,
-                            result_fun_name,
-                            result_bp_args
-                        );
-                    } else {
-                        emitln!(
-                            self.writer,
-                            "{} := {}({});",
-                            result_local,
-                            result_fun_name,
-                            result_bp_args
-                        );
-                    }
-                } else {
-                    // Mutable reference param output: wrap in $UpdateMutation
-                    let param_idx = mut_ref_param_indices[0];
-                    emitln!(
-                        self.writer,
-                        "{} := $UpdateMutation(p{}, {}({}));",
-                        result_local,
-                        param_idx,
-                        result_fun_name,
-                        result_bp_args
-                    );
-                }
+        // Helper for accessing the i-th output of the result Skolem (using post-state
+        // args). The Skolem is deterministic, so repeated application is equal.
+        let tuple_access = |i: usize| {
+            if total_outputs == 1 {
+                format!("{}({})", result_fun_name, result_bp_args)
             } else {
-                // Multiple results: use tuple projection
-                for (i, result_local) in result_locals.iter().enumerate() {
-                    if i < explicit_result_count {
-                        if explicit_results[i].is_mutable_reference() {
-                            let base_param = first_mut_ref_param.unwrap_or(0);
-                            emitln!(
-                                self.writer,
-                                "{} := $ChildMutation(p{}, -1, {}({})->${});",
-                                result_local,
-                                base_param,
-                                multi_result_fun_name,
-                                result_bp_args,
-                                i
-                            );
-                        } else {
-                            emitln!(
-                                self.writer,
-                                "{} := {}({})->${};",
-                                result_local,
-                                multi_result_fun_name,
-                                result_bp_args,
-                                i
-                            );
-                        }
-                    } else {
-                        let mut_ref_idx = i - explicit_result_count;
-                        let param_idx = mut_ref_param_indices[mut_ref_idx];
-                        emitln!(
-                            self.writer,
-                            "{} := $UpdateMutation(p{}, {}({})->${});",
-                            result_local,
-                            param_idx,
-                            multi_result_fun_name,
-                            result_bp_args,
-                            i
-                        );
-                    }
-                }
+                format!("{}({})->${}", multi_result_fun_name, result_bp_args, i)
             }
+        };
+
+        // Assign explicit results using the result Skolem.
+        for i in 0..explicit_result_count {
+            let result_local = &result_locals[i];
+            if explicit_results[i].is_mutable_reference() {
+                let base_param = first_mut_ref_param.unwrap_or(0);
+                emitln!(
+                    self.writer,
+                    "{} := $ChildMutation(p{}, -1, {});",
+                    result_local,
+                    base_param,
+                    tuple_access(i)
+                );
+            } else {
+                emitln!(self.writer, "{} := {};", result_local, tuple_access(i));
+            }
+        }
+        // Assign `&mut` outputs. Non-captured ones update the corresponding parameter
+        // mutation into a result local; captured ones are consumed by the repack of
+        // the closure value below.
+        let mut apply_mut_pos = 0;
+        for j in 0..mut_output_count {
+            let captured = capture_outputs.is_some_and(|c| c.mut_slots[j].is_some());
+            if captured {
+                continue;
+            }
+            let param_idx = mut_ref_param_indices[apply_mut_pos];
+            let result_local = &result_locals[explicit_result_count + apply_mut_pos];
+            apply_mut_pos += 1;
+            emitln!(
+                self.writer,
+                "{} := $UpdateMutation(p{}, {});",
+                result_local,
+                param_idx,
+                tuple_access(explicit_result_count + j)
+            );
+        }
+        // Repack the closure value with the updated captured mutations.
+        if let Some(outputs) = capture_outputs {
+            let repack_args = outputs
+                .capture_fields
+                .iter()
+                .map(|(field, tuple_idx)| match tuple_idx {
+                    Some(i) => format!("$UpdateMutation({}, {})", field, tuple_access(*i)),
+                    None => field.clone(),
+                })
+                .join(", ");
+            emitln!(
+                self.writer,
+                "{} := {}({});",
+                outputs.fun_out,
+                outputs.ctor_name,
+                repack_args
+            );
         }
 
         // Build result args for ensures_of, dereferencing mutable reference results.
-        // Behavioral predicates reason over plain values, not mutation types.
+        // Behavioral predicates reason over plain values, not mutation types. For a
+        // captured `&mut` output the post value comes directly from the Skolem.
         let mut ensures_result_args: Vec<String> = Vec::new();
-        for (i, result_local) in result_locals.iter().enumerate() {
-            if i < explicit_result_count {
-                if explicit_results[i].is_mutable_reference() {
-                    ensures_result_args.push(format!("$Dereference({})", result_local));
-                } else {
-                    ensures_result_args.push(result_local.clone());
-                }
+        for (i, ty) in explicit_results.iter().enumerate() {
+            if ty.is_mutable_reference() {
+                ensures_result_args.push(format!("$Dereference({})", result_locals[i]));
             } else {
-                // Mut ref param output: always a mutation, need dereference
-                ensures_result_args.push(format!("$Dereference({})", result_local));
+                ensures_result_args.push(result_locals[i].clone());
+            }
+        }
+        let mut apply_mut_pos = 0;
+        for j in 0..mut_output_count {
+            let captured = capture_outputs.is_some_and(|c| c.mut_slots[j].is_some());
+            if captured {
+                ensures_result_args.push(tuple_access(explicit_result_count + j));
+            } else {
+                ensures_result_args.push(format!(
+                    "$Dereference({})",
+                    result_locals[explicit_result_count + apply_mut_pos]
+                ));
+                apply_mut_pos += 1;
             }
         }
 
@@ -1757,7 +1914,16 @@ impl<'env> BoogieTranslator<'env> {
         // full parameter list, while the specialized closure and
         // fun_param axioms substitute a concrete constructor term for
         // `f` and therefore need the memory and data portions independently.
-        let (data_decls, data_args) = Self::data_param_decls_and_args(env, &params, kind, &results);
+        let carries_mutations = closure_infos
+            .iter()
+            .any(|info| !info.mut_capture_slots(env).is_empty());
+        let (data_decls, data_args) = Self::data_param_decls_and_args(
+            env,
+            &params,
+            kind,
+            &results,
+            carries_mutations.then_some(fun_ty_boogie_name.as_str()),
+        );
         let mut param_decls: Vec<String> = eval_mem_decls.to_vec();
         let mut arg_names: Vec<String> = eval_mem_args.to_vec();
         param_decls.push(format!("f: {}", fun_ty_boogie_name));
@@ -1790,7 +1956,7 @@ impl<'env> BoogieTranslator<'env> {
         // that matches in that case. Pool's `IsValid` pins such values to
         // the field variant, making the other variants' guards simplify to
         // false without materializing their right-hand sides.
-        for info in closure_infos {
+        for (variant_idx, info) in closure_infos.iter().enumerate() {
             self.emit_closure_variant_axiom(
                 &eval_fun_name,
                 &eval_mem_decls,
@@ -1798,6 +1964,7 @@ impl<'env> BoogieTranslator<'env> {
                 &data_decls,
                 &data_args,
                 info,
+                variant_idx,
                 &params,
                 &results,
                 kind,
@@ -1835,12 +2002,16 @@ impl<'env> BoogieTranslator<'env> {
     /// evaluator's signature: input parameters `p0..pn` and, for ensures_of,
     /// result values `r0..rm`. Memory and the function value `f` are handled
     /// separately because they vary between the general and specialized
-    /// axiom forms.
+    /// axiom forms. For function types carrying mutations, the ensures_of
+    /// evaluator additionally takes the updated fun value `f_post` as final
+    /// parameter, from which the closure variant axioms extract the post
+    /// values of captured mutations.
     fn data_param_decls_and_args(
         env: &GlobalEnv,
         params: &[Type],
         kind: BehaviorKind,
         results: &[Type],
+        carrying_fun_ty: Option<&str>,
     ) -> (Vec<String>, Vec<String>) {
         let behavioral_outputs = Self::behavioral_output_types(params, results);
         let mut decls = Vec::with_capacity(params.len() + behavioral_outputs.len());
@@ -1857,6 +2028,10 @@ impl<'env> BoogieTranslator<'env> {
             for (pos, ty) in behavioral_outputs.iter().enumerate() {
                 decls.push(format!("r{}: {}", pos, boogie_type(env, ty, false)));
                 args.push(format!("r{}", pos));
+            }
+            if let Some(fun_ty_name) = carrying_fun_ty {
+                decls.push(format!("f_post: {}", fun_ty_name));
+                args.push("f_post".to_string());
             }
         }
         (decls, args)
@@ -1875,6 +2050,7 @@ impl<'env> BoogieTranslator<'env> {
         data_decls: &[String],
         data_args: &[String],
         info: &ClosureInfo,
+        variant_idx: usize,
         params: &[Type],
         results: &[Type],
         kind: BehaviorKind,
@@ -1887,20 +2063,24 @@ impl<'env> BoogieTranslator<'env> {
             .map(|ty| ty.instantiate(&info.fun.inst))
             .collect();
         let ctor_name = boogie_closure_pack_name(env, &info.fun, info.mask);
+        let has_mut_captures = !info.mut_capture_slots(env).is_empty();
 
         // Captures become quantifier-bound variables `c0..cK`. The
-        // constructor term in the trigger takes them as arguments.
+        // constructor term in the trigger takes them as arguments. Slots
+        // capturing mutable references have `$Mutation` type, matching the
+        // datatype field.
         let mut capture_decls = Vec::new();
         let mut capture_args = Vec::new();
         let mut captured_pos = 0usize;
         for (i, ty) in callee_param_tys.iter().enumerate() {
             if info.mask.is_captured(i) {
                 let name = format!("c{}", captured_pos);
-                capture_decls.push(format!(
-                    "{}: {}",
-                    name,
+                let slot_ty = if ty.is_mutable_reference() {
+                    boogie_type(env, ty, false)
+                } else {
                     boogie_type(env, ty.skip_reference(), false)
-                ));
+                };
+                capture_decls.push(format!("{}: {}", name, slot_ty));
                 capture_args.push(name);
                 captured_pos += 1;
             }
@@ -1922,24 +2102,75 @@ impl<'env> BoogieTranslator<'env> {
         // Build the RHS call to the per-function spec function. Captured
         // params are taken directly from the bound `cK` variables, not
         // from `f->pK`, because the trigger commits `f = ctor(c0..cK)`.
+        // Mutation-carrying capture slots contribute their value component,
+        // since behavioral predicates reason over plain values.
         let bp_name = boogie_behavioral_fun_spec_name(env, &info.fun, kind);
         let mut rhs_args: Vec<String> =
             Self::build_instantiated_memory_args(env, &fun_env, &info.fun.inst);
         let mut captured_pos = 0usize;
         let mut non_captured_pos = 0usize;
-        for i in 0..callee_param_tys.len() {
+        for (i, ty) in callee_param_tys.iter().enumerate() {
             if info.mask.is_captured(i) {
-                rhs_args.push(format!("c{}", captured_pos));
+                if ty.is_mutable_reference() {
+                    rhs_args.push(format!("c{}->v", captured_pos));
+                } else {
+                    rhs_args.push(format!("c{}", captured_pos));
+                }
                 captured_pos += 1;
             } else {
                 rhs_args.push(format!("p{}", non_captured_pos));
                 non_captured_pos += 1;
             }
         }
+        // For ensures_of, the per-target result slots cover declared results
+        // plus post-states of all the target's `&mut` params in parameter
+        // order. Post values of captured mutations come from `f_post`'s
+        // capture slots, conjoined with the identity constraints matching
+        // the operational model (variant and mutation identity preserved).
+        let mut identity_conjuncts: Vec<String> = vec![];
         if kind == BehaviorKind::EnsuresOf {
-            rhs_args.extend(Self::behavioral_output_args(params, results));
+            if has_mut_captures {
+                identity_conjuncts.push(format!("(f_post is {})", ctor_name));
+                let explicit_count = results.len();
+                let mut fun_mut_pos = 0usize;
+                let mut slot = 0usize;
+                for i in 0..explicit_count {
+                    rhs_args.push(format!("r{}", i));
+                }
+                for (i, ty) in callee_param_tys.iter().enumerate() {
+                    let captured = info.mask.is_captured(i);
+                    if ty.is_mutable_reference() {
+                        if captured {
+                            let field = format!(
+                                "f_post->{}",
+                                boogie_closure_capture_field(slot, variant_idx)
+                            );
+                            identity_conjuncts
+                                .push(format!("$IsSameMutation(c{}, {})", slot, field));
+                            rhs_args.push(format!("{}->v", field));
+                        } else {
+                            rhs_args.push(format!("r{}", explicit_count + fun_mut_pos));
+                            fun_mut_pos += 1;
+                        }
+                    }
+                    if captured {
+                        slot += 1;
+                    }
+                }
+            } else {
+                rhs_args.extend(Self::behavioral_output_args(params, results));
+            }
         }
-        let rhs = format!("{}({})", bp_name, rhs_args.join(", "));
+        let rhs = if identity_conjuncts.is_empty() {
+            format!("{}({})", bp_name, rhs_args.join(", "))
+        } else {
+            format!(
+                "({} && {}({}))",
+                identity_conjuncts.join(" && "),
+                bp_name,
+                rhs_args.join(", ")
+            )
+        };
 
         // Build the evaluator application used in trigger and body, with
         // the concrete constructor term substituted for `f`.
@@ -2011,14 +2242,21 @@ impl<'env> BoogieTranslator<'env> {
             .collect();
         let eval_call = format!("{}({})", eval_fun_name, eval_call_args.join(", "));
 
-        emitln!(
-            self.writer,
-            "axiom (forall {} :: {{{}}} {} <==> {});",
-            quantifier.join(", "),
-            eval_call,
-            eval_call,
-            rhs
-        );
+        if quantifier.is_empty() {
+            // No bound variables (e.g. requires_of/aborts_of of a zero-argument
+            // function type without memory): emit a plain axiom, since Boogie
+            // requires at least one bound variable in a quantifier.
+            emitln!(self.writer, "axiom {} <==> {};", eval_call, rhs);
+        } else {
+            emitln!(
+                self.writer,
+                "axiom (forall {} :: {{{}}} {} <==> {});",
+                quantifier.join(", "),
+                eval_call,
+                eval_call,
+                rhs
+            );
+        }
     }
 
     /// Emit a guarded evaluator axiom for a struct-field variant. Struct
@@ -2158,11 +2396,18 @@ impl<'env> BoogieTranslator<'env> {
         }
 
         // Output tuple: declared results followed by `&mut` post-states.
-        // References are stripped — spec predicates work on values.
+        // References are stripped — spec predicates work on values. For
+        // function types carrying mutations, the updated fun value is
+        // appended as final component, matching the `f_post` slot of
+        // `ensures_of`.
+        let carries_mutations = closure_infos
+            .iter()
+            .any(|info| !info.mut_capture_slots(env).is_empty());
         let output_types: Vec<Type> = declared_results
             .iter()
             .chain(post_state_types.iter())
             .cloned()
+            .chain(carries_mutations.then(|| fun_type.clone()))
             .collect();
         let result_type = if output_types.len() == 1 {
             boogie_type(env, &output_types[0], false)
@@ -5846,6 +6091,33 @@ impl FunctionTranslator<'_> {
                     WriteBack(node, edge) => {
                         self.translate_write_back(node, edge, srcs[0]);
                     },
+                    IsParent(node, BorrowEdge::Capture(fun, mask, slot)) => {
+                        // The src is a closure value; the parent test holds if the
+                        // value is packed from the expected closure variant and the
+                        // mutation in its capture slot roots at the parent. The
+                        // variant test matters when packs of different variants merge
+                        // into the same temp at a control flow join.
+                        if let BorrowNode::Reference(parent) = node {
+                            let src_str = str_local(srcs[0]);
+                            let fun = fun.to_owned().instantiate(self.type_inst);
+                            let fun_ty = self.get_local_type(srcs[0]);
+                            let variant_idx =
+                                boogie_closure_variant_index(env, &fun_ty, &fun, *mask);
+                            let ctor_name = boogie_closure_pack_name(env, &fun, *mask);
+                            emitln!(
+                                writer,
+                                "{} := ({} is {}) && $IsSameMutation({}, {}->{});",
+                                str_local(dests[0]),
+                                src_str,
+                                ctor_name,
+                                str_local(*parent),
+                                src_str,
+                                boogie_closure_capture_field(*slot, variant_idx)
+                            );
+                        } else {
+                            panic!("inconsistent IsParent instruction: expected a reference node")
+                        }
+                    },
                     IsParent(node, edge) => {
                         if let BorrowNode::Reference(parent) = node {
                             let src_str = str_local(srcs[0]);
@@ -5860,13 +6132,27 @@ impl FunctionTranslator<'_> {
                                 })
                                 .collect_vec();
                             if edge_pattern.is_empty() {
-                                emitln!(
-                                    writer,
-                                    "{} := $IsSameMutation({}, {});",
-                                    str_local(dests[0]),
-                                    str_local(*parent),
-                                    src_str
-                                );
+                                if self.get_local_type(srcs[0]).is_function() {
+                                    // Between closure values carrying mutations (from
+                                    // an assignment): value equality is the correct
+                                    // parent test, since the carried mutations'
+                                    // location/path identity distinguishes the values.
+                                    emitln!(
+                                        writer,
+                                        "{} := ({} == {});",
+                                        str_local(dests[0]),
+                                        str_local(*parent),
+                                        src_str
+                                    );
+                                } else {
+                                    emitln!(
+                                        writer,
+                                        "{} := $IsSameMutation({}, {});",
+                                        str_local(dests[0]),
+                                        str_local(*parent),
+                                        src_str
+                                    );
+                                }
                             } else if edge_pattern.len() == 1 {
                                 emitln!(
                                     writer,
@@ -5922,7 +6208,28 @@ impl FunctionTranslator<'_> {
                             str_local(value),
                         );
                     },
-                    Function(mid, fid, inst) | Closure(mid, fid, inst, _) => {
+                    Closure(mid, fid, inst, mask) => {
+                        // Closure construction. Unlike for calls, `&mut` srcs are not
+                        // chained as implicit outputs: a captured mutation is moved
+                        // into the closure value as a whole `$Mutation` and comes back
+                        // via the `Capture` write-back when the closure dies.
+                        let inst = &self.inst_slice(inst);
+                        let args_str = srcs.iter().cloned().map(str_local).join(", ");
+                        let dest_str = dests.iter().cloned().map(str_local).join(",");
+                        let closure_ctor_name = boogie_closure_pack_name(
+                            env,
+                            &mid.qualified_inst(*fid, inst.clone()),
+                            *mask,
+                        );
+                        emitln!(
+                            writer,
+                            "{} := {}({});",
+                            dest_str,
+                            closure_ctor_name,
+                            args_str
+                        );
+                    },
+                    Function(mid, fid, inst) => {
                         let inst = &self.inst_slice(inst);
                         let module_env = env.get_module(*mid);
                         let callee_env = module_env.get_function(*fid);
@@ -5944,20 +6251,6 @@ impl FunctionTranslator<'_> {
 
                         if self.try_reflection_call(writer, env, inst, &callee_env, &dest_str) {
                             // Special case of reflection call, code is generated
-                        } else if let Closure(_, _, _, mask) = oper {
-                            // Special case of closure construction
-                            let closure_ctor_name = boogie_closure_pack_name(
-                                env,
-                                &mid.qualified_inst(*fid, inst.clone()),
-                                *mask,
-                            );
-                            emitln!(
-                                writer,
-                                "{} := {}({});",
-                                dest_str,
-                                closure_ctor_name,
-                                args_str
-                            );
                         } else {
                             // regular path
                             let targeted = self.fun_target.module_env().is_target();
@@ -6142,8 +6435,13 @@ impl FunctionTranslator<'_> {
                     },
                     Invoke => {
                         // Function is last argument
-                        let fun_type = self.inst(fun_target.get_local_type(*srcs.last().unwrap()));
+                        let fun_temp = *srcs.last().unwrap();
+                        let fun_type = self.inst(fun_target.get_local_type(fun_temp));
                         let args_str = srcs.iter().cloned().map(str_local).join(", ");
+                        // If the fun type carries mutations, the apply procedure
+                        // returns the updated fun value as trailing output.
+                        let fun_out = boogie_fun_ty_carries_mutations(env, &fun_type)
+                            .then(|| str_local(fun_temp));
                         let dest_str = dests
                             .iter()
                             .cloned()
@@ -6156,6 +6454,7 @@ impl FunctionTranslator<'_> {
                                     .cloned()
                                     .map(str_local),
                             )
+                            .chain(fun_out)
                             .join(",");
                         let apply_fun = boogie_fun_apply_name(env, &fun_type);
                         let call_prefix = if dest_str.is_empty() {
@@ -6465,6 +6764,56 @@ impl FunctionTranslator<'_> {
                             var_str,
                             temp_str
                         );
+                    },
+                    Havoc(HavocKind::CaptureValues) => {
+                        // Havoc the value parts of all mutations captured in the
+                        // closure value, preserving their location/path identity and
+                        // all other captured values, by repacking the variant with
+                        // `$UpdateMutation` per mutation slot.
+                        let var_str = str_local(dests[0]);
+                        let fun_ty = self.get_local_type(dests[0]);
+                        for (variant_idx, info) in
+                            boogie_closure_infos(env, &fun_ty).iter().enumerate()
+                        {
+                            if info.mut_capture_slots(env).is_empty() {
+                                continue;
+                            }
+                            let ctor_name = boogie_closure_pack_name(env, &info.fun, info.mask);
+                            emitln!(writer, "if ({} is {}) {{", var_str, ctor_name);
+                            writer.indent();
+                            let fun_env = env.get_function(info.fun.to_qualified_id());
+                            let param_tys = Type::instantiate_vec(
+                                fun_env.get_parameter_types(),
+                                &info.fun.inst,
+                            );
+                            let mut temp_counts: BTreeMap<String, usize> = BTreeMap::new();
+                            let mut args = vec![];
+                            for (pos, ty) in
+                                info.mask.extract(&param_tys, true).into_iter().enumerate()
+                            {
+                                let field = format!(
+                                    "{}->{}",
+                                    var_str,
+                                    boogie_closure_capture_field(pos, variant_idx)
+                                );
+                                if ty.is_mutable_reference() {
+                                    // Note: capture slot values default to the
+                                    // non-bv number representation.
+                                    let target_ty = ty.skip_reference();
+                                    let suffix = boogie_type_suffix(env, target_ty, false);
+                                    let instance = temp_counts.entry(suffix).or_insert(0);
+                                    let temp = boogie_temp(env, target_ty, *instance, false);
+                                    *instance += 1;
+                                    emitln!(writer, "havoc {};", temp);
+                                    args.push(format!("$UpdateMutation({}, {})", field, temp));
+                                } else {
+                                    args.push(field);
+                                }
+                            }
+                            emitln!(writer, "{} := {}({});", var_str, ctor_name, args.join(", "));
+                            writer.unindent();
+                            emitln!(writer, "}");
+                        }
                     },
                     Stop => {
                         // the two statements combined terminate any execution trace that reaches it
@@ -7191,7 +7540,27 @@ impl FunctionTranslator<'_> {
                         format!("ReadVec({}->p, LenVec($t{}->p) + {})", src_str, idx, offset)
                     }
                 };
-                if matches!(edge, BorrowEdge::Invoke) {
+                if let BorrowEdge::Capture(fun, mask, slot) = edge {
+                    // The source is a closure value carrying the captured mutation:
+                    // take the (updated) mutation back out of its capture slot. The
+                    // mutation's location and path are unchanged by packing, so the
+                    // remainder of the write-back chain works on it as usual.
+                    let fun = fun.to_owned().instantiate(self.type_inst);
+                    let fun_ty = self.get_local_type(src);
+                    let variant_idx = boogie_closure_variant_index(env, &fun_ty, &fun, *mask);
+                    emitln!(
+                        writer,
+                        "$t{} := {}->{};",
+                        idx,
+                        src_str,
+                        boogie_closure_capture_field(*slot, variant_idx)
+                    );
+                } else if self.get_local_type(src).is_function() {
+                    // Write-back between closure values carrying mutations, resulting
+                    // from an assignment: move the value back.
+                    assert!(matches!(edge, BorrowEdge::Direct));
+                    emitln!(writer, "$t{} := {};", idx, src_str);
+                } else if matches!(edge, BorrowEdge::Invoke) {
                     emitln!(writer, "call $t{} := $HavocMutation($t{});", idx, idx);
                 } else {
                     let update = if let BorrowEdge::Hyper(edges) = edge {
@@ -7369,7 +7738,12 @@ impl FunctionTranslator<'_> {
                         )
                     }
                 },
-                BorrowEdge::Hyper(_) | BorrowEdge::Invoke => unreachable!("unexpected borrow edge"),
+                // Capture edges are always the first hop off the closure temp and
+                // handled directly in `translate_write_back`; they never occur in
+                // hyper edges since closure values do not cross call boundaries.
+                BorrowEdge::Hyper(_) | BorrowEdge::Invoke | BorrowEdge::Capture(..) => {
+                    unreachable!("unexpected borrow edge")
+                },
             }
         }
     }
@@ -7528,6 +7902,23 @@ impl FunctionTranslator<'_> {
                             .unwrap();
                         let bv_flag = self.bv_flag(num_oper);
                         need(ty, bv_flag, 1)
+                    },
+                    Havoc(HavocKind::CaptureValues) => {
+                        // Temps for havocing capture slot values, counted per closure
+                        // variant (variant branches are exclusive, so temps are shared
+                        // across variants).
+                        let fun_ty = self.get_local_type(dests[0]);
+                        for info in boogie_closure_infos(env, &fun_ty) {
+                            let mut counts: BTreeMap<String, (Type, usize)> = BTreeMap::new();
+                            for (_, target_ty) in info.mut_capture_slots(env) {
+                                let suffix = boogie_type_suffix(env, &target_ty, false);
+                                let entry = counts.entry(suffix).or_insert((target_ty, 0));
+                                entry.1 += 1;
+                            }
+                            for (ty, n) in counts.into_values() {
+                                need(&ty, false, n);
+                            }
+                        }
                     },
                     _ => {},
                 },

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -10,12 +10,12 @@ use crate::{
         boogie_address, boogie_address_blob, boogie_behavioral_eval_fun_name,
         boogie_behavioral_fun_result_name, boogie_byte_blob, boogie_choice_fun_name,
         boogie_closure_pack_name, boogie_declare_global, boogie_field_sel, boogie_field_update,
-        boogie_inst_suffix, boogie_modifies_memory_name, boogie_num_type_base,
-        boogie_reflection_type_info, boogie_reflection_type_is_struct, boogie_reflection_type_name,
-        boogie_resource_memory_name, boogie_spec_fun_name, boogie_spec_var_name,
-        boogie_struct_name, boogie_struct_variant_name, boogie_type, boogie_type_suffix,
-        boogie_value_blob, boogie_variant_field_update, boogie_well_formed_expr,
-        compute_evaluator_memory_union, MAX_TUPLE_SIZE,
+        boogie_fun_ty_carries_mutations, boogie_inst_suffix, boogie_modifies_memory_name,
+        boogie_num_type_base, boogie_reflection_type_info, boogie_reflection_type_is_struct,
+        boogie_reflection_type_name, boogie_resource_memory_name, boogie_spec_fun_name,
+        boogie_spec_var_name, boogie_struct_name, boogie_struct_variant_name, boogie_type,
+        boogie_type_suffix, boogie_value_blob, boogie_variant_field_update,
+        boogie_well_formed_expr, compute_evaluator_memory_union, MAX_TUPLE_SIZE,
     },
     options::BoogieOptions,
 };
@@ -1852,8 +1852,38 @@ impl SpecTranslator<'_> {
 
         let eval_fun_name = boogie_behavioral_eval_fun_name(self.env, &inst_fun_type, kind);
 
+        // Whether the fun type carries mutations (mutable reference captures), in
+        // which case ensures_of/result_of have a trailing `f_post` slot, and whether
+        // `wrap_mut_ref_bp_inputs` appended a live fun-value clone as final trailing
+        // arg. The clone is detected by shape: a temporary whose type is the
+        // evaluator's own function type — no other trailing slot can have that type
+        // (a capture or result of the same type would be infinitely recursive).
+        // Note that spec expressions not passing through the bytecode instrumentation
+        // (e.g. behavioral spec function bodies) carry no clone.
+        let carries_mutations = boogie_fun_ty_carries_mutations(self.env, &inst_fun_type);
+        let has_fun_clone = matches!(kind, BehaviorKind::EnsuresOf | BehaviorKind::ResultOf)
+            && matches!(fun_exp.as_ref(), ExpData::Temporary(..))
+            && pred_args.last().is_some_and(|last| {
+                matches!(last.as_ref(), ExpData::Temporary(..))
+                    && boogie_type(
+                        self.env,
+                        &self
+                            .env
+                            .get_node_type(last.node_id())
+                            .instantiate(&self.type_inst),
+                        false,
+                    ) == boogie_type(self.env, &inst_fun_type, false)
+            });
+        if carries_mutations && kind == BehaviorKind::EnsuresOf && !has_fun_clone {
+            self.error(
+                &self.env.get_node_loc(node_id),
+                "ensures_of over a function value carrying mutable reference captures \
+                 is only supported for directly referenced function values",
+            );
+        }
+
         // The `ResultOf`/`WriteOf(j)` evaluator shares a single tuple Skolem
-        // returning `(declared..., post_states...)`. Compute the projection
+        // returning `(declared..., post_states...[, f_post])`. Compute the projection
         // needed at this call site — matches `translate_behavior_for_closure`.
         let (num_explicit_results, num_mut_refs) = match &inst_fun_type {
             Type::Fun(arg_ty, result_ty, _) => {
@@ -1867,7 +1897,7 @@ impl SpecTranslator<'_> {
             },
             _ => (0, 0),
         };
-        let total_outputs = num_explicit_results + num_mut_refs;
+        let total_outputs = num_explicit_results + num_mut_refs + carries_mutations as usize;
         let multi_in_boogie = total_outputs > 1;
         let projection = match kind {
             BehaviorKind::ResultOf if multi_in_boogie && total_outputs > num_explicit_results => {
@@ -1884,9 +1914,11 @@ impl SpecTranslator<'_> {
         };
 
         // For `ResultOf`, `wrap_mut_ref_bp_inputs` appends trailing post-state
-        // clones to `pred_args`. The tuple Skolem doesn't take them — the
-        // post-state is in its output tuple instead — so skip them here.
-        // `WriteOf(j)` never has trailing post-state clones.
+        // clones (and possibly the fun-value clone) to `pred_args`. The tuple
+        // Skolem doesn't take them — the post-state is in its output tuple
+        // instead — so skip them here. `WriteOf(j)` never has trailing clones.
+        // For `EnsuresOf`, the fun-value clone is dropped when the type does
+        // not carry mutations (the evaluator then has no `f_post` slot).
         let emit_arg_count = match kind {
             BehaviorKind::ResultOf => {
                 let num_inputs = match &inst_fun_type {
@@ -1895,6 +1927,7 @@ impl SpecTranslator<'_> {
                 };
                 num_inputs.min(pred_args.len())
             },
+            BehaviorKind::EnsuresOf if has_fun_clone && !carries_mutations => pred_args.len() - 1,
             _ => pred_args.len(),
         };
 
@@ -1955,13 +1988,18 @@ impl SpecTranslator<'_> {
             (None, None)
         };
         // Only `EnsuresOf` has a synthetic trailing post-state clone that
-        // `post_sub` should rewrite. For other kinds, the post-side witness
-        // belongs at the same `&mut` input slot that `pre_sub` would target.
+        // `post_sub` should rewrite; when a fun-value clone is appended after
+        // it, the post-state clone sits one position earlier. For other
+        // kinds, the post-side witness belongs at the same `&mut` input slot
+        // that `pre_sub` would target.
         let (post_slot_sub, input_witness) = if matches!(kind, BehaviorKind::EnsuresOf) {
             (
-                post_sub
-                    .clone()
-                    .map(|v| (v, pred_args.len().saturating_sub(1))),
+                post_sub.clone().map(|v| {
+                    (
+                        v,
+                        pred_args.len().saturating_sub(1 + has_fun_clone as usize),
+                    )
+                }),
                 pre_sub.clone(),
             )
         } else {
@@ -2086,6 +2124,17 @@ impl SpecTranslator<'_> {
         let inst = Type::instantiate_slice(&inst, &self.type_inst);
         let fun_qid = mid.qualified_inst(fid, inst);
         let fun_env = self.env.get_function(fun_qid.to_qualified_id());
+        if closure_args
+            .iter()
+            .any(|arg| self.env.get_node_type(arg.node_id()).is_mutable_reference())
+        {
+            self.error(
+                &self.env.get_node_loc(node_id),
+                "closures capturing mutable references are not supported in \
+                 specification expressions",
+            );
+            return;
+        }
         let num_params = fun_env.get_parameter_count();
         let num_explicit_results = fun_env.get_return_count();
         let num_mut_refs = fun_env

--- a/third_party/move/move-prover/bytecode-pipeline/src/clean_and_optimize.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/clean_and_optimize.rs
@@ -8,11 +8,13 @@
 use crate::options::ProverOptions;
 use move_binary_format::file_format::CodeOffset;
 use move_model::{
+    ast::TempIndex,
     model::FunctionEnv,
     pragmas::INTRINSIC_FUN_MAP_BORROW_MUT,
     well_known::{EVENT_EMIT_EVENT, VECTOR_BORROW_MUT},
 };
 use move_stackless_bytecode::{
+    borrow_analysis::mut_capture_carrying_temps,
     dataflow_analysis::{DataflowAnalysis, TransferFunctions},
     dataflow_domains::{AbstractDomain, JoinResult},
     function_target::{FunctionData, FunctionTarget},
@@ -52,6 +54,7 @@ impl FunctionTargetProcessor for CleanAndOptimizeProcessor {
         let new_instrs = Optimizer {
             options: &options,
             target: &FunctionTarget::new(func_env, &data),
+            carrying_temps: BTreeSet::new(),
         }
         .run(instrs);
         data.code = new_instrs;
@@ -88,6 +91,9 @@ impl AbstractDomain for AnalysisState {
 struct Optimizer<'a> {
     options: &'a ProverOptions,
     target: &'a FunctionTarget<'a>,
+    /// Temps holding closure values which capture mutable references (set by `run`).
+    /// They participate in the write-back analysis like references.
+    carrying_temps: BTreeSet<TempIndex>,
 }
 
 impl TransferFunctions for Optimizer<'_> {
@@ -99,7 +105,7 @@ impl TransferFunctions for Optimizer<'_> {
         use BorrowNode::*;
         use Bytecode::*;
         use Operation::*;
-        if let Call(_, _, oper, srcs, _) = instr {
+        if let Call(_, dests, oper, srcs, _) = instr {
             match oper {
                 WriteRef => {
                     state.unwritten.insert(Reference(srcs[0]));
@@ -126,10 +132,14 @@ impl TransferFunctions for Optimizer<'_> {
                         true
                     };
 
-                    // Mark &mut parameters to functions as unwritten.
+                    // Mark &mut parameters to functions as unwritten. A closure value
+                    // carrying captured mutations may be written through by the callee,
+                    // so it is treated like a &mut parameter.
                     if has_effect {
                         for src in srcs {
-                            if self.target.get_local_type(*src).is_mutable_reference() {
+                            if self.target.get_local_type(*src).is_mutable_reference()
+                                || self.carrying_temps.contains(src)
+                            {
                                 state.unwritten.insert(Reference(*src));
                             }
                         }
@@ -141,6 +151,17 @@ impl TransferFunctions for Optimizer<'_> {
                         if self.target.get_local_type(*src).is_mutable_reference() {
                             state.unwritten.insert(Reference(*src));
                         }
+                    }
+                },
+                Closure(..) => {
+                    // A closure pack capturing mutable references moves the mutations
+                    // into the closure value; keep the write-back chain from the
+                    // closure temp alive.
+                    if srcs
+                        .iter()
+                        .any(|src| self.target.get_local_type(*src).is_mutable_reference())
+                    {
+                        state.unwritten.insert(Reference(dests[0]));
                     }
                 },
                 _ => {},
@@ -166,6 +187,7 @@ impl DataflowAnalysis for Optimizer<'_> {}
 
 impl Optimizer<'_> {
     fn run(&mut self, instrs: Vec<Bytecode>) -> Vec<Bytecode> {
+        self.carrying_temps = mut_capture_carrying_temps(self.target, &instrs);
         // Rum Analysis
         let cfg = StacklessControlFlowGraph::new_forward(&instrs);
         let state = self.analyze_function(AnalysisState::default(), &instrs, &cfg);

--- a/third_party/move/move-prover/bytecode-pipeline/src/memory_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/memory_instrumentation.rs
@@ -477,7 +477,25 @@ impl<'a> Instrumenter<'a> {
                 },
             };
 
-            // Generate write_back for this reference.
+            // Generate write_back for this reference. Note that the dying node can also
+            // be a closure value carrying captured mutations (represented as a
+            // `Reference` node although of function type); its chains then start with a
+            // `Capture` edge which extracts the mutation from the closure value. Such
+            // chains may end at any root, including global storage: the deferred
+            // memory update at the final write-back is sound because the closure is
+            // the only channel to the location during the call (in the inline-expanded
+            // ground truth, reference safety and the AIP-112 reentrancy protection
+            // exclude any other access while the captured reference is live), and
+            // global invariants and modifies checks attach to the `WriteBack` here
+            // like for any mutation of global memory.
+            // A dying reference can have an empty ancestor chain when it has no
+            // incoming borrow edges, which occurs for the `&mut` result of an
+            // Invoke without `&mut` arguments: the over-approximation of dynamic
+            // call borrows draws parents only from `&mut` inputs. There is nothing
+            // to write back within the bytecode model in this case; effects through
+            // such a reference are only visible at the specification level.
+            let mut ancestors = ancestors;
+            ancestors.retain(|chain| !chain.is_empty());
             let is_conditional = ancestors.len() > 1;
             for (chain_index, chain) in ancestors.iter().enumerate() {
                 // sanity check: the src node of the first action must be the node itself

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -105,6 +105,23 @@ pub struct ClosureInfo {
     pub mask: ClosureMask,
 }
 
+impl ClosureInfo {
+    /// Returns the (slot position, target type) pairs for mutable references captured
+    /// by this closure. The slot position indexes the captured operands; the target
+    /// type is the value type behind the reference.
+    pub fn mut_capture_slots(&self, env: &GlobalEnv) -> Vec<(usize, Type)> {
+        let fun_env = env.get_function(self.fun.to_qualified_id());
+        let param_tys = Type::instantiate_vec(fun_env.get_parameter_types(), &self.fun.inst);
+        self.mask
+            .extract(&param_tys, true)
+            .into_iter()
+            .enumerate()
+            .filter(|(_, ty)| ty.is_mutable_reference())
+            .map(|(pos, ty)| (pos, ty.skip_reference().clone()))
+            .collect()
+    }
+}
+
 /// Information about a function parameter that has function type.
 /// This is used to track function-typed parameters in verification targets
 /// so that the Boogie backend can generate appropriate variants.
@@ -777,11 +794,15 @@ impl Analyzer<'_> {
                         self.normalize_fun_ty(self.instantiate(target.get_local_type(dests[0])));
                     let fun = mid.qualified_inst(*fid, self.instantiate_vec(targs));
                     self.add_closure_spec_memory(&fun);
+                    let info = ClosureInfo { fun, mask: *mask };
+                    if !info.mut_capture_slots(self.env).is_empty() {
+                        self.register_mut_capture_tuples(&info, &fun_type);
+                    }
                     self.info
                         .fun_infos
                         .entry(fun_type)
                         .or_default()
-                        .insert(ClosureInfo { fun, mask: *mask });
+                        .insert(info);
                 }
             },
             Call(_, _, WriteBack(_, edge), ..) => {
@@ -851,6 +872,52 @@ impl Analyzer<'_> {
             let mem = mem.instantiate(&fun.inst);
             let struct_env = self.env.get_struct_qid(mem.to_qualified_id());
             self.add_struct(struct_env, &mem.inst);
+        }
+    }
+
+    /// Register tuple instantiations needed for a mut-capturing closure variant: the
+    /// target's ensures_of result Skolem returns a tuple over declared results plus
+    /// post-states of all its `&mut` params (captured ones included), and the
+    /// evaluator-level result_of of the carrying function type gains a trailing
+    /// component for the updated fun value.
+    fn register_mut_capture_tuples(&mut self, info: &ClosureInfo, fun_type: &Type) {
+        let fun_env = self.env.get_function(info.fun.to_qualified_id());
+        let param_tys = Type::instantiate_vec(fun_env.get_parameter_types(), &info.fun.inst);
+        let target_outputs: Vec<Type> = fun_env
+            .get_result_type()
+            .instantiate(&info.fun.inst)
+            .flatten()
+            .into_iter()
+            .chain(
+                param_tys
+                    .iter()
+                    .filter(|ty| ty.is_mutable_reference())
+                    .cloned(),
+            )
+            .map(|ty| ty.skip_reference().clone())
+            .collect();
+        if target_outputs.len() >= 2 {
+            self.info.tuple_inst.insert(target_outputs);
+        }
+        let Type::Fun(params, results, _) = fun_type else {
+            panic!("expected fun type")
+        };
+        let eval_outputs: Vec<Type> = results
+            .clone()
+            .flatten()
+            .into_iter()
+            .chain(
+                params
+                    .clone()
+                    .flatten()
+                    .into_iter()
+                    .filter(|ty| ty.is_mutable_reference()),
+            )
+            .map(|ty| ty.skip_reference().clone())
+            .chain(std::iter::once(fun_type.clone()))
+            .collect();
+        if eval_outputs.len() >= 2 {
+            self.info.tuple_inst.insert(eval_outputs);
         }
     }
 
@@ -1078,6 +1145,9 @@ impl Analyzer<'_> {
     fn add_types_in_borrow_edge(&mut self, edge: &BorrowEdge) {
         match edge {
             BorrowEdge::Direct | BorrowEdge::Invoke | BorrowEdge::Index(_) => (),
+            // For Capture, the closure datatype instance is already registered via the
+            // `Closure` operation which packed the value.
+            BorrowEdge::Capture(..) => (),
             BorrowEdge::Field(qid, _, _) => {
                 self.add_type_root(&qid.to_type());
             },

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
@@ -2584,7 +2584,13 @@ impl<'env> TransferFunctions for SpecInferenceAnalyzer<'env> {
 
                     // WP[dest := closure<f>(captured_args)](Q) = Q[dest ↦ |provided| f(captured, provided)]
                     Operation::Closure(module_id, fun_id, type_inst, mask) => {
-                        if dests.len() == 1 {
+                        // Closures capturing mutable references cannot appear in
+                        // specification expressions; leave the destination
+                        // unsubstituted so inference degrades conservatively.
+                        let has_mut_capture = srcs
+                            .iter()
+                            .any(|&s| self.get_local_type(s).is_mutable_reference());
+                        if dests.len() == 1 && !has_mut_capture {
                             let captured_args: Vec<Exp> =
                                 srcs.iter().map(|&s| self.mk_temporary(s)).collect();
                             let (closure_exp, _) = self.mk_closure(
@@ -5456,7 +5462,10 @@ impl<'env> SpecInferenceAnalyzer<'env> {
                 Some(self.mk_field_update(&field_env, type_args, old_exp, new_exp))
             },
             // Other edge types not yet supported
-            BorrowEdge::Index(_) | BorrowEdge::Invoke | BorrowEdge::Hyper(_) => None,
+            BorrowEdge::Index(_)
+            | BorrowEdge::Invoke
+            | BorrowEdge::Capture(..)
+            | BorrowEdge::Hyper(_) => None,
         }
     }
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use move_core_types::function::ClosureMask;
 use move_model::{
     ast,
-    ast::{Exp, ExpData, MemoryLabel, QuantKind, RewriteResult, TempIndex, Value},
+    ast::{BehaviorKind, Exp, ExpData, MemoryLabel, QuantKind, RewriteResult, TempIndex, Value},
     exp_generator::ExpGenerator,
     exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
     memory_labels::all_labels_in_exp,
@@ -21,6 +21,7 @@ use move_model::{
     ty::{ReferenceKind, Type, TypeDisplayContext, BOOL_TYPE, NUM_TYPE},
 };
 use move_stackless_bytecode::{
+    borrow_analysis::mut_capture_carrying_temps,
     function_data_builder::FunctionDataBuilder,
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{
@@ -373,6 +374,8 @@ struct Instrumenter<'a> {
     /// Counter for deterministic label freshening across opaque call sites.
     /// Starts at 0 so that freshened labels are independent of the global counter.
     freshen_counter: usize,
+    /// Temps holding closure values which capture mutable references.
+    carrying_temps: BTreeSet<TempIndex>,
 }
 
 // =================================================================================================
@@ -440,6 +443,7 @@ impl<'a> Instrumenter<'a> {
         let spec = SpecTranslator::translate_fun_spec(
             auto_trace,
             false,
+            options.inference,
             &mut builder,
             fun_env,
             &[],
@@ -458,6 +462,7 @@ impl<'a> Instrumenter<'a> {
                     SpecTranslator::translate_inline_property(
                         &loc,
                         auto_trace,
+                        options.inference,
                         &mut builder,
                         &prop,
                     ),
@@ -475,6 +480,14 @@ impl<'a> Instrumenter<'a> {
                     .get_all_inst(&builder.data.type_args);
         }
 
+        // Temps holding closure values which capture mutable references. They are
+        // treated like `&mut` arguments at opaque call sites (captured mutation
+        // values havoced, constrained by behavioral post conditions).
+        let carrying_temps = mut_capture_carrying_temps(
+            &FunctionTarget::new(fun_env, &builder.data),
+            &builder.data.code,
+        );
+
         // Create and run the instrumenter.
         let mut instrumenter = Instrumenter {
             options,
@@ -486,6 +499,7 @@ impl<'a> Instrumenter<'a> {
             mem_info: &mem_info,
             split_points: vec![],
             freshen_counter: 0,
+            carrying_temps,
         };
         // Always inline spec lets in proof actions, independent of the
         // `inline_spec_lets` option. Proof-action exps are recorded in
@@ -763,6 +777,7 @@ impl<'a> Instrumenter<'a> {
         let mut callee_spec = SpecTranslator::translate_fun_spec(
             self.options.auto_trace_level.functions(),
             true,
+            self.options.inference,
             &mut self.builder,
             &callee_env,
             targs,
@@ -980,9 +995,40 @@ impl<'a> Instrumenter<'a> {
                 });
             }
 
+            // Havoc the captured mutation values of closure arguments which capture
+            // mutable references; like for `&mut` parameters, their post-values are
+            // determined by the callee's (behavioral) post conditions.
+            let carrying_srcs = srcs
+                .iter()
+                .cloned()
+                .filter(|src| self.carrying_temps.contains(src))
+                .collect_vec();
+            for src in &carrying_srcs {
+                self.builder.emit_with(|id| {
+                    Call(
+                        id,
+                        vec![*src],
+                        Operation::Havoc(HavocKind::CaptureValues),
+                        vec![],
+                        None,
+                    )
+                });
+            }
+
+            // A closure carrying captured mutations has a single havoced post
+            // value per captured location, so more than one `ensures_of` condition
+            // over it would assume constraints about different applications on the
+            // same value, which is unsatisfiable in general (vacuity). Reject.
+            let call_loc = self.builder.get_loc(id);
+            self.check_single_ensures_of_for_carrying(&callee_spec, &carrying_srcs, &call_loc);
+
             // Emit placeholders for assuming well-formedness of return values and mutable ref
             // parameters.
-            for idx in mut_srcs.into_iter().chain(dests.iter().cloned()) {
+            for idx in mut_srcs
+                .into_iter()
+                .chain(carrying_srcs)
+                .chain(dests.iter().cloned())
+            {
                 let exp = self
                     .builder
                     .mk_call(&BOOL_TYPE, ast::Operation::WellFormed, vec![self
@@ -1110,6 +1156,56 @@ impl<'a> Instrumenter<'a> {
 // # Spec Condition Emission
 
 impl<'a> Instrumenter<'a> {
+    /// Checks that at most one `ensures_of` condition constrains each closure
+    /// argument carrying captured mutations. The call-site model havocs each
+    /// captured location once and threads a single post value, so multiple
+    /// `ensures_of` conditions over the same closure would assume constraints
+    /// about different applications on that one value, which is unsatisfiable
+    /// in general and makes the verification context vacuous.
+    fn check_single_ensures_of_for_carrying(
+        &self,
+        callee_spec: &TranslatedSpec,
+        carrying_srcs: &[TempIndex],
+        loc: &Loc,
+    ) {
+        if carrying_srcs.is_empty() {
+            return;
+        }
+        // Behavioral predicate args may reference the pre-state snapshot temp of
+        // the closure argument; resolve those back to the original temp.
+        let unsaved: BTreeMap<TempIndex, TempIndex> = callee_spec
+            .saved_params
+            .iter()
+            .map(|(orig, saved)| (*saved, *orig))
+            .collect();
+        let mut counts: BTreeMap<TempIndex, usize> = BTreeMap::new();
+        for (_, cond) in &callee_spec.post {
+            cond.visit_pre_order(&mut |e| {
+                if let ExpData::Call(
+                    _,
+                    ast::Operation::Behavior(BehaviorKind::EnsuresOf, _),
+                    args,
+                ) = e
+                {
+                    if let Some(ExpData::Temporary(_, idx)) = args.first().map(|a| a.as_ref()) {
+                        let orig = unsaved.get(idx).copied().unwrap_or(*idx);
+                        if carrying_srcs.contains(&orig) {
+                            *counts.entry(orig).or_insert(0) += 1;
+                        }
+                    }
+                }
+                true
+            });
+        }
+        if counts.values().any(|count| *count > 1) {
+            self.builder.global_env().error(
+                loc,
+                "more than one `ensures_of` condition over a function value carrying \
+                 mutable reference captures cannot be used in an opaque spec",
+            );
+        }
+    }
+
     fn emit_save_for_old(&mut self, vars: &BTreeMap<TempIndex, TempIndex>) {
         use Bytecode::*;
         for (idx, saved_idx) in vars {

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inferred_mut_capture.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inferred_mut_capture.move
@@ -1,0 +1,34 @@
+//
+// A lambda which modifies a captured variable gets its `&mut`-converted
+// signature processed by spec inference: WP produces `ensures x == old(x) + i;
+// aborts_if old(x) + i > MAX_U64;` so the caller proves the captured variable's
+// post-state.
+module 0x42::inferred_mut_capture {
+
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    fun test_mut_capture(): u64 {
+        let x = 5;
+        call_once(|i| x = x + i);
+        x
+    }
+    spec test_mut_capture {
+        ensures result == 6;
+    }
+
+    fun test_mut_capture_twice(): u64 {
+        let x = 0;
+        call_once(|i| x = x + i);
+        call_once(|i| x = x + i);
+        x
+    }
+    spec test_mut_capture_twice {
+        ensures result == 2;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.exp
@@ -1,0 +1,8 @@
+Move prover returns: exiting with compilation errors
+error: cannot capture a mutable reference in a closure requiring the `copy` ability
+   ┌─ tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.move:36:29
+   │
+36 │         for_each_ref(v, |e| s = s + *e spec { // error: cannot capture a mutable reference in a closure requiring the `copy` ability
+   │                             ^
+   │
+   = expected function type: `|&u64| has copy + drop`

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.move
@@ -1,0 +1,50 @@
+// A loop-invoking HOF (`for_each_ref` style) with a `&mut`-capturing lambda —
+// the canonical accumulator pattern — is rejected: invoking `f` in a loop
+// requires the `copy` ability on the function parameter, and a mutable capture
+// makes the closure value linear (copying it would fork the carried mutation).
+//
+// Even apart from linearity, the HOF's quantified spec
+// `forall i: ensures_of<f>(v[i])` would generate N constraints on the SINGLE
+// havoced post-state of the capture; for inputs making those constraints
+// distinct the assumption is inconsistent and the caller's post-condition
+// would be provable vacuously (before the copy rule, the deliberately false
+// `ensures len(v) >= 2 ==> v[0] == v[1]` below verified for exactly the
+// inputs that falsified it). Expressing N sequential applications would need
+// state-label chaining over closure values or a fold-style spec vocabulary.
+module 0x42::inline_opaque_hof_quantified_ensures_of_fail {
+    use std::vector;
+
+    inline fun for_each_ref<T>(v: &vector<T>, f: |&T| has copy + drop) {
+        let i = 0;
+        let n = vector::length(v);
+        while (i < n) {
+            f(vector::borrow(v, i));
+            i = i + 1;
+        }
+    }
+    spec for_each_ref {
+        pragma opaque;
+        requires forall i in 0..len(v): !aborts_of<f>(v[i]);
+        aborts_if false;
+        ensures forall i in 0..len(v): ensures_of<f>(v[i]);
+    }
+
+    /// Caller with a `&mut`-capturing lambda for a `copy`-requiring function
+    /// parameter: rejected by the closure checker.
+    fun unsound_call(v: &vector<u64>): bool {
+        let s = 0;
+        for_each_ref(v, |e| s = s + *e spec { // error: cannot capture a mutable reference in a closure requiring the `copy` ability
+            aborts_if s + e > MAX_U64;
+            ensures s == old(s) + e;
+        });
+        s == s
+    }
+    spec unsound_call {
+        requires forall i in 0..len(v): v[i] < (1 << 32);
+        requires len(v) < 100;
+        aborts_if false;
+        // Semantically false for v = [1, 2]. Without the fix, the prover
+        // accepted this vacuously.
+        ensures len(v) >= 2 ==> v[0] == v[1];
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_alias_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_alias_fail.exp
@@ -1,0 +1,98 @@
+Move prover returns: exiting with compilation errors
+error: local `x` is mutated through more than one argument of this call
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:23:9
+   │
+23 │ ╭         call2( // error: mutated through more than one argument
+24 │ │             |i| x = x + i spec { ensures x == old(x) + i; },
+25 │ │             |i| x = x + 2 * i spec { ensures x == old(x) + 2 * i; }
+26 │ │         );
+   │ ╰─────────^
+   │
+   = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda
+
+error: local `x` is mutated through more than one argument of this call
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:45:9
+   │
+45 │ ╭         update_via(|q| { // error: mutated through more than one argument
+46 │ │             *q = *q + 1;
+47 │ │             x = x + 2;
+48 │ │         } spec {
+49 │ │             ensures q == old(q) + 1;
+50 │ │             ensures x == old(x) + 2;
+51 │ │         }, &mut x);
+   │ ╰──────────────────^
+   │
+   = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda
+
+error: local `x` is mutated through one argument of this call and referenced or captured through another
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:72:17
+   │
+72 │         let r = observe(|i| x = x + i spec { ensures x == old(x) + i; }, &x); // error: mutated and referenced
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda
+
+error: local `x` is mutated through one argument of this call and referenced or captured through another
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:85:9
+   │
+85 │ ╭         call2( // error: mutated and captured
+86 │ │             |i| x = x + i spec { ensures x == old(x) + i; },
+87 │ │             |_i| y = x spec { ensures y == x; }
+88 │ │         );
+   │ ╰─────────^
+   │
+   = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda
+
+error: local `x` is mutated through one argument of this call and referenced or captured through another
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:99:17
+   │
+99 │         let r = observe(|i| x = x + i spec { ensures x == old(x) + i; }, rx); // error: mutated and referenced
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda
+
+error: local `s` is mutated through one argument of this call and referenced or captured through another
+    ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:116:17
+    │
+116 │           let r = observe(|i| s.x = s.x + i spec { // error: mutated and referenced
+    │ ╭─────────────────^
+117 │ │             ensures s.x == old(s).x + i;
+118 │ │             ensures s.y == old(s).y;
+119 │ │         }, rx);
+    │ ╰──────────────^
+    │
+    = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda
+
+error: local `x` is mutated through one argument of this call and referenced or captured through another
+    ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:132:17
+    │
+132 │         let r = observe(|i| x = x + i spec { ensures x == old(x) + i; }, rx); // error: mutated and referenced
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda
+
+error: local `v` is mutated through one argument of this call and referenced or captured through another
+    ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:145:17
+    │
+145 │           let r = observe(|i| { // error: mutated through more than one argument
+    │ ╭─────────────────^
+146 │ │             let e = std::vector::borrow_mut(&mut v, 0);
+147 │ │             *e = *e + i;
+148 │ │         } spec {
+    · │
+151 │ │             ensures len(v) == len(old(v));
+152 │ │         }, std::vector::borrow(&v, 1));
+    │ ╰──────────────────────────────────────^
+    │
+    = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda
+
+error: local `s` is mutated through more than one argument of this call
+    ┌─ tests/sources/functional/closures/inline/opaque_inline_alias_fail.move:172:9
+    │
+172 │ ╭         update_field(|i| s.x = s.x + i spec { // error: mutated through more than one argument
+173 │ │             ensures s.x == old(s).x + i;
+174 │ │             ensures s.y == old(s).y;
+175 │ │         }, &mut s.y);
+    │ ╰────────────────────^
+    │
+    = the behavioral predicates in the callee's opaque spec relate the call's entry and exit states and cannot express sequential effects on the same location; combine the accesses in one lambda

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_alias_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_alias_fail.move
@@ -1,0 +1,181 @@
+// Tests for rejection of conflicting accesses to one location through different
+// arguments of a retained inline-opaque call. Such programs can be legal Move —
+// after inline expansion the accesses happen sequentially — but the behavioral
+// predicates in the callee's opaque spec relate the call's entry and exit
+// states and cannot express sequential effects on the same location; the
+// prover's call-site model (one pre-state value and one havoced post-state
+// value per location) would be unsound.
+module 0x42::opaque_inline_alias_fail {
+
+    inline fun call2(f: |u64|, g: |u64|) {
+        f(1);
+        g(1)
+    }
+    spec call2 {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+        ensures ensures_of<g>(1);
+    }
+
+    /// Test: two lambdas must not mutate the same captured variable in one call.
+    fun test_aliasing_captures(): u64 {
+        let x = 0;
+        call2( // error: mutated through more than one argument
+            |i| x = x + i spec { ensures x == old(x) + i; },
+            |i| x = x + 2 * i spec { ensures x == old(x) + 2 * i; }
+        );
+        x
+    }
+    spec test_aliasing_captures {
+        ensures result == 0;
+    }
+
+    inline fun update_via(f: |&mut u64|, r: &mut u64) {
+        f(r)
+    }
+    spec update_via {
+        pragma opaque;
+        ensures ensures_of<f>(r);
+    }
+
+    /// Test: a variable mutated via capture must not also be passed as a direct
+    /// `&mut` argument of the same call.
+    fun test_aliasing_capture_and_arg(): u64 {
+        let x = 0;
+        update_via(|q| { // error: mutated through more than one argument
+            *q = *q + 1;
+            x = x + 2;
+        } spec {
+            ensures q == old(q) + 1;
+            ensures x == old(x) + 2;
+        }, &mut x);
+        x
+    }
+    spec test_aliasing_capture_and_arg {
+        ensures result == 0;
+    }
+
+    inline fun observe(f: |u64|, r: &u64): u64 {
+        f(1);
+        *r
+    }
+    spec observe {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+        ensures result == r;
+    }
+
+    /// Test: a variable mutated via capture must not also be passed by immutable
+    /// reference (the spec would reason from a stale pre-state value).
+    fun test_mut_capture_and_imm_ref(): (u64, u64) {
+        let x = 0;
+        let r = observe(|i| x = x + i spec { ensures x == old(x) + i; }, &x); // error: mutated and referenced
+        (x, r)
+    }
+    spec test_mut_capture_and_imm_ref {
+        ensures result_2 == 0;
+    }
+
+    /// Test: a variable mutated via capture must not be value-captured by another
+    /// lambda of the same call (the capture snapshots the variable at closure
+    /// construction, while inline expansion would read it at its use sites).
+    fun test_mut_and_value_capture(): (u64, u64) {
+        let x = 1;
+        let y = 0;
+        call2( // error: mutated and captured
+            |i| x = x + i spec { ensures x == old(x) + i; },
+            |_i| y = x spec { ensures y == x; }
+        );
+        (x, y)
+    }
+    spec test_mut_and_value_capture {
+        ensures result_2 == 1;
+    }
+
+    /// Test: the same conflict through a reference-typed local binding.
+    fun test_mut_capture_and_imm_carrier(): (u64, u64) {
+        let x = 0;
+        let rx = &x;
+        let r = observe(|i| x = x + i spec { ensures x == old(x) + i; }, rx); // error: mutated and referenced
+        (x, r)
+    }
+    spec test_mut_capture_and_imm_carrier {
+        ensures result_2 == 0;
+    }
+
+    struct S has copy, drop {
+        x: u64,
+        y: u64,
+    }
+
+    /// Test: a chain of reference-typed bindings resolves to the root.
+    fun test_mut_capture_and_chained_carrier(): (u64, u64) {
+        let s = S { x: 0, y: 7 };
+        let rs = &s;
+        let rx = &rs.x;
+        let r = observe(|i| s.x = s.x + i spec { // error: mutated and referenced
+            ensures s.x == old(s).x + i;
+            ensures s.y == old(s).y;
+        }, rx);
+        (s.x, r)
+    }
+    spec test_mut_capture_and_chained_carrier {
+        ensures result_2 == 0;
+    }
+
+    /// Test: a carrier binding is checked with the bindings in effect at the
+    /// call, regardless of later rebindings.
+    fun test_carrier_rebound_after_call(): (u64, u64) {
+        let x = 0;
+        let y = 100;
+        let rx = &x;
+        let r = observe(|i| x = x + i spec { ensures x == old(x) + i; }, rx); // error: mutated and referenced
+        let rx = &y;
+        let _ = *rx;
+        (x, r)
+    }
+    spec test_carrier_rebound_after_call {
+        ensures result_2 == 0;
+    }
+
+    /// Test: a reference computed by a helper call derives from the references
+    /// inside it; mutating the same vector through a capture conflicts.
+    fun test_mut_capture_and_helper_borrow(): u64 {
+        let v = vector[1u64, 2];
+        let r = observe(|i| { // error: mutated through more than one argument
+            let e = std::vector::borrow_mut(&mut v, 0);
+            *e = *e + i;
+        } spec {
+            ensures v[0] == old(v)[0] + i;
+            ensures v[1] == old(v)[1];
+            ensures len(v) == len(old(v));
+        }, std::vector::borrow(&v, 1));
+        r
+    }
+    spec test_mut_capture_and_helper_borrow {
+        ensures result == 2;
+    }
+
+    inline fun update_field(f: |u64|, r: &mut u64) {
+        f(1);
+        *r = *r + 1
+    }
+    spec update_field {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+        ensures r == old(r) + 1;
+    }
+
+    /// Test: a direct field borrow conflicts with a mutation of the whole struct.
+    fun test_mut_capture_and_field_borrow(): u64 {
+        let s = S { x: 0, y: 7 };
+        update_field(|i| s.x = s.x + i spec { // error: mutated through more than one argument
+            ensures s.x == old(s).x + i;
+            ensures s.y == old(s).y;
+        }, &mut s.y);
+        s.x + s.y
+    }
+    spec test_mut_capture_and_field_borrow {
+        ensures result == 9;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_escape_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_escape_fail.exp
@@ -1,0 +1,32 @@
+Move prover returns: exiting with compilation errors
+error: a closure capturing references cannot be passed to this call: the callee may leak function values through its result or a `&mut` parameter
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_escape_fail.move:20:17
+   │
+20 │         let g = id_fun(|i| x = x + i spec { ensures x == old(x) + i; }); // error: callee may leak function values
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = such a closure must not outlive the call, since its captured locations are only modeled at this call site
+
+error: a closure capturing references cannot be passed to this call: the callee may leak function values through its result or a `&mut` parameter
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_escape_fail.move:37:9
+   │
+37 │         stash(|i| x = x + i spec { ensures x == old(x) + i; }, &mut s); // error: callee may leak function values
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = such a closure must not outlive the call, since its captured locations are only modeled at this call site
+
+error: a closure capturing references cannot be passed to this call: the callee may leak function values through its result or a `&mut` parameter
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_escape_fail.move:55:18
+   │
+55 │         let _h = wrap(|i| x = x + i spec { ensures x == old(x) + i; }); // error: callee may leak function values
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = such a closure must not outlive the call, since its captured locations are only modeled at this call site
+
+error: a closure capturing references cannot be passed to this call: the callee may leak function values through its result or a `&mut` parameter
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_escape_fail.move:74:24
+   │
+74 │         let (_a, _b) = wrap_pair(|i| x = x + i spec { ensures x == old(x) + i; }); // error: callee may leak function values
+   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = such a closure must not outlive the call, since its captured locations are only modeled at this call site

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_escape_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_escape_fail.move
@@ -1,0 +1,77 @@
+// Tests that a closure capturing references cannot outlive a retained
+// inline-opaque call: its captured locations are only modeled at that call
+// site, so the callee must not be able to leak the function value back to the
+// caller, neither through its result (directly or wrapped in a struct) nor
+// through a `&mut` parameter. Global storage is excluded already, since
+// reference captures lack the `store` ability.
+module 0x42::opaque_inline_escape_fail {
+
+    inline fun id_fun(f: |u64|): |u64| {
+        f
+    }
+    spec id_fun {
+        pragma opaque;
+        ensures result == f;
+    }
+
+    /// Test: escape through the result.
+    fun test_escape_via_result(): u64 {
+        let x = 0;
+        let g = id_fun(|i| x = x + i spec { ensures x == old(x) + i; }); // error: callee may leak function values
+        g(5);
+        x
+    }
+
+    inline fun stash(f: |u64| has drop, slot: &mut |u64| has drop) {
+        *slot = f
+    }
+    spec stash {
+        pragma opaque;
+        ensures slot == f;
+    }
+
+    /// Test: escape through a `&mut` parameter.
+    fun test_escape_via_mut_param(dummy: |u64| has drop) {
+        let x = 0;
+        let s = dummy;
+        stash(|i| x = x + i spec { ensures x == old(x) + i; }, &mut s); // error: callee may leak function values
+        s(1);
+    }
+
+    struct Holder has drop {
+        f: |u64| has drop,
+    }
+
+    inline fun wrap(f: |u64| has drop): Holder {
+        Holder { f }
+    }
+    spec wrap {
+        pragma opaque;
+    }
+
+    /// Test: escape through a struct-wrapped result.
+    fun test_escape_via_struct_result(): u64 {
+        let x = 0;
+        let _h = wrap(|i| x = x + i spec { ensures x == old(x) + i; }); // error: callee may leak function values
+        x
+    }
+
+    struct Wrap<T> has drop {
+        v: T,
+    }
+
+    inline fun wrap_pair(f: |u64| has drop): (Wrap<u64>, Wrap<|u64| has drop>) {
+        (Wrap { v: 1 }, Wrap { v: f })
+    }
+    spec wrap_pair {
+        pragma opaque;
+    }
+
+    /// Test: escape through a later instantiation of the same generic wrapper
+    /// (each instantiation must be inspected separately).
+    fun test_escape_via_generic_wrapper(): u64 {
+        let x = 0;
+        let (_a, _b) = wrap_pair(|i| x = x + i spec { ensures x == old(x) + i; }); // error: callee may leak function values
+        x
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fail.exp
@@ -20,3 +20,71 @@ error: post-condition does not hold
    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:23: test_wrong_lambda_spec
    =         y = <redacted>
    =         result = <redacted>
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_fail.move:44:9
+   │
+44 │         ensures result == 0; // error: post-condition does not hold (x is modified by the lambda)
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:39: test_wrong_mut_capture_post
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:40: test_wrong_mut_capture_post
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:41: test_wrong_mut_capture_post
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:38: test_wrong_mut_capture_post
+   =         result = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:44: test_wrong_mut_capture_post (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_fail.move:50:40
+   │
+50 │         call_once(|i| x = x + i spec { ensures x == old(x) + i + 1; }); // error: post-condition does not hold (lifted lambda)
+   │                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:50: test_wrong_mut_capture_lambda_spec
+   =         x = <redacted>
+   =         i = <redacted>
+   =         x = <redacted>
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_fail.move:71:9
+   │
+71 │         ensures result.y == 7; // error: post-condition does not hold (y is not framed by the lambda spec)
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:65: test_unframed_field
+   =         s = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:66: test_unframed_field
+   =         s = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:67: test_unframed_field
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:64: test_unframed_field
+   =         result = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:70: test_unframed_field (spec)
+   =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:71: test_unframed_field (spec)
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/closures/inline/opaque_inline_fail.move:100:9
+    │
+100 │         ensures result_1 == 102; // error: post-condition does not hold
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:84: test_swapped_mut_posts
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:97: test_swapped_mut_posts (spec)
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:84: test_swapped_mut_posts
+    =         p = <redacted>
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:85: test_swapped_mut_posts
+    =         count = <redacted>
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:86: test_swapped_mut_posts
+    =         v = <redacted>
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:89: test_swapped_mut_posts
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:87: test_swapped_mut_posts
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:93: test_swapped_mut_posts
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:87: test_swapped_mut_posts
+    =         count = <redacted>
+    =         v = <redacted>
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:94: test_swapped_mut_posts
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:84: test_swapped_mut_posts
+    =         result_1 = <redacted>
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/closures/inline/opaque_inline_fail.move:100: test_swapped_mut_posts (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fail.move
@@ -25,4 +25,78 @@ module 0x42::opaque_inline_fail {
     spec test_wrong_lambda_spec {
         ensures result == x + 2;
     }
+
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: wrong caller postcondition about a modified captured variable.
+    fun test_wrong_mut_capture_post(): u64 {
+        let x = 0;
+        call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec test_wrong_mut_capture_post {
+        ensures result == 0; // error: post-condition does not hold (x is modified by the lambda)
+    }
+
+    /// Test: the lambda's spec about the captured variable does not hold for its body.
+    fun test_wrong_mut_capture_lambda_spec(): u64 {
+        let x = 0;
+        call_once(|i| x = x + i spec { ensures x == old(x) + i + 1; }); // error: post-condition does not hold (lifted lambda)
+        x
+    }
+    spec test_wrong_mut_capture_lambda_spec {
+        ensures result == 2;
+    }
+
+    struct S has copy, drop {
+        x: u64,
+        y: u64,
+    }
+
+    /// Test: a lambda assigning to a field converts the whole struct variable
+    /// into a `&mut` capture; fields not framed by the lambda's spec are havoced.
+    fun test_unframed_field(): S {
+        let s = S { x: 1, y: 7 };
+        call_once(|i| s.x = s.x + i spec { ensures s.x == old(s).x + i; });
+        s
+    }
+    spec test_unframed_field {
+        ensures result.x == 2;
+        ensures result.y == 7; // error: post-condition does not hold (y is not framed by the lambda spec)
+    }
+
+    inline fun update_via(f: |&mut u64|, r: &mut u64) {
+        f(r)
+    }
+    spec update_via {
+        pragma opaque;
+        ensures ensures_of<f>(r);
+    }
+
+    /// Test: post-state slots of the `&mut` parameter and of the modified capture
+    /// must not be confused (the claims below are swapped between the two).
+    fun test_swapped_mut_posts(p: u64): (u64, u64) {
+        let count = 100;
+        let v = p;
+        update_via(|q| {
+            *q = *q + 1;
+            count = count + 2;
+        } spec {
+            ensures q == old(q) + 1;
+            ensures count == old(count) + 2;
+        }, &mut v);
+        (v, count)
+    }
+    spec test_swapped_mut_posts {
+        requires p < 1000;
+        // This would verify if the post-state slots were swapped (count's post
+        // value is 102); the actual value is `p + 1`.
+        ensures result_1 == 102; // error: post-condition does not hold
+    }
 }

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_inconsistency.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_inconsistency.move
@@ -1,8 +1,9 @@
 // flag: --check-inconsistency
 //
 // Guards against vacuity in the verification context created for retained
-// inline-opaque calls: the `ensures_of` assumptions injected for a value
-// capture must be satisfiable.
+// inline-opaque calls: the havocs and `ensures_of` assumptions injected for
+// value, immutable-reference, and `&mut` captures (including combined with
+// non-captured `&mut` parameters) must be satisfiable.
 module 0x42::opaque_inline_inconsistency {
 
     inline fun apply(f: |u64| u64, x: u64): u64 {
@@ -18,5 +19,47 @@ module 0x42::opaque_inline_inconsistency {
     }
     spec value_capture {
         ensures result == x + c;
+    }
+
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    fun mut_capture(): u64 {
+        let x = 0;
+        call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec mut_capture {
+        ensures result == 1;
+    }
+
+    inline fun update_via(f: |&mut u64|, r: &mut u64) {
+        f(r)
+    }
+    spec update_via {
+        pragma opaque;
+        ensures ensures_of<f>(r);
+    }
+
+    fun mut_capture_and_mut_param(p: u64): u64 {
+        let count = 0;
+        let v = p;
+        update_via(|q| {
+            *q = *q + 1;
+            count = count + 2;
+        } spec {
+            ensures q == old(q) + 1;
+            ensures count == old(count) + 2;
+        }, &mut v);
+        v + count
+    }
+    spec mut_capture_and_mut_param {
+        requires p < 1000;
+        ensures result == p + 3;
     }
 }

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with bytecode transformation errors
+error: more than one `ensures_of` condition over a function value carrying mutable reference captures cannot be used in an opaque spec
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.move:22:9
+   │
+22 │         call_trusted_twice(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` condition over a function value carrying mutable reference captures
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.move
@@ -1,0 +1,29 @@
+// Tests rejection of a (trusted) opaque spec which constrains a closure with
+// captured mutations through more than one `ensures_of` condition: the call-site
+// model havocs each captured location once and cannot express constraints about
+// different applications. (Without `pragma verify = false`, the body check
+// refutes such specs already.)
+module 0x42::opaque_inline_multi_ensures_fail {
+
+    inline fun call_trusted_twice(f: |u64|) {
+        f(1)
+    }
+    spec call_trusted_twice {
+        pragma opaque;
+        pragma verify = false;
+        ensures ensures_of<f>(1);
+        ensures ensures_of<f>(2);
+    }
+
+    /// Test: a (trusted) spec constraining one mutating closure through more
+    /// than one `ensures_of` cannot be instantiated at the call site.
+    fun test_multiple_ensures_of(): u64 {
+        let x = 0;
+        call_trusted_twice(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` condition over a function value carrying mutable reference captures
+        x
+    }
+    spec test_multiple_ensures_of {
+        ensures result == 1;
+    }
+
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture.move
@@ -1,0 +1,173 @@
+// Tests for lambdas which modify captured variables, passed to retained
+// inline-opaque functions. The lambda lifter converts such captures into
+// `&mut` captures: `|i| x = x + i` becomes a closure capturing `&mut x` over
+// a lifted function `fun lifted(x: &mut u64, i: u64) { *x = *x + i }`. At the
+// opaque call site, the captured locations are havoced and constrained by the
+// `ensures_of` conditions of the callee's spec.
+module 0x42::opaque_inline_mut_capture {
+
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: the effect of the lambda on the captured variable propagates
+    /// through the opaque inline call via `ensures_of`.
+    fun test_mut_capture(): u64 {
+        let x = 0;
+        call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec test_mut_capture {
+        ensures result == 1;
+    }
+
+    /// Test: chained mutations accumulate.
+    fun test_mut_capture_twice(): u64 {
+        let x = 0;
+        call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+        call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec test_mut_capture_twice {
+        ensures result == 2;
+    }
+
+    /// Test: lambda modifying two captured variables.
+    fun test_two_mut_captures(): u64 {
+        let x = 0;
+        let y = 10;
+        call_once(|i| {
+            x = x + i;
+            y = y + i;
+        } spec {
+            ensures x == old(x) + i;
+            ensures y == old(y) + i;
+        });
+        x + y
+    }
+    spec test_two_mut_captures {
+        ensures result == 12;
+    }
+
+    /// Test: mixed value and mutating captures.
+    fun test_mixed_captures(c: u64): u64 {
+        let x = 0;
+        call_once(|i| x = x + i + c spec { ensures x == old(x) + i + c; });
+        x
+    }
+    spec test_mixed_captures {
+        requires c < 1000;
+        ensures result == 1 + c;
+    }
+
+    struct S has copy, drop {
+        x: u64,
+        y: u64,
+    }
+
+    /// Test: lambda assigning to a field of a captured struct variable. The
+    /// whole struct is converted to a `&mut` capture; unmodified fields are
+    /// framed by the lambda's spec.
+    fun test_field_capture(): S {
+        let s = S { x: 1, y: 7 };
+        call_once(|i| s.x = s.x + i spec {
+            ensures s.x == old(s).x + i;
+            ensures s.y == old(s).y;
+        });
+        s
+    }
+    spec test_field_capture {
+        ensures result.x == 2;
+        ensures result.y == 7;
+    }
+
+    inline fun count(self: &S, f: |u64|) {
+        f(1)
+    }
+    spec count {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: the motivating shape — a receiver-style call with a compound
+    /// assignment to a context local.
+    fun test_receiver_compound(s: &S): u64 {
+        let n = 0;
+        s.count(|_x| n += 1 spec { ensures n == old(n) + 1; });
+        n
+    }
+    spec test_receiver_compound {
+        ensures result == 1;
+    }
+
+    fun bump(r: &mut u64) {
+        *r = *r + 1
+    }
+    spec bump {
+        ensures r == old(r) + 1;
+    }
+
+    /// Test: lambda passing a mutable borrow of a field of a captured struct
+    /// variable to a function. The borrow chain marks the whole struct as a
+    /// `&mut` capture; the lambda's spec is proven from `bump`'s spec.
+    fun test_field_borrow_to_fun(): S {
+        let s = S { x: 1, y: 7 };
+        call_once(|_i| bump(&mut s.x) spec {
+            ensures s.x == old(s).x + 1;
+            ensures s.y == old(s).y;
+        });
+        s
+    }
+    spec test_field_borrow_to_fun {
+        ensures result.x == 2;
+        ensures result.y == 7;
+    }
+
+    /// Test: lambda mutating an element of a captured vector.
+    fun test_vector_capture(): vector<u64> {
+        let v = vector[1, 5];
+        call_once(|i| v[0] = v[0] + i spec {
+            ensures v[0] == old(v)[0] + i;
+            ensures v[1] == old(v)[1];
+            ensures len(v) == len(old(v));
+        });
+        v
+    }
+    spec test_vector_capture {
+        ensures result[0] == 2;
+        ensures result[1] == 5;
+    }
+
+    inline fun update_via(f: |&mut u64|, r: &mut u64) {
+        f(r)
+    }
+    spec update_via {
+        pragma opaque;
+        ensures ensures_of<f>(r);
+    }
+
+    /// Test: lambda with a `&mut` parameter combined with a modified capture.
+    /// The lifted function has both a captured `&mut` (the counter) and a
+    /// non-captured `&mut` parameter (from the function type), whose post-state
+    /// slots must be merged in parameter order.
+    fun test_mut_param_and_mut_capture(p: u64): u64 {
+        let count = 0;
+        let v = p;
+        update_via(|q| {
+            *q = *q + 1;
+            count = count + 2;
+        } spec {
+            ensures q == old(q) + 1;
+            ensures count == old(count) + 2;
+        }, &mut v);
+        v + count
+    }
+    spec test_mut_param_and_mut_capture {
+        requires p < 1000;
+        ensures result == p + 3;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_alias_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_alias_fail.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with condition generation errors
+error: [boogie translator] ensures_of over a function value carrying mutable reference captures is only supported for directly referenced function values
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_mut_capture_alias_fail.move:14:17
+   │
+14 │         ensures ensures_of<g>(1); // error: only supported for directly referenced function values
+   │                 ^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_alias_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_alias_fail.move
@@ -1,0 +1,25 @@
+// Aliasing a mut-capturing function value through a spec `let` is not yet
+// supported: the `f_post` threading of `ensures_of` requires a directly
+// referenced function value (a spec-let binding would alias the pre-call
+// closure value).
+module 0x42::opaque_inline_mut_capture_alias_fail {
+
+    /// Test: the callee spec may alias the function value through a spec `let`.
+    inline fun call_aliased(f: |u64|) {
+        f(1)
+    }
+    spec call_aliased {
+        pragma opaque;
+        let g = f;
+        ensures ensures_of<g>(1); // error: only supported for directly referenced function values
+    }
+    fun test_spec_let_alias(): u64 {
+        let x = 0;
+        call_aliased(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec test_spec_let_alias {
+        ensures result == 1;
+    }
+
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_branch.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_branch.move
@@ -1,0 +1,38 @@
+// Test for mut-capturing closures packed under a branch: two packs of the
+// same closure shape from different roots merge into one temp at the join,
+// exercising the conditional write-back with `IsParent` on `Capture` edges.
+module 0x42::opaque_inline_mut_capture_branch {
+    inline fun modify(f: |u64|) {
+        f(1)
+    }
+    spec modify {
+        pragma opaque;
+        requires !aborts_of<f>(1);
+        aborts_if false;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: conditional capture of one of two locals.
+    fun test_branch_capture(c: bool): (u64, u64) {
+        let x = 10;
+        let z = 20;
+        if (c) {
+            let rx = &mut x;
+            modify(|y| *rx = *rx + y spec {
+                aborts_if rx + y > MAX_U64;
+                ensures rx == old(rx) + y;
+            });
+        } else {
+            let rz = &mut z;
+            modify(|y| *rz = *rz + y spec {
+                aborts_if rz + y > MAX_U64;
+                ensures rz == old(rz) + y;
+            });
+        };
+        (x, z)
+    }
+    spec test_branch_capture {
+        ensures c ==> result_1 == 11 && result_2 == 20;
+        ensures !c ==> result_1 == 10 && result_2 == 21;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_control.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_control.move
@@ -1,0 +1,235 @@
+// Tests for lambdas modifying captured variables at retained inline-opaque
+// call sites in various control-flow and shape contexts.
+module 0x42::opaque_inline_mut_capture_control {
+
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: calls under different branches.
+    fun test_branches(b: bool): u64 {
+        let x = 0;
+        if (b) {
+            call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+        } else {
+            call_once(|i| x = x + 2 * i spec { ensures x == old(x) + 2 * i; });
+        };
+        x
+    }
+    spec test_branches {
+        ensures b ==> result == 1;
+        ensures !b ==> result == 2;
+    }
+
+    /// Test: call in a loop with an invariant over the captured variable.
+    fun test_loop(n: u64): u64 {
+        let x = 0;
+        let k = 0;
+        while (k < n) {
+            call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+            k = k + 1;
+        } spec {
+            invariant x == k;
+            invariant k <= n;
+        };
+        x
+    }
+    spec test_loop {
+        ensures result == n;
+    }
+
+    /// Test: an inner let shadowing the captured name is not confused with it.
+    fun test_shadowing(): u64 {
+        let x = 1;
+        call_once(|i| {
+            x = x + i;
+            let x = 100;
+            assert!(x == 100, 1);
+        } spec {
+            ensures x == old(x) + i;
+        });
+        x
+    }
+    spec test_shadowing {
+        ensures result == 2;
+    }
+
+    /// Test: explicitly created `&mut` to a local, captured by the lambda.
+    fun test_explicit_ref_capture(): u64 {
+        let x = 1;
+        let r = &mut x;
+        call_once(|i| *r = *r + i spec { ensures r == old(r) + i; });
+        x
+    }
+    spec test_explicit_ref_capture {
+        ensures result == 2;
+    }
+
+    /// Test: lambda with multiple parameters and a modified capture.
+    inline fun call2(f: |u64, u64|) {
+        f(1, 2)
+    }
+    spec call2 {
+        pragma opaque;
+        ensures ensures_of<f>(1, 2);
+    }
+    fun test_two_lambda_params(): u64 {
+        let x = 0;
+        call2(|a, b| x = x + a + b spec { ensures x == old(x) + a + b; });
+        x
+    }
+    spec test_two_lambda_params {
+        ensures result == 3;
+    }
+
+    /// Test: two lambdas mutating distinct captured variables in one call;
+    /// the callee invokes them sequentially.
+    inline fun call_both(f: |u64|, g: |u64|) {
+        f(1);
+        g(1)
+    }
+    spec call_both {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+        ensures ensures_of<g>(1);
+    }
+    fun test_two_mut_lambdas(): u64 {
+        let x = 0;
+        let y = 10;
+        call_both(
+            |i| x = x + i spec { ensures x == old(x) + i; },
+            |i| y = y + 2 * i spec { ensures y == old(y) + 2 * i; }
+        );
+        x + y
+    }
+    spec test_two_mut_lambdas {
+        ensures result == 13;
+    }
+
+    /// Test: a direct non-reference argument of a mutated local is allowed; it
+    /// is evaluated at call entry under both closure and expansion semantics.
+    inline fun call_with(f: |u64|, v: u64): u64 {
+        f(1);
+        v
+    }
+    spec call_with {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+        ensures result == v;
+    }
+    fun test_mut_capture_and_value_arg(): (u64, u64) {
+        let x = 1;
+        let r = call_with(|i| x = x + i spec { ensures x == old(x) + i; }, x);
+        (x, r)
+    }
+    spec test_mut_capture_and_value_arg {
+        ensures result_1 == 2;
+        ensures result_2 == 1;
+    }
+
+    /// Test: abort condition of a lambda which modifies a capture propagates
+    /// through the opaque call.
+    inline fun guarded_once(f: |u64|) {
+        f(1)
+    }
+    spec guarded_once {
+        pragma opaque;
+        aborts_if aborts_of<f>(1);
+        ensures ensures_of<f>(1);
+    }
+    fun test_guarded_mut_capture(): u64 {
+        let x = 10;
+        guarded_once(|i| x = x + i spec {
+            aborts_if x + i > MAX_U64;
+            ensures x == old(x) + i;
+        });
+        x
+    }
+    spec test_guarded_mut_capture {
+        aborts_if false;
+        ensures result == 11;
+    }
+
+    /// Test: value-returning lambda which also modifies a capture; the declared
+    /// result and the capture's post-state are both constrained.
+    inline fun apply_once(f: |u64| u64): u64 {
+        f(1)
+    }
+    spec apply_once {
+        pragma opaque;
+        ensures result == result_of<f>(1);
+        ensures ensures_of<f>(1, result);
+    }
+    fun test_result_and_mut_capture(): u64 {
+        let x = 5;
+        let r = apply_once(|i| {
+            x = x + i;
+            x
+        } spec {
+            ensures x == old(x) + i;
+            ensures result == old(x) + i;
+        });
+        x + r
+    }
+    spec test_result_and_mut_capture {
+        ensures result == 12;
+    }
+
+    spec module {
+        global sum_ghost: u64;
+    }
+
+    /// Test: a ghost update over `result_of` of a mutating lambda is rewritten
+    /// like the other spec conditions and constrains the ghost variable.
+    inline fun apply_tracked(f: |u64| u64): u64 {
+        f(1)
+    }
+    spec apply_tracked {
+        pragma opaque;
+        ensures result == result_of<f>(1);
+        ensures ensures_of<f>(1, result);
+        update sum_ghost = result_of<f>(1);
+    }
+    fun test_ghost_update(): u64 {
+        let x = 5;
+        let r = apply_tracked(|i| {
+            x = x + i;
+            x
+        } spec {
+            ensures x == old(x) + i;
+            ensures result == old(x) + i;
+        });
+        spec {
+            assert sum_ghost == 6;
+        };
+        x + r
+    }
+    spec test_ghost_update {
+        ensures result == 12;
+    }
+
+    /// Test: nested field mutation of a captured struct.
+    struct Inner has copy, drop {
+        v: u64,
+    }
+    struct Outer has copy, drop {
+        i: Inner,
+        w: u64,
+    }
+    fun test_nested_field(): Outer {
+        let o = Outer { i: Inner { v: 1 }, w: 9 };
+        call_once(|k| o.i.v = o.i.v + k spec {
+            ensures o.i.v == old(o).i.v + k;
+            ensures o.w == old(o).w;
+        });
+        o
+    }
+    spec test_nested_field {
+        ensures result.i.v == 2;
+        ensures result.w == 9;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_global.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_global.move
@@ -1,0 +1,56 @@
+// Tests for lambdas capturing mutable references rooted in global storage.
+// The captured mutation is carried by the closure value across the retained
+// call and written back into the resource memory when the closure dies, where
+// global invariants and modifies checking attach as for any memory update.
+module 0x42::opaque_inline_mut_capture_global {
+    struct R has key {
+        value: u64,
+    }
+
+    struct G<T: store> has key {
+        t: T,
+    }
+
+    spec module {
+        invariant forall a: address where exists<R>(a): global<R>(a).value < 1000;
+    }
+
+    inline fun modify(f: |u64|) {
+        f(1)
+    }
+    spec modify {
+        pragma opaque;
+        requires !aborts_of<f>(1);
+        aborts_if false;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: capture of a mutable reference into global storage; the module
+    /// invariant is checked when the mutation is written back.
+    fun bump(a: address) {
+        let r = &mut R[a].value;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+    }
+    spec bump {
+        requires global<R>(a).value < 999;
+        aborts_if !exists<R>(a);
+        ensures global<R>(a).value == old(global<R>(a).value) + 1;
+    }
+
+    /// Test: capture rooted in a generic resource instance.
+    fun bump_generic(a: address) {
+        let r = &mut G<u64>[a].t;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+    }
+    spec bump_generic {
+        requires global<G<u64>>(a).t < MAX_U64;
+        aborts_if !exists<G<u64>>(a);
+        ensures global<G<u64>>(a).t == old(global<G<u64>>(a).t) + 1;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_inferred.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_inferred.move
@@ -1,0 +1,25 @@
+// Test for a mut-capturing lambda without an explicit spec block: the lambda's
+// spec (relating the captured location's pre and post state) is inferred from
+// its body by lambda spec inference.
+module 0x42::opaque_inline_mut_capture_inferred {
+    inline fun modify(f: |u64|) {
+        f(1)
+    }
+    spec modify {
+        pragma opaque;
+        requires !aborts_of<f>(1);
+        aborts_if false;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: the lambda's relational spec is inferred.
+    fun test_inferred_lambda_spec(): u64 {
+        let x = 10;
+        let r = &mut x;
+        modify(|y| *r = *r + y);
+        x
+    }
+    spec test_inferred_lambda_spec {
+        ensures result == 11;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_mixed_args.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_mixed_args.move
@@ -1,0 +1,32 @@
+// Test combining a mut-capturing closure with an independent plain `&mut`
+// argument of the retained call (distinct roots, both mutated by the callee).
+module 0x42::opaque_inline_mut_capture_mixed_args {
+    inline fun modify_both(f: |u64|, r: &mut u64) {
+        f(1);
+        *r = *r + 100;
+    }
+    spec modify_both {
+        pragma opaque;
+        requires !aborts_of<f>(1);
+        requires r < 1000000;
+        aborts_if false;
+        ensures ensures_of<f>(1);
+        ensures r == old(r) + 100;
+    }
+
+    /// Test: the capture and the plain `&mut` argument target distinct roots.
+    fun test_mixed_args(): (u64, u64) {
+        let x = 10;
+        let z = 20;
+        let rx = &mut x;
+        modify_both(|y| *rx = *rx + y spec {
+            aborts_if rx + y > MAX_U64;
+            ensures rx == old(rx) + y;
+        }, &mut z);
+        (x, z)
+    }
+    spec test_mixed_args {
+        ensures result_1 == 11;
+        ensures result_2 == 120;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture.move
@@ -1,0 +1,135 @@
+// Tests for lambdas capturing mutable references, passed to retained
+// inline-opaque functions. The prover models the captured mutation as carried
+// by the closure value: havoced across the call, constrained by the callee's
+// behavioral post conditions, and written back to its source location when
+// the closure dies.
+module 0x42::opaque_inline_mut_ref_capture {
+    struct S has drop {
+        f: u64,
+        g: u64,
+    }
+
+    inline fun modify(f: |u64|) {
+        f(1)
+    }
+    spec modify {
+        pragma opaque;
+        requires !aborts_of<f>(1);
+        aborts_if false;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: lambda capturing a mutable reference to a local.
+    fun test_local_mut_capture(): u64 {
+        let x = 10;
+        let r = &mut x;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+        x
+    }
+    spec test_local_mut_capture {
+        ensures result == 11;
+    }
+
+    /// Test: lambda capturing a mutable reference parameter.
+    fun test_param_mut_capture(r: &mut u64) {
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+    }
+    spec test_param_mut_capture {
+        requires r < MAX_U64;
+        aborts_if false;
+        ensures r == old(r) + 1;
+    }
+
+    /// Test: lambda capturing a mutable field borrow (a `Field` edge above the
+    /// `Capture` edge in the write-back chain).
+    fun test_field_mut_capture(): S {
+        let s = S { f: 1, g: 2 };
+        let r = &mut s.f;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+        s
+    }
+    spec test_field_mut_capture {
+        ensures result.f == 2;
+        ensures result.g == 2;
+    }
+
+    /// Test: two sequential retained calls mutating the same root.
+    fun test_sequential_calls(): u64 {
+        let x = 0;
+        let r = &mut x;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+        let r2 = &mut x;
+        modify(|y| *r2 = *r2 + y spec {
+            aborts_if r2 + y > MAX_U64;
+            ensures r2 == old(r2) + y;
+        });
+        x
+    }
+    spec test_sequential_calls {
+        ensures result == 2;
+    }
+
+    inline fun apply_ref(f: |&mut u64| &mut u64, x: &mut u64): u64 {
+        *f(x)
+    }
+    spec apply_ref {
+        // Not honored: `apply_ref` has a `&mut`-returning function parameter, so
+        // it is not retained; calls are expanded and verified through the body.
+        pragma opaque;
+    }
+
+    /// Test: a lambda capturing a `&mut` and returning a reference is admitted
+    /// because the callee is expanded rather than retained.
+    fun test_expanded_ref_result(): u64 {
+        let x = 10;
+        let z = 5;
+        let r = &mut z;
+        let v = apply_ref(|s| {
+            *s = *s + 1;
+            r
+        }, &mut x);
+        v + x + z
+    }
+    spec test_expanded_ref_result {
+        ensures result == 21;
+    }
+
+    inline fun scale(f: |u64|, k: u64) {
+        f(k)
+    }
+    spec scale {
+        pragma opaque;
+        requires !aborts_of<f>(k);
+        aborts_if false;
+        ensures ensures_of<f>(k);
+    }
+
+    /// Test: mixed capture of a mutable reference and a value, with a
+    /// non-captured parameter.
+    fun test_mixed_capture(k: u64): u64 {
+        let x = 10;
+        let b = 3;
+        let r = &mut x;
+        scale(|y| *r = *r * y + b spec {
+            aborts_if r * y + b > MAX_U64;
+            ensures r == old(r) * y + b;
+        }, k);
+        x
+    }
+    spec test_mixed_capture {
+        requires k < 1000;
+        ensures result == 10 * k + 3;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.exp
@@ -1,0 +1,62 @@
+Move prover returns: exiting with verification errors
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:12:9
+   │
+12 │         invariant forall a: address where exists<R>(a): global<R>(a).value < 1000;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:69: test_invariant_violated
+   =         a = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:70: test_invariant_violated
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:71: test_invariant_violated
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:20: modify (spec)
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:71: test_invariant_violated
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:12
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:20:9
+   │
+20 │         requires !aborts_of<f>(1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:40: test_abort_not_discharged
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:41: test_abort_not_discharged
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:42: test_abort_not_discharged
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:20: modify (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:36:9
+   │
+36 │         ensures result == 12; // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:27: test_wrong_post
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:28: test_wrong_post
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:29: test_wrong_post
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:20: modify (spec)
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:29: test_wrong_post
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:33: test_wrong_post
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:26: test_wrong_post
+   =         result = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:36: test_wrong_post (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:63:9
+   │
+63 │         ensures global<R>(a).value == old(global<R>(a).value) + 2; // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:53: test_wrong_global_post
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:61: test_wrong_global_post (spec)
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:53: test_wrong_global_post
+   =         a = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:54: test_wrong_global_post
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:55: test_wrong_global_post
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:20: modify (spec)
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:55: test_wrong_global_post
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:12
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:62: test_wrong_global_post (spec)
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move:63: test_wrong_global_post (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_ref_capture_fail.move
@@ -1,0 +1,80 @@
+// Expected-failure tests for lambdas capturing mutable references: the
+// captured location's post value is constrained exactly by the lambda's
+// behavioral spec, no more and no less, and mutations written back into
+// global storage are subject to global invariant checking.
+module 0x42::opaque_inline_mut_ref_capture_fail {
+    struct R has key {
+        value: u64,
+    }
+
+    spec module {
+        // error: global memory invariant does not hold (in test_invariant_violated)
+        invariant forall a: address where exists<R>(a): global<R>(a).value < 1000;
+    }
+
+    inline fun modify(f: |u64|) {
+        f(1)
+    }
+    spec modify {
+        pragma opaque;
+        requires !aborts_of<f>(1);
+        aborts_if false;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Test: wrong expectation about the captured location's post value.
+    fun test_wrong_post(): u64 {
+        let x = 10;
+        let r = &mut x;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+        x
+    }
+    spec test_wrong_post {
+        ensures result == 12; // error: post-condition does not hold
+    }
+
+    /// Test: the lambda's abort condition must be discharged at the call.
+    fun test_abort_not_discharged(x: u64): u64 {
+        let r = &mut x;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        }); // error: precondition does not hold (reported at the requires of `modify`)
+        x
+    }
+    spec test_abort_not_discharged {
+        ensures result == x + 1;
+    }
+
+    /// Test: wrong expectation about the post value of a captured global location.
+    fun test_wrong_global_post(a: address) {
+        let r = &mut R[a].value;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+    }
+    spec test_wrong_global_post {
+        requires global<R>(a).value < 999;
+        aborts_if !exists<R>(a);
+        ensures global<R>(a).value == old(global<R>(a).value) + 2; // error: post-condition does not hold
+    }
+
+    /// Test: the module invariant is checked when the captured mutation is
+    /// written back into global storage; without a bound on the pre value,
+    /// the increment can violate it.
+    fun test_invariant_violated(a: address) {
+        let r = &mut R[a].value;
+        modify(|y| *r = *r + y spec {
+            aborts_if r + y > MAX_U64;
+            ensures r == old(r) + y;
+        });
+    }
+    spec test_invariant_violated {
+        aborts_if !exists<R>(a);
+        aborts_if global<R>(a).value + 1 > MAX_U64;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture.move
@@ -1,0 +1,32 @@
+// Tests a lambda which itself contains a retained inline-opaque call with a
+// mutating capture: inside the lifted outer lambda, the inner closure captures
+// the outer's `&mut` parameter, which the carried-mutation model supports like
+// any explicit `&mut` capture.
+module 0x42::opaque_inline_nested_mut_capture {
+
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    inline fun call_outer(g: ||) {
+        g()
+    }
+    spec call_outer {
+        pragma opaque;
+        ensures ensures_of<g>();
+    }
+
+    fun test_nested_mut_capture(): u64 {
+        let x = 0;
+        call_outer(|| call_once(|i| x = x + i spec { ensures x == old(x) + i; })
+            spec { ensures x == old(x) + 1; });
+        x
+    }
+    spec test_nested_mut_capture {
+        ensures result == 1;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/ref_capture_restriction.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/ref_capture_restriction.exp
@@ -1,11 +1,11 @@
 Move prover returns: exiting with compilation errors
-error: captured value cannot be a reference, but has type `&u64`; in verification, lambdas may capture only immutable references, and only as direct arguments of calls to inline functions with `pragma opaque`
+error: captured value cannot be a reference, but has type `&u64`; in verification, lambdas may capture references only as direct arguments of calls to inline functions with `pragma opaque`
    ┌─ tests/sources/functional/closures/inline/ref_capture_restriction.move:16:32
    │
 16 │         regular_apply(|y| y + *r, x) // error: captured value cannot be a reference
    │                                ^
 
-error: captured value cannot be a reference, but has type `&u64`; in verification, lambdas may capture only immutable references, and only as direct arguments of calls to inline functions with `pragma opaque`
+error: captured value cannot be a reference, but has type `&u64`; in verification, lambdas may capture references only as direct arguments of calls to inline functions with `pragma opaque`
    ┌─ tests/sources/functional/closures/inline/ref_capture_restriction.move:26:37
    │
 26 │         let _w = Wrap { f: |y| y + *r }; // error: captured value cannot be a reference

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/ref_capture_restriction.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/ref_capture_restriction.move
@@ -1,9 +1,9 @@
-// In verification, closures capturing immutable references are only supported as
-// direct arguments of calls to retained inline-opaque functions, where the captured
-// locations are statically visible to the spec instrumentation. A reference capture
+// In verification, closures capturing references are only supported as direct
+// arguments of calls to retained inline-opaque functions. A reference capture
 // for any other call, or one hidden inside a struct value, is rejected by the
-// closure checker. (Modifying a captured variable is a separate error reported at
-// lambda lifting; see the compiler-v2 `inline-opaque` tests.)
+// closure checker. (Modification of a captured variable is converted into a
+// `&mut` capture by the lambda lifter in this position; see the compiler-v2
+// `inline-opaque` tests.)
 module 0x42::ref_capture_restriction {
 
     fun regular_apply(f: |u64| u64, x: u64): u64 {


### PR DESCRIPTION
## Description

Extends the retained inline-opaque treatment of higher-order functions to closures which capture mutable references. Lambdas mutating captured variables can now be passed to retained inline functions, with their effect propagating through the opaque call via `ensures_of`:

```move
inline fun call_once(f: |u64|) { f(1) }
spec call_once {
    pragma opaque;
    ensures ensures_of<f>(1);
}

fun call_twice(): u64 {
    let x = 0;
    call_once(|i| x = x + i);
    call_once(|i| x = x + i);
    x
}
spec call_twice {
    ensures result == 2; // verifies
}
```

The lambda lifter converts the mutation into a `&mut` capture: `|i| x = x + i` becomes a closure capturing `&mut x` over a lifted function `fun lifted(x: &mut u64, i: u64) { *x = *x + i }`. The lambda needs no explicit spec block: spec inference derives `ensures x == old(x) + i` from the lifted body, and each opaque call constrains the captured location with it, so the two mutations compose sequentially.

In the translation, the captured mutation is carried by the closure value:

- The `$Mutation` is packed as a whole into the capture slot (new `BorrowEdge::Capture`).
- Across the opaque call, its value component is havoced (location/path identity preserved) and constrained by the callee's `ensures_of` via a trailing `f_post` evaluator slot; mutation-carrying function values are threaded in-out through the apply procedure and `Invoke`.
- When the closure dies, the mutation is written back to its source location.

Captures may root anywhere, including global storage:

```move
fun bump(a: address) {
    let r = &mut R[a].value;
    modify(|y| *r = *r + y spec {
        aborts_if r + y > MAX_U64;
        ensures r == old(r) + y;
    });
}
```

The memory update (where global invariants and `modifies` checks attach) is deferred to the final write-back. This is sound because the closure is the only channel to the location during the call: in the inline-expanded ground truth, reference safety excludes direct access, and the AIP-112 reentrancy protection excludes access through dispatched function values.

Remaining restrictions:

- An inline function with a `&mut`-returning function parameter is not retained (TODO(#20268)): its opaque spec is not honored and calls are expanded without lambda lifting, so callers verify through the body.
- A mut-capturing closure cannot be used for a function parameter requiring the `copy` ability, since a mutable capture makes the value linear.

Also fixes a latent ICE on parentless write-back chains (the `&mut` result of an `Invoke` without `&mut` arguments).

## How Has This Been Tested?

New tests in `move-prover/tests/sources/functional/closures/inline/` covering value and reference captures, control flow, nesting, generics, and global storage roots, plus failure cases (aliasing, escape, failing lambda specs); lambda-lifter and closure-checker tests in `move-compiler-v2/tests/inline-opaque/`.

## Type of Change

- [x] New feature

## Which Components or Systems Does This Change Impact?

- [x] Move Compiler
- [x] Other (specify): Move Prover

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting changes to lambda lifting, closure validation, borrow/write-back instrumentation, and Boogie behavioral predicates for a security-sensitive verification path; mistakes could admit unsound proofs or reject valid specs.
> 
> **Overview**
> **Enables lambdas passed to retained inline-opaque calls to mutate captured state** in verification mode, so effects can compose across opaque calls via `ensures_of` instead of being rejected at compile time.
> 
> In **move-compiler-v2**, the lambda lifter now turns modified free variables into `&mut` captures (with `MutCaptureRewriter` rewriting reads/assigns/borrows in the lifted body). The closure checker allows mutable reference captures in the retained direct-argument position but errors when the closure type requires `copy`. Retained inline-opaque treatment is **disabled** for callees whose function-typed parameters return `&mut` (those calls expand instead).
> 
> The **prover pipeline** treats closure values that pack `&mut` captures as mutation carriers: new `BorrowEdge::Capture`, borrow/livevar/write-back and `HavocKind::CaptureValues` handling, and mono-analysis tuple registration. **Boogie** threads `fun_out` through apply/`Invoke`, repacks variants after inline calls, and extends behavioral-predicate evaluators with `f_post` and capture-slot identity constraints. **Spec translation** adds trailing fun-value clones for carrying types and routes function temps in `update` clauses through entry saves.
> 
> Tests expand `retained_mut_capture*` and related inline-opaque expectations; a latent ICE on parentless write-back chains from `Invoke` is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6773c5816eda102811d46d006ebf6508b5d88836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->