### PR TITLE
[prover] Chained mutations of capturing closures

### DIFF
--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/ast.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/ast.rs
@@ -2182,6 +2182,10 @@ impl AstDebug for Exp_ {
                     BehaviorKind::AbortsOf => "aborts_of",
                     BehaviorKind::EnsuresOf => "ensures_of",
                     BehaviorKind::ResultOf => "result_of",
+                    BehaviorKind::FunPostOf => "fun_post_of",
+                    BehaviorKind::WriteOf(_) => "write_of",
+                    BehaviorKind::PartialOf => "partial_of",
+                    BehaviorKind::CapturesOf => "captures_of",
                 };
                 w.write(kind_str);
                 w.write("<");

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/ast.rs
@@ -731,6 +731,15 @@ pub enum BehaviorKind {
     EnsuresOf,
     /// `result_of<f>(x)` - deterministic result selector based on `ensures_of`
     ResultOf,
+    /// `fun_post_of<f>(x)` - the function value after one application on `x`
+    /// (for values carrying mutable reference captures; identity otherwise)
+    FunPostOf,
+    /// `write_of<f, j>(x)` - the post-state of the j-th `&mut` parameter of `f`
+    WriteOf(u64),
+    /// `partial_of<f>(g)` - `f` is a closure over named function `g`
+    PartialOf,
+    /// `captures_of<f>(g)` - the `&mut`-captured value of a closure over `g`
+    CapturesOf,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -2428,6 +2437,10 @@ impl AstDebug for Exp_ {
                     BehaviorKind::AbortsOf => "aborts_of",
                     BehaviorKind::EnsuresOf => "ensures_of",
                     BehaviorKind::ResultOf => "result_of",
+                    BehaviorKind::FunPostOf => "fun_post_of",
+                    BehaviorKind::WriteOf(_) => "write_of",
+                    BehaviorKind::PartialOf => "partial_of",
+                    BehaviorKind::CapturesOf => "captures_of",
                 };
                 w.write(kind_str);
                 w.write("<");

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
@@ -2485,6 +2485,10 @@ fn behavior_kind_from_str(s: &str) -> Option<BehaviorKind> {
         "aborts_of" => Some(BehaviorKind::AbortsOf),
         "ensures_of" => Some(BehaviorKind::EnsuresOf),
         "result_of" => Some(BehaviorKind::ResultOf),
+        "fun_post_of" => Some(BehaviorKind::FunPostOf),
+        "write_of" => Some(BehaviorKind::WriteOf(0)),
+        "partial_of" => Some(BehaviorKind::PartialOf),
+        "captures_of" => Some(BehaviorKind::CapturesOf),
         _ => None,
     }
 }
@@ -2629,7 +2633,8 @@ fn parse_bare_behavior(context: &mut Context) -> Result<Exp_, Box<Diagnostic>> {
                 current_token_loc(context.tokens),
                 format!(
                     "expected a behavior predicate keyword \
-                     (requires_of, aborts_of, ensures_of, result_of), found '{}'",
+                     (requires_of, aborts_of, ensures_of, result_of, fun_post_of, write_of, \
+                     partial_of, captures_of), found '{}'",
                     kind_content
                 )
             )
@@ -2642,6 +2647,23 @@ fn parse_bare_behavior(context: &mut Context) -> Result<Exp_, Box<Diagnostic>> {
     // dots, and indexing, and naturally stops at `>`.
     consume_token(context.tokens, Tok::Less)?;
     let target = parse_dot_or_index_chain(context)?;
+    let kind = if matches!(kind, BehaviorKind::WriteOf(_)) && context.tokens.peek() == Tok::Comma {
+        // `write_of<f, j>`: explicit index of the `&mut` parameter
+        // (counted among `&mut` parameters); defaults to 0.
+        context.tokens.advance()?;
+        let loc = current_token_loc(context.tokens);
+        let idx_str = context.tokens.content().to_string();
+        consume_token(context.tokens, Tok::NumValue)?;
+        let idx = idx_str.parse::<u64>().map_err(|_| {
+            Box::new(diag!(
+                Syntax::UnexpectedToken,
+                (loc, "expected a decimal `&mut`-parameter index".to_string())
+            ))
+        })?;
+        BehaviorKind::WriteOf(idx)
+    } else {
+        kind
+    };
     consume_token(context.tokens, Tok::Greater)?;
 
     // Parse `(` args `)`

--- a/third_party/move/move-compiler-v2/src/env_pipeline/closure_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/closure_checker.rs
@@ -143,22 +143,12 @@ pub fn check_closures(env: &GlobalEnv) {
                                 // a mutable capture as a mutation carried by the closure
                                 // value, havoced across the call and written back to its
                                 // source location when the closure dies. A mutable
-                                // capture makes the closure value linear: copying it
-                                // would duplicate the carried mutation.
-                                if captured_ty.is_mutable_reference()
-                                    && required_abilities.has_ability(Ability::Copy)
-                                {
-                                    env.error_with_notes(
-                                        &env.get_node_loc(captured.node_id()),
-                                        "cannot capture a mutable reference in a closure \
-                                         requiring the `copy` ability",
-                                        vec![format!(
-                                            "expected function type: `{}`{}",
-                                            context_ty.display(&fun_env.get_type_display_ctx()),
-                                            wrapper_msg()
-                                        )],
-                                    );
-                                }
+                                // capture makes the closure value linear: a surviving
+                                // copy would fork the carried mutation. A `copy` ability
+                                // bound on the function type is nevertheless admitted
+                                // (loop-invoking HOF signatures require it); linearity is
+                                // enforced at the model level, where an actual copy of a
+                                // carrying value is rejected (see TODO(#20273)).
                                 if !ref_capture_allowed.contains(id) {
                                     let mut msg = format!(
                                         "captured value cannot be a reference, but has type \

--- a/third_party/move/move-compiler-v2/src/env_pipeline/lambda_lifter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/lambda_lifter.rs
@@ -670,8 +670,26 @@ impl<'a> LambdaLifter<'a> {
                         let mut lambda_param_pos = 0;
                         let mut captured = vec![];
                         let mut mask = ClosureMask::new(0);
+                        let ref_capturable = |arg: &Exp| {
+                            // In verify mode, a direct mutable borrow of a
+                            // local can be captured by the closure value (the
+                            // prover carries the mutation; see the retained
+                            // inline-opaque treatment).
+                            self.fun_env.module_env.env.is_verify_mode()
+                                && matches!(
+                                    arg.as_ref(),
+                                    Call(_, Operation::Borrow(ReferenceKind::Mutable), bargs)
+                                        if matches!(
+                                            bargs.as_slice(),
+                                            [b] if matches!(
+                                                b.as_ref(),
+                                                LocalVar(..) | Temporary(..)
+                                            )
+                                        )
+                                )
+                        };
                         for (pos, arg) in args.iter().enumerate() {
-                            if Self::exp_is_capturable(arg)
+                            if (Self::exp_is_capturable(arg) || ref_capturable(arg))
                                 && arg.free_vars().is_disjoint(&lambda_bound)
                             {
                                 // We can capture an argument if it can be eagerly evaluated and if
@@ -805,7 +823,7 @@ impl<'a> LambdaLifter<'a> {
         };
         if let Some(idx) = self
             .fun_env
-            .get_parameters()
+            .get_parameters_ref()
             .iter()
             .position(|p| p.0 == sym)
         {
@@ -823,8 +841,8 @@ impl<'a> LambdaLifter<'a> {
         F: FnOnce(&mut Self, Exp) -> Exp,
     {
         // Save the current context.
-        let mut curr_free_params = mem::take(&mut self.free_params);
-        let mut curr_free_locals = mem::take(&mut self.free_locals);
+        let curr_free_params = mem::take(&mut self.free_params);
+        let curr_free_locals = mem::take(&mut self.free_locals);
         let curr_scopes = mem::take(&mut self.scopes);
         // Perform the rewrite action.
         let result = rewrite(self, exp);
@@ -840,8 +858,24 @@ impl<'a> LambdaLifter<'a> {
         for sym in to_remove {
             self.free_locals.remove(&sym);
         }
-        self.free_locals.append(&mut curr_free_locals);
-        self.free_params.append(&mut curr_free_params);
+        // Merge the saved context back in. For variables recorded in both
+        // contexts, keep the saved (outer) entry but take the disjunction of
+        // the `modified` flags: a variable mutated inside a nested lambda is
+        // modified from the enclosing lambda's perspective as well — its
+        // lifted body borrows the variable mutably for the nested closure —
+        // which decides `&mut` capture vs. capture by value.
+        for (sym, mut info) in curr_free_locals {
+            if let Some(nested) = self.free_locals.get(&sym) {
+                info.modified |= nested.modified;
+            }
+            self.free_locals.insert(sym, info);
+        }
+        for (idx, mut info) in curr_free_params {
+            if let Some(nested) = self.free_params.get(&idx) {
+                info.modified |= nested.modified;
+            }
+            self.free_params.insert(idx, info);
+        }
         // Return the result of the rewrite.
         result
     }
@@ -1018,8 +1052,14 @@ impl ExpRewriterFunctions for LambdaLifter<'_> {
 
         // Try to rewrite a lambda directly into a curry expression. This is not
         // possible with converted `&mut` captures, which require a lifted function
-        // with a rewritten body.
-        if bindings.is_empty() && mut_captures.is_empty() {
+        // with a rewritten body — except when the lambda is a direct partial
+        // application whose capture arguments are mutable borrows themselves
+        // (verify mode): the borrow is then carried by the closure value, and
+        // the named target's own spec is the behavioral contract of the
+        // closure (enabling `partial_of`/`captures_of` over the target).
+        if bindings.is_empty()
+            && (mut_captures.is_empty() || self.fun_env.module_env.env.is_verify_mode())
+        {
             let possible_curry_exp = self.try_to_reduce_lambda_to_curry(id, &lambda_params, body);
             if possible_curry_exp.is_some() {
                 return possible_curry_exp;

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_state_label_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_state_label_err.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: `requires_of` describes a single state and cannot have a post-state label; only `ensures_of` and `result_of` support state transitions
+error: `requires_of` describes a single state and cannot have a post-state label; only `ensures_of`, `result_of`, `write_of` and `fun_post_of` support state transitions
    ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_state_label_err.move:11:27
    │
 11 │         ensures ..post |~ requires_of<f>(x); // Error: post-state label not allowed on requires_of
@@ -12,7 +12,7 @@ error: state label `post` is defined but never referenced; every post-state labe
 11 │         ensures ..post |~ requires_of<f>(x); // Error: post-state label not allowed on requires_of
    │                           ^^^^^^^^^^^^^^^^^
 
-error: `aborts_of` describes a single state and cannot have a post-state label; only `ensures_of` and `result_of` support state transitions
+error: `aborts_of` describes a single state and cannot have a post-state label; only `ensures_of`, `result_of`, `write_of` and `fun_post_of` support state transitions
    ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_state_label_err.move:20:29
    │
 20 │         aborts_if ..post |~ aborts_of<f>(x); // Error: post-state label not allowed on aborts_of
@@ -40,7 +40,7 @@ error: cyclic state label reference detected: a -> b -> a
 41 │ │     }
    │ ╰─────^
 
-error: ensures_of/result_of require two-state range notation; use `..S |~` (post-only), `S.. |~` (pre-only), or `A..S |~` (full range) instead of `S |~`
+error: ensures_of/result_of/write_of/fun_post_of require two-state range notation; use `..S |~` (post-only), `S.. |~` (pre-only), or `A..S |~` (full range) instead of `S |~`
    ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_state_label_err.move:49:25
    │
 49 │         ensures a..a |~ ensures_of<f>(x, result);

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/fun_post_of_check.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/fun_post_of_check.exp
@@ -1,0 +1,111 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::fun_post_of_check {
+    private fun apply(f: |u64|u64 has drop,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures Eq<|u64|u64 has drop>($t0, fun_post_of(Old<|u64|u64 has drop>($t0), $t1));
+      ensures Eq<|u64|u64 has drop>($t0, fun_post_of(fun_post_of(Old<|u64|u64 has drop>($t0), 1), 2));
+    }
+
+    private fun apply_ref(f: |&mut u64| has drop,r: &mut u64) {
+        (f)(r)
+    }
+    spec {
+      ensures Eq<|&mut u64| has drop>($t0, fun_post_of(Old<|&mut u64| has drop>($t0), $t1));
+    }
+
+} // end 0x42::fun_post_of_check
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::fun_post_of_check {
+    fun apply(f: |u64|u64 has drop, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply(f: |u64|u64 has drop, x: u64): u64 {
+        ensures f == fun_post_of<old(f)>(x);
+        ensures f == fun_post_of<fun_post_of<old(f)>(1)>(2);
+    }
+
+    fun apply_ref(f: |&mut u64| has drop, r: &mut u64) {
+        f(r)
+    }
+
+    spec apply_ref(f: |&mut u64| has drop, r: &mut u64) {
+        ensures f == fun_post_of<old(f)>(r);
+    }
+
+}
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun fun_post_of_check::apply($t0: |u64|u64 has drop, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun fun_post_of_check::apply_ref($t0: |&mut u64| has drop, $t1: &mut u64) {
+  0: invoke($t1, $t0)
+  1: return ()
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::fun_post_of_check {
+    private fun apply(f: |u64|u64 has drop,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures Eq<|u64|u64 has drop>($t0, fun_post_of(Old<|u64|u64 has drop>($t0), $t1));
+      ensures Eq<|u64|u64 has drop>($t0, fun_post_of(fun_post_of(Old<|u64|u64 has drop>($t0), 1), 2));
+    }
+
+    private fun apply_ref(f: |&mut u64| has drop,r: &mut u64) {
+        (f)(r)
+    }
+    spec {
+      ensures Eq<|&mut u64| has drop>($t0, fun_post_of(Old<|&mut u64| has drop>($t0), $t1));
+    }
+
+} // end 0x42::fun_post_of_check
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun fun_post_of_check::apply($t0: |u64|u64 has drop, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun fun_post_of_check::apply_ref($t0: |&mut u64| has drop, $t1: &mut u64) {
+  0: invoke($t1, $t0)
+  1: return ()
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x42::fun_post_of_check
+// Function definition at index 0
+fun apply(l0: |u64|u64 has drop, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64 has drop>
+    ret
+
+// Function definition at index 1
+fun apply_ref(l0: |&mut u64| has drop, l1: &mut u64)
+    move_loc l1
+    move_loc l0
+    call_closure <|&mut u64| has drop>
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/fun_post_of_check.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/fun_post_of_check.move
@@ -1,0 +1,23 @@
+// Type checking for `fun_post_of<f>(args)`: the result type is the subject's
+// own function type; arguments are the function's inputs (references
+// stripped).
+module 0x42::fun_post_of_check {
+
+    fun apply(f: |u64|u64 has drop, x: u64): u64 {
+        f(x)
+    }
+    spec apply {
+        // Result compares against the subject's own fun type.
+        ensures f == fun_post_of<old(f)>(x);
+        // Chains nest through the subject.
+        ensures f == fun_post_of<fun_post_of<old(f)>(1)>(2);
+    }
+
+    fun apply_ref(f: |&mut u64| has drop, r: &mut u64) {
+        f(r)
+    }
+    spec apply_ref {
+        // `&mut` inputs are passed as values.
+        ensures f == fun_post_of<old(f)>(r);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/fun_post_of_check_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/fun_post_of_check_err.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: behavior predicate target must have function type, found `u64`
+  ┌─ tests/checking-lang-v2.4/specs/fun_post_of_check_err.move:9:17
+  │
+9 │         ensures fun_post_of<x>(1) == f;
+  │                 ^^^^^^^^^^^^^^^^^
+
+error: expected 1 argument(s) for fun_post_of but 2 were provided
+   ┌─ tests/checking-lang-v2.4/specs/fun_post_of_check_err.move:17:17
+   │
+17 │         ensures fun_post_of<f>(1, 2) == f;
+   │                 ^^^^^^^^^^^^^^^^^^^^
+
+error: expected `bool` but found a value of type `|u64|u64 has drop`
+   ┌─ tests/checking-lang-v2.4/specs/fun_post_of_check_err.move:25:17
+   │
+25 │         ensures fun_post_of<f>(1);
+   │                 ^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/fun_post_of_check_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/fun_post_of_check_err.move
@@ -1,0 +1,27 @@
+// Type checking errors for `fun_post_of<f>(args)`.
+module 0x42::fun_post_of_check_err {
+
+    fun apply(f: |u64|u64 has drop, x: u64): u64 {
+        f(x)
+    }
+    spec apply {
+        // Error: x is u64, not a function
+        ensures fun_post_of<x>(1) == f;
+    }
+
+    fun apply2(f: |u64|u64 has drop, x: u64): u64 {
+        f(x)
+    }
+    spec apply2 {
+        // Error: wrong number of arguments (inputs only; no result slot)
+        ensures fun_post_of<f>(1, 2) == f;
+    }
+
+    fun apply3(f: |u64|u64 has drop, x: u64): u64 {
+        f(x)
+    }
+    spec apply3 {
+        // Error: result is a function value, not bool
+        ensures fun_post_of<f>(1);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/variant_observation_check.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/variant_observation_check.exp
@@ -1,0 +1,139 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::variant_observation_check {
+    private fun apply(f: |&u64| has copy + drop): |&u64| has copy + drop {
+        f
+    }
+    spec {
+      ensures Implies(partial_of($t0, closure#0variant_observation_check::step()), Eq<u64>(captures_of(result0(), closure#0variant_observation_check::step()), captures_of($t0, closure#0variant_observation_check::step())));
+      ensures Eq<|&u64| has copy + drop>(result0(), $t0);
+      ensures Eq<u64>(write_of_0(closure#0variant_observation_check::step(), 1, 2), write_of_0(closure#0variant_observation_check::step(), 1, 2));
+    }
+
+    private fun step(s: &mut u64,e: &u64) {
+        s = Add<u64>(Deref(s), Deref(e));
+        Tuple()
+    }
+    spec {
+      ensures Eq<u64>(Freeze(false)($t0), Add(Old<u64>($t0), $t1));
+    }
+
+    spec fun $step(s: u64,e: u64) {
+        s = Add<u64>(s, e);
+        Tuple()
+    }
+} // end 0x42::variant_observation_check
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::variant_observation_check {
+    fun apply(f: |&u64| has copy + drop): |&u64| has copy + drop {
+        f
+    }
+
+    spec apply(f: |&u64| has copy + drop): |&u64| has copy + drop {
+        ensures partial_of<f>(|x,y| step(x, y)) ==> captures_of<result>(|x,y| step(x, y)) == captures_of<f>(|x,y| step(x, y));
+        ensures result == f;
+        ensures write_of_0<step>(1, 2) == write_of_0<step>(1, 2);
+    }
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+
+    spec step(s: &mut u64, e: &u64) {
+        ensures s == old(s) + e;
+    }
+
+}
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun variant_observation_check::apply($t0: |&u64| has copy + drop): |&u64| has copy + drop {
+     var $t1: |&u64| has copy + drop
+  0: $t1 := infer($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun variant_observation_check::step($t0: &mut u64, $t1: &u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := read_ref($t0)
+  1: $t4 := read_ref($t1)
+  2: $t2 := +($t3, $t4)
+  3: write_ref($t0, $t2)
+  4: return ()
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::variant_observation_check {
+    private fun apply(f: |&u64| has copy + drop): |&u64| has copy + drop {
+        f
+    }
+    spec {
+      ensures Implies(partial_of($t0, closure#0variant_observation_check::step()), Eq<u64>(captures_of(result0(), closure#0variant_observation_check::step()), captures_of($t0, closure#0variant_observation_check::step())));
+      ensures Eq<|&u64| has copy + drop>(result0(), $t0);
+      ensures Eq<u64>(write_of_0(closure#0variant_observation_check::step(), 1, 2), write_of_0(closure#0variant_observation_check::step(), 1, 2));
+    }
+
+    private fun step(s: &mut u64,e: &u64) {
+        s = Add<u64>(Deref(s), Deref(e));
+        Tuple()
+    }
+    spec {
+      ensures Eq<u64>(Freeze(false)($t0), Add(Old<u64>($t0), $t1));
+    }
+
+    spec fun $step(s: u64,e: u64) {
+        s = Add<u64>(s, e);
+        Tuple()
+    }
+} // end 0x42::variant_observation_check
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun variant_observation_check::apply($t0: |&u64| has copy + drop): |&u64| has copy + drop {
+     var $t1: |&u64| has copy + drop
+  0: $t1 := infer($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun variant_observation_check::step($t0: &mut u64, $t1: &u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := read_ref($t0)
+  1: $t4 := read_ref($t1)
+  2: $t2 := +($t3, $t4)
+  3: write_ref($t0, $t2)
+  4: return ()
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x42::variant_observation_check
+// Function definition at index 0
+fun apply(l0: |&u64| has copy + drop): |&u64| has copy + drop
+    move_loc l0
+    ret
+
+// Function definition at index 1
+fun step(l0: &mut u64, l1: &u64)
+    copy_loc l0
+    read_ref
+    move_loc l1
+    read_ref
+    add
+    // @5
+    move_loc l0
+    write_ref
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/variant_observation_check.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/variant_observation_check.move
@@ -1,0 +1,22 @@
+// Type checking for `partial_of<f>(g)` / `captures_of<f>(g)` /
+// `write_of<g, j>(args)`.
+module 0x42::variant_observation_check {
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        ensures s == old(s) + e;
+    }
+
+    fun apply(f: |&u64| has copy + drop): |&u64| has copy + drop {
+        f
+    }
+    spec apply {
+        // Recognizer is bool; selector is typed by the captured param.
+        ensures partial_of<f>(step) ==> captures_of<result>(step) == captures_of<f>(step);
+        ensures result == f;
+        // `write_of` with defaulted and explicit index.
+        ensures write_of<step>(1, 2) == write_of<step, 0>(1, 2);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/variant_observation_check_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/variant_observation_check_err.exp
@@ -1,0 +1,31 @@
+
+Diagnostics:
+error: behavior predicate target must have function type, found `u64`
+   ┌─ tests/checking-lang-v2.4/specs/variant_observation_check_err.move:21:17
+   │
+21 │         ensures partial_of<x>(step);
+   │                 ^^^^^^^^^^^^^^^^^^^
+
+error: the argument of partial_of must be a function value
+   ┌─ tests/checking-lang-v2.4/specs/variant_observation_check_err.move:30:17
+   │
+30 │         ensures partial_of<f>(x + 1);
+   │                 ^^^^^^^^^^^^^^^^^^^^
+
+error: the witness of captures_of must take exactly one leading `&mut` (captured) parameter followed by the subject's parameters
+   ┌─ tests/checking-lang-v2.4/specs/variant_observation_check_err.move:39:17
+   │
+39 │         ensures captures_of<f>(no_capture) == 0;
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `write_of` index 3 exceeds the number of `&mut` parameters
+   ┌─ tests/checking-lang-v2.4/specs/variant_observation_check_err.move:48:17
+   │
+48 │         ensures write_of<step, 3>(1, 2) == 0;
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `bool` but found a value of type `u64`
+   ┌─ tests/checking-lang-v2.4/specs/variant_observation_check_err.move:57:17
+   │
+57 │         ensures captures_of<f>(step);
+   │                 ^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/variant_observation_check_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/variant_observation_check_err.move
@@ -1,0 +1,59 @@
+// Type checking errors for `partial_of` / `captures_of` / `write_of`.
+module 0x42::variant_observation_check_err {
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        ensures s == old(s) + e;
+    }
+
+    fun no_capture(e: &u64): u64 {
+        *e
+    }
+
+    fun apply1(f: |&u64| has copy + drop, x: u64): u64 {
+        f(&x);
+        x
+    }
+    spec apply1 {
+        // Error: x is u64, not a function
+        ensures partial_of<x>(step);
+    }
+
+    fun apply2(f: |&u64| has copy + drop, x: u64): u64 {
+        f(&x);
+        x
+    }
+    spec apply2 {
+        // Error: argument must be a simple function name
+        ensures partial_of<f>(x + 1);
+    }
+
+    fun apply3(f: |&u64| has copy + drop, x: u64): u64 {
+        f(&x);
+        x
+    }
+    spec apply3 {
+        // Error: target has no leading `&mut` (captured) parameter
+        ensures captures_of<f>(no_capture) == 0;
+    }
+
+    fun apply4(f: |&u64| has copy + drop, x: u64): u64 {
+        f(&x);
+        x
+    }
+    spec apply4 {
+        // Error: `write_of` index exceeds the number of `&mut` parameters
+        ensures write_of<step, 3>(1, 2) == 0;
+    }
+
+    fun apply5(f: |&u64| has copy + drop, x: u64): u64 {
+        f(&x);
+        x
+    }
+    spec apply5 {
+        // Error: captured value is u64, not bool
+        ensures captures_of<f>(step);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.exp
@@ -14,7 +14,31 @@ module 0x42::retained_mut_capture {
       ensures ensures_of($t0, 1);
     }
 
+    private inline fun call_once_copy(f: |u64| has copy + drop) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t0, 1);
+    }
+
     private fun caller(): u64 {
+        {
+          let x: u64 = 0;
+          {
+            let (): ();
+            {
+              let (i: u64): (u64) = Tuple(1);
+              x: u64 = Add<u64>(x, i)
+            }
+          };
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
+    private fun copy_bound_caller(): u64 {
         {
           let x: u64 = 0;
           {
@@ -134,6 +158,15 @@ module 0x42::retained_mut_capture {
         ensures ensures_of<f>(1);
     }
 
+    inline fun call_once_copy(f: |u64| has copy + drop) {
+        f(1)
+    }
+
+    spec call_once_copy(f: |u64| has copy + drop) {
+        pragma opaque = true;
+        ensures ensures_of<f>(1);
+    }
+
     fun caller(): u64 {
         let x = 0;
         {
@@ -145,6 +178,20 @@ module 0x42::retained_mut_capture {
     }
 
     spec caller(): u64 {
+        ensures result == 1;
+    }
+
+    fun copy_bound_caller(): u64 {
+        let x = 0;
+        {
+            let ();
+            let i = 1;
+            x = x + i
+        };
+        x
+    }
+
+    spec copy_bound_caller(): u64 {
         ensures result == 1;
     }
 
@@ -240,7 +287,25 @@ module 0x42::retained_mut_capture {
       ensures ensures_of($t0, 1);
     }
 
+    private inline fun call_once_copy(f: |u64| has copy + drop) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t0, 1);
+    }
+
     private fun caller(): u64 {
+        {
+          let x: u64 = 0;
+          x: u64 = Add<u64>(x, 1);
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
+    private fun copy_bound_caller(): u64 {
         {
           let x: u64 = 0;
           x: u64 = Add<u64>(x, 1);
@@ -331,6 +396,13 @@ fun caller(): u64
     ret
 
 // Function definition at index 1
+fun copy_bound_caller(): u64
+    ld_u64 0
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 2
 fun field_caller(): u64
     local l0: S
     ld_u64 1
@@ -357,7 +429,7 @@ fun field_caller(): u64
     add
     ret
 
-// Function definition at index 2
+// Function definition at index 3
 fun freeze_caller(): u64
     local l0: u64
     ld_u64 1
@@ -371,20 +443,20 @@ fun freeze_caller(): u64
     add
     ret
 
-// Function definition at index 3
+// Function definition at index 4
 fun param_caller(l0: u64): u64
     move_loc l0
     ld_u64 1
     add
     ret
 
-// Function definition at index 4
+// Function definition at index 5
 fun read(l0: &u64): u64
     move_loc l0
     read_ref
     ret
 
-// Function definition at index 5
+// Function definition at index 6
 fun receiver_caller(l0: &V): u64
     ld_u64 0
     move_loc l0

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.move
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.move
@@ -89,4 +89,24 @@ module 0x42::retained_mut_capture {
     spec read {
         ensures result == r;
     }
+
+    inline fun call_once_copy(f: |u64| has copy + drop) {
+        f(1)
+    }
+    spec call_once_copy {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    /// Conversion into a closure satisfying a `copy` ability bound: the
+    /// lifted closure captures `&mut x` and remains linear at the model
+    /// level, but the bound itself is admitted.
+    fun copy_bound_caller(): u64 {
+        let x = 0;
+        call_once_copy(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec copy_bound_caller {
+        ensures result == 1;
+    }
 }

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.verify.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture.verify.exp
@@ -14,10 +14,28 @@ module 0x42::retained_mut_capture {
       ensures ensures_of($t0, 1);
     }
 
+    private inline fun call_once_copy(f: |u64| has copy + drop) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t0, 1);
+    }
+
     private fun caller(): u64 {
         {
           let x: u64 = 0;
           retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__caller(Borrow(Mutable)(x)));
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
+    private fun copy_bound_caller(): u64 {
+        {
+          let x: u64 = 0;
+          retained_mut_capture::call_once_copy(closure#1retained_mut_capture::__lambda__1__copy_bound_caller(Borrow(Mutable)(x)));
           x
         }
     }
@@ -88,6 +106,13 @@ module 0x42::retained_mut_capture {
       ensures Eq<u64>($t0, Add(Old<u64>($t0), $t1));
     }
 
+    private fun __lambda__1__copy_bound_caller(x: &mut u64,i: u64) {
+        x = Add<u64>(Deref(x), i)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Old<u64>($t0), $t1));
+    }
+
     private fun __lambda__1__field_caller(s: &mut S,i: u64) {
         select retained_mut_capture::S.x<S>(s) = Add<u64>(select retained_mut_capture::S.x<S>(Deref(s)), i)
     }
@@ -140,6 +165,15 @@ module 0x42::retained_mut_capture {
         ensures ensures_of<f>(1);
     }
 
+    inline fun call_once_copy(f: |u64| has copy + drop) {
+        f(1)
+    }
+
+    spec call_once_copy(f: |u64| has copy + drop) {
+        pragma opaque = true;
+        ensures ensures_of<f>(1);
+    }
+
     fun caller(): u64 {
         let x = 0;
         call_once({
@@ -150,6 +184,19 @@ module 0x42::retained_mut_capture {
     }
 
     spec caller(): u64 {
+        ensures result == 1;
+    }
+
+    fun copy_bound_caller(): u64 {
+        let x = 0;
+        call_once_copy({
+            let a = &mut x;
+            |x_1| lambda__1__copy_bound_caller(a, x_1)
+        });
+        x
+    }
+
+    spec copy_bound_caller(): u64 {
         ensures result == 1;
     }
 
@@ -230,6 +277,14 @@ module 0x42::retained_mut_capture {
         ensures x == old(x) + i;
     }
 
+    fun lambda__1__copy_bound_caller(x: &mut u64, i: u64) {
+        *x = *x + i
+    }
+
+    spec lambda__1__copy_bound_caller(x: &mut u64, i: u64) {
+        ensures x == old(x) + i;
+    }
+
     fun lambda__1__field_caller(s: &mut S, i: u64) {
         s.x = (*s).x + i
     }
@@ -282,10 +337,28 @@ module 0x42::retained_mut_capture {
       ensures ensures_of($t0, 1);
     }
 
+    private inline fun call_once_copy(f: |u64| has copy + drop) {
+        (f)(1)
+    }
+    spec {
+      ensures ensures_of($t0, 1);
+    }
+
     private fun caller(): u64 {
         {
           let x: u64 = 0;
           retained_mut_capture::call_once(closure#1retained_mut_capture::__lambda__1__caller(Borrow(Mutable)(x)));
+          x
+        }
+    }
+    spec {
+      ensures Eq<u64>(result0(), 1);
+    }
+
+    private fun copy_bound_caller(): u64 {
+        {
+          let x: u64 = 0;
+          retained_mut_capture::call_once_copy(closure#1retained_mut_capture::__lambda__1__copy_bound_caller(Borrow(Mutable)(x)));
           x
         }
     }
@@ -356,6 +429,13 @@ module 0x42::retained_mut_capture {
       ensures Eq<u64>($t0, Add(Old<u64>($t0), $t1));
     }
 
+    private fun __lambda__1__copy_bound_caller(x: &mut u64,i: u64) {
+        x = Add<u64>(Deref(x), i)
+    }
+    spec {
+      ensures Eq<u64>($t0, Add(Old<u64>($t0), $t1));
+    }
+
     private fun __lambda__1__field_caller(s: &mut S,i: u64) {
         select retained_mut_capture::S.x<S>(s) = Add<u64>(select retained_mut_capture::S.x<S>(Deref(s)), i)
     }
@@ -406,6 +486,13 @@ fun call_once(l0: |u64|)
     ret
 
 // Function definition at index 1
+fun call_once_copy(l0: |u64| has copy + drop)
+    ld_u64 1
+    move_loc l0
+    call_closure <|u64| has copy + drop>
+    ret
+
+// Function definition at index 2
 fun caller(): u64
     local l0: u64
     ld_u64 0
@@ -417,7 +504,19 @@ fun caller(): u64
     move_loc l0
     ret
 
-// Function definition at index 2
+// Function definition at index 3
+fun copy_bound_caller(): u64
+    local l0: u64
+    ld_u64 0
+    st_loc l0
+    mut_borrow_loc l0
+    pack_closure __lambda__1__copy_bound_caller, 1
+    call call_once_copy
+    // @5
+    move_loc l0
+    ret
+
+// Function definition at index 4
 fun count(l0: &V, l1: |u64|)
     ld_u64 1
     move_loc l0
@@ -427,7 +526,7 @@ fun count(l0: &V, l1: |u64|)
     // @5
     ret
 
-// Function definition at index 3
+// Function definition at index 5
 fun field_caller(): u64
     local l0: S
     ld_u64 1
@@ -448,7 +547,7 @@ fun field_caller(): u64
     add
     ret
 
-// Function definition at index 4
+// Function definition at index 6
 fun freeze_caller(): u64
     local l0: u64
     ld_u64 1
@@ -460,7 +559,7 @@ fun freeze_caller(): u64
     move_loc l0
     ret
 
-// Function definition at index 5
+// Function definition at index 7
 fun param_caller(l0: u64): u64
     mut_borrow_loc l0
     pack_closure __lambda__1__param_caller, 1
@@ -468,13 +567,13 @@ fun param_caller(l0: u64): u64
     move_loc l0
     ret
 
-// Function definition at index 6
+// Function definition at index 8
 fun read(l0: &u64): u64
     move_loc l0
     read_ref
     ret
 
-// Function definition at index 7
+// Function definition at index 9
 fun receiver_caller(l0: &V): u64
     local l1: u64
     ld_u64 0
@@ -487,7 +586,7 @@ fun receiver_caller(l0: &V): u64
     move_loc l1
     ret
 
-// Function definition at index 8
+// Function definition at index 10
 fun __lambda__1__caller(l0: &mut u64, l1: u64)
     copy_loc l0
     read_ref
@@ -498,7 +597,18 @@ fun __lambda__1__caller(l0: &mut u64, l1: u64)
     write_ref
     ret
 
-// Function definition at index 9
+// Function definition at index 11
+fun __lambda__1__copy_bound_caller(l0: &mut u64, l1: u64)
+    copy_loc l0
+    read_ref
+    move_loc l1
+    add
+    move_loc l0
+    // @5
+    write_ref
+    ret
+
+// Function definition at index 12
 fun __lambda__1__field_caller(l0: &mut S, l1: u64)
     local l2: S
     copy_loc l0
@@ -516,7 +626,7 @@ fun __lambda__1__field_caller(l0: &mut S, l1: u64)
     write_ref
     ret
 
-// Function definition at index 10
+// Function definition at index 13
 fun __lambda__1__freeze_caller(l0: &mut u64, l1: u64)
     copy_loc l0
     read_ref
@@ -532,7 +642,7 @@ fun __lambda__1__freeze_caller(l0: &mut u64, l1: u64)
     // @10
     ret
 
-// Function definition at index 11
+// Function definition at index 14
 fun __lambda__1__param_caller(l0: &mut u64, l1: u64)
     copy_loc l0
     read_ref
@@ -543,7 +653,7 @@ fun __lambda__1__param_caller(l0: &mut u64, l1: u64)
     write_ref
     ret
 
-// Function definition at index 12
+// Function definition at index 15
 fun __lambda__1__receiver_caller(l0: &mut u64, l1: u64)
     copy_loc l0
     read_ref

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.exp
@@ -51,15 +51,15 @@ module 0x42::retained_mut_capture_err {
 
 Diagnostics:
 warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
-   ┌─ tests/inline-opaque/retained_mut_capture_err.move:17:17
+   ┌─ tests/inline-opaque/retained_mut_capture_err.move:16:17
    │
-17 │         let x = 0;
+16 │         let x = 0;
    │                 ^
 
 warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
-   ┌─ tests/inline-opaque/retained_mut_capture_err.move:18:17
+   ┌─ tests/inline-opaque/retained_mut_capture_err.move:17:17
    │
-18 │         let y = 0;
+17 │         let y = 0;
    │                 ^
 
 // -- Model dump before second bytecode pipeline

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.move
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.move
@@ -1,7 +1,6 @@
 // Restrictions on modifying captured variables in lambdas passed to retained
 // inline-opaque functions: converted variables cannot appear in tuple
-// assignments. (A mutating lambda for a `copy`-requiring function parameter is
-// rejected by the closure checker; see the prover test suite.)
+// assignments.
 module 0x42::retained_mut_capture_err {
 
     inline fun call_once(f: |u64|) {

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.verify.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_capture_err.verify.exp
@@ -1,7 +1,7 @@
 
 Diagnostics:
 error: modified captured variables are not yet supported in tuple or struct assignments inside of a lambda
-   ┌─ tests/inline-opaque/retained_mut_capture_err.move:19:23
+   ┌─ tests/inline-opaque/retained_mut_capture_err.move:18:23
    │
-19 │         call_once(|i| (x, y) = (i, i));
+18 │         call_once(|i| (x, y) = (i, i));
    │                       ^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.move
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.move
@@ -1,10 +1,11 @@
 // In verify mode, a lambda passed to a retained inline-opaque function may capture
-// mutable references rooted anywhere (locals, parameters, or global storage). The
-// closure must not require the `copy` ability (a mutable capture makes the value
-// linear). An inline function with a `&mut`-returning function parameter does not
-// get the retained treatment at all — its opaque spec is not honored and calls are
-// expanded, so no lambda is lifted. In normal compilation every inline function is
-// expanded, so no capture arises anywhere.
+// mutable references rooted anywhere (locals, parameters, or global storage). A
+// `copy` ability bound on the function parameter is admitted (a mutable capture
+// makes the value linear, but linearity is enforced at the model level, see
+// TODO(#20273)). An inline function with a `&mut`-returning function parameter does
+// not get the retained treatment at all — its opaque spec is not honored and calls
+// are expanded, so no lambda is lifted. In normal compilation every inline function
+// is expanded, so no capture arises anywhere.
 module 0x42::retained_mut_ref_capture {
 
     struct R has key {
@@ -45,7 +46,7 @@ module 0x42::retained_mut_ref_capture {
         apply(|y| { *r = *r + y; *r }, 5)
     }
 
-    /// Rejected: closure requiring the `copy` ability.
+    /// Admitted: closure satisfying a `copy` ability bound.
     fun copy_mut_capture(r: &mut u64): u64 {
         apply_copy(|y| { *r = *r + y; *r }, 5)
     }

--- a/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.verify.exp
+++ b/third_party/move/move-compiler-v2/tests/inline-opaque/retained_mut_ref_capture.verify.exp
@@ -1,9 +1,305 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::retained_mut_ref_capture {
+    struct R {
+        value: u64,
+    }
+    private inline fun apply(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures ensures_of($t0, $t1, result0());
+    }
 
-Diagnostics:
-error: cannot capture a mutable reference in a closure requiring the `copy` ability
-   ┌─ tests/inline-opaque/retained_mut_ref_capture.move:50:32
-   │
-50 │         apply_copy(|y| { *r = *r + y; *r }, 5)
-   │                                ^
-   │
-   = expected function type: `|u64|u64 has copy`
+    private inline fun apply_copy(f: |u64|u64 has copy,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures ensures_of($t0, $t1, result0());
+    }
+
+    private inline fun apply_ref(f: |u64|&mut u64,x: u64): u64 {
+        Deref((f)(x))
+    }
+    spec {
+    }
+
+    private fun copy_mut_capture(r: &mut u64): u64 {
+        retained_mut_ref_capture::apply_copy(closure#1retained_mut_ref_capture::__lambda__1__copy_mut_capture(r), 5)
+    }
+    private fun deref_helper(r: &mut u64,y: u64): &mut u64 {
+        r = Add<u64>(Deref(r), y);
+        r
+    }
+    private fun direct_mut_capture(r: &mut u64): u64 {
+        retained_mut_ref_capture::apply(closure#1retained_mut_ref_capture::__lambda__1__direct_mut_capture(r), 5)
+    }
+    private fun global_rooted_capture(a: address): u64 {
+        {
+          let r: &mut u64 = Borrow(Mutable)(select retained_mut_ref_capture::R.value<R>(BorrowGlobal(Mutable)<R>(a)));
+          retained_mut_ref_capture::apply(closure#1retained_mut_ref_capture::__lambda__1__global_rooted_capture(r), 5)
+        }
+    }
+    private fun ret_mut_capture(r: &mut u64): u64 {
+        {
+          let (x: u64): (u64) = Tuple(5);
+          Deref({
+            let (y: u64): (u64) = Tuple(x);
+            retained_mut_ref_capture::deref_helper(r, y)
+          })
+        }
+    }
+    private fun __lambda__1__copy_mut_capture(r: &mut u64,y: u64): u64 {
+        r = Add<u64>(Deref(r), y);
+        Deref(r)
+    }
+    private fun __lambda__1__direct_mut_capture(r: &mut u64,y: u64): u64 {
+        r = Add<u64>(Deref(r), y);
+        Deref(r)
+    }
+    private fun __lambda__1__global_rooted_capture(r: &mut u64,y: u64): u64 {
+        r = Add<u64>(Deref(r), y);
+        Deref(r)
+    }
+} // end 0x42::retained_mut_ref_capture
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::retained_mut_ref_capture {
+    struct R has key {
+        value: u64,
+    }
+    inline fun apply(f: |u64|u64, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply(f: |u64|u64, x: u64): u64 {
+        pragma opaque = true;
+        ensures ensures_of<f>(x, result);
+    }
+
+    inline fun apply_copy(f: |u64|u64 has copy, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_copy(f: |u64|u64 has copy, x: u64): u64 {
+        pragma opaque = true;
+        ensures ensures_of<f>(x, result);
+    }
+
+    inline fun apply_ref(f: |u64|&mut u64, x: u64): u64 {
+        *f(x)
+    }
+
+    spec apply_ref(f: |u64|&mut u64, x: u64): u64 {
+        pragma opaque = true;
+    }
+
+    fun copy_mut_capture(r: &mut u64): u64 {
+        apply_copy(|x| lambda__1__copy_mut_capture(r, x), 5)
+    }
+    fun deref_helper(r: &mut u64, y: u64): &mut u64 {
+        *r = *r + y;
+        r
+    }
+    fun direct_mut_capture(r: &mut u64): u64 {
+        apply(|x| lambda__1__direct_mut_capture(r, x), 5)
+    }
+    fun global_rooted_capture(a: address): u64 {
+        let r = &mut borrow_global_mut<R>(a).value;
+        apply(|x| lambda__1__global_rooted_capture(r, x), 5)
+    }
+    fun ret_mut_capture(r: &mut u64): u64 {
+        let x = 5;
+        *{
+            let y = x;
+            deref_helper(r, y)
+        }
+    }
+    fun lambda__1__copy_mut_capture(r: &mut u64, y: u64): u64 {
+        *r = *r + y;
+        *r
+    }
+    fun lambda__1__direct_mut_capture(r: &mut u64, y: u64): u64 {
+        *r = *r + y;
+        *r
+    }
+    fun lambda__1__global_rooted_capture(r: &mut u64, y: u64): u64 {
+        *r = *r + y;
+        *r
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::retained_mut_ref_capture {
+    struct R {
+        value: u64,
+    }
+    private inline fun apply(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures ensures_of($t0, $t1, result0());
+    }
+
+    private inline fun apply_copy(f: |u64|u64 has copy,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures ensures_of($t0, $t1, result0());
+    }
+
+    private inline fun apply_ref(f: |u64|&mut u64,x: u64): u64 {
+        Deref((f)(x))
+    }
+    spec {
+    }
+
+    private fun copy_mut_capture(r: &mut u64): u64 {
+        retained_mut_ref_capture::apply_copy(closure#1retained_mut_ref_capture::__lambda__1__copy_mut_capture(r), 5)
+    }
+    private fun deref_helper(r: &mut u64,y: u64): &mut u64 {
+        r = Add<u64>(Deref(r), y);
+        r
+    }
+    private fun direct_mut_capture(r: &mut u64): u64 {
+        retained_mut_ref_capture::apply(closure#1retained_mut_ref_capture::__lambda__1__direct_mut_capture(r), 5)
+    }
+    private fun global_rooted_capture(a: address): u64 {
+        {
+          let r: &mut u64 = Borrow(Mutable)(select retained_mut_ref_capture::R.value<R>(BorrowGlobal(Mutable)<R>(a)));
+          retained_mut_ref_capture::apply(closure#1retained_mut_ref_capture::__lambda__1__global_rooted_capture(r), 5)
+        }
+    }
+    private fun ret_mut_capture(r: &mut u64): u64 {
+        Deref(retained_mut_ref_capture::deref_helper(r, 5))
+    }
+    private fun __lambda__1__copy_mut_capture(r: &mut u64,y: u64): u64 {
+        r = Add<u64>(Deref(r), y);
+        Deref(r)
+    }
+    private fun __lambda__1__direct_mut_capture(r: &mut u64,y: u64): u64 {
+        r = Add<u64>(Deref(r), y);
+        Deref(r)
+    }
+    private fun __lambda__1__global_rooted_capture(r: &mut u64,y: u64): u64 {
+        r = Add<u64>(Deref(r), y);
+        Deref(r)
+    }
+} // end 0x42::retained_mut_ref_capture
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x42::retained_mut_ref_capture
+struct R has key
+  value: u64
+
+// Function definition at index 0
+fun apply(l0: |u64|u64, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64>
+    ret
+
+// Function definition at index 1
+fun apply_copy(l0: |u64|u64 has copy, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64 has copy>
+    ret
+
+// Function definition at index 2
+fun apply_ref(l0: |u64|&mut u64, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|&mut u64>
+    read_ref
+    ret
+
+// Function definition at index 3
+fun copy_mut_capture(l0: &mut u64): u64
+    move_loc l0
+    pack_closure __lambda__1__copy_mut_capture, 1
+    ld_u64 5
+    call apply_copy
+    ret
+
+// Function definition at index 4
+fun deref_helper(l0: &mut u64, l1: u64): &mut u64
+    copy_loc l0
+    read_ref
+    move_loc l1
+    add
+    copy_loc l0
+    // @5
+    write_ref
+    move_loc l0
+    ret
+
+// Function definition at index 5
+fun direct_mut_capture(l0: &mut u64): u64
+    move_loc l0
+    pack_closure __lambda__1__direct_mut_capture, 1
+    ld_u64 5
+    call apply
+    ret
+
+// Function definition at index 6
+fun global_rooted_capture(l0: address): u64 acquires R
+    move_loc l0
+    mut_borrow_global R
+    mut_borrow_field R, value
+    pack_closure __lambda__1__global_rooted_capture, 1
+    ld_u64 5
+    // @5
+    call apply
+    ret
+
+// Function definition at index 7
+fun ret_mut_capture(l0: &mut u64): u64
+    move_loc l0
+    ld_u64 5
+    call deref_helper
+    read_ref
+    ret
+
+// Function definition at index 8
+fun __lambda__1__copy_mut_capture(l0: &mut u64, l1: u64): u64
+    copy_loc l0
+    read_ref
+    move_loc l1
+    add
+    copy_loc l0
+    // @5
+    write_ref
+    move_loc l0
+    read_ref
+    ret
+
+// Function definition at index 9
+fun __lambda__1__direct_mut_capture(l0: &mut u64, l1: u64): u64
+    copy_loc l0
+    read_ref
+    move_loc l1
+    add
+    copy_loc l0
+    // @5
+    write_ref
+    move_loc l0
+    read_ref
+    ret
+
+// Function definition at index 10
+fun __lambda__1__global_rooted_capture(l0: &mut u64, l1: u64): u64
+    copy_loc l0
+    read_ref
+    move_loc l1
+    add
+    copy_loc l0
+    // @5
+    write_ref
+    move_loc l0
+    read_ref
+    ret
+
+
+============ bytecode verification skipped (verify mode) ====

--- a/third_party/move/move-model/bytecode/src/borrow_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/borrow_analysis.rs
@@ -711,15 +711,21 @@ impl TransferFunctions for BorrowAnalysis<'_> {
             .expect("livevar annotation");
 
         match instr {
-            Assign(_, dest, src, kind) if self.carrying_temps.contains(src) => {
+            Assign(attr_id, dest, src, kind) if self.carrying_temps.contains(src) => {
                 // Assignment of a closure value carrying captured mutations: the
                 // mutations move with the value. Model as a direct borrow edge so
-                // write-backs chain through the new temp. Copies are excluded
-                // since they would duplicate live mutations.
-                assert!(
-                    !matches!(kind, AssignKind::Copy),
-                    "copy of a closure value carrying captured mutations"
-                );
+                // write-backs chain through the new temp. Copies are rejected
+                // since a surviving copy would fork the carried mutations; the
+                // `copy` ability bound itself is admitted on such closures and
+                // linearity is enforced here (see TODO(#20273)). The admitted
+                // direct-argument shape consumes the closure at its single use,
+                // so this is only reachable through codegen artifacts.
+                if matches!(kind, AssignKind::Copy) {
+                    self.func_target.global_env().error(
+                        &self.func_target.get_bytecode_loc(*attr_id),
+                        "cannot copy a function value carrying mutable reference captures",
+                    );
+                }
                 let dest_node = BorrowNode::Reference(*dest);
                 state.add_node(dest_node.clone());
                 state.add_edge(BorrowNode::Reference(*src), dest_node, BorrowEdge::Direct);

--- a/third_party/move/move-model/bytecode/src/fat_loop.rs
+++ b/third_party/move/move-model/bytecode/src/fat_loop.rs
@@ -63,6 +63,16 @@ pub struct FatLoopSpecInfo {
     /// Loop-to-DAG transformation havocs these at the loop header, so the
     /// loop-exit path does not retain pre-loop memory.
     pub mem_targets: BTreeSet<QualifiedInstId<StructId>>,
+
+    /// Function-typed temporaries applied (`Invoke`) in the loop body which
+    /// are not reassigned by it (not in `val_targets`). Values carrying
+    /// mutable reference captures, and advancing fun-param family members,
+    /// change under application at the translation level without any
+    /// bytecode-level write; they are havoced with
+    /// `HavocKind::CaptureValues`, which the translation refines to a
+    /// variant-preserving havoc for such values and to a no-op for all
+    /// others.
+    pub fun_targets: BTreeSet<TempIndex>,
 }
 
 /// Information about fat loops in a function.
@@ -209,7 +219,7 @@ impl FatLoopBuilder<'_> {
                 None => {
                     // no spec mode, or loop invariant instrumentation route
                     let spec_info = if self.for_spec {
-                        let (val_targets, mut_targets) =
+                        let (val_targets, mut_targets, fun_targets) =
                             self.collect_loop_targets(&cfg, func_target, &sub_loops);
                         let mem_targets = self.collect_loop_memory(&cfg, func_target, &sub_loops);
                         Some(FatLoopSpecInfo {
@@ -217,6 +227,7 @@ impl FatLoopBuilder<'_> {
                             val_targets,
                             mut_targets,
                             mem_targets,
+                            fun_targets,
                         })
                     } else {
                         None
@@ -404,7 +415,11 @@ impl FatLoopBuilder<'_> {
         cfg: &StacklessControlFlowGraph,
         func_target: &FunctionTarget<'_>,
         sub_loops: &[NaturalLoop<BlockId>],
-    ) -> (BTreeSet<TempIndex>, BTreeMap<TempIndex, bool>) {
+    ) -> (
+        BTreeSet<TempIndex>,
+        BTreeMap<TempIndex, bool>,
+        BTreeSet<TempIndex>,
+    ) {
         let code = func_target.get_bytecode();
         let mut val_targets = BTreeSet::new();
         let mut mut_targets = BTreeMap::new();
@@ -413,6 +428,7 @@ impl FatLoopBuilder<'_> {
             .flat_map(|l| l.loop_body.iter())
             .copied()
             .collect();
+        let mut fun_targets = BTreeSet::new();
         for block_id in fat_loop_body {
             for code_offset in cfg
                 .instr_indexes(block_id)
@@ -429,9 +445,21 @@ impl FatLoopBuilder<'_> {
                         })
                         .or_insert(is_full_havoc);
                 }
+                // Applied fun values advance at the translation level (see
+                // `FatLoopSpecInfo::fun_targets`).
+                if let Bytecode::Call(_, _, crate::stackless_bytecode::Operation::Invoke, srcs, _) =
+                    bytecode
+                {
+                    if let Some(fun_temp) = srcs.last() {
+                        if func_target.get_local_type(*fun_temp).is_function() {
+                            fun_targets.insert(*fun_temp);
+                        }
+                    }
+                }
             }
         }
-        (val_targets, mut_targets)
+        fun_targets = fun_targets.difference(&val_targets).copied().collect();
+        (val_targets, mut_targets, fun_targets)
     }
 
     /// Collect global memories that may be modified during loop execution:

--- a/third_party/move/move-model/bytecode/src/reaching_def_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/reaching_def_analysis.rs
@@ -246,23 +246,27 @@ impl AbstractDomain for ReachingDefState {
 
 impl ReachingDefState {
     fn def_alias(&mut self, dest: TempIndex, src: TempIndex) {
-        // ensure that the previous def is killed
+        // The previous def, and any aliases referring to it, have been
+        // invalidated by `kill`.
         assert!(!self.map.contains_key(&dest));
-
-        // cascade the definition
-        for defs in self.map.values_mut() {
-            if defs.contains(&Def::Alias(dest)) {
-                defs.insert(Def::Alias(src));
-            }
-        }
-
-        // update the new alias
         self.map.entry(dest).or_default().insert(Def::Alias(src));
     }
 
     fn kill(&mut self, dest: TempIndex) {
         self.map.remove(&dest);
         self.havoced.remove(&dest);
+        // A redefinition of `dest` also invalidates every alias referring to
+        // it: those aliases denote the value `dest` held when the copy was
+        // made, which is no longer available. Without this, a copy `s := d`
+        // followed by a redefinition of `d` (e.g. as the dest of a call)
+        // would still propagate `s -> d` at later uses. Entries left without
+        // any defs are removed entirely: `join` unions defs per key, so an
+        // empty set would vanish against another path's defs instead of
+        // invalidating them.
+        self.map.retain(|_, defs| {
+            defs.retain(|d| !matches!(d, Def::Alias(a) if *a == dest));
+            !defs.is_empty()
+        });
     }
 
     fn havoc(&mut self, dest: TempIndex) {

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -326,6 +326,17 @@ pub enum BehaviorKind {
     /// surface syntax; emitted by spec inference and translated by the
     /// Boogie backend to a Skolem axiomatized against `ensures_of`.
     WriteOf(usize),
+    /// `fun_post_of<f>(args)` — the function value after one application on
+    /// `args`: for values carrying mutable reference captures, the trailing
+    /// fun slot of the `result_of` Skolem (the one-application successor);
+    /// the subject itself for all other function values.
+    FunPostOf,
+    /// `partial_of<f>(g)` — `f` is a closure over the named function `g`
+    /// with the capture arity implied by `f`'s type (variant recognizer).
+    PartialOf,
+    /// `captures_of<f>(g)` — the value captured by a closure over `g`
+    /// (single `&mut` capture); meaningful under `partial_of<f>(g)`.
+    CapturesOf,
 }
 
 impl BehaviorKind {
@@ -333,7 +344,10 @@ impl BehaviorKind {
     pub fn is_two_state(&self) -> bool {
         matches!(
             self,
-            BehaviorKind::EnsuresOf | BehaviorKind::ResultOf | BehaviorKind::WriteOf(_)
+            BehaviorKind::EnsuresOf
+                | BehaviorKind::ResultOf
+                | BehaviorKind::WriteOf(_)
+                | BehaviorKind::FunPostOf
         )
     }
 }
@@ -347,6 +361,9 @@ impl fmt::Display for BehaviorKind {
             EnsuresOf => write!(f, "ensures_of"),
             ResultOf => write!(f, "result_of"),
             WriteOf(j) => write!(f, "write_of_{}", j),
+            FunPostOf => write!(f, "fun_post_of"),
+            PartialOf => write!(f, "partial_of"),
+            CapturesOf => write!(f, "captures_of"),
         }
     }
 }
@@ -3771,7 +3788,13 @@ impl ExpData {
             use Operation::*;
             match e {
                 Temporary(id, _) => {
-                    if env.get_node_type(*id).is_mutable_reference() {
+                    // Function values are state-dependent: a value carrying
+                    // mutable reference captures advances with each
+                    // application (`old(f)` denotes the entry value). For
+                    // values that cannot carry, entry equals current, so
+                    // admitting `old(..)` is harmless.
+                    let ty = env.get_node_type(*id);
+                    if ty.is_mutable_reference() || ty.is_function() {
                         is_pure = false;
                         return false; // done visiting
                     }

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -6469,13 +6469,15 @@ impl ExpTranslator<'_, '_, '_> {
         expected_type: &Type,
         context: &ErrorMessageContext,
     ) -> ExpData {
-        // Model has a `WriteOf` variant too, but it's internal to spec
-        // inference and never produced by the parser.
         let model_kind = match kind {
             PA::BehaviorKind::RequiresOf => BehaviorKind::RequiresOf,
             PA::BehaviorKind::AbortsOf => BehaviorKind::AbortsOf,
             PA::BehaviorKind::EnsuresOf => BehaviorKind::EnsuresOf,
             PA::BehaviorKind::ResultOf => BehaviorKind::ResultOf,
+            PA::BehaviorKind::FunPostOf => BehaviorKind::FunPostOf,
+            PA::BehaviorKind::WriteOf(j) => BehaviorKind::WriteOf(j as usize),
+            PA::BehaviorKind::PartialOf => BehaviorKind::PartialOf,
+            PA::BehaviorKind::CapturesOf => BehaviorKind::CapturesOf,
         };
 
         // Translate the target expression and validate it has function type
@@ -6502,15 +6504,38 @@ impl ExpTranslator<'_, '_, '_> {
             return self.new_error_exp();
         };
 
+        if matches!(
+            model_kind,
+            BehaviorKind::PartialOf | BehaviorKind::CapturesOf
+        ) {
+            return self.translate_variant_observation(
+                loc,
+                model_kind,
+                fun_exp,
+                &arg_ty,
+                &result_ty,
+                args,
+                expected_type,
+                context,
+            );
+        }
+
         let translated_args =
             self.translate_and_check_behavior_args(loc, args, &arg_ty, &result_ty, &model_kind);
 
-        // Determine the result type based on the behavior kind
-        let fun_type = Type::Fun(
-            Box::new(arg_ty.clone()),
-            Box::new(result_ty),
-            AbilitySet::EMPTY,
-        );
+        // Determine the result type based on the behavior kind. For
+        // `fun_post_of` use the subject's actual (specialized) type so its
+        // abilities are preserved; for the other kinds a reconstruction
+        // without abilities suffices.
+        let fun_type = if model_kind == BehaviorKind::FunPostOf {
+            self.subs.specialize(&fun_type_var)
+        } else {
+            Type::Fun(
+                Box::new(arg_ty.clone()),
+                Box::new(result_ty),
+                AbilitySet::EMPTY,
+            )
+        };
         let Some(computed_result_ty) =
             self.compute_behavior_result_type(loc, &model_kind, &fun_type)
         else {
@@ -6706,11 +6731,9 @@ impl ExpTranslator<'_, '_, '_> {
                 ExpData::Call(id, SpecPublish(r) | SpecRemove(r) | SpecUpdate(r), _) => {
                     (*id, r, "mutation builtins (publish/remove/update)")
                 },
-                ExpData::Call(
-                    id,
-                    Behavior(BehaviorKind::EnsuresOf | BehaviorKind::ResultOf, r),
-                    _,
-                ) => (*id, r, "ensures_of/result_of"),
+                ExpData::Call(id, Behavior(kind, r), _) if kind.is_two_state() => {
+                    (*id, r, "ensures_of/result_of/write_of/fun_post_of")
+                },
                 ExpData::Call(id, SpecFunction(mid, fid, r), _) => {
                     let is_two_state = env.get_module_opt(*mid).is_some_and(|m| {
                         m.get_spec_funs()
@@ -6782,17 +6805,130 @@ impl ExpTranslator<'_, '_, '_> {
         types
     }
 
+    /// Type-checks `partial_of<f>(g)` / `captures_of<f>(g)`: the single
+    /// argument must be a plain function name whose signature is the
+    /// subject's inputs preceded by exactly one captured `&mut` parameter
+    /// (v1 scope: single mutable capture, prefix mask). `partial_of` is the
+    /// variant recognizer (bool); `captures_of` denotes the captured value.
+    #[allow(clippy::too_many_arguments)]
+    fn translate_variant_observation(
+        &mut self,
+        loc: &Loc,
+        kind: BehaviorKind,
+        fun_exp: Exp,
+        subject_arg_ty: &Type,
+        subject_result_ty: &Type,
+        args: &[EA::Exp],
+        expected_type: &Type,
+        context: &ErrorMessageContext,
+    ) -> ExpData {
+        if args.len() != 1 {
+            self.error(
+                loc,
+                &format!("expected 1 argument (a function name) for {}", kind),
+            );
+            return self.new_error_exp();
+        }
+        // The recognizer/selector are closed-world definitions over the
+        // verification session's closure variants. In a generic context they
+        // would be evaluated at skolemized types where no variants exist,
+        // making premises vacuously false while instantiations discharge
+        // them — unsound to transfer. Requires per-instantiation
+        // verification, which is future work (see issue #20273).
+        if !self.type_params.is_empty() {
+            self.error(
+                loc,
+                &format!(
+                    "{} is not yet supported in generic functions or lemmas \
+                     (needs per-type-instantiation verification)",
+                    kind
+                ),
+            );
+            return self.new_error_exp();
+        }
+        let target_var = self.fresh_type_var();
+        let target_exp = self.translate_exp(&args[0], &target_var).into_exp();
+        // The witness is any function value (a plain function name is the
+        // common case); its type carries the full signature. Resolve through
+        // the constraint system (a name produces a SomeFunctionValue var).
+        let Some((target_arg_ty, target_result_ty)) = self.subs.get_fun_type(&target_var) else {
+            self.error(
+                loc,
+                &format!("the argument of {} must be a function value", kind),
+            );
+            return self.new_error_exp();
+        };
+        let target_params: Vec<Type> = target_arg_ty.flatten();
+        let subject_inputs: Vec<Type> = subject_arg_ty.clone().flatten();
+        if target_params.len() != subject_inputs.len() + 1
+            || !target_params[0].is_mutable_reference()
+        {
+            self.error(
+                loc,
+                &format!(
+                    "the witness of {} must take exactly one leading `&mut` (captured) \
+                     parameter followed by the subject's parameters",
+                    kind,
+                ),
+            );
+            return self.new_error_exp();
+        }
+        for (expected, actual) in subject_inputs.iter().zip(&target_params[1..]) {
+            self.check_type(loc, actual, expected, context);
+        }
+        // The witness's result type must also match the subject's: otherwise
+        // no closure over the witness can inhabit the subject's function type
+        // and the observation would be vacuously false.
+        self.check_type(loc, &target_result_ty, subject_result_ty, context);
+        let result_ty = if kind == BehaviorKind::PartialOf {
+            BOOL_TYPE
+        } else {
+            target_params[0].skip_reference().clone()
+        };
+        let result_ty = self.check_type(loc, &result_ty, expected_type, context);
+        let id = self.new_node_id_with_type_loc(&result_ty, loc);
+        ExpData::Call(id, Operation::Behavior(kind, MemoryRange::default()), vec![
+            fun_exp,
+            target_exp.clone(),
+        ])
+    }
+
     /// Result type for a behavior predicate. `ResultOf` returns the
-    /// function's return type and is rejected for void callees; others
-    /// return `bool`. Returns `None` on rejection.
+    /// function's return type and is rejected for void callees; `FunPostOf`
+    /// returns the subject's own function type; others return `bool`.
+    /// Returns `None` on rejection.
     fn compute_behavior_result_type(
         &mut self,
         loc: &Loc,
         kind: &BehaviorKind,
         fun_type: &Type,
     ) -> Option<Type> {
-        if *kind != BehaviorKind::ResultOf {
-            return Some(BOOL_TYPE);
+        match kind {
+            BehaviorKind::ResultOf => {},
+            BehaviorKind::FunPostOf => return Some(fun_type.clone()),
+            BehaviorKind::WriteOf(j) => {
+                let Type::Fun(args, _, _) = fun_type else {
+                    return Some(Type::Error);
+                };
+                let Some(ty) = args
+                    .clone()
+                    .flatten()
+                    .into_iter()
+                    .filter(|ty| ty.is_mutable_reference())
+                    .nth(*j)
+                else {
+                    self.error(
+                        loc,
+                        &format!(
+                            "`write_of` index {} exceeds the number of `&mut` parameters",
+                            j
+                        ),
+                    );
+                    return None;
+                };
+                return Some(ty.skip_reference().clone());
+            },
+            _ => return Some(BOOL_TYPE),
         }
 
         let Type::Fun(_, result, _abilities) = fun_type else {

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1738,23 +1738,22 @@ impl ModuleBuilder<'_, '_> {
             if let Some(pre_name) = pre_label.and_then(&get_label_name) {
                 used_pre_labels.insert(pre_name);
             }
-            // Reject post-state labels on single-state predicates (requires_of, aborts_of).
+            // Reject post-state labels on single-state predicates
+            // (requires_of, aborts_of, partial_of, captures_of).
             if post_label.is_some() {
-                if let Some(BehaviorKind::RequiresOf | BehaviorKind::AbortsOf) = behavior_kind {
-                    let kind_name = match behavior_kind.unwrap() {
-                        BehaviorKind::RequiresOf => "requires_of",
-                        BehaviorKind::AbortsOf => "aborts_of",
-                        _ => unreachable!(),
-                    };
-                    let exp_loc = self.parent.env.get_node_loc(*node_id);
-                    self.parent.env.error(
-                        &exp_loc,
-                        &format!(
-                            "`{}` describes a single state and cannot have a post-state label; \
-                             only `ensures_of` and `result_of` support state transitions",
-                            kind_name,
-                        ),
-                    );
+                if let Some(kind) = behavior_kind {
+                    if !kind.is_two_state() {
+                        let exp_loc = self.parent.env.get_node_loc(*node_id);
+                        self.parent.env.error(
+                            &exp_loc,
+                            &format!(
+                                "`{}` describes a single state and cannot have a post-state \
+                                 label; only `ensures_of`, `result_of`, `write_of` and \
+                                 `fun_post_of` support state transitions",
+                                kind,
+                            ),
+                        );
+                    }
                 }
             }
         }

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -68,6 +68,13 @@ pub struct SpecTranslator<'a, 'b, T: ExpGenerator<'a>> {
     no_save_nodes: BTreeSet<NodeId>,
     /// Whether we are translating the right-hand side of an `update` clause.
     in_update: bool,
+    /// Function-typed parameters with two-state (`&mut`-like) spec semantics:
+    /// a bare reference in a post condition denotes the final value, `old(f)`
+    /// the value at entry. Opt-in per parameter, triggered by the spec
+    /// mentioning `old(f)` or `fun_post_of` over it; all other fun params
+    /// keep the legacy entry-value reading of bare post-state references.
+    /// Indices are pre-substitution (callee formals).
+    two_state_fun_params: BTreeSet<TempIndex>,
     /// Suppress appending live fun-value clones to behavioral predicates in
     /// `wrap_mut_ref_bp_inputs`. The clone is an artifact of the verification
     /// translation (the Boogie backend consumes it as the trailing `f_post`
@@ -75,6 +82,12 @@ pub struct SpecTranslator<'a, 'b, T: ExpGenerator<'a>> {
     /// must stay clone-free, since translated expressions can end up in
     /// inferred specs which are sourcified as ordinary Move code.
     omit_fun_clones: bool,
+    /// Node ids of behavioral-predicate subject occurrences. Subjects always
+    /// follow the legacy routing predicate — `ensures_of<f>(x)` describes one
+    /// application FROM a state, so in a post condition the subject denotes
+    /// the entry value even under two-state semantics, while in requires/
+    /// aborts conditions and loop invariants it stays the live value.
+    subject_legacy_nodes: BTreeSet<NodeId>,
 }
 
 /// A flattened proof action produced by translating a structured `Proof` tree.
@@ -314,6 +327,184 @@ impl TranslatedSpec {
     }
 }
 
+/// Computes the set of function-typed parameters of `fun_env` with two-state
+/// (`&mut`-like) spec semantics: those mentioned under `old(..)` or as the
+/// root subject of a `fun_post_of` chain anywhere in the function's spec.
+/// Since both forms are rejected resp. absent for legacy specs, the opt-in is
+/// backward compatible: without them, bare post-state references keep the
+/// entry-value reading.
+pub fn two_state_fun_params(fun_env: &FunctionEnv<'_>) -> BTreeSet<TempIndex> {
+    let env = fun_env.module_env.env;
+    let mut result = BTreeSet::new();
+    let spec = fun_env.get_spec();
+    for cond in spec.conditions.iter().chain(spec.update_map.values()) {
+        for exp in cond.all_exps() {
+            exp.visit_pre_order(&mut |e| {
+                match e {
+                    ExpData::Call(_, Operation::Old, args) if args.len() == 1 => {
+                        if let ExpData::Temporary(id, idx) = args[0].as_ref() {
+                            if env.get_node_type(*id).is_function() {
+                                result.insert(*idx);
+                            }
+                        }
+                    },
+                    ExpData::Call(_, Operation::Behavior(BehaviorKind::FunPostOf, _), args) => {
+                        // Find the chain root, stripping nested `fun_post_of`
+                        // and `old(..)` wrappers.
+                        let mut subject = args.first();
+                        while let Some(exp) = subject {
+                            match exp.as_ref() {
+                                ExpData::Call(
+                                    _,
+                                    Operation::Behavior(BehaviorKind::FunPostOf, _),
+                                    inner,
+                                ) => subject = inner.first(),
+                                ExpData::Call(_, Operation::Old, inner) if inner.len() == 1 => {
+                                    subject = inner.first()
+                                },
+                                _ => break,
+                            }
+                        }
+                        if let Some(ExpData::Temporary(_, idx)) = subject.map(|e| e.as_ref()) {
+                            result.insert(*idx);
+                        }
+                    },
+                    _ => {},
+                }
+                true
+            });
+        }
+    }
+    result
+}
+
+/// Computes the set of function-typed parameters of `fun_env` which are
+/// reflected over by `partial_of`/`captures_of` in the function's spec.
+/// Such parameters must be verified universally over their datatype (not
+/// pinned to their abstract `$param` variant): variant-membership
+/// observations are provably false for the abstract variant, which would
+/// make the function's own verification vacuous while call sites discharge
+/// the premise at concrete closures.
+///
+/// A parameter counts as reflected over when it occurs ANYWHERE inside an
+/// argument of such an observation, at any nesting depth, in the function
+/// spec, in inline spec blocks and loop invariants (`on_impl`), or as an
+/// argument of a spec function whose body (transitively) contains such an
+/// observation. A fun-typed spec-`let` alias in observation position hides
+/// the flow, so it conservatively unpins all fun-typed parameters.
+pub fn variant_observed_fun_params(fun_env: &FunctionEnv<'_>) -> BTreeSet<TempIndex> {
+    use crate::ast::BehaviorKind;
+
+    /// Whether the spec function's body transitively contains a variant
+    /// observation.
+    fn spec_fun_observes(
+        env: &GlobalEnv,
+        qid: QualifiedId<crate::model::SpecFunId>,
+        visited: &mut BTreeSet<QualifiedId<crate::model::SpecFunId>>,
+    ) -> bool {
+        if !visited.insert(qid) {
+            return false;
+        }
+        let Some(module) = env.get_module_opt(qid.module_id) else {
+            return false;
+        };
+        let decl = module.get_spec_fun(qid.id);
+        let Some(body) = &decl.body else {
+            return false;
+        };
+        let mut found = false;
+        body.visit_pre_order(&mut |e| {
+            match e {
+                ExpData::Call(
+                    _,
+                    Operation::Behavior(BehaviorKind::PartialOf | BehaviorKind::CapturesOf, _),
+                    _,
+                ) => {
+                    found = true;
+                    return false;
+                },
+                ExpData::Call(_, Operation::SpecFunction(mid, fid, _), _) => {
+                    if spec_fun_observes(env, mid.qualified(*fid), visited) {
+                        found = true;
+                        return false;
+                    }
+                },
+                _ => {},
+            }
+            true
+        });
+        found
+    }
+
+    /// Collects all condition expressions of a spec, including inline
+    /// (`on_impl`) specs such as loop invariants and inline assumes.
+    fn collect_spec_exps<'x>(spec: &'x crate::ast::Spec, out: &mut Vec<&'x Exp>) {
+        for cond in spec.conditions.iter().chain(spec.update_map.values()) {
+            out.extend(cond.all_exps());
+        }
+        for nested in spec.on_impl.values() {
+            collect_spec_exps(nested, out);
+        }
+    }
+
+    let env = fun_env.module_env.env;
+    let num_params = fun_env.get_parameter_count();
+    let mut result = BTreeSet::new();
+    let mut aliased = false;
+    let spec = fun_env.get_spec();
+    let mut exps: Vec<&Exp> = vec![];
+    collect_spec_exps(&spec, &mut exps);
+    let collect_from = |arg: &Exp, result: &mut BTreeSet<TempIndex>, aliased: &mut bool| {
+        arg.visit_pre_order(&mut |inner| {
+            match inner {
+                ExpData::Temporary(_, idx) if *idx < num_params => {
+                    result.insert(*idx);
+                },
+                ExpData::LocalVar(id, _) if env.get_node_type(*id).is_function() => {
+                    *aliased = true;
+                },
+                _ => {},
+            }
+            true
+        });
+    };
+    for exp in exps {
+        exp.visit_pre_order(&mut |e| {
+            match e {
+                ExpData::Call(
+                    _,
+                    Operation::Behavior(BehaviorKind::PartialOf | BehaviorKind::CapturesOf, _),
+                    args,
+                ) => {
+                    for arg in args {
+                        collect_from(arg, &mut result, &mut aliased);
+                    }
+                },
+                ExpData::Call(_, Operation::SpecFunction(mid, fid, _), args)
+                    if spec_fun_observes(env, mid.qualified(*fid), &mut BTreeSet::new()) =>
+                {
+                    // The observation sits inside the called spec function's
+                    // body; conservatively treat every fun-typed value flowing
+                    // in as reflected over.
+                    for arg in args {
+                        collect_from(arg, &mut result, &mut aliased);
+                    }
+                },
+                _ => {},
+            }
+            true
+        });
+    }
+    let params = fun_env.get_parameters_ref();
+    let fun_typed = |idx: &TempIndex| params.get(*idx).is_some_and(|p| p.1.is_function());
+    if aliased {
+        (0..num_params).filter(fun_typed).collect()
+    } else {
+        result.retain(fun_typed);
+        result
+    }
+}
+
 impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     /// Translates the specification of function `fun_env`. This can happen for a call of the
     /// function or for its definition (parameter `for_call`). This will process all the
@@ -349,6 +540,8 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             shared_old_label: None,
             no_save_nodes: BTreeSet::new(),
             in_update: false,
+            two_state_fun_params: two_state_fun_params(fun_env),
+            subject_legacy_nodes: BTreeSet::new(),
             omit_fun_clones,
         };
         translator.translate_spec(for_call);
@@ -378,6 +571,8 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             shared_old_label: None,
             no_save_nodes: BTreeSet::new(),
             in_update: false,
+            two_state_fun_params: BTreeSet::new(),
+            subject_legacy_nodes: BTreeSet::new(),
             omit_fun_clones: false,
         };
         // Clone invariants so `inst` lives for the entire loop
@@ -418,6 +613,8 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             shared_old_label: None,
             no_save_nodes: BTreeSet::new(),
             in_update: false,
+            two_state_fun_params: BTreeSet::new(),
+            subject_legacy_nodes: BTreeSet::new(),
             omit_fun_clones,
         };
 
@@ -898,6 +1095,11 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     }
 
     /// Expand `apply lemma(args)`: assert each requires, assume each ensures.
+    ///
+    /// TODO(#20275): applying a lemma inside its own (or a mutually
+    /// recursive) proof assumes the conclusion being proven; recursion needs
+    /// a well-foundedness check (`decreases` clause with a strictly
+    /// decreasing measure asserted at the application).
     fn expand_lemma_apply(
         &mut self,
         loc: &Loc,
@@ -1066,6 +1268,25 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
         let arg_types: Vec<Type> = (*arg_ty_box).flatten();
         let num_inputs = arg_types.len();
         let num_explicit_results = (*result_ty_box).flatten().len();
+
+        // Mark the subject occurrence for legacy routing, on all paths
+        // including the early returns below: a behavioral predicate describes
+        // one application FROM a state, so the subject keeps the entry-value
+        // reading in post conditions even when `f` has two-state semantics
+        // (`ensures f == fun_post_of<f>(x)` thus means final == successor of
+        // the entry value). In pre-state conditions and loop invariants the
+        // legacy routing is the live value, as before.
+        if let ExpData::Temporary(subject_id, _) = fun_exp.as_ref() {
+            self.subject_legacy_nodes.insert(*subject_id);
+        }
+
+        // Variant observations take `[f, witness]` — no subject inputs and no
+        // post-state or fun-clone slots. Only the subject marking above
+        // applies; the generic input-arity machinery below does not.
+        if matches!(kind, BehaviorKind::PartialOf | BehaviorKind::CapturesOf) {
+            return exp.clone();
+        }
+
         if args.len() < 1 + num_inputs {
             return exp.clone();
         }
@@ -1395,9 +1616,18 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
         // matters for values carrying mutable reference captures, whose temp is
         // updated across calls; the updated value is accessible only through the
         // trailing clone synthesized by `wrap_mut_ref_bp_inputs`.
+        //
+        // A fun param with two-state semantics (spec mentions `old(f)` or
+        // `fun_post_of` over it) reads like a `&mut` param instead: bare
+        // references in post-placed conditions denote the live (final) value
+        // and `old(f)` the entry value. Behavioral-predicate subjects are
+        // exempt and keep the legacy routing (entry value in post conditions).
+        let two_state_fun = local_type.is_function()
+            && self.two_state_fun_params.contains(&idx)
+            && !self.subject_legacy_nodes.contains(&id);
         if (self.in_old
-            || (self.in_post_state && !local_type.is_mutable_reference())
-            || (self.in_update && local_type.is_function()))
+            || (self.in_post_state && !local_type.is_mutable_reference() && !two_state_fun)
+            || (self.in_update && local_type.is_function() && !two_state_fun))
             && !self.no_save_nodes.contains(&id)
         {
             // We access a param inside of old context, or a value which might have been
@@ -1579,7 +1809,19 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
         if self.type_args.is_empty() {
             None
         } else {
-            ExpData::instantiate_node(self.builder.global_env(), id, self.type_args)
+            let new_id = ExpData::instantiate_node(self.builder.global_env(), id, self.type_args)?;
+            // Node-id-keyed markings must survive instantiation: the live
+            // fun-value clones (`no_save_nodes`) and behavioral-predicate
+            // subjects (`subject_legacy_nodes`) are recorded on the
+            // pre-instantiation ids by `wrap_mut_ref_bp_inputs`, but the
+            // routing decision in `rewrite_temporary` sees the re-minted id.
+            if self.no_save_nodes.contains(&id) {
+                self.no_save_nodes.insert(new_id);
+            }
+            if self.subject_legacy_nodes.contains(&id) {
+                self.subject_legacy_nodes.insert(new_id);
+            }
+            Some(new_id)
         }
     }
 

--- a/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -32,7 +32,7 @@ use move_stackless_bytecode::{function_target::FunctionTarget, stackless_bytecod
 use num::BigUint;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub const MAX_MAKE_VEC_ARGS: usize = 4;
 pub const MAX_TUPLE_SIZE: usize = 8;
@@ -1260,18 +1260,53 @@ pub fn boogie_closure_pack_name(
     format!("$closure'{}'_{}", fun_name, mask)
 }
 
-/// Return the closure variant infos generated for the datatype of the given function
-/// type, in variant order. The type is matched against MonoInfo via its Boogie name,
-/// so it does not need to be in normalized form.
-pub fn boogie_closure_infos(env: &GlobalEnv, fun_ty: &Type) -> Vec<ClosureInfo> {
-    let mono_info = mono_analysis::get_info(env);
+/// Look up the infos registered in a MonoInfo map for the given function type,
+/// in registration order. The type is matched against the map via its Boogie
+/// name, so it does not need to be in normalized form.
+fn boogie_fun_ty_infos<T: Clone>(
+    env: &GlobalEnv,
+    map: &BTreeMap<Type, BTreeSet<T>>,
+    fun_ty: &Type,
+) -> Vec<T> {
     let boogie_name = boogie_type(env, fun_ty, false);
-    for (ty, infos) in &mono_info.fun_infos {
+    for (ty, infos) in map {
         if boogie_type(env, ty, false) == boogie_name {
             return infos.iter().cloned().collect();
         }
     }
     vec![]
+}
+
+/// Return the closure variant infos generated for the datatype of the given function
+/// type, in variant order.
+pub fn boogie_closure_infos(env: &GlobalEnv, fun_ty: &Type) -> Vec<ClosureInfo> {
+    boogie_fun_ty_infos(env, &mono_analysis::get_info(env).fun_infos, fun_ty)
+}
+
+/// Name of the closed-world `partial_of` recognizer for a (subject, witness)
+/// fun-type pair.
+pub fn boogie_partial_fun_name(env: &GlobalEnv, ty_f: &Type, ty_g: &Type) -> String {
+    format!(
+        "$partial'{}${}'",
+        boogie_type_suffix(env, ty_f, false),
+        boogie_type_suffix(env, ty_g, false)
+    )
+}
+
+/// Name of the captured-value selector for a subject fun type and capture
+/// value type.
+pub fn boogie_captures_fun_name(env: &GlobalEnv, ty_f: &Type, cap_ty: &Type) -> String {
+    format!(
+        "$captures'{}${}'",
+        boogie_type_suffix(env, ty_f, false),
+        boogie_type_suffix(env, cap_ty, false)
+    )
+}
+
+/// Return the fun-param variant infos registered for the given function type
+/// (name-matched, like `boogie_closure_infos`).
+pub fn boogie_fun_param_infos(env: &GlobalEnv, fun_ty: &Type) -> Vec<mono_analysis::FunParamInfo> {
+    boogie_fun_ty_infos(env, &mono_analysis::get_info(env).fun_param_infos, fun_ty)
 }
 
 /// Return the variant index of the closure constructed from `fun` with `mask` within
@@ -1298,8 +1333,19 @@ pub fn boogie_closure_capture_field(pos: usize, variant_idx: usize) -> String {
 /// Returns true if values of the given function type may carry mutations, i.e. the
 /// type has closure variants capturing mutable references.
 pub fn boogie_fun_ty_carries_mutations(env: &GlobalEnv, fun_ty: &Type) -> bool {
-    boogie_closure_infos(env, fun_ty)
-        .iter()
+    boogie_infos_carry_mutations(env, &boogie_closure_infos(env, fun_ty))
+}
+
+/// Returns true if any of the given closure variant infos captures a mutable
+/// reference, i.e. values of their function type may carry mutations. Variant
+/// of `boogie_fun_ty_carries_mutations` for callers which already hold the
+/// closure infos.
+pub fn boogie_infos_carry_mutations<'a, I>(env: &GlobalEnv, infos: I) -> bool
+where
+    I: IntoIterator<Item = &'a ClosureInfo>,
+{
+    infos
+        .into_iter()
         .any(|info| !info.mut_capture_slots(env).is_empty())
 }
 
@@ -1451,7 +1497,11 @@ pub fn boogie_behavioral_eval_fun_name(
     kind: BehaviorKind,
 ) -> String {
     let kind_name = match kind {
-        BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => "result_of".to_string(),
+        // These share the `result_of` tuple Skolem; `fun_post_of` projects
+        // its trailing fun slot.
+        BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) | BehaviorKind::FunPostOf => {
+            "result_of".to_string()
+        },
         _ => kind.to_string(),
     };
     format!(

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -10,15 +10,16 @@ use crate::{
         boogie_address, boogie_address_blob, boogie_behavioral_eval_fun_name,
         boogie_behavioral_fun_result_name, boogie_behavioral_fun_spec_name,
         boogie_behavioral_result_fun_name, boogie_behavioral_spec_fun_name, boogie_byte_blob,
-        boogie_closure_capture_field, boogie_closure_infos, boogie_closure_pack_name,
-        boogie_closure_variant_index, boogie_constant_blob, boogie_debug_track_abort,
-        boogie_debug_track_local, boogie_debug_track_return, boogie_equality_for_type,
-        boogie_field_sel, boogie_field_update, boogie_fun_apply_name, boogie_fun_param_name,
-        boogie_fun_ty_carries_mutations, boogie_function_name, boogie_int_suffix,
+        boogie_captures_fun_name, boogie_closure_capture_field, boogie_closure_infos,
+        boogie_closure_pack_name, boogie_closure_variant_index, boogie_constant_blob,
+        boogie_debug_track_abort, boogie_debug_track_local, boogie_debug_track_return,
+        boogie_equality_for_type, boogie_field_sel, boogie_field_update, boogie_fun_apply_name,
+        boogie_fun_param_infos, boogie_fun_param_name, boogie_fun_ty_carries_mutations,
+        boogie_function_name, boogie_infos_carry_mutations, boogie_int_suffix,
         boogie_make_vec_from_strings, boogie_modifies_memory_name, boogie_native_spec_fun_name,
-        boogie_num_literal, boogie_num_type_base, boogie_reflection_type_info,
-        boogie_reflection_type_name, boogie_resource_memory_name, boogie_spec_fun_name,
-        boogie_struct_field_name, boogie_struct_field_result_fun_name,
+        boogie_num_literal, boogie_num_type_base, boogie_partial_fun_name,
+        boogie_reflection_type_info, boogie_reflection_type_name, boogie_resource_memory_name,
+        boogie_spec_fun_name, boogie_struct_field_name, boogie_struct_field_result_fun_name,
         boogie_struct_field_spec_fun_name, boogie_struct_name, boogie_struct_variant_name,
         boogie_temp, boogie_temp_from_suffix, boogie_type, boogie_type_for_struct_field,
         boogie_type_param, boogie_type_suffix, boogie_type_suffix_for_struct,
@@ -73,6 +74,7 @@ use move_stackless_bytecode::{
     },
 };
 use std::{
+    cell::RefCell,
     collections::{BTreeMap, BTreeSet},
     hash::{DefaultHasher, Hash, Hasher},
 };
@@ -130,6 +132,11 @@ pub struct BoogieTranslator<'env> {
     /// Map from function type to the set of function parameter infos for that type.
     /// Used to emit behavioral predicate assumptions at closure construction sites.
     fun_param_infos: BTreeMap<Type, BTreeSet<FunParamInfo>>,
+    /// Closure target functions whose per-function behavioral spec functions
+    /// have been emitted. Global across fun types: the same target can be a
+    /// variant of several types (different masks), and the spec functions
+    /// are named per function.
+    emitted_bp_funs: RefCell<BTreeSet<QualifiedInstId<FunId>>>,
 }
 
 pub struct FunctionTranslator<'env> {
@@ -206,13 +213,6 @@ struct BpMemArgs {
 }
 
 impl BpMemArgs {
-    fn empty() -> Self {
-        Self {
-            slots: vec![],
-            instance_id: None,
-        }
-    }
-
     /// Render the Boogie-arg prefix for a BP call of the given kind.
     fn render(&self, kind: BehaviorKind) -> String {
         let mut parts: Vec<String> = Vec::with_capacity(self.slots.len() * 2 + 1);
@@ -273,6 +273,7 @@ impl<'env> BoogieTranslator<'env> {
             writer,
             spec_translator: SpecTranslator::new(writer, env, options),
             fun_param_infos: BTreeMap::new(),
+            emitted_bp_funs: RefCell::new(BTreeSet::new()),
         }
     }
 
@@ -682,6 +683,10 @@ impl<'env> BoogieTranslator<'env> {
             )
         }
 
+        // Closed-world recognizer/selector definitions backing
+        // `partial_of`/`captures_of`, per observed fun-type pair.
+        self.translate_variant_observation_defs(&mono_info);
+
         // Emit any finalization items required by spec translation.
         self.spec_translator.finalize();
         let shard_info = if let Some(shard) = self.for_shard {
@@ -693,6 +698,87 @@ impl<'env> BoogieTranslator<'env> {
             "{} verification conditions{}",
             verified_functions_count, shard_info
         );
+    }
+
+    /// Emits, for each (subject, witness) fun-type pair observed by
+    /// `partial_of`/`captures_of`, a bodied recognizer relating single-
+    /// `&mut`-prefix-capture variants of the subject type to the bare
+    /// (mask 0) variant of the same target in the witness type, and an
+    /// uninterpreted captured-value selector with guarded defining axioms.
+    /// Closed-world over the session's variants, like the fun datatypes
+    /// themselves; values in abstract variants satisfy no recognizer.
+    fn translate_variant_observation_defs(&self, mono_info: &mono_analysis::MonoInfo) {
+        let env = self.env;
+        let empty = BTreeSet::new();
+        let mut emitted_captures: BTreeSet<String> = BTreeSet::new();
+        for (ty_f, ty_g) in &mono_info.variant_obs_pairs {
+            let f_ty_name = boogie_type(env, ty_f, false);
+            let g_ty_name = boogie_type(env, ty_g, false);
+            let Type::Fun(g_args, _, _) = ty_g else {
+                continue;
+            };
+            let Some(cap_ty) = g_args.clone().flatten().first().cloned() else {
+                continue;
+            };
+            let cap_ty = cap_ty.skip_reference().clone();
+            let infos_f = mono_info.fun_infos.get(ty_f).unwrap_or(&empty);
+            let infos_g = mono_info.fun_infos.get(ty_g).unwrap_or(&empty);
+            let mut disjuncts: Vec<String> = vec![];
+            let mut cap_defs: Vec<(String, String)> = vec![];
+            for (idx_f, info_f) in infos_f.iter().enumerate() {
+                let slots: Vec<(usize, Type)> = info_f.mut_capture_slots(env);
+                let [(pos, target_ty)] = slots.as_slice() else {
+                    continue;
+                };
+                if info_f.mask.bits() != 1 {
+                    // v1 scope: single `&mut` capture at prefix position.
+                    continue;
+                }
+                let ctor_f = boogie_closure_pack_name(env, &info_f.fun, info_f.mask);
+                for info_g in infos_g.iter() {
+                    if info_g.fun == info_f.fun && info_g.mask.bits() == 0 {
+                        let ctor_g = boogie_closure_pack_name(env, &info_g.fun, info_g.mask);
+                        disjuncts.push(format!("(f is {} && g is {})", ctor_f, ctor_g));
+                    }
+                }
+                if target_ty == &cap_ty {
+                    cap_defs.push((ctor_f, boogie_closure_capture_field(*pos, idx_f)));
+                }
+            }
+            emitln!(
+                self.writer,
+                "function {}(f: {}, g: {}): bool {{ {} }}",
+                boogie_partial_fun_name(env, ty_f, ty_g),
+                f_ty_name,
+                g_ty_name,
+                if disjuncts.is_empty() {
+                    "false".to_string()
+                } else {
+                    disjuncts.join(" || ")
+                }
+            );
+            let cap_name = boogie_captures_fun_name(env, ty_f, &cap_ty);
+            if emitted_captures.insert(cap_name.clone()) {
+                emitln!(
+                    self.writer,
+                    "function {}(f: {}): {};",
+                    cap_name,
+                    f_ty_name,
+                    boogie_type(env, &cap_ty, false)
+                );
+                for (ctor_f, field) in &cap_defs {
+                    emitln!(
+                        self.writer,
+                        "axiom (forall f: {} :: {{{}(f)}} (f is {}) ==> {}(f) == f->{}->v);",
+                        f_ty_name,
+                        cap_name,
+                        ctor_f,
+                        cap_name,
+                        field
+                    );
+                }
+            }
+        }
     }
 
     fn translate_fun_type(
@@ -767,13 +853,19 @@ impl<'env> BoogieTranslator<'env> {
                 info.param_sym.display(self.env.symbol_pool()),
                 fun_env.get_name().display(self.env.symbol_pool())
             );
-            // Parameter variants have no captured values, just a constant constructor
+            // Parameter variants of advancing params (two-state spec semantics)
+            // form an indexed family; all others are constant constructors.
             // Only emit comma if not the last variant
             let is_last = closure_count + idx == total_count - 1;
             emitln!(
                 self.writer,
-                "{}(){}",
+                "{}({}){}",
                 boogie_fun_param_name(self.env, &info.fun, info.param_sym),
+                if boogie_infos_carry_mutations(self.env, closure_infos) {
+                    "n: int"
+                } else {
+                    ""
+                },
                 if is_last { "" } else { "," }
             );
         }
@@ -927,9 +1019,7 @@ impl<'env> BoogieTranslator<'env> {
         // If closure variants of this type capture mutable references, the fun value
         // carries mutations and is threaded in-out: the apply procedure returns the
         // updated value as trailing output.
-        let carries_mutations = closure_infos
-            .iter()
-            .any(|info| !info.mut_capture_slots(self.env).is_empty());
+        let carries_mutations = boogie_infos_carry_mutations(self.env, closure_infos);
         if carries_mutations {
             if !result_locals.is_empty() {
                 emit!(self.writer, ",");
@@ -1134,6 +1224,17 @@ impl<'env> BoogieTranslator<'env> {
         // Generate branches for function parameter variants using behavioral predicates.
         // We use a conservative approach: havoc results and abort_flag, then constrain
         // with behavioral predicates if they exist.
+        // The union memory arguments for the successor Skolem are the same for
+        // all variants, so compute them once.
+        let union_mem_args_opt = carries_mutations.then(|| {
+            let (union_used, union_old) = Self::collect_union_memory(
+                self.env,
+                closure_infos,
+                fun_param_infos,
+                struct_field_infos,
+            );
+            self.build_spec_memory_args(&union_used, &union_old, &[], &None, None)
+        });
         for (idx, info) in fun_param_infos.iter().enumerate() {
             let is_last = closure_count + idx == total_variants - 1;
             let is_only = total_variants == 1;
@@ -1155,8 +1256,14 @@ impl<'env> BoogieTranslator<'env> {
             let mem_args = self.build_spec_memory_args(&used_memory, &old_memory, &[], &None, None);
 
             // Build the argument list for behavioral predicates.
-            // Memory args come first, then data args.
-            let data_args: Vec<String> = params
+            // Memory args come first, then data args. For advancing params
+            // the family index is prepended to the data args (struct-field
+            // variant precedent), matching the `n: int` slot of the
+            // per-param spec functions; the plain input list is kept for
+            // frame access and the `result_of` successor, which take the
+            // fun value itself.
+            let advances = carries_mutations;
+            let plain_data_args: Vec<String> = params
                 .iter()
                 .enumerate()
                 .map(|(pos, ty)| {
@@ -1166,6 +1273,11 @@ impl<'env> BoogieTranslator<'env> {
                         format!("p{}", pos)
                     }
                 })
+                .collect();
+            let data_args: Vec<String> = advances
+                .then(|| "fun->n".to_string())
+                .into_iter()
+                .chain(plain_data_args.iter().cloned())
                 .collect();
             let bp_args = mem_args.iter().chain(data_args.iter()).join(", ");
 
@@ -1198,8 +1310,30 @@ impl<'env> BoogieTranslator<'env> {
 
             // Compute frame access for this function parameter from access_of declarations
             let frame_access =
-                derive_param_frame_access(self.env, &info.fun, info.param_sym, &data_args);
+                derive_param_frame_access(self.env, &info.fun, info.param_sym, &plain_data_args);
 
+            if let Some(union_mem_args) = &union_mem_args_opt {
+                // Advance the fun value to its one-application successor. This
+                // must agree with the `f_post` conjunct of the fun-param
+                // variant axiom so that a single-application `ensures_of` is
+                // provable exactly when the body applied the parameter once:
+                // the def-side trailing clone then equals this successor.
+                // Emitted before the body so `&mut` params and memory are
+                // read in their pre-application state.
+                emitln!(
+                    self.writer,
+                    "fun_out := {};",
+                    Self::result_of_successor_term(
+                        self.env,
+                        fun_type,
+                        union_mem_args,
+                        "fun",
+                        &plain_data_args,
+                        &params,
+                        &explicit_results,
+                    )
+                );
+            }
             self.emit_behavioral_predicate_body(
                 &aborts_name,
                 &ensures_name,
@@ -1914,9 +2048,7 @@ impl<'env> BoogieTranslator<'env> {
         // full parameter list, while the specialized closure and
         // fun_param axioms substitute a concrete constructor term for
         // `f` and therefore need the memory and data portions independently.
-        let carries_mutations = closure_infos
-            .iter()
-            .any(|info| !info.mut_capture_slots(env).is_empty());
+        let carries_mutations = boogie_infos_carry_mutations(env, closure_infos);
         let (data_decls, data_args) = Self::data_param_decls_and_args(
             env,
             &params,
@@ -1959,6 +2091,7 @@ impl<'env> BoogieTranslator<'env> {
         for (variant_idx, info) in closure_infos.iter().enumerate() {
             self.emit_closure_variant_axiom(
                 &eval_fun_name,
+                &fun_ty_boogie_name,
                 &eval_mem_decls,
                 &eval_mem_args,
                 &data_decls,
@@ -1968,11 +2101,13 @@ impl<'env> BoogieTranslator<'env> {
                 &params,
                 &results,
                 kind,
+                carries_mutations,
             );
         }
         for info in fun_param_infos {
             self.emit_fun_param_variant_axiom(
                 &eval_fun_name,
+                fun_type,
                 &eval_mem_decls,
                 &eval_mem_args,
                 &data_decls,
@@ -1981,6 +2116,7 @@ impl<'env> BoogieTranslator<'env> {
                 &params,
                 &results,
                 kind,
+                carries_mutations,
             );
         }
         for info in struct_field_infos {
@@ -1994,6 +2130,7 @@ impl<'env> BoogieTranslator<'env> {
                 &union_used_memory,
                 &union_old_memory,
                 kind,
+                carries_mutations,
             );
         }
     }
@@ -2045,6 +2182,7 @@ impl<'env> BoogieTranslator<'env> {
     fn emit_closure_variant_axiom(
         &self,
         eval_fun_name: &str,
+        fun_ty_boogie_name: &str,
         mem_decls: &[String],
         mem_args: &[String],
         data_decls: &[String],
@@ -2054,6 +2192,7 @@ impl<'env> BoogieTranslator<'env> {
         params: &[Type],
         results: &[Type],
         kind: BehaviorKind,
+        carries_mutations: bool,
     ) {
         let env = self.env;
         let fun_env = env.get_function(info.fun.to_qualified_id());
@@ -2065,45 +2204,25 @@ impl<'env> BoogieTranslator<'env> {
         let ctor_name = boogie_closure_pack_name(env, &info.fun, info.mask);
         let has_mut_captures = !info.mut_capture_slots(env).is_empty();
 
-        // Captures become quantifier-bound variables `c0..cK`. The
-        // constructor term in the trigger takes them as arguments. Slots
-        // capturing mutable references have `$Mutation` type, matching the
-        // datatype field.
-        let mut capture_decls = Vec::new();
-        let mut capture_args = Vec::new();
-        let mut captured_pos = 0usize;
-        for (i, ty) in callee_param_tys.iter().enumerate() {
-            if info.mask.is_captured(i) {
-                let name = format!("c{}", captured_pos);
-                let slot_ty = if ty.is_mutable_reference() {
-                    boogie_type(env, ty, false)
-                } else {
-                    boogie_type(env, ty.skip_reference(), false)
-                };
-                capture_decls.push(format!("{}: {}", name, slot_ty));
-                capture_args.push(name);
-                captured_pos += 1;
-            }
-        }
-        let ctor_term = if capture_args.is_empty() {
-            format!("{}()", ctor_name)
-        } else {
-            format!("{}({})", ctor_name, capture_args.join(", "))
-        };
-
-        // Quantifier bindings: memory, captures, data.
+        // Guarded form (like struct-field variants): quantify over the fun
+        // value itself with the trigger on the evaluator application, guard
+        // with the variant recognizer, and read captures through field
+        // accessors. This fires on symbolic fun values whose variant is
+        // known only semantically (e.g. members of `fun_post_of` chains
+        // under a `partial_of` premise), where a constructor-keyed trigger
+        // would never match.
         let quantifier: Vec<String> = mem_decls
             .iter()
-            .chain(capture_decls.iter())
-            .chain(data_decls.iter())
             .cloned()
+            .chain(std::iter::once(format!("f: {}", fun_ty_boogie_name)))
+            .chain(data_decls.iter().cloned())
             .collect();
+        let field_of =
+            |slot: usize| format!("f->{}", boogie_closure_capture_field(slot, variant_idx));
 
-        // Build the RHS call to the per-function spec function. Captured
-        // params are taken directly from the bound `cK` variables, not
-        // from `f->pK`, because the trigger commits `f = ctor(c0..cK)`.
-        // Mutation-carrying capture slots contribute their value component,
-        // since behavioral predicates reason over plain values.
+        // Build the RHS call to the per-function spec function. Mutation-
+        // carrying capture slots contribute their value component, since
+        // behavioral predicates reason over plain values.
         let bp_name = boogie_behavioral_fun_spec_name(env, &info.fun, kind);
         let mut rhs_args: Vec<String> =
             Self::build_instantiated_memory_args(env, &fun_env, &info.fun.inst);
@@ -2112,9 +2231,9 @@ impl<'env> BoogieTranslator<'env> {
         for (i, ty) in callee_param_tys.iter().enumerate() {
             if info.mask.is_captured(i) {
                 if ty.is_mutable_reference() {
-                    rhs_args.push(format!("c{}->v", captured_pos));
+                    rhs_args.push(format!("{}->v", field_of(captured_pos)));
                 } else {
-                    rhs_args.push(format!("c{}", captured_pos));
+                    rhs_args.push(field_of(captured_pos));
                 }
                 captured_pos += 1;
             } else {
@@ -2130,10 +2249,20 @@ impl<'env> BoogieTranslator<'env> {
         let mut identity_conjuncts: Vec<String> = vec![];
         if kind == BehaviorKind::EnsuresOf {
             if has_mut_captures {
-                identity_conjuncts.push(format!("(f_post is {})", ctor_name));
+                // Equate `f_post` with a syntactic constructor application:
+                // by-value captures unchanged, mutation-carrying slots
+                // updated in place (same location and path, the new value
+                // taken from `f_post`'s own field). Semantically this is the
+                // recognizer plus per-slot mutation-identity constraints,
+                // but the planted constructor term additionally keeps
+                // e-matching alive when the successor of one application
+                // becomes the subject of the next (`fun_post_of` chains):
+                // the constructor-keyed trigger of this axiom only fires on
+                // values whose class contains a constructor application.
                 let explicit_count = results.len();
                 let mut fun_mut_pos = 0usize;
                 let mut slot = 0usize;
+                let mut post_ctor_args: Vec<String> = vec![];
                 for i in 0..explicit_count {
                     rhs_args.push(format!("r{}", i));
                 }
@@ -2145,20 +2274,39 @@ impl<'env> BoogieTranslator<'env> {
                                 "f_post->{}",
                                 boogie_closure_capture_field(slot, variant_idx)
                             );
-                            identity_conjuncts
-                                .push(format!("$IsSameMutation(c{}, {})", slot, field));
+                            post_ctor_args.push(format!(
+                                "$UpdateMutation({}, {}->v)",
+                                field_of(slot),
+                                field
+                            ));
                             rhs_args.push(format!("{}->v", field));
                         } else {
                             rhs_args.push(format!("r{}", explicit_count + fun_mut_pos));
                             fun_mut_pos += 1;
                         }
+                    } else if captured {
+                        post_ctor_args.push(field_of(slot));
                     }
                     if captured {
                         slot += 1;
                     }
                 }
+                identity_conjuncts.push(format!(
+                    "f_post == {}({})",
+                    ctor_name,
+                    post_ctor_args.join(", ")
+                ));
             } else {
                 rhs_args.extend(Self::behavioral_output_args(params, results));
+                if carries_mutations {
+                    // Values without captured mutations do not advance: the
+                    // post value is the value itself, matching the apply
+                    // procedure's `fun_out := fun` for this variant. Without
+                    // this, `fun_post_of` over such values would be fully
+                    // unconstrained (e.g. a pure closure passed to a
+                    // chain-spec'd HOF).
+                    identity_conjuncts.push("f_post == f".to_string());
+                }
             }
         }
         let rhs = if identity_conjuncts.is_empty() {
@@ -2172,31 +2320,25 @@ impl<'env> BoogieTranslator<'env> {
             )
         };
 
-        // Build the evaluator application used in trigger and body, with
-        // the concrete constructor term substituted for `f`.
+        // Build the evaluator application used in trigger and body; the
+        // bound fun value is guarded by the variant recognizer.
         let eval_call_args: Vec<String> = mem_args
             .iter()
             .cloned()
-            .chain(std::iter::once(ctor_term.clone()))
+            .chain(std::iter::once("f".to_string()))
             .chain(data_args.iter().cloned())
             .collect();
         let eval_call = format!("{}({})", eval_fun_name, eval_call_args.join(", "));
 
-        if quantifier.is_empty() {
-            // No bound variables (e.g. zero-argument function like `create()`):
-            // emit a plain axiom without `forall`, since Boogie requires at least
-            // one bound variable in a quantifier.
-            emitln!(self.writer, "axiom {} <==> {};", eval_call, rhs);
-        } else {
-            emitln!(
-                self.writer,
-                "axiom (forall {} :: {{{}}} {} <==> {});",
-                quantifier.join(", "),
-                eval_call,
-                eval_call,
-                rhs
-            );
-        }
+        emitln!(
+            self.writer,
+            "axiom (forall {} :: {{{}}} (f is {}) ==> ({} <==> {}));",
+            quantifier.join(", "),
+            eval_call,
+            ctor_name,
+            eval_call,
+            rhs
+        );
     }
 
     /// Emit a specialized evaluator axiom for a function-parameter variant.
@@ -2207,6 +2349,7 @@ impl<'env> BoogieTranslator<'env> {
     fn emit_fun_param_variant_axiom(
         &self,
         eval_fun_name: &str,
+        fun_type: &Type,
         mem_decls: &[String],
         mem_args: &[String],
         data_decls: &[String],
@@ -2215,24 +2358,65 @@ impl<'env> BoogieTranslator<'env> {
         params: &[Type],
         results: &[Type],
         kind: BehaviorKind,
+        carries_mutations: bool,
     ) {
         let env = self.env;
         let ctor_name = boogie_fun_param_name(env, &info.fun, info.param_sym);
-        let ctor_term = format!("{}()", ctor_name);
+        let advances = carries_mutations;
+        let ctor_term = if advances {
+            // The whole indexed family is covered by quantifying the index;
+            // each member is a distinct abstract state, passed on to the
+            // per-param spec functions.
+            format!("{}(n)", ctor_name)
+        } else {
+            format!("{}()", ctor_name)
+        };
 
-        let quantifier: Vec<String> = mem_decls.iter().chain(data_decls.iter()).cloned().collect();
+        let quantifier: Vec<String> = mem_decls
+            .iter()
+            .cloned()
+            .chain(advances.then(|| "n: int".to_string()))
+            .chain(data_decls.iter().cloned())
+            .collect();
 
         let bp_name = boogie_behavioral_spec_fun_name(env, &info.fun, info.param_sym, kind, &[]);
         let (used, old) = Self::get_param_memory(env, &info.fun, info.param_sym);
         let (_, param_mem_args) = Self::build_memory_params(env, &used, &old);
         let mut rhs_args: Vec<String> = param_mem_args;
+        if advances {
+            rhs_args.push("n".to_string());
+        }
         for pos in 0..params.len() {
             rhs_args.push(format!("p{}", pos));
         }
         if kind == BehaviorKind::EnsuresOf {
             rhs_args.extend(Self::behavioral_output_args(params, results));
         }
-        let rhs = format!("{}({})", bp_name, rhs_args.join(", "));
+        let mut rhs = format!("{}({})", bp_name, rhs_args.join(", "));
+        if kind == BehaviorKind::EnsuresOf && carries_mutations {
+            // Def-side/call-site coherence for carrying types: the `f_post`
+            // slot must be exactly the one-application successor given by the
+            // `result_of` Skolem — the same value the apply procedure assigns
+            // to the fun output. Without this conjunct `f_post` is
+            // unconstrained and a body applying the parameter zero or several
+            // times could still prove a single-application `ensures_of`,
+            // which the call site then assumes about the havoced capture.
+            rhs = format!(
+                "{} && f_post == {}",
+                rhs,
+                Self::result_of_successor_term(
+                    env,
+                    fun_type,
+                    mem_args,
+                    &ctor_term,
+                    &(0..params.len())
+                        .map(|pos| format!("p{}", pos))
+                        .collect_vec(),
+                    params,
+                    results,
+                )
+            );
+        }
 
         let eval_call_args: Vec<String> = mem_args
             .iter()
@@ -2278,6 +2462,7 @@ impl<'env> BoogieTranslator<'env> {
         union_used_memory: &BTreeSet<QualifiedInstId<StructId>>,
         union_old_memory: &BTreeSet<QualifiedInstId<StructId>>,
         kind: BehaviorKind,
+        carries_mutations: bool,
     ) {
         let env = self.env;
         let ctor_name = boogie_struct_field_name(env, &info.struct_id, info.field_sym);
@@ -2304,7 +2489,11 @@ impl<'env> BoogieTranslator<'env> {
         if kind == BehaviorKind::EnsuresOf {
             rhs_args.extend(Self::behavioral_output_args(params, results));
         }
-        let rhs = format!("{}({})", bp_name, rhs_args.join(", "));
+        let mut rhs = format!("{}({})", bp_name, rhs_args.join(", "));
+        if kind == BehaviorKind::EnsuresOf && carries_mutations {
+            // Field-stored values cannot carry mutations and do not advance.
+            rhs = format!("({} && f_post == f)", rhs);
+        }
 
         let eval_call = format!("{}({})", eval_fun_name, arg_names.join(", "));
         emitln!(
@@ -2345,6 +2534,37 @@ impl<'env> BoogieTranslator<'env> {
     /// inconsistent for inhabited types. Using a single tuple Skolem keyed on
     /// inputs alone — matching the per-function Skolem path — eliminates that
     /// inconsistency at the source.
+    /// Builds the term denoting the one-application successor of a carrying
+    /// fun value: the trailing fun slot of the `result_of` Skolem applied to
+    /// the given memory, fun value, and (pre-state) input argument values.
+    /// For a single-output Skolem the application itself is the successor.
+    fn result_of_successor_term(
+        env: &GlobalEnv,
+        fun_type: &Type,
+        mem_args: &[String],
+        fun_arg: &str,
+        input_args: &[String],
+        params: &[Type],
+        results: &[Type],
+    ) -> String {
+        let result_of_name = boogie_behavioral_eval_fun_name(env, fun_type, BehaviorKind::ResultOf);
+        let call_args: Vec<String> = mem_args
+            .iter()
+            .cloned()
+            .chain(std::iter::once(fun_arg.to_string()))
+            .chain(input_args.iter().cloned())
+            .collect();
+        let call = format!("{}({})", result_of_name, call_args.join(", "));
+        // Output tuple: declared results, then `&mut` post-states, then the
+        // updated fun value as final slot.
+        let total_outputs = Self::behavioral_output_types(params, results).len() + 1;
+        if total_outputs == 1 {
+            call
+        } else {
+            format!("{}->${}", call, total_outputs - 1)
+        }
+    }
+
     fn generate_result_of_function_and_axiom(
         &self,
         fun_type: &Type,
@@ -2364,8 +2584,15 @@ impl<'env> BoogieTranslator<'env> {
             .collect();
         let post_state_types = Self::behavioral_post_state_types(&params_flat);
 
+        // For function types carrying mutations, the updated fun value is an
+        // observable output even without declared results or `&mut` params;
+        // the successor Skolem anchors def-side/call-site coherence of
+        // `ensures_of` (the apply procedure assigns it and the fun-param
+        // variant axiom constrains `f_post` to it).
+        let carries_mutations = boogie_infos_carry_mutations(env, closure_infos);
+
         // Nothing to Skolemize when there are no observable outputs.
-        if declared_results.is_empty() && post_state_types.is_empty() {
+        if declared_results.is_empty() && post_state_types.is_empty() && !carries_mutations {
             return;
         }
 
@@ -2400,9 +2627,6 @@ impl<'env> BoogieTranslator<'env> {
         // function types carrying mutations, the updated fun value is
         // appended as final component, matching the `f_post` slot of
         // `ensures_of`.
-        let carries_mutations = closure_infos
-            .iter()
-            .any(|info| !info.mut_capture_slots(env).is_empty());
         let output_types: Vec<Type> = declared_results
             .iter()
             .chain(post_state_types.iter())
@@ -2456,6 +2680,77 @@ impl<'env> BoogieTranslator<'env> {
                 body
             );
         }
+
+        // For advancing fun params (indexed families), the successor of a
+        // family member stays in the family, at an index given by a fresh
+        // uninterpreted function. Never index arithmetic: an identity
+        // closure's successor is itself, so no ordering between indices may
+        // be provable. The constructor-keyed trigger seeds from the entry
+        // pinning `$t == $param(0)` and self-sustains along a chain, since
+        // the right-hand side reintroduces a constructor application.
+        if carries_mutations {
+            let (family_mem_decls, family_mem_args) =
+                Self::build_memory_params(env, &union_used_memory, &union_old_memory);
+            for info in fun_param_infos {
+                let ctor_name = boogie_fun_param_name(env, &info.fun, info.param_sym);
+                let next_name = format!(
+                    "$param_next{}",
+                    ctor_name
+                        .strip_prefix("$param")
+                        .expect("fun param constructor name")
+                );
+                let mut next_decls: Vec<String> = family_mem_decls.clone();
+                next_decls.push("n: int".to_string());
+                let mut next_args: Vec<String> = family_mem_args.clone();
+                next_args.push("n".to_string());
+                let mut input_names: Vec<String> = vec![];
+                for (pos, ty) in params_flat.iter().enumerate() {
+                    next_decls.push(format!(
+                        "p{}: {}",
+                        pos,
+                        boogie_type(env, ty.skip_reference(), false)
+                    ));
+                    next_args.push(format!("p{}", pos));
+                    input_names.push(format!("p{}", pos));
+                }
+                emitln!(
+                    self.writer,
+                    "function {}({}): int;",
+                    next_name,
+                    next_decls.join(", ")
+                );
+                let ctor_term = format!("{}(n)", ctor_name);
+                let successor = Self::result_of_successor_term(
+                    env,
+                    fun_type,
+                    &family_mem_args,
+                    &ctor_term,
+                    &input_names,
+                    &params_flat,
+                    &results_flat,
+                );
+                let trigger = format!(
+                    "{}({})",
+                    result_of_name,
+                    family_mem_args
+                        .iter()
+                        .cloned()
+                        .chain(std::iter::once(ctor_term.clone()))
+                        .chain(input_names.iter().cloned())
+                        .join(", ")
+                );
+                emitln!(
+                    self.writer,
+                    "axiom (forall {} :: {{{}}} {} == {}({}({})));",
+                    next_decls.join(", "),
+                    trigger,
+                    successor,
+                    ctor_name,
+                    next_name,
+                    next_args.join(", ")
+                );
+            }
+        }
     }
 
     /// Generate per-function behavioral spec functions for closure target functions.
@@ -2471,10 +2766,10 @@ impl<'env> BoogieTranslator<'env> {
         };
         let results_flat = results.clone().flatten();
 
-        // Deduplicate by qualified function id (different masks may target the same function)
-        let mut seen_funs: BTreeSet<QualifiedInstId<FunId>> = BTreeSet::new();
+        // Deduplicate by qualified function id, globally across fun types
+        // (different masks/types may target the same function).
         for info in closure_infos {
-            if !seen_funs.insert(info.fun.clone()) {
+            if !self.emitted_bp_funs.borrow_mut().insert(info.fun.clone()) {
                 continue;
             }
             let fun_env = self.env.get_function(info.fun.to_qualified_id());
@@ -2771,9 +3066,14 @@ impl<'env> BoogieTranslator<'env> {
                 BehaviorKind::RequiresOf => matches!(c.kind, ConditionKind::Requires),
                 BehaviorKind::AbortsOf => matches!(c.kind, ConditionKind::AbortsIf),
                 BehaviorKind::EnsuresOf => matches!(c.kind, ConditionKind::Ensures),
-                // ResultOf/WriteOf are uninterpreted Skolems; the axiom in
-                // `generate_result_of_function_and_axiom` ties them to `ensures_of`.
-                BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => false,
+                // ResultOf/WriteOf/FunPostOf are uninterpreted Skolems; the axiom
+                // in `generate_result_of_function_and_axiom` ties them to
+                // `ensures_of`.
+                BehaviorKind::ResultOf
+                | BehaviorKind::WriteOf(_)
+                | BehaviorKind::FunPostOf
+                | BehaviorKind::PartialOf
+                | BehaviorKind::CapturesOf => false,
             })
             .collect();
 
@@ -2797,7 +3097,11 @@ impl<'env> BoogieTranslator<'env> {
             return match kind {
                 BehaviorKind::RequiresOf | BehaviorKind::EnsuresOf => "true".to_string(),
                 BehaviorKind::AbortsOf => "false".to_string(),
-                BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => "true".to_string(),
+                BehaviorKind::ResultOf
+                | BehaviorKind::WriteOf(_)
+                | BehaviorKind::FunPostOf
+                | BehaviorKind::PartialOf
+                | BehaviorKind::CapturesOf => "true".to_string(),
             };
         }
 
@@ -2859,8 +3163,13 @@ impl<'env> BoogieTranslator<'env> {
                         BehaviorKind::RequiresOf | BehaviorKind::AbortsOf => {
                             format!("p{}", param_idx)
                         },
-                        // ResultOf/WriteOf are uninterpreted — no body translated.
-                        BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => unreachable!(),
+                        // ResultOf/WriteOf/FunPostOf are uninterpreted — no body
+                        // translated.
+                        BehaviorKind::ResultOf
+                        | BehaviorKind::WriteOf(_)
+                        | BehaviorKind::FunPostOf
+                        | BehaviorKind::PartialOf
+                        | BehaviorKind::CapturesOf => unreachable!(),
                     };
                     result =
                         result.replace(&format!("$Dereference($t{})", param_idx), &current_value);
@@ -2896,7 +3205,11 @@ impl<'env> BoogieTranslator<'env> {
                     format!("({})", translated.join(" || "))
                 }
             },
-            BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => return "true".to_string(),
+            BehaviorKind::ResultOf
+            | BehaviorKind::WriteOf(_)
+            | BehaviorKind::FunPostOf
+            | BehaviorKind::PartialOf
+            | BehaviorKind::CapturesOf => return "true".to_string(),
         };
 
         // Collect intermediate labels from conditions that need existential wrapping.
@@ -2931,7 +3244,11 @@ impl<'env> BoogieTranslator<'env> {
                         BehaviorKind::RequiresOf => matches!(c.kind, ConditionKind::Requires),
                         BehaviorKind::AbortsOf => matches!(c.kind, ConditionKind::AbortsIf),
                         BehaviorKind::EnsuresOf => matches!(c.kind, ConditionKind::Ensures),
-                        BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => false,
+                        BehaviorKind::ResultOf
+                        | BehaviorKind::WriteOf(_)
+                        | BehaviorKind::FunPostOf
+                        | BehaviorKind::PartialOf
+                        | BehaviorKind::CapturesOf => false,
                     };
                     if dominated {
                         return false;
@@ -3480,9 +3797,16 @@ impl<'env> BoogieTranslator<'env> {
                 Self::build_memory_params(self.env, &used_memory, &old_memory);
 
             // Build input parameters (used by all behavioral predicates)
-            // Memory params come first, then data params
+            // Memory params come first, then the family index for advancing
+            // params (each family member is a distinct abstract state, so
+            // all predicates are uninterpreted in the index), then data.
+            let advances = boogie_fun_ty_carries_mutations(self.env, fun_type);
             let mut input_param_decls = mem_param_decls.clone();
             let mut input_args: Vec<String> = mem_args;
+            if advances {
+                input_param_decls.push("n: int".to_string());
+                input_args.push("n".to_string());
+            }
             for (i, ty) in params.iter().enumerate() {
                 input_param_decls.push(format!(
                     "arg{}: {}",
@@ -3802,7 +4126,20 @@ impl<'env> BoogieTranslator<'env> {
                         struct_id: &info.struct_id,
                         field_sym: info.field_sym,
                     };
-                    let fp_mem_args = BpMemArgs::empty();
+                    // Per-param bp functions of mutation-carrying types take
+                    // the family index after memory; quantify it.
+                    let fp_carries = boogie_fun_ty_carries_mutations(self.env, fun_type);
+                    let fp_mem_args = BpMemArgs {
+                        slots: vec![],
+                        instance_id: fp_carries.then(|| "n".to_string()),
+                    };
+                    let fp_param_decls: Vec<String> = if fp_carries {
+                        std::iter::once("n: int".to_string())
+                            .chain(data_param_decls.iter().cloned())
+                            .collect()
+                    } else {
+                        data_param_decls.clone()
+                    };
                     for kind in [
                         BehaviorKind::EnsuresOf,
                         BehaviorKind::ResultOf,
@@ -3829,7 +4166,7 @@ impl<'env> BoogieTranslator<'env> {
                             self.emit_data_invariant_axiom_for_behavior(
                                 info,
                                 kind,
-                                &data_param_decls,
+                                &fp_param_decls,
                                 &fp_ctx,
                                 &fp_mem_args,
                                 &params,
@@ -5844,13 +6181,38 @@ impl FunctionTranslator<'_> {
 
         // Assume function-typed parameters equal their parameter variant.
         // This enables behavioral predicate handling in the apply function.
+        // Advancing params (two-state spec semantics) are pinned to index 0
+        // of their family; applications advance to fresh family members.
+        //
+        // Lemma fun params are NOT pinned: a lemma's conclusions are assumed
+        // at arbitrary instantiations (e.g. concrete closures), so its params
+        // must be verified universally over the whole datatype. Pinning would
+        // make variant-membership premises like `partial_of<f>(g)` provably
+        // false in the lemma's own VC (constructor distinctness), making the
+        // proof vacuous while callers instantiate it at values satisfying
+        // the premise.
+        if fun_target.func_env.is_lemma() {
+            return;
+        }
+        let unpinned =
+            move_model::spec_translator::variant_observed_fun_params(fun_target.func_env);
         let params = fun_target.func_env.get_parameters();
         let fun_id = fun_target.func_env.get_qualified_id().instantiate(vec![]);
         for (i, param) in params.iter().enumerate() {
+            if unpinned.contains(&i) {
+                // Subject/witness of `partial_of`/`captures_of`: verified
+                // universally (see `variant_observed_fun_params`).
+                continue;
+            }
             let ty = fun_target.get_local_type(i);
             if matches!(ty, Type::Fun(..)) {
                 let variant_name = boogie_fun_param_name(env, &fun_id, param.0);
-                emitln!(writer, "assume $t{} == {}();", i, variant_name);
+                let index_arg = if boogie_fun_ty_carries_mutations(env, &ty) {
+                    "0"
+                } else {
+                    ""
+                };
+                emitln!(writer, "assume $t{} == {}({});", i, variant_name, index_arg);
             }
         }
     }
@@ -6439,11 +6801,17 @@ impl FunctionTranslator<'_> {
                         let fun_type = self.inst(fun_target.get_local_type(fun_temp));
                         let args_str = srcs.iter().cloned().map(str_local).join(", ");
                         // If the fun type carries mutations, the apply procedure
-                        // returns the updated fun value as trailing output.
+                        // returns the updated fun value as trailing output. Spec
+                        // instrumentation lists the fun temp as trailing dest
+                        // unconditionally (carrying-ness is unknown before
+                        // monomorphization); it is dropped from the regular dest
+                        // position here and re-appended last when the type
+                        // carries, matching the apply signature's output order.
                         let fun_out = boogie_fun_ty_carries_mutations(env, &fun_type)
                             .then(|| str_local(fun_temp));
                         let dest_str = dests
                             .iter()
+                            .filter(|idx| **idx != fun_temp)
                             .cloned()
                             .map(str_local)
                             // Add implict dest returns for &mut srcs:
@@ -6805,6 +7173,13 @@ impl FunctionTranslator<'_> {
                                     let temp = boogie_temp(env, target_ty, *instance, false);
                                     *instance += 1;
                                     emitln!(writer, "havoc {};", temp);
+                                    // Re-establish type validity of the havoced
+                                    // value, as done for every other havoc kind.
+                                    emitln!(
+                                        writer,
+                                        "assume {};",
+                                        boogie_well_formed_expr(env, &temp, target_ty, false)
+                                    );
                                     args.push(format!("$UpdateMutation({}, {})", field, temp));
                                 } else {
                                     args.push(field);
@@ -6813,6 +7188,27 @@ impl FunctionTranslator<'_> {
                             emitln!(writer, "{} := {}({});", var_str, ctor_name, args.join(", "));
                             writer.unindent();
                             emitln!(writer, "}");
+                        }
+                        // Advancing fun-param family members re-index: the
+                        // value moves to an arbitrary member of its family,
+                        // to be constrained by the loop's chain invariant.
+                        if boogie_fun_ty_carries_mutations(env, &fun_ty) {
+                            for info in boogie_fun_param_infos(env, &fun_ty) {
+                                let ctor_name =
+                                    boogie_fun_param_name(env, &info.fun, info.param_sym);
+                                let idx_temp = boogie_temp(
+                                    env,
+                                    &Type::Primitive(PrimitiveType::U64),
+                                    0,
+                                    false,
+                                );
+                                emitln!(writer, "if ({} is {}) {{", var_str, ctor_name);
+                                writer.indent();
+                                emitln!(writer, "havoc {};", idx_temp);
+                                emitln!(writer, "{} := {}({});", var_str, ctor_name, idx_temp);
+                                writer.unindent();
+                                emitln!(writer, "}");
+                            }
                         }
                     },
                     Stop => {
@@ -7918,6 +8314,13 @@ impl FunctionTranslator<'_> {
                             for (ty, n) in counts.into_values() {
                                 need(&ty, false, n);
                             }
+                        }
+                        // One int temp for re-indexing advancing fun-param
+                        // family members.
+                        if boogie_fun_ty_carries_mutations(env, &fun_ty)
+                            && !boogie_fun_param_infos(env, &fun_ty).is_empty()
+                        {
+                            need(&Type::Primitive(PrimitiveType::U64), false, 1);
                         }
                     },
                     _ => {},

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -8,14 +8,15 @@
 use crate::{
     boogie_helpers::{
         boogie_address, boogie_address_blob, boogie_behavioral_eval_fun_name,
-        boogie_behavioral_fun_result_name, boogie_byte_blob, boogie_choice_fun_name,
-        boogie_closure_pack_name, boogie_declare_global, boogie_field_sel, boogie_field_update,
-        boogie_fun_ty_carries_mutations, boogie_inst_suffix, boogie_modifies_memory_name,
-        boogie_num_type_base, boogie_reflection_type_info, boogie_reflection_type_is_struct,
-        boogie_reflection_type_name, boogie_resource_memory_name, boogie_spec_fun_name,
-        boogie_spec_var_name, boogie_struct_name, boogie_struct_variant_name, boogie_type,
-        boogie_type_suffix, boogie_value_blob, boogie_variant_field_update,
-        boogie_well_formed_expr, compute_evaluator_memory_union, MAX_TUPLE_SIZE,
+        boogie_behavioral_fun_result_name, boogie_byte_blob, boogie_captures_fun_name,
+        boogie_choice_fun_name, boogie_closure_pack_name, boogie_declare_global, boogie_field_sel,
+        boogie_field_update, boogie_fun_ty_carries_mutations, boogie_inst_suffix,
+        boogie_modifies_memory_name, boogie_num_type_base, boogie_partial_fun_name,
+        boogie_reflection_type_info, boogie_reflection_type_is_struct, boogie_reflection_type_name,
+        boogie_resource_memory_name, boogie_spec_fun_name, boogie_spec_var_name,
+        boogie_struct_name, boogie_struct_variant_name, boogie_type, boogie_type_suffix,
+        boogie_value_blob, boogie_variant_field_update, boogie_well_formed_expr,
+        compute_evaluator_memory_union, MAX_TUPLE_SIZE,
     },
     options::BoogieOptions,
 };
@@ -520,10 +521,6 @@ impl SpecTranslator<'_> {
                 );
                 return;
             }
-        }
-        if let Type::Fun(..) = fun.result_type {
-            self.error(&fun.loc, "function result type not yet supported"); // TODO(LAMBDA)
-            return;
         }
         let qid = module_env.get_id().qualified(id);
         let recursive = self.env.is_spec_fun_recursive(qid);
@@ -1673,6 +1670,21 @@ impl SpecTranslator<'_> {
                 let fun_exp = &args[0];
                 let pred_args = &args[1..];
 
+                if matches!(kind, BehaviorKind::PartialOf | BehaviorKind::CapturesOf) {
+                    self.translate_variant_observation(node_id, *kind, fun_exp, pred_args);
+                    return;
+                }
+                if *kind == BehaviorKind::FunPostOf
+                    && matches!(
+                        fun_exp.as_ref(),
+                        ExpData::Call(_, Operation::Closure(..), _)
+                    )
+                {
+                    // Closure literals admitted in spec expressions never
+                    // carry mutations, so `fun_post_of` is the identity.
+                    self.translate_exp(fun_exp);
+                    return;
+                }
                 match fun_exp.as_ref() {
                     ExpData::Call(closure_id, Operation::Closure(mid, fid, mask), closure_args) => {
                         // Closure: use per-function behavioral spec function
@@ -1837,6 +1849,67 @@ impl SpecTranslator<'_> {
         self.in_behavior_pred_arg.replace(prev);
     }
 
+    /// Translate `partial_of<f>(g)` / `captures_of<f>(g)`: the closed-world
+    /// recognizer resp. captured-value selector for the (subject, witness)
+    /// fun-type pair, defined by the backend over the session's variants
+    /// (see `translate_variant_observation_defs`). The witness is any
+    /// function value; a plain function name is the common case.
+    fn translate_variant_observation(
+        &self,
+        node_id: NodeId,
+        kind: BehaviorKind,
+        fun_exp: &Exp,
+        pred_args: &[Exp],
+    ) {
+        let loc = self.env.get_node_loc(node_id);
+        let Some(witness_exp) = pred_args.first() else {
+            self.error(&loc, &format!("bug: missing witness for {}", kind));
+            return;
+        };
+        let ty_f = self
+            .env
+            .get_node_type(fun_exp.node_id())
+            .instantiate(&self.type_inst)
+            .normalize_fun();
+        let ty_g = self
+            .env
+            .get_node_type(witness_exp.node_id())
+            .instantiate(&self.type_inst)
+            .normalize_fun();
+        match kind {
+            BehaviorKind::PartialOf => {
+                emit!(
+                    self.writer,
+                    "{}(",
+                    boogie_partial_fun_name(self.env, &ty_f, &ty_g)
+                );
+                self.translate_exp(fun_exp);
+                emit!(self.writer, ", ");
+                self.translate_exp(witness_exp);
+                emit!(self.writer, ")");
+            },
+            BehaviorKind::CapturesOf => {
+                let Type::Fun(g_args, _, _) = &ty_g else {
+                    self.error(&loc, "bug: witness must have function type");
+                    return;
+                };
+                let Some(cap_ty) = g_args.clone().flatten().first().cloned() else {
+                    self.error(&loc, "bug: witness must have a leading parameter");
+                    return;
+                };
+                let cap_ty = cap_ty.skip_reference().clone();
+                emit!(
+                    self.writer,
+                    "{}(",
+                    boogie_captures_fun_name(self.env, &ty_f, &cap_ty)
+                );
+                self.translate_exp(fun_exp);
+                emit!(self.writer, ")");
+            },
+            _ => unreachable!(),
+        }
+    }
+
     /// Translate a behavioral predicate via the per-type evaluator dispatch
     /// function (used for runtime function values).
     fn translate_behavior_via_evaluator(
@@ -1861,6 +1934,29 @@ impl SpecTranslator<'_> {
         // Note that spec expressions not passing through the bytecode instrumentation
         // (e.g. behavioral spec function bodies) carry no clone.
         let carries_mutations = boogie_fun_ty_carries_mutations(self.env, &inst_fun_type);
+        if kind == BehaviorKind::FunPostOf && !carries_mutations {
+            // A value that cannot carry mutations does not advance under
+            // application: `fun_post_of` is the identity.
+            self.translate_exp(fun_exp);
+            return;
+        }
+        if kind == BehaviorKind::FunPostOf {
+            // The one-application successor is deterministic in `(f, args)`
+            // only when no variant of the fun type reads or writes global
+            // memory: a chain (e.g. a recursive spec fun folding
+            // `fun_post_of` over a vector) evaluates all steps at one memory
+            // snapshot, while the applications it describes thread distinct
+            // intermediate memories. See issue #20273.
+            let (union_used, _union_old) = compute_evaluator_memory_union(self.env, &inst_fun_type);
+            if !union_used.is_empty() {
+                self.error(
+                    &self.env.get_node_loc(node_id),
+                    "`fun_post_of` over a function value whose behavior depends on \
+                     global memory is not supported (see issue #20273)",
+                );
+                return;
+            }
+        }
         let has_fun_clone = matches!(kind, BehaviorKind::EnsuresOf | BehaviorKind::ResultOf)
             && matches!(fun_exp.as_ref(), ExpData::Temporary(..))
             && pred_args.last().is_some_and(|last| {
@@ -1880,6 +1976,23 @@ impl SpecTranslator<'_> {
                 "ensures_of over a function value carrying mutable reference captures \
                  is only supported for directly referenced function values",
             );
+            return;
+        }
+        if carries_mutations && kind == BehaviorKind::EnsuresOf {
+            // The apply procedure computes the successor at pre-application
+            // memory, while this evaluator binds the memory at the
+            // condition's state — coherent only when no variant of the type
+            // touches global memory. See issue #20273.
+            let (union_used, _) = compute_evaluator_memory_union(self.env, &inst_fun_type);
+            if !union_used.is_empty() {
+                self.error(
+                    &self.env.get_node_loc(node_id),
+                    "`ensures_of` over a function value carrying mutable reference \
+                     captures whose behavior depends on global memory is not supported \
+                     (see issue #20273)",
+                );
+                return;
+            }
         }
 
         // The `ResultOf`/`WriteOf(j)` evaluator shares a single tuple Skolem
@@ -1910,6 +2023,11 @@ impl SpecTranslator<'_> {
             BehaviorKind::WriteOf(j) if multi_in_boogie => {
                 Some(ProjKind::Single(num_explicit_results + j))
             },
+            // FunPostOf: the trailing fun slot; when it is the only output,
+            // the scalar Skolem is the successor itself.
+            BehaviorKind::FunPostOf if multi_in_boogie => {
+                Some(ProjKind::Single(num_explicit_results + num_mut_refs))
+            },
             _ => None,
         };
 
@@ -1920,7 +2038,7 @@ impl SpecTranslator<'_> {
         // For `EnsuresOf`, the fun-value clone is dropped when the type does
         // not carry mutations (the evaluator then has no `f_post` slot).
         let emit_arg_count = match kind {
-            BehaviorKind::ResultOf => {
+            BehaviorKind::ResultOf | BehaviorKind::FunPostOf => {
                 let num_inputs = match &inst_fun_type {
                     Type::Fun(arg_ty, _, _) => arg_ty.clone().flatten().len(),
                     _ => pred_args.len(),
@@ -2069,10 +2187,7 @@ impl SpecTranslator<'_> {
         // Use resolve_memory_name to resolve labels through the label chain — when a
         // resource type was not modified at a label, its memory resolves to the predecessor.
         let uses_old = !union_old_memory.is_empty();
-        let current = match kind {
-            BehaviorKind::RequiresOf | BehaviorKind::AbortsOf => pre,
-            BehaviorKind::EnsuresOf | BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => post,
-        };
+        let current = if kind.is_two_state() { post } else { pre };
         let mut first = true;
         for memory in &union_used_memory {
             if uses_old && union_old_memory.contains(memory) {
@@ -2305,10 +2420,7 @@ impl SpecTranslator<'_> {
             .map(|m| m.clone().instantiate(&fun_qid.inst))
             .collect();
         let uses_old = !old_memory.is_empty();
-        let current = match kind {
-            BehaviorKind::RequiresOf | BehaviorKind::AbortsOf => pre,
-            BehaviorKind::EnsuresOf | BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => post,
-        };
+        let current = if kind.is_two_state() { post } else { pre };
         let mut first = true;
         for memory in used_memory {
             let memory = &memory.clone().instantiate(&fun_qid.inst);
@@ -2392,6 +2504,9 @@ impl SpecTranslator<'_> {
             BehaviorKind::EnsuresOf => "ensures_of",
             BehaviorKind::ResultOf => "result_of",
             BehaviorKind::WriteOf(_) => "write_of",
+            BehaviorKind::FunPostOf => "fun_post_of",
+            BehaviorKind::PartialOf => "partial_of",
+            BehaviorKind::CapturesOf => "captures_of",
         };
         let struct_env = self.env.get_struct_qid(memory.to_qualified_id());
         let mem_display = struct_env.get_full_name_with_address().to_string();

--- a/third_party/move/move-prover/bytecode-pipeline/src/loop_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/loop_analysis.rs
@@ -174,6 +174,30 @@ impl LoopAnalysisProcessor {
                             );
                             builder.emit_with(move |id| Bytecode::Prop(id, PropKind::Assume, exp));
                         }
+                        // Fun values applied in the loop body advance at the
+                        // translation level (captured mutations, advancing
+                        // fun-param family members). The capture-value havoc
+                        // frees exactly that state, preserving the variant;
+                        // for values which cannot advance it is a no-op.
+                        // Verification-only: the spec-inference WP would
+                        // generalize a havoc-defined fun temp into a
+                        // quantified variable.
+                        for idx in loop_info
+                            .spec_info()
+                            .fun_targets
+                            .iter()
+                            .filter(|_| !options.inference)
+                        {
+                            builder.emit_with(|attr_id| {
+                                Bytecode::Call(
+                                    attr_id,
+                                    vec![*idx],
+                                    Operation::Havoc(HavocKind::CaptureValues),
+                                    vec![],
+                                    None,
+                                )
+                            });
+                        }
 
                         // havoc all memory the loop body may modify, so the
                         // loop-exit path does not retain pre-loop memory; the

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -66,6 +66,10 @@ pub struct MonoInfo {
     /// map to ask which intrinsic roles were called and with which type args.
     pub intrinsic_calls: BTreeMap<QualifiedId<FunId>, BTreeSet<Vec<Type>>>,
     pub all_types: BTreeSet<Type>,
+    /// Fun-type pairs (subject, witness) observed by `partial_of`/
+    /// `captures_of` in specs; the backend emits closed-world recognizer/
+    /// selector definitions per pair.
+    pub variant_obs_pairs: BTreeSet<(Type, Type)>,
     pub axioms: Vec<(Condition, Vec<Vec<Type>>)>,
     /// A map from function types used in the program to the closures appearing in
     /// code constructing values of this function type.
@@ -947,6 +951,28 @@ impl Analyzer<'_> {
     fn analyze_exp(&mut self, exp: &ExpData) {
         exp.visit_post_order(&mut |e| {
             let node_id = e.node_id();
+            // Record fun-type pairs observed by `partial_of`/`captures_of`
+            // (subject type, witness type): the backend emits the closed-world
+            // recognizer/selector definitions per pair.
+            if let ExpData::Call(
+                _,
+                ast::Operation::Behavior(
+                    ast::BehaviorKind::PartialOf | ast::BehaviorKind::CapturesOf,
+                    _,
+                ),
+                args,
+            ) = e
+            {
+                if let (Some(subject), Some(witness)) = (args.first(), args.get(1)) {
+                    let ty_f = self.normalize_fun_ty(
+                        self.instantiate(&self.env.get_node_type(subject.node_id())),
+                    );
+                    let ty_g = self.normalize_fun_ty(
+                        self.instantiate(&self.env.get_node_type(witness.node_id())),
+                    );
+                    self.info.variant_obs_pairs.insert((ty_f, ty_g));
+                }
+            }
             self.add_type_root(&self.env.get_node_type(node_id));
             for ref ty in self.env.get_node_instantiation(node_id) {
                 self.add_type_root(ty);

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -724,6 +724,31 @@ impl<'a> Instrumenter<'a> {
             Call(id, dests, Function(mid, fid, targs), srcs, aa) => {
                 self.instrument_call(spec, id, dests, mid, fid, targs, srcs, aa);
             },
+            Call(id, mut dests, Operation::Invoke, srcs, _) => {
+                // For a fun value carrying captured mutations, the apply
+                // procedure returns the updated value as trailing output
+                // (`fun_out` in the Boogie backend). Make that write visible
+                // at the bytecode level by listing the fun temp as trailing
+                // dest, so the subsequent copy propagation does not merge
+                // entry-state saves of the temp across the application.
+                // Whether the type actually carries is only known during
+                // monomorphization; the backend drops the extra dest for
+                // types which do not. (See TODO(#20273).) This is
+                // verification-only: the spec-inference WP walker reads
+                // Invoke dests as application results.
+                let fun_temp = *srcs.last().expect("closure operand of Invoke");
+                if !self.options.inference && !dests.contains(&fun_temp) {
+                    dests.push(fun_temp);
+                }
+                self.builder.emit(Call(
+                    id,
+                    dests,
+                    Operation::Invoke,
+                    srcs,
+                    Some(AbortAction(self.abort_label, self.abort_local)),
+                ));
+                self.can_abort = true;
+            },
             Call(id, dests, oper, srcs, _) if oper.can_abort() => {
                 self.builder.emit(Call(
                     id,
@@ -1156,12 +1181,14 @@ impl<'a> Instrumenter<'a> {
 // # Spec Condition Emission
 
 impl<'a> Instrumenter<'a> {
-    /// Checks that at most one `ensures_of` condition constrains each closure
-    /// argument carrying captured mutations. The call-site model havocs each
-    /// captured location once and threads a single post value, so multiple
-    /// `ensures_of` conditions over the same closure would assume constraints
-    /// about different applications on that one value, which is unsatisfiable
-    /// in general and makes the verification context vacuous.
+    /// Checks that exactly one application of each closure argument carrying
+    /// captured mutations is described by the callee's post conditions. The
+    /// call-site model havocs each captured location once and threads a single
+    /// post value, so multiple `ensures_of` conditions over the same closure —
+    /// or a single one under a quantifier, which stands for one constraint per
+    /// instantiation — would assume constraints about different applications
+    /// on that one value, which is unsatisfiable in general and makes the
+    /// verification context vacuous.
     fn check_single_ensures_of_for_carrying(
         &self,
         callee_spec: &TranslatedSpec,
@@ -1172,36 +1199,94 @@ impl<'a> Instrumenter<'a> {
             return;
         }
         // Behavioral predicate args may reference the pre-state snapshot temp of
-        // the closure argument; resolve those back to the original temp.
-        let unsaved: BTreeMap<TempIndex, TempIndex> = callee_spec
+        // the closure argument, or a spec-`let` alias of it; resolve those
+        // back to the original temp (aliases may chain).
+        let mut unsaved: BTreeMap<TempIndex, TempIndex> = callee_spec
             .saved_params
             .iter()
             .map(|(orig, saved)| (*saved, *orig))
             .collect();
+        for (_, _, let_temp, def) in &callee_spec.lets {
+            let mut def = def;
+            loop {
+                match def.as_ref() {
+                    ExpData::Call(_, ast::Operation::Old, inner) if inner.len() == 1 => {
+                        def = &inner[0];
+                    },
+                    ExpData::Temporary(_, idx) => {
+                        let root = unsaved.get(idx).copied().unwrap_or(*idx);
+                        unsaved.insert(*let_temp, root);
+                        break;
+                    },
+                    _ => break,
+                }
+            }
+        }
         let mut counts: BTreeMap<TempIndex, usize> = BTreeMap::new();
+        let mut quantified = false;
+        let mut quant_depth = 0usize;
         for (_, cond) in &callee_spec.post {
-            cond.visit_pre_order(&mut |e| {
-                if let ExpData::Call(
-                    _,
-                    ast::Operation::Behavior(BehaviorKind::EnsuresOf, _),
-                    args,
-                ) = e
-                {
-                    if let Some(ExpData::Temporary(_, idx)) = args.first().map(|a| a.as_ref()) {
-                        let orig = unsaved.get(idx).copied().unwrap_or(*idx);
-                        if carrying_srcs.contains(&orig) {
-                            *counts.entry(orig).or_insert(0) += 1;
+            cond.visit_pre_post(&mut |post, e| {
+                match e {
+                    ExpData::Quant(..) => {
+                        if post {
+                            quant_depth -= 1;
+                        } else {
+                            quant_depth += 1;
                         }
-                    }
+                    },
+                    // Each `ensures_of` over the closure, and each
+                    // `fun_post_of` chain root (a chain nests through the
+                    // subject, so only direct temporary subjects count),
+                    // independently constrains the single havoced post value.
+                    ExpData::Call(
+                        _,
+                        ast::Operation::Behavior(
+                            BehaviorKind::EnsuresOf | BehaviorKind::FunPostOf,
+                            _,
+                        ),
+                        args,
+                    ) if !post => {
+                        let subject = match args.first().map(|a| a.as_ref()) {
+                            Some(ExpData::Temporary(_, idx)) => Some(*idx),
+                            Some(ExpData::Call(_, ast::Operation::Old, inner))
+                                if inner.len() == 1 =>
+                            {
+                                match inner[0].as_ref() {
+                                    ExpData::Temporary(_, idx) => Some(*idx),
+                                    _ => None,
+                                }
+                            },
+                            _ => None,
+                        };
+                        if let Some(idx) = subject {
+                            let orig = unsaved.get(&idx).copied().unwrap_or(idx);
+                            if carrying_srcs.contains(&orig) {
+                                *counts.entry(orig).or_insert(0) += 1;
+                                quantified = quantified || quant_depth > 0;
+                            }
+                        }
+                    },
+                    _ => {},
                 }
                 true
             });
         }
-        if counts.values().any(|count| *count > 1) {
+        if quantified {
             self.builder.global_env().error(
                 loc,
-                "more than one `ensures_of` condition over a function value carrying \
-                 mutable reference captures cannot be used in an opaque spec",
+                "a quantified `ensures_of` or `fun_post_of` over a function value \
+                 carrying mutable reference captures would over-constrain its single \
+                 post value; describing iterated application requires `fun_post_of` \
+                 chains (see issue #20273)",
+            );
+        } else if counts.values().any(|count| *count > 1) {
+            self.builder.global_env().error(
+                loc,
+                "more than one `ensures_of` or `fun_post_of` condition over a function \
+                 value carrying mutable reference captures cannot be used in an opaque \
+                 spec; describe successive applications with a single nested \
+                 `fun_post_of` chain (see issue #20273)",
             );
         }
     }

--- a/third_party/move/move-prover/doc/dev/fun_values_note.md
+++ b/third_party/move/move-prover/doc/dev/fun_values_note.md
@@ -250,3 +250,151 @@ spec call_twice {
    ensures modifies<f>(Counter[addr]);  
 }
 ```
+
+# Mutable Reference Captures and Application Chains
+
+Closures modifying captured variables (`let s = 0; v.for_each_ref(|e| s += *e)`) are
+supported for retained inline-opaque calls in two layers: a carried-mutation model for the
+values themselves, and a chain vocabulary (`fun_post_of`) for describing repeated
+application. Tracking anchor: issue #20273.
+
+## Carried Mutations
+
+The lambda lifter converts a modified capture into a `&mut` capture over a lifted function.
+The closure value then *carries* the mutation: its datatype variant stores a `$Mutation`
+slot, whose location and path identity stay fixed while the value component evolves. At an
+opaque call site the captured values are havoced (`HavocKind::CaptureValues`, which repacks
+the variant with `$UpdateMutation` per slot) and constrained by the callee's `ensures_of`
+conditions; when the closure dies, the carried mutation is written back to its source
+location (`BorrowEdge::Capture`). Carrying values are linear: the `copy` ability *bound* is
+admitted on function types (loop-invoking HOF signatures require it), but a surviving copy
+of a carrying value is rejected, since it would fork the carried state.
+
+## The Successor Model
+
+One application of a function value is a deterministic transition `f' = step(f, x)`: for
+carrying types, the `$result_of` Skolem gains a trailing fun slot which *is* that successor.
+Three encoding pieces keep definition side and call site coherent:
+
+- The apply procedure advances its fun output to the successor
+  (`fun_out := $result_of'..'(mems, fun, args)[->slot]`), and `Invoke` rebinds the fun temp,
+  also at the bytecode level (spec instrumentation lists the temp as trailing dest so copy
+  propagation cannot merge entry-state saves across an application).
+- The fun-param variant axiom for `ensures_of` constrains its `f_post` slot to the same
+  successor term. A single-application claim `ensures ensures_of<f>(x)` is therefore provable
+  exactly when the body applies the parameter once on `x` — bodies applying zero or several
+  times, or on other arguments, face falsifiable verification conditions.
+- The closure-variant axiom for `ensures_of` *equates* `f_post` with a syntactic constructor
+  application (`f_post == ctor(.., $UpdateMutation(c_i, f_post->field_i->v), ..)`).
+  Semantically this is the recognizer plus mutation-identity constraints, but the planted
+  constructor term keeps e-matching alive when the successor of one application becomes the
+  subject of the next: the constructor-keyed trigger only fires on values whose e-class
+  contains a constructor application.
+
+## `fun_post_of` and Two-State Fun Parameters
+
+`fun_post_of<f>(args)` denotes the successor value (identity for values which cannot carry
+mutations). Chains describe successive applications:
+
+```move
+spec fun apply_all(f: |&u64| has copy + drop, v: vector<u64>, end: u64): |&u64| has copy + drop {
+    if (end == 0) f else fun_post_of<apply_all(f, v, end - 1)>(v[end - 1])
+}
+spec for_each_ref {
+    pragma opaque;
+    requires forall j in 0..len(v): !aborts_of<apply_all(f, v, j)>(v[j]);
+    aborts_if false;
+    ensures f == apply_all(old(f), v, len(v));
+}
+```
+
+A fun parameter becomes *two-state* when the function's spec mentions `old(f)` or
+`fun_post_of` over it: bare `f` in post conditions then denotes the final value and `old(f)`
+the value at entry, like a `&mut` parameter. This is opt-in per parameter — both trigger
+forms are new syntax, so legacy specs keep the entry-value reading of bare `f`. Subjects of
+behavioral predicates always follow the legacy routing (a predicate describes one
+application *from* a state), so `ensures f == fun_post_of<f>(x)` means final ==
+successor-of-entry.
+
+## Verifying the Callee: Indexed Parameter Families
+
+In the callee's own VC the parameter is an abstract family `$param'fn$p'(n: int)`, pinned to
+`$param(0)` at entry. A family axiom keeps successors in the family at a *fresh
+uninterpreted* index (`$result_of(mems, $param(n), p*)->slot == $param($param_next(mems, n,
+p*))`) — never index arithmetic, since an identity closure's successor is itself and no
+ordering between indices may be provable. All per-param behavioral spec functions take the
+index, so each family member is a distinct abstract state.
+
+Loops: every fun temp applied in a loop body is havoced at the loop header with
+`HavocKind::CaptureValues`, whose translation re-indexes advancing family members (and
+repacks carrying closure variants) while remaining a no-op for values which cannot advance —
+existing proofs over non-carrying HOFs are unaffected. The chain invariant
+`invariant f == apply_all(old(f), v, i)` then certifies the application discipline: the
+double-applying or element-skipping body fails the induction step.
+
+## Limitations
+
+- `fun_post_of` requires the fun type's evaluator memory union to be empty (pure lambdas):
+  a chain evaluates all steps at one memory snapshot, while the applications it describes
+  thread distinct intermediate memories, so memory-dependent values have no deterministic
+  successor in `(f, args)`.
+- At most one `ensures_of`/`fun_post_of` chain root per carrying closure argument in an
+  opaque spec, and none under quantifiers: the call site havocs each captured location once,
+  and independent constraints on that single post value are unsatisfiable in general
+  (successive applications belong in one nested chain).
+- Callers extract concrete facts by unfolding the chain, so direct extraction of exact
+  accumulator values needs concrete (or bounded, via case split) lengths. For unbounded
+  symbolic lengths, use the lemma recipe below.
+
+## Compositional Use: Chain Lemmas
+
+For fully symbolic contexts, the induction over the chain is written once as a recursive
+lemma, paired with a *named step function* which the lambda partially applies (in verify
+mode, `|e| step(&mut s, e)` reduces to a closure over `step` capturing `&mut s`, so
+`step`'s own spec is the closure's behavioral contract). Two further builtins make the
+induction hypothesis statable: `partial_of<f>(step)` (f is a closure over `step`;
+variant recognizer) and `captures_of<f>(step)` (the captured value; guarded selector).
+`write_of<g, j>(args)` (the post-state of `g`'s j-th `&mut` parameter) is also surface
+syntax, for value-level fold spec funs.
+
+```move
+spec lemma chain_sum(f: |&u64| has copy + drop, v: vector<u64>, k: u64) {
+    requires partial_of<f>(step);
+    requires k <= len(v);
+    ensures partial_of<apply_all(f, v, k)>(step);
+    ensures captures_of<apply_all(f, v, k)>(step)
+         == captures_of<f>(step) + spec_sum(v, k);
+} proof {
+    if (k > 0) { apply chain_sum(f, v, k - 1); }
+}
+```
+
+A caller with unbounded `len(v)` then verifies
+`ensures result == spec_sum(v, len(v))` with two quantified instantiations in its proof
+block (explicit triggers are load-bearing):
+
+```move
+proof {
+    forall f: |&u64| has copy + drop, k: u64 {apply_all(f, v, k)} apply chain_sum(f, v, k);
+    forall j: u64, k: u64 {spec_sum(v, j), spec_sum(v, k)} apply sum_prefix_bound(v, j, k);
+}
+```
+
+(`sum_prefix_bound` — `spec_sum(v, j) + v[j] <= spec_sum(v, k)` for `j < k <= len(v)` —
+discharges the chain-shaped abort requires.) See
+`tests/sources/functional/closures/inline/inline_opaque_hof_symbolic_sum.move`.
+
+The lemma can moreover be written **generically in the step function** and shipped once
+with the HOF: the witness of `partial_of`/`captures_of` is any function value, and
+`iterate(g, c0, v, k)` — the fold of `write_of<g>` — is the generic meaning of the loop.
+Under a determinism premise (`ensures_of<g>(c, e, w) ==> w == write_of<g>(c, e)`), the
+generic `for_each_chain(f, g, v, k)` proves
+`captures_of<apply_all(f, v, k)>(g) == iterate(g, captures_of<f>(g), v, k)` by the same
+three-line recursion; use sites add only the arithmetic inherent to their step function
+(e.g. `iterate(step, ..) == prefix sum`). See
+`tests/sources/functional/closures/inline/inline_opaque_hof_generic_chain.move`.
+Type-generic (`<A, T>`) lemmas are rejected for now — closed-world recognizers are
+meaningless at skolemized types; per-instantiation lemma verification is #20278. The proof
+of the lemma works over *universally quantified* fun params (lemma params are not pinned
+to `$param` variants) with the guarded (recognizer-triggered) closure-variant axioms.
+Note that recursive lemma application currently lacks a well-foundedness check (#20275).

--- a/third_party/move/move-prover/tests/sources/functional/closures/fun_param_identity_loop.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/fun_param_identity_loop.move
@@ -1,0 +1,24 @@
+// A fun param of a NON-carrying type does not advance: applying it in a loop
+// leaves the value itself unchanged, so `f == old(f)` holds — the abstract
+// variant stays a single constant, with no indexed family and no loop-head
+// re-indexing. (Advancement is purely a property of mutation-carrying types.)
+module 0x42::fun_param_identity_loop {
+
+    fun apply_loop(f: |u64| u64 has copy + drop, n: u64): u64 {
+        let i = 0;
+        let acc = 0;
+        while (i < n) {
+            acc = f(acc);
+            i = i + 1;
+        } spec {
+            invariant i <= n;
+        };
+        acc
+    }
+    spec apply_loop {
+        pragma opaque;
+        requires forall x: u64: !aborts_of<f>(x);
+        aborts_if false;
+        ensures f == old(f);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum.move
@@ -1,0 +1,45 @@
+// The motivating use case: an accumulator lambda over a loop-invoking HOF.
+// The HOF's spec describes the N applications as a `fun_post_of` chain over
+// the advancing fun value (`apply_all`); the loop invariant
+// `f == apply_all(old(f), v, i)` certifies the application discipline (one
+// application per element, in order — see the _fail variant), and the caller
+// unfolds the chain through the lambda's spec for concrete lengths.
+module 0x42::opaque_inline_for_each_sum {
+    use std::vector;
+
+    spec fun apply_all(f: |&u64| has copy + drop, v: vector<u64>, end: u64): |&u64| has copy + drop {
+        if (end == 0) f else fun_post_of<apply_all(f, v, end - 1)>(v[end - 1])
+    }
+
+    inline fun for_each_ref(v: &vector<u64>, f: |&u64| has copy + drop) {
+        let i = 0;
+        let n = vector::length(v);
+        while (i < n) {
+            f(vector::borrow(v, i));
+            i = i + 1;
+        } spec {
+            invariant i <= len(v);
+            invariant f == apply_all(old(f), v, i);
+        };
+    }
+    spec for_each_ref {
+        pragma opaque;
+        requires forall j in 0..len(v): !aborts_of<apply_all(f, v, j)>(v[j]);
+        aborts_if false;
+        ensures f == apply_all(old(f), v, len(v));
+    }
+
+    fun test_sum_two(v: &vector<u64>): u64 {
+        let s = 0;
+        for_each_ref(v, |e| s = s + *e spec {
+            aborts_if s + e > MAX_U64;
+            ensures s == old(s) + e;
+        });
+        s
+    }
+    spec test_sum_two {
+        requires len(v) == 2;
+        requires forall i in 0..len(v): v[i] < 1000;
+        ensures result == v[0] + v[1];
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.exp
@@ -1,0 +1,32 @@
+Move prover returns: exiting with verification errors
+error: induction case of the loop invariant does not hold
+   ┌─ tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:21:13
+   │
+21 │             invariant f == apply_all(old(f), v, i); // error: induction case of the loop invariant does not hold
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:12: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:26: for_each_ref_twice (spec)
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:12: for_each_ref_twice
+   =         v = <redacted>
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:13: for_each_ref_twice
+   =         i = <redacted>
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:14: for_each_ref_twice
+   =         n = <redacted>
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:19: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:20: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:21: for_each_ref_twice
+   =     enter loop, variable(s) i havocked and reassigned
+   =         i = <redacted>
+   =     loop invariant holds at current state
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:20: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:21: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:15: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:16: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:17: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:18: for_each_ref_twice
+   =         i = <redacted>
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:15: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:20: for_each_ref_twice
+   =     at tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move:21: for_each_ref_twice

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_for_each_sum_fail.move
@@ -1,0 +1,42 @@
+// A loop body deviating from the spec'd application chain (applying the fun
+// value twice per element) cannot prove the chain invariant: each application
+// advances the value to a fresh family member, so the induction step needs
+// exactly the one application `apply_all` describes.
+module 0x42::inline_opaque_hof_for_each_sum_fail {
+    use std::vector;
+
+    spec fun apply_all(f: |&u64| has copy + drop, v: vector<u64>, end: u64): |&u64| has copy + drop {
+        if (end == 0) f else fun_post_of<apply_all(f, v, end - 1)>(v[end - 1])
+    }
+
+    inline fun for_each_ref_twice(v: &vector<u64>, f: |&u64| has copy + drop) {
+        let i = 0;
+        let n = vector::length(v);
+        while (i < n) {
+            f(vector::borrow(v, i));
+            f(vector::borrow(v, i));
+            i = i + 1;
+        } spec {
+            invariant i <= len(v);
+            invariant f == apply_all(old(f), v, i); // error: induction case of the loop invariant does not hold
+        };
+    }
+    spec for_each_ref_twice {
+        pragma opaque;
+        requires forall j in 0..len(v): !aborts_of<apply_all(f, v, j)>(v[j]);
+        ensures f == apply_all(old(f), v, len(v));
+    }
+
+    fun caller(v: &vector<u64>): u64 {
+        let s = 0;
+        for_each_ref_twice(v, |e| s = s + *e spec {
+            aborts_if s + e > MAX_U64;
+            ensures s == old(s) + e;
+        });
+        s
+    }
+    spec caller {
+        requires len(v) == 2;
+        requires forall i in 0..len(v): v[i] < 1000;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_generic_chain.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_generic_chain.move
@@ -1,0 +1,123 @@
+// (See issue #20273.)
+// The once-and-for-all generic chain lemma: paired with `for_each_ref`,
+// generic in the step function `g`.
+module 0x42::inline_opaque_hof_generic_chain {
+    use std::vector;
+
+    spec fun apply_all(f: |&u64| has copy + drop, v: vector<u64>, end: u64): |&u64| has copy + drop {
+        if (end == 0) f else fun_post_of<apply_all(f, v, end - 1)>(v[end - 1])
+    }
+
+    // Value-level fold of g's write effect — generic in g.
+    spec fun iterate(g: |&mut u64, &u64| has drop, c0: u64, v: vector<u64>, k: u64): u64 {
+        if (k == 0) c0 else write_of<g>(iterate(g, c0, v, k - 1), v[k - 1])
+    }
+
+    inline fun for_each_ref(v: &vector<u64>, f: |&u64| has copy + drop) {
+        let i = 0;
+        let n = vector::length(v);
+        while (i < n) {
+            f(vector::borrow(v, i));
+            i = i + 1;
+        } spec {
+            invariant i <= len(v);
+            invariant f == apply_all(old(f), v, i);
+        };
+    }
+    spec for_each_ref {
+        pragma opaque;
+        requires forall j in 0..len(v): !aborts_of<apply_all(f, v, j)>(v[j]);
+        aborts_if false;
+        ensures f == apply_all(old(f), v, len(v));
+    }
+
+    spec module {
+        // Generic chain lemma: after k applications, the captured state is
+        // the k-fold of g's (deterministic) write effect.
+        lemma for_each_chain(
+            f: |&u64| has copy + drop,
+            g: |&mut u64, &u64| has drop,
+            v: vector<u64>,
+            k: u64
+        ) {
+            requires partial_of<f>(g);
+            requires forall c: u64, e: u64, w: u64:
+                ensures_of<g>(c, e, w) ==> w == write_of<g>(c, e);
+            requires k <= len(v);
+            ensures partial_of<apply_all(f, v, k)>(g);
+            ensures captures_of<apply_all(f, v, k)>(g)
+                 == iterate(g, captures_of<f>(g), v, k);
+        } proof {
+            if (k > 0) {
+                apply for_each_chain(f, g, v, k - 1);
+            }
+        }
+    }
+
+    // ================= use case: sum =================
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        aborts_if s + e > MAX_U64;
+        ensures s == old(s) + e;
+    }
+
+    spec fun spec_sum(v: vector<u64>, k: u64): u64 {
+        if (k == 0) 0 else spec_sum(v, k - 1) + v[k - 1]
+    }
+
+    spec module {
+        // Step-specific arithmetic (inherent per accumulator operation).
+        lemma iterate_step_is_sum(v: vector<u64>, c0: u64, k: u64) {
+            requires k <= len(v);
+            ensures iterate(step, c0, v, k) == c0 + spec_sum(v, k);
+        } proof {
+            if (k > 0) {
+                apply iterate_step_is_sum(v, c0, k - 1);
+            }
+        }
+
+        lemma sum_prefix_bound(v: vector<u64>, j: u64, k: u64) {
+            requires j < k;
+            requires k <= len(v);
+            ensures spec_sum(v, j) + v[j] <= spec_sum(v, k);
+        } proof {
+            if (j + 1 < k) {
+                apply sum_prefix_bound(v, j, k - 1);
+            }
+        }
+    }
+
+    /// Test: a PURE lambda through the chain-spec'd HOF — non-capturing
+    /// values do not advance (fun_post_of is the identity per variant), so
+    /// the chain collapses and the abort requires discharges (bounded
+    /// length: the collapse is per unfolded step; symbolic depth would need
+    /// a lemma like everything else).
+    fun noop_all(v: &vector<u64>): u64 {
+        for_each_ref(v, |_e| ());
+        7
+    }
+    spec noop_all {
+        requires len(v) < 8;
+        aborts_if false;
+        ensures result == 7;
+    }
+
+    fun sum_all(v: &vector<u64>): u64 {
+        let s = 0;
+        for_each_ref(v, |e| step(&mut s, e));
+        s
+    }
+    spec sum_all {
+        requires spec_sum(v, len(v)) <= MAX_U64;
+        aborts_if false;
+        ensures result == spec_sum(v, len(v));
+    } proof {
+        forall f: |&u64| has copy + drop, k: u64 {apply_all(f, v, k)}
+            apply for_each_chain(f, step, v, k);
+        forall c0: u64, k: u64 {iterate(step, c0, v, k)} apply iterate_step_is_sum(v, c0, k);
+        forall j: u64, k: u64 {spec_sum(v, j), spec_sum(v, k)} apply sum_prefix_bound(v, j, k);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.exp
@@ -1,8 +1,9 @@
-Move prover returns: exiting with compilation errors
-error: cannot capture a mutable reference in a closure requiring the `copy` ability
-   ┌─ tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.move:36:29
+Move prover returns: exiting with bytecode transformation errors
+error: a quantified `ensures_of` or `fun_post_of` over a function value carrying mutable reference captures would over-constrain its single post value; describing iterated application requires `fun_post_of` chains (see issue #20273)
+   ┌─ tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.move:33:9
    │
-36 │         for_each_ref(v, |e| s = s + *e spec { // error: cannot capture a mutable reference in a closure requiring the `copy` ability
-   │                             ^
-   │
-   = expected function type: `|&u64| has copy + drop`
+33 │ ╭         for_each_ref(v, |e| s = s + *e spec { // error: a quantified `ensures_of` or `fun_post_of` over a function value carrying mutable reference captures would over-constrain its single post value
+34 │ │             aborts_if s + e > MAX_U64;
+35 │ │             ensures s == old(s) + e;
+36 │ │         });
+   │ ╰──────────^

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_quantified_ensures_of_fail.move
@@ -1,16 +1,12 @@
 // A loop-invoking HOF (`for_each_ref` style) with a `&mut`-capturing lambda —
-// the canonical accumulator pattern — is rejected: invoking `f` in a loop
-// requires the `copy` ability on the function parameter, and a mutable capture
-// makes the closure value linear (copying it would fork the carried mutation).
-//
-// Even apart from linearity, the HOF's quantified spec
-// `forall i: ensures_of<f>(v[i])` would generate N constraints on the SINGLE
-// havoced post-state of the capture; for inputs making those constraints
-// distinct the assumption is inconsistent and the caller's post-condition
-// would be provable vacuously (before the copy rule, the deliberately false
-// `ensures len(v) >= 2 ==> v[0] == v[1]` below verified for exactly the
-// inputs that falsified it). Expressing N sequential applications would need
-// state-label chaining over closure values or a fold-style spec vocabulary.
+// the canonical accumulator pattern — instantiated against a (trusted)
+// quantified spec is rejected: `forall i: ensures_of<f>(v[i])` would generate
+// N constraints on the SINGLE havoced post-state of the capture; for inputs
+// making those constraints distinct the assumption is inconsistent and the
+// caller's post-condition would be provable vacuously (before the guard, the
+// deliberately false `ensures len(v) >= 2 ==> v[0] == v[1]` below verified
+// for exactly the inputs that falsified it). Expressing N sequential
+// applications requires `fun_post_of` chains (see issue #20273).
 module 0x42::inline_opaque_hof_quantified_ensures_of_fail {
     use std::vector;
 
@@ -24,16 +20,17 @@ module 0x42::inline_opaque_hof_quantified_ensures_of_fail {
     }
     spec for_each_ref {
         pragma opaque;
+        pragma verify = false;
         requires forall i in 0..len(v): !aborts_of<f>(v[i]);
         aborts_if false;
         ensures forall i in 0..len(v): ensures_of<f>(v[i]);
     }
 
-    /// Caller with a `&mut`-capturing lambda for a `copy`-requiring function
-    /// parameter: rejected by the closure checker.
+    /// Caller with a `&mut`-capturing lambda: the quantified `ensures_of` in
+    /// the callee's spec is rejected at the call site.
     fun unsound_call(v: &vector<u64>): bool {
         let s = 0;
-        for_each_ref(v, |e| s = s + *e spec { // error: cannot capture a mutable reference in a closure requiring the `copy` ability
+        for_each_ref(v, |e| s = s + *e spec { // error: a quantified `ensures_of` or `fun_post_of` over a function value carrying mutable reference captures would over-constrain its single post value
             aborts_if s + e > MAX_U64;
             ensures s == old(s) + e;
         });
@@ -43,7 +40,7 @@ module 0x42::inline_opaque_hof_quantified_ensures_of_fail {
         requires forall i in 0..len(v): v[i] < (1 << 32);
         requires len(v) < 100;
         aborts_if false;
-        // Semantically false for v = [1, 2]. Without the fix, the prover
+        // Semantically false for v = [1, 2]. Without the guard, the prover
         // accepted this vacuously.
         ensures len(v) >= 2 ==> v[0] == v[1];
     }

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_symbolic_sum.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/inline_opaque_hof_symbolic_sum.move
@@ -1,0 +1,85 @@
+// The compositional form of the accumulator use case: unbounded symbolic
+// length, closed via `partial_of`/`captures_of` chain lemmas paired with the
+// named step function, instantiated by `forall .. apply` at the call site.
+// (See issue #20273.)
+// Unbounded symbolic-length accumulator through a chain-spec'd HOF,
+// composed via a step-paired recursive lemma.
+module 0x42::inline_opaque_hof_symbolic_sum {
+    use std::vector;
+
+    spec fun spec_sum(v: vector<u64>, k: u64): u64 {
+        if (k == 0) 0 else spec_sum(v, k - 1) + v[k - 1]
+    }
+
+    spec fun apply_all(f: |&u64| has copy + drop, v: vector<u64>, end: u64): |&u64| has copy + drop {
+        if (end == 0) f else fun_post_of<apply_all(f, v, end - 1)>(v[end - 1])
+    }
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        aborts_if s + e > MAX_U64;
+        ensures s == old(s) + e;
+    }
+
+    inline fun for_each_ref(v: &vector<u64>, f: |&u64| has copy + drop) {
+        let i = 0;
+        let n = vector::length(v);
+        while (i < n) {
+            f(vector::borrow(v, i));
+            i = i + 1;
+        } spec {
+            invariant i <= len(v);
+            invariant f == apply_all(old(f), v, i);
+        };
+    }
+    spec for_each_ref {
+        pragma opaque;
+        requires forall j in 0..len(v): !aborts_of<apply_all(f, v, j)>(v[j]);
+        aborts_if false;
+        ensures f == apply_all(old(f), v, len(v));
+    }
+
+    spec module {
+        // Chain lemma, paired with `step`: after k applications the captured
+        // accumulator has grown by the prefix sum.
+        lemma chain_sum(f: |&u64| has copy + drop, v: vector<u64>, k: u64) {
+            requires partial_of<f>(step);
+            requires k <= len(v);
+            ensures partial_of<apply_all(f, v, k)>(step);
+            ensures captures_of<apply_all(f, v, k)>(step)
+                 == captures_of<f>(step) + spec_sum(v, k);
+        } proof {
+            if (k > 0) {
+                apply chain_sum(f, v, k - 1);
+            }
+        }
+
+        // A prefix sum plus its next element is bounded by any longer
+        // prefix sum.
+        lemma sum_prefix_bound(v: vector<u64>, j: u64, k: u64) {
+            requires j < k;
+            requires k <= len(v);
+            ensures spec_sum(v, j) + v[j] <= spec_sum(v, k);
+        } proof {
+            if (j + 1 < k) {
+                apply sum_prefix_bound(v, j, k - 1);
+            }
+        }
+    }
+
+    fun sum_all(v: &vector<u64>): u64 {
+        let s = 0;
+        for_each_ref(v, |e| step(&mut s, e));
+        s
+    }
+    spec sum_all {
+        requires spec_sum(v, len(v)) <= MAX_U64;
+        aborts_if false;
+        ensures result == spec_sum(v, len(v));
+    } proof {
+        forall f: |&u64| has copy + drop, k: u64 {apply_all(f, v, k)} apply chain_sum(f, v, k);
+        forall j: u64, k: u64 {spec_sum(v, j), spec_sum(v, k)} apply sum_prefix_bound(v, j, k);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.exp
@@ -1,0 +1,33 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:15:9
+   │
+15 │         ensures ensures_of<f>(1); // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:10: claim_without_apply
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:15: claim_without_apply (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:24:9
+   │
+24 │         ensures ensures_of<f>(1); // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:18: claim_once_apply_twice
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:19: claim_once_apply_twice
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:20: claim_once_apply_twice
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:24: claim_once_apply_twice (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:32:9
+   │
+32 │         ensures ensures_of<f>(1); // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:27: claim_wrong_arg
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:28: claim_wrong_arg
+   =     at tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move:32: claim_wrong_arg (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_apply_discipline_fail.move
@@ -1,0 +1,42 @@
+// A callee's `ensures_of` claim over a fun parameter is provable exactly when
+// the body applies the parameter once with the claimed arguments: at each
+// application the fun value advances to the `result_of` successor, and the
+// claim's post value must equal it. Bodies applying the parameter zero or two
+// times, or on other arguments, cannot verify a single-application claim —
+// which keeps the call-site assumption (one application constrains the
+// havoced capture) coherent with what the body actually did.
+module 0x42::opaque_inline_apply_discipline_fail {
+
+    inline fun claim_without_apply(f: |u64| has copy + drop) {
+        let _ = f;
+    }
+    spec claim_without_apply {
+        pragma opaque;
+        ensures ensures_of<f>(1); // error: post-condition does not hold
+    }
+
+    inline fun claim_once_apply_twice(f: |u64| has copy + drop) {
+        f(1);
+        f(1);
+    }
+    spec claim_once_apply_twice {
+        pragma opaque;
+        ensures ensures_of<f>(1); // error: post-condition does not hold
+    }
+
+    inline fun claim_wrong_arg(f: |u64| has copy + drop) {
+        f(2)
+    }
+    spec claim_wrong_arg {
+        pragma opaque;
+        ensures ensures_of<f>(1); // error: post-condition does not hold
+    }
+
+    /// A mutating caller making the fun type carrying; without a carrying
+    /// variant the successor machinery is not exercised.
+    fun make_carrying(): u64 {
+        let x = 0;
+        claim_without_apply(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of.move
@@ -1,0 +1,66 @@
+// Tests `fun_post_of` chains over `&mut`-capturing closures at retained
+// inline-opaque calls, and the opt-in two-state reading of fun params: when a
+// spec mentions `old(f)` or `fun_post_of`, bare `f` in post conditions
+// denotes the final value and `old(f)` the value at entry (like a `&mut`
+// param). The chain `fun_post_of<fun_post_of<old(f)>(1)>(2)` describes
+// exactly two applications in order: the callee can prove it only with a
+// conforming body, and the caller unfolds it through the closure's spec.
+module 0x42::opaque_inline_fun_post_of {
+
+    inline fun call_once(f: |u64| has drop) {
+        f(2)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures f == fun_post_of<old(f)>(2);
+    }
+
+    /// Test: a single application described by `fun_post_of` instead of
+    /// `ensures_of`.
+    fun test_single(): u64 {
+        let x = 0;
+        call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec test_single {
+        ensures result == 2;
+    }
+
+    inline fun call_twice(f: |u64| has copy + drop) {
+        f(1);
+        f(2);
+    }
+    spec call_twice {
+        pragma opaque;
+        ensures f == fun_post_of<fun_post_of<old(f)>(1)>(2);
+    }
+
+    /// Test: chained applications accumulate both effects at the caller.
+    fun test_chain(): u64 {
+        let x = 0;
+        call_twice(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec test_chain {
+        ensures result == 3;
+    }
+
+    inline fun apply_pure(f: |u64|u64 has drop, x: u64): u64 {
+        f(x)
+    }
+    spec apply_pure {
+        pragma opaque;
+        ensures result == result_of<f>(x);
+        ensures f == fun_post_of<old(f)>(x);
+    }
+
+    /// Test: for values which cannot carry mutations, `fun_post_of` is the
+    /// identity, so the chain claim holds trivially.
+    fun test_identity(y: u64): u64 {
+        apply_pure(|v| v + 1, y)
+    }
+    spec test_identity {
+        requires y < 1000;
+        ensures result == y + 1;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of_fail.exp
@@ -1,0 +1,11 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_fun_post_of_fail.move:13:9
+   │
+13 │         ensures f == fun_post_of<fun_post_of<old(f)>(1)>(2); // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_fun_post_of_fail.move:8: claim_two_apply_one
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_fun_post_of_fail.move:9: claim_two_apply_one
+   =     at tests/sources/functional/closures/inline/opaque_inline_fun_post_of_fail.move:13: claim_two_apply_one (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of_fail.move
@@ -1,0 +1,24 @@
+// A `fun_post_of` chain claims an exact application sequence: a callee whose
+// body performs fewer applications than the chain describes cannot verify it
+// (for carrying instantiations the live fun value advances once per
+// application, and the chain names a different successor). See
+// opaque_inline_fun_post_of.move for the conforming shapes.
+module 0x42::opaque_inline_fun_post_of_fail {
+
+    inline fun claim_two_apply_one(f: |u64| has copy + drop) {
+        f(1);
+    }
+    spec claim_two_apply_one {
+        pragma opaque;
+        ensures f == fun_post_of<fun_post_of<old(f)>(1)>(2); // error: post-condition does not hold
+    }
+
+    /// Carrying caller: the chain claim is refutable only for carrying
+    /// instantiations (for pure values `fun_post_of` is the identity and the
+    /// claim holds trivially).
+    fun make_carrying(): u64 {
+        let x = 0;
+        claim_two_apply_one(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of_memory_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of_memory_fail.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with condition generation errors
+error: [boogie translator] `fun_post_of` over a function value whose behavior depends on global memory is not supported (see issue #20273)
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_fun_post_of_memory_fail.move:19:22
+   │
+19 │         ensures f == fun_post_of<old(f)>(1); // error: `fun_post_of` over a function value whose behavior depends on global memory is not supported
+   │                      ^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of_memory_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_fun_post_of_memory_fail.move
@@ -1,0 +1,31 @@
+// The one-application successor denoted by `fun_post_of` is deterministic in
+// `(f, args)` only when no variant of the fun type touches global memory: a
+// chain evaluates all steps at one memory snapshot, while the applications it
+// describes thread distinct intermediate memories. Function values whose
+// declared accesses (`reads_of`) are non-empty are rejected.
+module 0x42::opaque_inline_fun_post_of_memory_fail {
+
+    struct R has key {
+        value: u64,
+    }
+
+    inline fun call_memory(f: |u64| has drop) {
+        f(1)
+    }
+    spec call_memory {
+        pragma opaque;
+        pragma verify = false;
+        reads_of<f> R;
+        ensures f == fun_post_of<old(f)>(1); // error: `fun_post_of` over a function value whose behavior depends on global memory is not supported
+    }
+
+    /// Test: the lambda reads global memory (declared via `reads_of`), so the
+    /// fun type's successor is not deterministic in `(f, args)`.
+    fun test_memory_dependent(): u64 {
+        let x = 0;
+        call_memory(|i| x = x + i + R[@0x1].value spec {
+            ensures x == old(x) + i + global<R>(@0x1).value;
+        });
+        x
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_generic_callee.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_generic_callee.move
@@ -1,0 +1,24 @@
+// A GENERIC retained inline-opaque callee with a `&mut`-capturing closure:
+// spec instantiation re-mints node ids for type-parameter-dependent nodes,
+// and the live fun-value clone's save exemption must survive that (else the
+// call site would assume the entry value for the post state).
+module 0x42::opaque_inline_generic_callee {
+
+    inline fun call_once<T>(f: |&T| has copy + drop, x: &T) {
+        f(x)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(x);
+    }
+
+    /// Test: the captured accumulator advances through the generic callee.
+    fun test_generic_mut_capture(): u64 {
+        let s = 0;
+        call_once(|e| s = s + *e spec { ensures s == old(s) + e; }, &2);
+        s
+    }
+    spec test_generic_mut_capture {
+        ensures result == 2;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.exp
@@ -1,6 +1,18 @@
 Move prover returns: exiting with bytecode transformation errors
-error: more than one `ensures_of` condition over a function value carrying mutable reference captures cannot be used in an opaque spec
+error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures cannot be used in an opaque spec; describe successive applications with a single nested `fun_post_of` chain (see issue #20273)
    ┌─ tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.move:22:9
    │
-22 │         call_trusted_twice(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` condition over a function value carrying mutable reference captures
+22 │         call_trusted_twice(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures cannot be used in an opaque spec; describe successive applications with a single nested `fun_post_of` chain (see issue #20273)
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.move:54:9
+   │
+54 │         call_aliased(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures cannot be used in an opaque spec; describe successive applications with a single nested `fun_post_of` chain (see issue #20273)
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.move:63:9
+   │
+63 │         call_mixed(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_multi_ensures_fail.move
@@ -19,11 +19,48 @@ module 0x42::opaque_inline_multi_ensures_fail {
     /// than one `ensures_of` cannot be instantiated at the call site.
     fun test_multiple_ensures_of(): u64 {
         let x = 0;
-        call_trusted_twice(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` condition over a function value carrying mutable reference captures
+        call_trusted_twice(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures
         x
     }
     spec test_multiple_ensures_of {
         ensures result == 1;
     }
 
+    inline fun call_mixed(f: |u64|) {
+        f(1)
+    }
+    spec call_mixed {
+        pragma opaque;
+        pragma verify = false;
+        ensures ensures_of<f>(1);
+        ensures f == fun_post_of<old(f)>(2);
+    }
+
+    inline fun call_aliased(f: |u64|) {
+        f(1)
+    }
+    spec call_aliased {
+        pragma opaque;
+        pragma verify = false;
+        let g = f;
+        ensures f == fun_post_of<g>(1);
+        ensures ensures_of<f>(2);
+    }
+
+    /// Test: a spec-`let` alias of the closure does not evade the
+    /// single-constraint guard.
+    fun test_aliased_constraints(): u64 {
+        let x = 0;
+        call_aliased(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures
+        x
+    }
+
+    /// Test: an `ensures_of` plus a separate `fun_post_of` chain root impose
+    /// two independent one-application constraints on the single havoced
+    /// value.
+    fun test_mixed_constraints(): u64 {
+        let x = 0;
+        call_mixed(|i| x = x + i spec { ensures x == old(x) + i; }); // error: more than one `ensures_of` or `fun_post_of` condition over a function value carrying mutable reference captures
+        x
+    }
 }

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.exp
@@ -1,0 +1,15 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.move:49:9
+   │
+49 │         ensures result == 2; // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.move:44: test_weak_spec
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.move:45: test_weak_spec
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.move:46: test_weak_spec
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.move:43: test_weak_spec
+   =         result = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.move:49: test_weak_spec (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_mut_capture_copy.move
@@ -1,0 +1,51 @@
+// Tests that a `&mut`-capturing lambda is admitted for a function parameter
+// requiring the `copy` ability. The ability BOUND is admitted (loop-invoking
+// HOF signatures require it); the closure value itself remains linear at the
+// model level (a surviving copy is rejected). Callee-side coherence of
+// `ensures_of` is anchored by the `result_of` successor, so a spec claiming
+// one application is provable exactly when the body applies the parameter
+// once (see opaque_inline_apply_discipline_fail for the rejected bodies).
+module 0x42::opaque_inline_mut_capture_copy {
+
+    inline fun call_once_copy(f: |u64| has copy + drop) {
+        f(2)
+    }
+    spec call_once_copy {
+        pragma opaque;
+        ensures ensures_of<f>(2);
+    }
+
+    /// Test: a mutating lambda satisfies a `copy` bound; the single
+    /// application fact propagates to the caller.
+    fun test_copy_bound(): u64 {
+        let x = 0;
+        call_once_copy(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec test_copy_bound {
+        ensures result == 2;
+    }
+
+    inline fun call_twice_weak(f: |u64| has copy + drop) {
+        f(1);
+        f(1);
+    }
+    spec call_twice_weak {
+        pragma opaque;
+        // No `ensures_of`: a twice-applying body cannot describe the
+        // accumulated effect with a single `ensures_of` claim, and chained
+        // claims need `fun_post_of` (issue #20273).
+    }
+
+    /// Test: with a weak callee spec the capture is havoced and unconstrained
+    /// at the call site — the caller cannot conclude a post value (but the
+    /// havoc is sound: no false facts either).
+    fun test_weak_spec(): u64 {
+        let x = 0;
+        call_twice_weak(|i| x = x + i spec { ensures x == old(x) + i; });
+        x
+    }
+    spec test_weak_spec {
+        ensures result == 2; // error: post-condition does not hold
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.exp
@@ -1,0 +1,20 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:48:9
+   │
+48 │         ensures result == 0; // error: the nested mutation of `x` reaches the caller
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:38: read_before_nested_mutation_incorrect
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:39: read_before_nested_mutation_incorrect
+   =         r = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:43: read_before_nested_mutation_incorrect
+   =     at tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:41: read_before_nested_mutation_incorrect
+   =     at tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:40: read_before_nested_mutation_incorrect
+   =         r = <redacted>
+   =         x = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:45: read_before_nested_mutation_incorrect
+   =     at tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:37: read_before_nested_mutation_incorrect
+   =         result = <redacted>
+   =     at tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move:48: read_before_nested_mutation_incorrect (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/inline/opaque_inline_nested_mut_capture_order.move
@@ -1,0 +1,50 @@
+// Regression test: a variable which the outer lambda reads BEFORE a nested
+// lambda mutates it must still be captured `&mut` by the outer lambda (the
+// `modified` flag recorded while lifting the nested lambda survives the
+// context restore), so the mutation reaches the caller's variable.
+module 0x42::opaque_inline_nested_mut_capture_order {
+
+    inline fun call_once(f: |u64|) {
+        f(1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures ensures_of<f>(1);
+    }
+
+    inline fun call_outer(g: ||) {
+        g()
+    }
+    spec call_outer {
+        pragma opaque;
+        ensures ensures_of<g>();
+    }
+
+    fun read_before_nested_mutation(): u64 {
+        let x = 0;
+        let r = 0;
+        call_outer(|| {
+            let a = x; // read of `x` before the nested mutating lambda
+            call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+            r = a;
+        } spec { ensures x == old(x) + 1 && r == old(x); });
+        x + r
+    }
+    spec read_before_nested_mutation {
+        ensures result == 1;
+    }
+
+    fun read_before_nested_mutation_incorrect(): u64 {
+        let x = 0;
+        let r = 0;
+        call_outer(|| {
+            let a = x;
+            call_once(|i| x = x + i spec { ensures x == old(x) + i; });
+            r = a;
+        } spec { ensures x == old(x) + 1 && r == old(x); });
+        x + r
+    }
+    spec read_before_nested_mutation_incorrect {
+        ensures result == 0; // error: the nested mutation of `x` reaches the caller
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/partial_of_nested_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/partial_of_nested_fail.exp
@@ -1,0 +1,21 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/partial_of_nested_fail.move:24:9
+   │
+24 │         ensures 1 == 2; // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:17: bump_nested
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:22: bump_nested (spec)
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:23: bump_nested (spec)
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:17: bump_nested
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:18: bump_nested
+   =         <redacted> = <redacted>
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:9: step
+   =         s = <redacted>
+   =         e = <redacted>
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:10: step
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:9: step
+   =         s = <redacted>
+   =     at tests/sources/functional/closures/partial_of_nested_fail.move:24: bump_nested (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/partial_of_nested_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/partial_of_nested_fail.move
@@ -1,0 +1,34 @@
+// Regression: a fun param reflected over only through a NESTED observation
+// argument (`partial_of<fun_post_of<f>(1)>(step)`) is still verified
+// universally. With the param pinned to its abstract variant, the premise
+// would be provably false and the deliberately false conclusion below would
+// verify vacuously — while call sites CAN discharge the premise (the
+// successor of a concrete step-closure stays in the step variant).
+module 0x42::partial_of_nested_fail {
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        aborts_if s + e > MAX_U64;
+        ensures s == old(s) + e;
+    }
+
+    inline fun bump_nested(f: |&u64| has copy + drop) {
+        f(&1)
+    }
+    spec bump_nested {
+        pragma opaque;
+        requires partial_of<fun_post_of<f>(1)>(step);
+        requires captures_of<fun_post_of<f>(1)>(step) < 1000;
+        ensures 1 == 2; // error: post-condition does not hold
+    }
+
+    /// Makes the session's step variant exist; the call site can discharge
+    /// the nested premise at the concrete closure.
+    fun make_variant(): u64 {
+        let s = 0;
+        bump_nested(|e| step(&mut s, e));
+        s
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/partial_of_params.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/partial_of_params.move
@@ -1,0 +1,36 @@
+// Fun params observed by `partial_of`/`captures_of` are verified universally
+// (not pinned to their abstract `$param` variant): the premise is satisfiable
+// exactly for the matching closures, so conclusions must genuinely follow
+// from it (see the _fail twin for non-vacuity), while call sites discharge
+// the premise at concrete values.
+module 0x42::partial_of_params {
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        aborts_if s + e > MAX_U64;
+        ensures s == old(s) + e;
+    }
+
+    inline fun bump_once(f: |&u64| has copy + drop) {
+        f(&1)
+    }
+    spec bump_once {
+        pragma opaque;
+        requires partial_of<f>(step);
+        requires captures_of<f>(step) < 1000;
+        ensures f == fun_post_of<old(f)>(1);
+    }
+
+    /// Test: the premise is discharged at the concrete closure, and the
+    /// captured accumulator advances by one.
+    fun use_bump(): u64 {
+        let s = 7;
+        bump_once(|e| step(&mut s, e));
+        s
+    }
+    spec use_bump {
+        ensures result == 8;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/partial_of_params_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/partial_of_params_fail.exp
@@ -1,0 +1,22 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/partial_of_params_fail.move:22:9
+   │
+22 │ ╭         ensures captures_of<fun_post_of<old(f)>(1)>(step)
+23 │ │              == captures_of<old(f)>(step) + 2; // error: post-condition does not hold
+   │ ╰──────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:15: bump_once
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:20: bump_once (spec)
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:21: bump_once (spec)
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:15: bump_once
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:16: bump_once
+   =         <redacted> = <redacted>
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:7: step
+   =         s = <redacted>
+   =         e = <redacted>
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:8: step
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:7: step
+   =         s = <redacted>
+   =     at tests/sources/functional/closures/partial_of_params_fail.move:22: bump_once (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/partial_of_params_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/partial_of_params_fail.move
@@ -1,0 +1,32 @@
+// Non-vacuity of `partial_of` premises: the subject param is verified
+// universally, so a false conclusion under a satisfiable premise must FAIL
+// (with the param pinned to its abstract variant, the premise would be
+// provably false and this would verify vacuously).
+module 0x42::partial_of_params_fail {
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        aborts_if s + e > MAX_U64;
+        ensures s == old(s) + e;
+    }
+
+    inline fun bump_once(f: |&u64| has copy + drop) {
+        f(&1)
+    }
+    spec bump_once {
+        pragma opaque;
+        requires partial_of<f>(step);
+        requires captures_of<f>(step) < 1000;
+        ensures captures_of<fun_post_of<old(f)>(1)>(step)
+             == captures_of<old(f)>(step) + 2; // error: post-condition does not hold
+    }
+
+    /// Makes the session's step variant exist (the premise is satisfiable).
+    fun make_variant(): u64 {
+        let s = 0;
+        bump_once(|e| step(&mut s, e));
+        s
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/partial_of_scan_fail.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/partial_of_scan_fail.exp
@@ -1,0 +1,31 @@
+Move prover returns: exiting with verification errors
+warning: Unused value of parameter `f`. Consider removing the parameter, or prefixing with an underscore (e.g., `_f`), or binding to `_`
+   ┌─ tests/sources/functional/closures/partial_of_scan_fail.move:30:21
+   │
+30 │     fun observe_via(f: |&u64| has copy + drop): u64 {
+   │                     ^
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/closures/partial_of_scan_fail.move:20:13
+   │
+20 │             assert 1 == 2; // error: unknown assertion failed
+   │             ^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/partial_of_scan_fail.move:17: observe_inline
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/partial_of_scan_fail.move:19: observe_inline
+   =     at tests/sources/functional/closures/partial_of_scan_fail.move:20: observe_inline
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closures/partial_of_scan_fail.move:35:9
+   │
+35 │         ensures 1 == 2; // error: post-condition does not hold
+   │         ^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closures/partial_of_scan_fail.move:30: observe_via
+   =     at tests/sources/functional/closures/partial_of_scan_fail.move:34: observe_via (spec)
+   =     at tests/sources/functional/closures/partial_of_scan_fail.move:30: observe_via
+   =         f = <redacted>
+   =     at tests/sources/functional/closures/partial_of_scan_fail.move:31: observe_via
+   =         result = <redacted>
+   =     at tests/sources/functional/closures/partial_of_scan_fail.move:35: observe_via (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closures/partial_of_scan_fail.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/partial_of_scan_fail.move
@@ -1,0 +1,52 @@
+// Reflected-over parameters are detected in ALL spec positions: inline spec
+// blocks and observations hidden inside called spec function bodies also
+// unpin the parameter. (With the parameter pinned, the observations would be
+// provably false and the deliberately false assertions below would verify
+// vacuously.)
+module 0x42::partial_of_scan_fail {
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        aborts_if s + e > MAX_U64;
+        ensures s == old(s) + e;
+    }
+
+    /// Observation in an inline spec block only.
+    fun observe_inline(f: |&u64| has copy + drop): u64 {
+        spec {
+            assume partial_of<f>(step);
+            assert 1 == 2; // error: unknown assertion failed
+        };
+        0
+    }
+
+    spec fun is_step(f: |&u64| has copy + drop): bool {
+        partial_of<f>(step)
+    }
+
+    /// Observation hidden inside a spec function body.
+    fun observe_via(f: |&u64| has copy + drop): u64 {
+        0
+    }
+    spec observe_via {
+        requires is_step(f);
+        ensures 1 == 2; // error: post-condition does not hold
+    }
+
+    inline fun call_once(f: |&u64| has copy + drop) {
+        f(&1)
+    }
+    spec call_once {
+        pragma opaque;
+        ensures f == fun_post_of<old(f)>(1);
+    }
+
+    /// Makes the session's step variant exist.
+    fun make_variant(): u64 {
+        let s = 0;
+        call_once(|e| step(&mut s, e));
+        s
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/write_of_surface.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/write_of_surface.move
@@ -1,0 +1,46 @@
+// Surface `write_of<g, j>(args)`: the post-state of `g`'s j-th `&mut`
+// parameter (j defaults to 0), a value-level step function usable to define
+// fold-style spec functions over captured-state updates (see issue #20273).
+module 0x42::write_of_surface {
+
+    fun step(s: &mut u64, e: &u64) {
+        *s = *s + *e;
+    }
+    spec step {
+        aborts_if s + e > MAX_U64;
+        ensures s == old(s) + e;
+    }
+
+    /// Test: nested `write_of` describes sequential applications.
+    fun run2(a: u64, b: u64): u64 {
+        let s = 0;
+        step(&mut s, &a);
+        step(&mut s, &b);
+        s
+    }
+    spec run2 {
+        requires a < 1000 && b < 1000;
+        ensures result == write_of<step>(write_of<step>(0, a), b);
+    }
+
+    spec fun spec_sum(v: vector<u64>, k: u64): u64 {
+        if (k == 0) 0 else spec_sum(v, k - 1) + v[k - 1]
+    }
+
+    /// A value-level fold of `step`'s write effect.
+    spec fun iterate(v: vector<u64>, c0: u64, k: u64): u64 {
+        if (k == 0) c0 else write_of<step>(iterate(v, c0, k - 1), v[k - 1])
+    }
+
+    spec module {
+        /// The fold of `step` is the prefix sum.
+        lemma iterate_is_sum(v: vector<u64>, c0: u64, k: u64) {
+            requires k <= len(v);
+            ensures iterate(v, c0, k) == c0 + spec_sum(v, k);
+        } proof {
+            if (k > 0) {
+                apply iterate_is_sum(v, c0, k - 1);
+            }
+        }
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/restrictions.exp
+++ b/third_party/move/move-prover/tests/sources/functional/restrictions.exp
@@ -1,9 +1,9 @@
 Move prover returns: exiting with condition generation errors
-error: [boogie translator] function result type not yet supported
-  ┌─ tests/sources/functional/restrictions.move:9:9
+error: [boogie translator] lambda not supported in spec expressions
+  ┌─ tests/sources/functional/restrictions.move:9:28
   │
 9 │         fun f2(): | |num { | | 1 }
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                            ^^^^^
 
 error: [boogie translator] current restriction: a function value cannot be used in a specification expression.
    ┌─ tests/sources/functional/restrictions.move:13:13


### PR DESCRIPTION
## Description

Enables verifying loop-invoking HOFs applied to closures capturing `&mut` state — the motivating accumulator use case, for unbounded symbolic vector length:

```move
fun sum_all(v: &vector<u64>): u64 {
    let s = 0;
    for_each_ref(v, |e| step(&mut s, e));
    s
}
spec sum_all {
    requires spec_sum(v, len(v)) <= MAX_U64;
    aborts_if false;
    ensures result == spec_sum(v, len(v));
} proof {
    forall f: |&u64| has copy + drop, k: u64 {apply_all(f, v, k)}
        apply for_each_chain(f, step, v, k);
    forall c0: u64, k: u64 {iterate(step, c0, v, k)} apply iterate_step_is_sum(v, c0, k);
    forall j: u64, k: u64 {spec_sum(v, j), spec_sum(v, k)} apply sum_prefix_bound(v, j, k);
}
```

The pieces this is built from:

**Chained application.** The new behavioral predicate `fun_post_of<f>(args)` denotes the value of the closure `f` after one application (with opt-in two-state semantics for fun params: bare `f` in post conditions is the final value, `old(f)` the entry value). A recursive spec fun chains it to describe N applications, certified callee-side by a loop invariant:

```move
spec fun apply_all(f: |&u64| has copy + drop, v: vector<u64>, end: u64): |&u64| has copy + drop {
    if (end == 0) f else fun_post_of<apply_all(f, v, end - 1)>(v[end - 1])
}

inline fun for_each_ref(v: &vector<u64>, f: |&u64| has copy + drop) {
    let i = 0;
    let n = vector::length(v);
    while (i < n) {
        f(vector::borrow(v, i));
        i = i + 1;
    } spec {
        invariant i <= len(v);
        invariant f == apply_all(old(f), v, i);
    };
}
spec for_each_ref {
    pragma opaque;
    requires forall j in 0..len(v): !aborts_of<apply_all(f, v, j)>(v[j]);
    aborts_if false;
    ensures f == apply_all(old(f), v, len(v));
}
```

**Compositional chain lemma.** At the call site, the lambda `|e| step(&mut s, e)` is a closure over the named step function `step`, capturing the accumulator. Two new builtins observe this: `partial_of<f>(g)` states that the closure `f` is a partial application of `g`, and `captures_of<f>(g)` selects its captured value; both compile to closed-world recognizer/selector definitions over the verification session's closure variants. Together with surface syntax for `write_of<g, j>(args)` (the post-state of `g`'s j-th `&mut` parameter after one application), the chain lemma is written once per HOF, generic in the step function `g`, under a determinism premise — and instantiated by `forall .. apply` at the call site (see `sum_all` above):

```move
// Value-level fold of g's write effect — generic in g.
spec fun iterate(g: |&mut u64, &u64| has drop, c0: u64, v: vector<u64>, k: u64): u64 {
    if (k == 0) c0 else write_of<g>(iterate(g, c0, v, k - 1), v[k - 1])
}

spec module {
    // Generic chain lemma: after k applications, the captured state is
    // the k-fold of g's (deterministic) write effect.
    lemma for_each_chain(
        f: |&u64| has copy + drop,
        g: |&mut u64, &u64| has drop,
        v: vector<u64>,
        k: u64
    ) {
        requires partial_of<f>(g);
        requires forall c: u64, e: u64, w: u64:
            ensures_of<g>(c, e, w) ==> w == write_of<g>(c, e);
        requires k <= len(v);
        ensures partial_of<apply_all(f, v, k)>(g);
        ensures captures_of<apply_all(f, v, k)>(g)
             == iterate(g, captures_of<f>(g), v, k);
    } proof {
        if (k > 0) {
            apply for_each_chain(f, g, v, k - 1);
        }
    }
}
```

Use sites then add only the arithmetic inherent to their step function:

```move
fun step(s: &mut u64, e: &u64) { *s = *s + *e; }
spec step {
    aborts_if s + e > MAX_U64;
    ensures s == old(s) + e;
}

spec module {
    // Step-specific: the fold of step's write effect is the prefix sum.
    lemma iterate_step_is_sum(v: vector<u64>, c0: u64, k: u64) {
        requires k <= len(v);
        ensures iterate(step, c0, v, k) == c0 + spec_sum(v, k);
    } proof {
        if (k > 0) {
            apply iterate_step_is_sum(v, c0, k - 1);
        }
    }
}
```

(For concrete vector lengths, callers verify without any lemma — the chain unfolds directly through the lambda's spec.)

Also closes soundness gaps found on the way: a callee applying its fun param zero or several times could prove a single-application `ensures_of` (apply discipline is now enforced); reaching-definition copy propagation did not invalidate aliases to redefined temps; quantified `ensures_of` over a carrying closure over-constrained the havoced post value (now rejected); the live fun clone leaked into sourcified inferred specs. The `copy` ability bound is admitted for mut-capturing closures, with linearity enforced at the model level.

Closed-world recognizers are rejected in generic functions/lemmas until per-type-instantiation lemma verification lands (#20278). Also files #20275 and #20279.

## How Has This Been Tested?

New functional tests under `move-prover/tests/sources/functional/closures/` (concrete and symbolic chains, generic and step-specific chain lemmas, apply-discipline / memory / over-constraint failure variants), compiler checking tests for the new builtins, and the existing prover and inference suites.

## Type of Change

- [x] New feature

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine (Move Prover)
