### PR TITLE
[mono-move] Add module location where the abort happened

### DIFF
--- a/third_party/move/mono-move/core/src/error.rs
+++ b/third_party/move/mono-move/core/src/error.rs
@@ -20,6 +20,7 @@
 //! maps each internal variant to one of these categories. The internal
 //! enums and conversions live in their own crates.
 
+use move_core_types::vm_status::AbortLocation;
 use std::{any::Any, fmt};
 use thiserror::Error;
 
@@ -119,6 +120,10 @@ pub enum ExecutionResult {
         /// Populated when the abort uses the message form; [`None`] for
         /// code-only aborts.
         message: Option<String>,
+        /// The module that raised the abort.
+        // TODO(perf, cleanup): materialize `AbortLocation` only at the output
+        // boundary; needs guard-lifetime.
+        location: AbortLocation,
     },
 
     /// VM-detected failure. See [`ExecutionError`] for the category and

--- a/third_party/move/mono-move/core/src/interner.rs
+++ b/third_party/move/mono-move/core/src/interner.rs
@@ -12,7 +12,7 @@ use move_core_types::{
     ability::AbilitySet,
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{StructTag, TypeTag},
+    language_storage::{self, StructTag, TypeTag},
 };
 use thiserror::Error;
 
@@ -226,6 +226,16 @@ pub fn type_tag_of(ty: InternedType) -> Option<TypeTag> {
         | Type::Function { .. }
         | Type::TypeParam { .. } => return None,
     })
+}
+
+/// The owned [`language_storage::ModuleId`] for an interned module ID, or
+/// [`None`] if the interned name is not a valid identifier.
+pub fn module_id_of(module_id: InternedModuleId) -> Option<language_storage::ModuleId> {
+    let module_id = view_module_id(module_id);
+    Some(language_storage::ModuleId::new(
+        *module_id.address(),
+        Identifier::new(view_name(module_id.name())).ok()?,
+    ))
 }
 
 /// The [`StructTag`] for an interned nominal (struct/enum) type, or [`None`] if

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -39,7 +39,7 @@ pub use instruction::{
     VEC_LENGTH_OFFSET,
 };
 pub use interner::{
-    struct_tag_of, type_tag_of, view_function_ref, view_module_id, FunctionRef,
+    module_id_of, struct_tag_of, type_tag_of, view_function_ref, view_module_id, FunctionRef,
     InternedFunctionRef, Interner, ModuleId, TypeSubstitutionError,
 };
 pub use move_binary_format::file_format::ConstantPoolIndex;

--- a/third_party/move/mono-move/core/src/native/registry.rs
+++ b/third_party/move/mono-move/core/src/native/registry.rs
@@ -43,6 +43,17 @@ pub enum NativeName {
     },
 }
 
+impl NativeName {
+    /// The module the native is declared in.
+    pub fn module(&self) -> InternedModuleId {
+        match self {
+            NativeName::Polymorphic { module, .. } | NativeName::Monomorphic { module, .. } => {
+                *module
+            },
+        }
+    }
+}
+
 /// Describes a family of [`NativeContext`] types indexed by a lifetime.
 ///
 /// See [`NativeFunction`] for why this is needed.
@@ -96,9 +107,15 @@ pub enum NativeRegistryError {
     DuplicateName,
 }
 
+/// A registered native: its fully-qualified name and function pointer.
+struct NativeEntry<F: NativeContextFamily> {
+    name: NativeName,
+    func: NativeFunction<F>,
+}
+
 /// Lookup table of native functions, generic over a [`NativeContextFamily`] `F`.
 pub struct NativeRegistry<F: NativeContextFamily> {
-    entries: Vec<NativeFunction<F>>,
+    entries: Vec<NativeEntry<F>>,
     by_name: UnorderedMap<NativeName, NativeIdx>,
 }
 
@@ -130,7 +147,7 @@ impl<F: NativeContextFamily> NativeRegistry<F> {
             return Err(NativeRegistryError::DuplicateName);
         }
         let idx = NativeIdx(self.entries.len() as u32);
-        self.entries.push(func);
+        self.entries.push(NativeEntry { name, func });
         self.by_name.insert(name, idx);
         Ok(idx)
     }
@@ -150,7 +167,14 @@ impl<F: NativeContextFamily> NativeRegistry<F> {
     /// Look up the function pointer for a [`NativeIdx`].
     #[inline]
     pub fn lookup_by_idx(&self, idx: NativeIdx) -> Option<&NativeFunction<F>> {
-        self.entries.get(idx.0 as usize)
+        self.entries.get(idx.0 as usize).map(|entry| &entry.func)
+    }
+
+    /// The module of the native registered at [`NativeIdx`].
+    pub fn module_by_idx(&self, idx: NativeIdx) -> Option<InternedModuleId> {
+        self.entries
+            .get(idx.0 as usize)
+            .map(|entry| entry.name.module())
     }
 
     /// Look up the [`NativeIdx`] of a fully-qualified name.

--- a/third_party/move/mono-move/output/src/output.rs
+++ b/third_party/move/mono-move/output/src/output.rs
@@ -12,7 +12,6 @@ use aptos_types::{
 };
 use mono_move_core::{value_layout::LayoutProvider, ExecutionErrorKind, ExecutionResult, VMResult};
 use mono_move_runtime::SessionEffects;
-use move_core_types::vm_status::AbortLocation;
 
 /// Builds the [`TransactionOutput`] for a finished MonoMove transaction from its
 /// [`SessionEffects`] and run `result`. `layouts` serializes the written values
@@ -52,16 +51,17 @@ pub fn to_transaction_output(
 
 /// Maps a MonoMove [`ExecutionResult`] to an Aptos [`TransactionStatus`].
 ///
-/// The abort location is a placeholder (the runtime status carries none yet),
-/// and non-abort failures other than out-of-gas collapse to a miscellaneous
+/// Non-abort failures other than out-of-gas collapse to a miscellaneous
 /// error.
 pub fn to_transaction_status(result: ExecutionResult) -> TransactionStatus {
     let status = match result {
         ExecutionResult::Success => ExecutionStatus::Success,
-        // TODO(completeness): report the real abort location (module or script)
-        // once the runtime status carries it, rather than always Script.
-        ExecutionResult::Aborted { code, message } => ExecutionStatus::MoveAbort {
-            location: AbortLocation::Script,
+        ExecutionResult::Aborted {
+            code,
+            message,
+            location,
+        } => ExecutionStatus::MoveAbort {
+            location,
             code,
             info: message.map(|description| AbortInfo {
                 // TODO(completeness): `reason_name` is filled from the module error map by a later
@@ -90,6 +90,10 @@ pub fn to_transaction_status(result: ExecutionResult) -> TransactionStatus {
 mod tests {
     use super::*;
     use mono_move_core::ExecutionError;
+    use move_core_types::{
+        account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
+        vm_status::AbortLocation,
+    };
 
     #[test]
     fn status_mapping() {
@@ -97,12 +101,18 @@ mod tests {
             to_transaction_status(ExecutionResult::Success),
             TransactionStatus::Keep(ExecutionStatus::Success)
         ));
+        let abort_in_coin = AbortLocation::Module(ModuleId::new(
+            AccountAddress::ONE,
+            Identifier::new("coin").expect("valid identifier"),
+        ));
         assert!(matches!(
             to_transaction_status(ExecutionResult::Aborted {
                 code: 42,
-                message: None
+                message: None,
+                location: abort_in_coin.clone(),
             }),
-            TransactionStatus::Keep(ExecutionStatus::MoveAbort { code: 42, .. })
+            TransactionStatus::Keep(ExecutionStatus::MoveAbort { code: 42, location, .. })
+                if location == abort_in_coin
         ));
         assert!(matches!(
             to_transaction_status(ExecutionResult::Failed(ExecutionError {

--- a/third_party/move/mono-move/replay-benchmark/src/compare.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/compare.rs
@@ -13,6 +13,7 @@ use aptos_types::{
     state_store::state_key::StateKey,
     write_set::{TransactionWrite, WriteOp, WriteOpKind},
 };
+use move_core_types::vm_status::AbortLocation;
 use std::collections::BTreeMap;
 
 /// A transaction's writes, keyed by [`StateKey`]. `BTreeMap` gives a canonical order for free.
@@ -58,8 +59,12 @@ pub enum ExecOutcome {
         writes: WriteSet,
     },
     /// The function executed a Move `abort` with this code. `message` is the optional abort message
-    /// (populated only for the message form of abort).
-    Aborted { code: u64, message: Option<String> },
+    /// (populated only for the message form of abort); `location` is the module that raised it.
+    Aborted {
+        code: u64,
+        message: Option<String>,
+        location: AbortLocation,
+    },
     /// A non-abort runtime failure, classified by kind (with detail for reporting).
     Failure { kind: FailureKind, detail: String },
 }
@@ -104,10 +109,12 @@ pub fn compare_outcomes(v1: &ExecOutcome, v2: Result<&ExecOutcome, &str>) -> Cor
             ExecOutcome::Aborted {
                 code: c1,
                 message: m1,
+                location: l1,
             },
             ExecOutcome::Aborted {
                 code: c2,
                 message: m2,
+                location: l2,
             },
         ) => {
             if c1 != c2 {
@@ -122,6 +129,13 @@ pub fn compare_outcomes(v1: &ExecOutcome, v2: Result<&ExecOutcome, &str>) -> Cor
                     detail: format!(
                         "both aborted with code {} but different messages: V1={:?}, V2={:?}",
                         c1, m1, m2
+                    ),
+                }
+            } else if l1 != l2 {
+                Correctness::Mismatch {
+                    detail: format!(
+                        "both aborted with code {} but in different locations: V1={}, V2={}",
+                        c1, l1, l2
                     ),
                 }
             } else {
@@ -150,7 +164,9 @@ pub fn compare_outcomes(v1: &ExecOutcome, v2: Result<&ExecOutcome, &str>) -> Cor
 fn describe(outcome: &ExecOutcome) -> String {
     match outcome {
         ExecOutcome::Success { .. } => "success".to_string(),
-        ExecOutcome::Aborted { code, .. } => format!("abort(code={})", code),
+        ExecOutcome::Aborted { code, location, .. } => {
+            format!("abort(code={} in {})", code, location)
+        },
         ExecOutcome::Failure { kind, .. } => format!("failure({})", kind),
     }
 }
@@ -284,10 +300,37 @@ mod tests {
         matches!(compare_outcomes(v1, Ok(v2)), Correctness::Match)
     }
 
+    fn abort_in(code: u64, module_name: &str) -> ExecOutcome {
+        use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+        ExecOutcome::Aborted {
+            code,
+            message: None,
+            location: AbortLocation::Module(move_core_types::language_storage::ModuleId::new(
+                AccountAddress::ONE,
+                Identifier::new(module_name).expect("valid identifier"),
+            )),
+        }
+    }
+
     #[test]
     fn identical_write_sets_match() {
         let w = || ws(vec![("A", WriteOp::legacy_creation(vec![1, 2, 3].into()))]);
         assert!(is_match(&success(w()), &success(w())));
+    }
+
+    #[test]
+    fn identical_aborts_match() {
+        assert!(is_match(&abort_in(7, "coin"), &abort_in(7, "coin")));
+    }
+
+    #[test]
+    fn abort_location_difference_is_a_mismatch() {
+        let Correctness::Mismatch { detail } =
+            compare_outcomes(&abort_in(7, "coin"), Ok(&abort_in(7, "account")))
+        else {
+            panic!("expected Mismatch");
+        };
+        assert!(detail.contains("different locations"), "{detail}");
     }
 
     #[test]

--- a/third_party/move/mono-move/replay-benchmark/src/report.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/report.rs
@@ -129,9 +129,13 @@ fn describe_outcome(outcome: &ExecOutcome) -> String {
                 writes.len()
             )
         },
-        ExecOutcome::Aborted { code, message } => match message {
-            Some(m) => format!("Move abort (code {}: {})", code, m),
-            None => format!("Move abort (code {})", code),
+        ExecOutcome::Aborted {
+            code,
+            message,
+            location,
+        } => match message {
+            Some(m) => format!("Move abort (code {} in {}: {})", code, location, m),
+            None => format!("Move abort (code {} in {})", code, location),
         },
         ExecOutcome::Failure { kind, detail } => format!("failure [{}] {}", kind, detail),
     }

--- a/third_party/move/mono-move/replay-benchmark/src/v1.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v1.rs
@@ -281,7 +281,15 @@ fn timed_once<L: Loader + InstantiatedFunctionLoader, R: AptosMoveResolver>(
 
 fn classify_error(err: VMError) -> ExecOutcome {
     match err.into_vm_status() {
-        VMStatus::MoveAbort { code, message, .. } => ExecOutcome::Aborted { code, message },
+        VMStatus::MoveAbort {
+            code,
+            message,
+            location,
+        } => ExecOutcome::Aborted {
+            code,
+            message,
+            location,
+        },
         VMStatus::ExecutionFailure {
             status_code,
             location,

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -189,7 +189,15 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
             });
             ExecOutcome::Success { events, writes }
         },
-        Ok(RuntimeStatus::Aborted { code, message }) => ExecOutcome::Aborted { code, message },
+        Ok(RuntimeStatus::Aborted {
+            code,
+            message,
+            location,
+        }) => ExecOutcome::Aborted {
+            code,
+            message,
+            location,
+        },
         Err(err) => classify_error(&err),
     };
 

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -4,7 +4,7 @@
 //! Interpreter-internal error types.
 
 use mono_move_core::{ExecutionErrorKind, IntTy, IntoExecutionError, ResourceProviderError};
-use move_core_types::account_address::AccountAddress;
+use move_core_types::{account_address::AccountAddress, vm_status::AbortLocation};
 use std::fmt;
 use thiserror::Error;
 
@@ -333,9 +333,13 @@ pub enum RuntimeInvariantViolation {
 #[derive(Debug)]
 pub enum RuntimeStatus {
     Success,
-    // TODO(completeness): carry the abort's `Location` (which module raised it) once
-    // we have a `Location` type defined.
-    Aborted { code: u64, message: Option<String> },
+    Aborted {
+        code: u64,
+        message: Option<String>,
+        /// The module that raised the abort.
+        /// TODO(completeness): extend with aborts in scripts.
+        location: AbortLocation,
+    },
 }
 
 /// Returns from the enclosing function with an [`RuntimeError::InvariantViolation`]

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -30,7 +30,7 @@ use crate::{
 use aptos_types::write_set::WriteSet;
 use mono_move_core::{
     captured_values_size,
-    interner::{InternedIdentifier, InternedModuleId},
+    interner::{module_id_of, InternedIdentifier, InternedModuleId},
     native::{NativeABI, NativeExtensions, NativeIdx, NativeStatus, ObjectHandle, RootPool},
     next_captured_value_offset,
     storage::resource_provider::InMemoryStorageKey,
@@ -46,7 +46,10 @@ use mono_move_core::{
     FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
 };
 use mono_move_loader::{Loader, ModuleReadSet};
-use move_core_types::int256::{I256, U256};
+use move_core_types::{
+    int256::{I256, U256},
+    vm_status::AbortLocation,
+};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::ptr::{null, NonNull};
 // ---------------------------------------------------------------------------
@@ -103,6 +106,17 @@ impl SessionEffects {
     /// The transaction's write set.
     pub fn write_set(&self, layouts: &impl LayoutProvider) -> VMResult<WriteSet> {
         crate::write_set::build_write_set(&self.read_write_set, layouts)
+    }
+}
+
+/// Materializes the [`AbortLocation`] naming the module that raised an abort.
+// TODO(completeness): return `AbortLocation::Script` for script aborts.
+fn abort_location(module_id: InternedModuleId) -> VMResult<AbortLocation> {
+    match module_id_of(module_id) {
+        Some(module_id) => Ok(AbortLocation::Module(module_id)),
+        None => invariant_violation!(Unreachable(
+            "interned module name is not a valid identifier".to_string()
+        )),
     }
 }
 
@@ -1143,7 +1157,21 @@ impl InterpreterContext<'_> {
                         if let Some((code, message)) =
                             self.exec_call_native(func, regs, native_idx, ty_args, abi)?
                         {
-                            break RuntimeStatus::Aborted { code, message };
+                            // Attribute the abort to the native's own module
+                            // (not the caller's, which `regs.func` names here)
+                            // — the same rule as a Move-level abort.
+                            let location = match self.natives.module_by_idx(native_idx) {
+                                Some(module_id) => abort_location(module_id)?,
+                                None => invariant_violation!(NativeIdxOutOfBounds {
+                                    idx: native_idx.0,
+                                    registry_size: self.natives.len(),
+                                }),
+                            };
+                            break RuntimeStatus::Aborted {
+                                code,
+                                message,
+                                location,
+                            };
                         }
                     },
 
@@ -1394,6 +1422,7 @@ impl InterpreterContext<'_> {
                         break RuntimeStatus::Aborted {
                             code,
                             message: None,
+                            location: abort_location(func.module_id)?,
                         };
                     },
 
@@ -1423,6 +1452,7 @@ impl InterpreterContext<'_> {
                         break RuntimeStatus::Aborted {
                             code,
                             message: Some(message),
+                            location: abort_location(func.module_id)?,
                         };
                     },
 

--- a/third_party/move/mono-move/testsuite/src/engine.rs
+++ b/third_party/move/mono-move/testsuite/src/engine.rs
@@ -19,7 +19,9 @@ use mono_move_natives::{make_all_production_natives, make_all_test_natives, Disp
 use mono_move_runtime::{
     InterpreterContext, ProductionContextFamily, ProductionNativeRegistry, RuntimeStatus,
 };
-use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, vm_status::AbortLocation,
+};
 
 /// Gas budget for engine runs. Effectively unbounded.
 const GAS_BUDGET: u64 = u64::MAX;
@@ -29,7 +31,11 @@ pub enum RunResult<R> {
     /// The function returned a value of type `R`.
     Success(R),
     /// The function aborted with this code and optional message.
-    Aborted { code: u64, message: Option<String> },
+    Aborted {
+        code: u64,
+        message: Option<String>,
+        location: AbortLocation,
+    },
     /// An internal VM error.
     Error(String),
 }
@@ -66,7 +72,15 @@ impl<'guard> MonoRunner<'guard> {
         let result = match self.interp.run() {
             Err(err) => RunResult::Error(format!("{}", err)),
             Ok(RuntimeStatus::Success) => RunResult::Success(extract_returns(&self.interp)),
-            Ok(RuntimeStatus::Aborted { code, message }) => RunResult::Aborted { code, message },
+            Ok(RuntimeStatus::Aborted {
+                code,
+                message,
+                location,
+            }) => RunResult::Aborted {
+                code,
+                message,
+                location,
+            },
         };
         self.gc_count = self.interp.gc_count();
         result
@@ -86,7 +100,7 @@ impl<'guard> MonoRunner<'guard> {
             |interp| interp.root_result(),
         ) {
             RunResult::Success(value) => Ok(value),
-            RunResult::Aborted { code, message } => match message {
+            RunResult::Aborted { code, message, .. } => match message {
                 Some(message) => bail!("aborted: code {} ({})", code, message),
                 None => bail!("aborted: code {}", code),
             },

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -38,14 +38,14 @@ use mono_move_core::{native::NativeExtensions, types::type_to_string};
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_natives::{EventKind, EventStore};
 use mono_move_runtime::serialize;
-use move_binary_format::CompiledModule;
+use move_binary_format::{errors::Location, CompiledModule};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     int256::{I256, U256},
     language_storage::{ModuleId, TypeTag},
     value::MoveValue,
-    vm_status::StatusCode,
+    vm_status::{AbortLocation, StatusCode},
 };
 use move_vm_runtime::{
     data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
@@ -509,11 +509,14 @@ fn execute_function_v1(
         },
         Err(err) if err.major_status() == StatusCode::ABORTED => {
             let code = err.sub_status().unwrap();
-            let display = match err.message() {
-                Some(m) => format!("aborted: code {} ({})", code, m),
-                None => format!("aborted: code {}", code),
+            let location = match err.location() {
+                Location::Module(module_id) => render_module_location(module_id),
+                Location::Script => "script".to_string(),
+                Location::Undefined => "undefined".to_string(),
             };
-            Output { display }
+            Output {
+                display: render_abort(code, err.message().map(String::as_str), &location),
+            }
         },
         Err(err) => Output {
             display: format!("error: {}", err),
@@ -604,13 +607,38 @@ fn execute_function_v2(
     let display = match outcome {
         Err(err) => format!("error: {}", err),
         Ok(RunResult::Error(err)) => format!("error: {}", err),
-        Ok(RunResult::Aborted { code, message }) => match message {
-            Some(m) => format!("aborted: code {} ({})", code, m),
-            None => format!("aborted: code {}", code),
+        Ok(RunResult::Aborted {
+            code,
+            message,
+            location,
+        }) => {
+            let location = match &location {
+                AbortLocation::Module(module_id) => render_module_location(module_id),
+                AbortLocation::Script => "script".to_string(),
+            };
+            render_abort(code, message.as_deref(), &location)
         },
         Ok(RunResult::Success((vals, events))) => render_execution_output(&vals, &events),
     };
     (Output { display }, gc_count)
+}
+
+/// Renders an abort outcome. Both VMs go through this so the abort location
+/// participates in the differential comparison.
+fn render_abort(code: u64, message: Option<&str>, location: &str) -> String {
+    match message {
+        Some(message) => format!("aborted: code {} ({}) in {}", code, message, location),
+        None => format!("aborted: code {} in {}", code, location),
+    }
+}
+
+/// The common rendering of a module abort location: `0x<address>::<module>`.
+pub(crate) fn render_module_location(module_id: &ModuleId) -> String {
+    format!(
+        "0x{}::{}",
+        module_id.address().short_str_lossless(),
+        module_id.name()
+    )
 }
 
 /// Kind supported as an argument or return value in differential tests

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -19,9 +19,12 @@ use mono_move_loader::{Loader, LoaderError, LoadingPolicy, LoweringPolicy, Modul
 use mono_move_runtime::{
     InterpreterContext, ProductionNativeRegistry, RuntimeError, RuntimeStatus,
 };
-use move_binary_format::CompiledModule;
+use move_binary_format::{errors::Location, CompiledModule};
 use move_core_types::{
-    identifier::IdentStr, language_storage::ModuleId, value::MoveValue, vm_status::StatusCode,
+    identifier::IdentStr,
+    language_storage::ModuleId,
+    value::MoveValue,
+    vm_status::{AbortLocation, StatusCode},
 };
 use move_model::metadata::LanguageVersion;
 use move_package::BuildConfig;
@@ -189,7 +192,15 @@ fn execute(
 
     match interpreter.run() {
         Ok(RuntimeStatus::Success) => TestResult::Success,
-        Ok(RuntimeStatus::Aborted { code, message }) => TestResult::Abort { code, message },
+        Ok(RuntimeStatus::Aborted {
+            code,
+            message,
+            location,
+        }) => TestResult::Abort {
+            code,
+            message,
+            location,
+        },
         Err(err) => classify_error(&err),
     }
 }
@@ -272,8 +283,13 @@ fn inline_bytes(value: &MoveValue) -> Vec<u8> {
 enum TestResult {
     /// Ran to completion.
     Success,
-    /// An explicit Move `abort`, with its code and optional message.
-    Abort { code: u64, message: Option<String> },
+    /// An explicit Move `abort`, with its code, optional message, and the
+    /// module that raised it.
+    Abort {
+        code: u64,
+        message: Option<String>,
+        location: AbortLocation,
+    },
     /// An implicit runtime failure: arithmetic overflow, index out of bounds, etc.
     RuntimeFailure(String),
     /// Cannot build or run this yet: missing native, unlowered construct, etc.
@@ -362,9 +378,9 @@ fn classify_runtime_error(err: &RuntimeError) -> TestResult {
 
 fn adjudicate(result: TestResult, expected: &Option<ExpectedFailure>) -> TestOutcome {
     // Outcomes that don't depend on the expectation; otherwise normalize the
-    // failure to (abort code, detail) — an explicit abort carries a code, an
-    // implicit runtime failure carries none.
-    let (code, detail) = match result {
+    // failure to (abort, detail) — an explicit abort carries a code and
+    // location, an implicit runtime failure carries neither.
+    let (abort, detail) = match result {
         TestResult::Success => {
             return match expected {
                 None => TestOutcome::Pass,
@@ -373,31 +389,54 @@ fn adjudicate(result: TestResult, expected: &Option<ExpectedFailure>) -> TestOut
                 },
             };
         },
-        TestResult::Abort { code, message } => (Some(code), message),
+        TestResult::Abort {
+            code,
+            message,
+            location,
+        } => (Some((code, location)), message),
         TestResult::RuntimeFailure(failure) => (None, Some(failure)),
         TestResult::Unsupported(reason) => return TestOutcome::Unsupported(reason),
         TestResult::Error(error) => return TestOutcome::Fail(error),
     };
 
-    // The program failed; judge it against the expectation, matching on the
-    // abort code only.
+    // The program failed; judge it against the expectation: the abort code
+    // must match, and so must the abort location when the expectation pins
+    // one. The abort message is never compared: `#[expected_failure]` cannot
+    // specify one, so it only feeds the failure diagnostics below.
     //
-    // TODO(completeness): a non-abort expected error (e.g. `arithmetic_error`) is currently
-    // satisfied by any failure; match it against mono-move's own error
-    // categories instead. Fine for now: move-stdlib and aptos-framework only
-    // use abort-code (or bare) expected failures.
+    // TODO(completeness): only abort expectations are fully checked. A
+    // non-ABORTED expectation (`arithmetic_error`, `vector_error`,
+    // `major_status = ..`, `out_of_gas`) — or ABORTED without `minor_status` —
+    // is satisfied by any failure; its status, minor status, and location go
+    // unchecked. Checking them requires mapping `RuntimeError` variants to
+    // status codes and attaching a location to non-abort failures.
     let reason = match expected {
         // No failure was expected.
-        None => match code {
-            Some(code) => format!("unexpected abort with code {code}"),
+        None => match abort {
+            Some((code, _)) => format!("unexpected abort with code {code}"),
             None => "unexpected runtime failure".to_string(),
         },
         // A failure was expected; if it requires a specific abort code, check it.
         Some(expected) => match expected_abort_code(expected) {
             None => return TestOutcome::Pass,
-            Some(want) if code == Some(want) => return TestOutcome::Pass,
-            Some(want) => match code {
-                Some(got) => format!("expected abort with code {want}, got code {got}"),
+            Some(want) => match &abort {
+                Some((got, got_location)) if *got == want => {
+                    match expected_abort_location(expected) {
+                        None => return TestOutcome::Pass,
+                        Some(want_location) => {
+                            if location_matches(want_location, got_location) {
+                                return TestOutcome::Pass;
+                            }
+                            format!(
+                                "expected abort with code {want} originating in {}, \
+                                 but it aborted in {}",
+                                render_expected_location(want_location),
+                                render_abort_location(got_location),
+                            )
+                        },
+                    }
+                },
+                Some((got, _)) => format!("expected abort with code {want}, got code {got}"),
                 None => format!("expected abort with code {want}, got a runtime failure"),
             },
         },
@@ -423,6 +462,46 @@ fn expected_abort_code(expected: &ExpectedFailure) -> Option<u64> {
                 None
             }
         },
+    }
+}
+
+/// The abort location the `#[expected_failure]` annotation pins, if any.
+fn expected_abort_location(expected: &ExpectedFailure) -> Option<&Location> {
+    match expected {
+        ExpectedFailure::Expected | ExpectedFailure::ExpectedWithCodeDEPRECATED(_) => None,
+        ExpectedFailure::ExpectedWithError(ExpectedMoveError(status, _, location, _)) => {
+            (*status == StatusCode::ABORTED).then_some(location)
+        },
+    }
+}
+
+/// Whether the actual abort location satisfies the expected one.
+fn location_matches(expected: &Location, actual: &AbortLocation) -> bool {
+    match (expected, actual) {
+        (Location::Module(expected), AbortLocation::Module(actual)) => expected == actual,
+        (Location::Script, AbortLocation::Script) => true,
+        (Location::Undefined, _)
+        | (Location::Script, AbortLocation::Module(_))
+        | (Location::Module(_), AbortLocation::Script) => false,
+    }
+}
+
+/// Renders a [`Location`] as `script`/`undefined`/`0x<address>::<module>`
+/// (unlike its `Display`).
+fn render_expected_location(location: &Location) -> String {
+    match location {
+        Location::Undefined => "undefined".to_string(),
+        Location::Script => "script".to_string(),
+        Location::Module(module_id) => crate::runner::render_module_location(module_id),
+    }
+}
+
+/// Renders an actual [`AbortLocation`] in the same form as
+/// [`render_expected_location`].
+fn render_abort_location(location: &AbortLocation) -> String {
+    match location {
+        AbortLocation::Script => "script".to_string(),
+        AbortLocation::Module(module_id) => crate::runner::render_module_location(module_id),
     }
 }
 
@@ -527,5 +606,105 @@ impl RunSummary {
         }
 
         out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+
+    fn module(name: &str) -> ModuleId {
+        ModuleId::new(
+            AccountAddress::ONE,
+            Identifier::new(name).expect("valid identifier"),
+        )
+    }
+
+    fn abort_in(code: u64, name: &str) -> TestResult {
+        TestResult::Abort {
+            code,
+            message: None,
+            location: AbortLocation::Module(module(name)),
+        }
+    }
+
+    fn expect_abort_in(code: u64, name: &str) -> Option<ExpectedFailure> {
+        Some(ExpectedFailure::ExpectedWithError(ExpectedMoveError(
+            StatusCode::ABORTED,
+            Some(code),
+            Location::Module(module(name)),
+            None,
+        )))
+    }
+
+    #[test]
+    fn abort_code_and_location_match() {
+        assert!(matches!(
+            adjudicate(abort_in(7, "a"), &expect_abort_in(7, "a")),
+            TestOutcome::Pass
+        ));
+    }
+
+    #[test]
+    fn abort_location_mismatch_fails() {
+        let TestOutcome::Fail(reason) = adjudicate(abort_in(7, "a"), &expect_abort_in(7, "b"))
+        else {
+            panic!("expected Fail");
+        };
+        assert!(
+            reason.contains("0x1::a") && reason.contains("0x1::b"),
+            "{reason}"
+        );
+    }
+
+    #[test]
+    fn abort_code_mismatch_reported_before_location() {
+        let TestOutcome::Fail(reason) = adjudicate(abort_in(8, "b"), &expect_abort_in(7, "a"))
+        else {
+            panic!("expected Fail");
+        };
+        assert!(reason.contains("got code 8"), "{reason}");
+    }
+
+    #[test]
+    fn expected_script_location_fails_module_abort() {
+        let expected = Some(ExpectedFailure::ExpectedWithError(ExpectedMoveError(
+            StatusCode::ABORTED,
+            Some(7),
+            Location::Script,
+            None,
+        )));
+        assert!(matches!(
+            adjudicate(abort_in(7, "a"), &expected),
+            TestOutcome::Fail(_)
+        ));
+    }
+
+    #[test]
+    fn deprecated_code_expectation_ignores_location() {
+        let expected = Some(ExpectedFailure::ExpectedWithCodeDEPRECATED(7));
+        assert!(matches!(
+            adjudicate(abort_in(7, "a"), &expected),
+            TestOutcome::Pass
+        ));
+    }
+
+    #[test]
+    fn non_abort_expectation_satisfied_by_any_failure() {
+        // Pins the under-checking documented at the TODO in `adjudicate`.
+        let expected = Some(ExpectedFailure::ExpectedWithError(ExpectedMoveError(
+            StatusCode::ARITHMETIC_ERROR,
+            None,
+            Location::Module(module("a")),
+            None,
+        )));
+        assert!(matches!(
+            adjudicate(
+                TestResult::RuntimeFailure("overflow".to_string()),
+                &expected
+            ),
+            TestOutcome::Pass
+        ));
     }
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/abort.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/abort.move
@@ -6,7 +6,7 @@ module 0x1::test {
 }
 
 // RUN: execute 0x1::test::do_abort --args 42
-// CHECK: aborted: code 42
+// CHECK: aborted: code 42 in 0x1::test
 
 // RUN: execute 0x1::test::do_abort --args 0
-// CHECK: aborted: code 0
+// CHECK: aborted: code 0 in 0x1::test

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/abort_msg.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/abort_msg.move
@@ -1,0 +1,9 @@
+// RUN: publish
+module 0x1::test {
+    fun abort_with_message() {
+        abort b"boom"
+    }
+}
+
+// RUN: execute 0x1::test::abort_with_message
+// CHECK: aborted: code 14566554180833181696 (boom) in 0x1::test

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/from_bytes.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/from_bytes.move
@@ -94,13 +94,13 @@ module 0x1::main {
 // Malformed input aborts with EFROM_BYTES on both VMs.
 
 // RUN: execute 0x1::main::truncated
-// CHECK: aborted: code 65537
+// CHECK: aborted: code 65537 in 0x1::from_bcs
 
 // RUN: execute 0x1::main::trailing
-// CHECK: aborted: code 65537
+// CHECK: aborted: code 65537 in 0x1::from_bcs
 
 // RUN: execute 0x1::main::signer_roundtrip
-// CHECK: aborted: code 65537
+// CHECK: aborted: code 65537 in 0x1::from_bcs
 
 // RUN: execute 0x1::main::signer_in_vector
-// CHECK: aborted: code 65537
+// CHECK: aborted: code 65537 in 0x1::from_bcs

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/native_u64_add.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/native_u64_add.move
@@ -15,4 +15,4 @@ module 0x1::main {
 // CHECK: results: 0
 
 // RUN: execute 0x1::main::wrap --args 18446744073709551615, 1
-// CHECK: aborted: code 1
+// CHECK: aborted: code 1 in 0x1::test_natives

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/string.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/string.move
@@ -100,13 +100,13 @@ module 0x1::main {
 // CHECK: results: "é"
 
 // RUN: execute 0x1::main::invalid_byte
-// CHECK: aborted: code 1
+// CHECK: aborted: code 1 in 0x1::string
 
 // RUN: execute 0x1::main::lone_continuation
-// CHECK: aborted: code 1
+// CHECK: aborted: code 1 in 0x1::string
 
 // RUN: execute 0x1::main::truncated
-// CHECK: aborted: code 1
+// CHECK: aborted: code 1 in 0x1::string
 
 // RUN: execute 0x1::main::index_found
 // CHECK: results: 6
@@ -139,11 +139,11 @@ module 0x1::main {
 
 // End index past the length aborts with EINVALID_INDEX (2).
 // RUN: execute 0x1::main::sub --args 0, 12
-// CHECK: aborted: code 2
+// CHECK: aborted: code 2 in 0x1::string
 
 // Start index after the end aborts with EINVALID_INDEX (2).
 // RUN: execute 0x1::main::sub --args 5, 3
-// CHECK: aborted: code 2
+// CHECK: aborted: code 2 in 0x1::string
 
 // Both indices are char boundaries: bytes [0, 3) of "héllo" is "hé".
 // RUN: execute 0x1::main::sub_multibyte --args 0, 3
@@ -155,8 +155,8 @@ module 0x1::main {
 
 // End index 2 splits the 'é' code point: not a char boundary, aborts.
 // RUN: execute 0x1::main::sub_multibyte --args 0, 2
-// CHECK: aborted: code 2
+// CHECK: aborted: code 2 in 0x1::string
 
 // Start index 2 splits the 'é' code point: not a char boundary, aborts.
 // RUN: execute 0x1::main::sub_multibyte --args 2, 3
-// CHECK: aborted: code 2
+// CHECK: aborted: code 2 in 0x1::string

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/table.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/table.move
@@ -147,10 +147,10 @@ module 0x42::main {
 // CHECK-V2: results: 0x6364
 
 // RUN: execute 0x42::main::add_duplicate_aborts
-// CHECK-V2: aborted: code 25607
+// CHECK-V2: aborted: code 25607 in 0x1::table
 
 // RUN: execute 0x42::main::get_missing_aborts
-// CHECK-V2: aborted: code 25863
+// CHECK-V2: aborted: code 25863 in 0x1::table
 
 // RUN: execute 0x42::main::remove_present
 // CHECK-V2: results: 0x6869
@@ -162,4 +162,4 @@ module 0x42::main {
 // CHECK-V2: results: true
 
 // RUN: execute 0x42::main::remove_missing_aborts
-// CHECK-V2: aborted: code 25863
+// CHECK-V2: aborted: code 25863 in 0x1::table

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/type_of.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/type_of.move
@@ -57,4 +57,4 @@ module 0x1::type_info {
 // CHECK: results: 0x4261723c7536343e
 
 // RUN: execute 0x1::type_info::non_struct_aborts
-// CHECK: aborted: code 1 (Expected a struct type, found: u64)
+// CHECK: aborted: code 1 (Expected a struct type, found: u64) in 0x1::type_info

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/move_range.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/move_range.move
@@ -79,9 +79,9 @@ module 0x66::move_range {
 
 // Out-of-bounds range, then out-of-bounds insert position; both abort.
 // RUN: execute 0x66::move_range::move_u64 --args 1, 5, 0
-// CHECK: aborted: code 1
+// CHECK: aborted: code 1 in 0x1::vector
 // RUN: execute 0x66::move_range::move_u64 --args 0, 1, 5
-// CHECK: aborted: code 1
+// CHECK: aborted: code 1 in 0x1::vector
 
 // Empty (null-pointer) destination.
 // RUN: execute 0x66::move_range::move_into_empty --args 0, 2


### PR DESCRIPTION
## Goal

Make MonoMove report **where** an abort originated (which module), not just its code and message — resolving a standing completeness TODO.

## Motivation

- **Production correctness:** the abort location is part of the on-chain transaction status, so MonoMove must populate it faithfully rather than with a placeholder.
- **Parity with the legacy VM:** abort attribution must match legacy semantics exactly — including the subtle rule that a native function's abort belongs to the native's own module, not its caller's.
- **Stronger test oracles:** the differential harness, replay benchmark, and unit-test harness were all ignoring location, so a VM that aborted with the right code from the wrong module would pass undetected.

## Changes Made

- Abort outcomes now carry an owned location, materialized at the abort site, flowing unchanged from the interpreter through to the transaction status.
- Native aborts are attributed to the native's declaring module, matching legacy behavior; the registry gained the reverse lookup this requires.
- All three test harnesses now exercise location: the differential suite renders and compares it across both VMs, the replay benchmark checks it against mainnet-derived outcomes, and unit-test adjudication enforces expected abort locations (closing a real under-checking gap).
- Verified end to end: full differential suite and all affected crate tests pass with both VMs agreeing on every location; an internal multi-agent adversarial review (its four confirmed findings all fixed) and an external adversarial review (approve, no findings) both came back clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observable transaction abort metadata and VM parity semantics (especially native abort attribution); scope is bounded to mono-move abort reporting and test harnesses rather than core consensus logic.
> 
> **Overview**
> MonoMove abort outcomes now carry **`AbortLocation`** end-to-end, replacing the prior placeholder so on-chain **`MoveAbort`** status reflects the real originating module.
> 
> The interpreter sets location on **`Abort` / `AbortMsg`** from the executing function’s module, and on **native aborts** from the native’s declaring module (via **`NativeRegistry::module_by_idx`** and stored **`NativeName`**). **`module_id_of`** converts interned module IDs for that mapping.
> 
> **`to_transaction_status`** forwards location into Aptos **`ExecutionStatus::MoveAbort`**. Replay benchmark, differential testsuite, and unit-test adjudication now compare or assert abort location (including **`#[expected_failure]`** module pins); CHECK lines include `in 0x…::module`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d953979f1d0eb6ef2797f120cc239ba079d701e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->