### PR TITLE
[mono-move] Fix signer deserialization

### DIFF
--- a/third_party/move/mono-move/core/src/value_layout.rs
+++ b/third_party/move/mono-move/core/src/value_layout.rs
@@ -93,8 +93,11 @@ pub enum LayoutKind {
     UnsignedInt,
     /// A signed integer (`i8`, ..., `i256`).
     SignedInt,
-    /// An `address` or `signer` (32 bytes).
+    /// An `address` (32 bytes).
     Address,
+    /// A `signer` (32 bytes). Distinct from `Address` so it can be rejected on
+    /// deserialization.
+    Signer,
     /// An inline struct: fields laid out flat in the parent's payload.
     /// TODO(completeness): for non-inline structs (resources), we need a descriptor ID.
     Struct {
@@ -241,7 +244,7 @@ impl ValueLayout {
         Self::signed_int(32, MAX_ALIGN as u32)
     }
 
-    /// Layout of `address` or a signer.
+    /// Layout of `address`.
     pub fn address() -> Self {
         Self {
             size: 32,
@@ -249,6 +252,19 @@ impl ValueLayout {
             fixed_bcs_size: Some(32),
             flags: LayoutFlags::NO_POINTERS_NO_PADDING | LayoutFlags::ALL_BYTE_PATTERNS_VALID,
             kind: LayoutKind::Address,
+        }
+    }
+
+    /// Layout of `signer`: the address shape without
+    /// [`LayoutFlags::ALL_BYTE_PATTERNS_VALID`], so deserialization does not
+    /// blit and can reject it.
+    pub fn signer() -> Self {
+        Self {
+            size: 32,
+            align: MAX_ALIGN as u32,
+            fixed_bcs_size: Some(32),
+            flags: LayoutFlags::NO_POINTERS_NO_PADDING,
+            kind: LayoutKind::Signer,
         }
     }
 
@@ -403,8 +419,7 @@ pub const I128_LAYOUT_ID: LayoutId = LayoutId(11);
 /// Reserved layout ID for [`Type::I256`].
 pub const I256_LAYOUT_ID: LayoutId = LayoutId(12);
 
-/// Reserved layout ID for [`Type::Address`]. Note that  [`Type::Signer`]
-/// has the same layout.
+/// Reserved layout ID for [`Type::Address`].
 pub const ADDRESS_LAYOUT_ID: LayoutId = LayoutId(13);
 
 /// Reserved layout ID shared by all reference types.
@@ -412,6 +427,9 @@ pub const REF_LAYOUT_ID: LayoutId = LayoutId(14);
 
 /// Reserved layout ID shared by all function values.
 pub const FUNCTION_LAYOUT_ID: LayoutId = LayoutId(15);
+
+/// Reserved layout ID for [`Type::Signer`].
+pub const SIGNER_LAYOUT_ID: LayoutId = LayoutId(16);
 
 /// Returns the reserved [`LayoutId`] for a type whose layout is arg-independent
 /// (primitives, references, functions), or [`None`] for types that must be
@@ -432,8 +450,8 @@ pub fn reserved_layout_id(ty: &Type) -> Option<LayoutId> {
         Type::I64 => I64_LAYOUT_ID,
         Type::I128 => I128_LAYOUT_ID,
         Type::I256 => I256_LAYOUT_ID,
-        // Signer shares the address layout.
-        Type::Address | Type::Signer => ADDRESS_LAYOUT_ID,
+        Type::Address => ADDRESS_LAYOUT_ID,
+        Type::Signer => SIGNER_LAYOUT_ID,
         Type::ImmutRef { .. } | Type::MutRef { .. } => REF_LAYOUT_ID,
         Type::Function { .. } => FUNCTION_LAYOUT_ID,
         Type::Vector { .. } | Type::Nominal { .. } | Type::TypeParam { .. } => return None,
@@ -460,6 +478,7 @@ pub fn reserved_layouts() -> Vec<ValueLayout> {
         ValueLayout::address(),
         ValueLayout::reference(),
         ValueLayout::function(),
+        ValueLayout::signer(),
     ]
 }
 
@@ -537,7 +556,7 @@ mod tests {
     #[test]
     fn reserved_layouts_match_ids() {
         let layouts = reserved_layouts();
-        assert_eq!(layouts.len(), 16);
+        assert_eq!(layouts.len(), 17);
 
         let cases = [
             (BOOL_LAYOUT_ID, 1),
@@ -579,13 +598,20 @@ mod tests {
         let f = &layouts[FUNCTION_LAYOUT_ID.as_usize()];
         assert_eq!(f.size, 8);
         assert!(matches!(f.kind, LayoutKind::Function));
+
+        let s = &layouts[SIGNER_LAYOUT_ID.as_usize()];
+        assert_eq!(s.size, 32);
+        assert_eq!(s.fixed_bcs_size, Some(32));
+        assert!(s.has_no_pointers_no_padding());
+        assert!(!s.all_byte_patterns_valid());
+        assert!(matches!(s.kind, LayoutKind::Signer));
     }
 
     #[test]
     fn reserved_layout_id_maps_primitives_and_pointers() {
         assert_eq!(reserved_layout_id(&Type::U64), Some(U64_LAYOUT_ID));
         assert_eq!(reserved_layout_id(&Type::Address), Some(ADDRESS_LAYOUT_ID));
-        assert_eq!(reserved_layout_id(&Type::Signer), Some(ADDRESS_LAYOUT_ID));
+        assert_eq!(reserved_layout_id(&Type::Signer), Some(SIGNER_LAYOUT_ID));
         assert_eq!(
             reserved_layout_id(&Type::ImmutRef {
                 inner: crate::types::U64_TY

--- a/third_party/move/mono-move/core/src/value_layout.rs
+++ b/third_party/move/mono-move/core/src/value_layout.rs
@@ -56,9 +56,10 @@ bitflags! {
         const NO_POINTERS_NO_PADDING = 0b0000_0001;
         /// Every byte pattern of this value's in-memory image is a valid value,
         /// so deserialization needs no per-byte validation and can copy the BCS
-        /// bytes in one `memcpy`. Holds for integers and addresses but not for
-        /// `bool` (only `0`/`1` are canonical). An aggregate has this flag only
-        /// when it has no padding, no pointers, and no `bool` reachable.
+        /// bytes in one `memcpy`. Holds for integers and addresses. It does not
+        /// hold for `bool` (only `0`/`1` are canonical) or `signer` (never
+        /// deserializable). An aggregate has this flag only when it has no
+        /// padding, no pointers, and no `bool` or `signer` reachable.
         const ALL_BYTE_PATTERNS_VALID = 0b0000_0010;
     }
 }
@@ -161,8 +162,9 @@ impl ValueLayout {
     }
 
     /// Returns true if every byte pattern of this value's in-memory size is a
-    /// valid value, so deserialization can blit the BCS bytes without per-byte
-    /// validation. False for anything that reaches a `bool`.
+    /// valid value, so deserialization can copy the BCS bytes in one `memcpy`
+    /// without per-byte validation. False for anything that reaches a `bool`
+    /// or `signer`.
     pub fn all_byte_patterns_valid(&self) -> bool {
         self.flags.contains(LayoutFlags::ALL_BYTE_PATTERNS_VALID)
     }
@@ -255,14 +257,14 @@ impl ValueLayout {
         }
     }
 
-    /// Layout of `signer`: the address shape without
-    /// [`LayoutFlags::ALL_BYTE_PATTERNS_VALID`], so deserialization does not
-    /// blit and can reject it.
+    /// Layout of `signer`: the address shape, but never deserializable.
     pub fn signer() -> Self {
         Self {
             size: 32,
             align: MAX_ALIGN as u32,
             fixed_bcs_size: Some(32),
+            // No `ALL_BYTE_PATTERNS_VALID`: without it deserialization takes the
+            // per-byte path, which rejects `signer` instead of copying the bytes.
             flags: LayoutFlags::NO_POINTERS_NO_PADDING,
             kind: LayoutKind::Signer,
         }

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -355,7 +355,8 @@ fn classify_runtime_error(err: &RuntimeError) -> FailureKind {
         | E::BCSInvalidUleb
         | E::BCSSequenceTooLong { .. }
         | E::BCSRemainingInput { .. }
-        | E::BCSInvalidBool { .. } => FailureKind::Other,
+        | E::BCSInvalidBool { .. }
+        | E::BCSSignerNotDeserializable => FailureKind::Other,
         E::InvariantViolation(_) | E::ResourceProvider(_) => FailureKind::InvariantViolation,
     }
 }

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -102,6 +102,9 @@ pub enum RuntimeError {
 
     #[error("BCS deserialize: non-canonical bool byte {byte}")]
     BCSInvalidBool { byte: u8 },
+
+    #[error("BCS deserialize: cannot deserialize a signer")]
+    BCSSignerNotDeserializable,
 }
 
 impl IntoExecutionError for RuntimeError {
@@ -135,7 +138,8 @@ impl IntoExecutionError for RuntimeError {
             | BCSInvalidUleb
             | BCSSequenceTooLong { .. }
             | BCSRemainingInput { .. }
-            | BCSInvalidBool { .. } => ExecutionErrorKind::InvalidOperation,
+            | BCSInvalidBool { .. }
+            | BCSSignerNotDeserializable => ExecutionErrorKind::InvalidOperation,
 
             InvariantViolation(_) => ExecutionErrorKind::InvariantViolation,
             ResourceProvider(e) => e.kind(),

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -117,7 +117,7 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
         | LayoutKind::SignedInt
         | LayoutKind::Address
         | LayoutKind::Signer => Err(VMInternalError::new(unreachable(
-            "Primitive types have no padding / pointers and must be already handled",
+            "Scalars serialize on the no-pointers-no-padding fast path and never reach this arm",
         ))),
         LayoutKind::Struct { fields } => {
             for field in fields.iter() {

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -115,7 +115,8 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
         LayoutKind::Bool
         | LayoutKind::UnsignedInt
         | LayoutKind::SignedInt
-        | LayoutKind::Address => Err(VMInternalError::new(unreachable(
+        | LayoutKind::Address
+        | LayoutKind::Signer => Err(VMInternalError::new(unreachable(
             "Primitive types have no padding / pointers and must be already handled",
         ))),
         LayoutKind::Struct { fields } => {
@@ -255,7 +256,8 @@ unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
         LayoutKind::Bool
         | LayoutKind::UnsignedInt
         | LayoutKind::SignedInt
-        | LayoutKind::Address => Err(VMInternalError::new(unreachable(
+        | LayoutKind::Address
+        | LayoutKind::Signer => Err(VMInternalError::new(unreachable(
             "Primitive layouts must be handled by fast-path",
         ))),
         LayoutKind::Struct { fields } => {
@@ -472,7 +474,7 @@ unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
                 }
             })
         },
-        LayoutKind::Address => {
+        LayoutKind::Address | LayoutKind::Signer => {
             // SAFETY: values are valid byte arrays of the size specified by
             // the layout, as guaranteed by the precondition of this function.
             Ok(unsafe { bytes_cmp(a, b, layout.size as usize) })
@@ -670,6 +672,8 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
         LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => {
             Err(unreachable("Integer and address layouts must be handled by fast-path").into())
         },
+        // A signer is never deserialized.
+        LayoutKind::Signer => Err(RuntimeError::BCSSignerNotDeserializable.into()),
         LayoutKind::Struct { fields } => {
             for field in fields.iter() {
                 let field_layout = layouts.layout(field.id).ok_or_else(layout_not_found)?;
@@ -927,7 +931,9 @@ mod tests {
     use mono_move_core::{
         align_up_u32,
         types::U64_TY,
-        value_layout::{BOOL_LAYOUT_ID, U16_LAYOUT_ID, U64_LAYOUT_ID, U8_LAYOUT_ID},
+        value_layout::{
+            BOOL_LAYOUT_ID, SIGNER_LAYOUT_ID, U16_LAYOUT_ID, U64_LAYOUT_ID, U8_LAYOUT_ID,
+        },
         DescriptorId, FieldValueLayout, LayoutFlags, LayoutId, ValueLayoutTable,
     };
     use serde::Serialize;
@@ -939,6 +945,74 @@ mod tests {
 
     fn vector_layout(elem_id: LayoutId) -> ValueLayout {
         ValueLayout::vector(elem_id, DescriptorId(2))
+    }
+
+    #[test]
+    fn deserialize_rejects_signer() {
+        let table = ValueLayoutTable::new();
+        let layout = table.layout(SIGNER_LAYOUT_ID).unwrap();
+        assert!(layout.has_no_pointers_no_padding());
+        assert!(!layout.all_byte_patterns_valid());
+
+        let mut heap = Heap::new(64);
+        let bytes = [0u8; 32];
+        let mut slot = [0u8; 32];
+        let mut cursor = 0;
+        let result = unsafe {
+            deserialize_impl(
+                &table,
+                &mut heap,
+                layout,
+                &bytes,
+                &mut cursor,
+                slot.as_mut_ptr(),
+            )
+        };
+        assert!(matches!(
+            result,
+            Err(AllocationError::RuntimeError(
+                RuntimeError::BCSSignerNotDeserializable
+            ))
+        ));
+    }
+
+    #[test]
+    fn deserialize_rejects_signer_in_vector() {
+        let mut table = ValueLayoutTable::new();
+        let vid = table.push(U64_TY, vector_layout(SIGNER_LAYOUT_ID));
+        let layout = table.layout(vid).unwrap();
+        let mut heap = Heap::new(4096);
+        // Length 1, then a 32-byte address.
+        let mut bytes = vec![0x01u8];
+        bytes.extend_from_slice(&[0u8; 32]);
+        let mut slot = 0u64;
+        let mut cursor = 0;
+        let result = unsafe {
+            deserialize_impl(
+                &table,
+                &mut heap,
+                layout,
+                &bytes,
+                &mut cursor,
+                &mut slot as *mut u64 as *mut u8,
+            )
+        };
+        assert!(matches!(
+            result,
+            Err(AllocationError::RuntimeError(
+                RuntimeError::BCSSignerNotDeserializable
+            ))
+        ));
+    }
+
+    #[test]
+    fn serialize_signer_emits_address_bytes() {
+        let table = ValueLayoutTable::new();
+        let layout = table.layout(SIGNER_LAYOUT_ID).unwrap();
+        let addr = [7u8; 32];
+        let mut out = vec![];
+        unsafe { serialize_impl(&table, addr.as_ptr(), layout, &mut out).unwrap() };
+        assert_eq!(out, addr);
     }
 
     #[test]

--- a/third_party/move/mono-move/specializer/src/lower/gc_layout.rs
+++ b/third_party/move/mono-move/specializer/src/lower/gc_layout.rs
@@ -159,7 +159,8 @@ fn layout_pointer_offsets(layouts: &dyn LayoutProvider, id: LayoutId) -> VMResul
         LayoutKind::Bool
         | LayoutKind::UnsignedInt
         | LayoutKind::SignedInt
-        | LayoutKind::Address => vec![],
+        | LayoutKind::Address
+        | LayoutKind::Signer => vec![],
         LayoutKind::Ref
         | LayoutKind::Vector { .. }
         | LayoutKind::FrozenEnum { .. }

--- a/third_party/move/mono-move/testsuite/src/resource_provider.rs
+++ b/third_party/move/mono-move/testsuite/src/resource_provider.rs
@@ -157,6 +157,7 @@ fn collect_pointer_offsets(
         LayoutKind::Bool
         | LayoutKind::UnsignedInt
         | LayoutKind::SignedInt
-        | LayoutKind::Address => {},
+        | LayoutKind::Address
+        | LayoutKind::Signer => {},
     }
 }

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -345,6 +345,7 @@ fn classify_runtime_error(err: &RuntimeError) -> TestResult {
         | RuntimeError::BCSInvalidBool { .. }
         | RuntimeError::BCSSequenceTooLong { .. }
         | RuntimeError::BCSRemainingInput { .. }
+        | RuntimeError::BCSSignerNotDeserializable
         | RuntimeError::StackOverflow
         | RuntimeError::OutOfHeapMemory { .. }
         | RuntimeError::AllocationTooLarge { .. }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/from_bytes.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/from_bytes.move
@@ -9,6 +9,9 @@ module 0x1::from_bcs {
 module 0x1::util {
     public native fun from_bytes<T>(bytes: vector<u8>): T;
 }
+module 0x1::create_signer {
+    public native fun create_signer(addr: address): signer;
+}
 module 0x1::main {
     use std::bcs;
 
@@ -55,6 +58,19 @@ module 0x1::main {
     public fun trailing(): u64 {
         0x1::from_bcs::from_bytes<u64>(x"2a0000000000000000")
     }
+
+    // A signer serializes to its address but must never deserialize.
+    public fun signer_roundtrip() {
+        let s = 0x1::create_signer::create_signer(@0x123);
+        0x1::from_bcs::from_bytes<signer>(bcs::to_bytes(&s));
+    }
+
+    // A signer nested in a vector is rejected too.
+    public fun signer_in_vector() {
+        0x1::from_bcs::from_bytes<vector<signer>>(
+            x"010000000000000000000000000000000000000000000000000000000000000000"
+        );
+    }
 }
 
 // RUN: execute 0x1::main::from_bcs_u64
@@ -81,4 +97,10 @@ module 0x1::main {
 // CHECK: aborted: code 65537
 
 // RUN: execute 0x1::main::trailing
+// CHECK: aborted: code 65537
+
+// RUN: execute 0x1::main::signer_roundtrip
+// CHECK: aborted: code 65537
+
+// RUN: execute 0x1::main::signer_in_vector
 // CHECK: aborted: code 65537


### PR DESCRIPTION
## What

`from_bytes<signer>` on mono-move deserialized a signer as a plain address and returned it. The legacy VM aborts with `0x10001` (`EFROM_BYTES`). This makes mono-move match.

The cause: mono-move mapped `Type::Signer` to the same layout as `address`, so the deserializer saw 32 address bytes and copied them straight through.

## Fix

Give `signer` its own layout (`LayoutKind::Signer` / `SIGNER_LAYOUT_ID`), mirroring the legacy VM's separate `MoveTypeLayout::Signer`. Same shape as an address, but it drops the "all byte patterns valid" flag, so:

- Serialization still emits the address bytes (`bcs::to_bytes(&signer)` keeps working).
- Deserialization no longer takes the fast copy path, reaches the walk, and rejects with a new `BCSSignerNotDeserializable` error that the native turns into the `EFROM_BYTES` abort.

Nested signers (`vector<signer>`, `Option<signer>`) are rejected too: the specializer clears the flag on any struct/vector/enum that contains a signer, so the walk descends and hits the rejection.

## Tests

- New unit tests: signer rejected on its own and inside a vector; signer still serializes to its address bytes.
- The `aptos_framework_on_mono_move` suite goes from 10 failures to 9 — only `util::test_signer_roundtrip` flips to passing. The remaining 9 (`big_ordered_map_test`) pre-exist on `main` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BCS deserialization semantics for a core Move type and adds a new reserved layout ID; behavior is security-relevant but narrowly scoped with tests aligning to the legacy VM.
> 
> **Overview**
> **mono-move** no longer treats `signer` as the same layout as `address`, so `from_bytes<signer>` cannot deserialize address bytes into a signer (matching the legacy VM’s `EFROM_BYTES` abort).
> 
> `signer` gets its own reserved layout (`SIGNER_LAYOUT_ID`, `LayoutKind::Signer`) with the same 32-byte shape as `address` but **without** `ALL_BYTE_PATTERNS_VALID`. Serialization still memcpy’s the address bytes; deserialization takes the structured path and fails with **`BCSSignerNotDeserializable`**, which natives surface as invalid BCS. Nested signers (e.g. `vector<signer>`) are covered because aggregates only get the blit flag when no reachable field is a signer.
> 
> Supporting updates thread `LayoutKind::Signer` through GC layout walks, error classification (replay benchmark / unit tests), and new unit plus differential `from_bytes` tests for signer round-trip and vector cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43da8e1265ebebaf868e2a3f7ee0313e899da2c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->