### PR TITLE
[indexer] Improve table info parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "aptos-rocksdb-options",
  "aptos-schemadb",
  "aptos-storage-interface",
+ "aptos-temppath",
  "aptos-types",
  "bcs 0.1.4",
  "bytes",

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
@@ -452,13 +452,15 @@ pub fn convert_write_set_change(change: &WriteSetChange) -> transaction::WriteSe
             )),
         },
         WriteSetChange::DeleteTableItem(delete_table_item) => {
-            let data = delete_table_item.data.as_ref().unwrap_or_else(|| {
-                panic!(
-                    "Could not extract data from DeletedTableItem '{:?}' with handle '{:?}'",
-                    delete_table_item,
-                    delete_table_item.handle.to_string()
-                )
-            });
+            // Decoded `data` can be absent if the table was never indexed; emit the change
+            // without it instead of panicking (raw key bytes are still preserved).
+            let data = delete_table_item
+                .data
+                .as_ref()
+                .map(|data| transaction::DeleteTableData {
+                    key: data.key.to_string(),
+                    key_type: data.key_type.clone(),
+                });
 
             transaction::WriteSetChange {
                 r#type: transaction::write_set_change::Type::DeleteTableItem as i32,
@@ -469,10 +471,7 @@ pub fn convert_write_set_change(change: &WriteSetChange) -> transaction::WriteSe
                         ),
                         handle: delete_table_item.handle.to_string(),
                         key: delete_table_item.key.to_string(),
-                        data: Some(transaction::DeleteTableData {
-                            key: data.key.to_string(),
-                            key_type: data.key_type.clone(),
-                        }),
+                        data,
                     },
                 )),
             }
@@ -505,13 +504,17 @@ pub fn convert_write_set_change(change: &WriteSetChange) -> transaction::WriteSe
             )),
         },
         WriteSetChange::WriteTableItem(write_table_item) => {
-            let data = write_table_item.data.as_ref().unwrap_or_else(|| {
-                panic!(
-                    "Could not extract data from DecodedTableData '{:?}' with handle '{:?}'",
-                    write_table_item,
-                    write_table_item.handle.to_string(),
-                )
-            });
+            // Decoded `data` can be absent if the table was never indexed; emit the change
+            // without it instead of panicking (raw key/value bytes are still preserved).
+            let data = write_table_item
+                .data
+                .as_ref()
+                .map(|data| transaction::WriteTableData {
+                    key: data.key.to_string(),
+                    key_type: data.key_type.clone(),
+                    value: data.value.to_string(),
+                    value_type: data.value_type.clone(),
+                });
             transaction::WriteSetChange {
                 r#type: transaction::write_set_change::Type::WriteTableItem as i32,
                 change: Some(transaction::write_set_change::Change::WriteTableItem(
@@ -521,12 +524,7 @@ pub fn convert_write_set_change(change: &WriteSetChange) -> transaction::WriteSe
                         ),
                         handle: write_table_item.handle.to_string(),
                         key: write_table_item.key.to_string(),
-                        data: Some(transaction::WriteTableData {
-                            key: data.key.to_string(),
-                            key_type: data.key_type.clone(),
-                            value: data.value.to_string(),
-                            value_type: data.value_type.clone(),
-                        }),
+                        data,
                     },
                 )),
             }
@@ -1108,4 +1106,62 @@ fn convert_validator_transaction(
         },
         events: convert_events(api_validator_txn.events()),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_api_types::{
+        DeleteTableItem as ApiDeleteTableItem, HexEncodedBytes, WriteTableItem as ApiWriteTableItem,
+    };
+
+    // Converting a table item with no decoded `data` must not panic.
+
+    #[test]
+    fn write_table_item_without_decoded_data_does_not_panic() {
+        let change = WriteSetChange::WriteTableItem(ApiWriteTableItem {
+            state_key_hash: "0xdeadbeef".to_string(),
+            handle: HexEncodedBytes::from(vec![0x11, 0x22]),
+            key: HexEncodedBytes::from(vec![0x33]),
+            value: HexEncodedBytes::from(vec![0x44]),
+            data: None,
+        });
+
+        match convert_write_set_change(&change).change.unwrap() {
+            transaction::write_set_change::Change::WriteTableItem(item) => {
+                assert!(
+                    item.data.is_none(),
+                    "decoded data must be omitted, not faked"
+                );
+                assert_eq!(
+                    item.handle,
+                    HexEncodedBytes::from(vec![0x11, 0x22]).to_string()
+                );
+                assert_eq!(item.key, HexEncodedBytes::from(vec![0x33]).to_string());
+            },
+            other => panic!("expected WriteTableItem, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn delete_table_item_without_decoded_data_does_not_panic() {
+        let change = WriteSetChange::DeleteTableItem(ApiDeleteTableItem {
+            state_key_hash: "0xdeadbeef".to_string(),
+            handle: HexEncodedBytes::from(vec![0x55]),
+            key: HexEncodedBytes::from(vec![0x66]),
+            data: None,
+        });
+
+        match convert_write_set_change(&change).change.unwrap() {
+            transaction::write_set_change::Change::DeleteTableItem(item) => {
+                assert!(
+                    item.data.is_none(),
+                    "decoded data must be omitted, not faked"
+                );
+                assert_eq!(item.handle, HexEncodedBytes::from(vec![0x55]).to_string());
+                assert_eq!(item.key, HexEncodedBytes::from(vec![0x66]).to_string());
+            },
+            other => panic!("expected DeleteTableItem, got {:?}", other),
+        }
+    }
 }

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/table_info_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/table_info_service.rs
@@ -295,15 +295,9 @@ impl TableInfoService {
                     .await;
                 }
 
-                assert!(
-                    self.indexer_async_v2.is_indexer_async_v2_pending_on_empty(),
-                    "Missing data in table info parsing after sequential retry"
-                );
-
-                // Update rocksdb's to be processed next version after verifying all txns are successfully parsed
-                self.indexer_async_v2
-                    .update_next_version(end_version + 1)
-                    .unwrap();
+                // Drop any handles still unresolved after the retry and advance, so parsing
+                // keeps making progress instead of stalling on them.
+                self.indexer_async_v2.finalize_batch(end_version).unwrap();
 
                 res
             },

--- a/storage/indexer/Cargo.toml
+++ b/storage/indexer/Cargo.toml
@@ -36,5 +36,6 @@ once_cell = { workspace = true }
 [dev-dependencies]
 aptos-proptest-helpers = { workspace = true }
 aptos-schemadb = { workspace = true, features = ["fuzzing"] }
+aptos-temppath = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }
 rand = { workspace = true }

--- a/storage/indexer/src/db_v2.rs
+++ b/storage/indexer/src/db_v2.rs
@@ -9,7 +9,7 @@ use aptos_db_indexer_schemas::{
     metadata::{MetadataKey, MetadataValue},
     schema::{indexer_metadata::IndexerMetadataSchema, table_info::TableInfoSchema},
 };
-use aptos_logger::{info, sample, sample::SampleRate};
+use aptos_logger::{info, sample, sample::SampleRate, warn};
 use aptos_resource_viewer::{AptosValueAnnotator, MoveTableInfo};
 use aptos_schemadb::{batch::SchemaBatch, DB};
 use aptos_storage_interface::{
@@ -121,6 +121,20 @@ impl IndexerAsyncV2 {
         )?;
         self.next_version.store(end_version, Ordering::Relaxed);
         Ok(())
+    }
+
+    /// Advances past a processed batch. Any table handles that couldn't be resolved are
+    /// dropped (their items left undecoded) instead of blocking progress, so parsing never
+    /// gets stuck on a transaction it can't fully handle.
+    pub fn finalize_batch(&self, end_version: Version) -> Result<()> {
+        if !self.is_indexer_async_v2_pending_on_empty() {
+            warn!(
+                end_version = end_version,
+                "[DB] Dropping unresolved table handles and advancing past this batch."
+            );
+            self.clear_pending_on();
+        }
+        self.update_next_version(end_version + 1)
     }
 
     /// Finishes the parsing process and writes the parsed table information to a SchemaBatch.
@@ -338,5 +352,55 @@ impl<'a, R: StateView> TableInfoParser<'a, R> {
             Some(table_info) => Ok(Some(table_info.clone())),
             None => self.indexer_async_v2.get_table_info(handle),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db_ops::open_db;
+    use aptos_config::config::RocksdbConfig;
+    use aptos_temppath::TempPath;
+    use move_core_types::account_address::AccountAddress;
+
+    fn new_test_indexer(tmp: &TempPath) -> IndexerAsyncV2 {
+        tmp.create_as_dir().unwrap();
+        let db = open_db(
+            tmp.path(),
+            &RocksdbConfig::default(),
+            /*readonly=*/ false,
+        )
+        .unwrap();
+        IndexerAsyncV2::new(db).unwrap()
+    }
+
+    /// An unresolved handle is dropped and the processed version advances, rather than
+    /// blocking progress.
+    #[test]
+    fn finalize_batch_advances_past_unresolvable_handle() {
+        let tmp = TempPath::new();
+        let indexer = new_test_indexer(&tmp);
+
+        let handle = TableHandle(AccountAddress::ONE);
+        indexer
+            .pending_on
+            .entry(handle)
+            .or_default()
+            .insert(Bytes::from_static(b"orphan-table-item"));
+        assert!(
+            !indexer.is_indexer_async_v2_pending_on_empty(),
+            "precondition: the orphan handle should be parked"
+        );
+
+        let end_version: Version = 41;
+        indexer
+            .finalize_batch(end_version)
+            .expect("finalize_batch must not fail on an unresolvable handle");
+
+        assert!(
+            indexer.is_indexer_async_v2_pending_on_empty(),
+            "the unresolvable handle should have been dropped"
+        );
+        assert_eq!(indexer.next_version(), end_version);
     }
 }

--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -419,6 +419,9 @@ impl FatType {
             FatType::MutableReference(ty) | FatType::Reference(ty) | FatType::Vector(ty) => {
                 ty.contains_tables()
             },
+            // A function value's captured arguments aren't described by its static type, so
+            // assume it may hold tables and let the value traversal inspect the captures.
+            FatType::Function(_) => true,
             FatType::Bool
             | FatType::U8
             | FatType::U64
@@ -429,7 +432,6 @@ impl FatType {
             | FatType::U16
             | FatType::U32
             | FatType::U256
-            | FatType::Function(_)
             | FatType::I8
             | FatType::I16
             | FatType::I32

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -1082,6 +1082,32 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                 }
             },
 
+            (FatType::Function(_), MoveValue::Closure(closure)) => {
+                // Reconstruct a function value's captured argument types from its signature
+                // and recurse into any that can hold tables. If the types can't be resolved,
+                // skip the captures rather than failing the scan.
+                let MoveClosure {
+                    module_id,
+                    fun_id,
+                    ty_args,
+                    mask,
+                    captured,
+                } = *closure;
+                match self.resolve_captured_types(&module_id, &fun_id, &ty_args, mask, limit) {
+                    Ok(Some(captured_tys)) if captured_tys.len() == captured.len() => {
+                        for ((_layout, value), ty) in captured.into_iter().zip(captured_tys.iter())
+                        {
+                            if ty.contains_tables() {
+                                self.collect_table_info_from_value(ty, value, limit, infos)?;
+                            }
+                        }
+                    },
+                    // Nothing captured, an arity mismatch, or types we couldn't resolve: skip.
+                    Ok(_) | Err(_) => {},
+                }
+                Ok(())
+            },
+
             // Every other combo cannot harbor tables.
             (FatType::Bool, _)
             | (FatType::U8, _)


### PR DESCRIPTION
Robustness and coverage improvements to table info parsing, with tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: unresolved table handles are dropped and some table items may lack decoded types in indexer/gRPC output, though indexing progress is restored. Closure/table traversal changes affect what table metadata is extracted from on-chain values.
> 
> **Overview**
> Makes **table info indexing** and **gRPC write-set conversion** tolerate missing decoded table metadata instead of panicking or stalling.
> 
> **Indexer async v2 / table info service:** After parallel parsing and a sequential retry, batches call new **`finalize_batch`**, which logs and **drops unresolved `pending_on` table handles**, then advances the processed version. Unresolvable handles no longer block the pipeline (some table items may stay undecoded).
> 
> **move-resource-viewer:** **`FatType::Function`** is treated as possibly containing tables, and **`collect_table_info_from_value`** walks **closure captures** (when types resolve) so nested tables inside closures can be discovered; unresolved captures are skipped rather than failing the scan.
> 
> **indexer-grpc-fullnode `convert`:** **`WriteTableItem`** / **`DeleteTableItem`** emit protobuf changes with **`data: None`** when decoded table data is absent (unindexed tables), while raw handle/key/value bytes are still forwarded.
> 
> Tests cover missing decoded data in conversion, **`finalize_batch`** advancing past orphan handles, plus **`aptos-temppath`** for DB tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d9c59ab22cc94ca6a6694c2bedf82f0db71117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->