### PR TITLE
[vm] Gate module publishing on a minimum bytecode version

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -120,6 +120,7 @@ use move_binary_format::{
     deserializer::DeserializerConfig,
     errors::{Location, PartialVMError, PartialVMResult, VMError, VMResult},
     file_format::CompiledScript,
+    file_format_common::VERSION_5,
     CompiledModule,
 };
 use move_core_types::{
@@ -1803,6 +1804,7 @@ impl AptosVM {
         allowed_deps: Option<BTreeMap<AccountAddress, BTreeSet<String>>>,
     ) -> VMResult<()> {
         self.reject_unstable_bytecode(modules)?;
+        self.reject_legacy_module_bytecode(modules)?;
         native_validation::validate_module_natives(modules)?;
 
         for m in modules {
@@ -1850,6 +1852,29 @@ impl AptosVM {
             return Err(Self::metadata_validation_error(
                 "not all registered modules published",
             ));
+        }
+        Ok(())
+    }
+
+    /// Reject publishing of legacy (v5) module bytecode. Publishing only; modules already on chain
+    /// keep loading and executing at any version.
+    fn reject_legacy_module_bytecode(&self, modules: &[CompiledModule]) -> VMResult<()> {
+        if self
+            .timed_features()
+            .is_enabled(TimedFeatureFlag::RejectV5ModulePublishing)
+        {
+            for module in modules {
+                if module.version <= VERSION_5 {
+                    return Err(PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
+                        .with_message(format!(
+                            "publishing module bytecode version {} is not allowed; the minimum \
+                             publishable version is {}",
+                            module.version,
+                            VERSION_5 + 1
+                        ))
+                        .finish(Location::Undefined));
+                }
+            }
         }
         Ok(())
     }

--- a/aptos-move/e2e-move-tests/src/tests/legacy_bytecode_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/legacy_bytecode_publishing.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Tests for the v5 module publishing ban (`TimedFeatureFlag::RejectV5ModulePublishing`).
+//!
+//! The honest toolchain no longer emits v5, so these tests craft v5 bytecode by building the
+//! module at a current version and re-serializing it at version 5.
+
+use crate::{assert_success, assert_vm_status, MoveHarness};
+use aptos_cached_packages::aptos_stdlib;
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_package_builder::PackageBuilder;
+use aptos_types::{account_address::AccountAddress, on_chain_config::TimedFeatureFlag};
+use move_core_types::vm_status::StatusCode;
+
+const ADDR: &str = "0xa11ce";
+
+// Trivial, dependency-free module so the build is fast.
+const SOURCE: &str = r#"
+module 0xa11ce::legacy {
+    struct Marker has key { v: u64 }
+
+    public entry fun create(s: &signer) {
+        move_to(s, Marker { v: 1 });
+    }
+}
+"#;
+
+fn addr() -> AccountAddress {
+    AccountAddress::from_hex_literal(ADDR).unwrap()
+}
+
+/// Re-serializes each module at bytecode version 5, stripping the v7/v8 file-format fields the
+/// current compiler emits (which can't exist at v5).
+fn code_at_v5(package: &BuiltPackage) -> Vec<Vec<u8>> {
+    package
+        .modules()
+        .map(|module| {
+            let mut module = module.clone();
+            module.version = 5;
+            for handle in &mut module.function_handles {
+                handle.attributes.clear();
+                handle.access_specifiers = None;
+            }
+            let mut bytes = vec![];
+            module
+                .serialize_for_version(Some(5), &mut bytes)
+                .expect("re-serializing module at v5 must succeed");
+            bytes
+        })
+        .collect()
+}
+
+#[test]
+fn legacy_v5_module_publishing_is_gated() {
+    let mut builder = PackageBuilder::new("Legacy");
+    builder.add_source("legacy.move", SOURCE);
+    // Keep `pkg_dir` alive: metadata/code extraction reads the sources back from disk.
+    let pkg_dir = builder.write_to_temp().unwrap();
+    let package = BuiltPackage::build(
+        pkg_dir.path().to_path_buf(),
+        BuildOptions::move_2().set_latest_language(),
+    )
+    .expect("building package must succeed");
+    let metadata = bcs::to_bytes(&package.extract_metadata().unwrap()).unwrap();
+    let code_v5 = code_at_v5(&package);
+
+    // Gate off: v5 publishes.
+    {
+        let mut h = MoveHarness::new_testnet();
+        h.set_timed_feature(TimedFeatureFlag::RejectV5ModulePublishing, false);
+        let account = h.new_account_at(addr());
+        assert_success!(h.run_transaction_payload(
+            &account,
+            aptos_stdlib::code_publish_package_txn(metadata.clone(), code_v5.clone()),
+        ));
+    }
+
+    // Gate on: v5 is rejected.
+    {
+        let mut h = MoveHarness::new_testnet();
+        h.set_timed_feature(TimedFeatureFlag::RejectV5ModulePublishing, true);
+        let account = h.new_account_at(addr());
+        assert_vm_status!(
+            h.run_transaction_payload(
+                &account,
+                aptos_stdlib::code_publish_package_txn(metadata.clone(), code_v5.clone()),
+            ),
+            StatusCode::CONSTRAINT_NOT_SATISFIED
+        );
+    }
+
+    // Gate on: a modern (v6+) build still publishes (no false positives).
+    {
+        let mut h = MoveHarness::new_testnet();
+        h.set_timed_feature(TimedFeatureFlag::RejectV5ModulePublishing, true);
+        let account = h.new_account_at(addr());
+        let txn = h.create_publish_built_package(&account, &package, |_| {});
+        assert_success!(h.run(txn));
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -45,6 +45,7 @@ mod keyless_feature_gating;
 mod large_package_publishing;
 mod layout_caches;
 mod lazy_natives;
+mod legacy_bytecode_publishing;
 mod macros;
 mod max_loop_depth;
 mod memory_quota;

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -50,6 +50,10 @@ pub enum TimedFeatureFlag {
     /// of same struct nodes, counting cache hits as 1 node instead of re-expanding its full
     /// subtree.
     ConstantSerializedSizeLocalCache,
+
+    /// Reject publishing of v5 module bytecode. Publishing only; already-published modules keep
+    /// loading and executing at any version.
+    RejectV5ModulePublishing,
 }
 
 /// Representation of features that are gated by the block timestamps.
@@ -96,7 +100,8 @@ impl TimedFeatureOverride {
                 | UseFullTransactionSizeForGasCheck
                 | EnableStrictBoundsInProdConfig
                 | RevisedBoundsInProdConfig
-                | ConstantSerializedSizeLocalCache,
+                | ConstantSerializedSizeLocalCache
+                | RejectV5ModulePublishing,
             ) => None,
         }
     }
@@ -232,6 +237,16 @@ impl TimedFeatureFlag {
                 .with_timezone(&Utc),
             (ConstantSerializedSizeLocalCache, MAINNET) => Los_Angeles
                 .with_ymd_and_hms(2026, 3, 13, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // Security hardening: ban publishing of v5 module bytecode.
+            (RejectV5ModulePublishing, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 7, 24, 17, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (RejectV5ModulePublishing, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 7, 29, 12, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 


### PR DESCRIPTION
Gates module publishing on a minimum bytecode version (rejects v5), behind the `RejectV5ModulePublishing` timed feature.

Publish-path only — modules already on chain continue to load and execute at any version. A modern (v6+) build is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VM publish validation on a security-sensitive path, but behavior is time-gated and limited to new publishes; existing on-chain code keeps running.
> 
> **Overview**
> Adds **publish-time rejection of Move module bytecode at version 5 or below**, gated by the new timed feature `RejectV5ModulePublishing`. When the flag is on, `validate_publish_request` fails with `CONSTRAINT_NOT_SATISFIED` and a message that the minimum publishable version is v6; when off, behavior is unchanged.
> 
> **Scope is publish-only:** modules already on chain are not affected for load/execute. Modern v6+ publishes are unchanged when the gate is enabled.
> 
> Scheduled activation is wired for testnet (2026-07-24) and mainnet (2026-07-29). E2E coverage builds synthetic v5 modules (re-serialize from a current build) and checks publish succeeds with the flag off, fails with it on, and current-version packages still publish with the flag on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768940eba2a1f24ce4b0e3f082ed66d560b072a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->