### PR TITLE
[github] Fix replay-verify job-level permissions

### DIFF
--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -91,6 +91,7 @@ jobs:
   build-images:
     needs: validate-inputs
     permissions:
+      contents: read
       id-token: write
     secrets: inherit
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
@@ -105,6 +106,7 @@ jobs:
     timeout-minutes: 420 # 7 hours
     needs: build-images
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

The replay-verify (on archive) workflows are currently broken with a workflow validation error:

```
Error calling workflow 'aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main'.
The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
```

**Root cause:** #20171 added job-level `permissions:` blocks with only `id-token: write` to `workflow-run-replay-verify-on-archive.yaml`. A job-level `permissions:` block *replaces* the workflow-level grant rather than merging with it, so `contents` dropped to `none` for those jobs. The `build-images` job calls the reusable `workflow-run-docker-rust-build.yaml`, which declares `contents: read` at its workflow level — and GitHub refuses to let a called workflow request more than its caller job grants, so the whole workflow fails validation and never runs.

**Fix:** grant `contents: read` in both job-level permission blocks:
- `build-images` — required to satisfy the called reusable workflow's permission request (this is what fixes the validation error).
- `run-replay-verify` — it runs `actions/checkout` with the job token; it only worked without the scope because the repo is public. This restores the intent of the workflow-level grant.

Verified by cross-checking every job in `.github/workflows/` that calls an in-repo reusable workflow against the callee's requested permissions — no remaining mismatches (the callers in `docker-build-test.yaml` and the testnet/mainnet entry points inherit sufficient workflow-level grants).

Note: `build-images` references the callee `@main`, so the fix takes effect once merged to main.

## How Has This Been Tested?

Static validation only (YAML parse + permission cross-check script); the workflow itself can only be exercised once this lands on main since the reusable workflow is pinned `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission YAML changes with no application or data-path impact.
> 
> **Overview**
> Fixes **replay-verify on archive** workflow validation failures caused by job-level `permissions` overriding the workflow grant and leaving `contents` at `none`.
> 
> Adds **`contents: read`** alongside existing **`id-token: write`** on the **`build-images`** and **`run-replay-verify`** jobs so the caller can invoke **`workflow-run-docker-rust-build.yaml`** (which requires `contents: read`) and so **`actions/checkout`** in **`run-replay-verify`** has an explicit read scope instead of relying on a public-repo default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925b427d14dd950f6308d918d72c9bb12c39b019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->