### PR TITLE
[mono-move] Lightweight translation validation: CFG equivalence of stackless execution IR with bytecode

### DIFF
--- a/third_party/move/mono-move/specializer/src/destack/analysis.rs
+++ b/third_party/move/mono-move/specializer/src/destack/analysis.rs
@@ -77,80 +77,16 @@
 //! upstream `MutBorrowLoc` (or `MutBorrowLocField`). (Field-level
 //! coalescing, if ever added, would need to revisit this.)
 
-#[cfg(debug_assertions)]
-use crate::stackless_exec_ir::instr_utils::for_each_value_use;
 use crate::stackless_exec_ir::{
-    instr_utils::{
-        call_boundary_rets_and_args, clobbers_transfer, for_each_def, for_each_use,
-        mut_local_borrow_target,
-    },
-    HomeIndex, Instr, NamedSlot, SsaSlot, TransferPosition,
+    instr_utils::{clobbers_transfer, for_each_def, for_each_use, mut_local_borrow_target},
+    HomeIndex, Instr, SsaSlot, TransferPosition,
 };
 #[cfg(debug_assertions)]
-use mono_move_core::{ExecutionErrorKind, IntoExecutionError, VMInternalError, VMResult};
+use crate::validate::transfer::check_call_structural_invariants;
 use shared_dsa::{UnorderedMap, UnorderedSet};
 use smallbitvec::SmallBitVec;
 #[cfg(debug_assertions)]
 use std::collections::BTreeMap;
-#[cfg(debug_assertions)]
-use thiserror::Error;
-
-#[cfg(debug_assertions)]
-#[derive(Debug, Error)]
-enum TransferVerifierError {
-    #[error("post-optimize Transfer verifier: block {block}, instr {instr}: {inner}")]
-    TransferCallStructural {
-        block: usize,
-        instr: usize,
-        inner: Box<TransferVerifierError>,
-    },
-
-    #[error(
-        "arg positionality: args[{arg_idx}] resolves to Transfer({got}), expected Transfer({arg_idx})"
-    )]
-    TransferArgPositionality { arg_idx: usize, got: u16 },
-
-    #[error(
-        "return Transfer prefix: rets[{ret_idx}] resolves to Transfer({got}) after a non-Transfer ret"
-    )]
-    TransferReturnPrefix { ret_idx: usize, got: u16 },
-
-    #[error("return monotonicity: rets[{ret_idx}] = Transfer({got}) <= prev Transfer({prev})")]
-    TransferReturnNotMonotonic { ret_idx: usize, got: u16, prev: u16 },
-
-    #[error("post-optimize Transfer verifier: block {block}, instr {instr}: use of Transfer({transfer}) with no live def earlier in this block")]
-    TransferUseWithoutLiveDef {
-        block: usize,
-        instr: usize,
-        transfer: u16,
-    },
-
-    #[error("post-optimize Transfer verifier: block {block}, instr {instr}: Transfer({transfer}) bound at call boundary but not consumed as args[{transfer}]")]
-    TransferBoundNotConsumed {
-        block: usize,
-        instr: usize,
-        transfer: u16,
-    },
-
-    #[error("post-optimize Transfer verifier: block {block}: Transfer({transfer}) bound at block end (Transfer lifetimes must be block-local)")]
-    TransferBoundAtBlockEnd { block: usize, transfer: u16 },
-}
-
-#[cfg(debug_assertions)]
-impl IntoExecutionError for TransferVerifierError {
-    fn kind(&self) -> ExecutionErrorKind {
-        use TransferVerifierError::*;
-        match self {
-            TransferCallStructural { .. }
-            | TransferArgPositionality { .. }
-            | TransferReturnPrefix { .. }
-            | TransferReturnNotMonotonic { .. }
-            | TransferUseWithoutLiveDef { .. }
-            | TransferBoundNotConsumed { .. }
-            | TransferBoundAtBlockEnd { .. } => ExecutionErrorKind::InvariantViolation,
-        }
-    }
-}
 
 /// Analysis results for a single basic block. All map keys are `ValueId`s.
 pub(crate) struct BlockAnalysis {
@@ -562,58 +498,6 @@ fn next_arg_lifetime_overlaps(
     !(a_lu <= b_def || b_lu <= a_def)
 }
 
-/// Check the per-call structural Transfer invariants:
-///
-/// - **Arg positionality** (invariant 2): if `args[j]` resolves to
-///   `Transfer(i)`, then `i == j`.
-/// - **Return Transfer prefix** (invariant 5): the rets list is a
-///   (possibly empty) Transfer-resolved prefix followed by a non-Transfer
-///   suffix.
-/// - **Return monotonicity** (invariant 3): within the Transfer prefix,
-///   resolved Transfer indices strictly increase.
-#[cfg(debug_assertions)]
-fn check_call_structural_invariants<SlotForm, F>(
-    args: &[SlotForm],
-    rets: &[SlotForm],
-    transfer_pos: F,
-) -> Result<(), TransferVerifierError>
-where
-    F: Fn(&SlotForm) -> Option<u16>,
-{
-    for (j, slot) in args.iter().enumerate() {
-        if let Some(i) = transfer_pos(slot)
-            && i as usize != j
-        {
-            return Err(TransferVerifierError::TransferArgPositionality { arg_idx: j, got: i });
-        }
-    }
-
-    let mut seen_non_transfer = false;
-    let mut last_transfer: Option<u16> = None;
-    for (k, slot) in rets.iter().enumerate() {
-        match transfer_pos(slot) {
-            Some(i) => {
-                if seen_non_transfer {
-                    return Err(TransferVerifierError::TransferReturnPrefix { ret_idx: k, got: i });
-                }
-                if let Some(prev) = last_transfer
-                    && i <= prev
-                {
-                    return Err(TransferVerifierError::TransferReturnNotMonotonic {
-                        ret_idx: k,
-                        got: i,
-                        prev,
-                    });
-                }
-                last_transfer = Some(i);
-            },
-            None => seen_non_transfer = true,
-        }
-    }
-
-    Ok(())
-}
-
 /// Verifies the seven Transfer invariants from the file header on the
 /// just-built `transfer_precolor` map. Per-call invariants (arg
 /// positionality, return monotonicity, pass-through contiguity, return
@@ -829,128 +713,6 @@ fn has_any_in_range(sorted: &[usize], lo: usize, hi: usize) -> bool {
     // Find the first element >= lo.
     let idx = sorted.partition_point(|&x| x < lo);
     idx < sorted.len() && sorted[idx] < hi
-}
-
-/// Verify that the post-optimize, slot-allocated IR satisfies the
-/// Transfer-slot invariants the lowering depends on.
-///
-/// The seven invariants at the top of this file are established by
-/// `BlockAnalysis::analyze` on the SSA-form IR, before slot allocation, but are not
-/// re-checked through `optimize_module`. This walk re-checks the
-/// subset that survives slot allocation:
-///
-/// 1. Every use of `Transfer(j)` is preceded by a def in the same block.
-/// 2. At a call boundary, every bound Transfer slot is consumed by the
-///    call's args (orphans signal an upstream regression).
-/// 3. Calls clobber every Transfer slot; ret defs re-bind on the same
-///    instruction.
-/// 4. No Transfer binding leaks across a block boundary.
-/// 5. Per-call structural invariants — arg positionality, return
-///    Transfer prefix, return monotonicity — via
-///    `check_call_structural_invariants`, the same helper
-///    `assert_transfer_invariants` uses on the ValueId-level maps.
-///
-/// Pass-through contiguity (invariant 4 in the header) is not
-/// checked here: it requires distinguishing bound positions that
-/// came from the previous call's rets from positions defined by
-/// intermediate non-call instrs, which this walk doesn't track.
-#[cfg(debug_assertions)]
-pub(crate) fn assert_transfer_invariants_on_final_ir(
-    func: &crate::stackless_exec_ir::FunctionIR,
-) -> VMResult<()> {
-    let num_transfer = func.num_transfer_positions as usize;
-    let mut bound: Vec<bool> = vec![false; num_transfer];
-    for (b_idx, block) in func.blocks.iter().enumerate() {
-        // Block-local lifetime: a fresh state at every block.
-        bound.iter_mut().for_each(|b| *b = false);
-        for (i, instr) in block.instrs.iter().enumerate() {
-            // (1) every Transfer value use must be live.
-            let mut unbound: Option<u16> = None;
-            for_each_value_use(instr, |s| {
-                if let NamedSlot::Transfer(j) = s
-                    && !bound[j.0 as usize]
-                    && unbound.is_none()
-                {
-                    unbound = Some(j.0);
-                }
-            });
-            if let Some(j) = unbound {
-                return Err(VMInternalError::new(
-                    TransferVerifierError::TransferUseWithoutLiveDef {
-                        block: b_idx,
-                        instr: i,
-                        transfer: j,
-                    },
-                ));
-            }
-
-            // (2) at a call boundary, every bound Transfer slot must
-            // be consumed by this call's args as args[j] = Transfer(j)
-            // (arg positionality).
-            if let Some((rets, args)) = call_boundary_rets_and_args(instr) {
-                // Structural invariants (arg positionality, return Transfer prefix,
-                // return monotonicity).
-                check_call_structural_invariants(args, rets, |s| match s {
-                    NamedSlot::Transfer(i) => Some(i.0),
-                    NamedSlot::Home(_) => None,
-                })
-                .map_err(|e| TransferVerifierError::TransferCallStructural {
-                    block: b_idx,
-                    instr: i,
-                    inner: Box::new(e),
-                })?;
-                // Orphan check: every bound slot must be consumed
-                // by this call's args. A bound position not in args
-                // signals a dead Transfer def from earlier in the block.
-                for (j, &b) in bound.iter().enumerate() {
-                    if b {
-                        let consumed_here = j < args.len()
-                            && args[j] == NamedSlot::Transfer(TransferPosition(j as u16));
-                        if !consumed_here {
-                            return Err(VMInternalError::new(
-                                TransferVerifierError::TransferBoundNotConsumed {
-                                    block: b_idx,
-                                    instr: i,
-                                    transfer: j as u16,
-                                },
-                            ));
-                        }
-                    }
-                }
-                // Clobber: a call reuses the entire callee region;
-                // the ret defs below re-bind whatever positions
-                // this call returns to.
-                bound.iter_mut().for_each(|b| *b = false);
-            } else {
-                // Non-call: value uses release their bindings (single-use).
-                for_each_value_use(instr, |s| {
-                    if let NamedSlot::Transfer(j) = s {
-                        bound[j.0 as usize] = false;
-                    }
-                });
-            }
-            // Defs bind: ret-Transfers for calls, Move/Copy dst (etc.)
-            // for non-calls.
-            for_each_def(instr, |s| {
-                if let NamedSlot::Transfer(j) = s {
-                    bound[j.0 as usize] = true;
-                }
-            });
-        }
-
-        // (3) no Transfer binding may survive past the end of a block.
-        for (j, &b) in bound.iter().enumerate() {
-            if b {
-                return Err(VMInternalError::new(
-                    TransferVerifierError::TransferBoundAtBlockEnd {
-                        block: b_idx,
-                        transfer: j as u16,
-                    },
-                ));
-            }
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/third_party/move/mono-move/specializer/src/destack/mod.rs
+++ b/third_party/move/mono-move/specializer/src/destack/mod.rs
@@ -42,10 +42,10 @@ pub fn destack(module: CompiledModule, interner: &impl Interner) -> VMResult<Mod
     // over-approximating (charging for instructions that optimization removes).
     gas::instrument(&mut module_ir, interner)?;
 
-    // Debug-mode failsafe: verify transfer invariants hold after optimization.
+    // Debug-mode failsafe: lightweight translation validation of the final
+    // IR against the bytecode it was translated from (CFG equivalence +
+    // transfer invariants).
     #[cfg(debug_assertions)]
-    for func in module_ir.functions.iter().flatten() {
-        analysis::assert_transfer_invariants_on_final_ir(func)?;
-    }
+    crate::validate::validate_module(&module_ir)?;
     Ok(module_ir)
 }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -8,9 +8,12 @@
 //! are mutable across blocks and keep their original slot indices.
 
 use super::ssa_function::SSAFunction;
-use crate::stackless_exec_ir::{
-    BasicBlock, BinaryOp, CallClosureData, CallData, CmpKind, HomeIndex, ImmValue, Instr, Label,
-    PackClosureData, SsaSlot, UnaryOp,
+use crate::{
+    stackless_exec_ir::{
+        BasicBlock, BinaryOp, CallClosureData, CallData, CmpKind, HomeIndex, ImmValue, Instr,
+        Label, PackClosureData, SsaSlot, UnaryOp,
+    },
+    validate::TranslationWitness,
 };
 use mono_move_core::{
     convert_mut_to_immut_ref, strip_ref,
@@ -372,15 +375,21 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
         }
     }
 
-    /// Converts the function's bytecode into SSA form, consuming the converter.
+    /// Converts the function's bytecode into SSA form, consuming the
+    /// converter. Also returns the translation witness: the label-to-offset
+    /// map recorded here, carried on the final IR for translation
+    /// validation.
     pub(crate) fn convert_function(
         mut self,
         module: &PreparedModule,
         code: &[Bytecode],
-    ) -> VMResult<SSAFunction> {
+    ) -> VMResult<(SSAFunction, TranslationWitness)> {
         self.assign_labels(code);
 
         let block_boundaries = split_bytecode_into_blocks(code, &self.label_map)?;
+
+        // Labels are dense over block starts, so one entry per block.
+        let mut label_to_offset: Vec<CodeOffset> = vec![0; block_boundaries.len()];
 
         for block in block_boundaries {
             if !self.stack.is_empty() {
@@ -391,6 +400,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
 
             // Every block gets a label (assigned on-demand if not already a branch target).
             let label = self.get_or_create_label(block.start as CodeOffset);
+            label_to_offset[label.0 as usize] = block.start as CodeOffset;
             self.start_new_block(label);
 
             for bc in &code[block] {
@@ -399,11 +409,12 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
         }
         self.finalize_current_block();
 
-        Ok(SSAFunction {
+        let ssa = SSAFunction {
             blocks: self.blocks,
             value_id_types: self.value_id_types,
             local_types: self.local_types,
-        })
+        };
+        Ok((ssa, TranslationWitness { label_to_offset }))
     }
 
     /// Converts a single stack-based bytecode into slot-based SSA instruction(s).

--- a/third_party/move/mono-move/specializer/src/destack/translate.rs
+++ b/third_party/move/mono-move/specializer/src/destack/translate.rs
@@ -59,10 +59,8 @@ pub fn translate_module(module: PreparedModule, interner: &impl Interner) -> VMR
 
             // Pass: Bytecode -> Intra-Block SSA -> Fusion
             let converter = SsaConverter::new(local_types, interner);
-            let ssa = converter
-                .convert_function(&module, &code.code)?
-                .with_fusion_passes()
-                .with_test_utils_passes(&module)?;
+            let (ssa, witness) = converter.convert_function(&module, &code.code)?;
+            let ssa = ssa.with_fusion_passes().with_test_utils_passes(&module)?;
 
             // Pass: Greedy Slot Allocation (consumes SSA, produces named-slot IR)
             let alloc = super::slot_alloc::allocate_slots(ssa)?;
@@ -78,6 +76,7 @@ pub fn translate_module(module: PreparedModule, interner: &impl Interner) -> VMR
                 home_slot_types: alloc.home_slot_types,
                 // Populated by the gas instrumentation pass.
                 block_costs: Vec::new(),
+                witness,
             }))
         })
         .collect::<VMResult<Vec<_>>>()?;

--- a/third_party/move/mono-move/specializer/src/lib.rs
+++ b/third_party/move/mono-move/specializer/src/lib.rs
@@ -6,6 +6,8 @@ pub mod stackless_exec_ir;
 pub mod destack;
 mod gas;
 pub mod lower;
+pub mod validate;
 
 pub use destack::destack;
 pub use stackless_exec_ir::{FunctionIR, ModuleIR};
+pub use validate::{validate_module, ValidationError, ValidationResult};

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -703,11 +703,10 @@ pub fn try_build_context<'a>(
             CalleeRegion::Skip(reason) => return Ok(BuildContextOutcome::Skipped(reason)),
         };
         let (callee_module_id, callee_func_name) = callee_identity(&module_ir.module, handle_idx);
-        // TODO(correctness): The native registry is trusted unconditionally here.
-        //
-        // Consider cross-checking against the callee module's `is_native` flag
-        // against the callee module's `is_native` flag so a registered impl cannot
-        // shadow a Move-body function with the same qualified name.
+        // TODO(correctness): The native registry is trusted unconditionally
+        // here. Consider cross-checking against the callee module's
+        // `is_native` flag so a registered impl cannot shadow a Move-body
+        // function with the same qualified name.
         let native_idx = natives.resolve(callee_module_id, callee_func_name, call_ty_args);
         // Descriptor IDs for the native's resource types (published by the
         // discovery pass, keyed on the concrete type); e.g. `add_box` uses its

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
@@ -33,7 +33,9 @@
 //!   caller-provided closures (`impl FnMut`) are monomorphized and inlined
 //!   at each call site.
 
-use super::{BinaryOp, CallClosureData, CallData, FieldPath, Instr, PackClosureData};
+use super::{
+    BasicBlock, BinaryOp, CallClosureData, CallData, FieldPath, Instr, Label, PackClosureData,
+};
 use mono_move_core::types::InternedType;
 use smallvec::SmallVec;
 
@@ -535,20 +537,65 @@ pub(crate) fn chain_field_path<SlotForm>(instr: &Instr<SlotForm>) -> Option<&Fie
     }
 }
 
-/// Whether `instr` is a terminator that falls through to the next block.
-#[inline]
-pub(crate) fn is_fallthrough_terminator<SlotForm>(instr: &Instr<SlotForm>) -> bool {
-    match instr {
-        Instr::BrTrue { .. }
-        | Instr::BrFalse { .. }
-        | Instr::BrCmp { .. }
-        | Instr::BrCmpImm { .. } => true,
+/// Which conditional terminator ends a block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CondJumpKind {
+    BrTrue,
+    BrFalse,
+    BrCmp,
+    BrCmpImm,
+}
 
-        Instr::Branch { .. }
-        | Instr::Ret { .. }
-        | Instr::Abort { .. }
-        | Instr::AbortMsg { .. }
-        | Instr::LdConst { .. }
+/// Which function-exit terminator ends a block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ExitKind {
+    Ret,
+    Abort,
+    AbortMsg,
+}
+
+/// Derived classification of how a basic block ends.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BlockExit {
+    /// Unconditional jump.
+    Jump { target: Label },
+    /// Conditional jump; falls through to the next block in layout order
+    /// when not taken.
+    CondJump { taken: Label, kind: CondJumpKind },
+    /// No instructions, or the last instruction is not a terminator:
+    /// control continues at the next block in layout order.
+    FallThrough,
+    /// Function exit.
+    Exit(ExitKind),
+}
+
+/// The [`BlockExit`] contributed by `instr` when it is a block's last
+/// instruction; `None` when `instr` is not a terminator.
+pub(crate) fn exit_of_instr<SlotForm>(instr: &Instr<SlotForm>) -> Option<BlockExit> {
+    match instr {
+        Instr::Branch { target } => Some(BlockExit::Jump { target: *target }),
+        Instr::BrTrue { target, .. } => Some(BlockExit::CondJump {
+            taken: *target,
+            kind: CondJumpKind::BrTrue,
+        }),
+        Instr::BrFalse { target, .. } => Some(BlockExit::CondJump {
+            taken: *target,
+            kind: CondJumpKind::BrFalse,
+        }),
+        Instr::BrCmp { target, .. } => Some(BlockExit::CondJump {
+            taken: *target,
+            kind: CondJumpKind::BrCmp,
+        }),
+        Instr::BrCmpImm { target, .. } => Some(BlockExit::CondJump {
+            taken: *target,
+            kind: CondJumpKind::BrCmpImm,
+        }),
+        Instr::Ret { .. } => Some(BlockExit::Exit(ExitKind::Ret)),
+        Instr::Abort { .. } => Some(BlockExit::Exit(ExitKind::Abort)),
+        Instr::AbortMsg { .. } => Some(BlockExit::Exit(ExitKind::AbortMsg)),
+
+        // Every other instruction: not a terminator.
+        Instr::LdConst { .. }
         | Instr::LdImm { .. }
         | Instr::Copy { .. }
         | Instr::Move { .. }
@@ -600,8 +647,25 @@ pub(crate) fn is_fallthrough_terminator<SlotForm>(instr: &Instr<SlotForm>) -> bo
         | Instr::VecPopBack { .. }
         | Instr::VecUnpack { .. }
         | Instr::VecSwap { .. }
-        | Instr::ForceGC => false,
+        | Instr::ForceGC => None,
     }
+}
+
+/// Classify how `block` ends. An empty block falls through.
+#[inline]
+pub(crate) fn classify_exit<SlotForm>(block: &BasicBlock<SlotForm>) -> BlockExit {
+    block
+        .instrs
+        .last()
+        .and_then(exit_of_instr)
+        .unwrap_or(BlockExit::FallThrough)
+}
+
+/// Whether `instr` is a terminator that falls through to the next block
+/// when not taken — i.e., a conditional branch.
+#[inline]
+pub(crate) fn is_fallthrough_terminator<SlotForm>(instr: &Instr<SlotForm>) -> bool {
+    matches!(exit_of_instr(instr), Some(BlockExit::CondJump { .. }))
 }
 
 /// Whether a binary operation is commutative (i.e., operands can be swapped

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -9,7 +9,7 @@
 mod display;
 pub(crate) mod instr_utils;
 
-use crate::gas::BlockCost;
+use crate::{gas::BlockCost, validate::TranslationWitness};
 pub use mono_move_core::CmpKind;
 use mono_move_core::{
     types::{InternedType, InternedTypeList},
@@ -740,8 +740,21 @@ impl<SlotForm> Instr<SlotForm> {
 /// A basic block of instructions, generic over the slot form like
 /// [`Instr`].
 ///
-/// Every block has a label. The last instruction is a terminator.
-/// (`Branch`, `BrTrue`, `BrFalse`, `Ret`, `Abort`, `AbortMsg`).
+/// Every block has a label. A block ends with a terminator (a branch,
+/// return, or abort) OR falls through — possibly with no instructions at
+/// all — to the next block in layout order:
+///
+/// ```text
+/// LL1:  op
+///       br_true LL3
+///       // fallthrough to LL2
+/// LL2:  op
+///       ...
+/// LL3:  op
+///       ...
+/// ```
+///
+/// See `instr_utils::classify_exit` for the derived exit classification.
 pub struct BasicBlock<SlotForm> {
     /// Label identifying this block.
     pub label: Label,
@@ -772,6 +785,9 @@ pub struct FunctionIR {
     pub home_slot_types: Vec<InternedType>,
     /// Gas cost of each block as an unresolved formula, indexed by block label.
     pub(crate) block_costs: Vec<BlockCost>,
+    /// Untrusted witness for translation validation — never read by
+    /// execution or lowering. See [`TranslationWitness`].
+    pub(crate) witness: TranslationWitness,
 }
 
 impl FunctionIR {

--- a/third_party/move/mono-move/specializer/src/validate/cfg_equivalence.rs
+++ b/third_party/move/mono-move/specializer/src/validate/cfg_equivalence.rs
@@ -1,0 +1,794 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! CFG equivalence between the final IR and the original bytecode, checked
+//! under the carried [`TranslationWitness`].
+//!
+//! The check is linear: the witness supplies the block bijection, so no
+//! isomorphism search is needed. Every edge is checked on both sides — the
+//! IR exit kind against the bytecode opcode at the block's exit — so a
+//! dropped, inserted, redirected, or kind-swapped edge fails even when the
+//! witness is corrupted consistently with the bug.
+//!
+//! The pass is structural: it certifies edges, not the semantics that
+//! select them.
+//!
+//! The bytecode-side oracle is [`VMControlFlowGraph`] from
+//! `move-binary-format`, not the specializer's own block splitter.
+
+use super::{FuncCtx, TranslationWitness};
+use crate::stackless_exec_ir::{
+    instr_utils::{classify_exit, exit_of_instr, BlockExit, CondJumpKind, ExitKind},
+    BasicBlock, NamedSlot,
+};
+use mono_move_core::{ExecutionErrorKind, IntoExecutionError};
+use move_binary_format::{
+    control_flow_graph::{ControlFlowGraph, VMControlFlowGraph},
+    file_format::{Bytecode, CodeOffset},
+};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum CfgEquivalenceError {
+    #[error("witness has {witness_len} entries for {num_blocks} IR blocks")]
+    WitnessLengthMismatch {
+        witness_len: usize,
+        num_blocks: usize,
+    },
+
+    #[error("block L{label}: terminator {opcode} at non-final position {position}")]
+    InteriorTerminator {
+        label: u16,
+        position: usize,
+        opcode: &'static str,
+    },
+
+    #[error("{num_ir_blocks} IR blocks vs {num_bytecode_blocks} bytecode blocks")]
+    BlockCountMismatch {
+        num_ir_blocks: usize,
+        num_bytecode_blocks: usize,
+    },
+
+    #[error("label L{label} is out of witness range")]
+    LabelOutOfRange { label: u16 },
+
+    #[error(
+        "block {block_idx} maps to offset {offset}, not after predecessor's offset {prev} \
+         (blocks must map to strictly increasing bytecode offsets)"
+    )]
+    WitnessNotMonotone {
+        block_idx: usize,
+        offset: CodeOffset,
+        prev: CodeOffset,
+    },
+
+    #[error("block L{label} maps to bytecode offset {offset}, expected block start {expected}")]
+    BlockStartMismatch {
+        label: u16,
+        offset: CodeOffset,
+        expected: CodeOffset,
+    },
+
+    #[error(
+        "block L{label} (bytecode block at {start}): IR exits via {ir_exit} but bytecode \
+         ends with {bytecode_exit}"
+    )]
+    ExitKindMismatch {
+        label: u16,
+        start: CodeOffset,
+        ir_exit: &'static str,
+        bytecode_exit: String,
+    },
+
+    #[error(
+        "block L{label} (bytecode block at {start}): IR branch target maps to offset {got}, \
+         bytecode branch operand is {expected}"
+    )]
+    TargetMismatch {
+        label: u16,
+        start: CodeOffset,
+        got: CodeOffset,
+        expected: CodeOffset,
+    },
+
+    #[error(
+        "block L{label} (bytecode block at {start}): next block in layout order maps to \
+         offset {got}, bytecode falls through to {exit_pc} + 1"
+    )]
+    FallthroughMismatch {
+        label: u16,
+        start: CodeOffset,
+        got: CodeOffset,
+        exit_pc: CodeOffset,
+    },
+
+    #[error("last block L{label} must end in an unconditional jump or a function exit")]
+    LastBlockFallsThrough { label: u16 },
+}
+
+impl IntoExecutionError for CfgEquivalenceError {
+    fn kind(&self) -> ExecutionErrorKind {
+        match self {
+            CfgEquivalenceError::WitnessLengthMismatch { .. }
+            | CfgEquivalenceError::InteriorTerminator { .. }
+            | CfgEquivalenceError::BlockCountMismatch { .. }
+            | CfgEquivalenceError::LabelOutOfRange { .. }
+            | CfgEquivalenceError::WitnessNotMonotone { .. }
+            | CfgEquivalenceError::BlockStartMismatch { .. }
+            | CfgEquivalenceError::ExitKindMismatch { .. }
+            | CfgEquivalenceError::TargetMismatch { .. }
+            | CfgEquivalenceError::FallthroughMismatch { .. }
+            | CfgEquivalenceError::LastBlockFallsThrough { .. } => {
+                ExecutionErrorKind::InvariantViolation
+            },
+        }
+    }
+}
+
+/// Certified block bijection between IR blocks and bytecode blocks. Only
+/// [`verify`] constructs one, so holding it is proof that CFG equivalence
+/// passed; later passes consume it instead of re-trusting the raw witness.
+pub(crate) struct BlockCorrespondence {
+    /// For each IR block in layout order, the start offset of its bytecode
+    /// block. Strictly increasing; exactly the oracle's block starts.
+    block_starts: Vec<CodeOffset>,
+}
+
+impl BlockCorrespondence {
+    /// Start offset of the bytecode block corresponding to IR block
+    /// `block_idx`. Pair with the bytecode CFG's `block_end` to recover the
+    /// block's full instruction range.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn bytecode_block_start(&self, block_idx: usize) -> Option<CodeOffset> {
+        self.block_starts.get(block_idx).copied()
+    }
+}
+
+/// Verify that the IR's control-flow graph is isomorphic to the bytecode's,
+/// edge-by-edge and kind-by-kind, under the carried witness.
+///
+/// Three steps, each O(code length):
+///
+/// 1. **Shape**: one witness entry per block, and terminators only in final
+///    position (the exit classification reads only the last instruction).
+/// 2. **Bijection**: `witness[blocks[i].label]` strictly increases and
+///    equals the oracle's ascending block-start list. This makes the
+///    witness a bijection onto bytecode blocks, pins IR layout order to
+///    bytecode order, and makes all later oracle lookups safe.
+/// 3. **Edges**: each exit kind pins both the bytecode opcode at the
+///    block's exit and the mapped target labels.
+pub(crate) fn verify(ctx: &FuncCtx) -> Result<BlockCorrespondence, CfgEquivalenceError> {
+    let blocks = &ctx.func_ir.blocks;
+    let witness = &ctx.func_ir.witness;
+
+    check_shape(blocks, witness)?;
+    let block_starts = check_bijection(blocks, witness, &ctx.bytecode_cfg)?;
+    check_edges(blocks, witness, &block_starts, ctx)?;
+
+    Ok(BlockCorrespondence { block_starts })
+}
+
+fn check_shape(
+    blocks: &[BasicBlock<NamedSlot>],
+    witness: &TranslationWitness,
+) -> Result<(), CfgEquivalenceError> {
+    if witness.label_to_offset.len() != blocks.len() {
+        return Err(CfgEquivalenceError::WitnessLengthMismatch {
+            witness_len: witness.label_to_offset.len(),
+            num_blocks: blocks.len(),
+        });
+    }
+    for block in blocks {
+        let interior_len = block.instrs.len().saturating_sub(1);
+        for (position, instr) in block.instrs[..interior_len].iter().enumerate() {
+            if exit_of_instr(instr).is_some() {
+                return Err(CfgEquivalenceError::InteriorTerminator {
+                    label: block.label.0,
+                    position,
+                    opcode: instr.opcode_name(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_bijection(
+    blocks: &[BasicBlock<NamedSlot>],
+    witness: &TranslationWitness,
+    bytecode_cfg: &VMControlFlowGraph,
+) -> Result<Vec<CodeOffset>, CfgEquivalenceError> {
+    // Sorted defensively: `VMControlFlowGraph::new` inserts blocks in
+    // ascending start order today, but nothing here should depend on that.
+    let mut oracle_starts = bytecode_cfg.blocks();
+    oracle_starts.sort_unstable();
+
+    if blocks.len() != oracle_starts.len() {
+        return Err(CfgEquivalenceError::BlockCountMismatch {
+            num_ir_blocks: blocks.len(),
+            num_bytecode_blocks: oracle_starts.len(),
+        });
+    }
+
+    // Strict monotonicity first (a full pass, so a permuted witness or a
+    // duplicated label is diagnosed as such), then elementwise equality
+    // with the oracle's ascending block starts.
+    let mut block_starts: Vec<CodeOffset> = Vec::with_capacity(blocks.len());
+    for (block_idx, block) in blocks.iter().enumerate() {
+        let offset = lookup(witness, block.label.0)?;
+        if let Some(&prev) = block_starts.last()
+            && offset <= prev
+        {
+            return Err(CfgEquivalenceError::WitnessNotMonotone {
+                block_idx,
+                offset,
+                prev,
+            });
+        }
+        block_starts.push(offset);
+    }
+    for (block_idx, block) in blocks.iter().enumerate() {
+        if block_starts[block_idx] != oracle_starts[block_idx] {
+            return Err(CfgEquivalenceError::BlockStartMismatch {
+                label: block.label.0,
+                offset: block_starts[block_idx],
+                expected: oracle_starts[block_idx],
+            });
+        }
+    }
+    Ok(block_starts)
+}
+
+fn check_edges(
+    blocks: &[BasicBlock<NamedSlot>],
+    witness: &TranslationWitness,
+    block_starts: &[CodeOffset],
+    ctx: &FuncCtx,
+) -> Result<(), CfgEquivalenceError> {
+    for (block_idx, block) in blocks.iter().enumerate() {
+        let start = block_starts[block_idx];
+        // Safe: `check_bijection` established `start` is an oracle block id.
+        let exit_pc = ctx.bytecode_cfg.block_end(start);
+        let exit_instr = &ctx.code[exit_pc as usize];
+        let label = block.label.0;
+
+        let exit = classify_exit(block);
+        // For a non-fallthrough exit the last instruction is the terminator
+        // the classification was derived from, so its opcode names the exit.
+        let ir_exit = match block.instrs.last() {
+            Some(instr) if !matches!(exit, BlockExit::FallThrough) => instr.opcode_name(),
+            _ => "fallthrough (no terminator)",
+        };
+        let kind_mismatch = || CfgEquivalenceError::ExitKindMismatch {
+            label,
+            start,
+            ir_exit,
+            bytecode_exit: format!("{exit_instr:?}"),
+        };
+
+        match exit {
+            // Unconditional jump: the bytecode block must end in `Branch`,
+            // and the mapped target must equal its operand.
+            BlockExit::Jump { target } => {
+                let Bytecode::Branch(operand) = exit_instr else {
+                    return Err(kind_mismatch());
+                };
+                check_target(witness, label, start, target.0, *operand)?;
+            },
+            // Conditional jump: `BrTrue`/`BrFalse` must match the same
+            // bytecode variant (conversion preserves it); `BrCmp`/`BrCmpImm`
+            // accept either, since fusion may negate the comparison operator
+            // (the operator itself is unchecked). The taken edge is pinned by
+            // the branch operand, the fallthrough edge positionally.
+            BlockExit::CondJump { taken, kind } => {
+                let operand = match (kind, exit_instr) {
+                    (CondJumpKind::BrTrue, Bytecode::BrTrue(operand))
+                    | (CondJumpKind::BrFalse, Bytecode::BrFalse(operand))
+                    | (
+                        CondJumpKind::BrCmp | CondJumpKind::BrCmpImm,
+                        Bytecode::BrTrue(operand) | Bytecode::BrFalse(operand),
+                    ) => *operand,
+                    _ => return Err(kind_mismatch()),
+                };
+                check_target(witness, label, start, taken.0, operand)?;
+                check_fallthrough(block_starts, block_idx, label, start, exit_pc)?;
+            },
+            // Plain fallthrough (including an empty block): the bytecode
+            // block must end in an ordinary instruction — a branch here is
+            // an edge the IR dropped. `is_branch` is the same predicate
+            // `VMControlFlowGraph` splits blocks on.
+            BlockExit::FallThrough => {
+                if exit_instr.is_branch() {
+                    return Err(kind_mismatch());
+                }
+                check_fallthrough(block_starts, block_idx, label, start, exit_pc)?;
+            },
+            // Function exit: exact opcode correspondence. Exits translate
+            // 1:1 with no fusion.
+            BlockExit::Exit(kind) => {
+                let opcode_matches = matches!(
+                    (kind, exit_instr),
+                    (ExitKind::Ret, Bytecode::Ret)
+                        | (ExitKind::Abort, Bytecode::Abort)
+                        | (ExitKind::AbortMsg, Bytecode::AbortMsg)
+                );
+                if !opcode_matches {
+                    return Err(kind_mismatch());
+                }
+            },
+        }
+    }
+    Ok(())
+}
+
+/// Fallible witness lookup: a corrupted label must surface as an error,
+/// never an index panic.
+fn lookup(witness: &TranslationWitness, label: u16) -> Result<CodeOffset, CfgEquivalenceError> {
+    witness
+        .label_to_offset
+        .get(label as usize)
+        .copied()
+        .ok_or(CfgEquivalenceError::LabelOutOfRange { label })
+}
+
+/// The mapped jump target must equal the bytecode branch operand.
+fn check_target(
+    witness: &TranslationWitness,
+    label: u16,
+    start: CodeOffset,
+    target_label: u16,
+    operand: CodeOffset,
+) -> Result<(), CfgEquivalenceError> {
+    let got = lookup(witness, target_label)?;
+    if got != operand {
+        return Err(CfgEquivalenceError::TargetMismatch {
+            label,
+            start,
+            got,
+            expected: operand,
+        });
+    }
+    Ok(())
+}
+
+/// The next block in layout order must map to `exit_pc + 1`; the last
+/// block must not fall through. The offset equality is already implied by
+/// `check_bijection` (the oracle partition is contiguous) and is re-checked
+/// here as defense in depth.
+fn check_fallthrough(
+    block_starts: &[CodeOffset],
+    block_idx: usize,
+    label: u16,
+    start: CodeOffset,
+    exit_pc: CodeOffset,
+) -> Result<(), CfgEquivalenceError> {
+    let next_start = block_starts
+        .get(block_idx + 1)
+        .copied()
+        .ok_or(CfgEquivalenceError::LastBlockFallsThrough { label })?;
+    // Widened: `exit_pc + 1` cannot overflow in u32.
+    if next_start as u32 != exit_pc as u32 + 1 {
+        return Err(CfgEquivalenceError::FallthroughMismatch {
+            label,
+            start,
+            got: next_start,
+            exit_pc,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stackless_exec_ir::{
+        BasicBlock, CmpKind, FunctionIR, HomeIndex, ImmValue, Instr, Label, NamedSlot,
+    };
+    use move_binary_format::file_format::{Bytecode, FunctionHandleIndex, IdentifierIndex};
+
+    fn slot() -> NamedSlot {
+        NamedSlot::Home(HomeIndex(0))
+    }
+
+    /// Any ordinary (non-terminator) instruction.
+    fn ld() -> Instr<NamedSlot> {
+        Instr::LdImm {
+            dst: slot(),
+            imm: ImmValue::Bool(true),
+        }
+    }
+
+    fn block(label: u16, instrs: Vec<Instr<NamedSlot>>) -> BasicBlock<NamedSlot> {
+        BasicBlock {
+            label: Label(label),
+            instrs,
+        }
+    }
+
+    fn make_func(blocks: Vec<BasicBlock<NamedSlot>>, witness: Vec<CodeOffset>) -> FunctionIR {
+        FunctionIR {
+            name_idx: IdentifierIndex(0),
+            handle_idx: FunctionHandleIndex(0),
+            num_params: 0,
+            num_locals: 0,
+            num_home_slots: 1,
+            num_transfer_positions: 0,
+            blocks,
+            home_slot_types: Vec::new(),
+            block_costs: Vec::new(),
+            witness: TranslationWitness {
+                label_to_offset: witness,
+            },
+        }
+    }
+
+    fn run(
+        func_ir: &FunctionIR,
+        code: &[Bytecode],
+    ) -> Result<BlockCorrespondence, CfgEquivalenceError> {
+        let ctx = FuncCtx {
+            func_ir,
+            code,
+            bytecode_cfg: VMControlFlowGraph::new(code),
+        };
+        verify(&ctx)
+    }
+
+    /// Diamond covering all four exit shapes:
+    ///
+    /// ```text
+    /// 0: LdTrue          \ block A [0..1]: conditional jump to 4
+    /// 1: BrTrue(4)       /
+    /// 2: LdTrue          \ block B [2..3]: unconditional jump to 5
+    /// 3: Branch(5)       /
+    /// 4: LdTrue            block C [4..4]: plain fallthrough into 5
+    /// 5: Ret               block D [5..5]: function exit
+    /// ```
+    fn diamond_code() -> Vec<Bytecode> {
+        vec![
+            Bytecode::LdTrue,
+            Bytecode::BrTrue(4),
+            Bytecode::LdTrue,
+            Bytecode::Branch(5),
+            Bytecode::LdTrue,
+            Bytecode::Ret,
+        ]
+    }
+
+    /// Correct IR for [`diamond_code`], with labels equal to positions.
+    fn diamond_ir() -> Vec<BasicBlock<NamedSlot>> {
+        vec![
+            block(0, vec![ld(), Instr::BrTrue {
+                target: Label(2),
+                cond: slot(),
+            }]),
+            block(1, vec![ld(), Instr::Branch { target: Label(3) }]),
+            block(2, vec![ld()]),
+            block(3, vec![Instr::Ret { srcs: Box::new([]) }]),
+        ]
+    }
+
+    fn diamond_witness() -> Vec<CodeOffset> {
+        vec![0, 2, 4, 5]
+    }
+
+    #[test]
+    fn diamond_passes_and_certifies_correspondence() {
+        let func = make_func(diamond_ir(), diamond_witness());
+        let correspondence = run(&func, &diamond_code()).expect("correct translation validates");
+        for (block_idx, expected) in [0u16, 2, 4, 5].into_iter().enumerate() {
+            assert_eq!(
+                correspondence.bytecode_block_start(block_idx),
+                Some(expected)
+            );
+        }
+        assert_eq!(correspondence.bytecode_block_start(4), None);
+    }
+
+    /// Labels are ids, not positions: the converter assigns them in
+    /// branch-target-encounter order. A permuted (but truthful) label
+    /// assignment must validate.
+    #[test]
+    fn permuted_labels_pass() {
+        // Converter-style assignment for the diamond: offset 4 -> L0
+        // (BrTrue target), offset 2 -> L1 (its fallthrough), offset 5 ->
+        // L2 (Branch target), offset 0 -> L3 (on demand).
+        let blocks = vec![
+            block(3, vec![ld(), Instr::BrTrue {
+                target: Label(0),
+                cond: slot(),
+            }]),
+            block(1, vec![ld(), Instr::Branch { target: Label(2) }]),
+            block(0, vec![ld()]),
+            block(2, vec![Instr::Ret { srcs: Box::new([]) }]),
+        ];
+        let func = make_func(blocks, vec![4, 2, 5, 0]);
+        run(&func, &diamond_code()).expect("permuted labels validate");
+    }
+
+    /// A `Nop`-only bytecode block converts to an *empty* IR block, which
+    /// classifies as fallthrough.
+    #[test]
+    fn empty_block_falls_through() {
+        let code = vec![
+            Bytecode::LdTrue,
+            Bytecode::BrTrue(3),
+            Bytecode::Nop,
+            Bytecode::Ret,
+        ];
+        let blocks = vec![
+            block(0, vec![ld(), Instr::BrTrue {
+                target: Label(2),
+                cond: slot(),
+            }]),
+            block(1, vec![]),
+            block(2, vec![Instr::Ret { srcs: Box::new([]) }]),
+        ];
+        let func = make_func(blocks, vec![0, 2, 3]);
+        run(&func, &code).expect("empty block validates as fallthrough");
+    }
+
+    /// A conditional whose target is its own fallthrough is legal and must
+    /// not be confused with an unconditional jump (the oracle's successor
+    /// list dedups it; the operand-based check does not).
+    #[test]
+    fn degenerate_conditional_passes() {
+        let code = vec![Bytecode::LdTrue, Bytecode::BrTrue(2), Bytecode::Ret];
+        let blocks = vec![
+            block(0, vec![ld(), Instr::BrTrue {
+                target: Label(1),
+                cond: slot(),
+            }]),
+            block(1, vec![Instr::Ret { srcs: Box::new([]) }]),
+        ];
+        let func = make_func(blocks, vec![0, 2]);
+        run(&func, &code).expect("degenerate conditional validates");
+    }
+
+    /// Compare-branch fusion keeps the taken target and negates the
+    /// operator for `BrFalse`, so `BrCmp` corresponds to either variant.
+    #[test]
+    fn fused_compare_branch_accepts_either_bytecode_polarity() {
+        for conditional in [Bytecode::BrTrue(2), Bytecode::BrFalse(2)] {
+            let code = vec![Bytecode::LdTrue, conditional, Bytecode::Ret];
+            let blocks = vec![
+                block(0, vec![Instr::BrCmp {
+                    target: Label(1),
+                    op: CmpKind::Eq,
+                    lhs: slot(),
+                    rhs: slot(),
+                }]),
+                block(1, vec![Instr::Ret { srcs: Box::new([]) }]),
+            ];
+            let func = make_func(blocks, vec![0, 2]);
+            run(&func, &code).expect("fused compare-branch validates");
+        }
+    }
+
+    /// Dropped conditional edge: the IR conditional was deleted, leaving a
+    /// fallthrough block. The fallthrough arm pins the bytecode exit
+    /// opcode, so this fails even though the positional check would pass.
+    #[test]
+    fn dropped_edge_fails() {
+        let mut blocks = diamond_ir();
+        blocks[0].instrs = vec![ld()];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::ExitKindMismatch { .. })
+        ));
+    }
+
+    /// Inserted conditional edge: `Branch` miscompiled to `BrCmp` with the
+    /// same target adds a fallthrough edge the bytecode does not have.
+    #[test]
+    fn inserted_edge_fails() {
+        let mut blocks = diamond_ir();
+        blocks[1].instrs = vec![ld(), Instr::BrCmp {
+            target: Label(3),
+            op: CmpKind::Eq,
+            lhs: slot(),
+            rhs: slot(),
+        }];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::ExitKindMismatch { .. })
+        ));
+    }
+
+    /// Conditional degenerating to an unconditional: IR `Branch` where the
+    /// bytecode has `BrTrue` — caught by the Jump arm's opcode pin.
+    #[test]
+    fn conditional_to_unconditional_degeneration_fails() {
+        let mut blocks = diamond_ir();
+        blocks[0].instrs = vec![ld(), Instr::Branch { target: Label(2) }];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::ExitKindMismatch { .. })
+        ));
+    }
+
+    /// Taken/fallthrough swap with set-equal successors: the taken edge
+    /// points at the fallthrough block. Successor-set comparison would
+    /// accept this; the operand-pinned taken edge does not.
+    #[test]
+    fn swapped_conditional_targets_fail() {
+        let mut blocks = diamond_ir();
+        blocks[0].instrs = vec![ld(), Instr::BrTrue {
+            target: Label(1),
+            cond: slot(),
+        }];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::TargetMismatch { .. })
+        ));
+
+        // The layout-order variant of the same swap: blocks reordered so
+        // the taken block sits in the fallthrough position — caught by the
+        // monotonicity clause that pins layout order to bytecode order.
+        let mut blocks = diamond_ir();
+        blocks.swap(1, 2);
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::WitnessNotMonotone { .. })
+        ));
+    }
+
+    #[test]
+    fn redirected_target_fails() {
+        let mut blocks = diamond_ir();
+        blocks[0].instrs = vec![ld(), Instr::BrTrue {
+            target: Label(3),
+            cond: slot(),
+        }];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::TargetMismatch { .. })
+        ));
+    }
+
+    /// Unfused conditionals are variant-preserving 1:1, so a
+    /// `BrTrue`/`BrFalse` swap (same target, inverted branch) is caught.
+    #[test]
+    fn conditional_variant_swap_fails() {
+        let mut blocks = diamond_ir();
+        blocks[0].instrs = vec![ld(), Instr::BrFalse {
+            target: Label(2),
+            cond: slot(),
+        }];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::ExitKindMismatch { .. })
+        ));
+    }
+
+    /// IR `Abort` where the bytecode returns: exits must match exactly.
+    #[test]
+    fn exit_kind_swap_fails() {
+        let mut blocks = diamond_ir();
+        blocks[3].instrs = vec![Instr::Abort { code: slot() }];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::ExitKindMismatch { .. })
+        ));
+    }
+
+    /// A terminator at a non-final position would execute before the
+    /// block's nominal exit; the classification may only trust the last
+    /// instruction after this scan.
+    #[test]
+    fn interior_terminator_fails() {
+        let mut blocks = diamond_ir();
+        blocks[2].instrs = vec![Instr::Branch { target: Label(3) }, ld()];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::InteriorTerminator { .. })
+        ));
+    }
+
+    /// Two blocks sharing a label alias onto one bytecode block (and
+    /// lowering's label table is last-write-wins) — caught because the
+    /// composed offsets repeat, breaking strict monotonicity.
+    #[test]
+    fn duplicated_label_fails() {
+        let mut blocks = diamond_ir();
+        blocks[2].label = Label(1);
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::WitnessNotMonotone { .. })
+        ));
+    }
+
+    #[test]
+    fn label_out_of_range_fails() {
+        let mut blocks = diamond_ir();
+        blocks[0].label = Label(9);
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::LabelOutOfRange { .. })
+        ));
+    }
+
+    /// A corrupted target label (not a corrupted block label) must also
+    /// surface as an error, never an index panic.
+    #[test]
+    fn out_of_range_target_label_fails() {
+        let mut blocks = diamond_ir();
+        blocks[1].instrs = vec![ld(), Instr::Branch { target: Label(9) }];
+        let func = make_func(blocks, diamond_witness());
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::LabelOutOfRange { .. })
+        ));
+    }
+
+    /// A witness offset pointing mid-block passes distinctness and
+    /// monotonicity but is not an oracle block start.
+    #[test]
+    fn mid_block_witness_offset_fails() {
+        let func = make_func(diamond_ir(), vec![0, 2, 3, 5]);
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::BlockStartMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn permuted_witness_fails() {
+        let func = make_func(diamond_ir(), vec![0, 4, 2, 5]);
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::WitnessNotMonotone { .. })
+        ));
+    }
+
+    /// Merged blocks (fewer IR blocks than bytecode blocks) fail totality.
+    #[test]
+    fn block_count_mismatch_fails() {
+        let blocks = vec![
+            block(0, vec![ld(), Instr::BrTrue {
+                target: Label(2),
+                cond: slot(),
+            }]),
+            block(1, vec![ld(), Instr::Branch { target: Label(2) }]),
+            block(2, vec![Instr::Ret { srcs: Box::new([]) }]),
+        ];
+        let func = make_func(blocks, vec![0, 2, 5]);
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::BlockCountMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn witness_length_mismatch_fails() {
+        let func = make_func(diamond_ir(), vec![0, 2, 4]);
+        assert!(matches!(
+            run(&func, &diamond_code()),
+            Err(CfgEquivalenceError::WitnessLengthMismatch { .. })
+        ));
+    }
+
+    /// The last block may not fall through (verified bytecode ends in an
+    /// unconditional exit); the lookup of `blocks[i + 1]` must be an
+    /// error, not a panic.
+    #[test]
+    fn last_block_fallthrough_fails() {
+        let code = vec![Bytecode::LdTrue];
+        let func = make_func(vec![block(0, vec![ld()])], vec![0]);
+        assert!(matches!(
+            run(&func, &code),
+            Err(CfgEquivalenceError::LastBlockFallsThrough { .. })
+        ));
+    }
+}

--- a/third_party/move/mono-move/specializer/src/validate/mod.rs
+++ b/third_party/move/mono-move/specializer/src/validate/mod.rs
@@ -1,0 +1,197 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Lightweight translation validation: checks of the final stackless execution
+//! IR against the Move bytecode it was translated from.
+//!
+//! Passes are plain functions over a read-only per-function [`FuncCtx`], listed
+//! in the body of [`validate_module`]. Structural passes produce certified
+//! artifacts ([`cfg_equivalence::BlockCorrespondence`]) that later semantic
+//! passes can consume instead of re-trusting the raw witness.
+//!
+//! No user error should show up as translation validation failure.
+
+pub(crate) mod cfg_equivalence;
+pub(crate) mod transfer;
+
+use crate::stackless_exec_ir::{FunctionIR, ModuleIR};
+use cfg_equivalence::CfgEquivalenceError;
+use mono_move_core::{ExecutionErrorKind, IntoExecutionError};
+use move_binary_format::{
+    access::ModuleAccess,
+    control_flow_graph::VMControlFlowGraph,
+    file_format::{Bytecode, CodeOffset},
+};
+use thiserror::Error;
+use transfer::TransferVerifierError;
+
+/// Facts translation knows and validation needs, carried on [`FunctionIR`].
+///
+/// Untrusted by validation passes. A corrupted witness must cause a check
+/// failure (see `cfg_equivalence`).
+pub(crate) struct TranslationWitness {
+    /// `Label` -> start offset of the originating basic block in the function's
+    /// original Move bytecode. Dense, indexed by `Label.0`. Recorded during
+    /// bytecode-to-SSA conversion; no pass creates, deletes, or reorders
+    /// blocks.
+    pub label_to_offset: Vec<CodeOffset>,
+}
+
+/// Read-only per-function view handed to every validation pass.
+pub(crate) struct FuncCtx<'a> {
+    pub func_ir: &'a FunctionIR,
+    /// The function's original bytecode.
+    pub code: &'a [Bytecode],
+    /// Independent bytecode-CFG oracle, derived directly from the bytecode
+    /// via a separate (non-mono-move) implementation.
+    pub bytecode_cfg: VMControlFlowGraph,
+}
+
+impl<'a> FuncCtx<'a> {
+    fn new(
+        module_ir: &'a ModuleIR,
+        def_idx: usize,
+        func_ir: &'a FunctionIR,
+    ) -> Result<Self, PassError> {
+        let fdef = module_ir
+            .module
+            .function_defs
+            .get(def_idx)
+            .ok_or(PassError::MissingBytecode)?;
+        if fdef.function != func_ir.handle_idx {
+            return Err(PassError::FunctionHandleMismatch {
+                ir_handle: func_ir.handle_idx.0,
+                def_handle: fdef.function.0,
+            });
+        }
+        let code = fdef.code.as_ref().ok_or(PassError::MissingBytecode)?;
+        Ok(FuncCtx {
+            func_ir,
+            code: &code.code,
+            bytecode_cfg: VMControlFlowGraph::new(&code.code),
+        })
+    }
+}
+
+pub type ValidationResult<T> = Result<T, ValidationError>;
+
+/// Translation-validation failure, carrying the identity of the violating
+/// function and the failing pass's error. Fail-fast: the first violating
+/// function aborts module validation.
+#[derive(Debug, Error)]
+#[error("translation validation failed for `{function}`: {source}")]
+pub struct ValidationError {
+    /// Qualified `module::function` name of the violating function.
+    function: String,
+    source: PassError,
+}
+
+/// A single pass's failure, wrapped by the driver into [`ValidationError`].
+#[derive(Debug, Error)]
+enum PassError {
+    #[error("function has IR but its bytecode code unit is unavailable")]
+    MissingBytecode,
+
+    #[error("module has {num_ir} function IR entries for {num_defs} function definitions")]
+    FunctionCountMismatch { num_ir: usize, num_defs: usize },
+
+    #[error("function definition has code but no IR")]
+    MissingFunctionIR,
+
+    #[error("native function definition has IR")]
+    UnexpectedFunctionIR,
+
+    #[error("IR carries function handle {ir_handle}, definition expects {def_handle}")]
+    FunctionHandleMismatch { ir_handle: u16, def_handle: u16 },
+
+    #[error("CFG equivalence: {0}")]
+    CfgEquivalence(#[from] CfgEquivalenceError),
+
+    #[error("transfer invariants: {0}")]
+    Transfer(#[from] TransferVerifierError),
+}
+
+impl IntoExecutionError for ValidationError {
+    fn kind(&self) -> ExecutionErrorKind {
+        match &self.source {
+            PassError::MissingBytecode
+            | PassError::FunctionCountMismatch { .. }
+            | PassError::MissingFunctionIR
+            | PassError::UnexpectedFunctionIR
+            | PassError::FunctionHandleMismatch { .. } => ExecutionErrorKind::InvariantViolation,
+            PassError::CfgEquivalence(err) => err.kind(),
+            PassError::Transfer(err) => err.kind(),
+        }
+    }
+}
+
+/// Run all validation passes over every non-native function of the module.
+pub fn validate_module(module_ir: &ModuleIR) -> ValidationResult<()> {
+    check_function_totality(module_ir)?;
+    for (def_idx, func_ir) in module_ir.functions.iter().enumerate() {
+        let Some(func_ir) = func_ir else { continue };
+        validate_function(module_ir, def_idx, func_ir).map_err(|source| ValidationError {
+            function: qualified_function_name(module_ir, def_idx),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+/// Check that every function definition with code has IR, and every native
+/// definition (no code) has no IR.
+fn check_function_totality(module_ir: &ModuleIR) -> ValidationResult<()> {
+    let function_defs = &module_ir.module.function_defs;
+    if module_ir.functions.len() != function_defs.len() {
+        return Err(ValidationError {
+            function: module_ir.module.self_name().to_string(),
+            source: PassError::FunctionCountMismatch {
+                num_ir: module_ir.functions.len(),
+                num_defs: function_defs.len(),
+            },
+        });
+    }
+    for (def_idx, (fdef, func_ir)) in function_defs.iter().zip(&module_ir.functions).enumerate() {
+        // TODO(correctness): a native registry entry shadowing a function
+        // that has a Move body is invisible here — that is the `(true, true)`
+        // case, since lowering resolves natives unconditionally per call site.
+        let source = match (fdef.code.is_some(), func_ir.is_some()) {
+            (true, false) => PassError::MissingFunctionIR,
+            (false, true) => PassError::UnexpectedFunctionIR,
+            (true, true) | (false, false) => continue,
+        };
+        return Err(ValidationError {
+            function: qualified_function_name(module_ir, def_idx),
+            source,
+        });
+    }
+    Ok(())
+}
+
+/// Function name for error attribution, resolved from the verified definition
+/// side.
+fn qualified_function_name(module_ir: &ModuleIR, def_idx: usize) -> String {
+    let module = &module_ir.module;
+    match module.function_defs.get(def_idx) {
+        Some(fdef) => format!(
+            "{}::{}",
+            module.self_name(),
+            module.identifier_at(module.function_handle_at(fdef.function).name)
+        ),
+        None => format!("{}::<function #{def_idx}>", module.self_name()),
+    }
+}
+
+/// The per-function pass list, in execution order.
+fn validate_function(
+    module_ir: &ModuleIR,
+    def_idx: usize,
+    func_ir: &FunctionIR,
+) -> Result<(), PassError> {
+    let ctx = FuncCtx::new(module_ir, def_idx, func_ir)?;
+    let _blocks = cfg_equivalence::verify(&ctx)?;
+    transfer::verify(&ctx)?;
+    // Future passes can consume `_blocks` (the certified block correspondence)
+    // instead of re-deriving or re-trusting the raw witness.
+    Ok(())
+}

--- a/third_party/move/mono-move/specializer/src/validate/transfer.rs
+++ b/third_party/move/mono-move/specializer/src/validate/transfer.rs
@@ -1,0 +1,424 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Transfer-slot discipline on the final IR.
+//!
+//! Verifies the subset of the transfer invariants (see the header of
+//! `destack/analysis.rs`) that survives slot allocation:
+//!
+//! 1. Every use of `Transfer(j)` is preceded by a def in the same block.
+//! 2. At a call boundary, every bound Transfer slot is consumed by the
+//!    call's args (orphans signal an upstream regression).
+//! 3. Calls clobber every Transfer slot; ret defs re-bind on the same
+//!    instruction.
+//! 4. No Transfer binding leaks across a block boundary.
+//! 5. Per-call structural invariants — arg positionality, return
+//!    Transfer prefix, return monotonicity — via
+//!    [`check_call_structural_invariants`], the same helper the
+//!    SSA-level `assert_transfer_invariants` uses on the ValueId-level
+//!    maps.
+//!
+//! In addition, every slot operand is range-checked against the function's
+//! declared Transfer/Home counts, and duplicate uses of one Transfer
+//! position within a single instruction are rejected.
+
+use super::FuncCtx;
+use crate::stackless_exec_ir::{
+    instr_utils::{call_boundary_rets_and_args, for_each_def, for_each_slot, for_each_value_use},
+    NamedSlot, TransferPosition,
+};
+use mono_move_core::{ExecutionErrorKind, IntoExecutionError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum TransferVerifierError {
+    #[error("block {block}, instr {instr}: {inner}")]
+    TransferCallStructural {
+        block: usize,
+        instr: usize,
+        inner: Box<TransferVerifierError>,
+    },
+
+    #[error(
+        "arg positionality: args[{arg_idx}] resolves to Transfer({got}), expected Transfer({arg_idx})"
+    )]
+    TransferArgPositionality { arg_idx: usize, got: u16 },
+
+    #[error(
+        "return Transfer prefix: rets[{ret_idx}] resolves to Transfer({got}) after a non-Transfer ret"
+    )]
+    TransferReturnPrefix { ret_idx: usize, got: u16 },
+
+    #[error("return monotonicity: rets[{ret_idx}] = Transfer({got}) <= prev Transfer({prev})")]
+    TransferReturnNotMonotonic { ret_idx: usize, got: u16, prev: u16 },
+
+    #[error("block {block}, instr {instr}: use of Transfer({transfer}) with no live def earlier in this block")]
+    TransferUseWithoutLiveDef {
+        block: usize,
+        instr: usize,
+        transfer: u16,
+    },
+
+    #[error("block {block}, instr {instr}: Transfer({transfer}) bound at call boundary but not consumed as args[{transfer}]")]
+    TransferBoundNotConsumed {
+        block: usize,
+        instr: usize,
+        transfer: u16,
+    },
+
+    #[error("block {block}: Transfer({transfer}) bound at block end (Transfer lifetimes must be block-local)")]
+    TransferBoundAtBlockEnd { block: usize, transfer: u16 },
+
+    #[error("block {block}, instr {instr}: Transfer({transfer}) out of range (function declares {num_transfer} positions)")]
+    TransferPositionOutOfRange {
+        block: usize,
+        instr: usize,
+        transfer: u16,
+        num_transfer: usize,
+    },
+
+    #[error("block {block}, instr {instr}: Home({home}) out of range (function declares {num_home_slots} home slots)")]
+    HomeSlotOutOfRange {
+        block: usize,
+        instr: usize,
+        home: u16,
+        num_home_slots: usize,
+    },
+
+    #[error(
+        "block {block}, instr {instr}: duplicate use of Transfer({transfer}) in one instruction"
+    )]
+    DuplicateTransferUse {
+        block: usize,
+        instr: usize,
+        transfer: u16,
+    },
+}
+
+impl IntoExecutionError for TransferVerifierError {
+    fn kind(&self) -> ExecutionErrorKind {
+        match self {
+            TransferVerifierError::TransferCallStructural { .. }
+            | TransferVerifierError::TransferArgPositionality { .. }
+            | TransferVerifierError::TransferReturnPrefix { .. }
+            | TransferVerifierError::TransferReturnNotMonotonic { .. }
+            | TransferVerifierError::TransferUseWithoutLiveDef { .. }
+            | TransferVerifierError::TransferBoundNotConsumed { .. }
+            | TransferVerifierError::TransferBoundAtBlockEnd { .. }
+            | TransferVerifierError::TransferPositionOutOfRange { .. }
+            | TransferVerifierError::HomeSlotOutOfRange { .. }
+            | TransferVerifierError::DuplicateTransferUse { .. } => {
+                ExecutionErrorKind::InvariantViolation
+            },
+        }
+    }
+}
+
+/// Check the per-call structural Transfer invariants:
+///
+/// - **Arg positionality** (invariant 2): if `args[j]` resolves to
+///   `Transfer(i)`, then `i == j`.
+/// - **Return Transfer prefix** (invariant 5): the rets list is a
+///   (possibly empty) Transfer-resolved prefix followed by a non-Transfer
+///   suffix.
+/// - **Return monotonicity** (invariant 3): within the Transfer prefix,
+///   resolved Transfer indices strictly increase.
+pub(crate) fn check_call_structural_invariants<SlotForm, F>(
+    args: &[SlotForm],
+    rets: &[SlotForm],
+    transfer_pos: F,
+) -> Result<(), TransferVerifierError>
+where
+    F: Fn(&SlotForm) -> Option<u16>,
+{
+    for (j, slot) in args.iter().enumerate() {
+        if let Some(i) = transfer_pos(slot)
+            && i as usize != j
+        {
+            return Err(TransferVerifierError::TransferArgPositionality { arg_idx: j, got: i });
+        }
+    }
+
+    let mut seen_non_transfer = false;
+    let mut last_transfer: Option<u16> = None;
+    for (k, slot) in rets.iter().enumerate() {
+        match transfer_pos(slot) {
+            Some(i) => {
+                if seen_non_transfer {
+                    return Err(TransferVerifierError::TransferReturnPrefix { ret_idx: k, got: i });
+                }
+                if let Some(prev) = last_transfer
+                    && i <= prev
+                {
+                    return Err(TransferVerifierError::TransferReturnNotMonotonic {
+                        ret_idx: k,
+                        got: i,
+                        prev,
+                    });
+                }
+                last_transfer = Some(i);
+            },
+            None => seen_non_transfer = true,
+        }
+    }
+
+    Ok(())
+}
+
+/// Verify the Transfer-slot discipline on the final named-slot IR (see the
+/// module header for the exact invariant subset).
+pub(crate) fn verify(ctx: &FuncCtx) -> Result<(), TransferVerifierError> {
+    let func = ctx.func_ir;
+    let num_transfer = func.num_transfer_positions as usize;
+    let num_home_slots = func.num_home_slots as usize;
+    let mut bound: Vec<bool> = vec![false; num_transfer];
+    for (b_idx, block) in func.blocks.iter().enumerate() {
+        // Block-local lifetime: a fresh state at every block.
+        bound.fill(false);
+        for (i, instr) in block.instrs.iter().enumerate() {
+            // Every slot operand must be within the function's declared
+            // ranges; an out-of-range slot (a slot-allocation bug) must
+            // surface as an error, not an index panic here or at lowering.
+            let mut out_of_range: Option<TransferVerifierError> = None;
+            for_each_slot(instr, |slot| {
+                if out_of_range.is_some() {
+                    return;
+                }
+                match slot {
+                    NamedSlot::Transfer(position) if position.0 as usize >= num_transfer => {
+                        out_of_range = Some(TransferVerifierError::TransferPositionOutOfRange {
+                            block: b_idx,
+                            instr: i,
+                            transfer: position.0,
+                            num_transfer,
+                        });
+                    },
+                    NamedSlot::Home(home) if home.0 as usize >= num_home_slots => {
+                        out_of_range = Some(TransferVerifierError::HomeSlotOutOfRange {
+                            block: b_idx,
+                            instr: i,
+                            home: home.0,
+                            num_home_slots,
+                        });
+                    },
+                    NamedSlot::Transfer(_) | NamedSlot::Home(_) => {},
+                }
+            });
+            if let Some(err) = out_of_range {
+                return Err(err);
+            }
+
+            // (1) every Transfer value use must be live.
+            let mut unbound: Option<u16> = None;
+            for_each_value_use(instr, |s| {
+                if let NamedSlot::Transfer(j) = s
+                    && !bound[j.0 as usize]
+                    && unbound.is_none()
+                {
+                    unbound = Some(j.0);
+                }
+            });
+            if let Some(j) = unbound {
+                return Err(TransferVerifierError::TransferUseWithoutLiveDef {
+                    block: b_idx,
+                    instr: i,
+                    transfer: j,
+                });
+            }
+
+            // (2) at a call boundary, every bound Transfer slot must
+            // be consumed by this call's args as args[j] = Transfer(j)
+            // (arg positionality).
+            if let Some((rets, args)) = call_boundary_rets_and_args(instr) {
+                // Structural invariants (arg positionality, return Transfer prefix,
+                // return monotonicity).
+                check_call_structural_invariants(args, rets, |s| match s {
+                    NamedSlot::Transfer(i) => Some(i.0),
+                    NamedSlot::Home(_) => None,
+                })
+                .map_err(|e| TransferVerifierError::TransferCallStructural {
+                    block: b_idx,
+                    instr: i,
+                    inner: Box::new(e),
+                })?;
+                // Orphan check: every bound slot must be consumed
+                // by this call's args. A bound position not in args
+                // signals a dead Transfer def from earlier in the block.
+                for (j, &b) in bound.iter().enumerate() {
+                    if b {
+                        let consumed_here = j < args.len()
+                            && args[j] == NamedSlot::Transfer(TransferPosition(j as u16));
+                        if !consumed_here {
+                            return Err(TransferVerifierError::TransferBoundNotConsumed {
+                                block: b_idx,
+                                instr: i,
+                                transfer: j as u16,
+                            });
+                        }
+                    }
+                }
+                // Clobber: a call reuses the entire callee region;
+                // the ret defs below re-bind whatever positions
+                // this call returns to.
+                bound.fill(false);
+            } else {
+                // Non-call: value uses release their bindings (single-use).
+                // A release that finds the binding already gone was released
+                // by this same instruction — a duplicate use (never-bound
+                // uses were rejected by the liveness check above).
+                let mut duplicate: Option<u16> = None;
+                for_each_value_use(instr, |slot| {
+                    if let NamedSlot::Transfer(position) = slot {
+                        if !bound[position.0 as usize] && duplicate.is_none() {
+                            duplicate = Some(position.0);
+                        }
+                        bound[position.0 as usize] = false;
+                    }
+                });
+                if let Some(transfer) = duplicate {
+                    return Err(TransferVerifierError::DuplicateTransferUse {
+                        block: b_idx,
+                        instr: i,
+                        transfer,
+                    });
+                }
+            }
+            // Defs bind: ret-Transfers for calls, Move/Copy dst (etc.)
+            // for non-calls.
+            for_each_def(instr, |s| {
+                if let NamedSlot::Transfer(j) = s {
+                    bound[j.0 as usize] = true;
+                }
+            });
+        }
+
+        // (3) no Transfer binding may survive past the end of a block.
+        for (j, &b) in bound.iter().enumerate() {
+            if b {
+                return Err(TransferVerifierError::TransferBoundAtBlockEnd {
+                    block: b_idx,
+                    transfer: j as u16,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        stackless_exec_ir::{
+            BasicBlock, BinaryOp, FunctionIR, HomeIndex, ImmValue, Instr, Label, NamedSlot,
+        },
+        validate::TranslationWitness,
+    };
+    use move_binary_format::{
+        control_flow_graph::VMControlFlowGraph,
+        file_format::{Bytecode, FunctionHandleIndex, IdentifierIndex},
+    };
+
+    fn home(index: u16) -> NamedSlot {
+        NamedSlot::Home(HomeIndex(index))
+    }
+
+    fn transfer(position: u16) -> NamedSlot {
+        NamedSlot::Transfer(TransferPosition(position))
+    }
+
+    fn ld(dst: NamedSlot) -> Instr<NamedSlot> {
+        Instr::LdImm {
+            dst,
+            imm: ImmValue::Bool(true),
+        }
+    }
+
+    fn func_with(
+        num_home_slots: u16,
+        num_transfer_positions: u16,
+        instrs: Vec<Instr<NamedSlot>>,
+    ) -> FunctionIR {
+        FunctionIR {
+            name_idx: IdentifierIndex(0),
+            handle_idx: FunctionHandleIndex(0),
+            num_params: 0,
+            num_locals: 0,
+            num_home_slots,
+            num_transfer_positions,
+            blocks: vec![BasicBlock {
+                label: Label(0),
+                instrs,
+            }],
+            home_slot_types: Vec::new(),
+            block_costs: Vec::new(),
+            witness: TranslationWitness {
+                label_to_offset: vec![0],
+            },
+        }
+    }
+
+    /// The pass reads only `func_ir`; the bytecode side is a placeholder.
+    fn run(func_ir: &FunctionIR) -> Result<(), TransferVerifierError> {
+        let code = [Bytecode::Ret];
+        let ctx = FuncCtx {
+            func_ir,
+            code: &code,
+            bytecode_cfg: VMControlFlowGraph::new(&code),
+        };
+        verify(&ctx)
+    }
+
+    #[test]
+    fn in_range_slots_pass() {
+        let func = func_with(1, 1, vec![
+            ld(transfer(0)),
+            Instr::Copy {
+                dst: home(0),
+                src: transfer(0),
+            },
+            Instr::Ret { srcs: Box::new([]) },
+        ]);
+        run(&func).expect("well-formed slots validate");
+    }
+
+    #[test]
+    fn out_of_range_home_slot_fails() {
+        let func = func_with(1, 0, vec![ld(home(5)), Instr::Ret { srcs: Box::new([]) }]);
+        assert!(matches!(
+            run(&func),
+            Err(TransferVerifierError::HomeSlotOutOfRange { home: 5, .. })
+        ));
+    }
+
+    #[test]
+    fn out_of_range_transfer_position_fails() {
+        let func = func_with(1, 0, vec![ld(transfer(0)), Instr::Ret {
+            srcs: Box::new([]),
+        }]);
+        assert!(matches!(
+            run(&func),
+            Err(TransferVerifierError::TransferPositionOutOfRange { transfer: 0, .. })
+        ));
+    }
+
+    /// Two uses of the same Transfer position in one instruction violate
+    /// the single-use discipline even though both see a live binding.
+    #[test]
+    fn duplicate_transfer_use_fails() {
+        let func = func_with(1, 1, vec![
+            ld(transfer(0)),
+            Instr::BinaryOp {
+                dst: home(0),
+                op: BinaryOp::Add,
+                lhs: transfer(0),
+                rhs: transfer(0),
+            },
+            Instr::Ret { srcs: Box::new([]) },
+        ]);
+        assert!(matches!(
+            run(&func),
+            Err(TransferVerifierError::DuplicateTransferUse { transfer: 0, .. })
+        ));
+    }
+}

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -206,7 +206,7 @@ pub fn run_test(steps: Vec<Step>, kind: SourceKind, test_path: &Path) -> anyhow:
 
     // Publish the Move stdlib into both VMs so tests can call real stdlib
     // natives.
-    for module in stdlib_modules().iter().chain(test_utils_modules()) {
+    for module in prelude_modules() {
         let mut blob = vec![];
         module.serialize(&mut blob).expect("module serializes");
         storage.add_module_bytes(module.self_addr(), module.self_name(), blob.into());
@@ -319,6 +319,12 @@ fn v1_native_table() -> NativeFunctionTable {
     );
     table.extend(crate::v1_test_natives::make_all_v1_test_natives());
     table
+}
+
+/// The prelude every differential test publishes before its own modules:
+/// the Move stdlib plus the `test_utils` library.
+fn prelude_modules() -> impl Iterator<Item = &'static CompiledModule> {
+    stdlib_modules().iter().chain(test_utils_modules())
 }
 
 /// The compiled Move stdlib, compiled once and shared across tests.

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/nop_block.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/nop_block.exp
@@ -1,0 +1,30 @@
+=== stackless ===
+// module 0x66::nop_block
+
+fun taken(): u64 {
+  slots: params(0), locals(0), temps(2)
+    r0: bool
+    r1: u64
+  code:
+  L2:
+    0: r0 := ld_true
+    1: br_true L0, r0
+  L1:
+  L0:
+    2: r1 := ld_u64 7
+    3: ret [r1]
+}
+
+fun not_taken(): u64 {
+  slots: params(0), locals(0), temps(2)
+    r0: bool
+    r1: u64
+  code:
+  L2:
+    0: r0 := ld_false
+    1: br_true L0, r0
+  L1:
+  L0:
+    2: r1 := ld_u64 8
+    3: ret [r1]
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/nop_block.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/control_flow/nop_block.masm
@@ -1,0 +1,26 @@
+// RUN: publish --print(stackless)
+module 0x66::nop_block
+
+// A conditional whose fallthrough block holds only `nop`.
+fun taken(): u64
+    ld_true
+    br_true done
+    nop
+done:
+    ld_u64 7
+    ret
+
+// Same shape with the branch not taken.
+fun not_taken(): u64
+    ld_false
+    br_true done
+    nop
+done:
+    ld_u64 8
+    ret
+
+// RUN: execute 0x66::nop_block::taken
+// CHECK: results: 7
+
+// RUN: execute 0x66::nop_block::not_taken
+// CHECK: results: 8


### PR DESCRIPTION
## Description

The specializer transforms verified Move bytecode into stackless execution IR (destackification, fusion, slot allocation, optimization). We want to introduce various mechanisms to catch any miscompilations. Previously the main line of defense was differential testing. This PR adds lightweigh *translation validation*: every compiled module's final IR is checked structurally against its own bytecode, on every (debug) compilation. More passes will be added in the future.

## Key ideas

- **Witness, not search.** The converter already knows the block correspondence (its label→offset map) and used to throw it away. It's now recorded as a `TranslationWitness` on `FunctionIR` — an *untrusted hint* that pins down what to compare, turning graph-isomorphism checking into a linear scan. A corrupted witness must fail loudly, never mis-accept or panic.
- **Independent oracle.** The bytecode side is rebuilt with `VMControlFlowGraph` from `move-binary-format`, never the specializer's own block splitter — a shared bug can't self-certify.
- **CFG equivalence pass.** Three linear steps: shape (no interior terminators), bijection (witness offsets must strictly increase and equal the oracle's block starts — one clause that pins every block, label, and layout order), and two-sided edge checks (each IR exit kind against the bytecode opcode at the block's exit), so dropped/inserted/redirected/kind-swapped edges all fail.
- **Certified products.** The pass returns a `BlockCorrespondence` that only it can construct — future semantic passes consume the certificate instead of re-trusting the witness.
- **One home for validation.** The existing transfer-slot verifier was relocated into the new `validate/` module and strengthened (slot-range checks, duplicate-use detection); the driver adds module-level totality (no silently dropped functions) and IR↔bytecode pairing checks. All errors are typed; no panics on malformed input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the specializer compile path and adds structural invariant checks; failures are debug-only invariant violations, not user-facing semantics, but bugs here could block debug builds or miss miscompilations if validation is wrong.
> 
> **Overview**
> Adds **translation validation** in debug builds: after optimization and gas instrumentation, `destack` runs `validate_module` instead of only checking transfer slots inline.
> 
> **Witness + driver.** SSA conversion now returns a `TranslationWitness` (`label` → bytecode block start) stored on `FunctionIR`. The new `validate/` module pairs each function IR with original bytecode via `VMControlFlowGraph` and runs passes in order.
> 
> **CFG equivalence** linearly checks shape (no interior terminators), witness bijection against oracle block starts, and edge-by-edge exit kinds (jumps, conditionals with fallthrough, exits)—including empty/`Nop`-only fallthrough blocks. It yields a `BlockCorrespondence` for future passes.
> 
> **Transfer checks** move from `destack/analysis.rs` into `validate/transfer.rs`, with added Home/Transfer range checks and duplicate Transfer-use detection; SSA analysis still calls shared `check_call_structural_invariants`.
> 
> **IR helpers:** `instr_utils` gains `BlockExit` / `classify_exit` so validation matches documented fallthrough semantics. A differential test covers `nop`-only fallthrough blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c22bf7efe3827c3589bb092321f11d6ad2808923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->