### PR TITLE
[replay-verify] Bump snapshot PVC sizes to fit grown PFN disks

### DIFF
--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -34,8 +34,8 @@ NAMESPACE = "replay-verify"
 ZONE = "us-central1-a"
 
 DEFAULT_PVC_ACCESS_MODE = "ReadOnlyMany"  # Default access mode for PVCs
-TESTNET_SNAPSHOT_DISK_SIZE = "20Ti"  # Default disk size for testnet snapshots
-MAINNET_SNAPSHOT_DISK_SIZE = "20Ti"  # Default disk size for mainnet snapshots
+TESTNET_SNAPSHOT_DISK_SIZE = "25Ti"  # Must be >= the testnet PFN disk size (25Ti as of 2026-07)
+MAINNET_SNAPSHOT_DISK_SIZE = "23Ti"  # Must be >= the mainnet PFN disk size (23Ti as of 2026-07)
 
 def get_disk_size_for_snapshot(snapshot_name: str) -> str:
     if TESTNET_SNAPSHOT_NAME in snapshot_name:


### PR DESCRIPTION
## Description

Replay-verify on archive has been hanging (and then getting killed by the 6h runner cap) on every run since July 9. Root cause: the PVCs that restore the archive snapshot use a hardcoded size (`20Ti`), and GCE cannot restore a snapshot onto a disk smaller than the snapshot's source disk:

- The mainnet PFN disks (the snapshot source) were resized 20Ti → 22Ti on 2026-06-25 (aptos-labs/internal-ops#8573) and again to 23Ti on 2026-07-28. Testnet PFN disks are at 25Ti.
- The 2026-07-08 provisioning run refreshed the `mainnet-archive` snapshot from the now-22Ti disk. The last green replay run (July 2) used the older, 20Ti-sized snapshot from June 19.
- Since then, the source PVC fails provisioning on every retry and stays Pending forever; the scheduler polls it silently until GitHub kills the job at 6h (`0/10 PVCs bound, 0 workers, 0/2499 tasks` for the whole run).

This sets the PVC sizes to match the current PFN disk sizes exactly: mainnet 23Ti, testnet 25Ti. Intentionally minimal to verify the diagnosis — follow-ups worth doing separately: sizing PVCs dynamically from the snapshot's `diskSizeGb` instead of a constant, a bind deadline + PVC event logging in the scheduler so provisioning failures surface in minutes instead of hanging for 6h, and making the provisioning workflow fail loudly instead of swallowing snapshot-creation exceptions.

## How Has This Been Tested?

Not testable locally (requires the GCP archive snapshot). Verification plan: dispatch `Replay-verify on archive: Mainnet` after merge and confirm the source PVC binds (last known-good bind time was ~500s) and workers start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
