### PR TITLE
[consensus] Validate execution pool windows

### DIFF
--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -26,6 +26,7 @@ use rayon::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashSet,
     fmt::{Display, Formatter},
     sync::Arc,
     vec::IntoIter,
@@ -347,8 +348,30 @@ impl ExecutionPoolWindow {
     }
 
     /// Verifies the execution pool window contents and returns an error if the data is invalid
-    pub fn verify_window_contents(&self, _expected_window_size: u64) -> Result<(), Error> {
-        Ok(()) // TODO: Implement this method!
+    pub fn verify_window_contents(&self, expected_window_size: u64) -> Result<(), Error> {
+        let expected_window_size = usize::try_from(expected_window_size).map_err(|error| {
+            Error::InvalidMessageError(format!(
+                "The expected execution pool window size cannot be represented! Error: {:?}",
+                error
+            ))
+        })?;
+
+        if self.block_ids.len() != expected_window_size {
+            return Err(Error::InvalidMessageError(format!(
+                "Execution pool window size does not match the expected size! Expected: {:?}, Received: {:?}",
+                expected_window_size,
+                self.block_ids.len()
+            )));
+        }
+
+        let unique_block_ids: HashSet<_> = self.block_ids.iter().collect();
+        if unique_block_ids.len() != self.block_ids.len() {
+            return Err(Error::InvalidMessageError(
+                "Execution pool window contains duplicate block IDs!".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -1729,6 +1752,40 @@ mod test {
 
         // Verify the ordered block and ensure it passes
         ordered_block.verify_ordered_blocks().unwrap();
+    }
+
+    #[test]
+    fn test_verify_execution_pool_window_contents() {
+        // Verify that an empty window is valid when an empty window is expected
+        let execution_pool_window = ExecutionPoolWindow::new(vec![]);
+        assert_ok!(execution_pool_window.verify_window_contents(0));
+
+        // Create a valid execution pool window
+        let block_ids = vec![
+            HashValue::random(),
+            HashValue::random(),
+            HashValue::random(),
+        ];
+        let execution_pool_window = ExecutionPoolWindow::new(block_ids);
+
+        // Verify that a window with the expected number of unique block IDs is valid
+        assert_ok!(execution_pool_window.verify_window_contents(3));
+
+        // Verify that undersized and oversized windows are invalid
+        let error = execution_pool_window.verify_window_contents(4).unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+        let error = execution_pool_window.verify_window_contents(2).unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Verify that duplicate block IDs are invalid
+        let duplicate_block_id = HashValue::random();
+        let execution_pool_window = ExecutionPoolWindow::new(vec![
+            duplicate_block_id,
+            HashValue::random(),
+            duplicate_block_id,
+        ]);
+        let error = execution_pool_window.verify_window_contents(3).unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`ExecutionPoolWindow::verify_window_contents()` previously returned `Ok(())` for every input. As a result, the consensus observer's existing validation path could not reject execution pool windows with an unexpected number of block IDs or structurally invalid repeated IDs.

This change implements the missing validation and adds focused regression coverage.

Fixes #20122.

## Root cause

The consensus observer already calls `verify_window_contents()` before accepting an `OrderedBlockWithWindow` message. It logs an error, increments the invalid-message metric, and stops processing when validation fails. The verification method itself was still a stub, so that rejection path was unreachable for malformed window contents.

## Proposed solution

- Convert the configured `u64` window size to `usize` with a checked conversion.
- Require the received block ID count to exactly match the configured window size.
- Require every block ID in the window to be unique.
- Return `Error::InvalidMessageError` for every failed invariant so the existing caller drops the message and records it as invalid.
- Perform duplicate detection only after the size check. This keeps the `HashSet` allocation bounded by the trusted configured window size rather than an attacker-controlled vector length.

The wire format and serialized message types are unchanged.

## Security impact

Consensus observers no longer accept arbitrarily sized execution pool windows or windows that repeat the same block ID. The validation runs before the message can proceed through the rest of the ordered-block-with-window handling path.

The window currently contains only block hashes, so this method cannot independently prove parent ordering or block contents. Those properties require the corresponding blocks. Within the data available to this method, exact cardinality and uniqueness are the enforceable structural invariants.

## Test coverage

The new unit test covers:

- an empty window when the configured size is zero
- a correctly sized window with unique block IDs
- an undersized window
- an oversized window
- a correctly sized window containing a duplicate block ID

## Validation

- `cargo +nightly fmt --check`
- `git diff --check`
- `cargo test -p aptos-consensus test_verify_execution_pool_window_contents --lib`
- package-scoped `cargo clippy -p aptos-consensus --lib` with the repository lint configuration
- `cargo test -p aptos-consensus --lib`
  - 419 passed
  - 4 unrelated encrypted-transaction batch-generator tests failed under parallel execution
  - 9 ignored
- The four parallel failures were rerun serially and all passed.

Clippy reported only pre-existing warnings in `aptos-metrics-core` and the existing unused `verify_inline_batches` method. No warning originated from this change.
