### PR TITLE
[move prover] ghost carrier and iterator validity for intrinsic maps

### DIFF
--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -218,6 +218,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     pub fn translate(&mut self, loc: Loc, module_def: EA::ModuleDefinition) {
         self.decl_ana(&module_def);
         self.def_ana(&module_def);
+        self.synthesize_validity_slots();
         self.collect_spec_block_infos(&module_def);
         let attrs = self.translate_attributes(&module_def.attributes);
         self.populate_and_finalize_env(loc, attrs);
@@ -4062,6 +4063,111 @@ impl ModuleBuilder<'_, '_> {
             .clear();
     }
 
+    /// Backend-synthesized iterator-validity slots. Binding a validity
+    /// predicate role (`map_spec_iter_valid`, `map_spec_leaf_iter_valid`, or
+    /// `map_spec_iter_preserved`) gives the intrinsic map — and, for the
+    /// per-iterator predicates, the predicate's iterator enum — a hidden
+    /// ghost field named `$validity`. The name is not spellable in Move
+    /// source, so no user spec can read, write, initialize, or constrain the
+    /// slot; the ghost machinery (carrier representation, fresh-at-pack,
+    /// havoc on structural mutation, equality exclusion) carries it, and the
+    /// role templates define the predicates over it.
+    fn synthesize_validity_slots(&mut self) {
+        use crate::pragmas::{
+            INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED, INTRINSIC_FUN_MAP_SPEC_ITER_VALID,
+            INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID,
+        };
+        let hidden = self.symbol_pool().make("$validity");
+        let mut to_stamp: Vec<QualifiedSymbol> = vec![];
+        let mut bad_roles: Vec<(&'static str, Loc)> = vec![];
+        for decl in &self.parent.intrinsics {
+            if decl.get_move_type().module_id != self.module_id {
+                continue;
+            }
+            let mut any = false;
+            for role in [
+                INTRINSIC_FUN_MAP_SPEC_ITER_VALID,
+                INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID,
+            ] {
+                let Some(sf_qid) = decl.lookup_spec_fun(self.parent.env, role) else {
+                    continue;
+                };
+                any = true;
+                // The iterator enum is the predicate's first parameter; it
+                // must live in this module so its slot can be synthesized
+                // here. Full signature validation happens at mono analysis.
+                let (iter_qsym, sf_loc) = if sf_qid.module_id == self.module_id {
+                    let sf = &self.spec_funs[sf_qid.id.as_usize()];
+                    let qsym = match sf.params.first() {
+                        Some(Parameter(_, Type::Struct(mid, sid, _), _))
+                            if *mid == self.module_id =>
+                        {
+                            Some(QualifiedSymbol {
+                                module_name: self.module_name.clone(),
+                                symbol: sid.symbol(),
+                            })
+                        },
+                        _ => None,
+                    };
+                    (qsym, sf.loc.clone())
+                } else {
+                    let sf_loc = self
+                        .parent
+                        .env
+                        .get_module(sf_qid.module_id)
+                        .get_spec_fun(sf_qid.id)
+                        .loc
+                        .clone();
+                    (None, sf_loc)
+                };
+                match iter_qsym {
+                    Some(qsym) => to_stamp.push(qsym),
+                    None => bad_roles.push((role, sf_loc)),
+                }
+            }
+            if decl
+                .lookup_spec_fun(self.parent.env, INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED)
+                .is_some()
+            {
+                any = true;
+            }
+            if any {
+                to_stamp.push(QualifiedSymbol {
+                    module_name: self.module_name.clone(),
+                    symbol: decl.get_move_type().id.symbol(),
+                });
+            }
+        }
+        for (role, loc) in bad_roles {
+            self.parent.env.error(
+                &loc,
+                &format!(
+                    "the first parameter of a `{}` binding must be an iterator \
+                     type declared in the same module as the map",
+                    role
+                ),
+            );
+        }
+        for qsym in to_stamp {
+            let Some(entry) = self.parent.struct_table.get_mut(&qsym) else {
+                continue;
+            };
+            if entry.ghost_fields.contains_key(&hidden) {
+                continue;
+            }
+            let offset = entry.ghost_fields.len();
+            entry.ghost_fields.insert(hidden, FieldData {
+                name: hidden,
+                loc: entry.loc.clone(),
+                offset,
+                variant: None,
+                ty: Type::Primitive(PrimitiveType::Num),
+                is_ghost: true,
+                init: None,
+            });
+        }
+    }
+
     /// Post-definition-analysis check of all ghost field types in this
     /// module for recursion through runtime fields. Rejecting ghosts whose
     /// type reaches back to the enclosing struct keeps the generated Boogie
@@ -4310,6 +4416,9 @@ impl ModuleBuilder<'_, '_> {
                 );
                 return;
             }
+            // Read-only-ness of intrinsic-map ghosts is checked in spec
+            // instrumentation, where the intrinsics annotation is complete
+            // even for same-module declarations.
             // Bitwise operators on the RHS produce bitvector-typed Boogie
             // expressions, but ghost fields are declared as unbounded integer
             // in Boogie (they are model-only and don't participate in
@@ -5324,18 +5433,22 @@ impl ModuleBuilder<'_, '_> {
             // New struct in this module
             let spec = self.struct_specs.remove(&name.symbol).unwrap_or_default();
             // Intrinsic types have no generated Boogie datatype to carry
-            // ghost constructor arguments; reject ghosts on them. This is
-            // the earliest point where the intrinsic pragma is reliably
-            // known (spec blocks are fully analyzed).
-            if !entry.ghost_fields.is_empty()
-                && spec
-                    .properties
-                    .contains_key(&self.parent.env.symbol_pool().make(INTRINSIC_PRAGMA))
-            {
-                for f in entry.ghost_fields.values() {
-                    self.parent
-                        .env
-                        .error(&f.loc, "ghost fields are not supported on intrinsic types");
+            // ghost constructor arguments; reject ghosts on them — except
+            // intrinsic MAP types, which gain a carrier datatype. This is the
+            // earliest point where the intrinsic pragma is reliably known.
+            if !entry.ghost_fields.is_empty() {
+                let pool = self.parent.env.symbol_pool();
+                if spec.properties.contains_key(&pool.make(INTRINSIC_PRAGMA)) {
+                    for f in entry.ghost_fields.values() {
+                        // Backend-synthesized validity slots carry unspellable
+                        // `$`-names and exist precisely for intrinsic maps.
+                        if pool.string(f.name).starts_with('$') {
+                            continue;
+                        }
+                        self.parent
+                            .env
+                            .error(&f.loc, "ghost fields are not supported on intrinsic types");
+                    }
                 }
             }
             let mut field_data: BTreeMap<FieldId, FieldData> = BTreeMap::new();

--- a/third_party/move/move-model/src/intrinsics.rs
+++ b/third_party/move/move-model/src/intrinsics.rs
@@ -132,6 +132,17 @@ pub(crate) fn process_intrinsic_declaration(
     // prepare the decl
     let type_entry = builder.parent.struct_table.get(&type_qsym).expect("struct");
     let move_type = type_entry.module_id.qualified(type_entry.struct_id);
+    // The map templates and monomorphization assume exactly a key and a value
+    // type parameter; any other arity would index the instantiation out of
+    // bounds downstream.
+    if type_entry.type_params.len() != 2 {
+        builder.parent.error(
+            loc,
+            "a `map` intrinsic type must have exactly two type parameters \
+             (key and value)",
+        );
+        return;
+    }
 
     let mut decl = IntrinsicDecl {
         move_type,
@@ -213,6 +224,24 @@ fn populate_intrinsic_decl(
                     // signature. This is implicitly done by Boogie right now, but we may want to
                     // make it more explicit and do the checking ourselves.
                     let qid = entry.module_id.qualified(entry.fun_id);
+                    // Also reject sharing across intrinsic types: template
+                    // definitions are emitted once per type under the bound
+                    // function's name and would collide.
+                    if builder
+                        .parent
+                        .intrinsics
+                        .iter()
+                        .any(|d| d.move_fun_to_intrinsic.contains_key(&qid))
+                    {
+                        builder.parent.error(
+                            loc,
+                            &format!(
+                                "move function is already bound to another intrinsic type: {}",
+                                qualified_sym.display(builder.parent.env)
+                            ),
+                        );
+                        continue;
+                    }
                     decl.intrinsic_to_move_fun.insert(key_sym, qid);
                     if decl.move_fun_to_intrinsic.insert(qid, key_sym).is_some() {
                         builder.parent.error(
@@ -266,6 +295,23 @@ fn populate_intrinsic_decl(
                     // make it more explicit and do the checking ourselves.
                     if let Operation::SpecFunction(mid, fid, ..) = &entry.oper {
                         let qid = mid.qualified(*fid);
+                        // Same cross-type sharing rejection as for move
+                        // functions: per-type template definitions collide.
+                        if builder
+                            .parent
+                            .intrinsics
+                            .iter()
+                            .any(|d| d.spec_fun_to_intrinsic.contains_key(&qid))
+                        {
+                            builder.parent.error(
+                                loc,
+                                &format!(
+                                    "spec function is already bound to another intrinsic type: {}",
+                                    qualified_sym.display(builder.parent.env)
+                                ),
+                            );
+                            continue;
+                        }
                         decl.intrinsic_to_spec_fun.insert(key_sym, qid);
                         if decl.spec_fun_to_intrinsic.insert(qid, key_sym).is_some() {
                             builder.parent.error(

--- a/third_party/move/move-model/src/pragmas.rs
+++ b/third_party/move/move-model/src/pragmas.rs
@@ -105,6 +105,20 @@ pub const INTRINSIC_FUN_MAP_NEW_WITH_CONFIG: &str = "map_new_with_config";
 /// `[spec] fun map_new<K, V>(): Map<K, V>`
 pub const INTRINSIC_FUN_MAP_SPEC_NEW: &str = "map_spec_new";
 
+/// Iterator validity predicates: `(iterator_enum, map): bool`, true iff the
+/// iterator's hidden validity slot matches the map's — i.e. the iterator was
+/// created from the map's current version. Binding one of these gives the map
+/// a backend-synthesized validity slot (havoced by structural mutations) and
+/// the predicate's iterator enum a matching slot; neither is visible to or
+/// nameable from user specs. Two role names so a map can cover both a keyed
+/// iterator and a key-agnostic (leaf/node) walker.
+pub const INTRINSIC_FUN_MAP_SPEC_ITER_VALID: &str = "map_spec_iter_valid";
+pub const INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID: &str = "map_spec_leaf_iter_valid";
+/// Validity-preservation predicate: `(map_new, map_old): bool`, true iff the
+/// two map states share a validity version (no structural mutation between
+/// them) — the frame promise for operations that keep iterators valid.
+pub const INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED: &str = "map_spec_iter_preserved";
+
 /// Get the value associated with key `k`.
 /// The behavior is undefined if `k` does not exist in the map
 /// `[spec] fun map_get<K, V>(m: Map<K, V>, k: K): V`
@@ -403,6 +417,18 @@ pub static INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS: Lazy<BTreeMap<&'static str, Intri
                 ),
             ),
             (INTRINSIC_FUN_MAP_SPEC_NEW, IntrinsicFunDef::spec_fun()),
+            (
+                INTRINSIC_FUN_MAP_SPEC_ITER_VALID,
+                IntrinsicFunDef::spec_fun(),
+            ),
+            (
+                INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID,
+                IntrinsicFunDef::spec_fun(),
+            ),
+            (
+                INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED,
+                IntrinsicFunDef::spec_fun(),
+            ),
             (INTRINSIC_FUN_MAP_SPEC_GET, IntrinsicFunDef::spec_fun()),
             (INTRINSIC_FUN_MAP_SPEC_SET, IntrinsicFunDef::spec_fun()),
             (INTRINSIC_FUN_MAP_SPEC_DEL, IntrinsicFunDef::spec_fun()),

--- a/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -59,6 +59,18 @@ pub fn boogie_module_name(env: &ModuleEnv<'_>) -> String {
 /// Return boogie name of given structure.
 pub fn boogie_struct_name(struct_env: &StructEnv<'_>, inst: &[Type], bv_flag: bool) -> String {
     if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+        if struct_env.get_ghost_fields().next().is_some() {
+            // Ghost-declaring intrinsic maps use a per-instance carrier
+            // datatype wrapping the table. The name must follow the suffix
+            // convention including the value's bv twin, so twin instances
+            // reference their own carrier.
+            return format!(
+                "${}_{}{}",
+                boogie_module_name(&struct_env.module_env),
+                struct_env.get_name().display(struct_env.symbol_pool()),
+                boogie_inst_suffix(struct_env.module_env.env, inst, &[false, bv_flag])
+            );
+        }
         // Map to the theory type representation, which is `Table int V`. The key
         // is encoded as an integer to avoid extensionality problems, and to support
         // $Mutation paths, which are sequences of ints.

--- a/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -1429,7 +1429,38 @@ impl ModelValue {
             Type::Struct(module_id, struct_id, params) => {
                 let struct_env = wrapper.env.get_struct_qid(module_id.qualified(*struct_id));
                 if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
-                    self.pretty_table(wrapper, model, &params[0], &params[1])
+                    // Ghost-bearing intrinsic maps are carrier datatypes:
+                    // unwrap the raw table and render the ghosts after the
+                    // entries.
+                    let ghost_fields = struct_env.get_ghost_fields().collect_vec();
+                    if ghost_fields.is_empty() {
+                        self.pretty_table(wrapper, model, &params[0], &params[1])
+                    } else {
+                        // The value's own constructor name disambiguates the
+                        // bv twin, so try both carrier names.
+                        let carrier_name = boogie_struct_name(&struct_env, params, false);
+                        let carrier_name_bv = boogie_struct_name(&struct_env, params, true);
+                        let args = self
+                            .extract_list(&carrier_name)
+                            .or_else(|| self.extract_list(&format!("|{}|", carrier_name)))
+                            .or_else(|| self.extract_list(&carrier_name_bv))
+                            .or_else(|| self.extract_list(&format!("|{}|", carrier_name_bv)))?;
+                        let mut doc = args
+                            .first()?
+                            .pretty_table(wrapper, model, &params[0], &params[1])?;
+                        for (i, f) in ghost_fields.iter().enumerate() {
+                            let ty = f.get_type().instantiate(params);
+                            let default = ModelValue::error();
+                            let v = args.get(1 + i).unwrap_or(&default);
+                            doc = doc
+                                .append(PrettyDoc::text(format!(
+                                    " ghost {} = ",
+                                    f.get_name().display(struct_env.symbol_pool())
+                                )))
+                                .append(v.pretty_or_raw(wrapper, model, &ty));
+                        }
+                        Some(doc)
+                    }
                 } else {
                     self.pretty_struct(wrapper, model, &struct_env, params)
                 }

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -46,7 +46,7 @@ use move_model::{
         StructEnv, StructId,
     },
     pragmas::{
-        ADDITION_OVERFLOW_UNCHECKED_PRAGMA, SEED_PRAGMA, TIMEOUT_PRAGMA,
+        ADDITION_OVERFLOW_UNCHECKED_PRAGMA, INTRINSIC_TYPE_MAP, SEED_PRAGMA, TIMEOUT_PRAGMA,
         VERIFY_DURATION_ESTIMATE_PRAGMA,
     },
     symbol::Symbol,
@@ -6346,59 +6346,107 @@ impl FunctionTranslator<'_> {
                     Pack(mid, sid, inst) => {
                         let inst = &self.inst_slice(inst);
                         let struct_env = env.get_module(*mid).into_struct(*sid);
-                        let mut args = srcs.iter().cloned().map(str_local).collect_vec();
-                        args.extend(self.ghost_field_pack_args(
-                            &struct_env,
-                            inst,
-                            Some(srcs),
-                            &loc,
-                        ));
-                        let dest_str = str_local(dests[0]);
-                        emitln!(
-                            writer,
-                            "{} := {}({});",
-                            dest_str,
-                            boogie_struct_name(&struct_env, inst, false),
-                            args.iter().join(", ")
-                        );
+                        // Intrinsic maps cannot be packed in verified code:
+                        // their declared fields are erased (creation goes
+                        // through the bound roles), so the constructor would
+                        // be ill-typed.
+                        if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+                            env.error(
+                                &loc,
+                                "cannot pack a value of an intrinsic map type in verified \
+                                 code; use the map's creation functions",
+                            );
+                        } else {
+                            let mut args = srcs.iter().cloned().map(str_local).collect_vec();
+                            args.extend(self.ghost_field_pack_args(
+                                &struct_env,
+                                inst,
+                                Some(srcs),
+                                &loc,
+                            ));
+                            let dest_str = str_local(dests[0]);
+                            emitln!(
+                                writer,
+                                "{} := {}({});",
+                                dest_str,
+                                boogie_struct_name(&struct_env, inst, false),
+                                args.iter().join(", ")
+                            );
+                        }
                     },
                     PackVariant(mid, sid, variant, inst) => {
                         let inst = &self.inst_slice(inst);
                         let struct_env = env.get_module(*mid).into_struct(*sid);
-                        let mut args = srcs.iter().cloned().map(str_local).collect_vec();
-                        args.extend(self.ghost_field_pack_args(&struct_env, inst, None, &loc));
-                        let dest_str = str_local(dests[0]);
-                        emitln!(
-                            writer,
-                            "{} := {}({});",
-                            dest_str,
-                            boogie_struct_variant_name(&struct_env, inst, *variant),
-                            args.iter().join(", ")
-                        );
+                        // See `Pack`: the intrinsic representation (raw table
+                        // or ghost carrier) declares no variant constructors.
+                        if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+                            env.error(
+                                &loc,
+                                "cannot pack a value of an intrinsic map type in verified \
+                                 code; use the map's creation functions",
+                            );
+                        } else {
+                            let mut args = srcs.iter().cloned().map(str_local).collect_vec();
+                            args.extend(self.ghost_field_pack_args(&struct_env, inst, None, &loc));
+                            let dest_str = str_local(dests[0]);
+                            emitln!(
+                                writer,
+                                "{} := {}({});",
+                                dest_str,
+                                boogie_struct_variant_name(&struct_env, inst, *variant),
+                                args.iter().join(", ")
+                            );
+                        }
                     },
                     Unpack(mid, sid, _) => {
                         let struct_env = env.get_module(*mid).into_struct(*sid);
-                        for (i, ref field_env) in struct_env.get_fields().enumerate() {
-                            let field_sel =
-                                format!("{}->{}", str_local(srcs[0]), boogie_field_sel(field_env),);
-                            emitln!(writer, "{} := {};", str_local(dests[i]), field_sel);
+                        // See `Pack`: intrinsic map fields are erased, so the
+                        // emitted selectors would be ill-typed.
+                        if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+                            env.error(
+                                &loc,
+                                "cannot unpack a value of an intrinsic map type in verified \
+                                 code",
+                            );
+                        } else {
+                            for (i, ref field_env) in struct_env.get_fields().enumerate() {
+                                let field_sel = format!(
+                                    "{}->{}",
+                                    str_local(srcs[0]),
+                                    boogie_field_sel(field_env),
+                                );
+                                emitln!(writer, "{} := {};", str_local(dests[i]), field_sel);
+                            }
                         }
                     },
                     UnpackVariant(mid, sid, variant, inst) => {
                         let inst = &self.inst_slice(inst);
                         let src_str = str_local(srcs[0]);
                         let struct_env = env.get_module(*mid).into_struct(*sid);
-                        let struct_variant_name =
-                            boogie_struct_variant_name(&struct_env, inst, *variant);
-                        emitln!(writer, "if ({} is {}) {{", src_str, struct_variant_name);
-                        for (i, ref field_env) in
-                            struct_env.get_fields_of_variant(*variant).enumerate()
-                        {
-                            let field_sel =
-                                format!("{}->{}", str_local(srcs[0]), boogie_field_sel(field_env),);
-                            emitln!(writer, "{} := {};", str_local(dests[i]), field_sel);
+                        // See `Pack`: the intrinsic representation (raw table
+                        // or ghost carrier) declares no variant constructors.
+                        if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+                            env.error(
+                                &loc,
+                                "cannot unpack a value of an intrinsic map type in verified \
+                                 code",
+                            );
+                        } else {
+                            let struct_variant_name =
+                                boogie_struct_variant_name(&struct_env, inst, *variant);
+                            emitln!(writer, "if ({} is {}) {{", src_str, struct_variant_name);
+                            for (i, ref field_env) in
+                                struct_env.get_fields_of_variant(*variant).enumerate()
+                            {
+                                let field_sel = format!(
+                                    "{}->{}",
+                                    str_local(srcs[0]),
+                                    boogie_field_sel(field_env),
+                                );
+                                emitln!(writer, "{} := {};", str_local(dests[i]), field_sel);
+                            }
+                            emitln!(writer, "} else { call $ExecFailureAbort(); }");
                         }
-                        emitln!(writer, "} else { call $ExecFailureAbort(); }");
                     },
                     BorrowField(mid, sid, _, field_offset) => {
                         let src_str = str_local(srcs[0]);
@@ -7379,6 +7427,24 @@ impl FunctionTranslator<'_> {
                 if matches!(edge, BorrowEdge::Invoke) {
                     emitln!(writer, "call $t{} := $HavocMutation($t{});", idx, idx);
                 } else {
+                    // Type and bitvector rendering of the value behind the
+                    // destination reference (matching its declared Boogie
+                    // type), for carrier detection and twin selection.
+                    let root_ty = self
+                        .inst(self.get_local_type(*idx).skip_reference())
+                        .clone();
+                    let global_state = &self
+                        .parent
+                        .env
+                        .get_extension::<GlobalNumberOperationState>()
+                        .expect("global number operation state");
+                    let baseline_flag = self.fun_target.data.variant == FunctionVariant::Baseline;
+                    let mid = self.fun_target.func_env.module_env.get_id();
+                    let fid = self.fun_target.func_env.get_id();
+                    let root_bv_flag = global_state
+                        .get_temp_index_oper(mid, fid, *idx, baseline_flag)
+                        .unwrap_or(&Bottom)
+                        == &Bitwise;
                     let update = if let BorrowEdge::Hyper(edges) = edge {
                         self.translate_write_back_update(
                             &mut || dst_value.clone(),
@@ -7386,6 +7452,8 @@ impl FunctionTranslator<'_> {
                             src_value,
                             edges,
                             0,
+                            &root_ty,
+                            root_bv_flag,
                         )
                     } else {
                         self.translate_write_back_update(
@@ -7394,6 +7462,8 @@ impl FunctionTranslator<'_> {
                             src_value,
                             &[edge.to_owned()],
                             0,
+                            &root_ty,
+                            root_bv_flag,
                         )
                     };
                     emitln!(
@@ -7409,7 +7479,15 @@ impl FunctionTranslator<'_> {
     }
 
     fn check_intrinsic_select(&self, attr_id: AttrId, struct_env: &StructEnv) {
-        if struct_env.is_intrinsic() && self.fun_target.global_env().generated_by_v2() {
+        if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+            // Map fields are erased, so the selector would be ill-typed
+            // against the table or its carrier. Hard error (vs the warning
+            // below): no reachable code selects a map field today.
+            self.parent.env.error(
+                &self.fun_target.get_bytecode_loc(attr_id),
+                "cannot select a field of an intrinsic map type in verified code",
+            )
+        } else if struct_env.is_intrinsic() && self.fun_target.global_env().generated_by_v2() {
             // There is code in the framework which produces this warning.
             // Only report if we are running v2.
             self.parent.env.diag(
@@ -7431,6 +7509,13 @@ impl FunctionTranslator<'_> {
         None
     }
 
+    /// `dest_ty` is the type of the value denoted by `mk_dest()` at this edge
+    /// position (threaded from the borrow root), used to detect intrinsic-map
+    /// ghost carriers on `Index(Table)` edges. `Type::Error` when unknown
+    /// (custom index edges), which never matches a carrier. `bv_flag` is that
+    /// value's bitvector rendering (fields switch to their own
+    /// classification, container elements inherit), selecting the matching
+    /// carrier twin.
     fn translate_write_back_update(
         &self,
         mk_dest: &mut dyn FnMut() -> String,
@@ -7438,14 +7523,22 @@ impl FunctionTranslator<'_> {
         src: String,
         edges: &[BorrowEdge],
         at: usize,
+        dest_ty: &Type,
+        bv_flag: bool,
     ) -> String {
         if at >= edges.len() {
             src
         } else {
             match &edges[at] {
-                BorrowEdge::Direct => {
-                    self.translate_write_back_update(mk_dest, get_path_index, src, edges, at + 1)
-                },
+                BorrowEdge::Direct => self.translate_write_back_update(
+                    mk_dest,
+                    get_path_index,
+                    src,
+                    edges,
+                    at + 1,
+                    dest_ty,
+                    bv_flag,
+                ),
                 BorrowEdge::Field(memory, variant, offset) => {
                     let memory = memory.to_owned().instantiate(self.type_inst);
                     let struct_env = &self.parent.env.get_struct_qid(memory.to_qualified_id());
@@ -7457,6 +7550,7 @@ impl FunctionTranslator<'_> {
                             *offset,
                         )
                     };
+                    let field_ty = field_env.get_type().instantiate(&memory.inst);
                     let field_sel = boogie_field_sel(&field_env);
                     let new_dest = format!("{}->{}", (*mk_dest)(), field_sel);
                     let mut new_dest_needed = false;
@@ -7469,6 +7563,15 @@ impl FunctionTranslator<'_> {
                         src,
                         edges,
                         at + 1,
+                        &field_ty,
+                        field_bv_flag_global_state(
+                            &self
+                                .parent
+                                .env
+                                .get_extension::<GlobalNumberOperationState>()
+                                .expect("global number operation state"),
+                            &field_env,
+                        ),
                     );
                     let update_fun = if variant.is_none() {
                         boogie_field_update(&field_env, &memory.inst)
@@ -7514,6 +7617,39 @@ impl FunctionTranslator<'_> {
                             self.get_borrow_native_aggregate_names(name).unwrap()
                         },
                     };
+                    let env = self.parent.env;
+                    // A ghost-carrier map wraps its table: content reads
+                    // through `->$$t`, and the update rebuilds the carrier
+                    // PRESERVING ghosts — a value write is not a structural
+                    // mutation and must not disturb e.g. the validity brand.
+                    let carrier = if matches!(index_edge_kind, IndexEdgeKind::Table) {
+                        if let Type::Struct(mid, sid, targs) = dest_ty.skip_reference() {
+                            let struct_env = env.get_struct(mid.qualified(*sid));
+                            let ghost_sels: Vec<String> = struct_env
+                                .get_ghost_fields()
+                                .map(|f| boogie_field_sel(&f))
+                                .collect();
+                            if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP)
+                                && !ghost_sels.is_empty()
+                            {
+                                Some((boogie_struct_name(&struct_env, targs, bv_flag), ghost_sels))
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                    // The element/value type for the recursion step.
+                    let elem_ty = match (index_edge_kind, dest_ty.skip_reference()) {
+                        (IndexEdgeKind::Vector, Type::Vector(elem)) => (**elem).clone(),
+                        (IndexEdgeKind::Table, Type::Struct(_, _, targs)) if targs.len() >= 2 => {
+                            targs[1].clone()
+                        },
+                        _ => Type::Error,
+                    };
 
                     // Compute the offset into the path where to retrieve the index.
                     let offset = edges[0..at]
@@ -7521,7 +7657,12 @@ impl FunctionTranslator<'_> {
                         .filter(|e| !matches!(e, BorrowEdge::Direct))
                         .count();
                     let index = (*get_path_index)(offset);
-                    let new_dest = format!("{}({}, {})", read_aggregate, (*mk_dest)(), index);
+                    let content = |dest: String| match &carrier {
+                        Some(_) => format!("{}->$$t", dest),
+                        None => dest,
+                    };
+                    let new_dest =
+                        format!("{}({}, {})", read_aggregate, content((*mk_dest)()), index);
                     let mut new_dest_needed = false;
                     // Recursively perform write backs for next edges
                     let new_src = self.translate_write_back_update(
@@ -7533,25 +7674,33 @@ impl FunctionTranslator<'_> {
                         src,
                         edges,
                         at + 1,
+                        &elem_ty,
+                        bv_flag,
                     );
+                    let mk_update = |dest: String, new_src: &str| match &carrier {
+                        Some((carrier_name, ghost_sels)) => {
+                            let ghosts = ghost_sels
+                                .iter()
+                                .map(|sel| format!(", {}->{}", dest, sel))
+                                .join("");
+                            format!(
+                                "{}({}({}->$$t, {}, {}){})",
+                                carrier_name, update_aggregate, dest, index, new_src, ghosts
+                            )
+                        },
+                        None => {
+                            format!("{}({}, {}, {})", update_aggregate, dest, index, new_src)
+                        },
+                    };
                     if new_dest_needed {
                         format!(
-                            "(var $$sel{} := {}; {}({}, {}, {}))",
+                            "(var $$sel{} := {}; {})",
                             at,
                             new_dest,
-                            update_aggregate,
-                            (*mk_dest)(),
-                            index,
-                            new_src
+                            mk_update((*mk_dest)(), &new_src)
                         )
                     } else {
-                        format!(
-                            "{}({}, {}, {})",
-                            update_aggregate,
-                            (*mk_dest)(),
-                            index,
-                            new_src
-                        )
+                        mk_update((*mk_dest)(), &new_src)
                     }
                 },
                 BorrowEdge::Hyper(_) | BorrowEdge::Invoke => unreachable!("unexpected borrow edge"),

--- a/third_party/move/move-prover/boogie-backend/src/lib.rs
+++ b/third_party/move/move-prover/boogie-backend/src/lib.rs
@@ -6,7 +6,9 @@
 #![forbid(unsafe_code)]
 
 use crate::{
-    boogie_helpers::{boogie_module_name, boogie_num_type_base, boogie_type, boogie_type_suffix},
+    boogie_helpers::{
+        boogie_field_sel, boogie_module_name, boogie_num_type_base, boogie_type, boogie_type_suffix,
+    },
     bytecode_translator::has_native_equality,
     options::{BoogieOptions, VectorTheory},
 };
@@ -17,7 +19,7 @@ use move_model::{
     ast::Address,
     code_writer::CodeWriter,
     emit, emitln,
-    model::{GlobalEnv, QualifiedId, StructId},
+    model::{GlobalEnv, Parameter, QualifiedId, StructId},
     pragmas::{
         INTRINSIC_FUN_MAP_ADD_ALL, INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE,
         INTRINSIC_FUN_MAP_ADD_OVERRIDE_IF_EXISTS, INTRINSIC_FUN_MAP_APPEND,
@@ -35,10 +37,11 @@ use move_model::{
         INTRINSIC_FUN_MAP_SPEC_ABORTS_BORROW, INTRINSIC_FUN_MAP_SPEC_ABORTS_DEL,
         INTRINSIC_FUN_MAP_SPEC_ABORTS_DESTROY_EMPTY, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_MUT,
         INTRINSIC_FUN_MAP_SPEC_DEL, INTRINSIC_FUN_MAP_SPEC_GET, INTRINSIC_FUN_MAP_SPEC_HAS_KEY,
-        INTRINSIC_FUN_MAP_SPEC_IS_EMPTY, INTRINSIC_FUN_MAP_SPEC_LEN, INTRINSIC_FUN_MAP_SPEC_NEW,
-        INTRINSIC_FUN_MAP_SPEC_SET, INTRINSIC_FUN_MAP_TO_ORDERED_MAP,
-        INTRINSIC_FUN_MAP_TO_VEC_PAIR, INTRINSIC_FUN_MAP_TRIM, INTRINSIC_FUN_MAP_UPSERT,
-        INTRINSIC_FUN_MAP_UPSERT_ALL, INTRINSIC_FUN_MAP_VALUES,
+        INTRINSIC_FUN_MAP_SPEC_IS_EMPTY, INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED,
+        INTRINSIC_FUN_MAP_SPEC_ITER_VALID, INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID,
+        INTRINSIC_FUN_MAP_SPEC_LEN, INTRINSIC_FUN_MAP_SPEC_NEW, INTRINSIC_FUN_MAP_SPEC_SET,
+        INTRINSIC_FUN_MAP_TO_ORDERED_MAP, INTRINSIC_FUN_MAP_TO_VEC_PAIR, INTRINSIC_FUN_MAP_TRIM,
+        INTRINSIC_FUN_MAP_UPSERT, INTRINSIC_FUN_MAP_UPSERT_ALL, INTRINSIC_FUN_MAP_VALUES,
     },
     ty::{PrimitiveType, Type},
 };
@@ -107,6 +110,12 @@ struct BvInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+struct GhostArg {
+    sel: String,
+    ty: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
 struct MapImpl {
     struct_name: String,
     insts: Vec<(TypeInfo, TypeInfo)>,
@@ -133,6 +142,31 @@ struct MapImpl {
     iter_ptr_prefix: String,
     iter_variant: String,
     iter_key_sel: String,
+    // Iterator-validity predicates: equality of the hidden `$$validity` slot
+    // between an iterator and its map (or two map states for `preserved`).
+    // The iterator enum's Boogie name is `prefix`, plus the key suffix when
+    // the enum is keyed (`generic`).
+    fun_spec_iter_valid: String,
+    iter_valid_prefix: String,
+    iter_valid_generic: bool,
+    fun_spec_leaf_iter_valid: String,
+    leaf_iter_valid_prefix: String,
+    leaf_iter_valid_generic: bool,
+    fun_spec_iter_preserved: String,
+    // Ghost carrier: an intrinsic map that declares ghost fields is
+    // represented as a per-instance datatype wrapping the table, so the
+    // ghosts have constructor arguments to live in. `struct_base` plus the
+    // instance suffix is the carrier datatype name (agreeing with
+    // `boogie_struct_name`); `ghost_args` are the ghost selectors and their
+    // (type-parameter-free) Boogie types.
+    has_ghost_carrier: bool,
+    struct_base: String,
+    ghost_args: Vec<GhostArg>,
+    gb_args: String,
+    gb_decls: String,
+    gb_havoc: String,
+    ghost_preserve_args: String,
+    ghost_zero_args: String,
     fun_get: String,
     fun_borrow_front: String,
     fun_borrow_back: String,
@@ -563,7 +597,7 @@ impl MapImpl {
         ty_args: &BTreeSet<(Type, Type)>,
         bv_flag: bool,
     ) -> Self {
-        let insts = ty_args
+        let insts: Vec<(TypeInfo, TypeInfo)> = ty_args
             .iter()
             .map(|(kty, vty)| {
                 (
@@ -588,6 +622,41 @@ impl MapImpl {
             env,
             decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ITER_BORROW_MUT),
         );
+        let iter_valid_parts = Self::validity_parts(env, decl, INTRINSIC_FUN_MAP_SPEC_ITER_VALID);
+        let leaf_iter_valid_parts =
+            Self::validity_parts(env, decl, INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID);
+        let ghost_args: Vec<GhostArg> = struct_env
+            .get_ghost_fields()
+            .map(|f| GhostArg {
+                sel: boogie_field_sel(&f),
+                ty: boogie_type(env, &f.get_type(), false),
+            })
+            .collect();
+        let has_ghost_carrier = !ghost_args.is_empty();
+        let struct_base = struct_name.clone();
+        // Rebuild plumbing for mutating templates: fresh (havoced) ghost
+        // values per rebuild site, shared between the rebuilt value and any
+        // post-state spec-function application describing it.
+        let (gb_args, gb_decls, gb_havoc) = if has_ghost_carrier {
+            let idxs = 0..ghost_args.len();
+            (
+                idxs.clone().map(|i| format!(", $gb{}", i)).join(""),
+                idxs.clone()
+                    .map(|i| format!("\n    var $gb{}: int;", i))
+                    .join(""),
+                idxs.map(|i| format!("havoc $gb{}; ", i)).join(""),
+            )
+        } else {
+            (String::new(), String::new(), String::new())
+        };
+        // Pure spec functions cannot havoc: map-returning spec funs preserve
+        // the input's ghost args (whole-map equalities are ghost-excluding,
+        // so the choice is immaterial) or use zeros when there is no input.
+        let ghost_preserve_args = ghost_args
+            .iter()
+            .map(|g| format!(", t->{}", g.sel))
+            .join("");
+        let ghost_zero_args = ghost_args.iter().map(|_| ", 0".to_string()).join("");
 
         MapImpl {
             struct_name,
@@ -651,9 +720,27 @@ impl MapImpl {
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BORROW_WITH_DEFAULT),
             ),
             fun_iter_borrow_mut,
+            fun_spec_iter_valid: iter_valid_parts.0,
+            iter_valid_prefix: iter_valid_parts.1,
+            iter_valid_generic: iter_valid_parts.2,
+            fun_spec_leaf_iter_valid: leaf_iter_valid_parts.0,
+            leaf_iter_valid_prefix: leaf_iter_valid_parts.1,
+            leaf_iter_valid_generic: leaf_iter_valid_parts.2,
+            fun_spec_iter_preserved: Self::triple_opt_to_name(
+                env,
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED),
+            ),
             iter_ptr_prefix: iter_parts.0,
             iter_variant: iter_parts.1,
             iter_key_sel: iter_parts.2,
+            has_ghost_carrier,
+            struct_base,
+            ghost_args,
+            gb_args,
+            gb_decls,
+            gb_havoc,
+            ghost_preserve_args,
+            ghost_zero_args,
             fun_get: Self::triple_opt_to_name(env, decl.get_fun_triple(env, INTRINSIC_FUN_MAP_GET)),
             fun_borrow_front: Self::triple_opt_to_name(
                 env,
@@ -776,8 +863,11 @@ impl MapImpl {
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_BORROW),
             ),
             fun_spec_aborts_iter_borrow_mut: {
-                // Only a NATIVE-bound predicate needs the template definition;
-                // and the template's fixed signature — two type parameters,
+                // Only a NATIVE-bound predicate needs the template definition:
+                // the condition mirrors the spec translator's skip exactly —
+                // bodied AND uninterpreted spec funs are emitted there, so a
+                // template definition would declare the symbol twice. Also,
+                // the template's fixed signature — two type parameters,
                 // `(Iter<K>, MapType<K, V>)` by value, `bool` — must match the
                 // binding, or spec translation would emit a call to a symbol
                 // the template never defines. The iterator type comes from the
@@ -785,11 +875,11 @@ impl MapImpl {
                 // co-bound.
                 match decl.lookup_spec_fun(env, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_MUT) {
                     Some(qid)
-                        if env
-                            .get_module(qid.module_id)
-                            .get_spec_fun(qid.id)
-                            .body
-                            .is_none() =>
+                        if {
+                            let module_env = env.get_module(qid.module_id);
+                            let sf = module_env.get_spec_fun(qid.id);
+                            sf.body.is_none() && !sf.uninterpreted
+                        } =>
                     {
                         let module_env = env.get_module(qid.module_id);
                         let fun_decl = module_env.get_spec_fun(qid.id);
@@ -845,6 +935,35 @@ impl MapImpl {
     /// variant (the variant with a field of the enum's first type parameter),
     /// and that field's Boogie selector. Returns empty strings when the role is
     /// not bound or the iterator enum does not have the expected shape.
+    /// Resolve a validity-predicate binding: the bound spec fun's Boogie
+    /// name, the iterator enum's uninstantiated Boogie name prefix, and
+    /// whether the enum is keyed (its Boogie name then carries the key
+    /// suffix per instance). Empty when unbound or malformed; signature
+    /// validation happens at mono analysis.
+    fn validity_parts(
+        env: &GlobalEnv,
+        decl: &move_model::intrinsics::IntrinsicDecl,
+        role: &str,
+    ) -> (String, String, bool) {
+        let empty = (String::new(), String::new(), false);
+        let Some(sf_qid) = decl.lookup_spec_fun(env, role) else {
+            return empty;
+        };
+        let name = Self::triple_opt_to_name(env, decl.get_fun_triple(env, role));
+        let module_env = env.get_module(sf_qid.module_id);
+        let sf = module_env.get_spec_fun(sf_qid.id);
+        let Some(Parameter(_, Type::Struct(mid, sid, inst), _)) = sf.params.first() else {
+            return empty;
+        };
+        let iter_env = env.get_struct(mid.qualified(*sid));
+        let prefix = format!(
+            "${}_{}",
+            boogie_module_name(&iter_env.module_env),
+            iter_env.get_name().display(iter_env.symbol_pool())
+        );
+        (name, prefix, !inst.is_empty())
+    }
+
     fn iter_ptr_parts(
         env: &GlobalEnv,
         decl: &move_model::intrinsics::IntrinsicDecl,

--- a/third_party/move/move-prover/boogie-backend/src/prelude/native.bpl
+++ b/third_party/move/move-prover/boogie-backend/src/prelude/native.bpl
@@ -388,42 +388,93 @@ axiom (
 {%- set K = instance.0.name -%}
 {%- set V = instance.1.name -%}
 {%- set Type = impl.struct_name -%}
-{%- set Self = "Table int (" ~ V ~ ")" -%}
+{%- set Table = "Table int (" ~ V ~ ")" -%}
 {%- set S = "'" ~ instance.0.suffix ~ "_" ~ instance.1.suffix ~ "'" -%}
 {%- set SK = "'" ~ instance.0.suffix ~ "'" -%}
 {%- set SV = "'" ~ instance.1.suffix ~ "'" -%}
 {%- set ENC = "$EncodeKey'" ~ instance.0.suffix ~ "'" -%}
 
-{#- A ghost-bearing value type must compare with `$IsEqual` rather than raw
-    `==`: ghosts are constructor arguments, so raw equality would include
-    them, while Move equality is the quotient over runtime state. -#}
-{%- if instance.1.has_ghost -%}
-{%- set VEQ = "$IsEqual'" ~ instance.1.suffix ~ "'(GetTable(t1, k), GetTable(t2, k))" -%}
+{%- if impl.has_ghost_carrier %}
+{# Ghost carrier: the map value wraps the table so declared ghost fields have
+   constructor arguments to live in; `Self` is the carrier (named per
+   `boogie_struct_name`). Template plumbing (all expand to nothing / identity
+   for ghost-less maps, keeping their output byte-identical):
+   - `U`: content unwrap suffix applied to map-typed values at raw table ops;
+   - `W1`/`W2`: wrap a table expression into a carrier with the `$gbN` ghost
+     values of the enclosing rebuild site;
+   - `GH`/`GBD`: havoc statements / local declarations for the `$gbN`s
+     (mutation gives the map fresh, unconstrained ghost state; validity of
+     outstanding iterators becomes UNDETERMINED — never provable, but not
+     provably false either — so uses gated on validity fail closed until a
+     new iterator re-establishes it);
+   - `TND`: local declarations for blocks using a fresh raw table `t_new`
+     (`t_new` stays a raw table — it is wrapped at each use site). #}
+{%- set Self = impl.struct_base ~ S -%}
+{%- set U = "->$$t" -%}
+{%- set W1 = Self ~ "(" -%}
+{%- set W2 = impl.gb_args ~ ")" -%}
+{%- set SW1 = Self ~ "(" -%}
+{%- set SW2 = impl.ghost_preserve_args ~ ")" -%}
+{%- set SZ2 = impl.ghost_zero_args ~ ")" -%}
+{%- set GH = impl.gb_havoc -%}
+{%- set GBD = impl.gb_decls -%}
+{%- set TND = "var t: " ~ Self ~ "; var t_new: " ~ Table ~ ";" ~ GBD -%}
+{#- The raw-table selector is `$$t`: Move field selectors render as `$<name>`,
+    so a `$$`-prefixed name cannot collide with any declared ghost field. -#}
+datatype {{Self}} {
+    {{Self}}($$t: {{Table}}{%- for g in impl.ghost_args %}, {{g.sel}}: {{g.ty}}{%- endfor %})
+}
+{%- else %}
+{%- set Self = Table -%}
+{%- set U = "" -%}
+{%- set W1 = "" -%}
+{%- set W2 = "" -%}
+{%- set SW1 = "" -%}
+{%- set SW2 = "" -%}
+{%- set SZ2 = "" -%}
+{%- set GH = "" -%}
+{%- set GBD = "" -%}
+{%- set TND = "var t, t_new: " ~ Self ~ ";" -%}
+{%- endif %}
+
+{#- Content accessors: value-level functions compare/validate the table
+    content; carrier ghosts are excluded from equality (Move equality is the
+    quotient over runtime state) and `num` ghosts add no validity constraint. -#}
+{%- if impl.has_ghost_carrier -%}
+{%- set c1 = "t1->$$t" -%}{%- set c2 = "t2->$$t" -%}{%- set c = "t->$$t" -%}
 {%- else -%}
-{%- set VEQ = "GetTable(t1, k) == GetTable(t2, k)" -%}
+{%- set c1 = "t1" -%}{%- set c2 = "t2" -%}{%- set c = "t" -%}
 {%- endif -%}
-{%- if options.native_equality and not instance.1.has_ghost -%}
+{#- A ghost-bearing VALUE type must compare with `$IsEqual` rather than raw
+    `==`, which would include its ghost constructor arguments. (Carrier
+    ghosts on the map itself are excluded via the `c1`/`c2` unwrap above.) -#}
+{%- if instance.1.has_ghost -%}
+{%- set VEQ = "$IsEqual'" ~ instance.1.suffix ~ "'(GetTable(" ~ c1 ~ ", k), GetTable(" ~ c2 ~ ", k))" -%}
+{%- else -%}
+{%- set VEQ = "GetTable(" ~ c1 ~ ", k) == GetTable(" ~ c2 ~ ", k)" -%}
+{%- endif -%}
+{%- if options.native_equality and not impl.has_ghost_carrier and not instance.1.has_ghost -%}
 function $IsEqual'{{Type}}{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
     t1 == t2
 }
 {%- else -%}
 function $IsEqual'{{Type}}{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
-    LenTable(t1) == LenTable(t2) &&
-    (forall k: int :: ContainsTable(t1, k) <==> ContainsTable(t2, k)) &&
-    (forall k: int :: ContainsTable(t1, k) ==> {{VEQ}}) &&
-    (forall k: int :: ContainsTable(t2, k) ==> {{VEQ}})
+    LenTable({{c1}}) == LenTable({{c2}}) &&
+    (forall k: int :: ContainsTable({{c1}}, k) <==> ContainsTable({{c2}}, k)) &&
+    (forall k: int :: ContainsTable({{c1}}, k) ==> {{VEQ}}) &&
+    (forall k: int :: ContainsTable({{c2}}, k) ==> {{VEQ}})
 }
 {%- endif %}
 
 // Not inlined.
 function $IsValid'{{Type}}{{S}}'(t: {{Self}}): bool {
-    $IsValid'u64'(LenTable(t)) &&
-    (forall i: int:: ContainsTable(t, i) ==> $IsValid{{SV}}(GetTable(t, i)))
+    $IsValid'u64'(LenTable({{c}})) &&
+    (forall i: int:: ContainsTable({{c}}, i) ==> $IsValid{{SV}}(GetTable({{c}}, i)))
 }
 
 {%- if impl.fun_new != "" %}
-procedure {:inline 2} {{impl.fun_new}}{{S}}() returns (v: {{Self}}) {
-    v := EmptyTable();
+procedure {:inline 2} {{impl.fun_new}}{{S}}() returns (v: {{Self}}) {{"{"}}{{GBD}}
+    {{GH}}v := {{W1}}EmptyTable(){{W2}};
 }
 {%- endif %}
 
@@ -432,7 +483,7 @@ procedure {:inline 2} {{impl.fun_new}}{{S}}() returns (v: {{Self}}) {
 // valid range (INNER_MIN_DEGREE=4 / LEAF_MIN_DEGREE=3 / MAX_DEGREE=4096, mirroring
 // big_ordered_map constants). ASSUMPTION: the implementation's size-validation abort
 // (key/entry serialized size exceeding node limits) is presumed not to fire.
-procedure {:inline 2} {{impl.fun_new_with_config}}{{S}}(inner_max_degree: int, leaf_max_degree: int, reuse_slots: bool) returns (v: {{Self}}) {
+procedure {:inline 2} {{impl.fun_new_with_config}}{{S}}(inner_max_degree: int, leaf_max_degree: int, reuse_slots: bool) returns (v: {{Self}}) {{"{"}}{{GBD}}
     if (inner_max_degree != 0 && (inner_max_degree < 4 || inner_max_degree > 4096)) {
         call $ExecFailureAbort();
         return;
@@ -441,13 +492,13 @@ procedure {:inline 2} {{impl.fun_new_with_config}}{{S}}(inner_max_degree: int, l
         call $ExecFailureAbort();
         return;
     }
-    v := EmptyTable();
+    {{GH}}v := {{W1}}EmptyTable(){{W2}};
 }
 {%- endif %}
 
 {%- if impl.fun_destroy_empty != "" %}
 procedure {:inline 2} {{impl.fun_destroy_empty}}{{S}}(t: {{Self}}) {
-    if (LenTable(t) != 0) {
+    if (LenTable(t{{U}}) != 0) {
         call $Abort($StdError(1/*INVALID_STATE*/, 102/*ENOT_EMPTY*/));
     }
 }
@@ -455,19 +506,19 @@ procedure {:inline 2} {{impl.fun_destroy_empty}}{{S}}(t: {{Self}}) {
 
 {%- if impl.fun_len != "" %}
 procedure {:inline 2} {{impl.fun_len}}{{S}}(t: ({{Self}})) returns (l: int) {
-    l := LenTable(t);
+    l := LenTable(t{{U}});
 }
 {%- endif %}
 
 {%- if impl.fun_is_empty != "" %}
 procedure {:inline 2} {{impl.fun_is_empty}}{{S}}(t: ({{Self}})) returns (r: bool) {
-    r := LenTable(t) == 0;
+    r := LenTable(t{{U}}) == 0;
 }
 {%- endif %}
 
 {%- if impl.fun_has_key != "" %}
 procedure {:inline 2} {{impl.fun_has_key}}{{S}}(t: ({{Self}}), k: {{K}}) returns (r: bool) {
-    r := ContainsTable(t, {{ENC}}(k));
+    r := ContainsTable(t{{U}}, {{ENC}}(k));
 }
 {%- endif %}
 
@@ -487,8 +538,8 @@ procedure {:inline 2} {{impl.fun_has_key}}{{S}}(t: ({{Self}}), k: {{K}}) returns
 procedure {:inline 2} {{impl.fun_get}}{{S}}(t: ({{Self}}), k: {{K}}) returns (result: $1_option_Option{{SV}}) {
     var enc_k: int;
     enc_k := {{ENC}}(k);
-    if (ContainsTable(t, enc_k)) {
-        result := $1_option_Option{{SV}}_Some(GetTable(t, enc_k));
+    if (ContainsTable(t{{U}}, enc_k)) {
+        result := $1_option_Option{{SV}}_Some(GetTable(t{{U}}, enc_k));
     } else {
         result := $1_option_Option{{SV}}_None();
     }
@@ -498,7 +549,7 @@ procedure {:inline 2} {{impl.fun_get}}{{S}}(t: ({{Self}}), k: {{K}}) returns (re
 {%- if impl.fun_borrow_front != "" and impl.fun_spec_has_key != "" and impl.fun_spec_get != "" and instance.0.cmp_available and not instance.1.is_bv %}
 // Smallest key under `cmp::compare` ordering. Aborts when the map is empty.
 procedure {:inline 2} {{impl.fun_borrow_front}}{{S}}(t: {{Self}}) returns (k: {{K}}, v: {{V}}) {
-    if (LenTable(t) == 0) {
+    if (LenTable(t{{U}}) == 0) {
         call $ExecFailureAbort();
         return;
     }
@@ -516,7 +567,7 @@ procedure {:inline 2} {{impl.fun_borrow_front}}{{S}}(t: {{Self}}) returns (k: {{
 {%- if impl.fun_borrow_back != "" and impl.fun_spec_has_key != "" and impl.fun_spec_get != "" and instance.0.cmp_available and not instance.1.is_bv %}
 // Largest key under `cmp::compare` ordering. Aborts when the map is empty.
 procedure {:inline 2} {{impl.fun_borrow_back}}{{S}}(t: {{Self}}) returns (k: {{K}}, v: {{V}}) {
-    if (LenTable(t) == 0) {
+    if (LenTable(t{{U}}) == 0) {
         call $ExecFailureAbort();
         return;
     }
@@ -534,7 +585,7 @@ procedure {:inline 2} {{impl.fun_borrow_back}}{{S}}(t: {{Self}}) returns (k: {{K
 {%- if impl.fun_front_key != "" and impl.fun_spec_has_key != "" and instance.0.cmp_available and not instance.1.is_bv %}
 // Smallest key under `cmp::compare` ordering. Aborts when the map is empty.
 procedure {:inline 2} {{impl.fun_front_key}}{{S}}(t: {{Self}}) returns (k: {{K}}) {
-    if (LenTable(t) == 0) {
+    if (LenTable(t{{U}}) == 0) {
         call $ExecFailureAbort();
         return;
     }
@@ -550,7 +601,7 @@ procedure {:inline 2} {{impl.fun_front_key}}{{S}}(t: {{Self}}) returns (k: {{K}}
 {%- if impl.fun_back_key != "" and impl.fun_spec_has_key != "" and instance.0.cmp_available and not instance.1.is_bv %}
 // Largest key under `cmp::compare` ordering. Aborts when the map is empty.
 procedure {:inline 2} {{impl.fun_back_key}}{{S}}(t: {{Self}}) returns (k: {{K}}) {
-    if (LenTable(t) == 0) {
+    if (LenTable(t{{U}}) == 0) {
         call $ExecFailureAbort();
         return;
     }
@@ -567,9 +618,9 @@ procedure {:inline 2} {{impl.fun_back_key}}{{S}}(t: {{Self}}) returns (k: {{K}})
 // Remove and return the smallest entry under `cmp::compare` ordering. Aborts when the map is empty.
 procedure {:inline 2} {{impl.fun_pop_front}}{{S}}(m: $Mutation ({{Self}}))
 returns (k: {{K}}, v: {{V}}, m': $Mutation ({{Self}})) {
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     t := $Dereference(m);
-    if (LenTable(t) == 0) {
+    if (LenTable(t{{U}}) == 0) {
         call $ExecFailureAbort();
         return;
     }
@@ -581,7 +632,7 @@ returns (k: {{K}}, v: {{V}}, m': $Mutation ({{Self}})) {
         !$IsEqual'{{instance.0.suffix}}'(other, k) ==>
         {{impl.fun_spec_has_key}}{{S}}(t, other) ==>
             $1_cmp_$compare'{{instance.0.suffix}}'(k, other) == $1_cmp_Ordering_Less());
-    m' := $UpdateMutation(m, RemoveTable(t, {{ENC}}(k)));
+    {{GH}}m' := $UpdateMutation(m, {{W1}}RemoveTable(t{{U}}, {{ENC}}(k)){{W2}});
 }
 {%- endif %}
 
@@ -589,9 +640,9 @@ returns (k: {{K}}, v: {{V}}, m': $Mutation ({{Self}})) {
 // Remove and return the largest entry under `cmp::compare` ordering. Aborts when the map is empty.
 procedure {:inline 2} {{impl.fun_pop_back}}{{S}}(m: $Mutation ({{Self}}))
 returns (k: {{K}}, v: {{V}}, m': $Mutation ({{Self}})) {
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     t := $Dereference(m);
-    if (LenTable(t) == 0) {
+    if (LenTable(t{{U}}) == 0) {
         call $ExecFailureAbort();
         return;
     }
@@ -603,7 +654,7 @@ returns (k: {{K}}, v: {{V}}, m': $Mutation ({{Self}})) {
         !$IsEqual'{{instance.0.suffix}}'(other, k) ==>
         {{impl.fun_spec_has_key}}{{S}}(t, other) ==>
             $1_cmp_$compare'{{instance.0.suffix}}'(k, other) == $1_cmp_Ordering_Greater());
-    m' := $UpdateMutation(m, RemoveTable(t, {{ENC}}(k)));
+    {{GH}}m' := $UpdateMutation(m, {{W1}}RemoveTable(t{{U}}, {{ENC}}(k)){{W2}});
 }
 {%- endif %}
 
@@ -663,7 +714,7 @@ procedure {:inline 2} {{impl.fun_next_key}}{{S}}(t: {{Self}}, key: {{K}}) return
 // ($ContainsVec cannot be a pattern: its inline body is an `exists`).
 procedure {:inline 2} {{impl.fun_keys}}{{S}}(t: ({{Self}})) returns (result: Vec ({{K}})) {
     assume $IsValid'vec'{{instance.0.suffix}}''(result);
-    assume LenVec(result) == LenTable(t);
+    assume LenVec(result) == LenTable(t{{U}});
     assume (forall i: int :: {ReadVec(result, i)} InRangeVec(result, i) ==>
         {{impl.fun_spec_has_key}}{{S}}(t, ReadVec(result, i)));
     assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
@@ -684,8 +735,8 @@ procedure {:inline 2} {{impl.fun_keys}}{{S}}(t: ({{Self}})) returns (result: Vec
 // Convert to another intrinsic-map type with identical contents. Never aborts.
 // Both map types share the `Table int V` representation and the per-K `$EncodeKey`,
 // so the conversion is the identity at this level.
-procedure {:inline 2} {{impl.fun_to_ordered_map}}{{S}}(t: ({{Self}})) returns (result: ({{Self}})) {
-    result := t;
+procedure {:inline 2} {{impl.fun_to_ordered_map}}{{S}}(t: ({{Self}})) returns (result: ({{Table}})) {
+    result := t{{U}};
 }
 {%- endif %}
 
@@ -693,7 +744,7 @@ procedure {:inline 2} {{impl.fun_to_ordered_map}}{{S}}(t: ({{Self}})) returns (r
 // All values in the map as a `vector<V>`. Never aborts. Only length is promised;
 // callers needing value/key correspondence should use `to_vec_pair`.
 procedure {:inline 2} {{impl.fun_values}}{{S}}(t: ({{Self}})) returns (result: Vec ({{V}})) {
-    assume LenVec(result) == LenTable(t);
+    assume LenVec(result) == LenTable(t{{U}});
 }
 {%- endif %}
 
@@ -704,8 +755,8 @@ procedure {:inline 2} {{impl.fun_values}}{{S}}(t: ({{Self}})) returns (result: V
 procedure {:inline 2} {{impl.fun_to_vec_pair}}{{S}}(t: ({{Self}})) returns (result_keys: Vec ({{K}}), result_values: Vec ({{V}})) {
     assume $IsValid'vec'{{instance.0.suffix}}''(result_keys);
     assume $IsValid'vec'{{instance.1.suffix}}''(result_values);
-    assume LenVec(result_keys) == LenTable(t);
-    assume LenVec(result_values) == LenTable(t);
+    assume LenVec(result_keys) == LenTable(t{{U}});
+    assume LenVec(result_values) == LenTable(t{{U}});
     assume (forall i: int :: {ReadVec(result_keys, i)} InRangeVec(result_keys, i) ==>
         {{impl.fun_spec_has_key}}{{S}}(t, ReadVec(result_keys, i)));
     assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
@@ -735,7 +786,7 @@ procedure {:inline 2} {{impl.fun_new_from}}{{S}}(keys_arg: Vec ({{K}}), values_a
         call $ExecFailureAbort();
         return;
     }
-    assume LenTable(result) == LenVec(keys_arg);
+    assume LenTable(result{{U}}) == LenVec(keys_arg);
     assume (forall i: int :: {ReadVec(keys_arg, i)} InRangeVec(keys_arg, i) ==>
         {{impl.fun_spec_has_key}}{{S}}(result, ReadVec(keys_arg, i)));
     assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(result, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
@@ -752,7 +803,7 @@ procedure {:inline 2} {{impl.fun_new_from}}{{S}}(keys_arg: Vec ({{K}}), values_a
 // spec_get(t, k) == spec_get(t_new, k)` shape would violate trigger discipline).
 procedure {:inline 2} {{impl.fun_add_all}}{{S}}(m: $Mutation ({{Self}}), keys_arg: Vec ({{K}}), values_arg: Vec ({{V}}))
 returns (m': $Mutation ({{Self}})) {
-    var t, t_new: {{Self}};
+    {{TND}}
     t := $Dereference(m);
     if (LenVec(keys_arg) != LenVec(values_arg)) {
         call $ExecFailureAbort();
@@ -767,19 +818,19 @@ returns (m': $Mutation ({{Self}})) {
         call $ExecFailureAbort();
         return;
     }
-    assume LenTable(t_new) == LenTable(t) + LenVec(keys_arg);
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
-        ({{impl.fun_spec_has_key}}{{S}}(t, k) ==> {{impl.fun_spec_has_key}}{{S}}(t_new, k)));
+    assume LenTable(t_new) == LenTable(t{{U}}) + LenVec(keys_arg);
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+        ({{impl.fun_spec_has_key}}{{S}}(t, k) ==> {{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)));
     assume (forall i: int :: {ReadVec(keys_arg, i)} i >= 0 && i < LenVec(keys_arg) ==>
-        {{impl.fun_spec_has_key}}{{S}}(t_new, ReadVec(keys_arg, i)));
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
-        {{impl.fun_spec_has_key}}{{S}}(t_new, k) ==>
+        {{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, ReadVec(keys_arg, i)));
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+        {{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k) ==>
         ({{impl.fun_spec_has_key}}{{S}}(t, k)
          || (exists i: int :: i >= 0 && i < LenVec(keys_arg)
              && $IsEqual'{{instance.0.suffix}}'(k, ReadVec(keys_arg, i)))));
     assume (forall i: int :: {ReadVec(keys_arg, i)} i >= 0 && i < LenVec(keys_arg) ==>
-        {{impl.fun_spec_get}}{{S}}(t_new, ReadVec(keys_arg, i)) == ReadVec(values_arg, i));
-    m' := $UpdateMutation(m, t_new);
+        {{impl.fun_spec_get}}{{S}}({{W1}}t_new{{W2}}, ReadVec(keys_arg, i)) == ReadVec(values_arg, i));
+    {{GH}}m' := $UpdateMutation(m, {{W1}}t_new{{W2}});
 }
 {%- endif %}
 
@@ -792,7 +843,7 @@ returns (m': $Mutation ({{Self}})) {
 // trigger-unsafe `forall k :: spec_get` shape).
 procedure {:inline 2} {{impl.fun_upsert_all}}{{S}}(m: $Mutation ({{Self}}), keys_arg: Vec ({{K}}), values_arg: Vec ({{V}}))
 returns (m': $Mutation ({{Self}})) {
-    var t, t_new: {{Self}};
+    {{TND}}
     t := $Dereference(m);
     if (LenVec(keys_arg) != LenVec(values_arg)) {
         call $ExecFailureAbort();
@@ -800,22 +851,22 @@ returns (m': $Mutation ({{Self}})) {
     }
     // Exact length needs a distinct-count over `keys_arg`; `>= LenVec(keys_arg)`
     // would be unsound under duplicate input keys, so only these bounds hold.
-    assume LenTable(t_new) >= LenTable(t);
-    assume LenTable(t_new) <= LenTable(t) + LenVec(keys_arg);
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
-        ({{impl.fun_spec_has_key}}{{S}}(t, k) ==> {{impl.fun_spec_has_key}}{{S}}(t_new, k)));
+    assume LenTable(t_new) >= LenTable(t{{U}});
+    assume LenTable(t_new) <= LenTable(t{{U}}) + LenVec(keys_arg);
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+        ({{impl.fun_spec_has_key}}{{S}}(t, k) ==> {{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)));
     assume (forall i: int :: {ReadVec(keys_arg, i)} i >= 0 && i < LenVec(keys_arg) ==>
-        {{impl.fun_spec_has_key}}{{S}}(t_new, ReadVec(keys_arg, i)));
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
-        {{impl.fun_spec_has_key}}{{S}}(t_new, k) ==>
+        {{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, ReadVec(keys_arg, i)));
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+        {{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k) ==>
         ({{impl.fun_spec_has_key}}{{S}}(t, k)
          || (exists i: int :: i >= 0 && i < LenVec(keys_arg)
              && $IsEqual'{{instance.0.suffix}}'(k, ReadVec(keys_arg, i)))));
     assume (forall i: int :: {ReadVec(keys_arg, i)} i >= 0 && i < LenVec(keys_arg) ==>
         (forall j: int :: {ReadVec(keys_arg, j)} j > i && j < LenVec(keys_arg) ==>
             !$IsEqual'{{instance.0.suffix}}'(ReadVec(keys_arg, j), ReadVec(keys_arg, i))) ==>
-        {{impl.fun_spec_get}}{{S}}(t_new, ReadVec(keys_arg, i)) == ReadVec(values_arg, i));
-    m' := $UpdateMutation(m, t_new);
+        {{impl.fun_spec_get}}{{S}}({{W1}}t_new{{W2}}, ReadVec(keys_arg, i)) == ReadVec(values_arg, i));
+    {{GH}}m' := $UpdateMutation(m, {{W1}}t_new{{W2}});
 }
 {%- endif %}
 
@@ -826,15 +877,15 @@ returns (m': $Mutation ({{Self}})) {
 // modeled — would require `forall k :: spec_get(t_new, k) == ...` shape.
 procedure {:inline 2} {{impl.fun_append}}{{S}}(m: $Mutation ({{Self}}), other: ({{Self}}))
 returns (m': $Mutation ({{Self}})) {
-    var t, t_new: {{Self}};
+    {{TND}}
     t := $Dereference(m);
-    assume LenTable(t_new) >= LenTable(t);
-    assume LenTable(t_new) >= LenTable(other);
-    assume LenTable(t_new) <= LenTable(t) + LenTable(other);
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(other, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
-        ({{impl.fun_spec_has_key}}{{S}}(t_new, k) <==>
+    assume LenTable(t_new) >= LenTable(t{{U}});
+    assume LenTable(t_new) >= LenTable(other{{U}});
+    assume LenTable(t_new) <= LenTable(t{{U}}) + LenTable(other{{U}});
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(other, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+        ({{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k) <==>
             ({{impl.fun_spec_has_key}}{{S}}(t, k) || {{impl.fun_spec_has_key}}{{S}}(other, k))));
-    m' := $UpdateMutation(m, t_new);
+    {{GH}}m' := $UpdateMutation(m, {{W1}}t_new{{W2}});
 }
 {%- endif %}
 
@@ -844,18 +895,18 @@ returns (m': $Mutation ({{Self}})) {
 // per-key `spec_get(t_new, k) == spec_get(t\|other, k)` mapping is not modeled.
 procedure {:inline 2} {{impl.fun_append_disjoint}}{{S}}(m: $Mutation ({{Self}}), other: ({{Self}}))
 returns (m': $Mutation ({{Self}})) {
-    var t, t_new: {{Self}};
+    {{TND}}
     t := $Dereference(m);
     if ((exists k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k), {{impl.fun_spec_has_key}}{{S}}(other, k)} $IsValid'{{instance.0.suffix}}'(k)
             && {{impl.fun_spec_has_key}}{{S}}(t, k) && {{impl.fun_spec_has_key}}{{S}}(other, k))) {
         call $ExecFailureAbort();
         return;
     }
-    assume LenTable(t_new) == LenTable(t) + LenTable(other);
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(other, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
-        ({{impl.fun_spec_has_key}}{{S}}(t_new, k) <==>
+    assume LenTable(t_new) == LenTable(t{{U}}) + LenTable(other{{U}});
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(other, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+        ({{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k) <==>
             ({{impl.fun_spec_has_key}}{{S}}(t, k) || {{impl.fun_spec_has_key}}{{S}}(other, k))));
-    m' := $UpdateMutation(m, t_new);
+    {{GH}}m' := $UpdateMutation(m, {{W1}}t_new{{W2}});
 }
 {%- endif %}
 
@@ -866,26 +917,26 @@ returns (m': $Mutation ({{Self}})) {
 // and not modeled.
 procedure {:inline 2} {{impl.fun_trim}}{{S}}(m: $Mutation ({{Self}}), at: int)
 returns (result: ({{Self}}), m': $Mutation ({{Self}})) {
-    var t, t_new: {{Self}};
+    {{TND}}
     t := $Dereference(m);
-    if (at > LenTable(t)) {
+    if (at > LenTable(t{{U}})) {
         call $ExecFailureAbort();
         return;
     }
     assume LenTable(t_new) == at;
-    assume LenTable(result) == LenTable(t) - at;
+    assume LenTable(result{{U}}) == LenTable(t{{U}}) - at;
 {%- if impl.fun_spec_has_key != "" %}
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
-        ({{impl.fun_spec_has_key}}{{S}}(t_new, k) ==> {{impl.fun_spec_has_key}}{{S}}(t, k)));
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+        ({{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k) ==> {{impl.fun_spec_has_key}}{{S}}(t, k)));
     assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(result, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
         ({{impl.fun_spec_has_key}}{{S}}(result, k) ==> {{impl.fun_spec_has_key}}{{S}}(t, k)));
     assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
         ({{impl.fun_spec_has_key}}{{S}}(t, k) ==>
-            ({{impl.fun_spec_has_key}}{{S}}(t_new, k) || {{impl.fun_spec_has_key}}{{S}}(result, k))));
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k), {{impl.fun_spec_has_key}}{{S}}(result, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
-        !({{impl.fun_spec_has_key}}{{S}}(t_new, k) && {{impl.fun_spec_has_key}}{{S}}(result, k)));
+            ({{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k) || {{impl.fun_spec_has_key}}{{S}}(result, k))));
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k), {{impl.fun_spec_has_key}}{{S}}(result, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+        !({{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k) && {{impl.fun_spec_has_key}}{{S}}(result, k)));
 {%- endif %}
-    m' := $UpdateMutation(m, t_new);
+    {{GH}}m' := $UpdateMutation(m, {{W1}}t_new{{W2}});
 }
 {%- endif %}
 
@@ -899,7 +950,7 @@ returns (result: ({{Self}}), m': $Mutation ({{Self}})) {
 // trigger-unsafe `forall k :: spec_get` shape).
 procedure {:inline 2} {{impl.fun_replace_key_inplace}}{{S}}(m: $Mutation ({{Self}}), old_key: {{K}}, new_key: {{K}})
 returns (m': $Mutation ({{Self}})) {
-    var t, t_new: {{Self}};
+    {{TND}}
     var may_abort_on_order: bool;
     t := $Dereference(m);
     if (!{{impl.fun_spec_has_key}}{{S}}(t, old_key)) {
@@ -914,27 +965,27 @@ returns (m': $Mutation ({{Self}})) {
         call $ExecFailureAbort();
         return;
     }
-    assume LenTable(t_new) == LenTable(t);
-    assume !{{impl.fun_spec_has_key}}{{S}}(t_new, old_key);
-    assume {{impl.fun_spec_has_key}}{{S}}(t_new, new_key);
-    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t_new, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
+    assume LenTable(t_new) == LenTable(t{{U}});
+    assume !{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, old_key);
+    assume {{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, new_key);
+    assume (forall k: {{K}} :: {{"{"}}{{impl.fun_spec_has_key}}{{S}}(t, k)} {{"{"}}{{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)} $IsValid'{{instance.0.suffix}}'(k) ==>
         !$IsEqual'{{instance.0.suffix}}'(k, old_key) ==>
         !$IsEqual'{{instance.0.suffix}}'(k, new_key) ==>
-        ({{impl.fun_spec_has_key}}{{S}}(t, k) == {{impl.fun_spec_has_key}}{{S}}(t_new, k)));
-    m' := $UpdateMutation(m, t_new);
+        ({{impl.fun_spec_has_key}}{{S}}(t, k) == {{impl.fun_spec_has_key}}{{S}}({{W1}}t_new{{W2}}, k)));
+    {{GH}}m' := $UpdateMutation(m, {{W1}}t_new{{W2}});
 }
 {%- endif %}
 
 {%- if impl.fun_add_no_override != "" %}
 procedure {:inline 2} {{impl.fun_add_no_override}}{{S}}(m: $Mutation ({{Self}}), k: {{K}}, v: {{V}}) returns (m': $Mutation({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     enc_k := {{ENC}}(k);
     t := $Dereference(m);
-    if (ContainsTable(t, enc_k)) {
+    if (ContainsTable(t{{U}}, enc_k)) {
         call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 100/*EALREADY_EXISTS*/));
     } else {
-        m' := $UpdateMutation(m, AddTable(t, enc_k, v));
+        {{GH}}m' := $UpdateMutation(m, {{W1}}AddTable(t{{U}}, enc_k, v){{W2}});
     }
 }
 {%- endif %}
@@ -942,13 +993,13 @@ procedure {:inline 2} {{impl.fun_add_no_override}}{{S}}(m: $Mutation ({{Self}}),
 {%- if impl.fun_add_override_if_exists != "" %}
 procedure {:inline 2} {{impl.fun_add_override_if_exists}}{{S}}(m: $Mutation ({{Self}}), k: {{K}}, v: {{V}}) returns (m': $Mutation({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     enc_k := {{ENC}}(k);
     t := $Dereference(m);
-    if (ContainsTable(t, enc_k)) {
-        m' := $UpdateMutation(m, UpdateTable(t, enc_k, v));
+    if (ContainsTable(t{{U}}, enc_k)) {
+        {{GH}}m' := $UpdateMutation(m, {{W1}}UpdateTable(t{{U}}, enc_k, v){{W2}});
     } else {
-        m' := $UpdateMutation(m, AddTable(t, enc_k, v));
+        {{GH}}m' := $UpdateMutation(m, {{W1}}AddTable(t{{U}}, enc_k, v){{W2}});
     }
 }
 {%- endif %}
@@ -959,15 +1010,15 @@ procedure {:inline 2} {{impl.fun_add_override_if_exists}}{{S}}(m: $Mutation ({{S
 procedure {:inline 2} {{impl.fun_upsert}}{{S}}(m: $Mutation ({{Self}}), k: {{K}}, v: {{V}})
 returns (prev_v: $1_option_Option{{SV}}, m': $Mutation ({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     enc_k := {{ENC}}(k);
     t := $Dereference(m);
-    if (ContainsTable(t, enc_k)) {
-        prev_v := $1_option_Option{{SV}}_Some(GetTable(t, enc_k));
-        m' := $UpdateMutation(m, UpdateTable(t, enc_k, v));
+    if (ContainsTable(t{{U}}, enc_k)) {
+        prev_v := $1_option_Option{{SV}}_Some(GetTable(t{{U}}, enc_k));
+        {{GH}}m' := $UpdateMutation(m, {{W1}}UpdateTable(t{{U}}, enc_k, v){{W2}});
     } else {
         prev_v := $1_option_Option{{SV}}_None();
-        m' := $UpdateMutation(m, AddTable(t, enc_k, v));
+        {{GH}}m' := $UpdateMutation(m, {{W1}}AddTable(t{{U}}, enc_k, v){{W2}});
     }
 }
 {%- endif %}
@@ -976,14 +1027,14 @@ returns (prev_v: $1_option_Option{{SV}}, m': $Mutation ({{Self}})) {
 procedure {:inline 2} {{impl.fun_del_must_exist}}{{S}}(m: $Mutation ({{Self}}), k: {{K}})
 returns (v: {{V}}, m': $Mutation({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     enc_k := {{ENC}}(k);
     t := $Dereference(m);
-    if (!ContainsTable(t, enc_k)) {
+    if (!ContainsTable(t{{U}}, enc_k)) {
         call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 101/*ENOT_FOUND*/));
     } else {
-        v := GetTable(t, enc_k);
-        m' := $UpdateMutation(m, RemoveTable(t, enc_k));
+        v := GetTable(t{{U}}, enc_k);
+        {{GH}}m' := $UpdateMutation(m, {{W1}}RemoveTable(t{{U}}, enc_k){{W2}});
     }
 }
 {%- endif %}
@@ -994,12 +1045,12 @@ returns (v: {{V}}, m': $Mutation({{Self}})) {
 procedure {:inline 2} {{impl.fun_remove_or_none}}{{S}}(m: $Mutation ({{Self}}), k: {{K}})
 returns (result: $1_option_Option{{SV}}, m': $Mutation ({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     enc_k := {{ENC}}(k);
     t := $Dereference(m);
-    if (ContainsTable(t, enc_k)) {
-        result := $1_option_Option{{SV}}_Some(GetTable(t, enc_k));
-        m' := $UpdateMutation(m, RemoveTable(t, enc_k));
+    if (ContainsTable(t{{U}}, enc_k)) {
+        result := $1_option_Option{{SV}}_Some(GetTable(t{{U}}, enc_k));
+        {{GH}}m' := $UpdateMutation(m, {{W1}}RemoveTable(t{{U}}, enc_k){{W2}});
     } else {
         result := $1_option_Option{{SV}}_None();
         m' := m;
@@ -1011,15 +1062,15 @@ returns (result: $1_option_Option{{SV}}, m': $Mutation ({{Self}})) {
 procedure {:inline 2} {{impl.fun_del_return_key}}{{S}}(m: $Mutation ({{Self}}), k: {{K}})
 returns (k': {{K}}, v: {{V}}, m': $Mutation({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     enc_k := {{ENC}}(k);
     t := $Dereference(m);
-    if (!ContainsTable(t, enc_k)) {
+    if (!ContainsTable(t{{U}}, enc_k)) {
         call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 101/*ENOT_FOUND*/));
     } else {
         k' := k;
-        v := GetTable(t, enc_k);
-        m' := $UpdateMutation(m, RemoveTable(t, enc_k));
+        v := GetTable(t{{U}}, enc_k);
+        {{GH}}m' := $UpdateMutation(m, {{W1}}RemoveTable(t{{U}}, enc_k){{W2}});
     }
 }
 {%- endif %}
@@ -1028,10 +1079,10 @@ returns (k': {{K}}, v: {{V}}, m': $Mutation({{Self}})) {
 procedure {:inline 2} {{impl.fun_borrow}}{{S}}(t: {{Self}}, k: {{K}}) returns (v: {{V}}) {
     var enc_k: int;
     enc_k := {{ENC}}(k);
-    if (!ContainsTable(t, enc_k)) {
+    if (!ContainsTable(t{{U}}, enc_k)) {
         call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 101/*ENOT_FOUND*/));
     } else {
-        v := GetTable(t, {{ENC}}(k));
+        v := GetTable(t{{U}}, {{ENC}}(k));
     }
 }
 {%- endif %}
@@ -1040,13 +1091,13 @@ procedure {:inline 2} {{impl.fun_borrow}}{{S}}(t: {{Self}}, k: {{K}}) returns (v
 procedure {:inline 2} {{impl.fun_borrow_mut}}{{S}}(m: $Mutation ({{Self}}), k: {{K}})
 returns (dst: $Mutation ({{V}}), m': $Mutation ({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     enc_k := {{ENC}}(k);
     t := $Dereference(m);
-    if (!ContainsTable(t, enc_k)) {
+    if (!ContainsTable(t{{U}}, enc_k)) {
         call $Abort($StdError(7/*INVALID_ARGUMENTS*/, 101/*ENOT_FOUND*/));
     } else {
-        dst := $Mutation(m->l, ExtendVec(m->p, enc_k), GetTable(t, enc_k));
+        dst := $Mutation(m->l, ExtendVec(m->p, enc_k), GetTable(t{{U}}, enc_k));
         m' := m;
     }
 }
@@ -1056,16 +1107,16 @@ returns (dst: $Mutation ({{V}}), m': $Mutation ({{Self}})) {
 procedure {:inline 2} {{impl.fun_borrow_mut_with_default}}{{S}}(m: $Mutation ({{Self}}), k: {{K}}, default: {{V}})
 returns (dst: $Mutation ({{V}}), m': $Mutation ({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     var t': {{Self}};
     enc_k := {{ENC}}(k);
     t := $Dereference(m);
-    if (!ContainsTable(t, enc_k)) {
-        m' := $UpdateMutation(m, AddTable(t, enc_k, default));
+    if (!ContainsTable(t{{U}}, enc_k)) {
+        {{GH}}m' := $UpdateMutation(m, {{W1}}AddTable(t{{U}}, enc_k, default){{W2}});
         t' := $Dereference(m');
-        dst := $Mutation(m'->l, ExtendVec(m'->p, enc_k), GetTable(t', enc_k));
+        dst := $Mutation(m'->l, ExtendVec(m'->p, enc_k), GetTable(t'{{U}}, enc_k));
     } else {
-        dst := $Mutation(m->l, ExtendVec(m->p, enc_k), GetTable(t, enc_k));
+        dst := $Mutation(m->l, ExtendVec(m->p, enc_k), GetTable(t{{U}}, enc_k));
         m' := m;
     }
 }
@@ -1075,10 +1126,10 @@ returns (dst: $Mutation ({{V}}), m': $Mutation ({{Self}})) {
 procedure {:inline 2} {{impl.fun_borrow_with_default}}{{S}}(t: {{Self}}, k: {{K}}, default: {{V}}) returns (v: {{V}}) {
     var enc_k: int;
     enc_k := {{ENC}}(k);
-    if (!ContainsTable(t, enc_k)) {
+    if (!ContainsTable(t{{U}}, enc_k)) {
         v := default;
     } else {
-        v := GetTable(t, {{ENC}}(k));
+        v := GetTable(t{{U}}, {{ENC}}(k));
     }
 }
 {%- endif %}
@@ -1093,16 +1144,16 @@ procedure {:inline 2} {{impl.fun_borrow_with_default}}{{S}}(t: {{Self}}, k: {{K}
 procedure {:inline 2} {{impl.fun_iter_borrow_mut}}{{S}}(self: {{impl.iter_ptr_prefix}}'{{instance.0.suffix}}', m: $Mutation ({{Self}}))
 returns (dst: $Mutation ({{V}}), m': $Mutation ({{Self}})) {
     var enc_k: int;
-    var t: {{Self}};
+    var t: {{Self}};{{GBD}}
     t := $Dereference(m);
     if (!(self is {{impl.iter_ptr_prefix}}'{{instance.0.suffix}}'_{{impl.iter_variant}})) {
         call $ExecFailureAbort();
     } else {
         enc_k := {{ENC}}(self->{{impl.iter_key_sel}});
-        if (!ContainsTable(t, enc_k)) {
+        if (!ContainsTable(t{{U}}, enc_k)) {
             call $ExecFailureAbort();
         } else {
-            dst := $Mutation(m->l, ExtendVec(m->p, enc_k), GetTable(t, enc_k));
+            dst := $Mutation(m->l, ExtendVec(m->p, enc_k), GetTable(t{{U}}, enc_k));
             m' := m;
         }
     }
@@ -1111,71 +1162,71 @@ returns (dst: $Mutation ({{V}}), m': $Mutation ({{Self}})) {
 
 {%- if impl.fun_spec_len != "" %}
 function {:inline} {{impl.fun_spec_len}}{{S}}(t: ({{Self}})): int {
-    LenTable(t)
+    LenTable(t{{U}})
 }
 {%- endif %}
 
 {%- if impl.fun_spec_is_empty != "" %}
 function {:inline} {{impl.fun_spec_is_empty}}{{S}}(t: ({{Self}})): bool {
-    LenTable(t) == 0
+    LenTable(t{{U}}) == 0
 }
 {%- endif %}
 
 {%- if impl.fun_spec_has_key != "" %}
 function {:inline} {{impl.fun_spec_has_key}}{{S}}(t: ({{Self}}), k: {{K}}): bool {
-    ContainsTable(t, {{ENC}}(k))
+    ContainsTable(t{{U}}, {{ENC}}(k))
 }
 {%- endif %}
 
 {%- if impl.fun_spec_set != "" %}
 function {:inline} {{impl.fun_spec_set}}{{S}}(t: {{Self}}, k: {{K}}, v: {{V}}): {{Self}} {
     (var enc_k := {{ENC}}(k);
-    if (ContainsTable(t, enc_k)) then
-        UpdateTable(t, enc_k, v)
+    if (ContainsTable(t{{U}}, enc_k)) then
+        {{SW1}}UpdateTable(t{{U}}, enc_k, v){{SW2}}
     else
-        AddTable(t, enc_k, v))
+        {{SW1}}AddTable(t{{U}}, enc_k, v){{SW2}})
 }
 {%- endif %}
 
 {%- if impl.fun_spec_del != "" %}
 function {:inline} {{impl.fun_spec_del}}{{S}}(t: {{Self}}, k: {{K}}): {{Self}} {
-    RemoveTable(t, {{ENC}}(k))
+    {{SW1}}RemoveTable(t{{U}}, {{ENC}}(k)){{SW2}}
 }
 {%- endif %}
 
 {%- if impl.fun_spec_get != "" %}
 function {:inline} {{impl.fun_spec_get}}{{S}}(t: {{Self}}, k: {{K}}): {{V}} {
-    GetTable(t, {{ENC}}(k))
+    GetTable(t{{U}}, {{ENC}}(k))
 }
 {%- endif %}
 
 {%- if impl.fun_spec_new != "" %}
 function {:inline} {{impl.fun_spec_new}}{{S}}(): {{Self}} {
-    EmptyTable()
+    {{SW1}}EmptyTable(){{SZ2}}
 }
 {%- endif %}
 
 {%- if impl.fun_spec_aborts_destroy_empty != "" %}
 function {:inline} {{impl.fun_spec_aborts_destroy_empty}}{{S}}(t: {{Self}}): bool {
-    LenTable(t) != 0
+    LenTable(t{{U}}) != 0
 }
 {%- endif %}
 
 {%- if impl.fun_spec_aborts_add != "" %}
 function {:inline} {{impl.fun_spec_aborts_add}}{{S}}(t: {{Self}}, k: {{K}}, v: {{V}}): bool {
-    ContainsTable(t, {{ENC}}(k))
+    ContainsTable(t{{U}}, {{ENC}}(k))
 }
 {%- endif %}
 
 {%- if impl.fun_spec_aborts_del != "" %}
 function {:inline} {{impl.fun_spec_aborts_del}}{{S}}(t: {{Self}}, k: {{K}}): bool {
-    !ContainsTable(t, {{ENC}}(k))
+    !ContainsTable(t{{U}}, {{ENC}}(k))
 }
 {%- endif %}
 
 {%- if impl.fun_spec_aborts_borrow != "" %}
 function {:inline} {{impl.fun_spec_aborts_borrow}}{{S}}(t: {{Self}}, k: {{K}}): bool {
-    !ContainsTable(t, {{ENC}}(k))
+    !ContainsTable(t{{U}}, {{ENC}}(k))
 }
 {%- endif %}
 
@@ -1186,7 +1237,29 @@ function {:inline} {{impl.fun_spec_aborts_borrow}}{{S}}(t: {{Self}}, k: {{K}}): 
 {%- if impl.fun_spec_aborts_iter_borrow_mut != "" and impl.fun_iter_borrow_mut != "" %}
 function {:inline} {{impl.fun_spec_aborts_iter_borrow_mut}}{{S}}(self: {{impl.iter_ptr_prefix}}'{{instance.0.suffix}}', t: {{Self}}): bool {
     !(self is {{impl.iter_ptr_prefix}}'{{instance.0.suffix}}'_{{impl.iter_variant}})
-        || !ContainsTable(t, {{ENC}}(self->{{impl.iter_key_sel}}))
+        || !ContainsTable(t{{U}}, {{ENC}}(self->{{impl.iter_key_sel}}))
+}
+{%- endif %}
+
+{#- Iterator-validity predicates over the hidden `$$validity` slots: an
+    iterator is valid iff its slot matches the map's current one (structural
+    mutations havoc the map's slot; see the carrier plumbing above), and two
+    map states preserve iterators iff their slots agree. -#}
+{%- if impl.fun_spec_iter_valid != "" and impl.has_ghost_carrier %}
+function {:inline} {{impl.fun_spec_iter_valid}}{{S}}(it: {{impl.iter_valid_prefix}}{% if impl.iter_valid_generic %}'{{instance.0.suffix}}'{% endif %}, t: {{Self}}): bool {
+    it->$$validity == t->$$validity
+}
+{%- endif %}
+
+{%- if impl.fun_spec_leaf_iter_valid != "" and impl.has_ghost_carrier %}
+function {:inline} {{impl.fun_spec_leaf_iter_valid}}{{S}}(it: {{impl.leaf_iter_valid_prefix}}{% if impl.leaf_iter_valid_generic %}'{{instance.0.suffix}}'{% endif %}, t: {{Self}}): bool {
+    it->$$validity == t->$$validity
+}
+{%- endif %}
+
+{%- if impl.fun_spec_iter_preserved != "" and impl.has_ghost_carrier %}
+function {:inline} {{impl.fun_spec_iter_preserved}}{{S}}(t1: {{Self}}, t2: {{Self}}): bool {
+    t1->$$validity == t2->$$validity
 }
 {%- endif %}
 

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -2420,9 +2420,28 @@ impl SpecTranslator<'_> {
         emit!(self.writer, ")");
     }
 
+    /// Reject `Pack`/`PackVariant` of an intrinsic map in a specification:
+    /// its declared fields are erased (the representation is the raw table or
+    /// the ghost carrier, which declares no variant constructors either), so
+    /// the emitted constructor would be ill-typed. Returns true if rejected.
+    fn reject_intrinsic_map_pack(&self, node_id: NodeId, struct_env: &StructEnv) -> bool {
+        let intrinsic = struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP);
+        if intrinsic {
+            self.error(
+                &self.env.get_node_loc(node_id),
+                "cannot pack a value of an intrinsic map type in a specification; \
+                 use the map's `map_spec_new` binding",
+            );
+        }
+        intrinsic
+    }
+
     fn translate_pack(&self, node_id: NodeId, mid: ModuleId, sid: StructId, args: &[Exp]) {
         let struct_env = &self.env.get_module(mid).into_struct(sid);
         let inst = &self.get_node_instantiation(node_id);
+        if self.reject_intrinsic_map_pack(node_id, struct_env) {
+            return;
+        }
         emit!(
             self.writer,
             "{}(",
@@ -2451,6 +2470,9 @@ impl SpecTranslator<'_> {
     ) {
         let struct_env = &self.env.get_module(mid).into_struct(sid);
         let inst = &self.get_node_instantiation(node_id);
+        if self.reject_intrinsic_map_pack(node_id, struct_env) {
+            return;
+        }
         emit!(
             self.writer,
             "{}(",
@@ -2825,7 +2847,12 @@ impl SpecTranslator<'_> {
         args: &[Exp],
     ) {
         let struct_env = self.env.get_module(module_id).into_struct(struct_id);
-        if struct_env.is_intrinsic() {
+        // Ghost fields of intrinsic maps live in the carrier datatype and are
+        // selectable; runtime fields of intrinsic structs are erased.
+        let is_ghost_sel = struct_env
+            .get_ghost_fields()
+            .any(|f| f.get_id() == field_id);
+        if struct_env.is_intrinsic() && !is_ghost_sel {
             self.env.error(
                 &self.env.get_node_loc(node_id),
                 "cannot select field of intrinsic struct",
@@ -2923,7 +2950,7 @@ impl SpecTranslator<'_> {
 
     fn translate_update_field(
         &self,
-        _node_id: NodeId,
+        node_id: NodeId,
         module_id: ModuleId,
         struct_id: StructId,
         field_id: FieldId,
@@ -2931,6 +2958,15 @@ impl SpecTranslator<'_> {
     ) {
         let struct_env = &self.env.get_module(module_id).into_struct(struct_id);
         let field_env = struct_env.get_field(field_id);
+        // Fields of an intrinsic map cannot be updated in specifications:
+        // they are erased by the intrinsic representation.
+        if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+            self.env.error(
+                &self.env.get_node_loc(node_id),
+                "cannot update a field of an intrinsic map type in a specification",
+            );
+            return;
+        }
         let receiver_type = self.get_node_type(args[0].node_id());
         let struct_inst = receiver_type.skip_reference().require_struct().2;
         let update_fun = if struct_env.has_variants() {
@@ -3663,11 +3699,19 @@ impl SpecTranslator<'_> {
                 Type::Struct(mid, sid, targs) => {
                     let struct_env = self.env.get_struct(mid.qualified(*sid));
                     if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+                        // A ghost-carrier map wraps its table; membership
+                        // reads through the raw-table selector.
+                        let unwrap = if struct_env.get_ghost_fields().next().is_some() {
+                            "->$$t"
+                        } else {
+                            ""
+                        };
                         emit!(
                             self.writer,
-                            "{}ContainsTable({}, $EncodeKey'{}'({}))",
+                            "{}ContainsTable({}{}, $EncodeKey'{}'({}))",
                             separator,
                             range_tmps.get(&var_name).unwrap(),
+                            unwrap,
                             boogie_type_suffix(self.env, &targs[0], num_oper == Bitwise),
                             var_name_str,
                         );

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -27,11 +27,16 @@ use move_model::{
         INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_MUT, INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_FROM,
         INTRINSIC_FUN_MAP_SPEC_ABORTS_NEW_WITH_CONFIG,
         INTRINSIC_FUN_MAP_SPEC_ABORTS_REPLACE_KEY_INPLACE, INTRINSIC_FUN_MAP_SPEC_ABORTS_TRIM,
-        INTRINSIC_FUN_MAP_SPEC_ABORTS_UPSERT_ALL, INTRINSIC_FUN_MAP_TO_VEC_PAIR,
-        INTRINSIC_FUN_MAP_UPSERT, INTRINSIC_TYPE_MAP,
+        INTRINSIC_FUN_MAP_SPEC_ABORTS_UPSERT_ALL, INTRINSIC_FUN_MAP_SPEC_DEL,
+        INTRINSIC_FUN_MAP_SPEC_GET, INTRINSIC_FUN_MAP_SPEC_HAS_KEY,
+        INTRINSIC_FUN_MAP_SPEC_IS_EMPTY, INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED,
+        INTRINSIC_FUN_MAP_SPEC_ITER_VALID, INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID,
+        INTRINSIC_FUN_MAP_SPEC_LEN, INTRINSIC_FUN_MAP_SPEC_NEW, INTRINSIC_FUN_MAP_SPEC_SET,
+        INTRINSIC_FUN_MAP_TO_ORDERED_MAP, INTRINSIC_FUN_MAP_TO_VEC_PAIR, INTRINSIC_FUN_MAP_UPSERT,
+        INTRINSIC_TYPE_MAP, INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS,
     },
     symbol::Symbol,
-    ty::{NoUnificationContext, ReferenceKind, Type, TypeDisplayContext, Variance},
+    ty::{NoUnificationContext, PrimitiveType, ReferenceKind, Type, TypeDisplayContext, Variance},
     ty_invariant_analysis::{TypeInstantiationDerivation, TypeUnificationAdapter},
     well_known::{
         TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_GET_MOVE, TYPE_NAME_GET_SPEC, TYPE_NAME_MOVE,
@@ -302,6 +307,15 @@ fn find_cmp_module(env: &GlobalEnv) -> Option<ModuleId> {
     None
 }
 
+/// How a data invariant can observe hidden validity slots: by (transitively)
+/// calling a bound validity predicate, or by lifting a function's spec
+/// conditions through a behavioral predicate.
+#[derive(Clone, Copy)]
+enum DataInvOffense {
+    Role(&'static str),
+    Behavioral,
+}
+
 impl Analyzer<'_> {
     /// Register companion types needed by intrinsic role templates that no Move source
     /// references directly:
@@ -368,6 +382,7 @@ impl Analyzer<'_> {
         let mut vec_k_to_register: Vec<Type> = vec![];
         let mut iter_ptr_to_register: Vec<Type> = vec![];
         let mut spec_fun_to_register: Vec<(QualifiedId<SpecFunId>, Vec<Type>)> = vec![];
+        let mut validity_preds: BTreeMap<QualifiedId<SpecFunId>, &'static str> = BTreeMap::new();
         for (struct_qid, ty_args) in self.info.table_inst.iter() {
             let Some(decl) = intrinsics.get_decl_for_struct(struct_qid) else {
                 continue;
@@ -495,6 +510,390 @@ impl Analyzer<'_> {
                     }
                 }
             }
+            // The abort predicate for `map_iter_borrow_mut` is called by the
+            // behavioral `aborts_of` translation with exactly the Move
+            // function's two parameters, whatever the binding's own signature
+            // — so validate it for every binding kind, not only the natives
+            // the template defines. The iterator type comes from the
+            // `map_iter_borrow_mut` binding, which must be co-bound.
+            if let Some(sf_qid) =
+                decl.lookup_spec_fun(self.env, INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_MUT)
+            {
+                let module_env = self.env.get_module(sf_qid.module_id);
+                let sf = module_env.get_spec_fun(sf_qid.id);
+                match decl.lookup_move_fun(self.env, INTRINSIC_FUN_MAP_ITER_BORROW_MUT) {
+                    None => {
+                        self.env.error(
+                            &sf.loc,
+                            "a `map_spec_aborts_iter_borrow_mut` binding requires \
+                             `map_iter_borrow_mut` bound on the same map",
+                        );
+                    },
+                    Some(fun_qid) => {
+                        let iter_ty = self
+                            .env
+                            .get_function(fun_qid)
+                            .get_parameter_types()
+                            .first()
+                            .map(|ty| ty.skip_reference().clone());
+                        if matches!(iter_ty, Some(Type::Struct(..))) {
+                            let expected_map = Type::Struct(
+                                decl.get_move_type().module_id,
+                                decl.get_move_type().id,
+                                vec![Type::TypeParameter(0), Type::TypeParameter(1)],
+                            );
+                            if sf.type_params.len() != 2
+                                || sf.params.len() != 2
+                                || Some(&sf.params[0].1) != iter_ty.as_ref()
+                                || sf.params[1].1 != expected_map
+                                || sf.result_type != Type::Primitive(PrimitiveType::Bool)
+                            {
+                                self.env.error(
+                                    &sf.loc,
+                                    "a `map_spec_aborts_iter_borrow_mut` function must \
+                                     have two type parameters and the signature \
+                                     (iterator_enum<K>, map<K, V>): bool, with the \
+                                     iterator enum of the `map_iter_borrow_mut` binding",
+                                );
+                            }
+                        }
+                    },
+                }
+            }
+            // Template-defined roles have fixed signatures: the template
+            // emits the definition in that shape while user spec text calls
+            // the binding as declared — a deviating declaration makes the
+            // two disagree in emitted Boogie.
+            {
+                let map_ty = || {
+                    Type::Struct(
+                        decl.get_move_type().module_id,
+                        decl.get_move_type().id,
+                        vec![Type::TypeParameter(0), Type::TypeParameter(1)],
+                    )
+                };
+                let k = || Type::TypeParameter(0);
+                let v = || Type::TypeParameter(1);
+                let num = || Type::Primitive(PrimitiveType::Num);
+                let boolean = || Type::Primitive(PrimitiveType::Bool);
+                let fixed_sigs: [(&str, Vec<Type>, Type, &str); 11] = [
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_NEW,
+                        vec![],
+                        map_ty(),
+                        "(): map<K, V>",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_LEN,
+                        vec![map_ty()],
+                        num(),
+                        "(map<K, V>): num",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_IS_EMPTY,
+                        vec![map_ty()],
+                        boolean(),
+                        "(map<K, V>): bool",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_HAS_KEY,
+                        vec![map_ty(), k()],
+                        boolean(),
+                        "(map<K, V>, K): bool",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_GET,
+                        vec![map_ty(), k()],
+                        v(),
+                        "(map<K, V>, K): V",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_SET,
+                        vec![map_ty(), k(), v()],
+                        map_ty(),
+                        "(map<K, V>, K, V): map<K, V>",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_DEL,
+                        vec![map_ty(), k()],
+                        map_ty(),
+                        "(map<K, V>, K): map<K, V>",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_ABORTS_DESTROY_EMPTY,
+                        vec![map_ty()],
+                        boolean(),
+                        "(map<K, V>): bool",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_ABORTS_ADD,
+                        vec![map_ty(), k(), v()],
+                        boolean(),
+                        "(map<K, V>, K, V): bool",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_ABORTS_DEL,
+                        vec![map_ty(), k()],
+                        boolean(),
+                        "(map<K, V>, K): bool",
+                    ),
+                    (
+                        INTRINSIC_FUN_MAP_SPEC_ABORTS_BORROW,
+                        vec![map_ty(), k()],
+                        boolean(),
+                        "(map<K, V>, K): bool",
+                    ),
+                ];
+                for (role, exp_params, exp_result, shape) in fixed_sigs {
+                    let Some(sf_qid) = decl.lookup_spec_fun(self.env, role) else {
+                        continue;
+                    };
+                    let module_env = self.env.get_module(sf_qid.module_id);
+                    let sf = module_env.get_spec_fun(sf_qid.id);
+                    if sf.type_params.len() != 2
+                        || sf.params.len() != exp_params.len()
+                        || sf
+                            .params
+                            .iter()
+                            .zip(exp_params.iter())
+                            .any(|(Parameter(_, ty, _), exp)| ty != exp)
+                        || sf.result_type != exp_result
+                    {
+                        self.env.error(
+                            &sf.loc,
+                            &format!(
+                                "a `{}` function must have two type parameters \
+                                 and the signature {}",
+                                role, shape
+                            ),
+                        );
+                    }
+                }
+            }
+            // Call-only abort predicates are defined by spec-function
+            // translation (never by the template) and are invoked by the
+            // behavioral `aborts_of` translation with exactly the paired
+            // Move function's parameters — so the binding must not be a
+            // `spec native fun`, and its signature must match the pairing.
+            {
+                let fixed_or_bespoke = [
+                    INTRINSIC_FUN_MAP_SPEC_ABORTS_DESTROY_EMPTY,
+                    INTRINSIC_FUN_MAP_SPEC_ABORTS_ADD,
+                    INTRINSIC_FUN_MAP_SPEC_ABORTS_DEL,
+                    INTRINSIC_FUN_MAP_SPEC_ABORTS_BORROW,
+                    INTRINSIC_FUN_MAP_SPEC_ABORTS_ITER_BORROW_MUT,
+                ];
+                let mut checked: BTreeSet<QualifiedId<SpecFunId>> = BTreeSet::new();
+                for (role_name, fun_def) in INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS.iter() {
+                    let Some(abort_name) = fun_def.abort_spec_fun else {
+                        continue;
+                    };
+                    if fixed_or_bespoke.contains(&abort_name) {
+                        continue;
+                    }
+                    let Some(sf_qid) = decl.lookup_spec_fun(self.env, abort_name) else {
+                        continue;
+                    };
+                    let Some(fun_qid) = decl.lookup_move_fun(self.env, role_name) else {
+                        continue;
+                    };
+                    if !checked.insert(sf_qid) {
+                        continue;
+                    }
+                    let module_env = self.env.get_module(sf_qid.module_id);
+                    let sf = module_env.get_spec_fun(sf_qid.id);
+                    if sf.body.is_none() && !sf.uninterpreted {
+                        self.env.error(
+                            &sf.loc,
+                            &format!(
+                                "a `{}` binding must have a body or be declared \
+                                 uninterpreted; the prover's model does not define it",
+                                abort_name
+                            ),
+                        );
+                        continue;
+                    }
+                    let fun_env = self.env.get_function(fun_qid);
+                    let exp_params: Vec<Type> = fun_env
+                        .get_parameter_types()
+                        .iter()
+                        .map(|ty| ty.skip_reference().clone())
+                        .collect();
+                    if sf.type_params.len() != fun_env.get_type_parameter_count()
+                        || sf.params.len() != exp_params.len()
+                        || sf
+                            .params
+                            .iter()
+                            .zip(exp_params.iter())
+                            .any(|(Parameter(_, ty, _), exp)| ty != exp)
+                        || sf.result_type != Type::Primitive(PrimitiveType::Bool)
+                    {
+                        self.env.error(
+                            &sf.loc,
+                            &format!(
+                                "a `{}` function must take the parameters of its \
+                                 `{}` binding (references by value) and return bool",
+                                abort_name, role_name
+                            ),
+                        );
+                    }
+                }
+            }
+            // Data invariants on the map itself are never applied: its
+            // validity predicate is template-defined and its pack/unpack
+            // sites are erased, so an `invariant` would be silently inert.
+            {
+                let struct_env = self.env.get_struct(*struct_qid);
+                for cond in struct_env
+                    .get_spec()
+                    .filter_kind(ConditionKind::StructInvariant)
+                {
+                    self.env.error(
+                        &cond.loc,
+                        "data invariants are not supported on intrinsic map types; \
+                         the map's validity is defined by its model",
+                    );
+                }
+            }
+            // Validity predicates have the fixed template shape
+            // `(iterator_enum, map<K, V>): bool` with the iterator enum either
+            // unparameterized (a key-agnostic walker) or instantiated with the
+            // key type parameter; anything else would emit ill-typed Boogie.
+            // Register the iterator enum's instances eagerly: the template
+            // references them per map instance.
+            for role in [
+                INTRINSIC_FUN_MAP_SPEC_ITER_VALID,
+                INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID,
+            ] {
+                let Some(sf_qid) = decl.lookup_spec_fun(self.env, role) else {
+                    continue;
+                };
+                let module_env = self.env.get_module(sf_qid.module_id);
+                let sf = module_env.get_spec_fun(sf_qid.id);
+                let expected_map = Type::Struct(
+                    decl.get_move_type().module_id,
+                    decl.get_move_type().id,
+                    vec![Type::TypeParameter(0), Type::TypeParameter(1)],
+                );
+                let iter_ok = matches!(
+                    sf.params.first().map(|Parameter(_, ty, _)| ty),
+                    Some(Type::Struct(_, _, inst))
+                        if inst.is_empty() || inst[..] == [Type::TypeParameter(0)]
+                );
+                if sf.type_params.len() != 2
+                    || sf.params.len() != 2
+                    || !iter_ok
+                    || sf.params[1].1 != expected_map
+                    || sf.result_type != Type::Primitive(PrimitiveType::Bool)
+                {
+                    self.env.error(
+                        &sf.loc,
+                        &format!(
+                            "a `{}` function must have two type parameters and the \
+                             signature (iterator_enum, map<K, V>): bool, with the \
+                             iterator enum either unparameterized or instantiated \
+                             with the key type parameter",
+                            role
+                        ),
+                    );
+                    continue;
+                }
+                if let Some(Parameter(_, Type::Struct(imid, isid, iinst), _)) = sf.params.first() {
+                    let generic = !iinst.is_empty();
+                    for (k, _v) in ty_args.iter() {
+                        iter_ptr_to_register.push(Type::Struct(
+                            *imid,
+                            *isid,
+                            if generic { vec![k.clone()] } else { vec![] },
+                        ));
+                    }
+                }
+            }
+            if let Some(sf_qid) =
+                decl.lookup_spec_fun(self.env, INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED)
+            {
+                let module_env = self.env.get_module(sf_qid.module_id);
+                let sf = module_env.get_spec_fun(sf_qid.id);
+                let expected_map = Type::Struct(
+                    decl.get_move_type().module_id,
+                    decl.get_move_type().id,
+                    vec![Type::TypeParameter(0), Type::TypeParameter(1)],
+                );
+                if sf.type_params.len() != 2
+                    || sf.params.len() != 2
+                    || sf.params[0].1 != expected_map
+                    || sf.params[1].1 != expected_map
+                    || sf.result_type != Type::Primitive(PrimitiveType::Bool)
+                {
+                    self.env.error(
+                        &sf.loc,
+                        "a `map_spec_iter_preserved` function must have two type \
+                         parameters and the signature (map<K, V>, map<K, V>): bool",
+                    );
+                }
+            }
+            // Roles whose definitions the prelude template emits must bind
+            // `spec native fun`s: they are the map model's own observers, and
+            // for a bodied (or uninterpreted) spec fun the spec translator
+            // emits a second Boogie function under the same name once any
+            // spec uses it. (`map_spec_aborts_iter_borrow_mut` is exempt: its
+            // template definition is gated on the binding being native, so a
+            // bodied predicate supplies the abort semantics itself.)
+            for role in [
+                INTRINSIC_FUN_MAP_SPEC_NEW,
+                INTRINSIC_FUN_MAP_SPEC_LEN,
+                INTRINSIC_FUN_MAP_SPEC_IS_EMPTY,
+                INTRINSIC_FUN_MAP_SPEC_HAS_KEY,
+                INTRINSIC_FUN_MAP_SPEC_GET,
+                INTRINSIC_FUN_MAP_SPEC_SET,
+                INTRINSIC_FUN_MAP_SPEC_DEL,
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_DESTROY_EMPTY,
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_ADD,
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_DEL,
+                INTRINSIC_FUN_MAP_SPEC_ABORTS_BORROW,
+                INTRINSIC_FUN_MAP_SPEC_ITER_VALID,
+                INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID,
+                INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED,
+            ] {
+                let Some(sf_qid) = decl.lookup_spec_fun(self.env, role) else {
+                    continue;
+                };
+                let module_env = self.env.get_module(sf_qid.module_id);
+                let sf = module_env.get_spec_fun(sf_qid.id);
+                if sf.body.is_some() || sf.uninterpreted {
+                    self.env.error(
+                        &sf.loc,
+                        &format!(
+                            "a `{}` binding must be a `spec native fun`; \
+                             its definition is provided by the intrinsic model",
+                            role
+                        ),
+                    );
+                }
+            }
+            // `to_ordered_map`'s template returns the destination map as a raw
+            // table. A destination type that declares ghost fields is
+            // represented by a carrier the template does not construct, so
+            // calls would be ill-typed; reject the binding.
+            if let Some(fun_qid) = decl.lookup_move_fun(self.env, INTRINSIC_FUN_MAP_TO_ORDERED_MAP)
+            {
+                let fun_env = self.env.get_function(fun_qid);
+                if let Type::Struct(dmid, dsid, _) = fun_env.get_result_type().skip_reference() {
+                    if self
+                        .env
+                        .get_struct(dmid.qualified(*dsid))
+                        .get_ghost_fields()
+                        .next()
+                        .is_some()
+                    {
+                        self.env.error(
+                            &fun_env.get_loc(),
+                            "a `map_to_ordered_map` function whose result map type \
+                             carries iterator-validity state is not supported",
+                        );
+                    }
+                }
+            }
             for role in &cmp_k_roles {
                 let Some(role_qid) = decl.lookup_move_fun(self.env, role) else {
                     continue;
@@ -529,7 +928,17 @@ impl Analyzer<'_> {
                     spec_fun_to_register.push((spec_fun_qid, vec![k.clone(), v.clone()]));
                 }
             }
+            for role in [
+                INTRINSIC_FUN_MAP_SPEC_ITER_VALID,
+                INTRINSIC_FUN_MAP_SPEC_LEAF_ITER_VALID,
+                INTRINSIC_FUN_MAP_SPEC_ITER_PRESERVED,
+            ] {
+                if let Some(sf_qid) = decl.lookup_spec_fun(self.env, role) {
+                    validity_preds.insert(sf_qid, role);
+                }
+            }
         }
+        self.check_no_validity_preds_in_data_invariants(&validity_preds);
         // The backend marks a map's K as `cmp_available` when K appears in the
         // *contained-type closure* of any `cmp::compare` instance (the prelude
         // expands `native_inst[cmp]` with `get_all_contained_types_with_skip_reference`
@@ -596,6 +1005,109 @@ impl Analyzer<'_> {
                 .or_default()
                 .insert(ty_args);
         }
+    }
+
+    /// Iterator-validity predicates must not appear in data invariants, on any
+    /// type. A data invariant is assumed wherever a value of the type is
+    /// assumed well-formed — in particular for opaque and native call results,
+    /// where nothing ever proves it (intrinsic producers have no pack site).
+    /// Since `map_spec_new`'s hidden slot is a fixed value, an invariant like
+    /// `spec_iter_valid(self.it, spec_new())` would pin slots to a known
+    /// constant and revalidate stale iterators after a structural mutation.
+    /// Behavioral predicates are rejected wholesale in this context: a
+    /// `requires_of<f>(..)` lifts `f`'s spec conditions — which may state
+    /// validity, transitively and through function-typed targets this rung
+    /// cannot resolve — into the same assumed position. The intrinsic map
+    /// type itself is excluded: its data invariants are rejected wholesale by
+    /// the per-declaration rung above.
+    fn check_no_validity_preds_in_data_invariants(
+        &self,
+        validity_preds: &BTreeMap<QualifiedId<SpecFunId>, &'static str>,
+    ) {
+        if validity_preds.is_empty() {
+            return;
+        }
+        let mut cache: BTreeMap<QualifiedId<SpecFunId>, Option<DataInvOffense>> = BTreeMap::new();
+        for module in self.env.get_modules() {
+            for struct_env in module.get_structs() {
+                if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+                    continue;
+                }
+                for cond in struct_env
+                    .get_spec()
+                    .filter_kind(ConditionKind::StructInvariant)
+                {
+                    let offense =
+                        self.data_inv_exp_offense(cond.exp.as_ref(), validity_preds, &mut cache);
+                    if let Some(offense) = offense {
+                        let msg = match offense {
+                            DataInvOffense::Role(role) => format!(
+                                "a `{}` binding cannot be used in a data invariant \
+                                 (directly or through called spec functions): data \
+                                 invariants are assumed for opaque results, which \
+                                 would revalidate stale iterators",
+                                role
+                            ),
+                            DataInvOffense::Behavioral => "a behavioral predicate \
+                                 (`requires_of`, `aborts_of`, `ensures_of`, or `result_of`) \
+                                 cannot be used in a data invariant when iterator-validity \
+                                 bindings are present: it lifts a function's spec conditions \
+                                 — possibly stating validity — into an assumed context"
+                                .to_string(),
+                        };
+                        self.env.error(&cond.loc, &msg);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Whether the expression can observe hidden validity slots: a call to a
+    /// bound validity predicate (directly or through called spec functions'
+    /// bodies), or any behavioral predicate. Memoized per spec function; the
+    /// `None` pre-insertion doubles as a cycle guard for recursive spec funs.
+    fn data_inv_exp_offense(
+        &self,
+        exp: &ExpData,
+        validity_preds: &BTreeMap<QualifiedId<SpecFunId>, &'static str>,
+        cache: &mut BTreeMap<QualifiedId<SpecFunId>, Option<DataInvOffense>>,
+    ) -> Option<DataInvOffense> {
+        let mut found = None;
+        exp.visit_pre_order(&mut |e| {
+            match e {
+                ExpData::Call(_, ast::Operation::Behavior(..), _) => {
+                    found = Some(DataInvOffense::Behavioral);
+                },
+                ExpData::Call(_, ast::Operation::SpecFunction(mid, fid, _), _) => {
+                    found = self.spec_fun_offense(mid.qualified(*fid), validity_preds, cache);
+                },
+                _ => {},
+            }
+            found.is_none()
+        });
+        found
+    }
+
+    fn spec_fun_offense(
+        &self,
+        qid: QualifiedId<SpecFunId>,
+        validity_preds: &BTreeMap<QualifiedId<SpecFunId>, &'static str>,
+        cache: &mut BTreeMap<QualifiedId<SpecFunId>, Option<DataInvOffense>>,
+    ) -> Option<DataInvOffense> {
+        if let Some(role) = validity_preds.get(&qid) {
+            return Some(DataInvOffense::Role(role));
+        }
+        if let Some(cached) = cache.get(&qid) {
+            return *cached;
+        }
+        cache.insert(qid, None);
+        let module_env = self.env.get_module(qid.module_id);
+        let found = match &module_env.get_spec_fun(qid.id).body {
+            Some(body) => self.data_inv_exp_offense(body.as_ref(), validity_preds, cache),
+            None => None,
+        };
+        cache.insert(qid, found);
+        found
     }
 
     fn analyze_funs(&mut self) {

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_err.exp
@@ -72,25 +72,37 @@ error: bitvector expressions (|, &, ^, int2bv) cannot appear in a ghost field up
    │                          ^^^^^^^
 
 error: ghost fields are not supported on intrinsic types
-   ┌─ tests/sources/functional/ghost_field_err.move:83:9
+   ┌─ tests/sources/functional/ghost_field_err.move:85:9
    │
-83 │         ghost g: u64; // error: ghost on intrinsic type
+85 │         ghost g: u64; // error: ghost on (non-map) intrinsic type
+   │         ^^^^^^^^^^^^^
+
+error: ghost fields are not supported on intrinsic types
+   ┌─ tests/sources/functional/ghost_field_err.move:96:9
+   │
+96 │         ghost brand: num; // error: ghost on intrinsic type
+   │         ^^^^^^^^^^^^^^^^^
+
+error: ghost fields are not supported on intrinsic types
+   ┌─ tests/sources/functional/ghost_field_err.move:97:9
+   │
+97 │         ghost bad: K; // error: ghost on intrinsic type
    │         ^^^^^^^^^^^^^
 
 error: bitvector expressions (|, &, ^, int2bv) cannot appear in a ghost field initializer (ghost integer fields are modeled as mathematical integers)
-   ┌─ tests/sources/functional/ghost_field_err.move:89:24
-   │
-89 │         ghost g: u64 = int2bv(x); // error: int2bv in ghost initializer
-   │                        ^^^^^^^^^
-
-error: bitvector expressions (|, &, ^, int2bv) cannot appear in a ghost field update expression (ghost integer fields are modeled as mathematical integers)
-   ┌─ tests/sources/functional/ghost_field_err.move:94:26
-   │
-94 │             update s.g = int2bv(s.g); // error: int2bv in ghost update
-   │                          ^^^^^^^^^^^
-
-error: bitvector expressions (|, &, ^, int2bv) cannot appear in a ghost field update expression (ghost integer fields are modeled as mathematical integers)
-    ┌─ tests/sources/functional/ghost_field_err.move:103:27
+    ┌─ tests/sources/functional/ghost_field_err.move:104:24
     │
-103 │         ensures result == update_field(s, g, s.g | 1);
+104 │         ghost g: u64 = int2bv(x); // error: int2bv in ghost initializer
+    │                        ^^^^^^^^^
+
+error: bitvector expressions (|, &, ^, int2bv) cannot appear in a ghost field update expression (ghost integer fields are modeled as mathematical integers)
+    ┌─ tests/sources/functional/ghost_field_err.move:109:26
+    │
+109 │             update s.g = int2bv(s.g); // error: int2bv in ghost update
+    │                          ^^^^^^^^^^^
+
+error: bitvector expressions (|, &, ^, int2bv) cannot appear in a ghost field update expression (ghost integer fields are modeled as mathematical integers)
+    ┌─ tests/sources/functional/ghost_field_err.move:118:27
+    │
+118 │         ensures result == update_field(s, g, s.g | 1);
     │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_err.move
@@ -75,13 +75,28 @@ module 0x42::ghost_field_err {
         };
     }
 
-    // Intrinsic types have no generated Boogie datatype to carry ghost
-    // constructor arguments.
-    struct IntrinsicMap<K, V> has store { dummy: bool }
-    spec IntrinsicMap {
-        pragma intrinsic = map;
-        ghost g: u64; // error: ghost on intrinsic type
+    // Non-map intrinsic types have no generated Boogie datatype to carry
+    // ghost constructor arguments and reject ghosts. (Intrinsic MAP types are
+    // the exception: they gain a carrier datatype, used for iterator
+    // validity.)
+    struct IntrinsicOther has store { dummy: bool }
+    spec IntrinsicOther {
+        pragma intrinsic;
+        ghost g: u64; // error: ghost on (non-map) intrinsic type
     }
+
+    // Intrinsic MAP ghosts are accepted (see ghost_field_intrinsic_map.move)
+    // but cannot reference the map's type parameters (the carrier bakes ghost
+    // types in once per map type). Read-only enforcement is checked in
+    // ghost_field_intrinsic_map_err.move (it is a transformation-stage error,
+    // which this module full of front-end errors never reaches).
+    struct IntrinsicMapG<K: copy + drop, V> has store { dummy: bool }
+    spec IntrinsicMapG {
+        pragma intrinsic = map;
+        ghost brand: num; // error: ghost on intrinsic type
+        ghost bad: K; // error: ghost on intrinsic type
+    }
+
 
     // int2bv also produces a bitvector and is rejected the same way.
     struct I2bG has copy, drop { x: u64 }

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_data_inv.exp
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_data_inv.exp
@@ -1,0 +1,17 @@
+Move prover returns: exiting with verification errors
+error: data invariant does not hold
+   ┌─ tests/sources/functional/ghost_field_intrinsic_map_data_inv.move:11:9
+   │
+11 │         invariant v != 0;
+   │         ^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/ghost_field_intrinsic_map_data_inv.move:40: bad
+   =         m = <redacted>
+   =         k = <redacted>
+   =     at tests/sources/functional/ghost_field_intrinsic_map_data_inv.move:41: bad
+   =         w = <redacted>
+   =     at tests/sources/functional/ghost_field_intrinsic_map_data_inv.move:42: bad
+   =         m = <redacted>
+   =     at tests/sources/functional/ghost_field_intrinsic_map_data_inv.move:40: bad
+   =         m = <redacted>
+   =     at tests/sources/functional/ghost_field_intrinsic_map_data_inv.move:11

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_data_inv.move
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_data_inv.move
@@ -1,0 +1,44 @@
+// A deep data invariant over the values of a carrier-represented intrinsic
+// map (hidden validity slot via the preserved binding): data-invariant
+// instrumentation quantifies THROUGH the map (the fabricated quantifier's
+// range is the map value itself, a path source syntax cannot express), so
+// the emitted membership constraint must read through the carrier's
+// raw-table selector. `good` verifies; `bad` violates the value invariant
+// through the modeled borrow and must be reported.
+module 0x42::ghost_field_intrinsic_map_data_inv {
+    struct W has store, drop { v: u64 }
+    spec W {
+        invariant v != 0;
+    }
+
+    struct MapG<phantom K: copy + drop, phantom V> has store, drop {}
+    spec MapG {
+        pragma intrinsic = map,
+            map_new = new,
+            map_add_no_override = add,
+            map_borrow_mut = borrow_mut,
+            map_spec_get = spec_get,
+            map_spec_set = spec_set,
+            map_spec_len = spec_len,
+            map_spec_has_key = spec_contains,
+            map_spec_iter_preserved = spec_preserved;
+    }
+    native fun new<K: copy + drop, V: store>(): MapG<K, V>;
+    native fun add<K: copy + drop, V>(m: &mut MapG<K, V>, k: K, v: V);
+    native fun borrow_mut<K: copy + drop, V>(m: &mut MapG<K, V>, k: K): &mut V;
+    spec native fun spec_get<K: copy + drop, V>(m: MapG<K, V>, k: K): V;
+    spec native fun spec_set<K: copy + drop, V>(m: MapG<K, V>, k: K, v: V): MapG<K, V>;
+    spec native fun spec_len<K: copy + drop, V>(m: MapG<K, V>): num;
+    spec native fun spec_contains<K: copy + drop, V>(m: MapG<K, V>, k: K): bool;
+    spec native fun spec_preserved<K: copy + drop, V>(m1: MapG<K, V>, m2: MapG<K, V>): bool;
+
+    fun good(m: &mut MapG<u64, W>, k: u64) {
+        let w = borrow_mut(m, k);
+        w.v = 5;
+    }
+
+    fun bad(m: &mut MapG<u64, W>, k: u64) {
+        let w = borrow_mut(m, k);
+        w.v = 0;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_full.move
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_full.move
@@ -1,0 +1,136 @@
+// The template-surface sweep as a test: a ghost-bearing intrinsic map
+// binding every Move-function role plus every native abort-predicate role.
+// Boogie type-checks all emitted code whether or not it is called, so a
+// single instance below forces every template block through the type
+// checker with the ghost carrier substituted for the raw table — any block
+// missing a carrier wrap/unwrap fails this test. `to_ordered_map` targets a
+// ghost-LESS destination (a ghost-bearing destination is rejected, see
+// intrinsic_map_conv_ghost_err).
+//
+// Option-returning roles (`map_upsert`, `map_remove_or_none`, `map_get`,
+// `map_prev_key`, `map_next_key`) are deliberately NOT bound: their template
+// blocks construct `Option` with the framework stdlib's enum constructors,
+// while this test suite's stdlib has the struct representation — a
+// pre-existing template dependency independent of ghost carriers; those
+// blocks are covered by the framework prover battery.
+module 0x42::ghost_field_intrinsic_map_full {
+    enum Iter<K: copy + drop> has copy, drop {
+        Some { key: K },
+        End,
+    }
+
+    struct Dest<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Dest {
+        pragma intrinsic = map,
+            map_new = dest_new;
+    }
+    native fun dest_new<K: copy + drop, V: store>(): Dest<K, V>;
+
+    struct MapG<phantom K: copy + drop, phantom V> has store, drop {}
+    spec MapG {
+        pragma intrinsic = map,
+            map_new = new,
+            map_new_with_config = new_with_config,
+            map_len = length,
+            map_is_empty = is_empty,
+            map_destroy_empty = destroy_empty,
+            map_has_key = contains,
+            map_add_no_override = add,
+            map_add_override_if_exists = set,
+            map_del_must_exist = remove,
+            map_del_return_key = remove_return_key,
+            map_borrow = borrow,
+            map_borrow_mut = borrow_mut,
+            map_borrow_mut_with_default = borrow_mut_with_default,
+            map_borrow_with_default = borrow_with_default,
+            map_borrow_front = borrow_front,
+            map_borrow_back = borrow_back,
+            map_front_key = front_key,
+            map_back_key = back_key,
+            map_pop_front = pop_front,
+            map_pop_back = pop_back,
+            map_keys = keys,
+            map_values = values,
+            map_to_vec_pair = to_vec_pair,
+            map_to_ordered_map = to_dest,
+            map_new_from = new_from,
+            map_add_all = add_all,
+            map_upsert_all = upsert_all,
+            map_append = append,
+            map_append_disjoint = append_disjoint,
+            map_trim = trim,
+            map_replace_key_inplace = replace_key_inplace,
+            map_iter_borrow_mut = iter_borrow_mut,
+            map_spec_aborts_iter_borrow_mut = spec_aborts_ibm,
+            map_spec_new = spec_new,
+            map_spec_get = spec_get,
+            map_spec_set = spec_set,
+            map_spec_del = spec_remove,
+            map_spec_len = spec_len,
+            map_spec_has_key = spec_contains,
+            map_spec_aborts_destroy_empty = spec_aborts_destroy_empty,
+            map_spec_aborts_add = spec_aborts_add,
+            map_spec_aborts_del = spec_aborts_del,
+            map_spec_aborts_borrow = spec_aborts_borrow,
+            map_spec_iter_valid = spec_iter_valid,
+            map_spec_iter_preserved = spec_preserved;
+    }
+
+    native fun new<K: copy + drop, V: store>(): MapG<K, V>;
+    native fun new_with_config<K: copy + drop, V: store>(inner_max_degree: u16, leaf_max_degree: u16, reuse_slots: bool): MapG<K, V>;
+    native fun length<K: copy + drop, V>(m: &MapG<K, V>): u64;
+    native fun is_empty<K: copy + drop, V>(m: &MapG<K, V>): bool;
+    native fun destroy_empty<K: copy + drop, V>(m: MapG<K, V>);
+    native fun contains<K: copy + drop, V>(m: &MapG<K, V>, k: K): bool;
+    native fun add<K: copy + drop, V>(m: &mut MapG<K, V>, k: K, v: V);
+    native fun set<K: copy + drop, V>(m: &mut MapG<K, V>, k: K, v: V);
+    native fun remove<K: copy + drop, V>(m: &mut MapG<K, V>, k: K): V;
+    native fun remove_return_key<K: copy + drop, V>(m: &mut MapG<K, V>, k: K): (K, V);
+    native fun borrow<K: copy + drop, V>(m: &MapG<K, V>, k: K): &V;
+    native fun borrow_mut<K: copy + drop, V>(m: &mut MapG<K, V>, k: K): &mut V;
+    native fun borrow_mut_with_default<K: copy + drop, V: drop>(m: &mut MapG<K, V>, k: K, d: V): &mut V;
+    native fun borrow_with_default<K: copy + drop, V>(m: &MapG<K, V>, k: K, d: &V): &V;
+    native fun borrow_front<K: copy + drop, V>(m: &MapG<K, V>): (K, &V);
+    native fun borrow_back<K: copy + drop, V>(m: &MapG<K, V>): (K, &V);
+    native fun front_key<K: copy + drop, V>(m: &MapG<K, V>): K;
+    native fun back_key<K: copy + drop, V>(m: &MapG<K, V>): K;
+    native fun pop_front<K: copy + drop, V>(m: &mut MapG<K, V>): (K, V);
+    native fun pop_back<K: copy + drop, V>(m: &mut MapG<K, V>): (K, V);
+    native fun keys<K: copy + drop, V>(m: &MapG<K, V>): vector<K>;
+    native fun values<K: copy + drop, V: copy>(m: &MapG<K, V>): vector<V>;
+    native fun to_vec_pair<K: copy + drop, V>(m: MapG<K, V>): (vector<K>, vector<V>);
+    native fun to_dest<K: copy + drop, V>(m: MapG<K, V>): Dest<K, V>;
+    native fun new_from<K: copy + drop, V: store>(keys: vector<K>, values: vector<V>): MapG<K, V>;
+    native fun add_all<K: copy + drop, V>(m: &mut MapG<K, V>, keys: vector<K>, values: vector<V>);
+    native fun upsert_all<K: copy + drop, V>(m: &mut MapG<K, V>, keys: vector<K>, values: vector<V>);
+    native fun append<K: copy + drop, V>(m: &mut MapG<K, V>, other: MapG<K, V>);
+    native fun append_disjoint<K: copy + drop, V>(m: &mut MapG<K, V>, other: MapG<K, V>);
+    native fun trim<K: copy + drop, V>(m: &mut MapG<K, V>, at: u64): MapG<K, V>;
+    native fun replace_key_inplace<K: copy + drop, V>(m: &mut MapG<K, V>, old_k: K, new_k: K);
+    native fun iter_borrow_mut<K: copy + drop, V>(it: Iter<K>, m: &mut MapG<K, V>): &mut V;
+
+    spec native fun spec_new<K: copy + drop, V>(): MapG<K, V>;
+    spec native fun spec_get<K: copy + drop, V>(m: MapG<K, V>, k: K): V;
+    spec native fun spec_set<K: copy + drop, V>(m: MapG<K, V>, k: K, v: V): MapG<K, V>;
+    spec native fun spec_remove<K: copy + drop, V>(m: MapG<K, V>, k: K): MapG<K, V>;
+    spec native fun spec_len<K: copy + drop, V>(m: MapG<K, V>): num;
+    spec native fun spec_contains<K: copy + drop, V>(m: MapG<K, V>, k: K): bool;
+    spec native fun spec_aborts_ibm<K: copy + drop, V>(it: Iter<K>, m: MapG<K, V>): bool;
+    spec native fun spec_aborts_destroy_empty<K: copy + drop, V>(m: MapG<K, V>): bool;
+    spec native fun spec_aborts_add<K: copy + drop, V>(m: MapG<K, V>, k: K, v: V): bool;
+    spec native fun spec_aborts_del<K: copy + drop, V>(m: MapG<K, V>, k: K): bool;
+    spec native fun spec_aborts_borrow<K: copy + drop, V>(m: MapG<K, V>, k: K): bool;
+    spec native fun spec_iter_valid<K: copy + drop, V>(it: Iter<K>, m: MapG<K, V>): bool;
+    spec native fun spec_preserved<K: copy + drop, V>(m1: MapG<K, V>, m2: MapG<K, V>): bool;
+
+    // One instance registers every bound role's template block for
+    // MapG<u64, u64>; Boogie then type-checks them all.
+    fun touch(): u64 {
+        let m = new<u64, u64>();
+        add(&mut m, 1, 2);
+        length(&m)
+    }
+    spec touch {
+        ensures result == 1;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_ops.exp
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_ops.exp
@@ -1,0 +1,27 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+    ┌─ tests/sources/functional/ghost_field_intrinsic_map_ops.move:100:9
+    │
+100 │         ensures spec_preserved(m, old(m)); // FAILS: mutation havocs the slot
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:95: add_preserved_bad
+    =         m = <redacted>
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:96: add_preserved_bad
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:95: add_preserved_bad
+    =         m = <redacted>
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:99: add_preserved_bad (spec)
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:100: add_preserved_bad (spec)
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/ghost_field_intrinsic_map_ops.move:128:9
+    │
+128 │         ensures spec_preserved(m, old(m)); // FAILS: mutation havocs the slot
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:124: addall_preserved_bad
+    =         m = <redacted>
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:125: addall_preserved_bad
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:124: addall_preserved_bad
+    =         m = <redacted>
+    =     at tests/sources/functional/ghost_field_intrinsic_map_ops.move:128: addall_preserved_bad (spec)

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_ops.move
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_ops.move
@@ -1,0 +1,188 @@
+// A bound intrinsic map with a hidden validity slot (via the
+// `map_spec_iter_preserved` binding): content operations must behave exactly
+// as without the carrier, structural mutations havoc the slot (preservation
+// is not provable afterwards), and writes through borrowed values PRESERVE
+// it (a value write is not a structural mutation).
+module 0x42::ghost_field_intrinsic_map_ops {
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_has_key = contains,
+            map_add_no_override = add,
+            map_del_must_exist = remove,
+            map_borrow = borrow,
+            map_borrow_mut = borrow_mut,
+            map_spec_get = spec_get,
+            map_spec_set = spec_set,
+            map_spec_del = spec_remove,
+            map_spec_len = spec_len,
+            map_spec_has_key = spec_contains,
+            map_new_from = new_from,
+            map_add_all = add_all,
+            map_upsert_all = upsert_all,
+            map_append = append,
+            map_append_disjoint = append_disjoint,
+            map_trim = trim,
+            map_replace_key_inplace = replace_key_inplace,
+            map_spec_iter_preserved = spec_preserved;
+    }
+
+    public native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    public native fun contains<K: copy + drop, V>(m: &Map<K, V>, key: K): bool;
+    public native fun add<K: copy + drop, V>(m: &mut Map<K, V>, key: K, val: V);
+    public native fun remove<K: copy + drop, V>(m: &mut Map<K, V>, key: K): V;
+    public native fun borrow<K: copy + drop, V>(m: &Map<K, V>, key: K): &V;
+    public native fun borrow_mut<K: copy + drop, V>(m: &mut Map<K, V>, key: K): &mut V;
+    public native fun new_from<K: copy + drop, V: store>(keys: vector<K>, values: vector<V>): Map<K, V>;
+    public native fun add_all<K: copy + drop, V>(m: &mut Map<K, V>, keys: vector<K>, values: vector<V>);
+    public native fun upsert_all<K: copy + drop, V: drop>(m: &mut Map<K, V>, keys: vector<K>, values: vector<V>);
+    public native fun append<K: copy + drop, V>(m: &mut Map<K, V>, other: Map<K, V>);
+    public native fun append_disjoint<K: copy + drop, V>(m: &mut Map<K, V>, other: Map<K, V>);
+    public native fun trim<K: copy + drop, V>(m: &mut Map<K, V>, at: u64): Map<K, V>;
+    public native fun replace_key_inplace<K: copy + drop, V>(m: &mut Map<K, V>, old_key: &K, new_key: K);
+
+    spec native fun spec_len<K, V>(m: Map<K, V>): num;
+    spec native fun spec_contains<K, V>(m: Map<K, V>, k: K): bool;
+    spec native fun spec_set<K, V>(m: Map<K, V>, k: K, v: V): Map<K, V>;
+    spec native fun spec_remove<K, V>(m: Map<K, V>, k: K): Map<K, V>;
+    spec native fun spec_get<K, V>(m: Map<K, V>, k: K): V;
+    spec native fun spec_preserved<K, V>(m_new: Map<K, V>, m_old: Map<K, V>): bool;
+
+    // Content behavior through the carrier.
+    fun add_get(m: &mut Map<u64, u64>) {
+        add(m, 1, 7);
+    }
+    spec add_get {
+        aborts_if spec_contains(m, 1);
+        ensures spec_get(m, 1) == 7;
+        ensures spec_contains(m, 1);
+        ensures spec_len(m) == spec_len(old(m)) + 1;
+    }
+
+    fun rem(m: &mut Map<u64, u64>): u64 {
+        remove(m, 1)
+    }
+    spec rem {
+        aborts_if !spec_contains(m, 1);
+        ensures result == spec_get(old(m), 1);
+        ensures !spec_contains(m, 1);
+        ensures spec_len(m) == spec_len(old(m)) - 1;
+    }
+
+    // Writes through a borrowed value go through the carrier write-back and
+    // must PRESERVE the slot: a value write is not a structural mutation.
+    fun borrow_write(m: &mut Map<u64, u64>) {
+        let r = borrow_mut(m, 1);
+        *r = 9;
+    }
+    spec borrow_write {
+        aborts_if !spec_contains(m, 1);
+        ensures spec_get(m, 1) == 9;
+        ensures spec_len(m) == spec_len(old(m));
+        ensures spec_preserved(m, old(m));
+    }
+
+    fun mk(): Map<u64, u64> {
+        new()
+    }
+    spec mk {
+        ensures spec_len(result) == 0;
+    }
+
+    // Structural mutation havocs the slot: preservation is not provable.
+    fun add_preserved_bad(m: &mut Map<u64, u64>) {
+        add(m, 2, 2);
+    }
+    spec add_preserved_bad {
+        aborts_if spec_contains(m, 2);
+        ensures spec_preserved(m, old(m)); // FAILS: mutation havocs the slot
+    }
+
+    // Bulk operations, which model post-state via a fresh raw table wrapped
+    // into the carrier at each use site. Membership facts phrased over
+    // concrete vector literals are trigger-fragile in the shared templates
+    // (same verdicts with the ghost field removed), so the cells below only
+    // assert what verifies identically without the carrier.
+    fun mk_from(): Map<u64, u64> {
+        new_from(vector[1, 2], vector[7, 8])
+    }
+    spec mk_from {
+        aborts_if false;
+        ensures spec_len(result) == 2;
+        ensures forall k: u64: spec_contains(result, k) ==> (k == 1 || k == 2);
+    }
+
+    fun addall(m: &mut Map<u64, u64>) {
+        add_all(m, vector[1, 2], vector[7, 8]);
+    }
+    spec addall {
+        ensures spec_len(m) == spec_len(old(m)) + 2;
+    }
+
+    fun addall_preserved_bad(m: &mut Map<u64, u64>) {
+        add_all(m, vector[1, 2], vector[7, 8]);
+    }
+    spec addall_preserved_bad {
+        ensures spec_preserved(m, old(m)); // FAILS: mutation havocs the slot
+    }
+
+    fun upsertall(m: &mut Map<u64, u64>) {
+        upsert_all(m, vector[1, 2], vector[7, 8]);
+    }
+    spec upsertall {
+        aborts_if false;
+        ensures spec_len(m) >= spec_len(old(m));
+        ensures spec_len(m) <= spec_len(old(m)) + 2;
+    }
+
+    fun app(m: &mut Map<u64, u64>, other: Map<u64, u64>) {
+        append(m, other);
+    }
+    spec app {
+        aborts_if false;
+        ensures spec_len(m) >= spec_len(old(m));
+        ensures spec_len(m) >= spec_len(other);
+        ensures spec_len(m) <= spec_len(old(m)) + spec_len(other);
+        ensures forall k: u64: spec_contains(m, k) <==>
+            (spec_contains(old(m), k) || spec_contains(other, k));
+    }
+
+    fun app_disjoint(m: &mut Map<u64, u64>, other: Map<u64, u64>) {
+        append_disjoint(m, other);
+    }
+    spec app_disjoint {
+        aborts_if exists k: u64: spec_contains(m, k) && spec_contains(other, k);
+        ensures spec_len(m) == spec_len(old(m)) + spec_len(other);
+        ensures forall k: u64: spec_contains(m, k) <==>
+            (spec_contains(old(m), k) || spec_contains(other, k));
+    }
+
+    fun tr(m: &mut Map<u64, u64>): Map<u64, u64> {
+        trim(m, 1)
+    }
+    spec tr {
+        aborts_if spec_len(m) < 1;
+        ensures spec_len(m) == 1;
+        ensures spec_len(result) == spec_len(old(m)) - 1;
+        ensures forall k: u64: spec_contains(old(m), k) <==>
+            (spec_contains(m, k) || spec_contains(result, k));
+        ensures forall k: u64: !(spec_contains(m, k) && spec_contains(result, k));
+    }
+
+    // May also abort nondeterministically (models the Move-level abort on the
+    // new key violating the map's key order), so the aborts spec stays partial.
+    fun rk(m: &mut Map<u64, u64>) {
+        replace_key_inplace(m, &1, 2)
+    }
+    spec rk {
+        pragma aborts_if_is_partial = true;
+        aborts_if !spec_contains(m, 1);
+        ensures !spec_contains(m, 1);
+        ensures spec_contains(m, 2);
+        ensures spec_len(m) == spec_len(old(m));
+        ensures forall k: u64: (k != 1 && k != 2) ==>
+            (spec_contains(m, k) == spec_contains(old(m), k));
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_quant.exp
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_quant.exp
@@ -1,0 +1,12 @@
+Move prover returns: exiting with compilation errors
+error: quantified variables must range over a vector, a type domain, a number range, or a state domain
+   ┌─ tests/sources/functional/ghost_field_intrinsic_map_quant.move:33:24
+   │
+33 │         ensures forall k in result: spec_get(result, k) == 7;
+   │                        ^
+
+error: quantified variables must range over a vector, a type domain, a number range, or a state domain
+   ┌─ tests/sources/functional/ghost_field_intrinsic_map_quant.move:34:24
+   │
+34 │         ensures exists k in result: k == 1;
+   │                        ^

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_quant.move
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_intrinsic_map_quant.move
@@ -1,0 +1,36 @@
+// SOURCE-level quantifiers cannot range over an intrinsic map: the model
+// builder rejects the range (map-ranged quantifiers exist only internally,
+// fabricated by data-invariant instrumentation — see
+// ghost_field_intrinsic_map_data_inv). If this front-end restriction is ever
+// lifted, the carrier-represented map below immediately exercises the
+// backend's carrier-unwrapped membership constraint.
+module 0x42::ghost_field_intrinsic_map_quant {
+    struct MapG<phantom K: copy + drop, phantom V> has store, drop {}
+    spec MapG {
+        pragma intrinsic = map,
+            map_new = new,
+            map_add_no_override = add,
+            map_spec_get = spec_get,
+            map_spec_set = spec_set,
+            map_spec_len = spec_len,
+            map_spec_has_key = spec_contains,
+            map_spec_iter_preserved = spec_preserved;
+    }
+    native fun new<K: copy + drop, V: store>(): MapG<K, V>;
+    native fun add<K: copy + drop, V>(m: &mut MapG<K, V>, k: K, v: V);
+    spec native fun spec_get<K: copy + drop, V>(m: MapG<K, V>, k: K): V;
+    spec native fun spec_set<K: copy + drop, V>(m: MapG<K, V>, k: K, v: V): MapG<K, V>;
+    spec native fun spec_len<K: copy + drop, V>(m: MapG<K, V>): num;
+    spec native fun spec_contains<K: copy + drop, V>(m: MapG<K, V>, k: K): bool;
+    spec native fun spec_preserved<K: copy + drop, V>(m1: MapG<K, V>, m2: MapG<K, V>): bool;
+
+    fun singleton(): MapG<u64, u64> {
+        let m = new();
+        add(&mut m, 1, 7);
+        m
+    }
+    spec singleton {
+        ensures forall k in result: spec_get(result, k) == 7;
+        ensures exists k in result: k == 1;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/ghost_field_iter_abort_native.move
+++ b/third_party/move/move-prover/tests/sources/functional/ghost_field_iter_abort_native.move
@@ -1,0 +1,34 @@
+// A carrier-represented intrinsic map (hidden validity slot via the
+// preserved binding) binding `map_spec_aborts_iter_borrow_mut` to a NATIVE
+// spec fun: the template-emitted predicate receives the carrier and must
+// read membership through the raw-table selector. The aborts_if below
+// mirrors the `iter_borrow_mut` procedure's abort behavior exactly, so
+// `poke` verifies.
+module 0x42::ghost_field_iter_abort_native {
+    enum Iter<K: copy + drop> has copy, drop {
+        Some { key: K },
+        End,
+    }
+
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_get = spec_get,
+            map_iter_borrow_mut = ibm,
+            map_spec_aborts_iter_borrow_mut = spec_aborts_ibm,
+            map_spec_iter_preserved = spec_preserved;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    native fun ibm<K: copy + drop, V>(it: Iter<K>, m: &mut Map<K, V>): &mut V;
+    spec native fun spec_aborts_ibm<K: copy + drop, V>(it: Iter<K>, m: Map<K, V>): bool;
+    spec native fun spec_get<K: copy + drop, V>(m: Map<K, V>, k: K): V;
+    spec native fun spec_preserved<K: copy + drop, V>(m1: Map<K, V>, m2: Map<K, V>): bool;
+
+    fun poke(m: &mut Map<u64, u64>, it: Iter<u64>): u64 {
+        *ibm(it, m)
+    }
+    spec poke {
+        aborts_if spec_aborts_ibm(it, m);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_iter_abort_sig_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_iter_abort_sig_err.exp
@@ -1,0 +1,9 @@
+Move prover returns: exiting with bytecode transformation errors
+error: a `map_spec_aborts_iter_borrow_mut` function must have two type parameters and the signature (iterator_enum<K>, map<K, V>): bool, with the iterator enum of the `map_iter_borrow_mut` binding
+   ┌─ tests/sources/functional/intrinsic_iter_abort_sig_err.move:24:10
+   │
+24 │       spec fun spec_aborts_ibm<K: copy + drop, V>(it: Iter<K>): bool {
+   │ ╭──────────^
+25 │ │         it is Iter::End<K>
+26 │ │     }
+   │ ╰─────^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_iter_abort_sig_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_iter_abort_sig_err.move
@@ -1,0 +1,31 @@
+// A `map_spec_aborts_iter_borrow_mut` binding whose signature does not match
+// `(iterator_enum<K>, map<K, V>): bool` must be rejected for EVERY binding
+// kind: the behavioral `aborts_of` translation calls the predicate with
+// exactly the `map_iter_borrow_mut` binding's two parameters, so a bodied
+// (or uninterpreted) mis-signed binding — which the template-side check
+// never sees — would emit an ill-typed Boogie call.
+module 0x42::intrinsic_iter_abort_sig_err {
+    enum Iter<K: copy + drop> has copy, drop {
+        Some { key: K },
+        End,
+    }
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_get = spec_get,
+            map_iter_borrow_mut = ibm,
+            map_spec_aborts_iter_borrow_mut = spec_aborts_ibm;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    spec native fun spec_get<K: copy + drop, V>(m: Map<K, V>, k: K): V;
+    native fun ibm<K: copy + drop, V>(it: Iter<K>, m: &mut Map<K, V>): &mut V;
+    // error: bodied AND mis-signed (missing the map parameter)
+    spec fun spec_aborts_ibm<K: copy + drop, V>(it: Iter<K>): bool {
+        it is Iter::End<K>
+    }
+
+    fun use_map(): Map<u64, u64> {
+        new<u64, u64>()
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_iter_abort_uninterp.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_iter_abort_uninterp.move
@@ -1,0 +1,36 @@
+// An UNINTERPRETED (bodyless, non-native) spec fun bound to
+// `map_spec_aborts_iter_borrow_mut`: the spec translator emits its
+// uninterpreted declaration, so the template must not also define it —
+// the binding is treated like a bodied one (user-supplied predicate),
+// not like a native. `probe` exercises a spec use of the predicate.
+module 0x42::intrinsic_iter_abort_uninterp {
+    enum Iter<K: copy + drop> has copy, drop {
+        Some { key: K },
+        End,
+    }
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_iter_borrow_mut = ibm,
+            map_spec_get = spec_get,
+            map_spec_aborts_iter_borrow_mut = spec_aborts_ibm;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    spec native fun spec_get<K: copy + drop, V>(m: Map<K, V>, k: K): V;
+    native fun ibm<K: copy + drop, V>(it: Iter<K>, m: &mut Map<K, V>): &mut V;
+    spec fun spec_aborts_ibm<K: copy + drop, V>(it: Iter<K>, m: Map<K, V>): bool;
+
+    fun touch(_m: &mut Map<u64, u64>, _it: Iter<u64>): bool {
+        true
+    }
+    spec touch {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if false;
+        ensures result == spec_aborts_ibm(_it, _m);
+    }
+    fun probe(m: &mut Map<u64, u64>, it: Iter<u64>): bool {
+        touch(m, it)
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_iter_role_err7.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_iter_role_err7.exp
@@ -1,11 +1,11 @@
-Move prover returns: exiting with condition generation errors
-error: a native `map_spec_aborts_iter_borrow_mut` function must have exactly two type parameters and the signature `(iterator_enum<K>, map<K, V>): bool`, with `map_iter_borrow_mut` bound on the same map
+Move prover returns: exiting with bytecode transformation errors
+error: a `map_spec_aborts_iter_borrow_mut` function must have two type parameters and the signature (iterator_enum<K>, map<K, V>): bool, with the iterator enum of the `map_iter_borrow_mut` binding
    ┌─ tests/sources/functional/intrinsic_iter_role_err7.move:21:10
    │
 21 │     spec native fun bad_aborts<K: copy + drop, V, W>(it: Iter<K>, m: Map<K, V>, w: W): bool;
    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: a native `map_spec_aborts_iter_borrow_mut` function must have exactly two type parameters and the signature `(iterator_enum<K>, map<K, V>): bool`, with `map_iter_borrow_mut` bound on the same map
+error: a `map_spec_aborts_iter_borrow_mut` binding requires `map_iter_borrow_mut` bound on the same map
    ┌─ tests/sources/functional/intrinsic_iter_role_err7.move:45:10
    │
 45 │     spec native fun lone_aborts<K: copy + drop, V>(it: Iter<K>, m: Map<K, V>): bool;

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_arity_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_arity_err.exp
@@ -1,0 +1,7 @@
+Move prover returns: exiting with compilation errors
+error: a `map` intrinsic type must have exactly two type parameters (key and value)
+  ┌─ tests/sources/functional/intrinsic_map_arity_err.move:8:9
+  │
+8 │ ╭         pragma intrinsic = map,
+9 │ │             map_new = new;
+  │ ╰──────────────────────────^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_arity_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_arity_err.move
@@ -1,0 +1,16 @@
+// An intrinsic map type must have exactly two type parameters: the templates
+// and monomorphization index the instantiation as (key, value), so any other
+// arity would previously panic with an out-of-bounds read once an instance
+// was registered. Rejected at the intrinsic declaration instead.
+module 0x42::intrinsic_map_arity_err {
+    struct Map<phantom K: copy + drop> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new;
+    }
+    native fun new<K: copy + drop>(): Map<K>;
+
+    fun mk(): Map<u64> {
+        new()
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_conv_ghost_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_conv_ghost_err.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with bytecode transformation errors
+error: a `map_to_ordered_map` function whose result map type carries iterator-validity state is not supported
+   ┌─ tests/sources/functional/intrinsic_map_conv_ghost_err.move:23:5
+   │
+23 │     native fun to_dest<K: copy + drop, V>(m: Src<K, V>): Dest<K, V>;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_conv_ghost_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_conv_ghost_err.move
@@ -1,0 +1,28 @@
+// A `map_to_ordered_map` binding whose destination map carries a hidden
+// validity slot: the conversion template returns the destination as a raw
+// table, but a slot-carrying destination is represented by a carrier
+// datatype, so emitted calls would be ill-typed Boogie. The binding is
+// rejected with a diagnostic instead.
+module 0x42::intrinsic_map_conv_ghost_err {
+    struct Dest<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Dest {
+        pragma intrinsic = map,
+            map_new = dest_new,
+            map_spec_iter_preserved = dest_preserved;
+    }
+    native fun dest_new<K: copy + drop, V: store>(): Dest<K, V>;
+    spec native fun dest_preserved<K: copy + drop, V>(m1: Dest<K, V>, m2: Dest<K, V>): bool;
+
+    struct Src<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Src {
+        pragma intrinsic = map,
+            map_new = src_new,
+            map_to_ordered_map = to_dest;
+    }
+    native fun src_new<K: copy + drop, V: store>(): Src<K, V>;
+    native fun to_dest<K: copy + drop, V>(m: Src<K, V>): Dest<K, V>;
+
+    fun convert(m: Src<u64, u64>): Dest<u64, u64> {
+        to_dest(m)
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_enum_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_enum_err.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with condition generation errors
+error: cannot pack a value of an intrinsic map type in verified code; use the map's creation functions
+   ┌─ tests/sources/functional/intrinsic_map_enum_err.move:18:9
+   │
+18 │         Map::Empty // error: cannot pack an intrinsic map
+   │         ^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_enum_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_enum_err.move
@@ -1,0 +1,20 @@
+// Enum intrinsic maps are legal declarations (the framework's ordered maps
+// are single-variant enums), but the intrinsic representation — raw table,
+// or ghost carrier — declares no variant constructors, so verified code
+// cannot pack or unpack a variant of one; each is a diagnostic instead of
+// undefined Boogie. (The map's own runtime implementation is unaffected:
+// role-bound functions are modeled by templates and never translated.)
+module 0x42::intrinsic_map_enum_err {
+    enum Map<phantom K: copy + drop, phantom V> has store, drop {
+        Empty,
+    }
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+
+    fun mk(): Map<u64, u64> {
+        Map::Empty // error: cannot pack an intrinsic map
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_field_access_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_field_access_err.exp
@@ -1,0 +1,12 @@
+Move prover returns: exiting with condition generation errors
+error: cannot pack a value of an intrinsic map type in verified code; use the map's creation functions
+   ┌─ tests/sources/functional/intrinsic_map_field_access_err.move:14:9
+   │
+14 │         MapD { dummy: true } // error: cannot pack an intrinsic map
+   │         ^^^^^^^^^^^^^^^^^^^^
+
+error: cannot select a field of an intrinsic map type in verified code
+   ┌─ tests/sources/functional/intrinsic_map_field_access_err.move:18:9
+   │
+18 │         m.dummy // error: cannot select a field of an intrinsic map
+   │         ^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_field_access_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_field_access_err.move
@@ -1,0 +1,20 @@
+// Declared fields of an intrinsic map are erased by the intrinsic
+// representation, so verified code cannot pack the map or select its fields
+// — the emission would be ill-typed against the raw table or its carrier.
+// Each is a diagnostic instead. (The map's own runtime implementation is
+// unaffected: role-bound functions are modeled by templates and never
+// translated.)
+module 0x42::intrinsic_map_field_access_err {
+    struct MapD<phantom K: copy + drop, phantom V> has store, drop { dummy: bool }
+    spec MapD {
+        pragma intrinsic = map;
+    }
+
+    fun make(): MapD<u64, u64> {
+        MapD { dummy: true } // error: cannot pack an intrinsic map
+    }
+
+    fun read(m: &MapD<u64, u64>): bool {
+        m.dummy // error: cannot select a field of an intrinsic map
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_invariant_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_invariant_err.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with bytecode transformation errors
+error: data invariants are not supported on intrinsic map types; the map's validity is defined by its model
+   ┌─ tests/sources/functional/intrinsic_map_invariant_err.move:10:9
+   │
+10 │         invariant 0 == 0; // error: even a trivial invariant is rejected
+   │         ^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_invariant_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_invariant_err.move
@@ -1,0 +1,17 @@
+// Data invariants on an intrinsic map type are rejected: the map's validity
+// predicate is template-defined and its pack/unpack sites are erased by the
+// intrinsic representation, so the invariant would be silently inert —
+// neither checked at creation/mutation nor assumed at use.
+module 0x42::intrinsic_map_invariant_err {
+    struct MapG<phantom K: copy + drop, phantom V> has store, drop {}
+    spec MapG {
+        pragma intrinsic = map,
+            map_new = new;
+        invariant 0 == 0; // error: even a trivial invariant is rejected
+    }
+    native fun new<K: copy + drop, V: store>(): MapG<K, V>;
+
+    fun mk(): MapG<u64, u64> {
+        new()
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_native_role_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_native_role_err.exp
@@ -1,0 +1,18 @@
+Move prover returns: exiting with bytecode transformation errors
+error: a `map_spec_len` binding must be a `spec native fun`; its definition is provided by the intrinsic model
+   ┌─ tests/sources/functional/intrinsic_map_native_role_err.move:22:10
+   │
+22 │       spec fun spec_len<K, V>(_m: Map<K, V>): num {
+   │ ╭──────────^
+23 │ │         0
+24 │ │     }
+   │ ╰─────^
+
+error: a `map_spec_iter_valid` binding must be a `spec native fun`; its definition is provided by the intrinsic model
+   ┌─ tests/sources/functional/intrinsic_map_native_role_err.move:26:10
+   │
+26 │       spec fun spec_iter_valid<K, V>(_it: Iter<K>, _m: Map<K, V>): bool {
+   │ ╭──────────^
+27 │ │         true
+28 │ │     }
+   │ ╰─────^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_native_role_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_native_role_err.move
@@ -1,0 +1,33 @@
+// Bindings for roles whose definitions the prelude template emits must be
+// `spec native fun`s: a bodied spec fun is also emitted by regular
+// spec-function translation, so the same Boogie function would be declared
+// twice. Covers a model-observer role (`map_spec_len`) and a validity role
+// (`map_spec_iter_valid`); `map_spec_aborts_iter_borrow_mut` stays exempt —
+// its template definition is gated on the binding being native.
+module 0x42::intrinsic_map_native_role_err {
+    enum Iter<K: copy + drop> has copy, drop {
+        Some { key: K },
+        End,
+    }
+
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_len = spec_len,
+            map_spec_iter_valid = spec_iter_valid;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    // error: bodied binding for a template-defined role
+    spec fun spec_len<K, V>(_m: Map<K, V>): num {
+        0
+    }
+    // error: bodied binding for a template-defined role
+    spec fun spec_iter_valid<K, V>(_it: Iter<K>, _m: Map<K, V>): bool {
+        true
+    }
+
+    fun use_map(): Map<u64, u64> {
+        new<u64, u64>()
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_role_sig_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_role_sig_err.exp
@@ -1,0 +1,21 @@
+Move prover returns: exiting with bytecode transformation errors
+error: a `map_spec_len` function must have two type parameters and the signature (map<K, V>): num
+   ┌─ tests/sources/functional/intrinsic_map_role_sig_err.move:17:10
+   │
+17 │     spec native fun spec_len<K, V>(t: Map<K, V>, extra: u64): num;
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: a `map_spec_aborts_empty` function must take the parameters of its `map_borrow_front` binding (references by value) and return bool
+   ┌─ tests/sources/functional/intrinsic_map_role_sig_err.move:39:10
+   │
+39 │       spec fun spec_aborts_empty<K, V>(t: Map<K, V>, extra: u64): bool {
+   │ ╭──────────^
+40 │ │         extra == 0
+41 │ │     }
+   │ ╰─────^
+
+error: a `map_spec_aborts_empty` binding must have a body or be declared uninterpreted; the prover's model does not define it
+   ┌─ tests/sources/functional/intrinsic_map_role_sig_err.move:63:10
+   │
+63 │     spec native fun spec_aborts_empty<K, V>(t: Map<K, V>): bool;
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_role_sig_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_role_sig_err.move
@@ -1,0 +1,67 @@
+// Template-defined role bindings have fixed signatures (the template emits
+// the definition in that shape; user spec text calls the declared shape),
+// and call-only abort predicates are invoked by the behavioral `aborts_of`
+// translation with the paired Move function's parameters. Mis-signed or
+// wrongly-natured bindings must be model-build errors, not ill-typed Boogie.
+
+// Mis-signed native on a template-defined model-observer role.
+module 0x42::intrinsic_map_sig_observer {
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_len = spec_len;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    // error: extra parameter (expected (map<K, V>): num)
+    spec native fun spec_len<K, V>(t: Map<K, V>, extra: u64): num;
+    fun touch(): Map<u64, u64> {
+        new<u64, u64>()
+    }
+}
+
+// Mis-signed bodied binding on a call-only abort role.
+module 0x42::intrinsic_map_sig_callonly {
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_has_key = spec_has_key,
+            map_spec_get = spec_get,
+            map_borrow_front = borrow_front,
+            map_spec_aborts_empty = spec_aborts_empty;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    spec native fun spec_has_key<K, V>(t: Map<K, V>, k: K): bool;
+    spec native fun spec_get<K, V>(t: Map<K, V>, k: K): V;
+    native fun borrow_front<K: copy + drop, V>(m: &Map<K, V>): (K, &V);
+    // error: extra parameter (expected the map alone, like `borrow_front`)
+    spec fun spec_aborts_empty<K, V>(t: Map<K, V>, extra: u64): bool {
+        extra == 0
+    }
+    fun touch(): Map<u64, u64> {
+        new<u64, u64>()
+    }
+}
+
+// Native binding on a call-only abort role: nothing would define it.
+module 0x42::intrinsic_map_sig_native_callonly {
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_has_key = spec_has_key,
+            map_spec_get = spec_get,
+            map_borrow_front = borrow_front,
+            map_spec_aborts_empty = spec_aborts_empty;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    spec native fun spec_has_key<K, V>(t: Map<K, V>, k: K): bool;
+    spec native fun spec_get<K, V>(t: Map<K, V>, k: K): V;
+    native fun borrow_front<K: copy + drop, V>(m: &Map<K, V>): (K, &V);
+    // error: native — neither the template nor spec translation defines it
+    spec native fun spec_aborts_empty<K, V>(t: Map<K, V>): bool;
+    fun touch(): Map<u64, u64> {
+        new<u64, u64>()
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_shared_fun_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_shared_fun_err.exp
@@ -1,0 +1,14 @@
+Move prover returns: exiting with compilation errors
+error: spec function is already bound to another intrinsic type: intrinsic_map_shared_spec_fun::shared_len
+   ┌─ tests/sources/functional/intrinsic_map_shared_fun_err.move:11:9
+   │
+11 │ ╭         pragma intrinsic = map, map_new = new_b,
+12 │ │             map_spec_len = shared_len; // error: already bound to MapA
+   │ ╰──────────────────────────────────────^
+
+error: move function is already bound to another intrinsic type: intrinsic_map_shared_move_fun::shared_length
+   ┌─ tests/sources/functional/intrinsic_map_shared_fun_err.move:29:9
+   │
+29 │ ╭         pragma intrinsic = map,
+30 │ │             map_len = shared_length; // error: already bound to MapA
+   │ ╰────────────────────────────────────^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_shared_fun_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_shared_fun_err.move
@@ -1,0 +1,36 @@
+// A function bound to one intrinsic type cannot be bound to another:
+// template definitions are emitted once per type under the bound function's
+// name, so sharing would declare the same Boogie symbol twice.
+module 0x42::intrinsic_map_shared_spec_fun {
+    struct MapA<phantom K: copy + drop, phantom V> has store, drop {}
+    struct MapB<phantom K: copy + drop, phantom V> has store, drop {}
+    spec MapA {
+        pragma intrinsic = map, map_new = new_a, map_spec_len = shared_len;
+    }
+    spec MapB {
+        pragma intrinsic = map, map_new = new_b,
+            map_spec_len = shared_len; // error: already bound to MapA
+    }
+    native fun new_a<K: copy + drop, V: store>(): MapA<K, V>;
+    native fun new_b<K: copy + drop, V: store>(): MapB<K, V>;
+    spec native fun shared_len<K, V>(t: MapA<K, V>): num;
+    fun touch(): (MapA<u64, u64>, MapB<u64, u64>) {
+        (new_a<u64, u64>(), new_b<u64, u64>())
+    }
+}
+
+module 0x42::intrinsic_map_shared_move_fun {
+    struct MapA<phantom K: copy + drop, phantom V> has store, drop {}
+    struct MapB<phantom K: copy + drop, phantom V> has store, drop {}
+    spec MapA {
+        pragma intrinsic = map, map_len = shared_length;
+    }
+    spec MapB {
+        pragma intrinsic = map,
+            map_len = shared_length; // error: already bound to MapA
+    }
+    native fun shared_length<K: copy + drop, V>(m: &MapA<K, V>): u64;
+    fun touch(m: &MapA<u64, u64>): u64 {
+        shared_length(m)
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_spec_pack_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_spec_pack_err.exp
@@ -1,0 +1,18 @@
+Move prover returns: exiting with condition generation errors
+error: [boogie translator] cannot pack a value of an intrinsic map type in a specification; use the map's `map_spec_new` binding
+   ┌─ tests/sources/functional/intrinsic_map_spec_pack_err.move:22:46
+   │
+22 │         ensures spec_len(result) == spec_len(Map<u64, u64> {});
+   │                                              ^^^^^^^^^^^^^^^^
+
+error: [boogie translator] cannot pack a value of an intrinsic map type in a specification; use the map's `map_spec_new` binding
+   ┌─ tests/sources/functional/intrinsic_map_spec_pack_err.move:49:46
+   │
+49 │         ensures spec_len(result) == spec_len(Map<u64, u64> {});
+   │                                              ^^^^^^^^^^^^^^^^
+
+error: [boogie translator] cannot pack a value of an intrinsic map type in a specification; use the map's `map_spec_new` binding
+   ┌─ tests/sources/functional/intrinsic_map_spec_pack_err.move:78:56
+   │
+78 │         ensures spec_len(result) == spec_len<u64, u64>(Map::Empty);
+   │                                                        ^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_spec_pack_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_spec_pack_err.move
@@ -1,0 +1,80 @@
+// Spec-level pack of an intrinsic map is a diagnostic, mirroring the
+// code-level rejection: the intrinsic representation — raw table, or ghost
+// carrier — has no field constructors, so the emitted constructor would be
+// ill-typed Boogie (wrong arguments for a struct, a nonexistent variant
+// constructor for an enum).
+
+// Raw-table representation (no validity roles bound).
+module 0x42::spec_pack_raw {
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_len = spec_len;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    spec native fun spec_len<K, V>(t: Map<K, V>): num;
+
+    fun mk(): Map<u64, u64> {
+        new()
+    }
+    spec mk {
+        ensures spec_len(result) == spec_len(Map<u64, u64> {});
+    }
+}
+
+// Ghost-carrier representation (validity role bound).
+module 0x42::spec_pack_carrier {
+    struct Map<phantom K: copy + drop, phantom V> has store, drop {}
+
+    enum IteratorPtr<K: copy + drop> has copy, drop {
+        End,
+        Some { key: K },
+    }
+
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_len = spec_len,
+            map_spec_iter_valid = spec_iter_valid;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    spec native fun spec_len<K, V>(t: Map<K, V>): num;
+    spec native fun spec_iter_valid<K, V>(it: IteratorPtr<K>, t: Map<K, V>): bool;
+
+    fun mk(): Map<u64, u64> {
+        new()
+    }
+    spec mk {
+        ensures spec_len(result) == spec_len(Map<u64, u64> {});
+    }
+}
+
+// Enum intrinsic map: the carrier declares no variant constructors.
+module 0x42::spec_pack_enum {
+    enum Map<phantom K: copy + drop, phantom V> has store, drop {
+        Empty,
+    }
+
+    enum IteratorPtr<K: copy + drop> has copy, drop {
+        End,
+        Some { key: K },
+    }
+
+    spec Map {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_len = spec_len,
+            map_spec_iter_valid = spec_iter_valid;
+    }
+    native fun new<K: copy + drop, V: store>(): Map<K, V>;
+    spec native fun spec_len<K, V>(t: Map<K, V>): num;
+    spec native fun spec_iter_valid<K, V>(it: IteratorPtr<K>, t: Map<K, V>): bool;
+
+    fun mk(): Map<u64, u64> {
+        new()
+    }
+    spec mk {
+        ensures spec_len(result) == spec_len<u64, u64>(Map::Empty);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_update_field_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_update_field_err.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with condition generation errors
+error: cannot update a field of an intrinsic map type in a specification
+   ┌─ tests/sources/functional/intrinsic_map_update_field_err.move:19:27
+   │
+19 │         ensures result == update_field(result, dummy, false);
+   │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_map_update_field_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_map_update_field_err.move
@@ -1,0 +1,21 @@
+// Functional `update_field` on an intrinsic map's field is the
+// expression-form twin of the rejected statement `update`: declared fields
+// are erased by the intrinsic representation, so no update function exists
+// in the emitted Boogie. Rejected with a diagnostic at translation instead
+// of emitting an undefined symbol.
+module 0x42::intrinsic_map_update_field_err {
+    struct MapD<phantom K: copy + drop, phantom V> has store, drop { dummy: bool }
+    spec MapD {
+        pragma intrinsic = map,
+            map_new = new;
+    }
+    native fun new<K: copy + drop, V: store>(): MapD<K, V>;
+
+    fun mk(): MapD<u64, u64> {
+        new()
+    }
+    spec mk {
+        // error: fields of an intrinsic map cannot be updated in specs
+        ensures result == update_field(result, dummy, false);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_validity_data_inv_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_validity_data_inv_err.exp
@@ -1,0 +1,36 @@
+Move prover returns: exiting with bytecode transformation errors
+error: a `map_spec_iter_valid` binding cannot be used in a data invariant (directly or through called spec functions): data invariants are assumed for opaque results, which would revalidate stale iterators
+   ┌─ tests/sources/functional/intrinsic_validity_data_inv_err.move:16:9
+   │
+16 │         invariant spec_iter_valid(self, spec_new<K, u64>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: a `map_spec_leaf_iter_valid` binding cannot be used in a data invariant (directly or through called spec functions): data invariants are assumed for opaque results, which would revalidate stale iterators
+   ┌─ tests/sources/functional/intrinsic_validity_data_inv_err.move:44:9
+   │
+44 │         invariant spec_node_valid(self, spec_new<u8, u64>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: a `map_spec_iter_valid` binding cannot be used in a data invariant (directly or through called spec functions): data invariants are assumed for opaque results, which would revalidate stale iterators
+   ┌─ tests/sources/functional/intrinsic_validity_data_inv_err.move:99:9
+   │
+99 │         invariant validity_inv_map::spec_iter_valid(self.it, validity_inv_map::spec_new<u8, u64>());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: a `map_spec_iter_preserved` binding cannot be used in a data invariant (directly or through called spec functions): data invariants are assumed for opaque results, which would revalidate stale iterators
+    ┌─ tests/sources/functional/intrinsic_validity_data_inv_err.move:113:9
+    │
+113 │         invariant same_epoch(self);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: a behavioral predicate (`requires_of`, `aborts_of`, `ensures_of`, or `result_of`) cannot be used in a data invariant when iterator-validity bindings are present: it lifts a function's spec conditions — possibly stating validity — into an assumed context
+    ┌─ tests/sources/functional/intrinsic_validity_data_inv_err.move:129:9
+    │
+129 │         invariant requires_of<validity_gate>(self.it, validity_inv_map::spec_new<u8, u64>());
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: a behavioral predicate (`requires_of`, `aborts_of`, `ensures_of`, or `result_of`) cannot be used in a data invariant when iterator-validity bindings are present: it lifts a function's spec conditions — possibly stating validity — into an assumed context
+    ┌─ tests/sources/functional/intrinsic_validity_data_inv_err.move:146:9
+    │
+146 │         invariant gated(self.it);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_validity_data_inv_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_validity_data_inv_err.move
@@ -1,0 +1,156 @@
+// Iterator-validity predicates must not appear in data invariants, on any
+// type: data invariants are assumed for opaque results without ever being
+// proven (intrinsic producers have no pack site), so such an invariant could
+// pin hidden validity slots to `spec_new()`'s fixed slot and revalidate a
+// stale iterator after a structural map mutation.
+
+// Surface 1: data invariant on the iterator enum itself.
+module 0x42::validity_inv_enum {
+    struct Table<phantom K: copy + drop, phantom V> has store, drop, copy {}
+
+    enum IteratorPtr<K: copy + drop> has copy, drop {
+        End,
+        Some { key: K },
+    }
+    spec IteratorPtr {
+        invariant spec_iter_valid(self, spec_new<K, u64>());
+    }
+
+    spec Table {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_new = spec_new,
+            map_spec_iter_valid = spec_iter_valid;
+    }
+
+    public native fun new<K: copy + drop, V: store>(): Table<K, V>;
+    spec native fun spec_new<K, V>(): Table<K, V>;
+    spec native fun spec_iter_valid<K, V>(it: IteratorPtr<K>, t: Table<K, V>): bool;
+
+    fun mk(): Table<u8, u64> {
+        new()
+    }
+}
+
+// Surface 2: data invariant on a plain-struct (non-enum) walker bound
+// through `map_spec_leaf_iter_valid`.
+module 0x42::validity_inv_leaf {
+    struct Table<phantom K: copy + drop, phantom V> has store, drop, copy {}
+
+    struct NodePtr has copy, drop {
+        node_index: u64,
+    }
+    spec NodePtr {
+        invariant spec_node_valid(self, spec_new<u8, u64>());
+    }
+
+    spec Table {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_new = spec_new,
+            map_spec_leaf_iter_valid = spec_node_valid;
+    }
+
+    public native fun new<K: copy + drop, V: store>(): Table<K, V>;
+    spec native fun spec_new<K, V>(): Table<K, V>;
+    spec native fun spec_node_valid<K, V>(it: NodePtr, t: Table<K, V>): bool;
+
+    fun mk(): Table<u8, u64> {
+        new()
+    }
+}
+
+// Surfaces 3 and 4 share a clean map module: the invariants live in CLIENT
+// modules wrapping the iterator.
+module 0x42::validity_inv_map {
+    struct Table<phantom K: copy + drop, phantom V> has store, drop, copy {}
+
+    enum IteratorPtr<K: copy + drop> has copy, drop {
+        End,
+        Some { key: K },
+    }
+
+    spec Table {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_new = spec_new,
+            map_spec_iter_valid = spec_iter_valid,
+            map_spec_iter_preserved = spec_iter_preserved;
+    }
+
+    public native fun new<K: copy + drop, V: store>(): Table<K, V>;
+    spec native fun spec_new<K, V>(): Table<K, V>;
+    spec native fun spec_iter_valid<K, V>(it: IteratorPtr<K>, t: Table<K, V>): bool;
+    spec native fun spec_iter_preserved<K, V>(t_new: Table<K, V>, t_old: Table<K, V>): bool;
+
+    fun mk(): Table<u8, u64> {
+        new()
+    }
+}
+
+// Surface 3: direct call in a client wrapper's data invariant.
+module 0x42::validity_inv_wrapper {
+    use 0x42::validity_inv_map::{Self, IteratorPtr};
+
+    struct Holder has copy, drop {
+        it: IteratorPtr<u8>,
+    }
+    spec Holder {
+        invariant validity_inv_map::spec_iter_valid(self.it, validity_inv_map::spec_new<u8, u64>());
+    }
+}
+
+// Surface 4: the predicate reached transitively through a helper spec fun
+// (here `map_spec_iter_preserved`, the two-map frame predicate).
+module 0x42::validity_inv_transitive {
+    use 0x42::validity_inv_map::{Self, Table};
+
+    struct TwoMaps has store, drop {
+        a: Table<u8, u64>,
+        b: Table<u8, u64>,
+    }
+    spec TwoMaps {
+        invariant same_epoch(self);
+    }
+    spec fun same_epoch(s: TwoMaps): bool {
+        validity_inv_map::spec_iter_preserved(s.a, s.b)
+    }
+}
+
+// Surface 5: the predicate laundered through a behavioral operator — the
+// invariant never calls a validity spec fun directly.
+module 0x42::validity_inv_behavioral {
+    use 0x42::validity_inv_map::{Self, Table, IteratorPtr};
+
+    struct Holder has copy, drop {
+        it: IteratorPtr<u8>,
+    }
+    spec Holder {
+        invariant requires_of<validity_gate>(self.it, validity_inv_map::spec_new<u8, u64>());
+    }
+
+    public fun validity_gate(_it: IteratorPtr<u8>, _t: Table<u8, u64>) {}
+    spec validity_gate {
+        requires validity_inv_map::spec_iter_valid(_it, _t);
+    }
+}
+
+// Surface 6: the behavioral operator hidden inside a helper spec fun.
+module 0x42::validity_inv_behavioral_helper {
+    use 0x42::validity_inv_map::{Self, Table, IteratorPtr};
+
+    struct Holder has copy, drop {
+        it: IteratorPtr<u8>,
+    }
+    spec Holder {
+        invariant gated(self.it);
+    }
+    spec fun gated(it: IteratorPtr<u8>): bool {
+        requires_of<validity_gate>(it, validity_inv_map::spec_new<u8, u64>())
+    }
+
+    public fun validity_gate(_it: IteratorPtr<u8>, _t: Table<u8, u64>) {}
+    spec validity_gate {
+        requires validity_inv_map::spec_iter_valid(_it, _t);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_validity_iter_loc_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_validity_iter_loc_err.exp
@@ -1,0 +1,18 @@
+Move prover returns: exiting with compilation errors
+error: the first parameter of a `map_spec_iter_valid` binding must be an iterator type declared in the same module as the map
+   ┌─ tests/sources/functional/intrinsic_validity_iter_loc_err.move:19:10
+   │
+19 │     spec native fun spec_iter_valid<K, V>(it: u64, t: Table<K, V>): bool;
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: undeclared `0x42::validity_iter_loc_other::ForeignPtr`
+   ┌─ tests/sources/functional/intrinsic_validity_iter_loc_err.move:37:47
+   │
+37 │     spec native fun spec_node_valid<K, V>(it: ForeignPtr, t: Table<K, V>): bool;
+   │                                               ^^^^^^^^^^
+
+error: the first parameter of a `map_spec_leaf_iter_valid` binding must be an iterator type declared in the same module as the map
+   ┌─ tests/sources/functional/intrinsic_validity_iter_loc_err.move:37:10
+   │
+37 │     spec native fun spec_node_valid<K, V>(it: ForeignPtr, t: Table<K, V>): bool;
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/intrinsic_validity_iter_loc_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/intrinsic_validity_iter_loc_err.move
@@ -1,0 +1,42 @@
+// A validity predicate's iterator (first) parameter must be a type declared
+// in the map's own module — its hidden slot is synthesized while that module
+// is built. The diagnostic points at the offending binding.
+module 0x42::validity_iter_loc_other {
+    struct ForeignPtr has copy, drop {
+        pos: u64,
+    }
+}
+
+// First parameter is not a struct type at all.
+module 0x42::validity_iter_loc_prim {
+    struct Table<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Table {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_iter_valid = spec_iter_valid;
+    }
+    native fun new<K: copy + drop, V: store>(): Table<K, V>;
+    spec native fun spec_iter_valid<K, V>(it: u64, t: Table<K, V>): bool;
+
+    fun mk(): Table<u8, u64> {
+        new()
+    }
+}
+
+// First parameter is a struct declared in a different module.
+module 0x42::validity_iter_loc_foreign {
+    use 0x42::validity_iter_loc_other::ForeignPtr;
+
+    struct Table<phantom K: copy + drop, phantom V> has store, drop {}
+    spec Table {
+        pragma intrinsic = map,
+            map_new = new,
+            map_spec_leaf_iter_valid = spec_node_valid;
+    }
+    native fun new<K: copy + drop, V: store>(): Table<K, V>;
+    spec native fun spec_node_valid<K, V>(it: ForeignPtr, t: Table<K, V>): bool;
+
+    fun mk(): Table<u8, u64> {
+        new()
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/verify_iterator_validity.exp
+++ b/third_party/move/move-prover/tests/sources/functional/verify_iterator_validity.exp
@@ -1,0 +1,243 @@
+Move prover returns: exiting with verification errors
+warning: This assignment/binding to the left-hand-side variable `it` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_it`), or renaming to `_`
+    ┌─ tests/sources/functional/verify_iterator_validity.move:159:18
+    │
+159 │         let it = find(&t, 1);
+    │                  ^^^^^^^^^^^
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:60:9
+   │
+60 │         requires spec_iter_valid(self, t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:282: stale_borrow_mut_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:283: stale_borrow_mut_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:284: stale_borrow_mut_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:285: stale_borrow_mut_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:286: stale_borrow_mut_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:287: stale_borrow_mut_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:60: iter_borrow_mut (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:155: forward_stale_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:156: forward_stale_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:157: forward_stale_fails
+   =         b = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:158: forward_stale_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:159: forward_stale_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:160: forward_stale_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:161: forward_stale_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:471: copy_diverges_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:472: copy_diverges_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:473: copy_diverges_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:474: copy_diverges_fails
+   =         t2 = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:475: copy_diverges_fails
+   =         t2 = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:476: copy_diverges_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:406: cross_map_fails
+   =         a = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:407: cross_map_fails
+   =         b = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:408: cross_map_fails
+   =         a = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:409: cross_map_fails
+   =         b = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:410: cross_map_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:411: cross_map_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:319: generic_stale_fails
+   =         t = <redacted>
+   =         k1 = <redacted>
+   =         k2 = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:320: generic_stale_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:321: generic_stale_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:322: generic_stale_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:323: generic_stale_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:525: loop_mutation_fails
+   =         n = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:526: loop_mutation_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:527: loop_mutation_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:528: loop_mutation_fails
+   =         it = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:529: loop_mutation_fails
+   =         <redacted> = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:530: loop_mutation_fails
+   =         <redacted> = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:531: loop_mutation_fails
+   =     enter loop, variable(s) t, $t5, $t4 havocked and reassigned
+   =         t = <redacted>
+   =         <redacted> = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:532: loop_mutation_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:507: opaque_mut_wrapper_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:508: opaque_mut_wrapper_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:509: opaque_mut_wrapper_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:510: opaque_mut_wrapper_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:511: opaque_mut_wrapper_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:357: revalidation_by_alias_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:358: revalidation_by_alias_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:359: revalidation_by_alias_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:360: revalidation_by_alias_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:361: revalidation_by_alias_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:362: revalidation_by_alias_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:273: stale_use_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:274: stale_use_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:275: stale_use_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:276: stale_use_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:277: stale_use_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:294: use_after_invalidate_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:295: use_after_invalidate_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:296: use_after_invalidate_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:297: use_after_invalidate_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:298: use_after_invalidate_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:299: use_after_invalidate_fails
+   =         it2 = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:94: erase (spec)
+   =     at tests/sources/functional/verify_iterator_validity.move:299: use_after_invalidate_fails
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:300: use_after_invalidate_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/verify_iterator_validity.move:81:9
+   │
+81 │         requires spec_iter_valid(self, _t);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_iterator_validity.move:431: vector_cross_element_fails
+   =         v = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:432: vector_cross_element_fails
+   =         v = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:433: vector_cross_element_fails
+   =         v = <redacted>
+   =     at tests/sources/functional/verify_iterator_validity.move:434: vector_cross_element_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:435: vector_cross_element_fails
+   =     at tests/sources/functional/verify_iterator_validity.move:81: iter_borrow (spec)
+
+error: precondition does not hold at this call
+    ┌─ tests/sources/functional/verify_iterator_validity.move:128:9
+    │
+128 │         requires spec_iter_valid(_self.it, _t);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/verify_iterator_validity.move:181: implant_stale_fails
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_iterator_validity.move:182: implant_stale_fails
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_iterator_validity.move:183: implant_stale_fails
+    =     at tests/sources/functional/verify_iterator_validity.move:184: implant_stale_fails
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_iterator_validity.move:185: implant_stale_fails
+    =         b = <redacted>
+    =     at tests/sources/functional/verify_iterator_validity.move:186: implant_stale_fails
+    =         b = <redacted>
+    =     at tests/sources/functional/verify_iterator_validity.move:187: implant_stale_fails
+    =     at tests/sources/functional/verify_iterator_validity.move:128: box_use (spec)
+
+error: precondition does not hold at this call
+    ┌─ tests/sources/functional/verify_iterator_validity.move:223:9
+    │
+223 │         requires spec_node_valid(self, _t);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/verify_iterator_validity.move:344: node_walk_stale_fails
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_iterator_validity.move:345: node_walk_stale_fails
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_iterator_validity.move:346: node_walk_stale_fails
+    =     at tests/sources/functional/verify_iterator_validity.move:347: node_walk_stale_fails
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_iterator_validity.move:348: node_walk_stale_fails
+    =     at tests/sources/functional/verify_iterator_validity.move:223: node_next (spec)

--- a/third_party/move/move-prover/tests/sources/functional/verify_iterator_validity.move
+++ b/third_party/move/move-prover/tests/sources/functional/verify_iterator_validity.move
@@ -1,0 +1,538 @@
+// Tests per-object iterator-validity for intrinsic maps. Binding a validity
+// predicate role gives the map — and the predicate's iterator enum — a
+// hidden validity slot: fresh at creation, havoced by every structural
+// mutation of the map, preserved by value writes, excluded from equality,
+// and not nameable from any spec. Validity itself is the bound native
+// predicate (slot equality), stated as ordinary `requires`/`ensures` on the
+// iterator API. Using an iterator after a structural mutation of its map —
+// or against a different map object — must fail verification; uses without
+// intervening mutation must verify.
+module 0x42::iter_table {
+    struct Table<phantom K: copy + drop, phantom V> has store, drop, copy {}
+
+    enum IteratorPtr<K: copy + drop> has copy, drop {
+        End,
+        Some { key: K },
+    }
+
+    spec Table {
+        pragma intrinsic = map,
+            map_new = new,
+            map_has_key = contains,
+            map_add_no_override = add,
+            map_del_must_exist = remove,
+            map_iter_borrow_mut = iter_borrow_mut,
+            map_spec_aborts_iter_borrow_mut = spec_aborts_iter_borrow_mut,
+            map_spec_new = spec_new,
+            map_spec_get = spec_get,
+            map_spec_set = spec_set,
+            map_spec_del = spec_remove,
+            map_spec_len = spec_len,
+            map_spec_has_key = spec_contains,
+            map_spec_iter_valid = spec_iter_valid,
+            map_spec_leaf_iter_valid = spec_node_valid,
+            map_spec_iter_preserved = spec_iter_preserved;
+    }
+
+    public native fun new<K: copy + drop, V: store>(): Table<K, V>;
+    public native fun contains<K: copy + drop, V>(t: &Table<K, V>, key: K): bool;
+    public native fun add<K: copy + drop, V>(t: &mut Table<K, V>, key: K, val: V);
+    public native fun remove<K: copy + drop, V>(t: &mut Table<K, V>, key: K): V;
+    public native fun iter_borrow_mut<K: copy + drop, V>(self: IteratorPtr<K>, t: &mut Table<K, V>): &mut V;
+
+    spec native fun spec_new<K, V>(): Table<K, V>;
+    spec native fun spec_len<K, V>(t: Table<K, V>): num;
+    spec native fun spec_contains<K, V>(t: Table<K, V>, k: K): bool;
+    spec native fun spec_set<K, V>(t: Table<K, V>, k: K, v: V): Table<K, V>;
+    spec native fun spec_remove<K, V>(t: Table<K, V>, k: K): Table<K, V>;
+    spec native fun spec_get<K, V>(t: Table<K, V>, k: K): V;
+    // The validity predicates and the preservation frame predicate: their
+    // definitions (hidden-slot equality) come from the role templates.
+    spec native fun spec_iter_valid<K, V>(it: IteratorPtr<K>, t: Table<K, V>): bool;
+    spec native fun spec_node_valid<K, V>(it: NodePtr, t: Table<K, V>): bool;
+    spec native fun spec_iter_preserved<K, V>(t_new: Table<K, V>, t_old: Table<K, V>): bool;
+
+    spec fun spec_aborts_iter_borrow_mut<K, V>(self: IteratorPtr<K>, t: Table<K, V>): bool {
+        (self is IteratorPtr::End<K>) || !spec_contains(t, self.key)
+    }
+
+    spec iter_borrow_mut {
+        requires spec_iter_valid(self, t);
+    }
+
+    public fun find<K: copy + drop, V>(_t: &Table<K, V>, _key: K): IteratorPtr<K> {
+        abort 0
+    }
+    spec find {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if false;
+        ensures spec_iter_valid(result, _t);
+        ensures (result is IteratorPtr::Some<K>) <==> spec_contains(_t, _key);
+        ensures (result is IteratorPtr::Some<K>) ==> result.key == _key;
+    }
+
+    public fun iter_borrow<K: copy + drop, V>(self: IteratorPtr<K>, _t: &Table<K, V>): &V {
+        abort 0
+    }
+    spec iter_borrow {
+        pragma opaque;
+        pragma verify = false;
+        requires spec_iter_valid(self, _t);
+        aborts_if (self is IteratorPtr::End<K>) || !spec_contains(_t, self.key);
+        ensures result == spec_get(_t, self.key);
+    }
+
+    // Structural mutation through an iterator: consumes it and invalidates all
+    // outstanding iterators of this map type.
+    public fun erase<K: copy + drop, V>(self: IteratorPtr<K>, _t: &mut Table<K, V>) {
+        abort 0
+    }
+    spec erase {
+        pragma opaque;
+        pragma verify = false;
+        requires spec_iter_valid(self, _t);
+        aborts_if (self is IteratorPtr::End<K>) || !spec_contains(_t, self.key);
+        // The whole-map equality excludes the hidden slot: the opaque `&mut`
+        // map's slot stays havoced, which IS the invalidation — no
+        // annotation needed.
+        ensures _t == spec_remove(old(_t), self.key);
+    }
+
+    // A wrapper carrying an iterator in a field (like `IteratorPtrWithPath`).
+    // The hidden slot travels inside the iterator value through field writes
+    // and write-backs, so implanting a stale iterator into a fresh wrapper
+    // is caught even though the wrapper itself was freshly created.
+    // Field access requires this module, so the scenario tests live here.
+    struct IterBox<K: copy + drop> has copy, drop {
+        it: IteratorPtr<K>,
+        tag: u64,
+    }
+
+    public fun box_find<K: copy + drop, V>(_t: &Table<K, V>, _key: K): IterBox<K> {
+        abort 0
+    }
+    spec box_find {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if false;
+        ensures spec_iter_valid(result.it, _t);
+    }
+
+    public fun box_use<K: copy + drop, V>(_self: IterBox<K>, _t: &Table<K, V>): u64 {
+        abort 0
+    }
+    spec box_use {
+        pragma opaque;
+        pragma verify = false;
+        requires spec_iter_valid(_self.it, _t);
+        aborts_if false;
+    }
+
+    // OPAQUE forwarding: the result's hidden slot is unconstrained
+    // (fail-closed) — even when the result overwrites a local that
+    // previously held a fresh iterator, and although the ensures equates
+    // the values (equality excludes the slot). An opaque function cannot
+    // state slot lineage; forwarders must be transparent (or take the map
+    // and re-establish validity).
+    public fun box_project<K: copy + drop>(_self: &IterBox<K>): IteratorPtr<K> {
+        abort 0
+    }
+    spec box_project {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if false;
+        ensures result == _self.it;
+    }
+
+    // TRANSPARENT projection: value flow carries the hidden slot, so the
+    // result inherits the wrapper's iterator validity with no contract.
+    public fun box_get<K: copy + drop>(_self: &IterBox<K>): IteratorPtr<K> {
+        _self.it
+    }
+
+    fun forward_stale_fails(): u64 {
+        let t = new<u8, u64>();
+        add(&mut t, 1, 2);
+        let b = box_find(&t, 1);
+        add(&mut t, 2, 3);
+        let it = find(&t, 1);
+        it = box_project(&b);
+        *iter_borrow(it, &t)
+    }
+
+    fun project_fresh(): u64 {
+        let t = new<u8, u64>();
+        add(&mut t, 1, 2);
+        let b = box_find(&t, 1);
+        let it = box_get(&b);
+        *iter_borrow(it, &t)
+    }
+
+    fun unpack_fresh(): u64 {
+        let t = new<u8, u64>();
+        add(&mut t, 1, 2);
+        let b = box_find(&t, 1);
+        let IterBox { it, tag: _ } = b;
+        *iter_borrow(it, &t)
+    }
+
+    fun implant_stale_fails(): u64 {
+        let t = new<u8, u64>();
+        add(&mut t, 1, 2);
+        let it_old = find(&t, 1);
+        add(&mut t, 2, 3);
+        let b = box_find(&t, 1);
+        b.it = it_old;
+        box_use(b, &t)
+    }
+
+    fun implant_fresh(): u64 {
+        let t = new<u8, u64>();
+        add(&mut t, 1, 2);
+        add(&mut t, 2, 3);
+        let it_new = find(&t, 1);
+        let b = box_find(&t, 1);
+        b.it = it_new;
+        box_use(b, &t)
+    }
+
+    // A key-agnostic (unkeyed) iterator, mirroring a leaf/node walk: bound
+    // through `map_spec_leaf_iter_valid`, it gets its own hidden slot and
+    // the same per-object validity model.
+    enum NodePtr has copy, drop {
+        Node { node_index: u64 },
+    }
+
+    public fun node_begin<K: copy + drop, V>(_t: &Table<K, V>): NodePtr {
+        abort 0
+    }
+    spec node_begin {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if false;
+        ensures spec_node_valid(result, _t);
+    }
+
+    public fun node_next<K: copy + drop, V>(self: NodePtr, _t: &Table<K, V>): NodePtr {
+        abort 0
+    }
+    spec node_next {
+        pragma opaque;
+        pragma verify = false;
+        requires spec_node_valid(self, _t);
+        aborts_if false;
+        ensures spec_node_valid(result, _t);
+    }
+
+    // A value-only write through the intrinsic borrow preserves validity;
+    // `spec_iter_preserved` states the same frame promise for opaque
+    // helpers whose implementations do not structurally mutate.
+    public fun value_touch<K: copy + drop, V>(_t: &mut Table<K, V>) {
+        abort 0
+    }
+    spec value_touch {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if false;
+        ensures spec_iter_preserved(_t, old(_t));
+        ensures _t == old(_t);
+    }
+}
+
+module 0x42::VerifyIteratorValidity {
+    use std::vector;
+    use 0x42::iter_table::{Self, Table};
+    use 0x42::iter_table::spec_get;
+
+    // Use without intervening mutation verifies.
+    fun fresh_use(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        *iter_table::iter_borrow(it, &t)
+    }
+    spec fresh_use {
+        ensures result == 2;
+    }
+
+    // Write-back through the intrinsic iter_borrow_mut role.
+    fun fresh_borrow_mut(): Table<u8, u64> {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        *iter_table::iter_borrow_mut(it, &mut t) = 5;
+        t
+    }
+    spec fresh_borrow_mut {
+        ensures spec_get(result, 1) == 5;
+    }
+
+    // Structural mutation between create and use: the validity requires fails.
+    fun stale_use_fails(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        iter_table::add(&mut t, 2, 3);
+        *iter_table::iter_borrow(it, &t)
+    }
+
+    // Same staleness through the intrinsic iter_borrow_mut role.
+    fun stale_borrow_mut_fails(): Table<u8, u64> {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        iter_table::remove(&mut t, 1);
+        iter_table::add(&mut t, 1, 4);
+        *iter_table::iter_borrow_mut(it, &mut t) = 5;
+        t
+    }
+
+    // An invalidating operation havocs the brand: an iterator created before
+    // the erase cannot be used after it.
+    fun use_after_invalidate_fails(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        iter_table::add(&mut t, 2, 3);
+        let it1 = iter_table::find(&t, 1);
+        let it2 = iter_table::find(&t, 2);
+        iter_table::erase(it1, &mut t);
+        *iter_table::iter_borrow(it2, &t)
+    }
+
+    // Re-created iterators after an invalidation are valid again.
+    fun refind_after_invalidate(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        iter_table::add(&mut t, 2, 3);
+        let it1 = iter_table::find(&t, 1);
+        iter_table::erase(it1, &mut t);
+        let it2 = iter_table::find(&t, 2);
+        *iter_table::iter_borrow(it2, &t)
+    }
+    spec refind_after_invalidate {
+        ensures result == 3;
+    }
+
+    // Tracking applies in generic functions too: stale use fails, fresh use
+    // verifies.
+    fun generic_stale_fails<K: copy + drop>(t: &mut Table<K, u64>, k1: K, k2: K): u64 {
+        iter_table::add(t, k1, 2);
+        let it = iter_table::find(t, k1);
+        iter_table::add(t, k2, 3);
+        *iter_table::iter_borrow(it, t)
+    }
+
+    fun generic_fresh<K: copy + drop>(t: &mut Table<K, u64>, k1: K): u64 {
+        iter_table::add(t, k1, 2);
+        let it = iter_table::find(t, k1);
+        *iter_table::iter_borrow(it, t)
+    }
+
+    // Unkeyed (node-walk) iterators chain through use+create without mutation.
+    fun node_walk_fresh(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let n = iter_table::node_begin(&t);
+        let n2 = iter_table::node_next(n, &t);
+        let _n3 = iter_table::node_next(n2, &t);
+        7
+    }
+
+    // A structural mutation invalidates unkeyed iterators too.
+    fun node_walk_stale_fails(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let n = iter_table::node_begin(&t);
+        iter_table::add(&mut t, 2, 3);
+        let _n2 = iter_table::node_next(n, &t);
+        7
+    }
+
+    // Creating another iterator with the same key does not re-validate a stale
+    // one: the hidden slot belongs to each iterator value and is excluded from
+    // value equality (here both iterators are equal as runtime values, since
+    // this iterator type is fully determined by the key).
+    fun revalidation_by_alias_fails(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it_old = iter_table::find(&t, 1);
+        iter_table::add(&mut t, 2, 3);
+        let _it_new = iter_table::find(&t, 1);
+        *iter_table::iter_borrow(it_old, &t)
+    }
+
+    // An iterator held across loop iterations stays valid when the loop does
+    // not mutate the map: neither the iterator nor the map is a loop target,
+    // so no havoc touches the stamp or the brand — no loop invariant needed.
+    fun loop_no_mutation(n: u8): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        let sum = 0;
+        let i = 0;
+        while (i < n) {
+            sum += *iter_table::iter_borrow(it, &t);
+            i += 1;
+        };
+        sum
+    }
+
+    // An iterator ADVANCED in the loop is a loop target and gets havocked;
+    // a user-written validity invariant re-establishes it (expressible since
+    // validity is a plain spec function).
+    fun node_loop_with_invariant(rounds: u8): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let np = iter_table::node_begin(&t);
+        let i = 0;
+        while ({
+            spec {
+                invariant iter_table::spec_node_valid(np, t);
+            };
+            i < rounds
+        }) {
+            np = iter_table::node_next(np, &t);
+            i += 1;
+        };
+        7
+    }
+
+    // ---- Per-object identity: the cells the brand model exists for ----
+
+    // An iterator from map A used against same-type map B fails, even with no
+    // intervening mutation: B's brand is an independent unconstrained value.
+    fun cross_map_fails(): u64 {
+        let a = iter_table::new<u8, u64>();
+        let b = iter_table::new<u8, u64>();
+        iter_table::add(&mut a, 1, 2);
+        iter_table::add(&mut b, 1, 9);
+        let it = iter_table::find(&a, 1);
+        *iter_table::iter_borrow(it, &b)
+    }
+
+    // Mutating a same-type sibling does NOT invalidate this map's iterators
+    // (per-object state; a type-level scheme would reject this).
+    fun sibling_independent(): u64 {
+        let a = iter_table::new<u8, u64>();
+        let b = iter_table::new<u8, u64>();
+        iter_table::add(&mut a, 1, 2);
+        let it = iter_table::find(&a, 1);
+        iter_table::add(&mut b, 7, 7);
+        *iter_table::iter_borrow(it, &a)
+    }
+    spec sibling_independent {
+        ensures result == 2;
+    }
+
+    // Vector of same-type maps: an iterator from element 0 fails against
+    // element 1 (no type-level scheme can distinguish the elements) ...
+    fun vector_cross_element_fails(): u64 {
+        let v = vector[iter_table::new<u8, u64>(), iter_table::new<u8, u64>()];
+        iter_table::add(vector::borrow_mut(&mut v, 0), 1, 2);
+        iter_table::add(vector::borrow_mut(&mut v, 1), 1, 9);
+        let it = iter_table::find(vector::borrow(&v, 0), 1);
+        let r = *iter_table::iter_borrow(it, vector::borrow(&v, 1));
+        let (a, b) = (vector::pop_back(&mut v), vector::pop_back(&mut v));
+        let (_, _) = (a, b);
+        r
+    }
+
+    // ... and verifies against its own element.
+    fun vector_same_element(): u64 {
+        let v = vector[iter_table::new<u8, u64>(), iter_table::new<u8, u64>()];
+        iter_table::add(vector::borrow_mut(&mut v, 0), 1, 2);
+        let it = iter_table::find(vector::borrow(&v, 0), 1);
+        let r = *iter_table::iter_borrow(it, vector::borrow(&v, 0));
+        let (a, b) = (vector::pop_back(&mut v), vector::pop_back(&mut v));
+        let (_, _) = (a, b);
+        r
+    }
+    spec vector_same_element {
+        ensures result == 2;
+    }
+
+    // A COPY shares the brand — correct: an iterator navigates a bit-identical
+    // copy exactly as the original ...
+    fun copy_shares_brand(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        let t2 = t;
+        *iter_table::iter_borrow(it, &t2)
+    }
+    spec copy_shares_brand {
+        ensures result == 2;
+    }
+
+    // ... until the copy diverges: mutating it havocs ITS brand only; the
+    // iterator dies on the copy but stays valid on the original.
+    fun copy_diverges_fails(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        let t2 = t;
+        iter_table::add(&mut t2, 2, 3);
+        *iter_table::iter_borrow(it, &t2)
+    }
+
+    fun copy_diverges_original_ok(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        let t2 = t;
+        iter_table::add(&mut t2, 2, 3);
+        *iter_table::iter_borrow(it, &t)
+    }
+    spec copy_diverges_original_ok {
+        ensures result == 2;
+    }
+
+    // An opaque helper promising `spec_iter_preserved` (a value-only write)
+    // keeps iterators alive across the call.
+    fun preserved_wrapper_ok(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        iter_table::value_touch(&mut t);
+        *iter_table::iter_borrow(it, &t)
+    }
+    spec preserved_wrapper_ok {
+        ensures result == 2;
+    }
+
+    // An opaque wrapper taking `&mut` map with NO frame promise:
+    // fail-closed, iterators die.
+    fun opaque_mut_wrapper_fails(): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        opaque_touch(&mut t);
+        *iter_table::iter_borrow(it, &t)
+    }
+
+    fun opaque_touch(_t: &mut Table<u8, u64>) {
+    }
+    spec opaque_touch {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if false;
+    }
+
+    // A loop body that structurally mutates the map invalidates an iterator
+    // held across iterations: the map is a loop target, its havoc loses the
+    // brand, and the validity requires in the next iteration fails.
+    fun loop_mutation_fails(n: u8): u64 {
+        let t = iter_table::new<u8, u64>();
+        iter_table::add(&mut t, 1, 2);
+        let it = iter_table::find(&t, 1);
+        let sum = 0;
+        let i = 0;
+        while (i < n) {
+            sum += *iter_table::iter_borrow(it, &t);
+            iter_table::add(&mut t, 100, 1);
+            i += 1;
+        };
+        sum
+    }
+}


### PR DESCRIPTION
## Description

Turn iterator validity for intrinsic maps (`pragma intrinsic = map`) into a machine-checked precondition — with **no user-visible ghost state**. Binding a validity predicate role gives the map and its iterator types hidden, backend-synthesized validity slots; specs interact with them only through native predicates.

**The model.** The map carries a hidden version slot; each iterator carries a hidden snapshot of it; both are synthesized when the map binds a validity role, under a name (`$validity`) that cannot be spelled in Move source. Validity is the bound native predicate (slot equality), used in ordinary contracts:

```move
spec Map {
    pragma intrinsic = map, ...,
        map_spec_iter_valid = spec_iter_valid,           // keyed iterator
        map_spec_leaf_iter_valid = spec_node_valid,      // key-agnostic walker
        map_spec_iter_preserved = spec_iter_preserved;   // frame predicate
}
spec native fun spec_iter_valid<K, V>(it: IteratorPtr<K>, m: Map<K, V>): bool;

spec new_begin_iter { ensures spec_iter_valid(result, self); }
spec iter_borrow    { requires spec_iter_valid(self, map); }
spec value_only_op  { ensures spec_iter_preserved(self, old(self)); }
```

At a call site this plays out as:

```move
let it = map.new_begin_iter();  // prover learns: it and map share a validity version
map.remove(&k);                 // structural mutation: map's slot havoced fresh
map.iter_borrow(&it);           // REJECTED: validity no longer provable
```

The creation `ensures` is the standard opaque-call assumption (it pins the havoced result's hidden slot); a mutation's havoc severs every outstanding iterator at once. One havoced value covers both identity and version: an iterator from the wrong map and a stale iterator both fail the same way — no fact connects their slot to this map's current one. Fail-closed rests on unprovability (no distinctness axioms, no counter allocator — hence havoc rather than increment). Because the slots are unnameable, no spec text can write, initialize, or constrain them: forging validity is a syntax error, not a policed violation. The always-trusted surfaces (`assume`, `verify = false` fiat, axioms) remain the only override, as everywhere else in the prover.

**Representation.** A validity-bound map instance becomes a per-instance Boogie carrier datatype wrapping the raw table (`$M($$t: Table int V, $$validity: int)`); the iterator enum's datatype gains the matching slot. The slots are excluded from Move equality, fresh at creation, havoced by structural mutations, and preserved by value writes through borrowed entries. Maps without validity bindings keep the raw `Table` representation and generate byte-identical Boogie.

**Also in this PR.** Intrinsic map declarations require exactly two type parameters (previously a monomorphization panic); pack/unpack/field-select — including the variant forms, since the framework's ordered maps are single-variant enums — are diagnostics in verified code instead of ill-typed Boogie; counterexamples decode the carrier (table entries plus the slot) instead of falling back to raw model output.

## How Has This Been Tested?

- `verify_iterator_validity.move`: staleness and identity acceptance matrix on a mock map (use-after-mutation, cross-map, `vector<Map>`, sibling maps, copy-diverges, opaque `&mut`, loops, wrapper structs, transparent vs opaque forwarding), a key-agnostic `NodePtr` walker via the leaf role, and the `preserved` frame predicate. All negatives fail, all positives verify.
- `ghost_field_intrinsic_map_{ops,data_inv,full,quant}.move`, `ghost_field_iter_abort_native.move`: carrier content operations, slot havoc/preservation, deep data invariants through the carrier, and the full role surface type-checked against the carrier in one instance.
- `intrinsic_map_{arity,enum,field_access,update_field,invariant,conv_ghost,mut_no_get}_err.move`: declaration and operation diagnostics, including the validity-binding signature ladder.
- Full move-prover suite, inference suite, and all four framework prover batteries green.

## Key Areas to Review

- `module_builder.rs` `synthesize_validity_slots`: the hidden-slot injection — unspellable names are the entire protection story (nothing to police).
- `prelude/native.bpl` (`table_module`): the carrier plumbing (every set variable expands to empty/identity for unbound maps, guaranteeing byte-identical output) and the three predicate blocks.
- `mono_analysis.rs`: the validity-binding signature rungs and eager iterator-enum registration.
- `bytecode_translator.rs`: write-back through Table edges rebuilds the carrier preserving the slot.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Other (specify): Move Prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting changes to Move Prover map modeling, Boogie prelude generation, and borrow write-back; incorrect carrier or havoc semantics could silently weaken or break verification of framework map specs.
> 
> **Overview**
> Introduces **iterator validity** for `pragma intrinsic = map` types via three new spec roles (`map_spec_iter_valid`, `map_spec_leaf_iter_valid`, `map_spec_iter_preserved`). Binding them causes the model builder to inject unspellable `$validity` ghost fields on the map and iterator types; the Boogie prelude wraps the raw table in a **per-instance carrier datatype** when ghosts are present, havocing the slot on structural mutations while preserving it on value-only table updates.
> 
> **Model & intrinsics:** `synthesize_validity_slots` runs after definition analysis; intrinsic maps may carry backend-synthesized `$`-prefixed ghosts while other intrinsics still reject user ghosts. Map intrinsics must have exactly two type parameters; move/spec functions cannot be shared across two intrinsic types.
> 
> **Backend:** Map templates unwrap/wrap through `->$$t`, emit inline validity predicates, and thread carrier-aware write-back in `bytecode_translator`. Verified code and specs get hard errors for packing/unpacking/selecting intrinsic map fields (including variants); counterexample pretty-printing decodes carriers.
> 
> **mono_analysis:** Extensive signature checks for template-defined roles, abort predicates, validity bindings, rejection of map data invariants and validity predicates in data invariants (including via behavioral operators), and `map_to_ordered_map` to ghost-bearing destinations.
> 
> Maps without validity bindings keep the raw `Table` representation and unchanged Boogie output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e6645786569de5c3a79c9f85ba97033d37115c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->