### PR TITLE
[Consensus] Add limit to number of batches in opt proposal.

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -40,6 +40,8 @@ pub struct ConsensusConfig {
     pub max_sending_inline_bytes: u64,
     pub max_receiving_block_txns: u64,
     pub max_receiving_block_bytes: u64,
+    // Maximum number of batch entries allowed in a single received proposal payload
+    pub max_receiving_num_batch_entries: u64,
     pub max_pruned_blocks_in_mem: usize,
     // Timeout for consensus to get an ack from mempool for executed transactions (in milliseconds)
     pub mempool_executed_txn_timeout_ms: u64,
@@ -250,6 +252,7 @@ impl Default for ConsensusConfig {
             max_sending_inline_txns: 100,
             max_sending_inline_bytes: 200 * 1024,       // 200 KB
             max_receiving_block_bytes: 6 * 1024 * 1024, // 6MB
+            max_receiving_num_batch_entries: 100,
             max_pruned_blocks_in_mem: 100,
             mempool_executed_txn_timeout_ms: 1000,
             mempool_txn_pull_timeout_ms: 1000,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -412,6 +412,28 @@ impl Payload {
         Ok(())
     }
 
+    /// Bounds the total number of batch entries a single payload may carry
+    fn verify_num_batch_entries(
+        num_proofs: usize,
+        num_inline_batches: usize,
+        num_opt_batches: usize,
+        max_num_batch_entries: u64,
+    ) -> anyhow::Result<()> {
+        let num_entries = (num_proofs as u64)
+            .saturating_add(num_inline_batches as u64)
+            .saturating_add(num_opt_batches as u64);
+        ensure!(
+            num_entries <= max_num_batch_entries,
+            "Payload batch entry count {} exceeds limit {} (proofs: {}, inline: {}, opt: {})",
+            num_entries,
+            max_num_batch_entries,
+            num_proofs,
+            num_inline_batches,
+            num_opt_batches,
+        );
+        Ok(())
+    }
+
     pub fn verify(
         &self,
         verifier: &ValidatorVerifier,
@@ -420,11 +442,19 @@ impl Payload {
         opt_qs_v2_rx_enabled: bool,
         max_batch_txns: u64,
         max_batch_bytes: u64,
+        max_num_batch_entries: u64,
     ) -> anyhow::Result<()> {
         match (quorum_store_enabled, self) {
             (false, Payload::DirectMempool(_)) => Ok(()),
             (true, Payload::OptQuorumStore(OptQuorumStorePayload::V1(p))) => {
                 let proof_with_data = p.proof_with_data();
+                // Bound the batch entry count
+                Self::verify_num_batch_entries(
+                    proof_with_data.batch_summary.len(),
+                    p.inline_batches().len(),
+                    p.opt_batches().batch_summary.len(),
+                    max_num_batch_entries,
+                )?;
                 Self::verify_with_cache(&proof_with_data.batch_summary, verifier, proof_cache)?;
                 for proof in &proof_with_data.batch_summary {
                     verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
@@ -450,6 +480,13 @@ impl Payload {
                     "OptQuorumStorePayload::V2 cannot be accepted yet"
                 );
                 let proof_with_data = p.proof_with_data();
+                // Bound the batch entry count
+                Self::verify_num_batch_entries(
+                    proof_with_data.batch_summary.len(),
+                    p.inline_batches().len(),
+                    p.opt_batches().batch_summary.len(),
+                    max_num_batch_entries,
+                )?;
                 Self::verify_with_cache(&proof_with_data.batch_summary, verifier, proof_cache)?;
                 for proof in &proof_with_data.batch_summary {
                     verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
@@ -668,7 +705,8 @@ mod tests {
     use super::*;
     use crate::{
         payload::{
-            BatchPointer, InlineBatches, OptBatches, OptQuorumStorePayload, PayloadExecutionLimit,
+            BatchPointer, InlineBatch, InlineBatches, OptBatches, OptQuorumStorePayload,
+            PayloadExecutionLimit,
         },
         proof_of_store::{BatchInfo, ProofCache},
     };
@@ -685,6 +723,7 @@ mod tests {
 
     const MAX_BATCH_TXNS: u64 = 100;
     const MAX_BATCH_BYTES: u64 = 1024 * 1024;
+    const MAX_NUM_BATCH_ENTRIES: u64 = 1000;
 
     fn make_batch_info(author: PeerId, num_txns: u64, num_bytes: u64) -> BatchInfo {
         BatchInfo::new(
@@ -798,6 +837,122 @@ mod tests {
                 .unwrap_err();
         // Should fail on batch limit, not author
         assert!(err.to_string().contains("Batch txn count"));
+    }
+
+    #[test]
+    fn test_payload_verify_rejects_excessive_opt_batch_entries() {
+        // Create test validators and a proof cache
+        let (_signers, validators) = random_validator_verifier(1, None, false);
+        let proof_cache = ProofCache::new(16);
+        let author = validators.get_ordered_account_addresses()[0];
+
+        // Create a payload with more than the max allowed number of batch entries
+        let batches: Vec<BatchInfo> = (0..MAX_NUM_BATCH_ENTRIES + 1)
+            .map(|_| make_batch_info(author, 1, 100))
+            .collect();
+        let empty_inline: InlineBatches<BatchInfo> = Vec::<InlineBatch<BatchInfo>>::new().into();
+        let payload = Payload::OptQuorumStore(OptQuorumStorePayload::new(
+            empty_inline,
+            BatchPointer::new(batches),
+            BatchPointer::new(vec![]),
+            PayloadExecutionLimit::None,
+        ));
+
+        // Verify that the payload is rejected due to excessive batch entries
+        let error = payload
+            .verify(
+                &validators,
+                &proof_cache,
+                true,
+                true,
+                MAX_BATCH_TXNS,
+                MAX_BATCH_BYTES,
+                MAX_NUM_BATCH_ENTRIES,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("Payload batch entry count"));
+
+        // Create a payload with exactly the max allowed number of batch entries
+        let batches: Vec<BatchInfo> = (0..MAX_NUM_BATCH_ENTRIES)
+            .map(|_| make_batch_info(author, 1, 100))
+            .collect();
+        let empty_inline: InlineBatches<BatchInfo> = Vec::<InlineBatch<BatchInfo>>::new().into();
+        let payload = Payload::OptQuorumStore(OptQuorumStorePayload::new(
+            empty_inline,
+            BatchPointer::new(batches),
+            BatchPointer::new(vec![]),
+            PayloadExecutionLimit::None,
+        ));
+
+        // Verify that the payload is accepted when the number of batch entries is within the limit
+        assert!(payload
+            .verify(
+                &validators,
+                &proof_cache,
+                true,
+                true,
+                MAX_BATCH_TXNS,
+                MAX_BATCH_BYTES,
+                MAX_NUM_BATCH_ENTRIES,
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn test_payload_verify_entry_limit_is_summed_across_buckets() {
+        // Create test validators and a proof cache
+        let (_signers, validators) = random_validator_verifier(1, None, false);
+        let proof_cache = ProofCache::new(16);
+        let author = validators.get_ordered_account_addresses()[0];
+
+        // Create a payload with a combination of inline and opt batches that is within the limit
+        let max_num_batches = 4;
+        let txns = vec![create_normal_signed_transaction()];
+        let inline_batch = make_batch_info_with_txns(author, &txns);
+        let inline_batches: InlineBatches<BatchInfo> = vec![(inline_batch, txns)].into();
+        let opt_batches: Vec<BatchInfo> = (0..3).map(|_| make_batch_info(author, 1, 100)).collect();
+        let payload = Payload::OptQuorumStore(OptQuorumStorePayload::new(
+            inline_batches.clone(),
+            BatchPointer::new(opt_batches),
+            BatchPointer::new(vec![]),
+            PayloadExecutionLimit::None,
+        ));
+
+        // Verify that the payload is accepted (total number of entries is 4)
+        assert!(payload
+            .verify(
+                &validators,
+                &proof_cache,
+                true,
+                true,
+                MAX_BATCH_TXNS,
+                MAX_BATCH_BYTES,
+                max_num_batches,
+            )
+            .is_ok());
+
+        // Create a payload with a combination of inline and opt batches that exceeds the limit
+        let opt_batches: Vec<BatchInfo> = (0..4).map(|_| make_batch_info(author, 1, 100)).collect();
+        let payload = Payload::OptQuorumStore(OptQuorumStorePayload::new(
+            inline_batches,
+            BatchPointer::new(opt_batches),
+            BatchPointer::new(vec![]),
+            PayloadExecutionLimit::None,
+        ));
+
+        // Verify that the payload is rejected (total number of entries is 5)
+        let error = payload
+            .verify(
+                &validators,
+                &proof_cache,
+                true,
+                true,
+                MAX_BATCH_TXNS,
+                MAX_BATCH_BYTES,
+                max_num_batches,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("Payload batch entry count"));
     }
 
     #[test]
@@ -988,6 +1143,7 @@ mod tests {
                 true, // opt_qs_v2_rx_enabled
                 MAX_BATCH_TXNS,
                 MAX_BATCH_BYTES,
+                MAX_NUM_BATCH_ENTRIES,
             )
             .unwrap_err();
         assert!(

--- a/consensus/consensus-types/src/opt_proposal_msg.rs
+++ b/consensus/consensus-types/src/opt_proposal_msg.rs
@@ -102,12 +102,20 @@ impl OptProposalMsg {
         opt_qs_v2_enabled: bool,
         max_batch_txns: u64,
         max_batch_bytes: u64,
+        max_num_batch_entries: u64,
     ) -> Result<()> {
         ensure!(
             self.proposer() == sender,
             "OptProposal author {:?} doesn't match sender {:?}",
             self.proposer(),
             sender
+        );
+
+        // Ensure that the proposer is in the validator set
+        ensure!(
+            validator.get_voting_power(&self.proposer()).is_some(),
+            "OptProposal author {:?} is not in the validator set",
+            self.proposer()
         );
 
         let (payload_verify_result, qc_verify_result) = rayon::join(
@@ -119,6 +127,7 @@ impl OptProposalMsg {
                     opt_qs_v2_enabled,
                     max_batch_txns,
                     max_batch_bytes,
+                    max_num_batch_entries,
                 )
             },
             || self.block_data().grandparent_qc().verify(validator),
@@ -227,7 +236,8 @@ mod tests {
                 false,
                 false,
                 100,
-                1024 * 1024
+                1024 * 1024,
+                1000,
             )
             .is_ok());
     }
@@ -248,7 +258,8 @@ mod tests {
                 false,
                 false,
                 100,
-                1024 * 1024
+                1024 * 1024,
+                1000,
             )
             .is_err());
 
@@ -280,7 +291,8 @@ mod tests {
                 false,
                 false,
                 100,
-                1024 * 1024
+                1024 * 1024,
+                1000,
             )
             .is_err());
 
@@ -305,9 +317,40 @@ mod tests {
                 false,
                 false,
                 100,
-                1024 * 1024
+                1024 * 1024,
+                1000,
             )
             .is_err());
+    }
+
+    #[test]
+    fn test_verify_rejects_author_outside_validator_set() {
+        // Create a proposer that is not in the validator set
+        let (_signers, validators) = random_validator_verifier(1, None, false);
+        let outsider = ValidatorSigner::random([0u8; 32]);
+        assert!(
+            validators.get_voting_power(&outsider.author()).is_none(),
+            "test setup: signer must be outside the validator set"
+        );
+
+        // Create a proposal message with the outsider as the proposer
+        let msg = create_opt_proposal_msg(3, 1, &outsider);
+        let proof_cache = ProofCache::new(1024);
+
+        // Verify that the message fails verification due to the proposer not being in the set
+        let error = msg
+            .verify(
+                outsider.author(),
+                &validators,
+                &proof_cache,
+                false,
+                false,
+                100,
+                1024 * 1024,
+                1000,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("is not in the validator set"),);
     }
 
     #[test]
@@ -327,7 +370,8 @@ mod tests {
                 false,
                 false,
                 100,
-                1024 * 1024
+                1024 * 1024,
+                1000,
             )
             .is_err());
     }

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -93,6 +93,7 @@ impl ProposalMsg {
         opt_qs_v2_rx_enabled: bool,
         max_batch_txns: u64,
         max_batch_bytes: u64,
+        max_num_batch_entries: u64,
     ) -> Result<()> {
         if let Some(proposal_author) = self.proposal.author() {
             ensure!(
@@ -112,6 +113,7 @@ impl ProposalMsg {
                         opt_qs_v2_rx_enabled,
                         max_batch_txns,
                         max_batch_bytes,
+                        max_num_batch_entries,
                     )
                 })
             },

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1711,6 +1711,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 self.config.quorum_store.batch_expiry_gap_when_init_usecs;
             let max_batch_txns = self.config.quorum_store.receiver_max_batch_txns as u64;
             let max_batch_bytes = self.config.quorum_store.receiver_max_batch_bytes as u64;
+            let max_num_batch_entries = self.config.max_receiving_num_batch_entries;
             let payload_manager = self.payload_manager.clone();
             let pending_blocks = self.pending_blocks.clone();
             self.bounded_executor
@@ -1728,6 +1729,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             max_batch_expiry_gap_usecs,
                             max_batch_txns,
                             max_batch_bytes,
+                            max_num_batch_entries,
                             encrypted_enabled,
                         )
                     ) {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -113,6 +113,7 @@ impl UnverifiedEvent {
         max_batch_expiry_gap_usecs: u64,
         max_batch_txns: u64,
         max_batch_bytes: u64,
+        max_num_batch_entries: u64,
         encrypted_enabled: bool,
     ) -> Result<VerifiedEvent, VerifyError> {
         // Temporary: reject encrypted batches/PoS at the entry point until the
@@ -133,6 +134,7 @@ impl UnverifiedEvent {
                         opt_qs_v2_rx_enabled,
                         max_batch_txns,
                         max_batch_bytes,
+                        max_num_batch_entries,
                     )?;
                     counters::VERIFY_MSG
                         .with_label_values(&["proposal"])
@@ -150,6 +152,7 @@ impl UnverifiedEvent {
                         opt_qs_v2_rx_enabled,
                         max_batch_txns,
                         max_batch_bytes,
+                        max_num_batch_entries,
                     )?;
                     counters::VERIFY_MSG
                         .with_label_values(&["opt_proposal"])
@@ -2536,6 +2539,7 @@ mod reject_encrypted_tests {
                 u64::MAX, // max_batch_expiry_gap_usecs
                 1_000_000,
                 1_000_000,
+                1000,
                 true, // encrypted_enabled
             )
             .expect_err("must reject mixed-variant BatchMsgV2");


### PR DESCRIPTION
## Description
This PR adds a bound on the total number of batch entries (proofs, inline, and opt batches) a proposal payload may carry.
It also adds an explicit validator-set membership check for optimistic proposal authors.

## Testing Plan
New and existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus inbound validation for proposal payloads; mis-tuned limits or stricter opt-proposer checks could cause peers to drop otherwise well-formed messages, but the change is bounded resource protection on the receive path.
> 
> **Overview**
> Adds **`max_receiving_num_batch_entries`** to consensus config (default **100**) and enforces it when validators verify **OptQuorumStore** proposal payloads. **`Payload::verify`** now takes a `max_num_batch_entries` argument and rejects payloads whose combined count of proof-of-store entries, inline batches, and opt batches exceeds the limit.
> 
> The new cap is threaded through **standard and optimistic proposal** verification (`ProposalMsg`, `OptProposalMsg`) and inbound message handling in **`epoch_manager`** / **`round_manager`**, using `consensus.max_receiving_num_batch_entries`.
> 
> **`OptProposalMsg::verify`** also rejects proposals whose proposer is **not in the current validator set** (in addition to the existing sender match check). Unit tests cover over-limit payloads, cross-bucket counting, and non-validator proposers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c9cd258a894f2d20f79ed5c6b27e3ce8f532e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->