### PR TITLE
[vm] Refactor code validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-code-validation"
+version = "0.1.0"
+dependencies = [
+ "aptos-types",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
+]
+
+[[package]]
 name = "aptos-collections"
 version = "0.1.0"
 
@@ -5122,6 +5133,7 @@ dependencies = [
  "aptos-aggregator",
  "aptos-block-executor",
  "aptos-block-partitioner",
+ "aptos-code-validation",
  "aptos-crypto",
  "aptos-experimental-runtimes",
  "aptos-framework-natives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-code-validation"
+version = "0.1.0"
+dependencies = [
+ "aptos-types",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
+]
+
+[[package]]
 name = "aptos-collections"
 version = "0.1.0"
 
@@ -5115,6 +5126,7 @@ dependencies = [
  "aptos-aggregator",
  "aptos-block-executor",
  "aptos-block-partitioner",
+ "aptos-code-validation",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-experimental-runtimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "aptos-move/aptos-workspace-server",
     "aptos-move/block-executor",
     "aptos-move/cli",
+    "aptos-move/code-validation",
     "aptos-move/e2e-benchmark",
     "aptos-move/e2e-move-test-harness",
     "aptos-move/e2e-move-tests",
@@ -329,6 +330,7 @@ aptos-cached-packages = { path = "aptos-move/framework/cached-packages" }
 aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
 aptos-channels = { path = "crates/channel" }
 aptos-cli-common = { path = "crates/aptos-cli-common" }
+aptos-code-validation = { path = "aptos-move/code-validation" }
 aptos-collections = { path = "crates/aptos-collections" }
 aptos-compression = { path = "crates/aptos-compression" }
 aptos-config = { path = "config" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "aptos-move/aptos-workspace-server",
     "aptos-move/block-executor",
     "aptos-move/cli",
+    "aptos-move/code-validation",
     "aptos-move/e2e-benchmark",
     "aptos-move/e2e-move-test-harness",
     "aptos-move/e2e-move-tests",
@@ -332,6 +333,7 @@ aptos-cached-packages = { path = "aptos-move/framework/cached-packages" }
 aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
 aptos-channels = { path = "crates/channel" }
 aptos-cli-common = { path = "crates/aptos-cli-common" }
+aptos-code-validation = { path = "aptos-move/code-validation" }
 aptos-collections = { path = "crates/aptos-collections" }
 aptos-compression = { path = "crates/aptos-compression" }
 aptos-config = { path = "config" }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -34,6 +34,7 @@ ahash = { workspace = true }
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
 aptos-block-executor = { workspace = true }
+aptos-code-validation = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
 aptos-framework-natives = { workspace = true }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -34,6 +34,7 @@ ahash = { workspace = true }
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
 aptos-block-executor = { workspace = true }
+aptos-code-validation = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -26,16 +26,17 @@ use crate::{
     system_module_names::*,
     transaction_metadata::TransactionMetadata,
     transaction_validation,
-    verifier::{
-        event_validation, native_validation, resource_groups, transaction_arg_validation,
-        view_function,
-    },
+    verifier::{transaction_arg_validation, view_function},
     VMBlockExecutor, VMValidator,
 };
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManager,
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::{default::DefaultTxnProvider, TxnProvider},
+};
+use aptos_code_validation::{
+    publishing,
+    validation::{bytecode, events},
 };
 use aptos_crypto::HashValue;
 use aptos_framework_natives::code::PublishRequest;
@@ -83,10 +84,7 @@ use aptos_types::{
         TransactionOutput, TransactionPayload, TransactionStatus, TxnLimitsRequest,
         VMValidatorResult, ViewFunctionOutput, WriteSetPayload,
     },
-    vm::module_metadata::{
-        get_compilation_metadata, get_metadata, get_randomness_annotation_for_entry_function,
-        verify_module_metadata_for_module_publishing,
-    },
+    vm::module_metadata::{get_metadata, get_randomness_annotation_for_entry_function},
     vm_status::{AbortLocation, StatusCode, VMStatus},
     write_set::WriteOp,
 };
@@ -119,8 +117,6 @@ use move_binary_format::{
     compatibility::Compatibility,
     deserializer::DeserializerConfig,
     errors::{Location, PartialVMError, PartialVMResult, VMError, VMResult},
-    file_format::CompiledScript,
-    file_format_common::VERSION_5,
     CompiledModule,
 };
 use move_core_types::{
@@ -984,8 +980,8 @@ impl AptosVM {
 
             // Check that unstable bytecode cannot be executed on mainnet and verify events.
             let script = func.owner_as_script()?;
-            self.reject_unstable_bytecode_for_script(script)?;
-            event_validation::verify_no_event_emission_in_compiled_script(script)?;
+            bytecode::reject_unstable_bytecode_for_script(self.chain_id().is_mainnet(), script)?;
+            events::verify_no_event_emission_in_compiled_script(script)?;
 
             // Record the script's declared module dependencies as reads. These are a function of
             // the script bytecode, so recording them here keeps the read set independent of the
@@ -1808,121 +1804,21 @@ impl AptosVM {
         traversal_context: &mut TraversalContext,
         gas_meter: &mut impl GasMeter,
         modules: &[CompiledModule],
-        mut expected_modules: BTreeSet<String>,
+        expected_modules: BTreeSet<String>,
         allowed_deps: Option<BTreeMap<AccountAddress, BTreeSet<String>>>,
     ) -> VMResult<()> {
-        self.reject_unstable_bytecode(modules)?;
-        self.reject_legacy_module_bytecode(modules)?;
-        native_validation::validate_module_natives(modules)?;
-
-        for m in modules {
-            if !expected_modules.remove(m.self_id().name().as_str()) {
-                return Err(Self::metadata_validation_error(&format!(
-                    "unregistered module: '{}'",
-                    m.self_id().name()
-                )));
-            }
-            if let Some(allowed) = &allowed_deps {
-                for dep in m.immediate_dependencies() {
-                    if !allowed
-                        .get(dep.address())
-                        .map(|modules| {
-                            modules.contains("") || modules.contains(dep.name().as_str())
-                        })
-                        .unwrap_or(false)
-                    {
-                        return Err(Self::metadata_validation_error(&format!(
-                            "unregistered dependency: '{}'",
-                            dep
-                        )));
-                    }
-                }
-            }
-            verify_module_metadata_for_module_publishing(m, self.features())
-                .map_err(|err| Self::metadata_validation_error(&err.to_string()))?;
-        }
-
-        resource_groups::validate_resource_groups(
+        publishing::validate_publish_request(
             self.features(),
+            self.chain_id().is_mainnet(),
+            self.timed_features()
+                .is_enabled(TimedFeatureFlag::RejectV5ModulePublishing),
             module_storage,
             traversal_context,
             gas_meter,
             modules,
-        )?;
-        event_validation::validate_module_events(
-            self.features(),
-            module_storage,
-            traversal_context,
-            modules,
-        )?;
-
-        if !expected_modules.is_empty() {
-            return Err(Self::metadata_validation_error(
-                "not all registered modules published",
-            ));
-        }
-        Ok(())
-    }
-
-    /// Reject publishing of legacy (v5) module bytecode. Publishing only; modules already on chain
-    /// keep loading and executing at any version.
-    fn reject_legacy_module_bytecode(&self, modules: &[CompiledModule]) -> VMResult<()> {
-        if self
-            .timed_features()
-            .is_enabled(TimedFeatureFlag::RejectV5ModulePublishing)
-        {
-            for module in modules {
-                if module.version <= VERSION_5 {
-                    return Err(PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
-                        .with_message(format!(
-                            "publishing module bytecode version {} is not allowed; the minimum \
-                             publishable version is {}",
-                            module.version,
-                            VERSION_5 + 1
-                        ))
-                        .finish(Location::Undefined));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Check whether the bytecode can be published to mainnet based on the unstable tag in the metadata
-    fn reject_unstable_bytecode(&self, modules: &[CompiledModule]) -> VMResult<()> {
-        if self.chain_id().is_mainnet() {
-            for module in modules {
-                if let Some(metadata) = get_compilation_metadata(module) {
-                    if metadata.unstable {
-                        return Err(PartialVMError::new(StatusCode::UNSTABLE_BYTECODE_REJECTED)
-                            .with_message(
-                                "code marked unstable is not published on mainnet".to_string(),
-                            )
-                            .finish(Location::Undefined));
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Check whether the script can be run on mainnet based on the unstable tag in the metadata
-    pub fn reject_unstable_bytecode_for_script(&self, script: &CompiledScript) -> VMResult<()> {
-        if self.chain_id().is_mainnet() {
-            if let Some(metadata) = get_compilation_metadata(script) {
-                if metadata.unstable {
-                    return Err(PartialVMError::new(StatusCode::UNSTABLE_BYTECODE_REJECTED)
-                        .with_message("script marked unstable cannot be run on mainnet".to_string())
-                        .finish(Location::Script));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn metadata_validation_error(msg: &str) -> VMError {
-        PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
-            .with_message(format!("metadata and code bundle mismatch: {}", msg))
-            .finish(Location::Undefined)
+            expected_modules,
+            allowed_deps,
+        )
     }
 
     fn validate_signed_transaction(

--- a/aptos-move/code-validation/Cargo.toml
+++ b/aptos-move/code-validation/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aptos-code-validation"
+description = "Aptos code validation"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+aptos-types = { workspace = true }
+move-binary-format = { workspace = true }
+move-core-types = { workspace = true }
+move-vm-runtime = { workspace = true }
+move-vm-types = { workspace = true }

--- a/aptos-move/code-validation/src/lib.rs
+++ b/aptos-move/code-validation/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
-pub(crate) mod module_init;
-pub mod transaction_arg_validation;
-pub(crate) mod view_function;
+
+pub mod publishing;
+pub mod validation;

--- a/aptos-move/code-validation/src/publishing.rs
+++ b/aptos-move/code-validation/src/publishing.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::validation::{bytecode, events, natives, resource_groups};
+use aptos_types::{
+    on_chain_config::Features, vm::module_metadata::verify_module_metadata_for_module_publishing,
+};
+use move_binary_format::{
+    access::ModuleAccess,
+    errors::{Location, PartialVMError, VMError, VMResult},
+    CompiledModule,
+};
+use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
+use move_vm_runtime::{module_traversal::TraversalContext, ModuleStorage};
+use move_vm_types::gas::GasMeter;
+use std::collections::{BTreeMap, BTreeSet};
+
+fn metadata_validation_error(msg: &str) -> VMError {
+    PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
+        .with_message(format!("metadata and code bundle mismatch: {}", msg))
+        .finish(Location::Undefined)
+}
+
+/// Validate a publish request.
+pub fn validate_publish_request(
+    features: &Features,
+    is_mainnet: bool,
+    reject_legacy_bytecode: bool,
+    module_storage: &impl ModuleStorage,
+    traversal_context: &mut TraversalContext,
+    gas_meter: &mut impl GasMeter,
+    modules: &[CompiledModule],
+    mut expected_modules: BTreeSet<String>,
+    allowed_deps: Option<BTreeMap<AccountAddress, BTreeSet<String>>>,
+) -> VMResult<()> {
+    bytecode::reject_unstable_bytecode(is_mainnet, modules)?;
+    bytecode::reject_legacy_module_bytecode(reject_legacy_bytecode, modules)?;
+    natives::validate_module_natives(modules)?;
+
+    for m in modules {
+        if !expected_modules.remove(m.self_id().name().as_str()) {
+            return Err(metadata_validation_error(&format!(
+                "unregistered module: '{}'",
+                m.self_id().name()
+            )));
+        }
+        if let Some(allowed) = &allowed_deps {
+            for dep in m.immediate_dependencies() {
+                if !allowed
+                    .get(dep.address())
+                    .map(|modules| modules.contains("") || modules.contains(dep.name().as_str()))
+                    .unwrap_or(false)
+                {
+                    return Err(metadata_validation_error(&format!(
+                        "unregistered dependency: '{}'",
+                        dep
+                    )));
+                }
+            }
+        }
+        verify_module_metadata_for_module_publishing(m, features)
+            .map_err(|err| metadata_validation_error(&err.to_string()))?;
+    }
+
+    resource_groups::validate_resource_groups(
+        features,
+        module_storage,
+        traversal_context,
+        gas_meter,
+        modules,
+    )?;
+    events::validate_module_events(features, module_storage, traversal_context, modules)?;
+
+    if !expected_modules.is_empty() {
+        return Err(metadata_validation_error(
+            "not all registered modules published",
+        ));
+    }
+    Ok(())
+}

--- a/aptos-move/code-validation/src/validation/bytecode.rs
+++ b/aptos-move/code-validation/src/validation/bytecode.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_types::vm::module_metadata::get_compilation_metadata;
+use move_binary_format::{
+    errors::{Location, PartialVMError, VMResult},
+    file_format::CompiledScript,
+    file_format_common::VERSION_5,
+    CompiledModule,
+};
+use move_core_types::vm_status::StatusCode;
+
+/// Reject publishing of legacy (v5) module bytecode. Publishing only; modules already on chain
+/// keep loading and executing at any version.
+pub fn reject_legacy_module_bytecode(
+    reject_legacy_bytecode: bool,
+    modules: &[CompiledModule],
+) -> VMResult<()> {
+    if reject_legacy_bytecode {
+        for module in modules {
+            if module.version <= VERSION_5 {
+                return Err(PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
+                    .with_message(format!(
+                        "publishing module bytecode version {} is not allowed; the minimum \
+                         publishable version is {}",
+                        module.version,
+                        VERSION_5 + 1
+                    ))
+                    .finish(Location::Undefined));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Check whether the bytecode can be published to mainnet based on the unstable tag in the metadata
+pub fn reject_unstable_bytecode(is_mainnet: bool, modules: &[CompiledModule]) -> VMResult<()> {
+    if is_mainnet {
+        for module in modules {
+            if let Some(metadata) = get_compilation_metadata(module) {
+                if metadata.unstable {
+                    return Err(PartialVMError::new(StatusCode::UNSTABLE_BYTECODE_REJECTED)
+                        .with_message(
+                            "code marked unstable is not published on mainnet".to_string(),
+                        )
+                        .finish(Location::Undefined));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Check whether the script can be run on mainnet based on the unstable tag in the metadata
+pub fn reject_unstable_bytecode_for_script(
+    is_mainnet: bool,
+    script: &CompiledScript,
+) -> VMResult<()> {
+    if is_mainnet {
+        if let Some(metadata) = get_compilation_metadata(script) {
+            if metadata.unstable {
+                return Err(PartialVMError::new(StatusCode::UNSTABLE_BYTECODE_REJECTED)
+                    .with_message("script marked unstable cannot be run on mainnet".to_string())
+                    .finish(Location::Script));
+            }
+        }
+    }
+    Ok(())
+}

--- a/aptos-move/code-validation/src/validation/events.rs
+++ b/aptos-move/code-validation/src/validation/events.rs
@@ -35,7 +35,7 @@ fn metadata_validation_error(msg: &str) -> VMError {
 /// Validate event metadata on modules one by one:
 /// * Extract the event metadata
 /// * Verify all changes are compatible upgrades (existing event attributes cannot be removed)
-pub(crate) fn validate_module_events(
+pub fn validate_module_events(
     features: &Features,
     module_storage: &impl ModuleStorage,
     traversal_context: &TraversalContext,
@@ -97,7 +97,7 @@ pub(crate) fn validate_module_events(
 ///    0x1::event::emit<Event>();
 /// }
 /// ```
-pub(crate) fn validate_emit_calls(
+pub fn validate_emit_calls(
     event_structs: &HashSet<String>,
     module: &CompiledModule,
 ) -> VMResult<()> {
@@ -255,9 +255,7 @@ pub(crate) fn validate_emit_calls(
 }
 
 /// Given a module id extract all event metadata
-pub(crate) fn extract_event_metadata(
-    metadata: &RuntimeModuleMetadataV1,
-) -> VMResult<HashSet<String>> {
+pub fn extract_event_metadata(metadata: &RuntimeModuleMetadataV1) -> VMResult<HashSet<String>> {
     let mut event_structs = HashSet::new();
     for (struct_, attrs) in &metadata.struct_attributes {
         for attr in attrs {
@@ -288,7 +286,7 @@ pub(crate) fn extract_event_metadata(
 /// ```
 ///
 /// This is ok to fail here, as event emission should be done by the module where event is defined.
-pub(crate) fn verify_no_event_emission_in_compiled_script(script: &CompiledScript) -> VMResult<()> {
+pub fn verify_no_event_emission_in_compiled_script(script: &CompiledScript) -> VMResult<()> {
     for func_handle in &script.function_handles {
         if is_event_emit_call(BinaryIndexedView::Script(script), func_handle) {
             debug_assert!(func_handle.type_parameters.len() == 1);

--- a/aptos-move/code-validation/src/validation/mod.rs
+++ b/aptos-move/code-validation/src/validation/mod.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
-pub(crate) mod module_init;
-pub mod transaction_arg_validation;
-pub(crate) mod view_function;
+
+pub mod bytecode;
+pub mod events;
+pub mod natives;
+pub mod resource_groups;

--- a/aptos-move/code-validation/src/validation/natives.rs
+++ b/aptos-move/code-validation/src/validation/natives.rs
@@ -9,7 +9,7 @@ use move_binary_format::{
 use move_core_types::vm_status::StatusCode;
 
 /// Validate that only system address can publish new non-entry natives.
-pub(crate) fn validate_module_natives(modules: &[CompiledModule]) -> VMResult<()> {
+pub fn validate_module_natives(modules: &[CompiledModule]) -> VMResult<()> {
     for module in modules {
         let module_address = module.self_addr();
         for native in module.function_defs().iter().filter(|def| def.is_native()) {

--- a/aptos-move/code-validation/src/validation/resource_groups.rs
+++ b/aptos-move/code-validation/src/validation/resource_groups.rs
@@ -33,7 +33,7 @@ fn metadata_validation_error(msg: &str) -> VMError {
 /// * Ensure that each member has a membership and it does not change
 /// * Ensure that each group has a scope and that it does not become more restrictive
 /// * For any new members, verify that they are in a valid resource group
-pub(crate) fn validate_resource_groups(
+pub fn validate_resource_groups(
     features: &Features,
     module_storage: &impl ModuleStorage,
     traversal_context: &mut TraversalContext,
@@ -107,7 +107,7 @@ pub(crate) fn validate_resource_groups(
 /// * Extract the resource group metadata
 /// * Verify all changes are compatible upgrades
 /// * Return any new members to validate correctness and all groups to assist in validation
-pub(crate) fn validate_module_and_extract_new_entries(
+pub fn validate_module_and_extract_new_entries(
     module_storage: &impl ModuleStorage,
     new_module: &CompiledModule,
     features: &Features,
@@ -189,7 +189,7 @@ pub(crate) fn validate_module_and_extract_new_entries(
 }
 
 /// Given a module id extract all resource group metadata
-pub(crate) fn extract_resource_group_metadata_from_module(
+pub fn extract_resource_group_metadata_from_module(
     old_module: &CompiledModule,
 ) -> VMResult<(
     BTreeMap<String, ResourceGroupScope>,
@@ -213,7 +213,7 @@ pub(crate) fn extract_resource_group_metadata_from_module(
 }
 
 /// Given a module id extract all resource group metadata
-pub(crate) fn extract_resource_group_metadata(
+pub fn extract_resource_group_metadata(
     metadata: &RuntimeModuleMetadataV1,
 ) -> VMResult<(
     BTreeMap<String, ResourceGroupScope>,


### PR DESCRIPTION
## Description

Module-publishing validation currently lives entirely inside `aptos-vm`. The reusable
checks (`native_validation`, `resource_groups`, `event_validation`) are `pub(crate)`
submodules of `aptos-vm/src/verifier/`, and the orchestration (`validate_publish_request`,
`reject_unstable_bytecode`, `reject_legacy_module_bytecode`,
`reject_unstable_bytecode_for_script`) are private `AptosVM` methods that read their inputs
from `self`. No other layer can call them.

This PR extracts that logic into a new crate, `aptos-code-validation`, so other layers can
run the same checks. This is step 1 of a larger rewrite of how modules are published.

Behavior is unchanged. This is a pure move:

- `validation/{natives,resource_groups,events}.rs` are moved verbatim from
  `aptos-vm/src/verifier/{native_validation,resource_groups,event_validation}.rs`, with
  `pub(crate)` raised to `pub`.
- `validation/bytecode.rs` holds the bytecode-level checks `reject_unstable_bytecode`,
  `reject_unstable_bytecode_for_script`, and `reject_legacy_module_bytecode`.
- `publishing.rs` holds the orchestrator `validate_publish_request`, which composes the
  bytecode checks and the `validation` submodules. Inputs previously read from the `AptosVM`
  receiver (`is_mainnet`, the reject-legacy-bytecode flag, `features`) are now explicit
  parameters.
- `aptos-vm`'s `validate_publish_request` becomes a thin wrapper that computes those inputs
  from `self` and delegates to the new crate. The single call site is unchanged.

The new crate is generic over the base `ModuleStorage` trait rather than `AptosModuleStorage`,
so it does not depend on `aptos-vm-types`. Its dependencies are `aptos-types`,
`move-binary-format`, `move-core-types`, `move-vm-runtime`, and `move-vm-types`.

## How Has This Been Tested?

- `cargo check -p aptos-code-validation` and `cargo check -p aptos-vm` both pass.
- Existing publish-path e2e tests in `e2e-move-tests` pass unchanged:
  - `tests::metadata::*` (7/7) — unstable-bytecode rejection and metadata validation on publish.
  - `tests::module_event::{test_event_emission_in_modules, test_event_emission_not_allowed_in_scripts, verify_module_event_upgrades}` — event validation and script event checks.
  - `tests::code_publishing::*` and `tests::legacy_bytecode_publishing::legacy_v5_module_publishing_is_gated` — full publish loop and legacy-bytecode gating.

  (`test_module_event_enabled` fails locally only because it builds a Move package with a
  `git` dependency on `aptos-framework` that could not be fetched in the sandbox; the failure
  is in package resolution, before any VM code runs.)

## Key Areas to Review

- `aptos-move/code-validation/src/publishing.rs` — the moved orchestration loop. Confirm the
  `self.*` reads map correctly to the new parameters: `self.chain_id().is_mainnet()` →
  `is_mainnet`, `self.timed_features().is_enabled(RejectV5ModulePublishing)` →
  `reject_legacy_bytecode`, `self.features()` → `features`. The rest of the loop (including
  the `expected_modules` / `allowed_deps` request-matching) is verbatim.
- `aptos-move/code-validation/src/validation/bytecode.rs` — the three `reject_*` checks,
  unchanged except that `is_mainnet` and the reject-legacy flag are now parameters.
- `aptos-move/aptos-vm/src/aptos_vm.rs` — the thin wrapper and the removed methods; the script
  path now calls the new crate for `bytecode::reject_unstable_bytecode_for_script` and
  `events::verify_no_event_emission_in_compiled_script`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the VM module publish and script validation paths, but the PR describes a verbatim move with unchanged behavior; risk is mainly regression if parameter wiring diverges from the old `self`-based reads.
> 
> **Overview**
> Introduces **`aptos-code-validation`** as a shared home for publish-time and bytecode checks that previously lived inside **`aptos-vm`** (`verifier` submodules and private `AptosVM` helpers).
> 
> **`publishing::validate_publish_request`** now orchestrates the full publish loop (unstable/legacy bytecode, natives, expected modules and deps, metadata, resource groups, events). **`aptos-vm`** passes **`Features`**, mainnet, and the reject-v5 flag as explicit arguments instead of reading them from **`self`**.
> 
> The script execution path calls **`bytecode::reject_unstable_bytecode_for_script`** and **`events::verify_no_event_emission_in_compiled_script`** from the new crate. **`event_validation`**, **`native_validation`**, and **`resource_groups`** are removed from **`aptos-vm/src/verifier`**; their implementations are **`pub`** under **`code-validation/src/validation/`**. The crate depends on generic **`ModuleStorage`** (not **`aptos-vm-types`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15815cbf2d3e5345c14abde64abc0631909bc07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->