### PR TITLE
[mono-move] `unit_test` signer natives

### DIFF
--- a/third_party/move/mono-move/core/src/native/context.rs
+++ b/third_party/move/mono-move/core/src/native/context.rs
@@ -106,7 +106,25 @@ pub trait NativeContext {
     /// Allocates a `vector<u8>` on the VM heap initialized with `bytes` and
     /// returns a handle to it. The vector stays live for the rest of the
     /// native call.
-    fn new_byte_vector<'a>(&'a self, bytes: &[u8]) -> VMResult<Vector<'a, u8>>;
+    fn new_byte_vector<'a>(&'a self, bytes: &[u8]) -> VMResult<Vector<'a, u8>> {
+        let vec = self.new_vector_no_pointers(1, bytes.len() as u64, bytes)?;
+        // SAFETY: Vec<8> has element size of 1, and its length is exactly
+        // the length of the supplied byte buffer.
+        Ok(unsafe { vec.transmute_unchecked() })
+    }
+
+    /// Allocates a vector of the specified number of pointer-free elements on
+    /// the heap, initialized from already packed in-frame element bytes. These
+    /// bytes must be exactly `count * elem_size` bytes long.
+    ///
+    /// Only valid when the element has no internal heap pointers (for example,
+    /// an integer or address).
+    fn new_vector_no_pointers<'a>(
+        &'a self,
+        elem_size: u32,
+        count: u64,
+        data: &[u8],
+    ) -> VMResult<Vector<'a, Opaque>>;
 
     /// Moves the elements of `from` at `[removal_position, removal_position + length)`
     /// into `to` at `insert_position`.

--- a/third_party/move/mono-move/core/src/native/context.rs
+++ b/third_party/move/mono-move/core/src/native/context.rs
@@ -108,8 +108,8 @@ pub trait NativeContext {
     /// native call.
     fn new_byte_vector<'a>(&'a self, bytes: &[u8]) -> VMResult<Vector<'a, u8>> {
         let vec = self.new_vector_no_pointers(1, bytes.len() as u64, bytes)?;
-        // SAFETY: Vec<8> has element size of 1, and its length is exactly
-        // the length of the supplied byte buffer.
+        // SAFETY: the vector was allocated with element size 1 and no internal
+        // pointers, matching the layout of `u8`.
         Ok(unsafe { vec.transmute_unchecked() })
     }
 

--- a/third_party/move/mono-move/core/src/native/value.rs
+++ b/third_party/move/mono-move/core/src/native/value.rs
@@ -317,6 +317,17 @@ impl<'a, V> Vector<'a, V> {
         self.len() == 0
     }
 
+    /// Reinterprets the element type of a vector.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the object's actual element layout matches
+    /// the target layout.
+    #[inline]
+    pub(crate) unsafe fn transmute_unchecked<U>(self) -> Vector<'a, U> {
+        Vector::from_handle(self.handle)
+    }
+
     // TODO(completeness): Other vector APIs, added on-demand.
 }
 

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -31,6 +31,7 @@ pub mod table;
 pub mod test_natives;
 pub mod transaction_context;
 pub mod type_info;
+pub mod unit_test;
 pub mod vector;
 
 pub use aggregator_v2::make_all_aggregator_v2_natives;
@@ -51,6 +52,7 @@ pub use table::make_all_table_natives;
 pub use test_natives::{make_all_test_natives, native_u64_add, native_u64_identity};
 pub use transaction_context::{make_all_transaction_context_natives, TransactionContextExtension};
 pub use type_info::make_all_type_info_natives;
+pub use unit_test::make_all_unit_test_natives;
 pub use vector::make_all_vector_natives;
 
 /// How a native is dispatched against a call's type arguments. A native that

--- a/third_party/move/mono-move/natives/src/unit_test.rs
+++ b/third_party/move/mono-move/natives/src/unit_test.rs
@@ -22,7 +22,7 @@ pub fn native_create_signers_for_testing<C: NativeContext>(ctx: &C) -> VMResult<
 
     // A `signer` has the same 32-byte layout as its `address`, and addresses are
     // pointer-free, so pack the addresses back-to-back and build the vector once.
-    let mut data = vec![];
+    let mut data = Vec::with_capacity(num_signers as usize * AccountAddress::LENGTH);
     for i in 0..num_signers {
         let mut bytes = [0u8; AccountAddress::LENGTH];
         bytes[..8].copy_from_slice(&i.to_le_bytes());

--- a/third_party/move/mono-move/natives/src/unit_test.rs
+++ b/third_party/move/mono-move/natives/src/unit_test.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Test-only natives for the `std::unit_test` module.
+
+use crate::{monomorphic_natives, NativeEntry};
+use mono_move_core::{
+    native::{NativeContext, NativeContextFamily, NativeStatus, Opaque, Vector},
+    VMResult,
+};
+use move_core_types::account_address::AccountAddress;
+
+/// `0x1::unit_test::create_signers_for_testing(num_signers: u64): vector<signer>`
+///
+/// Test-only. Returns `num_signers` signers whose addresses are the little-endian
+/// encoding of `0, 1, ..., num_signers - 1`.
+//
+// TODO(metering): charge gas and bound `num_signers`.
+pub fn native_create_signers_for_testing<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `u64`.
+    let num_signers: u64 = unsafe { ctx.arg(0)? };
+
+    // A `signer` has the same 32-byte layout as its `address`, and addresses are
+    // pointer-free, so pack the addresses back-to-back and build the vector once.
+    let mut data = vec![];
+    for i in 0..num_signers {
+        let mut bytes = [0u8; AccountAddress::LENGTH];
+        bytes[..8].copy_from_slice(&i.to_le_bytes());
+        data.extend_from_slice(&bytes);
+    }
+    let signers: Vector<Opaque> =
+        ctx.new_vector_no_pointers(AccountAddress::LENGTH as u32, num_signers, &data)?;
+    // SAFETY: return 0 is `vector<signer>`, whose element layout is a bare address.
+    unsafe { ctx.set_return(0, signers)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Test-only natives for the `unit_test` module.
+pub fn make_all_unit_test_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![(
+        "0x1::unit_test::create_signers_for_testing",
+        native_create_signers_for_testing
+    )]
+}

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -318,14 +318,23 @@ impl NativeContext for ProductionNativeContext<'_> {
         }
     }
 
-    fn new_byte_vector<'a>(&'a self, bytes: &[u8]) -> VMResult<Vector<'a, u8>> {
+    fn new_vector_no_pointers<'a>(
+        &'a self,
+        elem_size: u32,
+        count: u64,
+        data: &[u8],
+    ) -> VMResult<Vector<'a, Opaque>> {
         if self.returns_started.get() {
             return Err(native_invariant_violation(
-                "new_byte_vector called after a return value was written".into(),
+                "new_vector_no_pointers called after a return value was written".into(),
             ));
         }
-        let len = bytes.len() as u64;
-        if len == 0 {
+        if (count as usize).checked_mul(elem_size as usize) != Some(data.len()) {
+            return Err(native_invariant_violation(
+                "new_vector_no_pointers: data length must equal count * elem_size".into(),
+            ));
+        }
+        if count == 0 {
             // TODO(correctness): audit empty <=> null vector invariant
             // SAFETY: passing `null` is always safe.
             let handle = unsafe { self.pool.root_object(std::ptr::null_mut()) };
@@ -337,14 +346,14 @@ impl NativeContext for ProductionNativeContext<'_> {
         // live (see the type-level aliasing rule).
         let heap = unsafe { &mut **self.heap.get() };
         let rws = unsafe { &mut **self.rws.get() };
-        // A heap-aliasing `bytes` would be invalidated by the GC `alloc_vec` may
+        // A heap-aliasing `data` would be invalidated by the GC `alloc_vec` may
         // trigger, before the copy below.
-        if is_heap_ptr(heap, bytes.as_ptr()) {
+        if is_heap_ptr(heap, data.as_ptr()) {
             return Err(native_invariant_violation(
-                "new_byte_vector: bytes must not alias the VM heap".into(),
+                "new_vector_no_pointers: data must not alias the VM heap".into(),
             ));
         }
-        // A `vector<u8>` has no inner pointers, so it uses the trivial descriptor.
+        // Pointer-free elements, so the vector uses the trivial descriptor.
         let ptr = alloc_vec(
             heap,
             self.desc_provider,
@@ -354,14 +363,14 @@ impl NativeContext for ProductionNativeContext<'_> {
             self.frame_ptr,
             TopFrame::Native(self.abi),
             TRIVIAL_DESCRIPTOR_ID,
-            1,
-            len,
+            elem_size,
+            count,
         )?;
-        // SAFETY: `ptr` is a fresh vector with room for `len` bytes; no GC runs
-        // between here and these writes, so the raw pointer is valid.
+        // SAFETY: `ptr` is a fresh vector with room for `count` elements; no GC
+        // runs between here and these writes, so the raw pointer is valid.
         unsafe {
-            write_u64(ptr, VEC_LENGTH_OFFSET, len);
-            std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr.add(VEC_DATA_OFFSET), bytes.len());
+            write_u64(ptr, VEC_LENGTH_OFFSET, count);
+            std::ptr::copy_nonoverlapping(data.as_ptr(), ptr.add(VEC_DATA_OFFSET), data.len());
         }
         // Root it so it survives later allocations and is GC-relocated.
         // SAFETY: `ptr` is the data pointer of the freshly allocated vector.

--- a/third_party/move/mono-move/testsuite/src/engine.rs
+++ b/third_party/move/mono-move/testsuite/src/engine.rs
@@ -15,7 +15,9 @@ use mono_move_core::{
 };
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
-use mono_move_natives::{make_all_production_natives, make_all_test_natives, Dispatch};
+use mono_move_natives::{
+    make_all_production_natives, make_all_test_natives, make_all_unit_test_natives, Dispatch,
+};
 use mono_move_runtime::{
     InterpreterContext, ProductionContextFamily, ProductionNativeRegistry, RuntimeStatus,
 };
@@ -117,6 +119,7 @@ pub fn build_natives(guard: &ExecutionGuard<'_>) -> ProductionNativeRegistry {
         .register_all(
             make_all_test_natives::<ProductionContextFamily>()
                 .into_iter()
+                .chain(make_all_unit_test_natives::<ProductionContextFamily>())
                 .chain(make_all_production_natives::<ProductionContextFamily>())
                 .map(|(addr, module, function, dispatch, func)| {
                     let module = guard.module_id_of(&addr, &module);

--- a/third_party/move/mono-move/testsuite/src/v1_test_natives.rs
+++ b/third_party/move/mono-move/testsuite/src/v1_test_natives.rs
@@ -36,6 +36,34 @@ fn v1_native_u64_identity(
     ]))
 }
 
+/// The little-endian encoding of `i` in the first 8 bytes of an address.
+fn to_le_bytes(i: u64) -> [u8; AccountAddress::LENGTH] {
+    let bytes = i.to_le_bytes();
+    let mut result = [0u8; AccountAddress::LENGTH];
+    result[..bytes.len()].clone_from_slice(bytes.as_ref());
+    result
+}
+
+/// Mirrors `std::unit_test::create_signers_for_testing`
+/// (`aptos-move/framework/move-stdlib/src/natives/unit_test.rs`): returns
+/// `num_signers` master signers whose addresses are the little-endian encodings
+/// of `0, 1, ..., num_signers - 1`.
+///
+/// Registered here because the testsuite does not enable
+/// `aptos-move-stdlib/testing`, so `aptos_natives` omits this test-only native;
+/// the V2 side registers it via `make_all_unit_test_natives`.
+fn v1_native_create_signers_for_testing(
+    _ctx: &mut NativeContext,
+    _ty_args: &[Type],
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    let num_signers = pop_arg!(args, u64);
+    let signers = Value::vector_unchecked(
+        (0..num_signers).map(|i| Value::master_signer(AccountAddress::new(to_le_bytes(i)))),
+    )?;
+    Ok(NativeResult::ok(InternalGas::zero(), smallvec![signers]))
+}
+
 /// Build a list of test natives for the v1 VM, matching the ones we have for v2
 /// (in the `mono-move-natives` crate).
 ///
@@ -55,6 +83,12 @@ pub fn make_all_v1_test_natives() -> NativeFunctionTable {
             module,
             ident_str!("u64_identity").to_owned(),
             Arc::new(v1_native_u64_identity) as NativeFunction,
+        ),
+        (
+            AccountAddress::ONE,
+            ident_str!("unit_test").to_owned(),
+            ident_str!("create_signers_for_testing").to_owned(),
+            Arc::new(v1_native_create_signers_for_testing) as NativeFunction,
         ),
     ]
 }

--- a/third_party/move/mono-move/testsuite/src/v1_test_natives.rs
+++ b/third_party/move/mono-move/testsuite/src/v1_test_natives.rs
@@ -36,8 +36,9 @@ fn v1_native_u64_identity(
     ]))
 }
 
-/// The little-endian encoding of `i` in the first 8 bytes of an address.
-fn to_le_bytes(i: u64) -> [u8; AccountAddress::LENGTH] {
+/// The address byte array for index `i`, with `i` little-endian encoded in the
+/// first 8 bytes.
+fn address_bytes_for_index(i: u64) -> [u8; AccountAddress::LENGTH] {
     let bytes = i.to_le_bytes();
     let mut result = [0u8; AccountAddress::LENGTH];
     result[..bytes.len()].clone_from_slice(bytes.as_ref());
@@ -59,7 +60,8 @@ fn v1_native_create_signers_for_testing(
 ) -> PartialVMResult<NativeResult> {
     let num_signers = pop_arg!(args, u64);
     let signers = Value::vector_unchecked(
-        (0..num_signers).map(|i| Value::master_signer(AccountAddress::new(to_le_bytes(i)))),
+        (0..num_signers)
+            .map(|i| Value::master_signer(AccountAddress::new(address_bytes_for_index(i)))),
     )?;
     Ok(NativeResult::ok(InternalGas::zero(), smallvec![signers]))
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/unit_test.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/unit_test.move
@@ -1,0 +1,43 @@
+// Differential test for the test-only unit_test native.
+
+// RUN: publish
+module 0x1::unit_test {
+    use std::signer;
+    use std::vector;
+
+    public fun count(n: u64): u64 {
+        let signers = create_signers_for_testing(n);
+        vector::length(&signers)
+    }
+
+    public fun equals(): bool {
+        let signers = create_signers_for_testing(4);
+        let a = *signer::borrow_address(vector::borrow(&signers, 0)) == @0x0;
+        let b = *signer::borrow_address(vector::borrow(&signers, 1)) == @0x0100000000000000000000000000000000000000000000000000000000000000;
+        let c = *signer::borrow_address(vector::borrow(&signers, 2)) == @0x0200000000000000000000000000000000000000000000000000000000000000;
+        let d = *signer::borrow_address(vector::borrow(&signers, 3)) == @0x0300000000000000000000000000000000000000000000000000000000000000;
+        a && b && c && d
+    }
+
+    public fun distinct(): bool {
+        let signers = create_signers_for_testing(3);
+        let a = *signer::borrow_address(vector::borrow(&signers, 0));
+        let b = *signer::borrow_address(vector::borrow(&signers, 1));
+        let c = *signer::borrow_address(vector::borrow(&signers, 2));
+        a != b && a != c && b != c
+    }
+
+    native fun create_signers_for_testing(num_signers: u64): vector<signer>;
+}
+
+// RUN: execute 0x1::unit_test::count --args 0
+// CHECK: results: 0
+
+// RUN: execute 0x1::unit_test::count --args 3
+// CHECK: results: 3
+
+// RUN: execute 0x1::unit_test::equals
+// CHECK: results: true
+
+// RUN: execute 0x1::unit_test::distinct
+// CHECK: results: true


### PR DESCRIPTION
## Description

Ports `unit_test` native `unit_test::create_signers_for_testing` (test-only).

Supporting change:
- New `NativeContext` primitive `new_vector_no_pointers(elem_size, count, data)`,
  implemented in `ProductionNativeContext`. It builds a typed, pointer-free vector
  (e.g. `vector<signer>`) via the trivial GC descriptor, mirroring `new_byte_vector`
  for element widths other than 1. `create_signers_for_testing` needs it.

Metering is deferred (`// TODO(metering): charge gas.`), consistent with the other
mono-move natives; the gas meter is plumbed but not yet exposed to natives.

## How Has This Been Tested?

Differential tests under `testsuite/tests/test_cases/differential/natives/`

## Key Areas to Review

- `new_vector_no_pointers` in `runtime/src/native_context.rs` — the layout it
  produces (length header + packed element bytes, trivial descriptor) must match
  what the specialized `vector<signer>` ops expect. Only valid for pointer-free
  element types. `new_byte_vector` calls into this new function now.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VM native heap vector layout plumbing; incorrect `new_vector_no_pointers` layout would break vector/signer ops, though scope is test-focused natives and a refactored `new_byte_vector` path.
> 
> **Overview**
> Adds **`NativeContext::new_vector_no_pointers`** so natives can allocate heap vectors of pointer-free elements (e.g. `signer` / address-sized slots) from packed bytes, using the trivial GC descriptor. **`new_byte_vector`** is now a thin wrapper over this API, and **`ProductionNativeContext`** implements the generalized allocator (with `count * elem_size` validation and the same heap-alias checks as before). **`Vector::transmute_unchecked`** supports safe-ish reinterpretation after allocation.
> 
> Introduces the test-only mono-move native **`0x1::unit_test::create_signers_for_testing`**, which builds `vector<signer>` with addresses `0..n-1` (LE in the first 8 bytes). The testsuite registers it via **`make_all_unit_test_natives`**, mirrors behavior on the v1 VM for differential runs, and adds **`unit_test.move`** differential cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6bfd3137638d31ec9e4e72e1c376c92d0534f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->