### PR TITLE
[vm] fix cache layouts of vector-wrapped structs

### DIFF
--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/read_recording.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/read_recording.rs
@@ -20,7 +20,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{
     ambassador_impl_LayoutCache, ambassador_impl_WithRuntimeEnvironment, LayoutCache,
-    LayoutCacheEntry, Module, ModuleStorage, RuntimeEnvironment, Script, StructKey,
+    LayoutCacheEntry, LayoutCacheKey, Module, ModuleStorage, RuntimeEnvironment, Script,
     WithRuntimeEnvironment,
 };
 use move_vm_types::code::{ambassador_impl_ScriptCache, Code, ScriptCache};

--- a/aptos-move/block-executor/src/code_cache.rs
+++ b/aptos-move/block-executor/src/code_cache.rs
@@ -29,7 +29,7 @@ use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
 };
 use move_vm_runtime::{
-    LayoutCache, LayoutCacheEntry, Module, RuntimeEnvironment, Script, StructKey,
+    LayoutCache, LayoutCacheEntry, LayoutCacheKey, Module, RuntimeEnvironment, Script,
     WithRuntimeEnvironment,
 };
 use move_vm_types::code::{
@@ -262,17 +262,21 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> LatestView<'_, T, S> {
 }
 
 impl<T: Transaction, S: TStateView<Key = T::Key>> LayoutCache for LatestView<'_, T, S> {
-    fn get_struct_layout(&self, key: &StructKey) -> Option<LayoutCacheEntry> {
+    fn get_struct_layout(&self, key: &LayoutCacheKey) -> Option<LayoutCacheEntry> {
         self.global_module_cache.get_struct_layout_entry(key)
     }
 
-    fn store_struct_layout(&self, key: &StructKey, entry: LayoutCacheEntry) -> PartialVMResult<()> {
+    fn store_struct_layout(
+        &self,
+        key: &LayoutCacheKey,
+        entry: LayoutCacheEntry,
+    ) -> PartialVMResult<()> {
         self.global_module_cache
             .store_struct_layout_entry(key, entry)?;
         Ok(())
     }
 
-    fn remove_struct_layout(&self, key: &StructKey) {
+    fn remove_struct_layout(&self, key: &LayoutCacheKey) {
         self.global_module_cache.remove_struct_layout_entry(key);
     }
 }

--- a/aptos-move/block-executor/src/code_cache_global.rs
+++ b/aptos-move/block-executor/src/code_cache_global.rs
@@ -10,7 +10,7 @@ use dashmap::DashMap;
 use hashbrown::{Equivalent, HashMap};
 use move_binary_format::{errors::PartialVMResult, CompiledModule};
 use move_core_types::language_storage::ModuleId;
-use move_vm_runtime::{LayoutCacheEntry, Module, RuntimeEnvironment, StructKey};
+use move_vm_runtime::{LayoutCacheEntry, LayoutCacheKey, Module, RuntimeEnvironment};
 use move_vm_types::code::{ModuleCache, ModuleCode, WithSize};
 use std::{
     hash::Hash,
@@ -91,7 +91,7 @@ pub struct GlobalModuleCache<K, D, V, E> {
     size: usize,
     /// Cached layouts of structs or enums. This cache stores roots only and is invalidated when
     /// modules are published.
-    struct_layouts: DashMap<StructKey, LayoutCacheEntry>,
+    struct_layouts: DashMap<LayoutCacheKey, LayoutCacheEntry>,
 }
 
 impl<K, D, V, E> GlobalModuleCache<K, D, V, E>
@@ -167,7 +167,7 @@ where
     }
 
     /// Returns layout entry if it exists in global cache.
-    pub(crate) fn get_struct_layout_entry(&self, key: &StructKey) -> Option<LayoutCacheEntry> {
+    pub(crate) fn get_struct_layout_entry(&self, key: &LayoutCacheKey) -> Option<LayoutCacheEntry> {
         match self.struct_layouts.get(key) {
             None => {
                 GLOBAL_LAYOUT_CACHE_MISSES.inc();
@@ -179,7 +179,7 @@ where
 
     pub(crate) fn store_struct_layout_entry(
         &self,
-        key: &StructKey,
+        key: &LayoutCacheKey,
         entry: LayoutCacheEntry,
     ) -> PartialVMResult<()> {
         if let dashmap::Entry::Vacant(e) = self.struct_layouts.entry(*key) {
@@ -188,7 +188,7 @@ where
         Ok(())
     }
 
-    pub(crate) fn remove_struct_layout_entry(&self, key: &StructKey) {
+    pub(crate) fn remove_struct_layout_entry(&self, key: &LayoutCacheKey) {
         self.struct_layouts.remove(key);
     }
 

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -106,7 +106,7 @@ impl Default for ExecutionConfig {
             genesis_waypoint: None,
             blockstm_v2_enabled: true,
             layout_caches_enabled: true,
-            async_runtime_checks: true,
+            async_runtime_checks: false,
             enable_pre_write: true,
         }
     }

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -47,7 +47,7 @@ pub use storage::{
         unsync_module_storage::{AsUnsyncModuleStorage, BorrowedOrOwned, UnsyncModuleStorage},
     },
     layout_cache::{
-        ambassador_impl_LayoutCache, LayoutCache, LayoutCacheEntry, NoOpLayoutCache, StructKey,
+        ambassador_impl_LayoutCache, LayoutCache, LayoutCacheEntry, LayoutCacheKey, NoOpLayoutCache,
     },
     loader::{
         eager::EagerLoader,

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -12,7 +12,7 @@ use crate::{
     module_traversal::TraversalContext,
     native_extensions::NativeContextExtensions,
     storage::{
-        layout_cache::StructKey,
+        layout_cache::LayoutCacheKey,
         loader::traits::NativeModuleLoader,
         module_storage::FunctionValueExtensionAdapter,
         ty_layout_converter::{LayoutConverter, LayoutWithDelayedFields},
@@ -535,15 +535,19 @@ struct ModuleStorageWrapper<'a> {
 }
 
 impl<'a> LayoutCache for ModuleStorageWrapper<'a> {
-    fn get_struct_layout(&self, key: &StructKey) -> Option<LayoutCacheEntry> {
+    fn get_struct_layout(&self, key: &LayoutCacheKey) -> Option<LayoutCacheEntry> {
         self.module_storage.get_struct_layout(key)
     }
 
-    fn store_struct_layout(&self, key: &StructKey, entry: LayoutCacheEntry) -> PartialVMResult<()> {
+    fn store_struct_layout(
+        &self,
+        key: &LayoutCacheKey,
+        entry: LayoutCacheEntry,
+    ) -> PartialVMResult<()> {
         self.module_storage.store_struct_layout(key, entry)
     }
 
-    fn remove_struct_layout(&self, key: &StructKey) {
+    fn remove_struct_layout(&self, key: &LayoutCacheKey) {
         self.module_storage.remove_struct_layout(key)
     }
 }

--- a/third_party/move/move-vm/runtime/src/storage/layout_cache.rs
+++ b/third_party/move/move-vm/runtime/src/storage/layout_cache.rs
@@ -21,7 +21,7 @@ use crate::LayoutWithDelayedFields;
 use ambassador::delegatable_trait;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::language_storage::ModuleId;
-use move_vm_types::{loaded_data::struct_name_indexing::StructNameIndex, ty_interner::TypeVecId};
+use move_vm_types::ty_interner::TypeId;
 use std::collections::HashSet;
 use triomphe::Arc as TriompheArc;
 
@@ -88,10 +88,11 @@ impl LayoutCacheEntry {
     }
 }
 
+/// Key of a cached layout: the interned id of the whole type it was built for, so that `S`,
+/// `vector<S>` and `vector<vector<S>>` each get their own entry.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct StructKey {
-    pub idx: StructNameIndex,
-    pub ty_args_id: TypeVecId,
+pub struct LayoutCacheKey {
+    pub id: TypeId,
 }
 
 /// Interface for fetching and storing layouts into the cache.
@@ -100,13 +101,17 @@ pub trait LayoutCache {
     /// If layout root is cached, returns the cached entry (with the modules that were used to
     /// construct it). The reader must ensure to read the module-set for gas charging of validation
     /// purposes.
-    fn get_struct_layout(&self, key: &StructKey) -> Option<LayoutCacheEntry>;
+    fn get_struct_layout(&self, key: &LayoutCacheKey) -> Option<LayoutCacheEntry>;
 
     /// Stores layout into cache. If layout already exists (e.g., concurrent insertion) - a no-op.
-    fn store_struct_layout(&self, key: &StructKey, entry: LayoutCacheEntry) -> PartialVMResult<()>;
+    fn store_struct_layout(
+        &self,
+        key: &LayoutCacheKey,
+        entry: LayoutCacheEntry,
+    ) -> PartialVMResult<()>;
 
     /// Removes the cached layout entry for the given key.
-    fn remove_struct_layout(&self, key: &StructKey);
+    fn remove_struct_layout(&self, key: &LayoutCacheKey);
 }
 
 /// Marker for no-op layout caches.
@@ -116,19 +121,19 @@ impl<T> LayoutCache for T
 where
     T: NoOpLayoutCache,
 {
-    fn get_struct_layout(&self, _key: &StructKey) -> Option<LayoutCacheEntry> {
+    fn get_struct_layout(&self, _key: &LayoutCacheKey) -> Option<LayoutCacheEntry> {
         None
     }
 
     fn store_struct_layout(
         &self,
-        _key: &StructKey,
+        _key: &LayoutCacheKey,
         _entry: LayoutCacheEntry,
     ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn remove_struct_layout(&self, _key: &StructKey) {
+    fn remove_struct_layout(&self, _key: &LayoutCacheKey) {
         // No-op.
     }
 }

--- a/third_party/move/move-vm/runtime/src/storage/loader/lazy.rs
+++ b/third_party/move/move-vm/runtime/src/storage/loader/lazy.rs
@@ -10,8 +10,8 @@ use crate::{
         LegacyLoaderConfig, Loader, ModuleMetadataLoader, NativeModuleLoader, ScriptLoader,
         StructDefinitionLoader,
     },
-    Function, LayoutCacheEntry, LayoutWithDelayedFields, LoadedFunction, Module, ModuleStorage,
-    RuntimeEnvironment, Script, StructKey, WithRuntimeEnvironment,
+    Function, LayoutCacheEntry, LayoutCacheKey, LayoutWithDelayedFields, LoadedFunction, Module,
+    ModuleStorage, RuntimeEnvironment, Script, WithRuntimeEnvironment,
 };
 use move_binary_format::{
     access::ScriptAccess,
@@ -216,7 +216,7 @@ where
         &self,
         gas_meter: &mut impl DependencyGasMeter,
         traversal_context: &mut TraversalContext,
-        key: &StructKey,
+        key: &LayoutCacheKey,
     ) -> Option<PartialVMResult<LayoutWithDelayedFields>> {
         let entry = self.module_storage.get_struct_layout(key)?;
         let (layout, modules) = entry.unpack();
@@ -269,7 +269,7 @@ where
 
     fn store_layout_to_cache(
         &self,
-        key: &StructKey,
+        key: &LayoutCacheKey,
         entry: LayoutCacheEntry,
     ) -> PartialVMResult<()> {
         self.module_storage.store_struct_layout(key, entry)

--- a/third_party/move/move-vm/runtime/src/storage/loader/traits.rs
+++ b/third_party/move/move-vm/runtime/src/storage/loader/traits.rs
@@ -4,8 +4,8 @@
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    module_traversal::TraversalContext, Function, LayoutCacheEntry, LayoutWithDelayedFields,
-    LoadedFunction, LoadedFunctionOwner, Module, ModuleStorage, Script, StructKey,
+    module_traversal::TraversalContext, Function, LayoutCacheEntry, LayoutCacheKey,
+    LayoutWithDelayedFields, LoadedFunction, LoadedFunctionOwner, Module, ModuleStorage, Script,
     WithRuntimeEnvironment,
 };
 use move_binary_format::{
@@ -59,7 +59,7 @@ pub trait StructDefinitionLoader: WithRuntimeEnvironment {
         &self,
         _gas_meter: &mut impl DependencyGasMeter,
         _traversal_context: &mut TraversalContext,
-        _key: &StructKey,
+        _key: &LayoutCacheKey,
     ) -> Option<PartialVMResult<LayoutWithDelayedFields>> {
         None
     }
@@ -67,7 +67,7 @@ pub trait StructDefinitionLoader: WithRuntimeEnvironment {
     /// Stores computed layout to the layout cache.
     fn store_layout_to_cache(
         &self,
-        _key: &StructKey,
+        _key: &LayoutCacheKey,
         _entry: LayoutCacheEntry,
     ) -> PartialVMResult<()> {
         // Default as no-op.

--- a/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
@@ -8,7 +8,7 @@ use crate::{
         layout_cache::DefiningModules, loader::traits::StructDefinitionLoader,
         ty_tag_converter::TypeTagConverter,
     },
-    LayoutCacheEntry, RuntimeEnvironment, StructKey,
+    LayoutCacheEntry, LayoutCacheKey, RuntimeEnvironment,
 };
 use fxhash::FxHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
@@ -154,6 +154,44 @@ where
         self.struct_definition_loader.is_lazy_loading_enabled()
     }
 
+    /// Returns the cache key for the given root type, or [None] if its layout is not cached.
+    ///
+    /// Only struct- and vector-headed types are cached, keyed by the interned id of the whole
+    /// type. Keying on the whole type means an entry is only ever served for the exact type it was
+    /// built from, so a hit stays equivalent to a miss in gas and in node/depth accounting.
+    fn layout_cache_key(&self, ty: &Type) -> Option<LayoutCacheKey> {
+        match ty {
+            Type::Struct { .. } | Type::StructInstantiation { .. } | Type::Vector(_) => {},
+            Type::Bool
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::U128
+            | Type::U256
+            | Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::I128
+            | Type::I256
+            | Type::Address
+            | Type::Signer
+            | Type::Function { .. }
+            | Type::Reference(_)
+            | Type::MutableReference(_)
+            | Type::TyParam(_) => return None,
+        }
+
+        // Types here are fully instantiated, so there is nothing to substitute. Interning panics
+        // if that ever does not hold, as it already did when keys were built from `intern_ty_args`.
+        let id = self
+            .runtime_environment()
+            .ty_pool()
+            .instantiate_and_intern(ty, &[]);
+        Some(LayoutCacheKey { id })
+    }
+
     /// Returns the layout of a type, as well as a flag if it contains delayed fields or not.
     pub(crate) fn type_to_type_layout_with_delayed_fields(
         &self,
@@ -161,27 +199,8 @@ where
         traversal_context: &mut TraversalContext,
         ty: &Type,
     ) -> PartialVMResult<LayoutWithDelayedFields> {
-        let ty_pool = self.runtime_environment().ty_pool();
         if self.vm_config().enable_layout_caches {
-            let key = match ty {
-                Type::Struct { idx, .. } => {
-                    let ty_args_id = ty_pool.intern_ty_args(&[]);
-                    Some(StructKey {
-                        idx: *idx,
-                        ty_args_id,
-                    })
-                },
-                Type::StructInstantiation { idx, ty_args, .. } => {
-                    let ty_args_id = ty_pool.intern_ty_args(ty_args);
-                    Some(StructKey {
-                        idx: *idx,
-                        ty_args_id,
-                    })
-                },
-                _ => None,
-            };
-
-            if let Some(key) = key {
+            if let Some(key) = self.layout_cache_key(ty) {
                 if let Some(result) = self.struct_definition_loader.load_layout_from_cache(
                     gas_meter,
                     traversal_context,
@@ -845,7 +864,7 @@ mod tests {
         module_traversal::{TraversalContext, TraversalStorage},
         storage::loader::test_utils::{generic_struct_ty, struct_ty, MockStructDefinitionLoader},
     };
-    use claims::{assert_err, assert_ok, assert_some};
+    use claims::{assert_err, assert_none, assert_ok, assert_some};
     use move_core_types::{
         ability::AbilitySet, account_address::AccountAddress, language_storage::StructTag,
     };
@@ -876,6 +895,99 @@ mod tests {
                 ty,
             )
         }
+    }
+
+    /// Wraps `ty` in `n` nested vectors.
+    fn vec_ty(ty: Type, n: usize) -> Type {
+        (0..n).fold(ty, |ty, _| Type::Vector(triomphe::Arc::new(ty)))
+    }
+
+    /// Asserts that every key in `keys` is distinct from every other.
+    fn assert_all_distinct(keys: &[LayoutCacheKey]) {
+        for (i, key) in keys.iter().enumerate() {
+            for other in &keys[i + 1..] {
+                assert_ne!(key, other);
+            }
+        }
+    }
+
+    #[test]
+    fn test_layout_cache_key_for_vector_wrapped_structs() {
+        let loader = MockStructDefinitionLoader::default();
+        let layout_converter = LayoutConverter::new(&loader);
+        let idx = StructNameIndex::new(0);
+
+        // Each nesting level keys to its own entry, else `vector<S>` gets the layout of `S`.
+        let by_nesting = (0..4)
+            .map(|n| assert_some!(layout_converter.layout_cache_key(&vec_ty(struct_ty(idx), n))))
+            .collect::<Vec<_>>();
+        assert_all_distinct(&by_nesting);
+
+        // The same type always keys to the same entry.
+        for (n, key) in by_nesting.iter().enumerate() {
+            assert_eq!(
+                assert_some!(layout_converter.layout_cache_key(&vec_ty(struct_ty(idx), n))),
+                *key
+            );
+        }
+
+        // Generic structs behind vectors stay keyed by their type arguments.
+        let by_ty_args = [Type::U8, Type::Bool, Type::U64]
+            .map(|ty_arg| vec_ty(generic_struct_ty(idx, vec![ty_arg]), 1))
+            .map(|ty| assert_some!(layout_converter.layout_cache_key(&ty)));
+        assert_all_distinct(&by_ty_args);
+
+        // Different structs never collide, at any nesting level.
+        let other_idx = StructNameIndex::new(1);
+        for n in 0..4 {
+            assert_ne!(
+                assert_some!(layout_converter.layout_cache_key(&vec_ty(struct_ty(idx), n))),
+                assert_some!(layout_converter.layout_cache_key(&vec_ty(struct_ty(other_idx), n)))
+            );
+        }
+    }
+
+    #[test]
+    fn test_layout_cache_key_for_uncacheable_tys() {
+        let loader = MockStructDefinitionLoader::default();
+        let layout_converter = LayoutConverter::new(&loader);
+
+        // Primitives and functions have constant-size layouts; references and type parameters have
+        // no layout at all. Neither is worth an entry.
+        let uncacheable = [
+            Type::Bool,
+            Type::U8,
+            Type::U16,
+            Type::U32,
+            Type::U64,
+            Type::U128,
+            Type::U256,
+            Type::I8,
+            Type::I16,
+            Type::I32,
+            Type::I64,
+            Type::I128,
+            Type::I256,
+            Type::Address,
+            Type::Signer,
+            Type::Function {
+                args: vec![Type::U8],
+                results: vec![Type::U256],
+                abilities: AbilitySet::EMPTY,
+            },
+            Type::Reference(Box::new(Type::U8)),
+            Type::MutableReference(Box::new(Type::U8)),
+            Type::TyParam(0),
+        ];
+        for ty in &uncacheable {
+            assert_none!(layout_converter.layout_cache_key(ty));
+        }
+
+        // Selection is on the head only, so wrapping any of them in a vector does make it
+        // cacheable. Those layouts are tiny, but carving out an exception would not pay for itself.
+        let vector_wrapped = [Type::U8, Type::Bool, Type::Address]
+            .map(|ty| assert_some!(layout_converter.layout_cache_key(&vec_ty(ty, 1))));
+        assert_all_distinct(&vector_wrapped);
     }
 
     #[test_case(true)]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Layout cache key semantics affect serialization/layout paths across parallel execution; incorrect keys could cause subtle correctness bugs, though the change is targeted and well-tested. Default async runtime check behavior changes node defaults.
> 
> **Overview**
> Fixes incorrect **Move VM layout caching** where types like `vector<S>` could reuse the layout built for bare struct `S`, because cache keys were only `(struct index, type args)` and ignored vector nesting.
> 
> **Layout cache keys** are renamed from `StructKey` to **`LayoutCacheKey`** holding a single interned **`TypeId`** for the whole type, so `S`, `vector<S>`, and deeper nestings each get distinct entries. **`LayoutConverter`** gains `layout_cache_key()` to cache struct-, instantiation-, and vector-headed types (primitives/refs still uncached; `vector<u8>` etc. remain cacheable). Aptos block executor and read-recording storage paths are updated to the new key type.
> 
> Adds unit tests for key distinctness across nesting, generics, and uncacheable types.
> 
> Separately, default **`ExecutionConfig::async_runtime_checks`** changes from `true` to **`false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfcf09b69b6de995d3736783d8eb6f982c0ce4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->