### PR TITLE
[vm] Add charges for bcs value traversals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,6 +3375,7 @@ dependencies = [
 name = "aptos-move-stdlib"
 version = "0.1.1"
 dependencies = [
+ "aptos-gas-algebra",
  "aptos-gas-schedule",
  "aptos-native-interface",
  "aptos-types",

--- a/aptos-move/e2e-move-tests/src/tests/bcs.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bcs.rs
@@ -3,15 +3,21 @@
 
 use crate::{assert_success, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
-use aptos_language_e2e_tests::executor::FakeExecutor;
+use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
 use aptos_package_builder::PackageBuilder;
-use aptos_types::{move_utils::MemberId, transaction::ExecutionStatus};
+use aptos_types::{
+    move_utils::MemberId,
+    transaction::{ExecutionStatus, TransactionStatus},
+};
 use claims::assert_ok;
 use move_core_types::{
     account_address::AccountAddress,
     ident_str,
     language_storage::ModuleId,
-    vm_status::{sub_status::NFE_BCS_SERIALIZATION_FAILURE, AbortLocation},
+    vm_status::{
+        sub_status::NFE_BCS_SERIALIZATION_FAILURE, AbortLocation,
+        StatusCode::EXECUTION_LIMIT_REACHED,
+    },
 };
 use std::str::FromStr;
 
@@ -120,4 +126,113 @@ fn test_constant_serialized_size_dag_no_stall() {
         vec![],
         vec![],
     ));
+}
+
+/// Generates a module with a `depth`-deep single-field wrapper chain
+/// (`D1{f: D2} ... D{depth}{f: u8}`) and an entry `run` that builds a
+/// `vector<D1>` of `n_elems` such values and serializes it `iters` times.
+///
+/// Mirrors the PoC: each wrapper struct is one Value node but serializes to zero
+/// BCS bytes, so the node count far exceeds the output byte count. This is the
+/// case the per-output-byte cost under-charges.
+fn deep_wrapper_source(depth: usize, n_elems: u64, iters: u64) -> String {
+    let mut src =
+        String::from("module 0xcafe::test {\n    use std::bcs;\n    use std::vector;\n\n");
+    for k in 1..depth {
+        src.push_str(&format!("    struct D{} has drop {{ f: D{} }}\n", k, k + 1));
+    }
+    src.push_str(&format!("    struct D{} has drop {{ f: u8 }}\n\n", depth));
+
+    let mut ctor = String::from("0u8");
+    for k in (1..=depth).rev() {
+        ctor = format!("D{}{{f:{}}}", k, ctor);
+    }
+
+    src.push_str("    public entry fun run() {\n");
+    src.push_str("        let v = vector::empty<D1>();\n");
+    src.push_str("        let i: u64 = 0;\n");
+    src.push_str(&format!(
+        "        while (i < {n_elems}) {{ vector::push_back(&mut v, {ctor}); i = i + 1; }};\n"
+    ));
+    src.push_str("        let j: u64 = 0;\n");
+    src.push_str(&format!(
+        "        while (j < {iters}) {{ let _b = bcs::to_bytes(&v); j = j + 1; }}\n"
+    ));
+    src.push_str("    }\n}");
+    src
+}
+
+fn publish_deep_wrapper(
+    h: &mut MoveHarness,
+    acc: &Account,
+    depth: usize,
+    n_elems: u64,
+    iters: u64,
+) {
+    let mut builder = PackageBuilder::new("BcsGas");
+    builder.add_source("test", &deep_wrapper_source(depth, n_elems, iters));
+    builder.add_local_dep(
+        "MoveStdlib",
+        &common::framework_dir_path("move-stdlib").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+    assert_success!(h.publish_package_with_options(
+        acc,
+        path.path(),
+        BuildOptions::move_2().set_latest_language(),
+    ));
+}
+
+fn run_id() -> MemberId {
+    MemberId::from_str("0xcafe::test::run").unwrap()
+}
+
+/// `bcs::to_bytes` of a node-heavy, byte-light value should cost far more once the
+/// value-size metering flag is on. Run with `-- --nocapture` to see the numbers.
+///
+/// `MoveHarness::new()` starts on the TESTING chain before the flag's activation
+/// time, so the first run is metered the old (per-byte) way; `new_epoch` forwards
+/// past the activation time to turn the flag on for the second run.
+#[test]
+fn test_bcs_to_bytes_value_size_metering() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    publish_deep_wrapper(&mut h, &acc, 120, 200, 50);
+
+    let gas_off = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
+
+    h.new_epoch();
+    let gas_on = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
+
+    println!("bcs::to_bytes gas  off={gas_off}  on={gas_on}");
+    assert!(
+        gas_on > gas_off * 20,
+        "value-size metering should dominate: on={gas_on} off={gas_off}"
+    );
+}
+
+/// With the flag on, repeatedly serializing a node-heavy value exhausts the
+/// execution-gas budget that the old per-byte cost sails under -- the liveness
+/// attack is now metered. Same value + iteration count, opposite outcomes.
+#[test]
+fn test_bcs_to_bytes_execution_limit() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    publish_deep_wrapper(&mut h, &acc, 120, 200, 100);
+
+    // Flag off: byte-metered, cheap -> the whole loop succeeds.
+    assert_success!(h.run_entry_function(&acc, run_id(), vec![], vec![]));
+
+    // Flag on: node-metered -> the loop blows max_execution_gas.
+    h.new_epoch();
+    let status = h.run_entry_function(&acc, run_id(), vec![], vec![]);
+    assert!(
+        matches!(
+            status,
+            TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(
+                EXECUTION_LIMIT_REACHED
+            )))
+        ),
+        "expected EXECUTION_LIMIT_REACHED, got {status:?}"
+    );
 }

--- a/aptos-move/e2e-move-tests/src/tests/bcs.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bcs.rs
@@ -131,10 +131,6 @@ fn test_constant_serialized_size_dag_no_stall() {
 /// Generates a module with a `depth`-deep single-field wrapper chain
 /// (`D1{f: D2} ... D{depth}{f: u8}`) and an entry `run` that builds a
 /// `vector<D1>` of `n_elems` such values and serializes it `iters` times.
-///
-/// Mirrors the PoC: each wrapper struct is one Value node but serializes to zero
-/// BCS bytes, so the node count far exceeds the output byte count. This is the
-/// case the per-output-byte cost under-charges.
 fn deep_wrapper_source(depth: usize, n_elems: u64, iters: u64) -> String {
     let mut src =
         String::from("module 0xcafe::test {\n    use std::bcs;\n    use std::vector;\n\n");
@@ -169,7 +165,7 @@ fn publish_deep_wrapper(
     n_elems: u64,
     iters: u64,
 ) {
-    let mut builder = PackageBuilder::new("BcsGas");
+    let mut builder = PackageBuilder::new("P");
     builder.add_source("test", &deep_wrapper_source(depth, n_elems, iters));
     builder.add_local_dep(
         "MoveStdlib",
@@ -187,20 +183,13 @@ fn run_id() -> MemberId {
     MemberId::from_str("0xcafe::test::run").unwrap()
 }
 
-/// `bcs::to_bytes` of a node-heavy, byte-light value should cost far more once the
-/// value-size metering flag is on. Run with `-- --nocapture` to see the numbers.
-///
-/// `MoveHarness::new()` starts on the TESTING chain before the flag's activation
-/// time, so the first run is metered the old (per-byte) way; `new_epoch` forwards
-/// past the activation time to turn the flag on for the second run.
 #[test]
 fn test_bcs_to_bytes_value_size_metering() {
     let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    publish_deep_wrapper(&mut h, &acc, 120, 200, 50);
+    publish_deep_wrapper(&mut h, &acc, 120, 100, 30);
 
     let gas_off = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
-
     h.new_epoch();
     let gas_on = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
 
@@ -211,28 +200,22 @@ fn test_bcs_to_bytes_value_size_metering() {
     );
 }
 
-/// With the flag on, repeatedly serializing a node-heavy value exhausts the
-/// execution-gas budget that the old per-byte cost sails under -- the liveness
-/// attack is now metered. Same value + iteration count, opposite outcomes.
 #[test]
 fn test_bcs_to_bytes_execution_limit() {
     let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     publish_deep_wrapper(&mut h, &acc, 120, 200, 100);
 
-    // Flag off: byte-metered, cheap -> the whole loop succeeds.
     assert_success!(h.run_entry_function(&acc, run_id(), vec![], vec![]));
 
-    // Flag on: node-metered -> the loop blows max_execution_gas.
+    // Enable timed feature flag.
     h.new_epoch();
+
     let status = h.run_entry_function(&acc, run_id(), vec![], vec![]);
-    assert!(
-        matches!(
-            status,
-            TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(
-                EXECUTION_LIMIT_REACHED
-            )))
-        ),
-        "expected EXECUTION_LIMIT_REACHED, got {status:?}"
-    );
+    assert!(matches!(
+        status,
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(
+            EXECUTION_LIMIT_REACHED
+        )))
+    ));
 }

--- a/aptos-move/framework/move-stdlib/Cargo.toml
+++ b/aptos-move/framework/move-stdlib/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+aptos-gas-algebra = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-native-interface = { workspace = true }
 aptos-types = { workspace = true }

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -59,8 +59,18 @@ fn native_to_bytes(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let ref_to_val = safely_pop_arg!(args, Reference);
+    let reference_value = safely_pop_arg!(args);
     let arg_type = &ty_args[0];
+
+    // Charge for the value traversal before the deep copy. `to_bytes` makes three
+    // O(node-count) passes over the value -- the `read_ref` deep copy, the
+    // serialization, and the drop of the copy -- which the per-output-byte cost
+    // misses for node-heavy but byte-light values (e.g. single-field wrapper
+    // structs). Uses the same dimension and constants as `cmp::compare`.
+    if context.timed_feature_enabled(TimedFeatureFlag::MeterBcsByValueSize) {
+        let size = context.abs_val_size_dereferenced(&reference_value)?;
+        context.charge(CMP_COMPARE_BASE + CMP_COMPARE_PER_ABS_VAL_UNIT * size)?;
+    }
 
     let layout = if context.get_feature_flags().is_lazy_loading_enabled() {
         // With lazy loading, propagate the error directly. This is because errors here are likely
@@ -86,6 +96,9 @@ fn native_to_bytes(
 
     // TODO(#14175): Reading the reference performs a deep copy, and we can
     //               implement it in a more efficient way.
+    let ref_to_val = reference_value
+        .value_as::<Reference>()
+        .map_err(SafeNativeError::InvariantViolation)?;
     let val = ref_to_val.read_ref()?;
 
     let closure_serialization_disabled = context
@@ -130,8 +143,20 @@ fn native_serialized_size(
 
     context.charge(BCS_SERIALIZED_SIZE_BASE)?;
 
-    let reference = safely_pop_arg!(args, Reference);
+    let reference_value = safely_pop_arg!(args);
     let ty = &ty_args[0];
+
+    // See `native_to_bytes`: charge for the value traversal (deep copy,
+    // serialization, drop) before the `read_ref` deep copy inside
+    // `serialized_size_impl`.
+    if context.timed_feature_enabled(TimedFeatureFlag::MeterBcsByValueSize) {
+        let size = context.abs_val_size_dereferenced(&reference_value)?;
+        context.charge(CMP_COMPARE_BASE + CMP_COMPARE_PER_ABS_VAL_UNIT * size)?;
+    }
+
+    let reference = reference_value
+        .value_as::<Reference>()
+        .map_err(SafeNativeError::InvariantViolation)?;
 
     let serialized_size = match serialized_size_impl(context, reference, ty) {
         Ok(serialized_size) => serialized_size as u64,

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -5,6 +5,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_gas_algebra::{InternalGas, InternalGasPerAbstractValueUnit};
 use aptos_gas_schedule::gas_params::natives::move_stdlib::*;
 use aptos_native_interface::{
     safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
@@ -25,6 +26,13 @@ use move_vm_types::{
 };
 use smallvec::{smallvec, SmallVec};
 use std::collections::VecDeque;
+
+// Set to 3x `cmp::compare`'s base and per-abstract-value-unit costs
+// (3670 and 140).
+// TODO: add these to 1.50 schedule.
+const BCS_PER_VALUE_TRAVERSAL_BASE: InternalGas = InternalGas::new(11010);
+const BCS_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT: InternalGasPerAbstractValueUnit =
+    InternalGasPerAbstractValueUnit::new(420);
 
 pub fn create_option_u64(enum_option_enabled: bool, value: Option<u64>) -> Value {
     if enum_option_enabled {
@@ -62,14 +70,13 @@ fn native_to_bytes(
     let reference_value = safely_pop_arg!(args);
     let arg_type = &ty_args[0];
 
-    // Charge for the value traversal before the deep copy. `to_bytes` makes three
-    // O(node-count) passes over the value -- the `read_ref` deep copy, the
-    // serialization, and the drop of the copy -- which the per-output-byte cost
-    // misses for node-heavy but byte-light values (e.g. single-field wrapper
-    // structs). Uses the same dimension and constants as `cmp::compare`.
+    // Charge for the value traversal before (read_ref's deep copy, later
+    // serialization traversal and drop).
     if context.timed_feature_enabled(TimedFeatureFlag::MeterBcsByValueSize) {
         let size = context.abs_val_size_dereferenced(&reference_value)?;
-        context.charge(CMP_COMPARE_BASE + CMP_COMPARE_PER_ABS_VAL_UNIT * size)?;
+        context.charge(
+            BCS_PER_VALUE_TRAVERSAL_BASE + BCS_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT * size,
+        )?;
     }
 
     let layout = if context.get_feature_flags().is_lazy_loading_enabled() {
@@ -146,12 +153,13 @@ fn native_serialized_size(
     let reference_value = safely_pop_arg!(args);
     let ty = &ty_args[0];
 
-    // See `native_to_bytes`: charge for the value traversal (deep copy,
-    // serialization, drop) before the `read_ref` deep copy inside
-    // `serialized_size_impl`.
+    // Charge for the value traversal before (read_ref's deep copy, later
+    // serialization traversal and drop).
     if context.timed_feature_enabled(TimedFeatureFlag::MeterBcsByValueSize) {
         let size = context.abs_val_size_dereferenced(&reference_value)?;
-        context.charge(CMP_COMPARE_BASE + CMP_COMPARE_PER_ABS_VAL_UNIT * size)?;
+        context.charge(
+            BCS_PER_VALUE_TRAVERSAL_BASE + BCS_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT * size,
+        )?;
     }
 
     let reference = reference_value

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -60,9 +60,8 @@ pub enum TimedFeatureFlag {
     /// module version instead of executing stale pre-upgrade code.
     RevalidateResolvedClosures,
 
-    /// Charge `bcs::to_bytes` and `bcs::serialized_size` per input value node instead of only per
-    /// output byte, so values whose nodes serialize to few or zero bytes (e.g. single-field wrapper
-    /// structs) are metered for the deep copy, serialization, and drop work they actually cost.
+    /// Charge `bcs::to_bytes` and `bcs::serialized_size` per input value node
+    /// instead of only per output byte.
     MeterBcsByValueSize,
 }
 
@@ -271,9 +270,6 @@ impl TimedFeatureFlag {
                 .unwrap()
                 .with_timezone(&Utc),
 
-            // Security fix: meter bcs serialization natives by input value size.
-            // For testing, time set to 1 hour after the beginning of time so tests can
-            // exercise the old and new behaviors on the same harness via `new_epoch`.
             (MeterBcsByValueSize, TESTING) => Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap(),
             (MeterBcsByValueSize, TESTNET) => Los_Angeles
                 .with_ymd_and_hms(2026, 8, 4, 10, 0, 0)

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -59,6 +59,11 @@ pub enum TimedFeatureFlag {
     /// republished within the same transaction, so it binds to the current
     /// module version instead of executing stale pre-upgrade code.
     RevalidateResolvedClosures,
+
+    /// Charge `bcs::to_bytes` and `bcs::serialized_size` per input value node instead of only per
+    /// output byte, so values whose nodes serialize to few or zero bytes (e.g. single-field wrapper
+    /// structs) are metered for the deep copy, serialization, and drop work they actually cost.
+    MeterBcsByValueSize,
 }
 
 /// Representation of features that are gated by the block timestamps.
@@ -107,7 +112,8 @@ impl TimedFeatureOverride {
                 | RevisedBoundsInProdConfig
                 | ConstantSerializedSizeLocalCache
                 | RejectV5ModulePublishing
-                | RevalidateResolvedClosures,
+                | RevalidateResolvedClosures
+                | MeterBcsByValueSize,
             ) => None,
         }
     }
@@ -262,6 +268,19 @@ impl TimedFeatureFlag {
                 .with_timezone(&Utc),
             (RevalidateResolvedClosures, MAINNET) => Los_Angeles
                 .with_ymd_and_hms(2026, 7, 24, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // Security fix: meter bcs serialization natives by input value size.
+            // For testing, time set to 1 hour after the beginning of time so tests can
+            // exercise the old and new behaviors on the same harness via `new_epoch`.
+            (MeterBcsByValueSize, TESTING) => Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap(),
+            (MeterBcsByValueSize, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 8, 4, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (MeterBcsByValueSize, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 8, 5, 10, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -272,11 +272,11 @@ impl TimedFeatureFlag {
 
             (MeterBcsByValueSize, TESTING) => Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap(),
             (MeterBcsByValueSize, TESTNET) => Los_Angeles
-                .with_ymd_and_hms(2026, 8, 4, 10, 0, 0)
+                .with_ymd_and_hms(2026, 8, 4, 14, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
             (MeterBcsByValueSize, MAINNET) => Los_Angeles
-                .with_ymd_and_hms(2026, 8, 5, 10, 0, 0)
+                .with_ymd_and_hms(2026, 8, 6, 14, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Move VM gas for widely used stdlib BCS natives; after activation, transactions that serialize large values may run out of gas or hit execution limits, though behavior stays off until the timed feature activates.
> 
> **Overview**
> Introduces **`MeterBcsByValueSize`**, a timed on-chain flag (testnet/mainnet activation in Aug 2026) that turns on extra gas for **`bcs::to_bytes`** and **`bcs::serialized_size`**.
> 
> When the flag is on, both natives measure the dereferenced argument with **`abs_val_size_dereferenced`** and charge a base plus per–abstract-value-unit fee (constants set at 3× `cmp::compare` costs; not yet in the 1.50 gas schedule). Charging runs **before** `read_ref` and serialization so large/deep values pay for traversal up front. Args are popped as generic **`Value`** first so sizing can happen before casting to **`Reference`**.
> 
> **`aptos-move-stdlib`** gains **`aptos-gas-algebra`**. New e2e tests build deep wrapper chains, assert gas with metering is much higher than without, and that the same workload hits **`EXECUTION_LIMIT_REACHED`** after a new epoch enables the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef0562e039af7b29b07bc0b2b3d02d862f6b30f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->