### PR TITLE
[vm] Add ordering for side-effects traversal

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -77,6 +77,7 @@ mod remote_state;
 mod resource_groups;
 mod rotate_auth_key;
 mod scripts;
+mod serialize_effects_determinism;
 mod sessions_with_delayed_fields;
 mod simple_defi;
 mod smart_data_structures;

--- a/aptos-move/e2e-move-tests/src/tests/serialize_effects_determinism.rs
+++ b/aptos-move/e2e-move-tests/src/tests/serialize_effects_determinism.rs
@@ -1,0 +1,191 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Regression test: the transaction status must not depend on struct-name
+//! interning order.
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_block_executor::{
+    code_cache_global_manager::AptosModuleCacheManager, txn_commit_hook::NoOpTransactionCommitHook,
+    txn_provider::default::DefaultTxnProvider,
+};
+use aptos_language_e2e_tests::account::Account;
+use aptos_package_builder::PackageBuilder;
+use aptos_types::{
+    account_address::AccountAddress,
+    block_executor::{
+        config::BlockExecutorConfig, transaction_slice_metadata::TransactionSliceMetadata,
+    },
+    state_store::StateView,
+    transaction::{
+        signature_verified_transaction::into_signature_verified_block, ExecutionStatus,
+        SignedTransaction, Transaction, TransactionOutput, TransactionStatus,
+    },
+    vm_status::VMStatus,
+};
+use aptos_vm::block_executor::AptosVMBlockExecutorWrapper;
+use move_core_types::vm_status::StatusCode;
+
+fn agg_source(addr: &str) -> String {
+    // There are at most 10 aggregators per resource, so use 11 to force the
+    // serialization to fail.
+    const NUM_AGGS: usize = 11;
+
+    let mut s = String::new();
+    s.push_str(&format!("module {}::agg {{\n", addr));
+    s.push_str("    use aptos_framework::aggregator_v2::{Self, Aggregator};\n");
+    s.push_str("    struct A has key {\n");
+    for i in 0..NUM_AGGS {
+        s.push_str(&format!("        a{}: Aggregator<u64>,\n", i));
+    }
+    s.push_str("    }\n");
+    s.push_str("    public fun make(s: &signer) {\n        move_to(s, A {\n");
+    for i in 0..NUM_AGGS {
+        s.push_str(&format!(
+            "            a{}: aggregator_v2::create_unbounded_aggregator<u64>(),\n",
+            i
+        ));
+    }
+    s.push_str("        })\n    }\n");
+    s.push_str("}\n");
+    s
+}
+
+fn clo_source(addr: &str) -> String {
+    // Using 11 here to trigger serialization failure because layout of the struct
+    // is too large.
+    const N: usize = 11;
+
+    let mut s = String::new();
+    s.push_str(&format!("module {}::clo {{\n", addr));
+    s.push_str("    struct S0 has copy, drop, store { v: u8 }\n");
+    for i in 0..N {
+        s.push_str(&format!(
+            "    struct S{} has copy, drop, store {{ l: S{}, r: S{} }}\n",
+            i + 1,
+            i,
+            i
+        ));
+    }
+    s.push_str("    struct Work has copy, drop, store, key { bar: || }\n");
+    s.push_str(&format!(
+        "    #[persistent] fun consumer(_o: vector<S{}>) {{}}\n",
+        N
+    ));
+    s.push_str(&format!(
+        "    public fun make(s: &signer) {{\n        \
+                 let o: vector<S{}> = vector[];\n        \
+                 move_to(s, Work {{ bar: || consumer(o) }})\n    \
+             }}\n",
+        N
+    ));
+    s.push_str("    public entry fun touch(_s: &signer) {}\n");
+    s.push_str("}\n");
+    s
+}
+
+fn setup() -> (MoveHarness, Account) {
+    let addr = "0xcafe";
+    let mut builder = PackageBuilder::new("P");
+    builder.add_source("agg.move", &agg_source(addr));
+    builder.add_source("clo.move", &clo_source(addr));
+
+    let driver_source = format!(
+        "module {addr}::drv {{\n    \
+             use {addr}::agg;\n    \
+             use {addr}::clo;\n    \
+             public entry fun agg_then_clo(s: &signer) {{ agg::make(s); clo::make(s) }}\n\
+         }}\n",
+    );
+    builder.add_source("drv.move", &driver_source);
+
+    for (name, path) in [
+        ("MoveStdlib", "move-stdlib"),
+        ("AptosStdlib", "aptos-stdlib"),
+        ("AptosFramework", "aptos-framework"),
+    ] {
+        builder.add_local_dep(name, &common::framework_dir_path(path).to_string_lossy());
+    }
+    let path = builder.write_to_temp().unwrap();
+
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal(addr).unwrap());
+    assert_success!(h.publish_package(&acc, path.path()));
+    (h, acc)
+}
+
+fn execute_block(
+    txn: SignedTransaction,
+    state_view: &(impl StateView + Sync),
+    manager: &AptosModuleCacheManager,
+    parent: u64,
+    child: u64,
+) -> TransactionOutput {
+    let block = into_signature_verified_block(vec![Transaction::UserTransaction(txn)]);
+    let txn_provider = DefaultTxnProvider::new_without_info(block);
+    AptosVMBlockExecutorWrapper::execute_block::<_, NoOpTransactionCommitHook<VMStatus>, _>(
+        &txn_provider,
+        state_view,
+        manager,
+        BlockExecutorConfig::new_no_block_limit(1),
+        TransactionSliceMetadata::block(
+            aptos_crypto::HashValue::from_u64(parent),
+            aptos_crypto::HashValue::from_u64(child),
+        ),
+        None,
+    )
+    .unwrap()
+    .into_transaction_outputs_forced()
+    .first()
+    .unwrap()
+    .clone()
+}
+
+/// Same state, same block, only interner warmth differs. Every output field must
+/// agree, and the status must be the `StructTag`-first failure. Before the fix
+/// the statuses diverged.
+#[test]
+fn cold_vs_warm_status_matches() {
+    let (mut h, acc) = setup();
+    let manager = AptosModuleCacheManager::new();
+
+    // Block 1: Runs a transaction to warm up the cache.
+    let sender = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+    let warming_txn = h.create_entry_function(
+        &sender,
+        str::parse("0xcafe::clo::touch").unwrap(),
+        vec![],
+        vec![],
+    );
+    let outs = execute_block(warming_txn, h.executor.get_state_view(), &manager, 1, 2);
+    assert_success!(outs.status().clone());
+    h.executor.apply_write_set(outs.write_set());
+
+    // Transaction that touches and serializes resources in both modules.
+    let target = h.create_entry_function(
+        &acc,
+        str::parse("0xcafe::drv::agg_then_clo").unwrap(),
+        vec![],
+        vec![],
+    );
+
+    // Warm: still has `clo` data in the cache from the previous block.
+    let warm = execute_block(target.clone(), h.executor.get_state_view(), &manager, 2, 3);
+
+    // Cold: run with no caches.
+    let cold = execute_block(
+        target,
+        h.executor.get_state_view(),
+        &AptosModuleCacheManager::new(),
+        2,
+        3,
+    );
+
+    assert_eq!(cold.status(), warm.status());
+    assert_eq!(
+        cold.status().clone(),
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(
+            StatusCode::TOO_MANY_DELAYED_FIELDS,
+        ))),
+    );
+}

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -30,7 +30,7 @@ use move_vm_types::{
     value_serde::{FunctionValueExtension, ValueSerDeContext},
     values::{GlobalValue, Value},
 };
-use std::collections::btree_map::{BTreeMap, Entry};
+use std::collections::{hash_map::Entry, BTreeMap, HashMap};
 use triomphe::Arc as TriompheArc;
 
 /// A hack to be able to use [MoveVmDataCache] in native context where there is no access to
@@ -223,7 +223,9 @@ struct DataCacheEntry {
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
 pub struct TransactionDataCache {
-    account_map: BTreeMap<AccountAddress, BTreeMap<Type, DataCacheEntry>>,
+    // CAUTION: Iterating the inner map is not deterministic, one should
+    // enforce the ordering deterministically.
+    account_map: BTreeMap<AccountAddress, HashMap<Type, DataCacheEntry>>,
 }
 
 impl TransactionDataCache {
@@ -271,7 +273,18 @@ impl TransactionDataCache {
         let mut change_set = Changes::<Resource>::new();
         for (addr, account_data_cache) in self.account_map.into_iter() {
             let mut resources = BTreeMap::new();
-            for entry in account_data_cache.into_values() {
+
+            // Serialize resources in struct tag order so that the ordering is
+            // deterministic. This protects against
+            //   1) Non-deterministic hashmap iteration,
+            //   2) Non-deterministic type ordering (struct names are interned
+            //      in non-deterministic way and cannot be compared).
+            // This matters for cases when serialization of a resource fails,
+            // and the reported error may depend on the iteration order.
+            let mut account_data_cache = account_data_cache.into_values().collect::<Vec<_>>();
+            account_data_cache.sort_by(|a, b| a.struct_tag.cmp(&b.struct_tag));
+
+            for entry in account_data_cache {
                 let DataCacheEntry {
                     struct_tag,
                     layout,

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -304,7 +304,9 @@ impl StructIdentifier {
     }
 }
 
-#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+// CAUTION: Do not derive/implement `Ord`/`PartialOrd` because `StructNameIndex`
+// is not guaranteed to be deterministic.
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum Type {
     Bool,
     U8,

--- a/third_party/move/move-vm/types/src/loaded_data/struct_name_indexing.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/struct_name_indexing.rs
@@ -21,7 +21,7 @@ macro_rules! panic_error {
 
 /// Represents a unique identifier for the struct name. Note that this index has no public
 /// constructor - the only way to construct it is via [StructNameIndexMap].
-#[derive(Debug, Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub struct StructNameIndex(u32);
 
 impl StructNameIndex {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core VM effect serialization and transaction outcome determinism, which consensus depends on; the change is a targeted ordering fix plus a regression test.
> 
> **Overview**
> Fixes **non-deterministic transaction status** when resource serialization fails during effect building. The VM could report different errors depending on module-cache warmth because dirty resources were processed in hash-map iteration order and `Type` ordering relied on non-deterministic `StructNameIndex` values.
> 
> **`TransactionDataCache`** now stores per-account resources in a `HashMap` (lookup unchanged) but **sorts entries by `StructTag`** before serializing in `into_custom_effects`, so failure order is stable. **`Type`** and **`StructNameIndex`** no longer implement `Ord`/`PartialOrd`, with comments warning against using them for ordering.
> 
> Adds e2e test **`serialize_effects_determinism::cold_vs_warm_status_matches`** that runs the same failing txn with warm vs cold module caches and asserts identical `TOO_MANY_DELAYED_FIELDS` status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd058ff48449a4b7be78f6f6e3cfac222b18f34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->