### PR TITLE
[mono-move] Remaining bls12381 natives

### DIFF
--- a/third_party/move/mono-move/core/src/native/value.rs
+++ b/third_party/move/mono-move/core/src/native/value.rs
@@ -331,6 +331,24 @@ impl<'a, V> Vector<'a, V> {
     // TODO(completeness): Other vector APIs, added on-demand.
 }
 
+impl<'a, V> Vector<'a, Vector<'a, V>> {
+    /// Returns element `i` of a `vector<vector<V>>` -- the inner `vector<V>` --
+    /// as a handle rooted for the rest of the native call.
+    ///
+    /// Each element of a nested vector is an 8-byte heap pointer to the inner
+    /// vector object, so this reads that pointer and roots it, mirroring
+    /// [`Ref::borrow`]. The caller must ensure `i < len()`.
+    #[inline]
+    pub fn get(&self, i: u64) -> Vector<'a, V> {
+        // SAFETY: element `i` (within bounds) of a `vector<vector<V>>` is an
+        // 8-byte heap pointer to the inner vector object.
+        let inner_ptr = unsafe { read_ptr(self.ptr(), VEC_DATA_OFFSET + i as usize * 8) };
+        // Root the inner vector so it survives GC for the rest of the call,
+        // even if the outer slot is later overwritten.
+        Vector::from_handle(unsafe { self.handle.pool().root_object(inner_ptr) })
+    }
+}
+
 impl Vector<'_, u8> {
     /// Returns a reference to the bytes stored in the vector, borrowed directly from the heap.
     ///
@@ -450,5 +468,54 @@ mod tests {
             unsafe { read_fat_ptr(frame.as_ptr(), 16usize) },
             (base, offset)
         );
+    }
+
+    /// Lays out a `vector<u8>` heap object -- `[len: u64][bytes...]` -- in an
+    /// 8-byte-aligned buffer. The object's data pointer is the buffer's start:
+    /// the length is at `VEC_LENGTH_OFFSET`, the bytes at `VEC_DATA_OFFSET`.
+    fn byte_vec_object_for_test(bytes: &[u8]) -> Vec<u64> {
+        let mut buf = vec![0u64; 1 + bytes.len().div_ceil(8)];
+        buf[0] = bytes.len() as u64;
+        // SAFETY: `buf` has room for `bytes.len()` bytes after the length word.
+        let data = unsafe {
+            std::slice::from_raw_parts_mut(buf.as_mut_ptr().add(1) as *mut u8, bytes.len())
+        };
+        data.copy_from_slice(bytes);
+        buf
+    }
+
+    /// `Vector::<Vector<u8>>::get` reads each inner byte vector back by value,
+    /// including an empty inner vector.
+    #[test]
+    fn nested_byte_vector_get_reads_elements() {
+        let pool = RootPool::new();
+
+        // Three inner byte vectors, kept alive for the reads below.
+        let inners = [
+            byte_vec_object_for_test(b"hello"),
+            byte_vec_object_for_test(b""),
+            byte_vec_object_for_test(b"world!!"),
+        ];
+
+        // Outer object: `[len: u64][inner_ptr0][inner_ptr1][inner_ptr2]`.
+        let mut outer = vec![0u64; 1 + inners.len()];
+        outer[0] = inners.len() as u64;
+        for (i, inner) in inners.iter().enumerate() {
+            outer[1 + i] = inner.as_ptr() as u64;
+        }
+
+        // SAFETY: `outer` is a valid `vector<vector<u8>>` object and the inner
+        // buffers outlive the reads.
+        let vec: Vector<Vector<u8>> =
+            Vector::from_handle(unsafe { pool.root_object(outer.as_ptr() as *mut u8) });
+
+        assert_eq!(vec.len(), 3);
+        // Bind each inner handle so its bytes outlive the borrow.
+        let e0 = vec.get(0);
+        let e1 = vec.get(1);
+        let e2 = vec.get(2);
+        assert_eq!(unsafe { e0.as_bytes() }, b"hello");
+        assert_eq!(unsafe { e1.as_bytes() }, b"");
+        assert_eq!(unsafe { e2.as_bytes() }, b"world!!");
     }
 }

--- a/third_party/move/mono-move/core/src/native/value.rs
+++ b/third_party/move/mono-move/core/src/native/value.rs
@@ -331,6 +331,24 @@ impl<'a, V> Vector<'a, V> {
     // TODO(completeness): Other vector APIs, added on-demand.
 }
 
+impl<'a, V> Vector<'a, Vector<'a, V>> {
+    /// Returns element `i` of a `vector<vector<V>>` -- the inner `vector<V>` --
+    /// as a handle rooted for the rest of the native call.
+    ///
+    /// Each element of a nested vector is an 8-byte heap pointer to the inner
+    /// vector object, so this reads that pointer and roots it, mirroring
+    /// [`Ref::borrow`]. The caller must ensure `i < len()`.
+    #[inline]
+    pub fn get(&self, i: u64) -> Vector<'a, V> {
+        // SAFETY: element `i` (within bounds) of a `vector<vector<V>>` is an
+        // 8-byte heap pointer to the inner vector object.
+        let inner_ptr = unsafe { read_ptr(self.ptr(), VEC_DATA_OFFSET + i as usize * 8) };
+        // Root the inner vector so it survives GC for the rest of the call,
+        // even if the outer slot is later overwritten.
+        Vector::from_handle(unsafe { self.handle.pool().root_object(inner_ptr) })
+    }
+}
+
 impl Vector<'_, u8> {
     /// Returns a reference to the bytes stored in the vector, borrowed directly from the heap.
     ///
@@ -450,5 +468,53 @@ mod tests {
             unsafe { read_fat_ptr(frame.as_ptr(), 16usize) },
             (base, offset)
         );
+    }
+
+    /// Lays out a `vector<u8>` heap object -- `[len: u64][bytes...]` -- in an
+    /// 8-byte-aligned buffer. The object's data pointer is the buffer's start:
+    /// the length is at `VEC_LENGTH_OFFSET`, the bytes at `VEC_DATA_OFFSET`.
+    fn byte_vec_object(bytes: &[u8]) -> Vec<u64> {
+        let mut buf = vec![0u64; 1 + bytes.len().div_ceil(8)];
+        buf[0] = bytes.len() as u64;
+        // SAFETY: `buf` has room for `bytes.len()` bytes after the length word.
+        let data =
+            unsafe { std::slice::from_raw_parts_mut(buf.as_mut_ptr().add(1) as *mut u8, bytes.len()) };
+        data.copy_from_slice(bytes);
+        buf
+    }
+
+    /// `Vector::<Vector<u8>>::get` reads each inner byte vector back by value,
+    /// including an empty inner vector.
+    #[test]
+    fn nested_byte_vector_get_reads_elements() {
+        let pool = RootPool::new();
+
+        // Three inner byte vectors, kept alive for the reads below.
+        let inners = [
+            byte_vec_object(b"hello"),
+            byte_vec_object(b""),
+            byte_vec_object(b"world!!"),
+        ];
+
+        // Outer object: `[len: u64][inner_ptr0][inner_ptr1][inner_ptr2]`.
+        let mut outer = vec![0u64; 1 + inners.len()];
+        outer[0] = inners.len() as u64;
+        for (i, inner) in inners.iter().enumerate() {
+            outer[1 + i] = inner.as_ptr() as u64;
+        }
+
+        // SAFETY: `outer` is a valid `vector<vector<u8>>` object and the inner
+        // buffers outlive the reads.
+        let vec: Vector<Vector<u8>> =
+            Vector::from_handle(unsafe { pool.root_object(outer.as_ptr() as *mut u8) });
+
+        assert_eq!(vec.len(), 3);
+        // Bind each inner handle so its bytes outlive the borrow.
+        let e0 = vec.get(0);
+        let e1 = vec.get(1);
+        let e2 = vec.get(2);
+        assert_eq!(unsafe { e0.as_bytes() }, b"hello");
+        assert_eq!(unsafe { e1.as_bytes() }, b"");
+        assert_eq!(unsafe { e2.as_bytes() }, b"world!!");
     }
 }

--- a/third_party/move/mono-move/core/src/root_pool.rs
+++ b/third_party/move/mono-move/core/src/root_pool.rs
@@ -210,7 +210,12 @@ pub struct ObjectHandle<'a> {
     idx: usize,
 }
 
-impl ObjectHandle<'_> {
+impl<'a> ObjectHandle<'a> {
+    /// The pool this handle is rooted in.
+    pub(crate) fn pool(&self) -> &'a RootPool {
+        self.pool
+    }
+
     /// Reads the current pointer to the object.
     ///
     /// # Safety

--- a/third_party/move/mono-move/natives/src/bls12381.rs
+++ b/third_party/move/mono-move/natives/src/bls12381.rs
@@ -4,13 +4,12 @@
 //! Natives for the `bls12381` module.
 
 use crate::{monomorphic_natives, NativeEntry};
-use aptos_crypto::{bls12381, traits::Signature};
-#[cfg(feature = "testing")]
 use aptos_crypto::{
-    bls12381::{PrivateKey, ProofOfPossession, PublicKey},
-    test_utils::KeyPair,
-    SigningKey, Uniform,
+    bls12381::{self, ProofOfPossession, PublicKey},
+    traits::Signature,
 };
+#[cfg(feature = "testing")]
+use aptos_crypto::{bls12381::PrivateKey, test_utils::KeyPair, SigningKey, Uniform};
 use mono_move_core::{
     native::{NativeContext, NativeContextFamily, NativeStatus, Vector},
     VMResult,
@@ -135,6 +134,164 @@ pub fn native_verify_proof_of_possession<C: NativeContext>(ctx: &C) -> VMResult<
     Ok(NativeStatus::Success)
 }
 
+/// Writes the "no aggregate" result -- `(empty vector<u8>, false)` -- shared by
+/// the two aggregate natives when there is nothing to aggregate or an input
+/// fails to deserialize.
+fn aggregate_none<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let empty = ctx.new_byte_vector(&[])?;
+    // SAFETY: return slot 0 is `vector<u8>`, slot 1 is `bool`.
+    unsafe { ctx.set_return(0, empty)? };
+    unsafe { ctx.set_return(1, false)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::bls12381::aggregate_pubkeys_internal(public_keys: vector<PublicKeyWithPoP>): (vector<u8>, bool)`
+///
+/// TODO(metering): charge gas.
+pub fn native_aggregate_pubkeys<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // A `PublicKeyWithPoP` is a one-field struct wrapping `vector<u8>`, so a
+    // `vector<PublicKeyWithPoP>` has the same representation as
+    // `vector<vector<u8>>`: each element reads back as an inner byte vector.
+    // SAFETY: arg 0 is `vector<PublicKeyWithPoP>`.
+    let pks: Vector<Vector<u8>> = unsafe { ctx.arg(0)? };
+    let num_pks = pks.len();
+
+    // If zero PKs were given as input, there is no aggregate.
+    if num_pks == 0 {
+        return aggregate_none(ctx);
+    }
+
+    // Deserialize every public key, stopping at the first that fails.
+    let mut deserialized = Vec::with_capacity(num_pks as usize);
+    for i in 0..num_pks {
+        let pk = pks.get(i);
+        // SAFETY: byte slice consumed before any allocation.
+        let Ok(pk) = PublicKey::try_from(unsafe { pk.as_bytes() }) else {
+            break;
+        };
+        deserialized.push(pk);
+    }
+
+    // If not all PKs deserialized, or aggregation fails, there is no aggregate.
+    if deserialized.len() as u64 != num_pks {
+        return aggregate_none(ctx);
+    }
+    let Ok(aggpk) = PublicKey::aggregate(deserialized.iter().collect::<Vec<_>>()) else {
+        return aggregate_none(ctx);
+    };
+
+    let bytes = ctx.new_byte_vector(&aggpk.to_bytes())?;
+    // SAFETY: return slot 0 is `vector<u8>`, slot 1 is `bool`.
+    unsafe { ctx.set_return(0, bytes)? };
+    unsafe { ctx.set_return(1, true)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::bls12381::aggregate_signatures_internal(signatures: vector<Signature>): (vector<u8>, bool)`
+///
+/// TODO(metering): charge gas.
+pub fn native_aggregate_signatures<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // A `Signature` is a one-field struct wrapping `vector<u8>`, read the same
+    // way as a `vector<vector<u8>>`.
+    // SAFETY: arg 0 is `vector<Signature>`.
+    let sigs: Vector<Vector<u8>> = unsafe { ctx.arg(0)? };
+    let num_sigs = sigs.len();
+
+    // If zero signatures were given as input, there is no aggregate.
+    if num_sigs == 0 {
+        return aggregate_none(ctx);
+    }
+
+    // Deserialize every signature, stopping at the first that fails.
+    let mut deserialized = Vec::with_capacity(num_sigs as usize);
+    for i in 0..num_sigs {
+        let sig = sigs.get(i);
+        // SAFETY: byte slice consumed before any allocation.
+        let Ok(sig) = bls12381::Signature::try_from(unsafe { sig.as_bytes() }) else {
+            break;
+        };
+        deserialized.push(sig);
+    }
+
+    // If not all signatures deserialized, or aggregation fails, there is no
+    // aggregate.
+    if deserialized.len() as u64 != num_sigs {
+        return aggregate_none(ctx);
+    }
+    let Ok(aggsig) = bls12381::Signature::aggregate(deserialized) else {
+        return aggregate_none(ctx);
+    };
+
+    let bytes = ctx.new_byte_vector(&aggsig.to_bytes())?;
+    // SAFETY: return slot 0 is `vector<u8>`, slot 1 is `bool`.
+    unsafe { ctx.set_return(0, bytes)? };
+    unsafe { ctx.set_return(1, true)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::bls12381::verify_aggregate_signature_internal(aggsig: vector<u8>, public_keys: vector<PublicKeyWithPoP>, messages: vector<vector<u8>>): bool`
+///
+/// TODO(metering): charge gas.
+pub fn native_verify_aggregate_signature<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`, arg 1 is `vector<PublicKeyWithPoP>`, arg 2
+    // is `vector<vector<u8>>`.
+    let aggsig: Vector<u8> = unsafe { ctx.arg(0)? };
+    let pks: Vector<Vector<u8>> = unsafe { ctx.arg(1)? };
+    let messages: Vector<Vector<u8>> = unsafe { ctx.arg(2)? };
+
+    let num_pks = pks.len();
+
+    // The number of messages must match the number of public keys.
+    if num_pks != messages.len() {
+        // SAFETY: return slot 0 is `bool`.
+        unsafe { ctx.set_return(0, false)? };
+        return Ok(NativeStatus::Success);
+    }
+
+    // Deserialize every public key, stopping at the first that fails.
+    let mut pk_vals = Vec::with_capacity(num_pks as usize);
+    for i in 0..num_pks {
+        let pk = pks.get(i);
+        // SAFETY: byte slice consumed before any allocation.
+        let Ok(pk) = PublicKey::try_from(unsafe { pk.as_bytes() }) else {
+            break;
+        };
+        pk_vals.push(pk);
+    }
+    if pk_vals.len() as u64 != num_pks {
+        // SAFETY: return slot 0 is `bool`.
+        unsafe { ctx.set_return(0, false)? };
+        return Ok(NativeStatus::Success);
+    }
+
+    // SAFETY: byte slice consumed before any allocation.
+    let Ok(aggsig) = bls12381::Signature::try_from(unsafe { aggsig.as_bytes() }) else {
+        // SAFETY: return slot 0 is `bool`.
+        unsafe { ctx.set_return(0, false)? };
+        return Ok(NativeStatus::Success);
+    };
+
+    // Root every message vector, then borrow their bytes together for the
+    // verify call. No VM allocation happens in between, so the slices stay
+    // valid.
+    let msg_vecs = (0..messages.len())
+        .map(|i| messages.get(i))
+        .collect::<Vec<_>>();
+    // SAFETY: byte slices consumed before any allocation.
+    let msg_refs = msg_vecs
+        .iter()
+        .map(|m| unsafe { m.as_bytes() })
+        .collect::<Vec<_>>();
+    let pk_refs = pk_vals.iter().collect::<Vec<_>>();
+
+    let valid = aggsig
+        .verify_aggregate_arbitrary_msg(&msg_refs, &pk_refs)
+        .is_ok();
+    // SAFETY: return slot 0 is `bool`.
+    unsafe { ctx.set_return(0, valid)? };
+    Ok(NativeStatus::Success)
+}
+
 /// Production natives for the `bls12381` module.
 pub fn make_all_bls12381_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
     monomorphic_natives![
@@ -161,6 +318,18 @@ pub fn make_all_bls12381_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>
         (
             "0x1::bls12381::verify_proof_of_possession_internal",
             native_verify_proof_of_possession
+        ),
+        (
+            "0x1::bls12381::aggregate_pubkeys_internal",
+            native_aggregate_pubkeys
+        ),
+        (
+            "0x1::bls12381::aggregate_signatures_internal",
+            native_aggregate_signatures
+        ),
+        (
+            "0x1::bls12381::verify_aggregate_signature_internal",
+            native_verify_aggregate_signature
         ),
     ]
 }

--- a/third_party/move/mono-move/natives/src/bls12381.rs
+++ b/third_party/move/mono-move/natives/src/bls12381.rs
@@ -4,12 +4,11 @@
 //! Natives for the `bls12381` module.
 
 use crate::{monomorphic_natives, NativeEntry};
-use aptos_crypto::{bls12381, traits::Signature};
 #[cfg(feature = "testing")]
+use aptos_crypto::{bls12381::PrivateKey, test_utils::KeyPair, SigningKey, Uniform};
 use aptos_crypto::{
-    bls12381::{PrivateKey, ProofOfPossession, PublicKey},
-    test_utils::KeyPair,
-    SigningKey, Uniform,
+    bls12381::{self, ProofOfPossession, PublicKey},
+    traits::Signature,
 };
 use mono_move_core::{
     native::{NativeContext, NativeContextFamily, NativeStatus, Vector},
@@ -135,6 +134,164 @@ pub fn native_verify_proof_of_possession<C: NativeContext>(ctx: &C) -> VMResult<
     Ok(NativeStatus::Success)
 }
 
+/// Writes the "no aggregate" result -- `(empty vector<u8>, false)` -- shared by
+/// the two aggregate natives when there is nothing to aggregate or an input
+/// fails to deserialize.
+fn aggregate_none<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let empty = ctx.new_byte_vector(&[])?;
+    // SAFETY: return slot 0 is `vector<u8>`, slot 1 is `bool`.
+    unsafe { ctx.set_return(0, empty)? };
+    unsafe { ctx.set_return(1, false)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::bls12381::aggregate_pubkeys_internal(public_keys: vector<PublicKeyWithPoP>): (vector<u8>, bool)`
+///
+/// TODO(metering): charge gas.
+pub fn native_aggregate_pubkeys<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // A `PublicKeyWithPoP` is a one-field struct wrapping `vector<u8>`, so a
+    // `vector<PublicKeyWithPoP>` has the same representation as
+    // `vector<vector<u8>>`: each element reads back as an inner byte vector.
+    // SAFETY: arg 0 is `vector<PublicKeyWithPoP>`.
+    let pks: Vector<Vector<u8>> = unsafe { ctx.arg(0)? };
+    let num_pks = pks.len();
+
+    // If zero PKs were given as input, there is no aggregate.
+    if num_pks == 0 {
+        return aggregate_none(ctx);
+    }
+
+    // Deserialize every public key, stopping at the first that fails.
+    let mut deserialized = Vec::with_capacity(num_pks as usize);
+    for i in 0..num_pks {
+        let pk = pks.get(i);
+        // SAFETY: byte slice consumed before any allocation.
+        let Ok(pk) = PublicKey::try_from(unsafe { pk.as_bytes() }) else {
+            break;
+        };
+        deserialized.push(pk);
+    }
+
+    // If not all PKs deserialized, or aggregation fails, there is no aggregate.
+    if deserialized.len() as u64 != num_pks {
+        return aggregate_none(ctx);
+    }
+    let Ok(aggpk) = PublicKey::aggregate(deserialized.iter().collect::<Vec<_>>()) else {
+        return aggregate_none(ctx);
+    };
+
+    let bytes = ctx.new_byte_vector(&aggpk.to_bytes())?;
+    // SAFETY: return slot 0 is `vector<u8>`, slot 1 is `bool`.
+    unsafe { ctx.set_return(0, bytes)? };
+    unsafe { ctx.set_return(1, true)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::bls12381::aggregate_signatures_internal(signatures: vector<Signature>): (vector<u8>, bool)`
+///
+/// TODO(metering): charge gas.
+pub fn native_aggregate_signatures<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // A `Signature` is a one-field struct wrapping `vector<u8>`, read the same
+    // way as a `vector<vector<u8>>`.
+    // SAFETY: arg 0 is `vector<Signature>`.
+    let sigs: Vector<Vector<u8>> = unsafe { ctx.arg(0)? };
+    let num_sigs = sigs.len();
+
+    // If zero signatures were given as input, there is no aggregate.
+    if num_sigs == 0 {
+        return aggregate_none(ctx);
+    }
+
+    // Deserialize every signature, stopping at the first that fails.
+    let mut deserialized = Vec::with_capacity(num_sigs as usize);
+    for i in 0..num_sigs {
+        let sig = sigs.get(i);
+        // SAFETY: byte slice consumed before any allocation.
+        let Ok(sig) = bls12381::Signature::try_from(unsafe { sig.as_bytes() }) else {
+            break;
+        };
+        deserialized.push(sig);
+    }
+
+    // If not all signatures deserialized, or aggregation fails, there is no
+    // aggregate.
+    if deserialized.len() as u64 != num_sigs {
+        return aggregate_none(ctx);
+    }
+    let Ok(aggsig) = bls12381::Signature::aggregate(deserialized) else {
+        return aggregate_none(ctx);
+    };
+
+    let bytes = ctx.new_byte_vector(&aggsig.to_bytes())?;
+    // SAFETY: return slot 0 is `vector<u8>`, slot 1 is `bool`.
+    unsafe { ctx.set_return(0, bytes)? };
+    unsafe { ctx.set_return(1, true)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::bls12381::verify_aggregate_signature_internal(aggsig: vector<u8>, public_keys: vector<PublicKeyWithPoP>, messages: vector<vector<u8>>): bool`
+///
+/// TODO(metering): charge gas.
+pub fn native_verify_aggregate_signature<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`, arg 1 is `vector<PublicKeyWithPoP>`, arg 2
+    // is `vector<vector<u8>>`.
+    let aggsig: Vector<u8> = unsafe { ctx.arg(0)? };
+    let pks: Vector<Vector<u8>> = unsafe { ctx.arg(1)? };
+    let messages: Vector<Vector<u8>> = unsafe { ctx.arg(2)? };
+
+    let num_pks = pks.len();
+
+    // The number of messages must match the number of public keys.
+    if num_pks != messages.len() {
+        // SAFETY: return slot 0 is `bool`.
+        unsafe { ctx.set_return(0, false)? };
+        return Ok(NativeStatus::Success);
+    }
+
+    // Deserialize every public key, stopping at the first that fails.
+    let mut pk_vals = Vec::with_capacity(num_pks as usize);
+    for i in 0..num_pks {
+        let pk = pks.get(i);
+        // SAFETY: byte slice consumed before any allocation.
+        let Ok(pk) = PublicKey::try_from(unsafe { pk.as_bytes() }) else {
+            break;
+        };
+        pk_vals.push(pk);
+    }
+    if pk_vals.len() as u64 != num_pks {
+        // SAFETY: return slot 0 is `bool`.
+        unsafe { ctx.set_return(0, false)? };
+        return Ok(NativeStatus::Success);
+    }
+
+    // SAFETY: byte slice consumed before any allocation.
+    let Ok(aggsig) = bls12381::Signature::try_from(unsafe { aggsig.as_bytes() }) else {
+        // SAFETY: return slot 0 is `bool`.
+        unsafe { ctx.set_return(0, false)? };
+        return Ok(NativeStatus::Success);
+    };
+
+    // Root every message vector, then borrow their bytes together for the
+    // verify call. No VM allocation happens in between, so the slices stay
+    // valid.
+    let msg_vecs = (0..messages.len())
+        .map(|i| messages.get(i))
+        .collect::<Vec<_>>();
+    // SAFETY: byte slices consumed before any allocation.
+    let msg_refs = msg_vecs
+        .iter()
+        .map(|m| unsafe { m.as_bytes() })
+        .collect::<Vec<_>>();
+    let pk_refs = pk_vals.iter().collect::<Vec<_>>();
+
+    let valid = aggsig
+        .verify_aggregate_arbitrary_msg(&msg_refs, &pk_refs)
+        .is_ok();
+    // SAFETY: return slot 0 is `bool`.
+    unsafe { ctx.set_return(0, valid)? };
+    Ok(NativeStatus::Success)
+}
+
 /// Production natives for the `bls12381` module.
 pub fn make_all_bls12381_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
     monomorphic_natives![
@@ -161,6 +318,18 @@ pub fn make_all_bls12381_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>
         (
             "0x1::bls12381::verify_proof_of_possession_internal",
             native_verify_proof_of_possession
+        ),
+        (
+            "0x1::bls12381::aggregate_pubkeys_internal",
+            native_aggregate_pubkeys
+        ),
+        (
+            "0x1::bls12381::aggregate_signatures_internal",
+            native_aggregate_signatures
+        ),
+        (
+            "0x1::bls12381::verify_aggregate_signature_internal",
+            native_verify_aggregate_signature
         ),
     ]
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/bls12381.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/bls12381.move
@@ -2,6 +2,17 @@
 
 // RUN: publish
 module 0x1::bls12381 {
+    // One-field wrappers matching the framework structs. Each is byte-identical
+    // to a bare `vector<u8>`, so the aggregate natives receive them as a
+    // `vector<vector<u8>>` on v2 while v1 unpacks the struct field.
+    struct PublicKeyWithPoP has copy, drop, store {
+        bytes: vector<u8>,
+    }
+
+    struct Signature has copy, drop, store {
+        bytes: vector<u8>,
+    }
+
     native fun validate_pubkey_internal(public_key: vector<u8>): bool;
 
     native fun signature_subgroup_check_internal(signature: vector<u8>): bool;
@@ -34,6 +45,28 @@ module 0x1::bls12381 {
     native fun sign_internal(sk: vector<u8>, msg: vector<u8>): vector<u8>;
 
     native fun generate_proof_of_possession_internal(sk: vector<u8>): vector<u8>;
+
+    native fun aggregate_pubkeys_internal(
+        public_keys: vector<PublicKeyWithPoP>,
+    ): (vector<u8>, bool);
+
+    native fun aggregate_signatures_internal(
+        signatures: vector<Signature>,
+    ): (vector<u8>, bool);
+
+    native fun verify_aggregate_signature_internal(
+        aggsig: vector<u8>,
+        public_keys: vector<PublicKeyWithPoP>,
+        messages: vector<vector<u8>>,
+    ): bool;
+
+    fun pk(bytes: vector<u8>): PublicKeyWithPoP {
+        PublicKeyWithPoP { bytes }
+    }
+
+    fun sig(bytes: vector<u8>): Signature {
+        Signature { bytes }
+    }
 
     // Sign and verify a normal signature (subgroup-checks the key): always true.
     public fun verify_normal_roundtrip(): bool {
@@ -94,6 +127,94 @@ module 0x1::bls12381 {
     public fun verify_pop_wrong_length(): bool {
         verify_proof_of_possession_internal(x"00", x"00")
     }
+
+    // Aggregating two real public keys succeeds.
+    public fun aggregate_pubkeys_success(): bool {
+        let (_, pk0) = generate_keys_internal();
+        let (_, pk1) = generate_keys_internal();
+        let (_, success) = aggregate_pubkeys_internal(vector[pk(pk0), pk(pk1)]);
+        success
+    }
+
+    // Aggregating no public keys reports no aggregate.
+    public fun aggregate_pubkeys_empty(): bool {
+        let (_, success) = aggregate_pubkeys_internal(vector[]);
+        success
+    }
+
+    // Aggregating two real signatures succeeds.
+    public fun aggregate_signatures_success(): bool {
+        let (sk0, _) = generate_keys_internal();
+        let (sk1, _) = generate_keys_internal();
+        let s0 = sign_internal(sk0, b"msg");
+        let s1 = sign_internal(sk1, b"msg");
+        let (_, success) = aggregate_signatures_internal(vector[sig(s0), sig(s1)]);
+        success
+    }
+
+    // Aggregating no signatures reports no aggregate.
+    public fun aggregate_signatures_empty(): bool {
+        let (_, success) = aggregate_signatures_internal(vector[]);
+        success
+    }
+
+    // Two signers over two distinct messages: the aggregate signature verifies.
+    public fun verify_aggregate_roundtrip(): bool {
+        let (sk0, pk0) = generate_keys_internal();
+        let (sk1, pk1) = generate_keys_internal();
+        let m0 = b"message zero";
+        let m1 = b"message one";
+        let s0 = sign_internal(sk0, m0);
+        let s1 = sign_internal(sk1, m1);
+        let (aggsig, ok) = aggregate_signatures_internal(vector[sig(s0), sig(s1)]);
+        assert!(ok, 0);
+        verify_aggregate_signature_internal(aggsig, vector[pk(pk0), pk(pk1)], vector[m0, m1])
+    }
+
+    // Verifying the aggregate against a tampered message fails.
+    public fun verify_aggregate_wrong_message(): bool {
+        let (sk0, pk0) = generate_keys_internal();
+        let (sk1, pk1) = generate_keys_internal();
+        let s0 = sign_internal(sk0, b"message zero");
+        let s1 = sign_internal(sk1, b"message one");
+        let (aggsig, ok) = aggregate_signatures_internal(vector[sig(s0), sig(s1)]);
+        assert!(ok, 0);
+        verify_aggregate_signature_internal(
+            aggsig,
+            vector[pk(pk0), pk(pk1)],
+            vector[b"message zero", b"tampered"],
+        )
+    }
+
+    // A public-key count that disagrees with the message count fails.
+    public fun verify_aggregate_length_mismatch(): bool {
+        let (sk0, pk0) = generate_keys_internal();
+        let s0 = sign_internal(sk0, b"m");
+        let (aggsig, _) = aggregate_signatures_internal(vector[sig(s0)]);
+        verify_aggregate_signature_internal(aggsig, vector[pk(pk0)], vector[b"m", b"n"])
+    }
+
+    // Aggregate pubkeys + signatures over one shared message, then verify as a
+    // multisignature: ties the two aggregate natives to the multisig verifier.
+    public fun multisig_roundtrip(): bool {
+        let (sk0, pk0) = generate_keys_internal();
+        let (sk1, pk1) = generate_keys_internal();
+        let msg = b"same message";
+        let s0 = sign_internal(sk0, msg);
+        let s1 = sign_internal(sk1, msg);
+        let (aggsig, ok_s) = aggregate_signatures_internal(vector[sig(s0), sig(s1)]);
+        let (aggpk, ok_p) = aggregate_pubkeys_internal(vector[pk(pk0), pk(pk1)]);
+        assert!(ok_s && ok_p, 0);
+        verify_multisignature_internal(aggsig, aggpk, msg)
+    }
+
+    // Mirrors the framework wrapper `aggregate_pubkeys`, which aborts with
+    // `std::error::invalid_argument(EZERO_PUBKEYS)` (== 65537) when the native
+    // reports no aggregate for empty input.
+    public fun aggregate_pubkeys_empty_aborts() {
+        let (_, success) = aggregate_pubkeys_internal(vector[]);
+        assert!(success, 65537);
+    }
 }
 
 // RUN: execute 0x1::bls12381::verify_normal_roundtrip
@@ -122,3 +243,30 @@ module 0x1::bls12381 {
 
 // RUN: execute 0x1::bls12381::verify_pop_wrong_length
 // CHECK: results: false
+
+// RUN: execute 0x1::bls12381::aggregate_pubkeys_success
+// CHECK: results: true
+
+// RUN: execute 0x1::bls12381::aggregate_pubkeys_empty
+// CHECK: results: false
+
+// RUN: execute 0x1::bls12381::aggregate_signatures_success
+// CHECK: results: true
+
+// RUN: execute 0x1::bls12381::aggregate_signatures_empty
+// CHECK: results: false
+
+// RUN: execute 0x1::bls12381::verify_aggregate_roundtrip
+// CHECK: results: true
+
+// RUN: execute 0x1::bls12381::verify_aggregate_wrong_message
+// CHECK: results: false
+
+// RUN: execute 0x1::bls12381::verify_aggregate_length_mismatch
+// CHECK: results: false
+
+// RUN: execute 0x1::bls12381::multisig_roundtrip
+// CHECK: results: true
+
+// RUN: execute 0x1::bls12381::aggregate_pubkeys_empty_aborts
+// CHECK: aborted: code 65537 in 0x1::bls12381

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/bls12381.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/bls12381.move
@@ -2,6 +2,14 @@
 
 // RUN: publish
 module 0x1::bls12381 {
+    struct PublicKeyWithPoP has copy, drop, store {
+        bytes: vector<u8>,
+    }
+
+    struct Signature has copy, drop, store {
+        bytes: vector<u8>,
+    }
+
     native fun validate_pubkey_internal(public_key: vector<u8>): bool;
 
     native fun signature_subgroup_check_internal(signature: vector<u8>): bool;
@@ -34,6 +42,28 @@ module 0x1::bls12381 {
     native fun sign_internal(sk: vector<u8>, msg: vector<u8>): vector<u8>;
 
     native fun generate_proof_of_possession_internal(sk: vector<u8>): vector<u8>;
+
+    native fun aggregate_pubkeys_internal(
+        public_keys: vector<PublicKeyWithPoP>,
+    ): (vector<u8>, bool);
+
+    native fun aggregate_signatures_internal(
+        signatures: vector<Signature>,
+    ): (vector<u8>, bool);
+
+    native fun verify_aggregate_signature_internal(
+        aggsig: vector<u8>,
+        public_keys: vector<PublicKeyWithPoP>,
+        messages: vector<vector<u8>>,
+    ): bool;
+
+    fun pk(bytes: vector<u8>): PublicKeyWithPoP {
+        PublicKeyWithPoP { bytes }
+    }
+
+    fun sig(bytes: vector<u8>): Signature {
+        Signature { bytes }
+    }
 
     // Sign and verify a normal signature (subgroup-checks the key): always true.
     public fun verify_normal_roundtrip(): bool {
@@ -94,6 +124,94 @@ module 0x1::bls12381 {
     public fun verify_pop_wrong_length(): bool {
         verify_proof_of_possession_internal(x"00", x"00")
     }
+
+    // Aggregating two real public keys succeeds.
+    public fun aggregate_pubkeys_success(): bool {
+        let (_, pk0) = generate_keys_internal();
+        let (_, pk1) = generate_keys_internal();
+        let (_, success) = aggregate_pubkeys_internal(vector[pk(pk0), pk(pk1)]);
+        success
+    }
+
+    // Aggregating no public keys reports no aggregate.
+    public fun aggregate_pubkeys_empty(): bool {
+        let (_, success) = aggregate_pubkeys_internal(vector[]);
+        success
+    }
+
+    // Aggregating two real signatures succeeds.
+    public fun aggregate_signatures_success(): bool {
+        let (sk0, _) = generate_keys_internal();
+        let (sk1, _) = generate_keys_internal();
+        let s0 = sign_internal(sk0, b"msg");
+        let s1 = sign_internal(sk1, b"msg");
+        let (_, success) = aggregate_signatures_internal(vector[sig(s0), sig(s1)]);
+        success
+    }
+
+    // Aggregating no signatures reports no aggregate.
+    public fun aggregate_signatures_empty(): bool {
+        let (_, success) = aggregate_signatures_internal(vector[]);
+        success
+    }
+
+    // Two signers over two distinct messages: the aggregate signature verifies.
+    public fun verify_aggregate_roundtrip(): bool {
+        let (sk0, pk0) = generate_keys_internal();
+        let (sk1, pk1) = generate_keys_internal();
+        let m0 = b"message zero";
+        let m1 = b"message one";
+        let s0 = sign_internal(sk0, m0);
+        let s1 = sign_internal(sk1, m1);
+        let (aggsig, ok) = aggregate_signatures_internal(vector[sig(s0), sig(s1)]);
+        assert!(ok, 0);
+        verify_aggregate_signature_internal(aggsig, vector[pk(pk0), pk(pk1)], vector[m0, m1])
+    }
+
+    // Verifying the aggregate against a tampered message fails.
+    public fun verify_aggregate_wrong_message(): bool {
+        let (sk0, pk0) = generate_keys_internal();
+        let (sk1, pk1) = generate_keys_internal();
+        let s0 = sign_internal(sk0, b"message zero");
+        let s1 = sign_internal(sk1, b"message one");
+        let (aggsig, ok) = aggregate_signatures_internal(vector[sig(s0), sig(s1)]);
+        assert!(ok, 0);
+        verify_aggregate_signature_internal(
+            aggsig,
+            vector[pk(pk0), pk(pk1)],
+            vector[b"message zero", b"tampered"],
+        )
+    }
+
+    // A public-key count that disagrees with the message count fails.
+    public fun verify_aggregate_length_mismatch(): bool {
+        let (sk0, pk0) = generate_keys_internal();
+        let s0 = sign_internal(sk0, b"m");
+        let (aggsig, _) = aggregate_signatures_internal(vector[sig(s0)]);
+        verify_aggregate_signature_internal(aggsig, vector[pk(pk0)], vector[b"m", b"n"])
+    }
+
+    // Aggregate pubkeys + signatures over one shared message, then verify as a
+    // multisignature: ties the two aggregate natives to the multisig verifier.
+    public fun multisig_roundtrip(): bool {
+        let (sk0, pk0) = generate_keys_internal();
+        let (sk1, pk1) = generate_keys_internal();
+        let msg = b"same message";
+        let s0 = sign_internal(sk0, msg);
+        let s1 = sign_internal(sk1, msg);
+        let (aggsig, ok_s) = aggregate_signatures_internal(vector[sig(s0), sig(s1)]);
+        let (aggpk, ok_p) = aggregate_pubkeys_internal(vector[pk(pk0), pk(pk1)]);
+        assert!(ok_s && ok_p, 0);
+        verify_multisignature_internal(aggsig, aggpk, msg)
+    }
+
+    // Mirrors the framework wrapper `aggregate_pubkeys`, which aborts with
+    // `std::error::invalid_argument(EZERO_PUBKEYS)` (== 65537) when the native
+    // reports no aggregate for empty input.
+    public fun aggregate_pubkeys_empty_aborts() {
+        let (_, success) = aggregate_pubkeys_internal(vector[]);
+        assert!(success, 65537);
+    }
 }
 
 // RUN: execute 0x1::bls12381::verify_normal_roundtrip
@@ -122,3 +240,30 @@ module 0x1::bls12381 {
 
 // RUN: execute 0x1::bls12381::verify_pop_wrong_length
 // CHECK: results: false
+
+// RUN: execute 0x1::bls12381::aggregate_pubkeys_success
+// CHECK: results: true
+
+// RUN: execute 0x1::bls12381::aggregate_pubkeys_empty
+// CHECK: results: false
+
+// RUN: execute 0x1::bls12381::aggregate_signatures_success
+// CHECK: results: true
+
+// RUN: execute 0x1::bls12381::aggregate_signatures_empty
+// CHECK: results: false
+
+// RUN: execute 0x1::bls12381::verify_aggregate_roundtrip
+// CHECK: results: true
+
+// RUN: execute 0x1::bls12381::verify_aggregate_wrong_message
+// CHECK: results: false
+
+// RUN: execute 0x1::bls12381::verify_aggregate_length_mismatch
+// CHECK: results: false
+
+// RUN: execute 0x1::bls12381::multisig_roundtrip
+// CHECK: results: true
+
+// RUN: execute 0x1::bls12381::aggregate_pubkeys_empty_aborts
+// CHECK: aborted: code 65537 in 0x1::bls12381


### PR DESCRIPTION
## Description

Ports the three bls12381 **aggregate** natives from the legacy MoveVM to
mono-move, folding them into the existing `natives/src/bls12381.rs`:

- `aggregate_pubkeys_internal(public_keys: vector<PublicKeyWithPoP>): (vector<u8>, bool)`
- `aggregate_signatures_internal(signatures: vector<Signature>): (vector<u8>, bool)`
- `verify_aggregate_signature_internal(aggsig, public_keys, messages): bool`

These are stateless — no context or handle store. They reuse `aptos-crypto`
for the backend, so replay produces byte-identical results against the legacy
VM. Failure is signalled by returning `(empty, false)` / `false`, byte-for-byte
with V1; there are no abort codes in the natives (the only abort, `EZERO_PUBKEYS`,
lives in the Move wrapper, which mono-move runs unchanged).

### Value-model primitive

The aggregate natives take vector-of-byte-vector arguments, which mono-move's
`Vector<'a, V>` could not read (only `Vector<u8>::as_bytes` existed). This PR
adds one accessor, `Vector<'a, Vector<'a, V>>::get(i)`, which reads the inner
vector's 8-byte heap pointer and roots it for the rest of the call, mirroring
`Ref::borrow`. It is a non-copying, GC-tracked borrow — no bytes are copied and
the native owns no storage.

One accessor covers `vector<vector<u8>>`, `vector<PublicKeyWithPoP>`, and
`vector<Signature>`: the one-field wrapper structs are laid out inline, so each
is byte-identical to a bare `vector<u8>`. `ObjectHandle::pool()` is exposed
(crate-internal) so the accessor can root through the pool.

### Also in this PR

Fixes a compile break committed in the previous crypto-natives PR:
`PublicKey` / `ProofOfPossession` were imported only under
`#[cfg(feature = "testing")]` but used by production functions, so
`mono-move-natives` did not build without `--features testing`. Moved them to
the non-test import block.

Gas metering is deferred as elsewhere in mono-move; each native carries
`// TODO(metering): charge gas.`

## Testing

- Unit test in `value.rs` for the nested-vector accessor (reads three inner
  byte vectors, including an empty one).
- Differential test cases in `testsuite/.../natives/bls12381.move` — 10 new
  cases run on both the legacy VM and mono-move and checked for agreement:
  aggregate pubkeys/signatures (success + empty), aggregate-verify roundtrip,
  wrong-message, length-mismatch, multisig roundtrip, and the `EZERO_PUBKEYS`
  (65537) abort path through a wrapper mimic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches BLS12-381 verification and aggregation on-chain paths where byte-identical behavior vs the legacy VM matters; nested-vector GC rooting is safety-sensitive but localized and tested.
> 
> **Overview**
> Ports the remaining **BLS12-381 aggregate** paths to mono-move: `aggregate_pubkeys_internal`, `aggregate_signatures_internal`, and `verify_aggregate_signature_internal`, wired into `bls12381.rs` with the same failure semantics as the legacy VM (`(empty vector, false)` / `false`, no native aborts).
> 
> To read `vector<vector<u8>>`-style args (including one-field wrapper structs), the PR adds **`Vector<'a, Vector<'a, V>>::get`**, which loads each inner heap pointer and **roots** it for the rest of the native call (like `Ref::borrow`), plus crate-internal **`ObjectHandle::pool()`** for that rooting.
> 
> Also fixes a **build break** where `PublicKey` / `ProofOfPossession` were only imported under `testing` but used in production natives.
> 
> Coverage: a unit test for nested-vector `get`, and **10 new differential** `bls12381.move` cases (aggregate success/empty, aggregate verify, multisig tie-in, `EZERO_PUBKEYS` abort mimic). Gas metering remains TODO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba2cf5ee7b5e67210226ad94a39d00931950f57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->