### PR TITLE
[executor] Push-invalidation for cache at boundaries

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -78,11 +78,11 @@ use aptos_types::{
         },
         block_epilogue::{BlockEpiloguePayload, FeeDistribution},
         signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockExecutionResult, EntryFunction, ExecutionError, ExecutionStatus,
-        ModuleBundle, MultisigTransactionPayload, ReplayProtector, Script, SignedTransaction,
-        Transaction, TransactionArgument, TransactionExecutableRef, TransactionExtraConfig,
-        TransactionOutput, TransactionPayload, TransactionStatus, TxnLimitsRequest,
-        VMValidatorResult, ViewFunctionOutput, WriteSetPayload,
+        AuxiliaryInfo, BlockExecutionResult, CacheInvalidationInfo, EntryFunction, ExecutionError,
+        ExecutionStatus, ModuleBundle, MultisigTransactionPayload, ReplayProtector, Script,
+        SignedTransaction, Transaction, TransactionArgument, TransactionExecutableRef,
+        TransactionExtraConfig, TransactionOutput, TransactionPayload, TransactionStatus,
+        TxnLimitsRequest, VMValidatorResult, ViewFunctionOutput, WriteSetPayload,
     },
     vm::module_metadata::{get_metadata, get_randomness_annotation_for_entry_function},
     vm_status::{AbortLocation, StatusCode, VMStatus},
@@ -3341,6 +3341,14 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
             onchain: onchain_config,
         };
         self.execute_block_with_config(txn_provider, state_view, config, transaction_slice_metadata)
+    }
+
+    fn invalidate(&self, info: &CacheInvalidationInfo) {
+        // TODO: Wire this to `self.module_cache_manager` once the code-publish flow
+        // populates real invalidation payloads. Nothing sets non-None info yet.
+        match info {
+            CacheInvalidationInfo::Dummy => {},
+        }
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, C: ExecutorClient<S>>(

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -78,11 +78,11 @@ use aptos_types::{
         },
         block_epilogue::{BlockEpiloguePayload, FeeDistribution},
         signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockExecutionResult, EntryFunction, ExecutionError, ExecutionStatus,
-        ModuleBundle, MultisigTransactionPayload, ReplayProtector, Script, SignedTransaction,
-        Transaction, TransactionArgument, TransactionExecutableRef, TransactionExtraConfig,
-        TransactionOutput, TransactionPayload, TransactionStatus, TxnLimitsRequest,
-        VMValidatorResult, ViewFunctionOutput, WriteSetPayload,
+        AuxiliaryInfo, BlockExecutionResult, CacheInvalidationInfo, EntryFunction, ExecutionError,
+        ExecutionStatus, ModuleBundle, MultisigTransactionPayload, ReplayProtector, Script,
+        SignedTransaction, Transaction, TransactionArgument, TransactionExecutableRef,
+        TransactionExtraConfig, TransactionOutput, TransactionPayload, TransactionStatus,
+        TxnLimitsRequest, VMValidatorResult, ViewFunctionOutput, WriteSetPayload,
     },
     vm::module_metadata::{get_metadata, get_randomness_annotation_for_entry_function},
     vm_status::{AbortLocation, StatusCode, VMStatus},
@@ -3341,6 +3341,14 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
             onchain: onchain_config,
         };
         self.execute_block_with_config(txn_provider, state_view, config, transaction_slice_metadata)
+    }
+
+    fn invalidate(&self, info: &CacheInvalidationInfo) {
+        // TODO: Wire this to `self.module_cache_manager` once the code-publish flow
+        // populates real invalidation payloads. Nothing sets non-None info yet.
+        match info {
+            CacheInvalidationInfo::Legacy { published: _ } => {},
+        }
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, C: ExecutorClient<S>>(

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -441,7 +441,8 @@ impl<
         );
         match ret {
             Ok(block_output) => {
-                let (transaction_outputs, block_epilogue_txn) = block_output.into_inner();
+                let (transaction_outputs, block_epilogue_txn, cache_invalidation_info) =
+                    block_output.into_inner();
 
                 // Flush the speculative logs of the committed transactions.
                 let pos = transaction_outputs.partition_point(|o| !o.status().is_retry());
@@ -452,7 +453,11 @@ impl<
                     flush_speculative_logs(pos);
                 }
 
-                Ok(BlockOutput::new(transaction_outputs, block_epilogue_txn))
+                Ok(BlockOutput::new_with_cache_invalidation_info(
+                    transaction_outputs,
+                    block_epilogue_txn,
+                    cache_invalidation_info,
+                ))
             },
             Err(err) => Err(err),
         }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -441,7 +441,8 @@ impl<
         );
         match ret {
             Ok(block_output) => {
-                let (transaction_outputs, block_epilogue_txn) = block_output.into_inner();
+                let (transaction_outputs, block_epilogue_txn, cache_invalidation_info) =
+                    block_output.into_inner();
 
                 // Flush the speculative logs of the committed transactions.
                 let pos = transaction_outputs.partition_point(|o| !o.status().is_retry());
@@ -452,7 +453,11 @@ impl<
                     flush_speculative_logs(pos);
                 }
 
-                Ok(BlockOutput::new(transaction_outputs, block_epilogue_txn))
+                Ok(BlockOutput::new(
+                    transaction_outputs,
+                    block_epilogue_txn,
+                    cache_invalidation_info,
+                ))
             },
             Err(err) => Err(err),
         }

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -135,7 +135,8 @@ use aptos_types::{
     state_store::StateView,
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
-        BlockExecutionResult, BlockOutput, SignedTransaction, TransactionOutput, VMValidatorResult,
+        BlockExecutionResult, BlockOutput, CacheInvalidationInfo, SignedTransaction,
+        TransactionOutput, VMValidatorResult,
     },
     vm_status::VMStatus,
 };
@@ -191,6 +192,13 @@ pub trait VMBlockExecutor: Send + Sync {
         )
         .map(BlockOutput::into_transaction_outputs_forced)
     }
+
+    /// Invalidate any executor-held caches after a block is committed, based on the
+    /// block's cache-invalidation info. Required (no default): implementations that
+    /// keep caches (e.g. the module cache) must stay coherent when a block publishes
+    /// code; a silent default would hide missing invalidation. Invoked only after
+    /// the block's ledger is committed, never at pre-commit.
+    fn invalidate(&self, info: &CacheInvalidationInfo);
 
     /// Executes a block of transactions using a sharded block executor and returns the results.
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1585,7 +1585,7 @@ where
 
         let num_txns = signature_verified_block.num_txns();
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, None));
         }
 
         let num_workers = self.config.local.concurrency_level.min(num_txns / 2).max(2) as u32;
@@ -1727,6 +1727,7 @@ where
         Ok(BlockOutput::new(
             final_results.into_inner(),
             maybe_block_epilogue_txn,
+            None,
         ))
     }
 
@@ -1786,7 +1787,7 @@ where
 
         let num_txns = signature_verified_block.num_txns();
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, None));
         }
 
         let num_workers = self.config.local.concurrency_level.min(num_txns / 2).max(2);
@@ -1911,6 +1912,7 @@ where
         Ok(BlockOutput::new(
             final_results.into_inner(),
             maybe_block_epilogue_txn,
+            None,
         ))
     }
 
@@ -2100,7 +2102,7 @@ where
         let num_txns = signature_verified_block.num_txns();
 
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, None));
         }
 
         let init_timer = VM_INIT_SECONDS.start_timer();
@@ -2342,7 +2344,7 @@ where
             .module_cache_mut()
             .insert_verified(unsync_map.into_modules_iter())?;
 
-        Ok(BlockOutput::new(ret, block_epilogue_txn))
+        Ok(BlockOutput::new(ret, block_epilogue_txn, None))
     }
 
     pub fn execute_block(
@@ -2455,7 +2457,7 @@ where
                     CommittedOutput::<E>::discard(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                 })
                 .collect();
-            return Ok(BlockOutput::new(ret, None));
+            return Ok(BlockOutput::new(ret, None, None));
         }
 
         Err(sequential_error)

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -80,7 +80,7 @@ fn test_block_epilogue_happy_path() {
                 false,
             )
             .unwrap();
-        let (output, block_epilogue_txn) = result.into_inner();
+        let (output, block_epilogue_txn, _) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -98,7 +98,7 @@ fn test_block_epilogue_happy_path() {
                 &mut guard,
             )
             .unwrap();
-        let (output, block_epilogue_txn) = result.into_inner();
+        let (output, block_epilogue_txn, _) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -144,7 +144,7 @@ fn test_block_epilogue_block_gas_limit_reached() {
                 false,
             )
             .unwrap();
-        let (output, block_epilogue_txn) = result.into_inner();
+        let (output, block_epilogue_txn, _) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -162,7 +162,7 @@ fn test_block_epilogue_block_gas_limit_reached() {
                 &mut guard,
             )
             .unwrap();
-        let (output, block_epilogue_txn) = result.into_inner();
+        let (output, block_epilogue_txn, _) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);

--- a/aptos-move/e2e-move-tests/src/tests/hot_state.rs
+++ b/aptos-move/e2e-move-tests/src/tests/hot_state.rs
@@ -74,7 +74,7 @@ fn execute_and_get_hot_state_promotions(
             TransactionSliceMetadata::block(HashValue::zero(), HashValue::new([1; 32])),
         )
         .expect("Block execution should succeed");
-    let (outputs, epilogue_txn) = block_output.into_inner();
+    let (outputs, epilogue_txn, _) = block_output.into_inner();
 
     let statuses = outputs
         .iter()

--- a/aptos-move/e2e-move-tests/src/tests/hot_state.rs
+++ b/aptos-move/e2e-move-tests/src/tests/hot_state.rs
@@ -74,7 +74,7 @@ fn execute_and_get_hot_state_promotions(
             TransactionSliceMetadata::block(HashValue::zero(), HashValue::new([1; 32])),
         )
         .expect("Block execution should succeed");
-    let (outputs, epilogue_txn) = block_output.into_inner();
+    let (outputs, epilogue_txn, _cache_invalidation_info) = block_output.into_inner();
 
     let statuses = outputs
         .iter()

--- a/consensus/src/pipeline/pipeline_builder.rs
+++ b/consensus/src/pipeline/pipeline_builder.rs
@@ -591,6 +591,7 @@ impl PipelineBuilder {
             Self::execute(
                 prepare_fut.clone(),
                 parent.execute_fut.clone(),
+                parent.commit_ledger_fut.clone(),
                 rand_check_fut.clone(),
                 self.executor.clone(),
                 block.clone(),
@@ -931,6 +932,7 @@ impl PipelineBuilder {
     async fn execute(
         prepare_fut: TaskFuture<PrepareResult>,
         parent_block_execute_fut: TaskFuture<ExecuteResult>,
+        parent_block_commit_fut: TaskFuture<CommitLedgerResult>,
         rand_check: TaskFuture<RandResult>,
         executor: Arc<dyn BlockExecutorTrait>,
         block: Arc<Block>,
@@ -940,6 +942,13 @@ impl PipelineBuilder {
     ) -> TaskResult<ExecuteResult> {
         let mut tracker = Tracker::start_waiting("execute", &block);
         parent_block_execute_fut.await?;
+
+        if executor.block_wait_for_commit(block.parent_id()) {
+            // A module-publishing parent is a barrier: do not speculatively
+            // execute on top of it until it commits. A branch discard aborts
+            // this future instead.
+            parent_block_commit_fut.await?;
+        }
         let (user_txns, block_gas_limit, decryption_outcome) = prepare_fut.await?;
         let onchain_execution_config =
             onchain_execution_config.with_block_gas_limit_override(block_gas_limit);

--- a/consensus/src/pipeline/pipeline_builder.rs
+++ b/consensus/src/pipeline/pipeline_builder.rs
@@ -591,6 +591,7 @@ impl PipelineBuilder {
             Self::execute(
                 prepare_fut.clone(),
                 parent.execute_fut.clone(),
+                parent.commit_ledger_fut.clone(),
                 rand_check_fut.clone(),
                 self.executor.clone(),
                 block.clone(),
@@ -931,6 +932,7 @@ impl PipelineBuilder {
     async fn execute(
         prepare_fut: TaskFuture<PrepareResult>,
         parent_block_execute_fut: TaskFuture<ExecuteResult>,
+        parent_block_commit_fut: TaskFuture<CommitLedgerResult>,
         rand_check: TaskFuture<RandResult>,
         executor: Arc<dyn BlockExecutorTrait>,
         block: Arc<Block>,
@@ -940,6 +942,15 @@ impl PipelineBuilder {
     ) -> TaskResult<ExecuteResult> {
         let mut tracker = Tracker::start_waiting("execute", &block);
         parent_block_execute_fut.await?;
+
+        if executor
+            .block_wait_for_commit(block.parent_id())
+            .map_err(anyhow::Error::from)?
+        {
+            // This block is a barrier: do not speculatively execute on top of it
+            // until it commits. A branch discard aborts this future instead.
+            parent_block_commit_fut.await?;
+        }
         let (user_txns, block_gas_limit, decryption_outcome) = prepare_fut.await?;
         let onchain_execution_config =
             onchain_execution_config.with_block_gas_limit_override(block_gas_limit);

--- a/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
+++ b/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
@@ -13,7 +13,8 @@ use aptos_types::{
     state_store::StateView,
     transaction::{
         block_epilogue::BlockEndInfo, signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockError, BlockOutput, Transaction, TransactionOutput,
+        AuxiliaryInfo, BlockError, BlockOutput, CacheInvalidationInfo, Transaction,
+        TransactionOutput,
     },
 };
 use aptos_vm::{AptosVM, VMBlockExecutor};
@@ -77,6 +78,11 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
         Ok(BlockOutput::new(
             transaction_outputs,
             Some(block_epilogue_txn.into()),
+            None,
         ))
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 }

--- a/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
+++ b/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
@@ -13,7 +13,8 @@ use aptos_types::{
     state_store::StateView,
     transaction::{
         block_epilogue::BlockEndInfo, signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockError, BlockOutput, Transaction, TransactionOutput,
+        AuxiliaryInfo, BlockError, BlockOutput, CacheInvalidationInfo, Transaction,
+        TransactionOutput,
     },
 };
 use aptos_vm::{AptosVM, VMBlockExecutor};
@@ -78,5 +79,9 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
             transaction_outputs,
             Some(block_epilogue_txn.into()),
         ))
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 }

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -38,7 +38,7 @@ use aptos_types::{
     state_store::{state_key::StateKey, state_value::StateValueMetadata, StateView},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
-        BlockOutput, TransactionOutput, TransactionStatus,
+        BlockOutput, CacheInvalidationInfo, TransactionOutput, TransactionStatus,
     },
     write_set::WriteOp,
 };
@@ -108,6 +108,10 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
             transaction_slice_metadata,
             None,
         )
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 }
 

--- a/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
+++ b/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
@@ -28,8 +28,8 @@ use aptos_types::{
     state_store::{state_key::StateKey, StateView},
     transaction::{
         block_epilogue::BlockEndInfo, signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockError, BlockOutput, ExecutionStatus, Transaction,
-        TransactionAuxiliaryData, TransactionOutput, TransactionStatus,
+        AuxiliaryInfo, BlockError, BlockOutput, CacheInvalidationInfo, ExecutionStatus,
+        Transaction, TransactionAuxiliaryData, TransactionOutput, TransactionStatus,
     },
     write_set::{WriteOp, WriteSetMut},
 };
@@ -114,6 +114,10 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
             transaction_outputs,
             Some(block_epilogue_txn.into()),
         ))
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 }
 

--- a/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
+++ b/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
@@ -28,8 +28,8 @@ use aptos_types::{
     state_store::{state_key::StateKey, StateView},
     transaction::{
         block_epilogue::BlockEndInfo, signature_verified_transaction::SignatureVerifiedTransaction,
-        AuxiliaryInfo, BlockError, BlockOutput, ExecutionStatus, Transaction,
-        TransactionAuxiliaryData, TransactionOutput, TransactionStatus,
+        AuxiliaryInfo, BlockError, BlockOutput, CacheInvalidationInfo, ExecutionStatus,
+        Transaction, TransactionAuxiliaryData, TransactionOutput, TransactionStatus,
     },
     write_set::{WriteOp, WriteSetMut},
 };
@@ -113,7 +113,12 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
         Ok(BlockOutput::new(
             transaction_outputs,
             Some(block_epilogue_txn.into()),
+            None,
         ))
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 }
 

--- a/execution/executor-types/src/execution_output.rs
+++ b/execution/executor-types/src/execution_output.rs
@@ -16,7 +16,8 @@ use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
     transaction::{
-        block_epilogue::BlockEndInfo, ExecutionStatus, Transaction, TransactionStatus, Version,
+        block_epilogue::BlockEndInfo, CacheInvalidationInfo, ExecutionStatus, Transaction,
+        TransactionStatus, Version,
     },
 };
 use derive_more::Deref;
@@ -43,6 +44,7 @@ impl ExecutionOutput {
         hot_state_updates: HotStateUpdates,
         block_end_info: Option<BlockEndInfo>,
         next_epoch_state: Option<EpochState>,
+        cache_invalidation_info: Option<CacheInvalidationInfo>,
         subscribable_events: Planned<Vec<ContractEvent>>,
         transaction_info_v1: bool,
         hot_state_root_in_txn_info: bool,
@@ -71,6 +73,7 @@ impl ExecutionOutput {
             hot_state_updates,
             block_end_info,
             next_epoch_state,
+            cache_invalidation_info,
             subscribable_events,
             transaction_info_v1,
             hot_state_root_in_txn_info,
@@ -91,6 +94,7 @@ impl ExecutionOutput {
             hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: None,
+            cache_invalidation_info: None,
             subscribable_events: Planned::ready(vec![]),
             transaction_info_v1: false,
             hot_state_root_in_txn_info: false,
@@ -113,6 +117,7 @@ impl ExecutionOutput {
             hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: None,
+            cache_invalidation_info: None,
             subscribable_events: Planned::ready(vec![]),
             transaction_info_v1: false,
             hot_state_root_in_txn_info: false,
@@ -137,6 +142,7 @@ impl ExecutionOutput {
             hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: self.next_epoch_state.clone(),
+            cache_invalidation_info: None,
             subscribable_events: Planned::ready(vec![]),
             transaction_info_v1: self.transaction_info_v1,
             hot_state_root_in_txn_info: self.hot_state_root_in_txn_info,
@@ -160,6 +166,12 @@ impl ExecutionOutput {
 
     pub fn expect_last_version(&self) -> Version {
         self.first_version + self.num_transactions_to_commit() as Version - 1
+    }
+
+    /// Whether this block carries cache-invalidation info, i.e. it published
+    /// code and downstream caches must be invalidated after it commits.
+    pub fn needs_invalidation(&self) -> bool {
+        self.cache_invalidation_info.is_some()
     }
 }
 
@@ -189,6 +201,11 @@ pub struct Inner {
     /// Only present if the block is the last block of an epoch, and is parsed output of the
     /// state cache.
     pub next_epoch_state: Option<EpochState>,
+    /// Opaque, forward-compatible description of the cache invalidation this
+    /// block's outputs require for cache coherence (e.g. module-cache
+    /// invalidation when the block publishes code). `None` means nothing to
+    /// invalidate. Populated by the code-publish flow.
+    pub cache_invalidation_info: Option<CacheInvalidationInfo>,
     pub subscribable_events: Planned<Vec<ContractEvent>>,
     /// Whether to assemble `TransactionInfoV1` (instead of `TransactionInfoV0`) in the
     /// subsequent state-checkpoint / ledger-update phases.

--- a/execution/executor-types/src/execution_output.rs
+++ b/execution/executor-types/src/execution_output.rs
@@ -16,7 +16,8 @@ use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
     transaction::{
-        block_epilogue::BlockEndInfo, ExecutionStatus, Transaction, TransactionStatus, Version,
+        block_epilogue::BlockEndInfo, CacheInvalidationInfo, ExecutionStatus, Transaction,
+        TransactionStatus, Version,
     },
 };
 use derive_more::Deref;
@@ -43,6 +44,7 @@ impl ExecutionOutput {
         hot_state_updates: HotStateUpdates,
         block_end_info: Option<BlockEndInfo>,
         next_epoch_state: Option<EpochState>,
+        cache_invalidation_info: Option<CacheInvalidationInfo>,
         subscribable_events: Planned<Vec<ContractEvent>>,
         transaction_info_v1: bool,
         hot_state_root_in_txn_info: bool,
@@ -71,6 +73,7 @@ impl ExecutionOutput {
             hot_state_updates,
             block_end_info,
             next_epoch_state,
+            cache_invalidation_info,
             subscribable_events,
             transaction_info_v1,
             hot_state_root_in_txn_info,
@@ -91,6 +94,7 @@ impl ExecutionOutput {
             hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: None,
+            cache_invalidation_info: None,
             subscribable_events: Planned::ready(vec![]),
             transaction_info_v1: false,
             hot_state_root_in_txn_info: false,
@@ -113,6 +117,7 @@ impl ExecutionOutput {
             hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: None,
+            cache_invalidation_info: None,
             subscribable_events: Planned::ready(vec![]),
             transaction_info_v1: false,
             hot_state_root_in_txn_info: false,
@@ -137,6 +142,7 @@ impl ExecutionOutput {
             hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: self.next_epoch_state.clone(),
+            cache_invalidation_info: None,
             subscribable_events: Planned::ready(vec![]),
             transaction_info_v1: self.transaction_info_v1,
             hot_state_root_in_txn_info: self.hot_state_root_in_txn_info,
@@ -160,6 +166,12 @@ impl ExecutionOutput {
 
     pub fn expect_last_version(&self) -> Version {
         self.first_version + self.num_transactions_to_commit() as Version - 1
+    }
+
+    /// True if this block carries cache-invalidation info, and cross-block
+    /// caches must be synchronized or invalidated after it commits.
+    pub fn needs_invalidation(&self) -> bool {
+        self.cache_invalidation_info.is_some()
     }
 }
 
@@ -189,6 +201,9 @@ pub struct Inner {
     /// Only present if the block is the last block of an epoch, and is parsed output of the
     /// state cache.
     pub next_epoch_state: Option<EpochState>,
+    /// Information about the cache invalidation this block requires on commit
+    /// for cache coherence. None means no cache invalidation is needed.
+    pub cache_invalidation_info: Option<CacheInvalidationInfo>,
     pub subscribable_events: Planned<Vec<ContractEvent>>,
     /// Whether to assemble `TransactionInfoV1` (instead of `TransactionInfoV0`) in the
     /// subsequent state-checkpoint / ledger-update phases.

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -171,6 +171,13 @@ pub trait BlockExecutorTrait: Send + Sync {
 
     fn commit_ledger(&self, ledger_info_with_sigs: LedgerInfoWithSignatures) -> ExecutorResult<()>;
 
+    /// Whether consensus must wait for this block's commit before executing any
+    /// block on top of it. True when the block carries cache-invalidation info
+    /// (i.e. it published modules), so speculative execution cannot run against
+    /// a stale module cache. False for genesis / already-pruned blocks not in
+    /// the tree.
+    fn block_wait_for_commit(&self, block_id: HashValue) -> bool;
+
     /// Finishes the block executor by releasing memory held by inner data structures(SMT).
     fn finish(&self);
 

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -171,6 +171,13 @@ pub trait BlockExecutorTrait: Send + Sync {
 
     fn commit_ledger(&self, ledger_info_with_sigs: LedgerInfoWithSignatures) -> ExecutorResult<()>;
 
+    /// Whether consensus must wait for this block's commit before executing any
+    /// block on top of it. True when the block carries cache-invalidation info
+    /// (e.g., when modules are published), so that speculative execution cannot
+    /// run against a stale cache. False for genesis or already-pruned blocks not
+    /// in the tree.
+    fn block_wait_for_commit(&self, block_id: HashValue) -> ExecutorResult<bool>;
+
     /// Finishes the block executor by releasing memory held by inner data structures(SMT).
     fn finish(&self);
 

--- a/execution/executor/src/block_executor/mod.rs
+++ b/execution/executor/src/block_executor/mod.rs
@@ -155,6 +155,17 @@ where
             .commit_ledger(ledger_info_with_sigs)
     }
 
+    fn block_wait_for_commit(&self, block_id: HashValue) -> bool {
+        let _guard = CONCURRENCY_GAUGE.concurrency_with(&["block", "block_wait_for_commit"]);
+
+        self.maybe_initialize().expect("Failed to initialize.");
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .block_wait_for_commit(block_id)
+    }
+
     fn finish(&self) {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["block", "finish"]);
 
@@ -431,7 +442,7 @@ where
         }
 
         // Confirm the block to be committed is tracked in the tree.
-        self.block_tree.get_block(block_id)?;
+        let block = self.block_tree.get_block(block_id)?;
 
         fail_point!("executor::commit_blocks", |_| {
             Err(anyhow::anyhow!("Injected error in commit_blocks.").into())
@@ -444,7 +455,29 @@ where
 
         self.block_tree.prune(ledger_info_with_sigs.ledger_info())?;
 
+        // Invalidate executor-held caches only after the ledger is committed. A
+        // block that carries cache-invalidation info published code; its
+        // descendants are forced to wait for this commit (the consensus
+        // execute-stage barrier), so it always commits as the tip and can never
+        // be a batch-commit intermediate.
+        if let Some(info) = block
+            .output
+            .execution_output
+            .cache_invalidation_info
+            .as_ref()
+        {
+            self.block_executor.invalidate(info);
+        }
+
         Ok(())
+    }
+
+    fn block_wait_for_commit(&self, block_id: HashValue) -> bool {
+        // A block not tracked in the tree (genesis / already pruned) never
+        // needs to be waited on.
+        self.block_tree
+            .get_block(block_id)
+            .is_ok_and(|block| block.output.execution_output.needs_invalidation())
     }
 
     fn state_view(&self, block_id: HashValue) -> ExecutorResult<CachedStateView> {

--- a/execution/executor/src/block_executor/mod.rs
+++ b/execution/executor/src/block_executor/mod.rs
@@ -155,6 +155,19 @@ where
             .commit_ledger(ledger_info_with_sigs)
     }
 
+    fn block_wait_for_commit(&self, block_id: HashValue) -> ExecutorResult<bool> {
+        let _guard = CONCURRENCY_GAUGE.concurrency_with(&["block", "block_wait_for_commit"]);
+
+        self.maybe_initialize()?;
+        self.inner
+            .read()
+            .as_ref()
+            .ok_or_else(|| ExecutorError::InternalError {
+                error: "BlockExecutor is not reset".into(),
+            })?
+            .block_wait_for_commit(block_id)
+    }
+
     fn finish(&self) {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["block", "finish"]);
 
@@ -431,7 +444,7 @@ where
         }
 
         // Confirm the block to be committed is tracked in the tree.
-        self.block_tree.get_block(block_id)?;
+        let block = self.block_tree.get_block(block_id)?;
 
         fail_point!("executor::commit_blocks", |_| {
             Err(anyhow::anyhow!("Injected error in commit_blocks.").into())
@@ -444,7 +457,31 @@ where
 
         self.block_tree.prune(ledger_info_with_sigs.ledger_info())?;
 
+        // Invalidate executor-held caches only after the ledger is committed. A
+        // block that carries cache-invalidation info published code; its
+        // descendants are forced to wait for this commit (the consensus
+        // execute-stage barrier), so it always commits as the tip and can never
+        // be a batch-commit intermediate.
+        if let Some(info) = block
+            .output
+            .execution_output
+            .cache_invalidation_info
+            .as_ref()
+        {
+            self.block_executor.invalidate(info);
+        }
+
         Ok(())
+    }
+
+    fn block_wait_for_commit(&self, block_id: HashValue) -> ExecutorResult<bool> {
+        // A block not tracked in the tree (genesis / already pruned) never
+        // needs to be waited on.
+        let mut block_vec = self.block_tree.get_blocks_opt(&[block_id])?;
+        Ok(block_vec
+            .pop()
+            .expect("Must exist.")
+            .is_some_and(|block| block.output.execution_output.needs_invalidation()))
     }
 
     fn state_view(&self, block_id: HashValue) -> ExecutorResult<CachedStateView> {

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -19,7 +19,8 @@ use aptos_types::{
         signature_verified_transaction::{
             into_signature_verified_block, SignatureVerifiedTransaction,
         },
-        AuxiliaryInfo, BlockError, BlockOutput, Transaction, TransactionOutput, Version,
+        AuxiliaryInfo, BlockError, BlockOutput, CacheInvalidationInfo, Transaction,
+        TransactionOutput, Version,
     },
     vm_status::VMStatus,
 };
@@ -82,7 +83,11 @@ impl VMBlockExecutor for FakeVM {
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
-        Ok(BlockOutput::new(vec![], None))
+        Ok(BlockOutput::new(vec![], None, None))
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 }
 

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -19,7 +19,8 @@ use aptos_types::{
         signature_verified_transaction::{
             into_signature_verified_block, SignatureVerifiedTransaction,
         },
-        AuxiliaryInfo, BlockError, BlockOutput, Transaction, TransactionOutput, Version,
+        AuxiliaryInfo, BlockError, BlockOutput, CacheInvalidationInfo, Transaction,
+        TransactionOutput, Version,
     },
     vm_status::VMStatus,
 };
@@ -83,6 +84,10 @@ impl VMBlockExecutor for FakeVM {
         _transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
         Ok(BlockOutput::new(vec![], None))
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 }
 

--- a/execution/executor/src/tests/mock_vm/mod.rs
+++ b/execution/executor/src/tests/mock_vm/mod.rs
@@ -7,6 +7,7 @@ mod mock_vm_test;
 use anyhow::Result;
 use aptos_block_executor::txn_provider::{default::DefaultTxnProvider, TxnProvider};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use aptos_infallible::Mutex;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG,
@@ -22,8 +23,8 @@ use aptos_types::{
     state_store::{state_key::StateKey, StateView},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockEndInfo,
-        BlockError, BlockOutput, ChangeSet, ExecutionStatus, RawTransaction, Script,
-        SignedTransaction, Transaction, TransactionArgument, TransactionAuxiliaryData,
+        BlockError, BlockOutput, CacheInvalidationInfo, ChangeSet, ExecutionStatus, RawTransaction,
+        Script, SignedTransaction, Transaction, TransactionArgument, TransactionAuxiliaryData,
         TransactionExecutableRef, TransactionOutput, TransactionStatus, WriteSetPayload,
     },
     vm_status::{StatusCode, VMStatus},
@@ -33,7 +34,10 @@ use aptos_vm::{
     sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor},
     VMBlockExecutor,
 };
-use move_core_types::language_storage::TypeTag;
+use move_core_types::{
+    ident_str,
+    language_storage::{ModuleId, TypeTag},
+};
 use once_cell::sync::Lazy;
 use std::{collections::HashMap, sync::Arc};
 
@@ -48,7 +52,20 @@ enum MockVMTransaction {
         recipient: AccountAddress,
         amount: u64,
     },
+    // A module-publishing transaction (marked by non-empty script code). Produces
+    // a write so the block has something to commit, and flags the block as
+    // requiring cache invalidation.
+    Publish {
+        sender: AccountAddress,
+    },
 }
+
+/// Records the cache-invalidation infos passed to [MockVM::invalidate], so tests
+/// can assert invalidation happens (and only at commit, not pre-commit). Global
+/// because the VM is constructed internally via [VMBlockExecutor::new]; tests run
+/// under nextest process isolation, and should `lock().clear()` at start.
+pub static INVALIDATE_CALLS: Lazy<Mutex<Vec<CacheInvalidationInfo>>> =
+    Lazy::new(|| Mutex::new(vec![]));
 
 pub static KEEP_STATUS: Lazy<TransactionStatus> =
     Lazy::new(|| TransactionStatus::Keep(ExecutionStatus::Success));
@@ -78,6 +95,7 @@ impl VMBlockExecutor for MockVM {
         let mut outputs = vec![];
 
         let mut skip_rest = false;
+        let mut published = vec![];
         for idx in 0..txn_provider.num_txns() {
             if skip_rest {
                 outputs.push(TransactionOutput::new(
@@ -194,6 +212,21 @@ impl VMBlockExecutor for MockVM {
                         TransactionAuxiliaryData::default(),
                     ));
                 },
+                MockVMTransaction::Publish { sender } => {
+                    // Bump the sender's seqnum so the block has a write to commit,
+                    // and mark the block as publishing modules.
+                    let balance = read_balance(&output_cache, state_view, sender);
+                    let new_seqnum = read_seqnum(&output_cache, state_view, sender) + 1;
+                    output_cache.insert(seqnum_ap(sender), new_seqnum);
+                    outputs.push(TransactionOutput::new(
+                        gen_mint_writeset(sender, balance, new_seqnum),
+                        vec![],
+                        0,
+                        KEEP_STATUS.clone(),
+                        TransactionAuxiliaryData::default(),
+                    ));
+                    published.push(ModuleId::new(sender, ident_str!("mock").to_owned()));
+                },
             }
         }
 
@@ -211,7 +244,12 @@ impl VMBlockExecutor for MockVM {
         Ok(BlockOutput::new(
             outputs,
             block_epilogue_txn.map(Into::into),
+            (!published.is_empty()).then_some(CacheInvalidationInfo::Legacy { published }),
         ))
+    }
+
+    fn invalidate(&self, info: &CacheInvalidationInfo) {
+        INVALIDATE_CALLS.lock().push(info.clone());
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(
@@ -373,6 +411,12 @@ pub fn encode_mint_transaction(sender: AccountAddress, amount: u64) -> Transacti
     encode_transaction(sender, encode_mint_program(amount))
 }
 
+pub fn encode_publish_transaction(sender: AccountAddress) -> Transaction {
+    // Non-empty code marks this as a module-publishing transaction for MockVM.
+    let program = Script::new(vec![1, 2, 3], vec![], vec![]);
+    encode_transaction(sender, program)
+}
+
 pub fn encode_transfer_transaction(
     sender: AccountAddress,
     recipient: AccountAddress,
@@ -403,7 +447,10 @@ pub fn encode_reconfiguration_transaction() -> Transaction {
 fn decode_transaction(txn: &SignedTransaction) -> MockVMTransaction {
     let sender = txn.sender();
     let script_to_mock_vm_txn = |script: &Script| {
-        assert!(script.code().is_empty(), "Code should be empty.");
+        // Non-empty code marks a module-publishing transaction.
+        if !script.code().is_empty() {
+            return MockVMTransaction::Publish { sender };
+        }
         match script.args().len() {
             1 => match script.args()[0] {
                 TransactionArgument::U64(amount) => MockVMTransaction::Mint { sender, amount },

--- a/execution/executor/src/tests/mock_vm/mod.rs
+++ b/execution/executor/src/tests/mock_vm/mod.rs
@@ -7,6 +7,7 @@ mod mock_vm_test;
 use anyhow::Result;
 use aptos_block_executor::txn_provider::{default::DefaultTxnProvider, TxnProvider};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use aptos_infallible::Mutex;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG,
@@ -22,8 +23,8 @@ use aptos_types::{
     state_store::{state_key::StateKey, StateView},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockEndInfo,
-        BlockError, BlockOutput, ChangeSet, ExecutionStatus, RawTransaction, Script,
-        SignedTransaction, Transaction, TransactionArgument, TransactionAuxiliaryData,
+        BlockError, BlockOutput, CacheInvalidationInfo, ChangeSet, ExecutionStatus, RawTransaction,
+        Script, SignedTransaction, Transaction, TransactionArgument, TransactionAuxiliaryData,
         TransactionExecutableRef, TransactionOutput, TransactionStatus, WriteSetPayload,
     },
     vm_status::{StatusCode, VMStatus},
@@ -48,7 +49,20 @@ enum MockVMTransaction {
         recipient: AccountAddress,
         amount: u64,
     },
+    // A module-publishing transaction (marked by non-empty script code). Produces
+    // a write so the block has something to commit, and flags the block as
+    // requiring cache invalidation.
+    Publish {
+        sender: AccountAddress,
+    },
 }
+
+/// Records the cache-invalidation infos passed to [MockVM::invalidate], so tests
+/// can assert invalidation happens (and only at commit, not pre-commit). Global
+/// because the VM is constructed internally via [VMBlockExecutor::new]; tests run
+/// under nextest process isolation, and should `lock().clear()` at start.
+pub static INVALIDATE_CALLS: Lazy<Mutex<Vec<CacheInvalidationInfo>>> =
+    Lazy::new(|| Mutex::new(vec![]));
 
 pub static KEEP_STATUS: Lazy<TransactionStatus> =
     Lazy::new(|| TransactionStatus::Keep(ExecutionStatus::Success));
@@ -78,6 +92,7 @@ impl VMBlockExecutor for MockVM {
         let mut outputs = vec![];
 
         let mut skip_rest = false;
+        let mut published = false;
         for idx in 0..txn_provider.num_txns() {
             if skip_rest {
                 outputs.push(TransactionOutput::new(
@@ -194,6 +209,21 @@ impl VMBlockExecutor for MockVM {
                         TransactionAuxiliaryData::default(),
                     ));
                 },
+                MockVMTransaction::Publish { sender } => {
+                    // Bump the sender's seqnum so the block has a write to commit,
+                    // and mark the block as publishing modules.
+                    let balance = read_balance(&output_cache, state_view, sender);
+                    let new_seqnum = read_seqnum(&output_cache, state_view, sender) + 1;
+                    output_cache.insert(seqnum_ap(sender), new_seqnum);
+                    outputs.push(TransactionOutput::new(
+                        gen_mint_writeset(sender, balance, new_seqnum),
+                        vec![],
+                        0,
+                        KEEP_STATUS.clone(),
+                        TransactionAuxiliaryData::default(),
+                    ));
+                    published = true;
+                },
             }
         }
 
@@ -208,10 +238,15 @@ impl VMBlockExecutor for MockVM {
             }
         }
 
-        Ok(BlockOutput::new(
+        Ok(BlockOutput::new_with_cache_invalidation_info(
             outputs,
             block_epilogue_txn.map(Into::into),
+            published.then_some(CacheInvalidationInfo::Dummy),
         ))
+    }
+
+    fn invalidate(&self, info: &CacheInvalidationInfo) {
+        INVALIDATE_CALLS.lock().push(info.clone());
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(
@@ -373,6 +408,12 @@ pub fn encode_mint_transaction(sender: AccountAddress, amount: u64) -> Transacti
     encode_transaction(sender, encode_mint_program(amount))
 }
 
+pub fn encode_publish_transaction(sender: AccountAddress) -> Transaction {
+    // Non-empty code marks this as a module-publishing transaction for MockVM.
+    let program = Script::new(vec![1, 2, 3], vec![], vec![]);
+    encode_transaction(sender, program)
+}
+
 pub fn encode_transfer_transaction(
     sender: AccountAddress,
     recipient: AccountAddress,
@@ -403,7 +444,10 @@ pub fn encode_reconfiguration_transaction() -> Transaction {
 fn decode_transaction(txn: &SignedTransaction) -> MockVMTransaction {
     let sender = txn.sender();
     let script_to_mock_vm_txn = |script: &Script| {
-        assert!(script.code().is_empty(), "Code should be empty.");
+        // Non-empty code marks a module-publishing transaction.
+        if !script.code().is_empty() {
+            return MockVMTransaction::Publish { sender };
+        }
         match script.args().len() {
             1 => match script.args()[0] {
                 TransactionArgument::U64(amount) => MockVMTransaction::Mint { sender, amount },

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -28,16 +28,18 @@ use aptos_types::{
         signature_verified_transaction::{
             into_signature_verified_block, SignatureVerifiedTransaction,
         },
-        AuxiliaryInfo, ExecutionStatus, PersistedAuxiliaryInfo, RawTransaction, Script,
-        SignedTransaction, Transaction, TransactionAuxiliaryData, TransactionListWithProofV2,
-        TransactionOutput, TransactionPayload, TransactionStatus, Version,
+        AuxiliaryInfo, CacheInvalidationInfo, ExecutionStatus, PersistedAuxiliaryInfo,
+        RawTransaction, Script, SignedTransaction, Transaction, TransactionAuxiliaryData,
+        TransactionListWithProofV2, TransactionOutput, TransactionPayload, TransactionStatus,
+        Version,
     },
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use itertools::Itertools;
+use move_core_types::{ident_str, language_storage::ModuleId};
 use mock_vm::{
-    encode_mint_transaction, encode_reconfiguration_transaction, encode_transfer_transaction,
-    MockVM, DISCARD_STATUS, KEEP_STATUS,
+    encode_mint_transaction, encode_publish_transaction, encode_reconfiguration_transaction,
+    encode_transfer_transaction, MockVM, DISCARD_STATUS, INVALIDATE_CALLS, KEEP_STATUS,
 };
 use proptest::prelude::*;
 use std::iter::once;
@@ -297,6 +299,71 @@ fn test_executor_commit_twice() {
     executor.pre_commit_block(block1_id).unwrap();
     executor.commit_ledger(ledger_info.clone()).unwrap();
     executor.commit_ledger(ledger_info).unwrap();
+}
+
+#[test]
+fn test_executor_invalidates_cache_at_commit_for_publishing_block() {
+    INVALIDATE_CALLS.lock().clear();
+
+    let executor = TestExecutor::new();
+    let parent_block_id = executor.committed_block_id();
+    let block_id = gen_block_id(1);
+    let publish_txn = encode_publish_transaction(gen_address(0));
+
+    let output = executor
+        .execute_block(
+            (block_id, block(vec![publish_txn])).into(),
+            parent_block_id,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
+        )
+        .unwrap();
+
+    // A publishing block is a barrier: consensus must wait for its commit.
+    assert!(executor.block_wait_for_commit(block_id).unwrap());
+
+    // Invalidation must not happen at pre-commit; a pre-committed branch can
+    // still be discarded.
+    executor.pre_commit_block(block_id).unwrap();
+    assert!(INVALIDATE_CALLS.lock().is_empty());
+
+    let ledger_info = gen_ledger_info(2, output.root_hash(), block_id, 1);
+    executor.commit_ledger(ledger_info).unwrap();
+
+    // Now that the ledger is committed, the VM cache is invalidated exactly once
+    // with the module published by this block.
+    assert_eq!(
+        *INVALIDATE_CALLS.lock(),
+        vec![CacheInvalidationInfo::Legacy {
+            published: vec![ModuleId::new(gen_address(0), ident_str!("mock").to_owned())],
+        }]
+    );
+}
+
+#[test]
+fn test_executor_does_not_invalidate_cache_for_normal_block() {
+    INVALIDATE_CALLS.lock().clear();
+
+    let executor = TestExecutor::new();
+    let parent_block_id = executor.committed_block_id();
+    let block_id = gen_block_id(1);
+    let mint_txn = encode_mint_transaction(gen_address(0), 100);
+
+    let output = executor
+        .execute_block(
+            (block_id, block(vec![mint_txn])).into(),
+            parent_block_id,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
+        )
+        .unwrap();
+
+    // A non-publishing block is not a barrier.
+    assert!(!executor.block_wait_for_commit(block_id).unwrap());
+
+    let ledger_info = gen_ledger_info(2, output.root_hash(), block_id, 1);
+    executor.pre_commit_block(block_id).unwrap();
+    executor.commit_ledger(ledger_info).unwrap();
+
+    assert!(INVALIDATE_CALLS.lock().is_empty());
 }
 
 #[test]

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -28,16 +28,17 @@ use aptos_types::{
         signature_verified_transaction::{
             into_signature_verified_block, SignatureVerifiedTransaction,
         },
-        AuxiliaryInfo, ExecutionStatus, PersistedAuxiliaryInfo, RawTransaction, Script,
-        SignedTransaction, Transaction, TransactionAuxiliaryData, TransactionListWithProofV2,
-        TransactionOutput, TransactionPayload, TransactionStatus, Version,
+        AuxiliaryInfo, CacheInvalidationInfo, ExecutionStatus, PersistedAuxiliaryInfo,
+        RawTransaction, Script, SignedTransaction, Transaction, TransactionAuxiliaryData,
+        TransactionListWithProofV2, TransactionOutput, TransactionPayload, TransactionStatus,
+        Version,
     },
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use itertools::Itertools;
 use mock_vm::{
-    encode_mint_transaction, encode_reconfiguration_transaction, encode_transfer_transaction,
-    MockVM, DISCARD_STATUS, KEEP_STATUS,
+    encode_mint_transaction, encode_publish_transaction, encode_reconfiguration_transaction,
+    encode_transfer_transaction, MockVM, DISCARD_STATUS, INVALIDATE_CALLS, KEEP_STATUS,
 };
 use proptest::prelude::*;
 use std::iter::once;
@@ -297,6 +298,65 @@ fn test_executor_commit_twice() {
     executor.pre_commit_block(block1_id).unwrap();
     executor.commit_ledger(ledger_info.clone()).unwrap();
     executor.commit_ledger(ledger_info).unwrap();
+}
+
+#[test]
+fn test_executor_invalidates_cache_at_commit_for_publishing_block() {
+    INVALIDATE_CALLS.lock().clear();
+
+    let executor = TestExecutor::new();
+    let parent_block_id = executor.committed_block_id();
+    let block_id = gen_block_id(1);
+    let publish_txn = encode_publish_transaction(gen_address(0));
+
+    let output = executor
+        .execute_block(
+            (block_id, block(vec![publish_txn])).into(),
+            parent_block_id,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
+        )
+        .unwrap();
+
+    // A publishing block is a barrier: consensus must wait for its commit.
+    assert!(executor.block_wait_for_commit(block_id));
+
+    // Invalidation must not happen at pre-commit; a pre-committed branch can
+    // still be discarded.
+    executor.pre_commit_block(block_id).unwrap();
+    assert!(INVALIDATE_CALLS.lock().is_empty());
+
+    let ledger_info = gen_ledger_info(2, output.root_hash(), block_id, 1);
+    executor.commit_ledger(ledger_info).unwrap();
+
+    // Now that the ledger is committed, the VM cache is invalidated exactly once.
+    assert_eq!(*INVALIDATE_CALLS.lock(), vec![CacheInvalidationInfo::Dummy]);
+}
+
+#[test]
+fn test_executor_does_not_invalidate_cache_for_normal_block() {
+    INVALIDATE_CALLS.lock().clear();
+
+    let executor = TestExecutor::new();
+    let parent_block_id = executor.committed_block_id();
+    let block_id = gen_block_id(1);
+    let mint_txn = encode_mint_transaction(gen_address(0), 100);
+
+    let output = executor
+        .execute_block(
+            (block_id, block(vec![mint_txn])).into(),
+            parent_block_id,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
+        )
+        .unwrap();
+
+    // A non-publishing block is not a barrier.
+    assert!(!executor.block_wait_for_commit(block_id));
+
+    let ledger_info = gen_ledger_info(2, output.root_hash(), block_id, 1);
+    executor.pre_commit_block(block_id).unwrap();
+    executor.commit_ledger(ledger_info).unwrap();
+
+    assert!(INVALIDATE_CALLS.lock().is_empty());
 }
 
 #[test]

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -44,8 +44,8 @@ use aptos_types::{
     },
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo,
-        AuxiliaryInfoTrait, BlockOutput, PersistedAuxiliaryInfo, Transaction, TransactionOutput,
-        TransactionStatus, Version,
+        AuxiliaryInfoTrait, BlockOutput, CacheInvalidationInfo, PersistedAuxiliaryInfo,
+        Transaction, TransactionOutput, TransactionStatus, Version,
     },
     write_set::{TransactionWrite, WriteSet},
 };
@@ -120,7 +120,8 @@ impl DoGetExecutionOutput {
             onchain_config,
             transaction_slice_metadata,
         )?;
-        let (mut transaction_outputs, block_epilogue_txn) = block_output.into_inner();
+        let (mut transaction_outputs, block_epilogue_txn, cache_invalidation_info) =
+            block_output.into_inner();
         let (transactions, mut auxiliary_infos) = txn_provider.into_inner();
         let mut transactions = transactions
             .into_iter()
@@ -179,6 +180,7 @@ impl DoGetExecutionOutput {
             .parent_state(parent_state)
             .base_state_view(state_view)
             .prime_state_cache(false)
+            .maybe_cache_invalidation_info(cache_invalidation_info)
             .is_block(
                 transaction_slice_metadata
                     .append_state_checkpoint_to_block()
@@ -356,6 +358,7 @@ impl DoGetExecutionOutput {
                     })
                     .collect::<Vec<_>>(),
                 None,
+                None,
             ),
         };
         Ok(transaction_outputs)
@@ -375,6 +378,7 @@ impl Parser {
         parent_state: &LedgerState,
         base_state_view: CachedStateView,
         prime_state_cache: bool,
+        cache_invalidation_info: Option<CacheInvalidationInfo>,
         is_block: bool,
         transaction_info_v1: bool,
         hot_state_root_in_txn_info: bool,
@@ -465,6 +469,7 @@ impl Parser {
             .hot_state_updates(hot_state_updates)
             .maybe_block_end_info(block_end_info)
             .maybe_next_epoch_state(next_epoch_state)
+            .maybe_cache_invalidation_info(cache_invalidation_info)
             .subscribable_events(Planned::place_holder())
             .transaction_info_v1(transaction_info_v1)
             .hot_state_root_in_txn_info(hot_state_root_in_txn_info)

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -44,8 +44,8 @@ use aptos_types::{
     },
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo,
-        AuxiliaryInfoTrait, BlockOutput, PersistedAuxiliaryInfo, Transaction, TransactionOutput,
-        TransactionStatus, Version,
+        AuxiliaryInfoTrait, BlockOutput, CacheInvalidationInfo, PersistedAuxiliaryInfo,
+        Transaction, TransactionOutput, TransactionStatus, Version,
     },
     write_set::{TransactionWrite, WriteSet},
 };
@@ -120,7 +120,8 @@ impl DoGetExecutionOutput {
             onchain_config,
             transaction_slice_metadata,
         )?;
-        let (mut transaction_outputs, block_epilogue_txn) = block_output.into_inner();
+        let (mut transaction_outputs, block_epilogue_txn, cache_invalidation_info) =
+            block_output.into_inner();
         let (transactions, mut auxiliary_infos) = txn_provider.into_inner();
         let mut transactions = transactions
             .into_iter()
@@ -179,6 +180,7 @@ impl DoGetExecutionOutput {
             .parent_state(parent_state)
             .base_state_view(state_view)
             .prime_state_cache(false)
+            .maybe_cache_invalidation_info(cache_invalidation_info)
             .is_block(
                 transaction_slice_metadata
                     .append_state_checkpoint_to_block()
@@ -375,6 +377,7 @@ impl Parser {
         parent_state: &LedgerState,
         base_state_view: CachedStateView,
         prime_state_cache: bool,
+        cache_invalidation_info: Option<CacheInvalidationInfo>,
         is_block: bool,
         transaction_info_v1: bool,
         hot_state_root_in_txn_info: bool,
@@ -465,6 +468,7 @@ impl Parser {
             .hot_state_updates(hot_state_updates)
             .maybe_block_end_info(block_end_info)
             .maybe_next_epoch_state(next_epoch_state)
+            .maybe_cache_invalidation_info(cache_invalidation_info)
             .subscribable_events(Planned::place_holder())
             .transaction_info_v1(transaction_info_v1)
             .hot_state_root_in_txn_info(hot_state_root_in_txn_info)

--- a/experimental/execution/ptx-executor/src/lib.rs
+++ b/experimental/execution/ptx-executor/src/lib.rs
@@ -33,7 +33,7 @@ use aptos_types::{
     state_store::StateView,
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
-        BlockOutput, TransactionOutput,
+        BlockOutput, CacheInvalidationInfo, TransactionOutput,
     },
 };
 use aptos_vm::{
@@ -106,7 +106,11 @@ impl VMBlockExecutor for PtxBlockExecutor {
             ret_clone.lock().replace(txn_outputs);
         });
         let ret = ret.lock().take().unwrap();
-        Ok(BlockOutput::new(ret, None))
+        Ok(BlockOutput::new(ret, None, None))
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(

--- a/experimental/execution/ptx-executor/src/lib.rs
+++ b/experimental/execution/ptx-executor/src/lib.rs
@@ -33,7 +33,7 @@ use aptos_types::{
     state_store::StateView,
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockError,
-        BlockOutput, TransactionOutput,
+        BlockOutput, CacheInvalidationInfo, TransactionOutput,
     },
 };
 use aptos_vm::{
@@ -107,6 +107,10 @@ impl VMBlockExecutor for PtxBlockExecutor {
         });
         let ret = ret.lock().take().unwrap();
         Ok(BlockOutput::new(ret, None))
+    }
+
+    fn invalidate(&self, _info: &CacheInvalidationInfo) {
+        // No caches to invalidate.
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(

--- a/types/src/transaction/block_output.rs
+++ b/types/src/transaction/block_output.rs
@@ -3,6 +3,7 @@
 
 use super::BlockExecutableTransaction;
 use crate::error::PanicError;
+use move_core_types::language_storage::ModuleId;
 use std::fmt::{self, Debug, Display};
 
 /// Unrecoverable error that aborts execution of an entire block.
@@ -38,6 +39,17 @@ impl From<PanicError> for BlockError {
 /// Result of executing a block: either its output, or an unrecoverable [BlockError].
 pub type BlockExecutionResult<T, Output> = Result<BlockOutput<T, Output>, BlockError>;
 
+/// Opaque, forward-compatible description of what a block's outputs require for
+/// cache coherence (e.g. module-cache invalidation when the block publishes
+/// code). Extended with real payloads as the code-publish flow lands.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CacheInvalidationInfo {
+    /// Coarse invalidation: the block published these modules, and downstream
+    /// caches must be synchronized against them. Finer-grained variants can be
+    /// added as the code-publish flow evolves.
+    Legacy { published: Vec<ModuleId> },
+}
+
 #[derive(Debug)]
 pub struct BlockOutput<T, Output>
 where
@@ -48,6 +60,9 @@ where
     // A BlockEpilogueTxn might be appended to the block.
     // This field will be None iff the input is not a block, or an epoch change is triggered.
     block_epilogue_txn: Option<T>,
+    // Information for the cache coherence protocol. None means the block requires
+    // no cache invalidation.
+    cache_invalidation_info: Option<CacheInvalidationInfo>,
 }
 
 impl<T, Output> BlockOutput<T, Output>
@@ -55,10 +70,15 @@ where
     T: BlockExecutableTransaction,
     Output: Debug,
 {
-    pub fn new(transaction_outputs: Vec<Output>, block_epilogue_txn: Option<T>) -> Self {
+    pub fn new(
+        transaction_outputs: Vec<Output>,
+        block_epilogue_txn: Option<T>,
+        cache_invalidation_info: Option<CacheInvalidationInfo>,
+    ) -> Self {
         Self {
             transaction_outputs,
             block_epilogue_txn,
+            cache_invalidation_info,
         }
     }
 
@@ -66,11 +86,50 @@ where
         self.transaction_outputs
     }
 
-    pub fn into_inner(self) -> (Vec<Output>, Option<T>) {
-        (self.transaction_outputs, self.block_epilogue_txn)
+    pub fn into_inner(self) -> (Vec<Output>, Option<T>, Option<CacheInvalidationInfo>) {
+        (
+            self.transaction_outputs,
+            self.block_epilogue_txn,
+            self.cache_invalidation_info,
+        )
     }
 
     pub fn get_transaction_outputs_forced(&self) -> &[Output] {
         &self.transaction_outputs
+    }
+
+    pub fn cache_invalidation_info(&self) -> &Option<CacheInvalidationInfo> {
+        &self.cache_invalidation_info
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transaction::signature_verified_transaction::SignatureVerifiedTransaction;
+
+    // `T` appears only as a type parameter; with `block_epilogue_txn = None` no
+    // transaction is ever constructed, so a real transaction type suffices.
+    type TestBlockOutput = BlockOutput<SignatureVerifiedTransaction, u64>;
+
+    #[test]
+    fn no_cache_invalidation_info() {
+        let output = TestBlockOutput::new(vec![1, 2], None, None);
+        assert!(output.cache_invalidation_info().is_none());
+
+        let (outputs, epilogue, info) = output.into_inner();
+        assert_eq!(outputs, vec![1, 2]);
+        assert!(epilogue.is_none());
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn cache_invalidation_info_round_trips() {
+        let info = CacheInvalidationInfo::Legacy { published: vec![] };
+        let output = TestBlockOutput::new(vec![1, 2], None, Some(info.clone()));
+        assert_eq!(output.cache_invalidation_info(), &Some(info.clone()));
+
+        let (_outputs, _epilogue, round_tripped) = output.into_inner();
+        assert_eq!(round_tripped, Some(info));
     }
 }

--- a/types/src/transaction/block_output.rs
+++ b/types/src/transaction/block_output.rs
@@ -38,6 +38,16 @@ impl From<PanicError> for BlockError {
 /// Result of executing a block: either its output, or an unrecoverable [BlockError].
 pub type BlockExecutionResult<T, Output> = Result<BlockOutput<T, Output>, BlockError>;
 
+/// Opaque, forward-compatible description of what a block's outputs require for
+/// cache coherence (e.g. module-cache invalidation when the block publishes
+/// code). Extended with real payloads as the code-publish flow lands.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CacheInvalidationInfo {
+    /// Placeholder marker until real invalidation payloads exist.
+    Dummy,
+    // Future: published module ids / serialized blobs / granularity markers.
+}
+
 #[derive(Debug)]
 pub struct BlockOutput<T, Output>
 where
@@ -48,6 +58,9 @@ where
     // A BlockEpilogueTxn might be appended to the block.
     // This field will be None iff the input is not a block, or an epoch change is triggered.
     block_epilogue_txn: Option<T>,
+    // Side-band information for the cache coherence protocol. None means the block
+    // requires no cache invalidation (the common case).
+    cache_invalidation_info: Option<CacheInvalidationInfo>,
 }
 
 impl<T, Output> BlockOutput<T, Output>
@@ -59,6 +72,19 @@ where
         Self {
             transaction_outputs,
             block_epilogue_txn,
+            cache_invalidation_info: None,
+        }
+    }
+
+    pub fn new_with_cache_invalidation_info(
+        transaction_outputs: Vec<Output>,
+        block_epilogue_txn: Option<T>,
+        cache_invalidation_info: Option<CacheInvalidationInfo>,
+    ) -> Self {
+        Self {
+            transaction_outputs,
+            block_epilogue_txn,
+            cache_invalidation_info,
         }
     }
 
@@ -66,11 +92,56 @@ where
         self.transaction_outputs
     }
 
-    pub fn into_inner(self) -> (Vec<Output>, Option<T>) {
-        (self.transaction_outputs, self.block_epilogue_txn)
+    pub fn into_inner(self) -> (Vec<Output>, Option<T>, Option<CacheInvalidationInfo>) {
+        (
+            self.transaction_outputs,
+            self.block_epilogue_txn,
+            self.cache_invalidation_info,
+        )
     }
 
     pub fn get_transaction_outputs_forced(&self) -> &[Output] {
         &self.transaction_outputs
+    }
+
+    pub fn cache_invalidation_info(&self) -> &Option<CacheInvalidationInfo> {
+        &self.cache_invalidation_info
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transaction::signature_verified_transaction::SignatureVerifiedTransaction;
+
+    // `T` appears only as a type parameter; with `block_epilogue_txn = None` no
+    // transaction is ever constructed, so a real transaction type suffices.
+    type TestBlockOutput = BlockOutput<SignatureVerifiedTransaction, u64>;
+
+    #[test]
+    fn new_defaults_to_no_cache_invalidation_info() {
+        let output = TestBlockOutput::new(vec![1, 2], None);
+        assert!(output.cache_invalidation_info().is_none());
+
+        let (outputs, epilogue, info) = output.into_inner();
+        assert_eq!(outputs, vec![1, 2]);
+        assert!(epilogue.is_none());
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn cache_invalidation_info_round_trips() {
+        let output = TestBlockOutput::new_with_cache_invalidation_info(
+            vec![1, 2],
+            None,
+            Some(CacheInvalidationInfo::Dummy),
+        );
+        assert_eq!(
+            output.cache_invalidation_info(),
+            &Some(CacheInvalidationInfo::Dummy)
+        );
+
+        let (_outputs, _epilogue, info) = output.into_inner();
+        assert_eq!(info, Some(CacheInvalidationInfo::Dummy));
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -74,7 +74,7 @@ use crate::{
     validator_txn::ValidatorTransaction,
     write_set::TransactionWrite,
 };
-pub use block_output::{BlockError, BlockExecutionResult, BlockOutput};
+pub use block_output::{BlockError, BlockExecutionResult, BlockOutput, CacheInvalidationInfo};
 pub use change_set::ChangeSet;
 pub use module::{Module, ModuleBundle};
 pub use move_core_types::transaction_argument::TransactionArgument;

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -72,7 +72,7 @@ use crate::{
     validator_txn::ValidatorTransaction,
     write_set::TransactionWrite,
 };
-pub use block_output::{BlockError, BlockExecutionResult, BlockOutput};
+pub use block_output::{BlockError, BlockExecutionResult, BlockOutput, CacheInvalidationInfo};
 pub use change_set::ChangeSet;
 pub use module::{Module, ModuleBundle};
 pub use move_core_types::transaction_argument::TransactionArgument;


### PR DESCRIPTION
## Description

Scaffolding for an upcoming code-publishing flow. This PR threads an opaque, extensible cache-invalidation signal from block execution through the executor to two commit-time hook points, and adds a consensus barrier so a module-publishing block is never speculatively executed on top of before it commits.

It is a no-op in production today: nothing populates the signal yet, so the info defaults to `None` and neither the barrier nor invalidation fires.

Two behaviors are wired but dormant:

1. After a block **commits** (not merely pre-commits), the executor's VM invalidates its caches from the block's info. Invalidating at pre-commit would be wrong — a pre-committed branch can still be discarded, which would leave the cache invalidated against writes that never committed.
2. In the pipelined ("Zaptos") consensus, a publishing block becomes a barrier: no block executes on top of it until it commits (or its branch is discarded), so speculative execution cannot run against a stale module cache.

The opaque type is `Option<CacheInvalidationInfo>`, where `CacheInvalidationInfo::Legacy { published: Vec<ModuleId> }` names the modules a block published. `None` means no invalidation and no barrier. Consumers use exhaustive matches, so adding finer-grained variants later forces every site to be updated.

### Data flow

- VM `BlockOutput` carries `cache_invalidation_info: Option<CacheInvalidationInfo>` (now an explicit arg on `BlockOutput::new`).
- It threads through `ExecutionOutput`/`Inner`, exposed as `needs_invalidation()`.
- `VMBlockExecutor::invalidate(&CacheInvalidationInfo)` is a new **required** trait method (no default, so a new VM cannot silently skip invalidation). Non-caching implementors get an explicit empty body; `AptosVM` has a TODO no-op until real payloads exist.
- Executor `commit_ledger` calls `invalidate` after the DB commit succeeds.
- `BlockExecutorTrait::block_wait_for_commit(block_id) -> ExecutorResult<bool>` is the consensus barrier query; the execute stage awaits the parent's commit future when it returns `true`.

## How Has This Been Tested?

- `cargo check` across `aptos-types`, `aptos-executor-types`, `aptos-executor`, `aptos-vm`, `aptos-consensus`.
- New unit tests in `types/src/transaction/block_output.rs`: `None` round-trips as no invalidation; `Some(Legacy { .. })` round-trips through the accessor and `into_inner`.
- New end-to-end wiring tests via `MockVM` in `execution/executor/src/tests/mod.rs`:
  - Publishing block: `block_wait_for_commit` is `true`, `invalidate` is NOT called at pre-commit, and is called exactly once at `commit_ledger` with the published module ids.
  - Normal block: `block_wait_for_commit` is `false` and `invalidate` is never called.
- Existing `test_executor_commit_twice` is the regression check that the defaulted plumbing changes no behavior.

## Key Areas to Review

- **Invalidation fires only at commit, never pre-commit** (`execution/executor/src/block_executor/mod.rs`). The execute-stage gate guarantees a publishing block always commits as the tip, so it is never a batch-commit intermediate.
- **The consensus barrier waits for the parent's full commit** (`consensus/src/pipeline/pipeline_builder.rs`). Cost is a one-commit-latency pipeline bubble per publishing block, refinable later via the opaque signal. Reconfiguration's existing pre-commit self-wait is left untouched — it is a separate mechanism.
- **`VMBlockExecutor::invalidate` is intentionally required** (no default no-op), so every VM implementor must opt in explicitly.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator execution/consensus ordering around commit and speculative execute; logic is gated on optional invalidation info but incorrect wiring later could cause stale caches or pipeline stalls on publish blocks.
> 
> **Overview**
> Scaffolding for **module-publish cache coherence**: block execution can attach optional **`CacheInvalidationInfo`** (today only `Legacy { published: Vec<ModuleId> }`) on **`BlockOutput`**, carried through **`ExecutionOutput`** as **`needs_invalidation()`**.
> 
> **`VMBlockExecutor::invalidate`** is a new required hook; **`AptosVM`** implements it as a no-op until real payloads are wired. After **`commit_ledger`** succeeds (not pre-commit), the executor calls **`invalidate`** when the committed block carries info.
> 
> Consensus **execute** now queries **`block_wait_for_commit(parent)`** and, when true, awaits the parent’s **commit** future before running—so speculative execution cannot stack on a publishing barrier with a stale module cache. **`BlockExecutorTrait::block_wait_for_commit`** implements that query from stored execution output.
> 
> Production behavior is unchanged while nothing sets non-`None` invalidation info; **MockVM** tests exercise publish → barrier → commit-time invalidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 095f9f5ce74b2cc73c3a16a8947edfd666f30d4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->