### PR TITLE
[move-vm] Bounding per-instruction cache memory in the Move VM

### DIFF
--- a/third_party/move/move-vm/integration-tests/src/tests/frame_cache_budget_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/frame_cache_budget_tests.rs
@@ -1,0 +1,336 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Tests for the bound on per-instruction frame caches.
+//!
+//! A frame cache is created per distinct `(function, type arguments)` pair and its per-instruction
+//! cache is sized by the callee's bytecode length. Both quantities are user controlled, so the
+//! product is bounded by [`move_vm_runtime::InstructionCacheBudgetOverride`]'s budget.
+//!
+//! The bound itself is asserted deterministically by the unit tests in
+//! `move-vm-runtime/src/frame_type_cache.rs`. What these tests establish is the property the bound
+//! relies on to ship without a feature gate: the per-instruction cache is a pure memoization of
+//! the frame cache's function maps, so varying the budget - including removing the cache entirely -
+//! cannot change execution results or gas.
+
+use move_binary_format::{
+    errors::VMResult,
+    file_format::{
+        empty_module, Bytecode, CodeUnit, CompiledModule, FieldDefinition, FunctionDefinition,
+        FunctionHandle, FunctionHandleIndex, FunctionInstantiation, FunctionInstantiationIndex,
+        IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
+        StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex, TypeSignature,
+        Visibility,
+    },
+};
+use move_core_types::{
+    ability::{Ability, AbilitySet},
+    account_address::AccountAddress,
+    ident_str,
+    identifier::Identifier,
+    vm_status::StatusCode,
+};
+use move_vm_runtime::{
+    config::VMConfig,
+    data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
+    dispatch_loader,
+    module_traversal::{TraversalContext, TraversalStorage},
+    move_vm::{MoveVM, SerializedReturnValues},
+    native_extensions::NativeContextExtensions,
+    AsUnsyncModuleStorage, InstantiatedFunctionLoader, InstructionCacheBudgetOverride,
+    LegacyLoaderConfig, ModuleStorage, RuntimeEnvironment,
+};
+use move_vm_test_utils::{
+    gas_schedule::{Gas, GasStatus, INITIAL_COST_SCHEDULE},
+    InMemoryStorage,
+};
+
+const ADDRESS: AccountAddress = AccountAddress::TWO;
+
+/// Number of distinct single-field structs used to build type arguments. Every ordered pair is a
+/// distinct instantiation of `pad`, so this produces `STRUCT_COUNT * STRUCT_COUNT` frame caches.
+const STRUCT_COUNT: usize = 23;
+const INSTANTIATIONS: usize = STRUCT_COUNT * STRUCT_COUNT;
+
+/// Bytecode length of the callee. Only the first instruction executes; the rest is padding that a
+/// publisher gets for free, since `Nop` costs nothing in the binary complexity meter and the
+/// bytecode verifier skips unreachable blocks. Keep this small: the `usize::MAX`-budget runs
+/// allocate the full `INSTANTIATIONS * PAD_CODE_SIZE` product (~12 MiB here), and a larger pad
+/// proves nothing more — the blow-up is scale-invariant.
+const PAD_CODE_SIZE: usize = 1_001;
+
+/// `call_all` is one `CallGeneric` per instantiation plus a `Ret`. Its own frame cache is allocated
+/// too, so it counts towards the budget.
+const CALL_ALL_CODE_SIZE: usize = INSTANTIATIONS + 1;
+
+/// Entries the pre-fix code allocated for this call graph: one full-length per-instruction cache
+/// per distinct instantiation, plus the entry function's own.
+const UNBOUNDED_ENTRIES: usize = INSTANTIATIONS * PAD_CODE_SIZE + CALL_ALL_CODE_SIZE;
+
+/// What an execution produced. `call_all` returns nothing, so the status and the gas consumed fully
+/// describe the observable outcome.
+#[derive(Debug, PartialEq, Eq)]
+struct Outcome {
+    status: Option<StatusCode>,
+    gas_used: u64,
+}
+
+fn push_identifier(module: &mut CompiledModule, name: &str) -> IdentifierIndex {
+    let index = module.identifiers.len() as u16;
+    module.identifiers.push(Identifier::new(name).unwrap());
+    IdentifierIndex(index)
+}
+
+/// Builds a module with the shape: one long generic callee reached at many
+/// distinct type vectors.
+///
+///
+/// ```text
+/// module 0x2::m {
+///     struct S0 has copy, drop, store { value: u8 }
+///     ...
+///     public fun pad<T0, T1>() { return; <PAD_CODE_SIZE - 2 nops>; return }
+///     public fun call_all() { pad<S0, S0>(); pad<S0, S1>(); ...; return }
+/// }
+/// ```
+fn many_instantiations_module() -> CompiledModule {
+    let mut module = empty_module();
+    module.address_identifiers[0] = ADDRESS;
+    module.identifiers[0] = Identifier::new("m").unwrap();
+
+    let pad_name = push_identifier(&mut module, "pad");
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: pad_name,
+        parameters: SignatureIndex(0),
+        return_: SignatureIndex(0),
+        type_parameters: vec![AbilitySet::EMPTY, AbilitySet::EMPTY],
+        access_specifiers: None,
+        attributes: vec![],
+    });
+
+    let call_all_name = push_identifier(&mut module, "call_all");
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: call_all_name,
+        parameters: SignatureIndex(0),
+        return_: SignatureIndex(0),
+        type_parameters: vec![],
+        access_specifiers: None,
+        attributes: vec![],
+    });
+
+    let field_name = push_identifier(&mut module, "value");
+    let abilities = AbilitySet::singleton(Ability::Copy) | Ability::Drop | Ability::Store;
+    for index in 0..STRUCT_COUNT {
+        let struct_name = push_identifier(&mut module, &format!("S{index}"));
+        module.struct_handles.push(StructHandle {
+            module: ModuleHandleIndex(0),
+            name: struct_name,
+            abilities,
+            type_parameters: vec![],
+        });
+        module.struct_defs.push(StructDefinition {
+            struct_handle: StructHandleIndex(index as u16),
+            field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+                name: field_name,
+                signature: TypeSignature(SignatureToken::U8),
+            }]),
+        });
+    }
+
+    // The first `Ret` makes everything after it unreachable, so the padding is never executed and
+    // never analyzed by the verifier's abstract interpreter.
+    let mut pad_code = Vec::with_capacity(PAD_CODE_SIZE);
+    pad_code.push(Bytecode::Ret);
+    pad_code.resize(PAD_CODE_SIZE - 1, Bytecode::Nop);
+    pad_code.push(Bytecode::Ret);
+    assert_eq!(pad_code.len(), PAD_CODE_SIZE);
+
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Public,
+        is_entry: false,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: pad_code,
+        }),
+    });
+
+    let mut call_all_code = Vec::with_capacity(INSTANTIATIONS + 1);
+    for first in 0..STRUCT_COUNT {
+        for second in 0..STRUCT_COUNT {
+            let signature_index = module.signatures.len() as u16;
+            module.signatures.push(Signature(vec![
+                SignatureToken::Struct(StructHandleIndex(first as u16)),
+                SignatureToken::Struct(StructHandleIndex(second as u16)),
+            ]));
+
+            let instantiation_index = module.function_instantiations.len() as u16;
+            module.function_instantiations.push(FunctionInstantiation {
+                handle: FunctionHandleIndex(0),
+                type_parameters: SignatureIndex(signature_index),
+            });
+            call_all_code.push(Bytecode::CallGeneric(FunctionInstantiationIndex(
+                instantiation_index,
+            )));
+        }
+    }
+    call_all_code.push(Bytecode::Ret);
+
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(1),
+        visibility: Visibility::Public,
+        is_entry: false,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: call_all_code,
+        }),
+    });
+
+    module
+}
+
+/// Executes `0x2::m::call_all` with the per-instruction cache budget capped at `max_cache_entries`,
+/// returning the observable outcome and the number of cache entries the run allocated.
+fn run_call_all(module: &CompiledModule, max_cache_entries: usize) -> (Outcome, usize) {
+    let budget_override = InstructionCacheBudgetOverride::new(max_cache_entries);
+
+    let runtime_environment = RuntimeEnvironment::new_with_config(vec![], VMConfig {
+        paranoid_type_checks: true,
+        ..VMConfig::default_for_test()
+    });
+    let mut storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
+
+    let mut module_bytes = vec![];
+    module.serialize(&mut module_bytes).unwrap();
+    storage.add_module_bytes(module.self_addr(), module.self_name(), module_bytes.into());
+
+    let module_storage = storage.as_unsync_module_storage();
+    let traversal_storage = TraversalStorage::new();
+    let mut traversal_context = TraversalContext::new(&traversal_storage);
+    let mut data_cache = TransactionDataCache::empty();
+
+    let gas_budget = Gas::new(1_000_000);
+    let mut gas_meter = GasStatus::new(INITIAL_COST_SCHEDULE.clone(), gas_budget);
+
+    let result = execute_call_all(
+        module,
+        &module_storage,
+        &storage,
+        &mut data_cache,
+        &mut gas_meter,
+        &mut traversal_context,
+    );
+
+    let outcome = Outcome {
+        status: result.err().map(|err| err.major_status()),
+        gas_used: u64::from(gas_budget) - u64::from(gas_meter.remaining_gas()),
+    };
+    (outcome, budget_override.entries_allocated())
+}
+
+fn execute_call_all(
+    module: &CompiledModule,
+    module_storage: &impl ModuleStorage,
+    storage: &InMemoryStorage,
+    data_cache: &mut TransactionDataCache,
+    gas_meter: &mut GasStatus,
+    traversal_context: &mut TraversalContext,
+) -> VMResult<SerializedReturnValues> {
+    dispatch_loader!(module_storage, loader, {
+        let function = loader.load_instantiated_function(
+            &LegacyLoaderConfig::unmetered(),
+            gas_meter,
+            traversal_context,
+            &module.self_id(),
+            ident_str!("call_all"),
+            &[],
+        )?;
+        MoveVM::execute_loaded_function(
+            function,
+            Vec::<Vec<u8>>::new(),
+            &mut MoveVmDataCacheAdapter::new(data_cache, storage, &loader),
+            gas_meter,
+            traversal_context,
+            &mut NativeContextExtensions::default(),
+            &loader,
+        )
+    })
+}
+
+/// The property that lets the bound ship without a feature gate.
+///
+/// The per-instruction cache is only ever written after the corresponding entry exists in
+/// `FrameTypeCache::function_cache` / `generic_function_cache`, and gas is charged only when those
+/// maps miss. A hit in the per-instruction cache therefore implies a hit in the maps, so removing
+/// it can never cause work to be redone or gas to be charged twice.
+#[test]
+fn cache_budget_does_not_change_results_or_gas() {
+    let module = many_instantiations_module();
+    move_bytecode_verifier::verify_module(&module).expect("module must verify");
+
+    // No per-instruction caching at all: every call site falls through to the function maps.
+    let (without_cache, entries) = run_call_all(&module, 0);
+    assert_eq!(
+        without_cache.status, None,
+        "execution must succeed, got {:?}",
+        without_cache.status
+    );
+    assert_eq!(entries, 0);
+    assert!(
+        without_cache.gas_used > 0,
+        "gas must actually be metered for this comparison to mean anything"
+    );
+
+    // Enough budget for every instantiation, i.e. the unbounded pre-fix allocation.
+    let (with_full_cache, entries) = run_call_all(&module, usize::MAX);
+    assert_eq!(entries, UNBOUNDED_ENTRIES);
+    assert_eq!(with_full_cache, without_cache);
+
+    // Partial: the budget runs out partway through, so some frame caches have a per-instruction
+    // cache and some do not. This is the state the production bound actually produces.
+    let max_entries = PAD_CODE_SIZE * 3;
+    let (with_partial_cache, entries) = run_call_all(&module, max_entries);
+    assert!((1..=max_entries).contains(&entries), "allocated {entries}");
+    assert_eq!(with_partial_cache, without_cache);
+
+    // A budget too small for the padded callee, so only the entry function gets a cache.
+    let max_entries = PAD_CODE_SIZE - 1;
+    let (with_unusable_cache, entries) = run_call_all(&module, max_entries);
+    assert_eq!(entries, CALL_ALL_CODE_SIZE);
+    assert_eq!(with_unusable_cache, without_cache);
+}
+
+/// Regression test for APTOSNT-487.
+///
+/// Before the fix, `FrameTypeCache::make_rc_for_function` resized the per-instruction cache to the
+/// callee's full bytecode length unconditionally and every distinct instantiation got its own, so
+/// this call graph retained `INSTANTIATIONS * PAD_CODE_SIZE` entries for a transaction that
+/// executes `INSTANTIATIONS + 1` instructions. The unbounded run below reproduces that number
+/// exactly; scaled to mainnet's transaction and dependency limits the same shape reaches ~190 GiB.
+#[test]
+fn many_instantiations_of_a_long_function_stay_within_budget() {
+    let module = many_instantiations_module();
+    move_bytecode_verifier::verify_module(&module).expect("module must verify");
+
+    // Pre-fix behaviour: allocation is the product of two user-controlled quantities.
+    let (unbounded_outcome, unbounded_entries) = run_call_all(&module, usize::MAX);
+    assert_eq!(unbounded_outcome.status, None);
+    assert_eq!(unbounded_entries, UNBOUNDED_ENTRIES);
+
+    // Post-fix: the same call graph is capped at the budget, and still runs.
+    let max_entries = PAD_CODE_SIZE * 2;
+    let (bounded_outcome, bounded_entries) = run_call_all(&module, max_entries);
+    assert_eq!(bounded_outcome.status, None, "execution must succeed");
+    assert!(
+        bounded_entries <= max_entries,
+        "allocated {bounded_entries} entries against a budget of {max_entries}"
+    );
+    assert!(
+        unbounded_entries / bounded_entries >= 100,
+        "bound must be a material reduction: {unbounded_entries} -> {bounded_entries}"
+    );
+}

--- a/third_party/move/move-vm/integration-tests/src/tests/mod.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mod.rs
@@ -26,6 +26,7 @@ mod bad_entry_point_tests;
 mod bad_storage_tests;
 mod binary_format_version;
 mod exec_func_effects_tests;
+mod frame_cache_budget_tests;
 mod function_arg_tests;
 mod instantiation_tests;
 mod leak_tests;

--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{frame::Frame, LoadedFunction};
+use crate::{frame::Frame, interpreter_caches::InstructionCacheBudget, LoadedFunction};
 use move_binary_format::{
     errors::*,
     file_format::{
@@ -60,7 +60,20 @@ pub(crate) struct FrameTypeCache {
     /// the argument of the bytecode instructions, for which it is
     /// guaranteed that everything will be exactly the same as when we
     /// did the insertion.
-    pub(crate) per_instruction_cache: Vec<PerInstructionCache>,
+    ///
+    /// INVARIANT: `per_instruction_cache` is a pure memoization of [Self::function_cache] for
+    /// `Call` sites and [Self::generic_function_cache] for `CallGeneric` sites. Those two maps,
+    /// not this cache, decide whether a call site is resolved and gas is charged.
+    ///
+    /// A slot is filled only after that call site's entry in the matching map exists, and neither
+    /// the slot nor that map entry is ever removed. Both are owned by the enclosing
+    /// [FrameTypeCache], which lives for one interpreter invocation.
+    ///
+    /// A hit in `per_instruction_cache` therefore guarantees the matching map lookup would have
+    /// hit too, and neither path charges gas; a miss must fall through to that map rather than
+    /// resolving the call itself. This cache can consequently be shorter than the bytecode, or
+    /// empty, with no effect on gas or execution results.
+    per_instruction_cache: Vec<PerInstructionCache>,
 
     /// Caches function and its cache for non-generic handles. Uses weak reference for cache to
     /// prevent memory leaks for recursive functions.
@@ -223,17 +236,140 @@ impl FrameTypeCache {
         Ok((ty, *ty_count, *depth))
     }
 
+    /// Returns the memoized entry for the instruction at `pc`, if any.
+    ///
+    /// A `None` result means "not memoized" and must be handled by falling through to
+    /// [Self::function_cache] / [Self::generic_function_cache]. See the invariant on
+    /// [Self::per_instruction_cache].
+    pub(crate) fn instruction_cache_at(&self, pc: u16) -> Option<&PerInstructionCache> {
+        self.per_instruction_cache.get(pc as usize)
+    }
+
+    /// Best-effort memoization of the resolved call target at `pc`.
+    ///
+    /// Dropping the write is always safe: it only costs a map lookup next time, never a different
+    /// result or a different gas charge. See the invariant on [Self::per_instruction_cache].
+    pub(crate) fn memoize_instruction(&mut self, pc: u16, entry: PerInstructionCache) {
+        if let Some(slot) = self.per_instruction_cache.get_mut(pc as usize) {
+            *slot = entry;
+        }
+    }
+
     pub(crate) fn make_rc() -> Rc<RefCell<Self>> {
         Rc::new(RefCell::<Self>::new(Default::default()))
     }
 
-    pub(crate) fn make_rc_for_function(function: &LoadedFunction) -> Rc<RefCell<Self>> {
-        let frame_cache = Rc::new(RefCell::<Self>::new(Default::default()));
+    /// Creates a frame cache for a function with `code_size` instructions, giving it a
+    /// per-instruction cache only if `budget` can cover it. When the budget is exhausted the
+    /// cache still works, just without the per-instruction fast path.
+    pub(crate) fn make_rc_for_code_size(
+        code_size: usize,
+        budget: &mut InstructionCacheBudget,
+    ) -> Rc<RefCell<Self>> {
+        let mut frame_cache = Self::default();
+        if budget.try_reserve(code_size) {
+            frame_cache
+                .per_instruction_cache
+                .resize(code_size, PerInstructionCache::Nothing);
+        }
+        Rc::new(RefCell::new(frame_cache))
+    }
+}
 
-        frame_cache
-            .borrow_mut()
-            .per_instruction_cache
-            .resize(function.code_size(), PerInstructionCache::Nothing);
-        frame_cache
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interpreter_caches::InstructionCacheBudgetOverride;
+
+    fn budget_with(max_entries: usize) -> InstructionCacheBudget {
+        let _override = InstructionCacheBudgetOverride::new(max_entries);
+        InstructionCacheBudget::new()
+    }
+
+    fn allocated_entries(frame_cache: &Rc<RefCell<FrameTypeCache>>) -> usize {
+        frame_cache.borrow().per_instruction_cache.len()
+    }
+
+    #[test]
+    fn allocated_instruction_cache_is_addressable_within_bounds() {
+        let mut budget = budget_with(1_000);
+        let frame_cache = FrameTypeCache::make_rc_for_code_size(500, &mut budget);
+        assert_eq!(allocated_entries(&frame_cache), 500);
+
+        let mut frame_cache = frame_cache.borrow_mut();
+        assert!(matches!(
+            frame_cache.instruction_cache_at(0),
+            Some(PerInstructionCache::Nothing)
+        ));
+        assert!(matches!(
+            frame_cache.instruction_cache_at(499),
+            Some(PerInstructionCache::Nothing)
+        ));
+        assert!(frame_cache.instruction_cache_at(500).is_none());
+
+        // Out of range writes are dropped rather than panicking.
+        frame_cache.memoize_instruction(500, PerInstructionCache::Nothing);
+    }
+
+    /// Absence of a per-instruction cache must read as a plain miss. Before the fix the access
+    /// sites indexed the vector directly, so an unallocated cache was not representable: reads
+    /// would have panicked instead of falling through to the function caches.
+    #[test]
+    fn absent_instruction_cache_reads_as_a_miss() {
+        let mut budget = budget_with(0);
+        let frame_cache = FrameTypeCache::make_rc_for_code_size(500, &mut budget);
+        assert_eq!(allocated_entries(&frame_cache), 0);
+
+        let mut frame_cache = frame_cache.borrow_mut();
+        assert!(frame_cache.instruction_cache_at(0).is_none());
+        assert!(frame_cache.instruction_cache_at(499).is_none());
+
+        // Writes are dropped rather than panicking, and the cache stays absent.
+        frame_cache.memoize_instruction(0, PerInstructionCache::Nothing);
+        assert!(frame_cache.instruction_cache_at(0).is_none());
+    }
+
+    /// The shape of APTOSNT-487: one long generic callee reached at many distinct type vectors,
+    /// each of which gets its own frame cache sized by the callee's bytecode length.
+    #[test]
+    fn aggregate_allocation_is_bounded_across_instantiations() {
+        const CODE_SIZE: usize = 10_000;
+        const INSTANTIATIONS: usize = 1_000;
+        const MAX_ENTRIES: usize = 100_000;
+
+        // Before the fix the resize was unconditional, so the total allocated was the product of
+        // two attacker-controlled quantities with no ceiling.
+        let unbounded_entries = CODE_SIZE * INSTANTIATIONS;
+
+        let mut budget = budget_with(MAX_ENTRIES);
+        let frame_caches = (0..INSTANTIATIONS)
+            .map(|_| FrameTypeCache::make_rc_for_code_size(CODE_SIZE, &mut budget))
+            .collect::<Vec<_>>();
+
+        let allocated = frame_caches.iter().map(allocated_entries).sum::<usize>();
+        assert_eq!(allocated, MAX_ENTRIES);
+        assert_eq!(unbounded_entries / allocated, 100);
+
+        // Exactly the first `MAX_ENTRIES / CODE_SIZE` instantiations get a per-instruction cache;
+        // the rest fall back to the function caches.
+        let with_cache = frame_caches
+            .iter()
+            .filter(|frame_cache| allocated_entries(frame_cache) > 0)
+            .count();
+        assert_eq!(with_cache, MAX_ENTRIES / CODE_SIZE);
+        assert_eq!(allocated_entries(frame_caches.last().unwrap()), 0);
+    }
+
+    /// A refused reservation must not consume budget, otherwise one oversized function would
+    /// starve every later one.
+    #[test]
+    fn refused_allocation_leaves_budget_for_smaller_functions() {
+        let mut budget = budget_with(1_000);
+
+        let too_big = FrameTypeCache::make_rc_for_code_size(1_001, &mut budget);
+        assert_eq!(allocated_entries(&too_big), 0);
+
+        let fits = FrameTypeCache::make_rc_for_code_size(1_000, &mut budget);
+        assert_eq!(allocated_entries(&fits), 1_000);
     }
 }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -430,8 +430,8 @@ where
                     let (function, frame_cache) = if self.vm_config.enable_function_caches {
                         let current_frame_cache = &mut *current_frame.frame_cache.borrow_mut();
 
-                        if let PerInstructionCache::Call(ref function, ref frame_cache) =
-                            current_frame_cache.per_instruction_cache[current_frame.pc as usize]
+                        if let Some(PerInstructionCache::Call(function, frame_cache)) =
+                            current_frame_cache.instruction_cache_at(current_frame.pc)
                         {
                             let frame_cache = frame_cache.upgrade().ok_or_else(|| {
                                 PartialVMError::new_invariant_violation(
@@ -469,11 +469,13 @@ where
                                         (function.clone(), frame_cache)
                                     },
                                 };
-                            current_frame_cache.per_instruction_cache[current_frame.pc as usize] =
+                            current_frame_cache.memoize_instruction(
+                                current_frame.pc,
                                 PerInstructionCache::Call(
                                     Rc::clone(&function),
                                     Rc::downgrade(&frame_cache),
-                                );
+                                ),
+                            );
                             (function, frame_cache)
                         }
                     } else {
@@ -543,8 +545,8 @@ where
                     let (function, frame_cache) = if self.vm_config.enable_function_caches {
                         let current_frame_cache = &mut *current_frame.frame_cache.borrow_mut();
 
-                        if let PerInstructionCache::CallGeneric(ref function, ref frame_cache) =
-                            current_frame_cache.per_instruction_cache[current_frame.pc as usize]
+                        if let Some(PerInstructionCache::CallGeneric(function, frame_cache)) =
+                            current_frame_cache.instruction_cache_at(current_frame.pc)
                         {
                             let frame_cache = frame_cache.upgrade().ok_or_else(|| {
                                 PartialVMError::new_invariant_violation(
@@ -582,11 +584,13 @@ where
                                     (function.clone(), frame_cache)
                                 },
                             };
-                            current_frame_cache.per_instruction_cache[current_frame.pc as usize] =
+                            current_frame_cache.memoize_instruction(
+                                current_frame.pc,
                                 PerInstructionCache::CallGeneric(
                                     Rc::clone(&function),
                                     Rc::downgrade(&frame_cache),
-                                );
+                                ),
+                            );
                             (function, frame_cache)
                         }
                     } else {

--- a/third_party/move/move-vm/runtime/src/interpreter_caches.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter_caches.rs
@@ -13,10 +13,113 @@ use crate::{
 };
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
+/// Maximum number of per-instruction cache entries one interpreter invocation may allocate,
+/// summed over its frame caches. There is one frame cache per distinct
+/// `(function, type arguments)` pair, and one for an N-instruction function consumes N entries.
+///
+/// Sized to sit above demand and below capacity. At 24 bytes per entry, max entries cost
+/// ~24 MB per invocation for one thread. Exceeding it only costs speed; see
+/// [InstructionCacheBudget].
+const MAX_PER_INSTRUCTION_CACHE_ENTRIES: usize = 1_000_000;
+
+/// Bounds the number of per-instruction cache entries allocated by one interpreter invocation.
+///
+/// Refusing an allocation is not observable in gas or in execution results. A frame cache without
+/// a per-instruction cache falls through to [FrameTypeCache]'s function caches, which resolve the
+/// same function, hold the same frame cache, and charge the same gas. The budget therefore trades
+/// speed for a hard memory bound, and needs no feature gate.
+pub(crate) struct InstructionCacheBudget {
+    remaining: usize,
+}
+
+impl InstructionCacheBudget {
+    pub(crate) fn new() -> Self {
+        Self {
+            remaining: max_per_instruction_cache_entries(),
+        }
+    }
+
+    /// Reserves `num_entries`. Returns false, leaving the budget untouched, if it cannot cover the
+    /// request.
+    pub(crate) fn try_reserve(&mut self, num_entries: usize) -> bool {
+        match self.remaining.checked_sub(num_entries) {
+            Some(remaining) => {
+                self.remaining = remaining;
+                record_entries_allocated(num_entries);
+                true
+            },
+            None => false,
+        }
+    }
+}
+
+#[cfg(not(any(test, feature = "testing")))]
+fn record_entries_allocated(_num_entries: usize) {}
+
+#[cfg(any(test, feature = "testing"))]
+fn record_entries_allocated(num_entries: usize) {
+    ENTRIES_ALLOCATED.with(|allocated| allocated.set(allocated.get().saturating_add(num_entries)));
+}
+
+#[cfg(not(any(test, feature = "testing")))]
+fn max_per_instruction_cache_entries() -> usize {
+    MAX_PER_INSTRUCTION_CACHE_ENTRIES
+}
+
+#[cfg(any(test, feature = "testing"))]
+fn max_per_instruction_cache_entries() -> usize {
+    INSTRUCTION_CACHE_BUDGET_OVERRIDE.with(|budget| budget.get())
+}
+
+#[cfg(any(test, feature = "testing"))]
+thread_local! {
+    static INSTRUCTION_CACHE_BUDGET_OVERRIDE: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(MAX_PER_INSTRUCTION_CACHE_ENTRIES) };
+
+    static ENTRIES_ALLOCATED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Overrides the per-instruction cache budget on the current thread until dropped, and counts the
+/// entries allocated while it is installed.
+///
+/// Because the budget is invisible to gas and to execution results, tests can vary it freely and
+/// assert that outputs are unchanged. Setting it to [usize::MAX] reproduces the unbounded
+/// allocation that preceded the bound.
+#[cfg(any(test, feature = "testing"))]
+pub struct InstructionCacheBudgetOverride {
+    previous_max_entries: usize,
+    previous_entries_allocated: usize,
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl InstructionCacheBudgetOverride {
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            previous_max_entries: INSTRUCTION_CACHE_BUDGET_OVERRIDE
+                .with(|budget| budget.replace(max_entries)),
+            previous_entries_allocated: ENTRIES_ALLOCATED.with(|allocated| allocated.replace(0)),
+        }
+    }
+
+    /// Per-instruction cache entries allocated on this thread since the override was installed.
+    pub fn entries_allocated(&self) -> usize {
+        ENTRIES_ALLOCATED.with(|allocated| allocated.get())
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl Drop for InstructionCacheBudgetOverride {
+    fn drop(&mut self) {
+        INSTRUCTION_CACHE_BUDGET_OVERRIDE.with(|budget| budget.set(self.previous_max_entries));
+        ENTRIES_ALLOCATED.with(|allocated| allocated.set(self.previous_entries_allocated));
+    }
+}
+
 /// Interpreter-level caches for function data (single-threaded)
 pub struct InterpreterFunctionCaches {
     function_instruction_caches: HashMap<FunctionPtr, Rc<RefCell<FrameTypeCache>>>,
     generic_function_instruction_caches: HashMap<GenericFunctionPtr, Rc<RefCell<FrameTypeCache>>>,
+    budget: InstructionCacheBudget,
 }
 
 impl InterpreterFunctionCaches {
@@ -24,7 +127,13 @@ impl InterpreterFunctionCaches {
         Self {
             function_instruction_caches: HashMap::new(),
             generic_function_instruction_caches: HashMap::new(),
+            budget: InstructionCacheBudget::new(),
         }
+    }
+
+    /// Budget shared by all frame caches created during this invocation.
+    pub(crate) fn budget_mut(&mut self) -> &mut InstructionCacheBudget {
+        &mut self.budget
     }
 
     pub(crate) fn get_or_create_frame_cache(
@@ -45,10 +154,16 @@ impl InterpreterFunctionCaches {
     ) -> Rc<RefCell<FrameTypeCache>> {
         debug_assert!(function.ty_args().is_empty());
 
+        let Self {
+            function_instruction_caches,
+            budget,
+            ..
+        } = self;
+
         let ptr = FunctionPtr::from_loaded_function(function);
-        self.function_instruction_caches
+        function_instruction_caches
             .entry(ptr)
-            .or_insert_with(|| FrameTypeCache::make_rc_for_function(function))
+            .or_insert_with(|| FrameTypeCache::make_rc_for_code_size(function.code_size(), budget))
             .clone()
     }
 
@@ -59,10 +174,60 @@ impl InterpreterFunctionCaches {
     ) -> Rc<RefCell<FrameTypeCache>> {
         debug_assert!(!function.ty_args().is_empty());
 
+        let Self {
+            generic_function_instruction_caches,
+            budget,
+            ..
+        } = self;
+
         let ptr = GenericFunctionPtr::from_loaded_function(function);
-        self.generic_function_instruction_caches
+        generic_function_instruction_caches
             .entry(ptr)
-            .or_insert_with(|| FrameTypeCache::make_rc_for_function(function))
+            .or_insert_with(|| FrameTypeCache::make_rc_for_code_size(function.code_size(), budget))
             .clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_reserves_until_exhausted() {
+        let mut budget = InstructionCacheBudget { remaining: 100 };
+
+        assert!(budget.try_reserve(60));
+        assert_eq!(budget.remaining, 40);
+
+        // Does not fit, and must leave the budget untouched so smaller later requests still fit.
+        assert!(!budget.try_reserve(41));
+        assert_eq!(budget.remaining, 40);
+
+        assert!(budget.try_reserve(40));
+        assert_eq!(budget.remaining, 0);
+        assert!(!budget.try_reserve(1));
+    }
+
+    #[test]
+    fn budget_reserve_does_not_underflow() {
+        let mut budget = InstructionCacheBudget { remaining: 0 };
+        assert!(!budget.try_reserve(usize::MAX));
+        assert_eq!(budget.remaining, 0);
+    }
+
+    #[test]
+    fn budget_override_is_scoped_and_restored() {
+        let default = InstructionCacheBudget::new().remaining;
+        assert_eq!(default, MAX_PER_INSTRUCTION_CACHE_ENTRIES);
+
+        {
+            let _override = InstructionCacheBudgetOverride::new(7);
+            assert_eq!(InstructionCacheBudget::new().remaining, 7);
+        }
+
+        assert_eq!(
+            InstructionCacheBudget::new().remaining,
+            MAX_PER_INSTRUCTION_CACHE_ENTRIES
+        );
     }
 }

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -12,6 +12,8 @@ pub mod data_cache;
 pub mod execution_tracing;
 mod interpreter;
 mod interpreter_caches;
+#[cfg(any(test, feature = "testing"))]
+pub use interpreter_caches::InstructionCacheBudgetOverride;
 mod loader;
 pub mod logging;
 pub mod move_vm;

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks_async.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks_async.rs
@@ -202,7 +202,19 @@ where
                         .consume_closure_call()
                         .map_err(|err| err.finish(Location::Undefined))
                         .map(|(f, mask)| (Rc::new(f.clone()), mask))?;
-                    let callee_frame_cache = FrameTypeCache::make_rc_for_function(&callee);
+                    // The other call paths take their cache from `function_caches`, which memoizes
+                    // per (function, type arguments) and so charges the budget once per
+                    // instantiation. Closure calls build a fresh cache each time, and its budget is
+                    // not reclaimed when that cache is freed, so a trace with enough closure calls
+                    // exhausts the budget and falls back to uncached lookups. Speed only: this
+                    // checker is unmetered, and the budget cannot change results.
+                    //
+                    // TODO(perf): take the cache from `function_caches` here too, which drops
+                    // both the per-call allocation and the unreclaimed budget.
+                    let callee_frame_cache = FrameTypeCache::make_rc_for_code_size(
+                        callee.code_size(),
+                        self.function_caches.budget_mut(),
+                    );
                     self.execute_closure_call::<RTTCheck>(
                         cursor,
                         &mut current_frame,
@@ -664,42 +676,43 @@ where
     ) -> PartialVMResult<(Rc<LoadedFunction>, Rc<RefCell<FrameTypeCache>>)> {
         use PerInstructionCache::*;
 
-        let pc = current_frame.pc as usize;
+        let pc = current_frame.pc;
         let current_frame_cache = &mut *current_frame.frame_cache.borrow_mut();
 
-        let function_and_cache =
-            if let Call(function, frame_cache) = &current_frame_cache.per_instruction_cache[pc] {
-                let frame_cache = frame_cache.upgrade().ok_or_else(|| {
-                    PartialVMError::new_invariant_violation(
-                        "Frame cache is dropped during interpreter execution",
-                    )
-                })?;
-                (Rc::clone(function), frame_cache)
-            } else {
-                let (function, frame_cache) = match current_frame_cache.function_cache.entry(idx) {
-                    Entry::Vacant(e) => {
-                        let function = self.idx_to_loaded_function(current_frame, idx)?;
-                        let frame_cache = self
-                            .function_caches
-                            .get_or_create_frame_cache_non_generic(&function);
-                        e.insert((function.clone(), Rc::downgrade(&frame_cache)));
-                        (function, frame_cache)
-                    },
-                    Entry::Occupied(e) => {
-                        let (function, frame_cache) = e.get();
-                        let frame_cache = frame_cache.upgrade().ok_or_else(|| {
-                            PartialVMError::new_invariant_violation(
-                                "Frame cache is dropped during interpreter execution",
-                            )
-                        })?;
-                        (function.clone(), frame_cache)
-                    },
-                };
-
-                current_frame_cache.per_instruction_cache[pc] =
-                    Call(Rc::clone(&function), Rc::downgrade(&frame_cache));
-                (function, frame_cache)
+        let function_and_cache = if let Some(Call(function, frame_cache)) =
+            current_frame_cache.instruction_cache_at(pc)
+        {
+            let frame_cache = frame_cache.upgrade().ok_or_else(|| {
+                PartialVMError::new_invariant_violation(
+                    "Frame cache is dropped during interpreter execution",
+                )
+            })?;
+            (Rc::clone(function), frame_cache)
+        } else {
+            let (function, frame_cache) = match current_frame_cache.function_cache.entry(idx) {
+                Entry::Vacant(e) => {
+                    let function = self.idx_to_loaded_function(current_frame, idx)?;
+                    let frame_cache = self
+                        .function_caches
+                        .get_or_create_frame_cache_non_generic(&function);
+                    e.insert((function.clone(), Rc::downgrade(&frame_cache)));
+                    (function, frame_cache)
+                },
+                Entry::Occupied(e) => {
+                    let (function, frame_cache) = e.get();
+                    let frame_cache = frame_cache.upgrade().ok_or_else(|| {
+                        PartialVMError::new_invariant_violation(
+                            "Frame cache is dropped during interpreter execution",
+                        )
+                    })?;
+                    (function.clone(), frame_cache)
+                },
             };
+
+            current_frame_cache
+                .memoize_instruction(pc, Call(Rc::clone(&function), Rc::downgrade(&frame_cache)));
+            (function, frame_cache)
+        };
         Ok(function_and_cache)
     }
 
@@ -709,45 +722,51 @@ where
         current_frame: &mut Frame,
         idx: FunctionInstantiationIndex,
     ) -> PartialVMResult<(Rc<LoadedFunction>, Rc<RefCell<FrameTypeCache>>)> {
-        let pc = current_frame.pc as usize;
+        let pc = current_frame.pc;
         let current_frame_cache = &mut *current_frame.frame_cache.borrow_mut();
 
-        let function_and_cache = if let PerInstructionCache::CallGeneric(function, frame_cache) =
-            &current_frame_cache.per_instruction_cache[pc]
-        {
-            let frame_cache = frame_cache.upgrade().ok_or_else(|| {
-                PartialVMError::new_invariant_violation(
-                    "Frame cache is dropped during interpreter execution",
-                )
-            })?;
-            (Rc::clone(function), frame_cache)
-        } else {
-            let (function, frame_cache) =
-                match current_frame_cache.generic_function_cache.entry(idx) {
-                    Entry::Vacant(e) => {
-                        let function =
-                            self.instantiation_idx_to_loaded_function(current_frame, idx)?;
-                        let frame_cache = self
-                            .function_caches
-                            .get_or_create_frame_cache_generic(&function);
-                        e.insert((function.clone(), Rc::downgrade(&frame_cache)));
-                        (function, frame_cache)
-                    },
-                    Entry::Occupied(e) => {
-                        let (function, frame_cache) = e.get();
-                        let frame_cache = frame_cache.upgrade().ok_or_else(|| {
-                            PartialVMError::new_invariant_violation(
-                                "Frame cache is dropped during interpreter execution",
-                            )
-                        })?;
-                        (function.clone(), frame_cache)
-                    },
-                };
+        let function_and_cache =
+            if let Some(PerInstructionCache::CallGeneric(function, frame_cache)) =
+                current_frame_cache.instruction_cache_at(pc)
+            {
+                let frame_cache = frame_cache.upgrade().ok_or_else(|| {
+                    PartialVMError::new_invariant_violation(
+                        "Frame cache is dropped during interpreter execution",
+                    )
+                })?;
+                (Rc::clone(function), frame_cache)
+            } else {
+                let (function, frame_cache) =
+                    match current_frame_cache.generic_function_cache.entry(idx) {
+                        Entry::Vacant(e) => {
+                            let function =
+                                self.instantiation_idx_to_loaded_function(current_frame, idx)?;
+                            let frame_cache = self
+                                .function_caches
+                                .get_or_create_frame_cache_generic(&function);
+                            e.insert((function.clone(), Rc::downgrade(&frame_cache)));
+                            (function, frame_cache)
+                        },
+                        Entry::Occupied(e) => {
+                            let (function, frame_cache) = e.get();
+                            let frame_cache = frame_cache.upgrade().ok_or_else(|| {
+                                PartialVMError::new_invariant_violation(
+                                    "Frame cache is dropped during interpreter execution",
+                                )
+                            })?;
+                            (function.clone(), frame_cache)
+                        },
+                    };
 
-            current_frame_cache.per_instruction_cache[pc] =
-                PerInstructionCache::CallGeneric(Rc::clone(&function), Rc::downgrade(&frame_cache));
-            (function, frame_cache)
-        };
+                current_frame_cache.memoize_instruction(
+                    pc,
+                    PerInstructionCache::CallGeneric(
+                        Rc::clone(&function),
+                        Rc::downgrade(&frame_cache),
+                    ),
+                );
+                (function, frame_cache)
+            };
         Ok(function_and_cache)
     }
 


### PR DESCRIPTION
## Description

The Move VM speeds up repeated instruction execution by memoizing type information in per-frame caches, one per distinct function instantiation. Each of these caches was eagerly sized to the full bytecode length of its function.

This change places all such allocation under a single per-execution budget. Each cache is only materialized if the budget can accommodate it; when it can't, execution proceeds through the existing slower lookup path, and a cache-not-present state is handled as an ordinary miss rather than an error. Aggregate cache memory per transaction is thereby capped at a fixed constant regardless of the workload's shape.

The fix is deliberately conservative: it is provably neutral to both execution results and gas. The bounded structure is a pure memoization layer over deeper caches whose population is what actually determines gas charges, and an entry is only ever written after the corresponding deeper entry exists. Skipping, capping, or even removing the layer can change only speed, never outcomes — so old and new binaries agree on every transaction, and the change is safe to roll out without a feature gate or coordinated upgrade. To keep that invariant enforceable, the cache is now private behind a small accessor surface, making its access points auditable.

Verification covers both halves of the claim: deterministic tests assert that aggregate allocation stays within the budget under the adversarial many-instantiations-of-a-long-function shape, and end-to-end tests confirm that runs with no cache, a partial cache, and a full cache produce byte-identical results and identical gas. The test workloads are intentionally scaled down — the memory blow-up being defended against is scale-invariant, so small inputs prove the same property without reproducing the exhaustion in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core interpreter call resolution and VM memory behavior on every cached invocation, but semantics are explicitly designed to be gas- and result-neutral with regression tests; residual risk is performance regression or edge cases in cache miss paths.
> 
> **Overview**
> **Caps unbounded per-instruction cache growth** in the Move VM that could reach very large memory use when many generic instantiations each sized a cache to full bytecode length (APTOSNT-487).
> 
> Per interpreter invocation, all per-instruction cache slots now share a **single budget** (default 1M entries, ~24 MB). Frame caches are created via `make_rc_for_code_size` only when `try_reserve` succeeds; otherwise execution uses the existing `function_cache` / `generic_function_cache` paths with no change to results or gas. The per-instruction vector is **private**; reads/writes go through `instruction_cache_at` / `memoize_instruction` so a missing or partial cache is a normal miss, not a panic.
> 
> Tests add unit coverage for budget semantics and integration tests that assert identical status and gas with zero, partial, and full cache budgets, plus bounded allocation on an adversarial many-instantiation module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00696b2f5ae57d34dba2da65f879fbd6d53d6ce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->