### PR TITLE
fix mono unit tests

### DIFF
--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -317,7 +317,16 @@ fn v1_native_table() -> NativeFunctionTable {
         TimedFeaturesBuilder::enable_all().build(),
         Features::default(),
     );
-    table.extend(crate::v1_test_natives::make_all_v1_test_natives());
+    // The mirrors take precedence over same-name production natives (cargo
+    // feature unification can put `unit_test` natives into the production
+    // table), so both VMs run the same implementation in the comparison.
+    let overrides = crate::v1_test_natives::make_all_v1_test_natives();
+    table.retain(|(addr, module, fun, _)| {
+        !overrides.iter().any(|(o_addr, o_module, o_fun, _)| {
+            addr == o_addr && module == o_module && fun == o_fun
+        })
+    });
+    table.extend(overrides);
     table
 }
 


### PR DESCRIPTION
## Description

Fixes a duplicate-native panic that fails every mono-move differential test under CI's `targeted-unit-tests`, blocking unrelated PRs.

The differential harness mirrors `unit_test::create_signers_for_testing` on the legacy VM so both VMs register the same test natives. The production table built by `aptos_natives` also carries that native when `aptos-move-stdlib` is compiled with its `testing` feature. A solo `cargo test -p mono-move-testsuite` never enables it — but CI's `targeted-unit-tests` builds all affected packages in one cargo invocation, and for PRs with a framework footprint the selected set enables the feature chain; cargo feature unification then compiles the stdlib with the native, `RuntimeEnvironment` rejects the duplicate, and all 204 differential tests panic at native-table construction. This is why the failure appears in CI for framework-touching PRs but is not reproducible with a plain local test run.

Fix: `v1_native_table` drops production entries the harness's mirrors override before extending. The mirrors take precedence so both VMs run the same implementation in the differential comparison.

Local reproduction of the CI failure (before this fix):

```
cargo test -p mono-move-testsuite --test differential --features aptos-move-stdlib/testing
```

## How Has This Been Tested?

- The reproduction above now passes (205/205), as does the full `mono-move-testsuite` package under the same feature.
- The plain feature shape is unchanged: differential 205/205.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Other (specify): mono-move test infrastructure

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in the mono-move differential runner; no production VM or runtime behavior.
> 
> **Overview**
> Fixes **duplicate-native panics** in mono-move differential tests when CI enables `aptos-move-stdlib/testing` via cargo feature unification.
> 
> `v1_native_table` now **removes production natives** that collide with harness test mirrors (same address/module/function) **before** appending `make_all_v1_test_natives()`, so mirrors win and both VMs use the same implementations for comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e53334817685e90b226026db6806d089dc5bfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->