### PR TITLE
[vm] Memoize closure frame caches in trace replay to share budget across repeated calls

### DIFF
--- a/third_party/move/move-vm/integration-tests/src/tests/frame_cache_budget_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/frame_cache_budget_tests.rs
@@ -26,19 +26,21 @@ use move_binary_format::{
 use move_core_types::{
     ability::{Ability, AbilitySet},
     account_address::AccountAddress,
+    function::ClosureMask,
     ident_str,
-    identifier::Identifier,
+    identifier::{IdentStr, Identifier},
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
     config::VMConfig,
     data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
     dispatch_loader,
+    execution_tracing::{FullTraceRecorder, NoOpTraceRecorder, Trace, TraceRecorder},
     module_traversal::{TraversalContext, TraversalStorage},
     move_vm::{MoveVM, SerializedReturnValues},
     native_extensions::NativeContextExtensions,
     AsUnsyncModuleStorage, InstantiatedFunctionLoader, InstructionCacheBudgetOverride,
-    LegacyLoaderConfig, ModuleStorage, RuntimeEnvironment,
+    LegacyLoaderConfig, ModuleStorage, RuntimeEnvironment, TypeChecker,
 };
 use move_vm_test_utils::{
     gas_schedule::{Gas, GasStatus, INITIAL_COST_SCHEDULE},
@@ -81,6 +83,50 @@ fn push_identifier(module: &mut CompiledModule, name: &str) -> IdentifierIndex {
     IdentifierIndex(index)
 }
 
+/// Pushes a handle for a function with no parameters and no return values.
+fn push_function_handle(
+    module: &mut CompiledModule,
+    name: &str,
+    type_parameters: Vec<AbilitySet>,
+) -> FunctionHandleIndex {
+    let name = push_identifier(module, name);
+    let index = module.function_handles.len() as u16;
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name,
+        parameters: SignatureIndex(0),
+        return_: SignatureIndex(0),
+        type_parameters,
+        access_specifiers: None,
+        attributes: vec![],
+    });
+    FunctionHandleIndex(index)
+}
+
+/// The first `Ret` makes everything after it unreachable, so the padding is never executed and
+/// never analyzed by the verifier's abstract interpreter.
+fn padded_code(code_size: usize) -> Vec<Bytecode> {
+    let mut code = vec![Bytecode::Ret];
+    code.extend(std::iter::repeat_n(Bytecode::Nop, code_size - 2));
+    code.push(Bytecode::Ret);
+    assert_eq!(code.len(), code_size);
+    code
+}
+
+/// Builds a storage with the module published and paranoid type checks enabled.
+fn storage_with_module(module: &CompiledModule) -> InMemoryStorage {
+    let runtime_environment = RuntimeEnvironment::new_with_config(vec![], VMConfig {
+        paranoid_type_checks: true,
+        ..VMConfig::default_for_test()
+    });
+    let mut storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
+
+    let mut module_bytes = vec![];
+    module.serialize(&mut module_bytes).unwrap();
+    storage.add_module_bytes(module.self_addr(), module.self_name(), module_bytes.into());
+    storage
+}
+
 /// Builds a module with the shape: one long generic callee reached at many
 /// distinct type vectors.
 ///
@@ -98,27 +144,11 @@ fn many_instantiations_module() -> CompiledModule {
     module.address_identifiers[0] = ADDRESS;
     module.identifiers[0] = Identifier::new("m").unwrap();
 
-    let pad_name = push_identifier(&mut module, "pad");
-    module.function_handles.push(FunctionHandle {
-        module: ModuleHandleIndex(0),
-        name: pad_name,
-        parameters: SignatureIndex(0),
-        return_: SignatureIndex(0),
-        type_parameters: vec![AbilitySet::EMPTY, AbilitySet::EMPTY],
-        access_specifiers: None,
-        attributes: vec![],
-    });
-
-    let call_all_name = push_identifier(&mut module, "call_all");
-    module.function_handles.push(FunctionHandle {
-        module: ModuleHandleIndex(0),
-        name: call_all_name,
-        parameters: SignatureIndex(0),
-        return_: SignatureIndex(0),
-        type_parameters: vec![],
-        access_specifiers: None,
-        attributes: vec![],
-    });
+    let pad_handle = push_function_handle(&mut module, "pad", vec![
+        AbilitySet::EMPTY,
+        AbilitySet::EMPTY,
+    ]);
+    let call_all_handle = push_function_handle(&mut module, "call_all", vec![]);
 
     let field_name = push_identifier(&mut module, "value");
     let abilities = AbilitySet::singleton(Ability::Copy) | Ability::Drop | Ability::Store;
@@ -139,22 +169,14 @@ fn many_instantiations_module() -> CompiledModule {
         });
     }
 
-    // The first `Ret` makes everything after it unreachable, so the padding is never executed and
-    // never analyzed by the verifier's abstract interpreter.
-    let mut pad_code = Vec::with_capacity(PAD_CODE_SIZE);
-    pad_code.push(Bytecode::Ret);
-    pad_code.resize(PAD_CODE_SIZE - 1, Bytecode::Nop);
-    pad_code.push(Bytecode::Ret);
-    assert_eq!(pad_code.len(), PAD_CODE_SIZE);
-
     module.function_defs.push(FunctionDefinition {
-        function: FunctionHandleIndex(0),
+        function: pad_handle,
         visibility: Visibility::Public,
         is_entry: false,
         acquires_global_resources: vec![],
         code: Some(CodeUnit {
             locals: SignatureIndex(0),
-            code: pad_code,
+            code: padded_code(PAD_CODE_SIZE),
         }),
     });
 
@@ -169,7 +191,7 @@ fn many_instantiations_module() -> CompiledModule {
 
             let instantiation_index = module.function_instantiations.len() as u16;
             module.function_instantiations.push(FunctionInstantiation {
-                handle: FunctionHandleIndex(0),
+                handle: pad_handle,
                 type_parameters: SignatureIndex(signature_index),
             });
             call_all_code.push(Bytecode::CallGeneric(FunctionInstantiationIndex(
@@ -180,7 +202,7 @@ fn many_instantiations_module() -> CompiledModule {
     call_all_code.push(Bytecode::Ret);
 
     module.function_defs.push(FunctionDefinition {
-        function: FunctionHandleIndex(1),
+        function: call_all_handle,
         visibility: Visibility::Public,
         is_entry: false,
         acquires_global_resources: vec![],
@@ -198,16 +220,7 @@ fn many_instantiations_module() -> CompiledModule {
 fn run_call_all(module: &CompiledModule, max_cache_entries: usize) -> (Outcome, usize) {
     let budget_override = InstructionCacheBudgetOverride::new(max_cache_entries);
 
-    let runtime_environment = RuntimeEnvironment::new_with_config(vec![], VMConfig {
-        paranoid_type_checks: true,
-        ..VMConfig::default_for_test()
-    });
-    let mut storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
-
-    let mut module_bytes = vec![];
-    module.serialize(&mut module_bytes).unwrap();
-    storage.add_module_bytes(module.self_addr(), module.self_name(), module_bytes.into());
-
+    let storage = storage_with_module(module);
     let module_storage = storage.as_unsync_module_storage();
     let traversal_storage = TraversalStorage::new();
     let mut traversal_context = TraversalContext::new(&traversal_storage);
@@ -216,13 +229,15 @@ fn run_call_all(module: &CompiledModule, max_cache_entries: usize) -> (Outcome, 
     let gas_budget = Gas::new(1_000_000);
     let mut gas_meter = GasStatus::new(INITIAL_COST_SCHEDULE.clone(), gas_budget);
 
-    let result = execute_call_all(
+    let result = execute_function(
         module,
+        ident_str!("call_all"),
         &module_storage,
         &storage,
         &mut data_cache,
         &mut gas_meter,
         &mut traversal_context,
+        &mut NoOpTraceRecorder,
     );
 
     let outcome = Outcome {
@@ -232,13 +247,15 @@ fn run_call_all(module: &CompiledModule, max_cache_entries: usize) -> (Outcome, 
     (outcome, budget_override.entries_allocated())
 }
 
-fn execute_call_all(
+fn execute_function(
     module: &CompiledModule,
+    function_name: &IdentStr,
     module_storage: &impl ModuleStorage,
     storage: &InMemoryStorage,
     data_cache: &mut TransactionDataCache,
     gas_meter: &mut GasStatus,
     traversal_context: &mut TraversalContext,
+    recorder: &mut impl TraceRecorder,
 ) -> VMResult<SerializedReturnValues> {
     dispatch_loader!(module_storage, loader, {
         let function = loader.load_instantiated_function(
@@ -246,10 +263,10 @@ fn execute_call_all(
             gas_meter,
             traversal_context,
             &module.self_id(),
-            ident_str!("call_all"),
+            function_name,
             &[],
         )?;
-        MoveVM::execute_loaded_function(
+        MoveVM::execute_loaded_function_with_tracing(
             function,
             Vec::<Vec<u8>>::new(),
             &mut MoveVmDataCacheAdapter::new(data_cache, storage, &loader),
@@ -257,6 +274,7 @@ fn execute_call_all(
             traversal_context,
             &mut NativeContextExtensions::default(),
             &loader,
+            recorder,
         )
     })
 }
@@ -333,4 +351,138 @@ fn many_instantiations_of_a_long_function_stay_within_budget() {
         unbounded_entries / bounded_entries >= 100,
         "bound must be a material reduction: {unbounded_entries} -> {bounded_entries}"
     );
+}
+
+/// Number of times `call_repeatedly` packs and calls a closure over the same callee.
+const CLOSURE_CALLS: usize = 100;
+
+/// `call_repeatedly` is one `PackClosure` + `CallClosure` pair per call plus a `Ret`.
+const CLOSURE_CALLER_CODE_SIZE: usize = 2 * CLOSURE_CALLS + 1;
+
+/// Bytecode length of the closure callee, padded like `pad` so that a fresh cache per call would
+/// dominate the entry count.
+const CLOSURE_CALLEE_CODE_SIZE: usize = 1_001;
+
+/// Builds a module that calls the same function through a closure many times:
+///
+/// ```text
+/// module 0x2::n {
+///     fun callee() { return; <padding>; return }
+///     public fun call_repeatedly() { (|| callee())(); ...; return }
+/// }
+/// ```
+fn repeated_closure_calls_module() -> CompiledModule {
+    let mut module = empty_module();
+    module.address_identifiers[0] = ADDRESS;
+    module.identifiers[0] = Identifier::new("n").unwrap();
+
+    let callee_handle = push_function_handle(&mut module, "callee", vec![]);
+    let caller_handle = push_function_handle(&mut module, "call_repeatedly", vec![]);
+
+    // `PackClosure` of a function without the persistent attribute pushes `|| has copy + drop`,
+    // and `CallClosure`'s signature must be assignable from that type.
+    let closure_signature_index = SignatureIndex(module.signatures.len() as u16);
+    module
+        .signatures
+        .push(Signature(vec![SignatureToken::Function(
+            vec![],
+            vec![],
+            AbilitySet::PRIVATE_FUNCTIONS,
+        )]));
+
+    module.function_defs.push(FunctionDefinition {
+        function: callee_handle,
+        visibility: Visibility::Private,
+        is_entry: false,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: padded_code(CLOSURE_CALLEE_CODE_SIZE),
+        }),
+    });
+
+    let mut caller_code = Vec::with_capacity(CLOSURE_CALLER_CODE_SIZE);
+    for _ in 0..CLOSURE_CALLS {
+        caller_code.push(Bytecode::PackClosure(callee_handle, ClosureMask::empty()));
+        caller_code.push(Bytecode::CallClosure(closure_signature_index));
+    }
+    caller_code.push(Bytecode::Ret);
+    assert_eq!(caller_code.len(), CLOSURE_CALLER_CODE_SIZE);
+
+    module.function_defs.push(FunctionDefinition {
+        function: caller_handle,
+        visibility: Visibility::Public,
+        is_entry: false,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: caller_code,
+        }),
+    });
+
+    module
+}
+
+/// Executes `0x2::n::call_repeatedly` recording a trace. With a recorder installed, paranoid type
+/// checks are deferred from execution to trace replay.
+fn record_call_repeatedly_trace(
+    module: &CompiledModule,
+    module_storage: &impl ModuleStorage,
+    storage: &InMemoryStorage,
+) -> Trace {
+    let traversal_storage = TraversalStorage::new();
+    let mut traversal_context = TraversalContext::new(&traversal_storage);
+    let mut data_cache = TransactionDataCache::empty();
+    let mut gas_meter = GasStatus::new(INITIAL_COST_SCHEDULE.clone(), Gas::new(1_000_000));
+
+    let mut recorder = FullTraceRecorder::new();
+    execute_function(
+        module,
+        ident_str!("call_repeatedly"),
+        module_storage,
+        storage,
+        &mut data_cache,
+        &mut gas_meter,
+        &mut traversal_context,
+        &mut recorder,
+    )
+    .expect("execution must succeed");
+    recorder.finish()
+}
+
+/// Replays the trace with the per-instruction cache budget capped at `max_cache_entries`,
+/// returning the replay result and the number of cache entries the replay allocated. The override
+/// is installed here, after recording, so the counter sees replay allocations alone and the
+/// budget is snapshotted when the type checker is created.
+fn replay_with_budget(
+    module_storage: &impl ModuleStorage,
+    trace: &Trace,
+    max_cache_entries: usize,
+) -> (VMResult<()>, usize) {
+    let budget_override = InstructionCacheBudgetOverride::new(max_cache_entries);
+    let result = TypeChecker::new(module_storage).replay(trace);
+    (result, budget_override.entries_allocated())
+}
+
+/// Replay takes closure frame caches from the same memoized map as every other call path, so many
+/// closure calls of one callee charge the budget for that callee once, not per call.
+#[test]
+fn replayed_closure_calls_share_one_frame_cache() {
+    let module = repeated_closure_calls_module();
+    move_bytecode_verifier::verify_module(&module).expect("module must verify");
+
+    let storage = storage_with_module(&module);
+    let module_storage = storage.as_unsync_module_storage();
+    let trace = record_call_repeatedly_trace(&module, &module_storage, &storage);
+    assert_eq!(trace.num_recorded_calls(), CLOSURE_CALLS + 1);
+
+    // A fresh cache per closure call would charge CLOSURE_CALLS * CLOSURE_CALLEE_CODE_SIZE.
+    let (result, entries) = replay_with_budget(&module_storage, &trace, usize::MAX);
+    result.expect("replay must succeed");
+    assert_eq!(entries, CLOSURE_CALLER_CODE_SIZE + CLOSURE_CALLEE_CODE_SIZE);
+
+    // With no budget, the closure path degrades to uncached lookups like every other call path.
+    let (result, entries) = replay_with_budget(&module_storage, &trace, 0);
+    result.expect("replay must succeed with a zero budget");
+    assert_eq!(entries, 0);
 }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -801,7 +801,6 @@ where
                             callee,
                             fn_guard,
                             CallType::ClosureDynamicDispatch,
-                            // Make sure the frame cache is empty for the new call.
                             frame_cache,
                             mask,
                             captured_vec,

--- a/third_party/move/move-vm/runtime/src/interpreter_caches.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter_caches.rs
@@ -131,11 +131,6 @@ impl InterpreterFunctionCaches {
         }
     }
 
-    /// Budget shared by all frame caches created during this invocation.
-    pub(crate) fn budget_mut(&mut self) -> &mut InstructionCacheBudget {
-        &mut self.budget
-    }
-
     pub(crate) fn get_or_create_frame_cache(
         &mut self,
         function: &LoadedFunction,

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks_async.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks_async.rs
@@ -202,19 +202,8 @@ where
                         .consume_closure_call()
                         .map_err(|err| err.finish(Location::Undefined))
                         .map(|(f, mask)| (Rc::new(f.clone()), mask))?;
-                    // The other call paths take their cache from `function_caches`, which memoizes
-                    // per (function, type arguments) and so charges the budget once per
-                    // instantiation. Closure calls build a fresh cache each time, and its budget is
-                    // not reclaimed when that cache is freed, so a trace with enough closure calls
-                    // exhausts the budget and falls back to uncached lookups. Speed only: this
-                    // checker is unmetered, and the budget cannot change results.
-                    //
-                    // TODO(perf): take the cache from `function_caches` here too, which drops
-                    // both the per-call allocation and the unreclaimed budget.
-                    let callee_frame_cache = FrameTypeCache::make_rc_for_code_size(
-                        callee.code_size(),
-                        self.function_caches.budget_mut(),
-                    );
+                    let callee_frame_cache =
+                        self.function_caches.get_or_create_frame_cache(&callee);
                     self.execute_closure_call::<RTTCheck>(
                         cursor,
                         &mut current_frame,


### PR DESCRIPTION
## Description

Closure calls during trace replay now share the same memoized frame cache as all other call paths, rather than allocating a fresh `FrameTypeCache` on every `CallClosure` instruction. Previously, each closure call built its own cache whose budget was never reclaimed, meaning a trace with many closure calls over the same callee would exhaust the instruction cache budget and fall back to uncached lookups. Now `get_or_create_frame_cache` is called for closure callees in the async type checker, so repeated calls to the same callee charge the budget once and reuse the cached result on subsequent calls.

The `budget_mut` accessor on `InterpreterFunctionCaches` is removed since it was only used by the now-replaced closure cache allocation path. The stale comment on the closure dynamic dispatch path in the interpreter is also removed.

## How Has This Been Tested?

A new integration test, `replayed_closure_calls_share_one_frame_cache`, verifies the fix directly. It builds a module whose `call_repeatedly` function packs and calls a closure over the same callee 100 times, records a full execution trace, and then replays it. The test asserts:

- The total cache entries allocated equal `CLOSURE_CALLER_CODE_SIZE + CLOSURE_CALLEE_CODE_SIZE`, confirming the callee's cache is charged once rather than once per call.
- Replay succeeds even with a zero budget, confirming graceful degradation to uncached lookups.

Helper functions (`push_function_handle`, `padded_code`, `storage_with_module`, `execute_function`) were extracted from existing test code and reused across both the existing `many_instantiations_of_a_long_function_stay_within_budget` test and the new closure test.

## Key Areas to Review

- **`runtime_type_checks_async.rs`**: The replacement of the ad-hoc `FrameTypeCache::make_rc_for_code_size` call with `self.function_caches.get_or_create_frame_cache(&callee)` is the core behavioral change. Reviewers should confirm that the callee identity used as the memoization key correctly identifies the same function across repeated closure calls.
- **`interpreter_caches.rs`**: Removal of `budget_mut`. Confirm no other callers exist.
- **`interpreter.rs`**: Removal of the now-inaccurate comment about ensuring an empty frame cache for closure calls.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paranoid type-check replay for closures in the Move VM; behavior should be equivalent (memoization only) but affects VM internals and instruction-cache budgeting during trace replay.
> 
> **Overview**
> **Trace replay** now obtains closure callee `FrameTypeCache` values from `InterpreterFunctionCaches::get_or_create_frame_cache`, matching regular and generic calls. That replaces per-`CallClosure` `FrameTypeCache::make_rc_for_code_size` allocation, which could burn the shared instruction-cache budget on every repeated call to the same callee and force uncached fallbacks.
> 
> `InterpreterFunctionCaches::budget_mut` is removed (it only supported the old closure path). A stale interpreter comment about empty closure frame caches is dropped.
> 
> Integration tests add shared helpers (`push_function_handle`, `padded_code`, `storage_with_module`, parameterized `execute_function` with tracing) and **`replayed_closure_calls_share_one_frame_cache`**, which records 100 closure calls to one callee and asserts replay allocates caller + callee cache sizes once, and still succeeds with a zero budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7293959c8aaf902cef5366b9b3e8c207775d785d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->