### PR TITLE
[api][cp-v1.48] Add API-layer stages to transaction tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-transaction-filters",
+ "aptos-transaction-tracing",
  "aptos-types",
  "aptos-vm",
  "bcs 0.1.4",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -27,6 +27,7 @@ aptos-metrics-core = { workspace = true }
 aptos-runtimes = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-storage-interface = { workspace = true }
+aptos-transaction-tracing = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 bcs = { workspace = true }

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -17,6 +17,9 @@ use aptos_crypto::{
 };
 use aptos_sdk::types::{AccountKey, LocalAccount};
 use aptos_transaction_filters::transaction_filter::TransactionFilter;
+use aptos_transaction_tracing::{
+    TransactionFilter as TracingFilter, TransactionStage, TransactionTraceStore,
+};
 use aptos_types::{
     account_address::AccountAddress,
     account_config::aptos_test_root_address,
@@ -1140,6 +1143,71 @@ async fn test_get_pending_transaction_by_hash(
         .get("/transactions/by_hash/0xdadfeddcca7cb6396c735e9094c76c6e4e9cb3e3ef814730693aed59bd87b31d")
         .await;
     context.check_golden_output(not_found);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_submit_transaction_records_api_trace_stages() {
+    let mut context = new_test_context(current_function_name!());
+    let account = context.gen_account();
+    let txn = context.create_user_account(&account).await;
+    let txn_hash = txn.committed_hash();
+    let sender = txn.sender();
+
+    TransactionTraceStore::global().update_filter(TracingFilter::new(
+        true,
+        [sender].into_iter().collect(),
+        1.0,
+        1.0,
+    ));
+
+    context
+        .expect_status_code(202)
+        .post_bcs_txn("/transactions", bcs::to_bytes(&txn).unwrap())
+        .await;
+
+    let trace = TransactionTraceStore::global()
+        .get_trace(&txn_hash)
+        .expect("submitted transaction should have an active trace");
+    assert!(trace.insertion_time_usecs.is_some());
+    for stage in [
+        TransactionStage::ApiHandlerEnter,
+        TransactionStage::ApiTransactionDecoded,
+        TransactionStage::ApiMempoolSubmit,
+        TransactionStage::MempoolInsert,
+        TransactionStage::ApiMempoolAccepted,
+    ] {
+        assert!(
+            trace.has_stage(stage),
+            "missing API trace stage {:?}",
+            stage
+        );
+    }
+    let timestamp = |stage| {
+        trace
+            .stages
+            .iter()
+            .find(|record| record.stage == stage)
+            .expect("stage should exist")
+            .timestamp_usecs
+    };
+    assert!(
+        timestamp(TransactionStage::ApiHandlerEnter)
+            <= timestamp(TransactionStage::ApiTransactionDecoded)
+    );
+    assert!(
+        timestamp(TransactionStage::ApiTransactionDecoded)
+            <= timestamp(TransactionStage::ApiMempoolSubmit)
+    );
+    assert!(
+        timestamp(TransactionStage::ApiMempoolSubmit) <= timestamp(TransactionStage::MempoolInsert)
+    );
+    assert!(
+        timestamp(TransactionStage::MempoolInsert)
+            <= timestamp(TransactionStage::ApiMempoolAccepted)
+    );
+
+    TransactionTraceStore::global().finalize_trace(&txn_hash);
+    TransactionTraceStore::global().update_filter(TracingFilter::disabled());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1480,7 +1480,7 @@ impl TransactionsApi {
     async fn create_internal(
         &self,
         txn: SignedTransaction,
-        api_trace: Option<ApiTraceToken>,
+        mut api_trace: Option<ApiTraceToken>,
     ) -> Result<(), AptosError> {
         let trace_store = TransactionTraceStore::global();
         if let Some(token) = api_trace.as_ref() {
@@ -1504,8 +1504,9 @@ impl TransactionsApi {
             },
         };
         if mempool_status.code == MempoolStatusCode::Accepted {
-            if let Some(token) = api_trace.as_ref() {
+            if let Some(token) = api_trace.as_mut() {
                 trace_store.record_api_stage(token, TransactionStage::ApiMempoolAccepted);
+                token.disarm();
             }
         } else if let Some(token) = api_trace {
             trace_store.cancel_api_trace(token);

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -30,6 +30,7 @@ use aptos_api_types::{
 };
 use aptos_crypto::signing_message;
 use aptos_logger::error;
+use aptos_transaction_tracing::{ApiTraceToken, TransactionStage, TransactionTraceStore};
 use aptos_types::{
     account_address::AccountAddress,
     mempool_status::MempoolStatusCode,
@@ -478,6 +479,7 @@ impl TransactionsApi {
         accept_type: AcceptType,
         data: SubmitTransactionPost,
     ) -> SubmitTransactionResult<PendingTransaction> {
+        let api_handler_enter_usecs = api_now_usecs();
         data.verify()
             .context("Submitted transaction invalid'")
             .map_err(|err| {
@@ -494,7 +496,17 @@ impl TransactionsApi {
             .check_api_output_enabled("Submit transaction", &accept_type)?;
         let ledger_info = self.context.get_latest_ledger_info()?;
         let signed_transaction = self.get_signed_transaction(&ledger_info, data)?;
-        self.create(&accept_type, &ledger_info, signed_transaction)
+        let txn_hash = signed_transaction.committed_hash();
+        let api_trace = TransactionTraceStore::global().maybe_start_api_trace(
+            txn_hash,
+            signed_transaction.sender(),
+            api_handler_enter_usecs,
+        );
+        if let Some(token) = api_trace.as_ref() {
+            TransactionTraceStore::global()
+                .record_api_stage(token, TransactionStage::ApiTransactionDecoded);
+        }
+        self.create(&accept_type, &ledger_info, signed_transaction, api_trace)
             .await
     }
 
@@ -1465,15 +1477,39 @@ impl TransactionsApi {
     }
 
     /// Submits a single transaction, and converts mempool codes to errors
-    async fn create_internal(&self, txn: SignedTransaction) -> Result<(), AptosError> {
-        let (mempool_status, vm_status_opt) = self
+    async fn create_internal(
+        &self,
+        txn: SignedTransaction,
+        api_trace: Option<ApiTraceToken>,
+    ) -> Result<(), AptosError> {
+        let trace_store = TransactionTraceStore::global();
+        if let Some(token) = api_trace.as_ref() {
+            trace_store.record_api_stage(token, TransactionStage::ApiMempoolSubmit);
+        }
+        let submission_result = self
             .context
             .submit_transaction(txn)
             .await
             .context("Mempool failed to initially evaluate submitted transaction")
             .map_err(|err| {
                 aptos_api_types::AptosError::new_with_error_code(err, AptosErrorCode::InternalError)
-            })?;
+            });
+        let (mempool_status, vm_status_opt) = match submission_result {
+            Ok(result) => result,
+            Err(error) => {
+                if let Some(token) = api_trace {
+                    trace_store.cancel_api_trace(token);
+                }
+                return Err(error);
+            },
+        };
+        if mempool_status.code == MempoolStatusCode::Accepted {
+            if let Some(token) = api_trace.as_ref() {
+                trace_store.record_api_stage(token, TransactionStage::ApiMempoolAccepted);
+            }
+        } else if let Some(token) = api_trace {
+            trace_store.cancel_api_trace(token);
+        }
         match mempool_status.code {
             MempoolStatusCode::Accepted => Ok(()),
             MempoolStatusCode::MempoolIsFull | MempoolStatusCode::TooManyTransactions => {
@@ -1530,8 +1566,9 @@ impl TransactionsApi {
         accept_type: &AcceptType,
         ledger_info: &LedgerInfo,
         txn: SignedTransaction,
+        api_trace: Option<ApiTraceToken>,
     ) -> SubmitTransactionResult<PendingTransaction> {
-        match self.create_internal(txn.clone()).await {
+        match self.create_internal(txn.clone(), api_trace).await {
             Ok(()) => match accept_type {
                 AcceptType::Json => {
                     let state_view = self
@@ -1604,7 +1641,7 @@ impl TransactionsApi {
         // Iterate through transactions keeping track of failures
         let mut txn_failures = Vec::new();
         for (idx, txn) in txns.iter().enumerate() {
-            if let Err(error) = self.create_internal(txn.clone()).await {
+            if let Err(error) = self.create_internal(txn.clone(), None).await {
                 txn_failures.push(TransactionsBatchSingleSubmissionFailure {
                     error,
                     transaction_index: idx,
@@ -1936,6 +1973,13 @@ impl TransactionsApi {
             },
         }
     }
+}
+
+fn api_now_usecs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as u64
 }
 
 fn override_gas_parameters(

--- a/config/src/config/transaction_tracing_config.rs
+++ b/config/src/config/transaction_tracing_config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for transaction lifecycle tracing.
 ///
 /// When `enabled` is true and the filter matches, the node traces transactions
-/// through the pipeline (mempool → QS → consensus → execution → commit)
+/// through the pipeline (API → mempool → QS → consensus → execution → commit)
 /// and logs a `TxnTrace` line for each.
 ///
 /// Two-level sampling controls overhead:

--- a/crates/aptos-transaction-tracing/src/lib.rs
+++ b/crates/aptos-transaction-tracing/src/lib.rs
@@ -4,9 +4,9 @@
 //! Per-transaction lifecycle tracing for latency analysis.
 //!
 //! Tracks individual transactions through the Aptos pipeline stages
-//! (mempool → QS batching → consensus → execution → commit) and records
-//! timestamps at each stage. Only transactions from configured sender
-//! addresses are traced.
+//! (API → mempool → QS batching → consensus → execution → commit) and
+//! records timestamps at each stage. Only transactions from configured
+//! sender addresses are traced.
 
 pub mod counters;
 pub mod filter;
@@ -15,7 +15,7 @@ pub mod store;
 pub mod types;
 
 pub use filter::TransactionFilter;
-pub use store::TransactionTraceStore;
+pub use store::{ApiTraceToken, TransactionTraceStore};
 pub use types::{
     BatchInclusionType, ExecutionStatus, StageMetadata, TransactionStage, TransactionTrace,
 };

--- a/crates/aptos-transaction-tracing/src/logging.rs
+++ b/crates/aptos-transaction-tracing/src/logging.rs
@@ -35,6 +35,11 @@ pub struct LogSchema {
     outcome: Option<&'static str>,
     age_ms: Option<u64>,
     num_stages: Option<usize>,
+    api_handler_enter_timestamp_usecs: Option<u64>,
+    api_transaction_decoded_timestamp_usecs: Option<u64>,
+    api_mempool_submit_timestamp_usecs: Option<u64>,
+    api_mempool_accepted_timestamp_usecs: Option<u64>,
+    mempool_insert_timestamp_usecs: Option<u64>,
 
     // GC summary counters (only used by `TxnTraceGcSummary`)
     evicted_traces: Option<u64>,
@@ -55,8 +60,13 @@ pub struct LogSchema {
     //
     // `block_proposed_ms` can be negative: it records the proposer's
     // `block.timestamp_usecs`, which is on a different validator's clock and
-    // can precede this node's MempoolInsert. Every other stage uses the
-    // local clock and is non-negative.
+    // can precede this node's MempoolInsert. API stages also precede
+    // MempoolInsert and are intentionally negative for accepted transactions.
+    api_handler_enter_ms: Option<i64>,
+    api_transaction_decoded_ms: Option<i64>,
+    api_mempool_submit_ms: Option<i64>,
+    api_mempool_accepted_ms: Option<i64>,
+    api_to_mempool_ms: Option<i64>,
     mempool_insert_ms: Option<i64>,
     qs_batch_pull_ms: Option<i64>,
     qs_batch_created_ms: Option<i64>,
@@ -105,12 +115,22 @@ impl LogSchema {
             outcome: None,
             age_ms: None,
             num_stages: None,
+            api_handler_enter_timestamp_usecs: None,
+            api_transaction_decoded_timestamp_usecs: None,
+            api_mempool_submit_timestamp_usecs: None,
+            api_mempool_accepted_timestamp_usecs: None,
+            mempool_insert_timestamp_usecs: None,
             evicted_traces: None,
             evicted_batch_mappings: None,
             evicted_block_mappings: None,
             remaining_traces: None,
             remaining_batch_mappings: None,
             remaining_block_mappings: None,
+            api_handler_enter_ms: None,
+            api_transaction_decoded_ms: None,
+            api_mempool_submit_ms: None,
+            api_mempool_accepted_ms: None,
+            api_to_mempool_ms: None,
             mempool_insert_ms: None,
             qs_batch_pull_ms: None,
             qs_batch_created_ms: None,

--- a/crates/aptos-transaction-tracing/src/store.rs
+++ b/crates/aptos-transaction-tracing/src/store.rs
@@ -11,7 +11,7 @@ use aptos_crypto::HashValue;
 use aptos_logger::{info, warn};
 use aptos_types::account_address::AccountAddress;
 use arc_swap::ArcSwap;
-use dashmap::DashMap;
+use dashmap::{mapref::entry::Entry, DashMap};
 use once_cell::sync::Lazy;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
@@ -31,10 +31,20 @@ const GC_TTL_USECS: u64 = 60_000_000;
 /// traces ≈ 10MB — well within safe limits.
 const MAX_TRACES: usize = 10_000;
 
+/// Identifies the API request that owns a pending pre-mempool trace.
+///
+/// A token prevents concurrent submissions of the same signed transaction
+/// from recording stages on, or cleaning up, another request's trace.
+#[derive(Debug)]
+pub struct ApiTraceToken {
+    hash: HashValue,
+    generation: u64,
+}
+
 /// Global store for transaction lifecycle traces.
 ///
 /// Thread-safe via DashMap. Only traces transactions whose sender is in the
-/// allowlist (checked at mempool insertion time via `maybe_start_trace`).
+/// allowlist (checked at API handler entry or mempool insertion).
 pub struct TransactionTraceStore {
     /// Active traces keyed by transaction hash.
     traces: DashMap<HashValue, TransactionTrace>,
@@ -51,6 +61,7 @@ pub struct TransactionTraceStore {
     /// Timestamp (usecs) of the last GC sweep. Used by `finalize_trace()` to
     /// throttle periodic GC to once per `GC_INTERVAL_USECS`.
     last_gc_usecs: AtomicU64,
+    next_api_generation: AtomicU64,
 }
 
 impl TransactionTraceStore {
@@ -61,6 +72,7 @@ impl TransactionTraceStore {
             block_txns: DashMap::new(),
             filter: ArcSwap::new(Arc::new(TransactionFilter::default())),
             last_gc_usecs: AtomicU64::new(0),
+            next_api_generation: AtomicU64::new(1),
         }
     }
 
@@ -83,31 +95,119 @@ impl TransactionTraceStore {
         self.filter.load().should_sample_batch(pull_round)
     }
 
+    /// Starts a trace after the API has decoded enough of the request to know
+    /// the transaction hash. The supplied timestamp should be captured at API
+    /// handler entry so it includes API verification and conversion time.
+    pub fn maybe_start_api_trace(
+        &self,
+        hash: HashValue,
+        sender: AccountAddress,
+        handler_enter_usecs: u64,
+    ) -> Option<ApiTraceToken> {
+        if !self.filter.load().should_trace(&sender, &hash) {
+            return None;
+        }
+        // API futures can be cancelled after creating pending state. Running
+        // the throttled GC here ensures those entries are eventually reclaimed
+        // even if no trace reaches a terminal pipeline stage.
+        self.maybe_gc();
+        if self.traces.len() >= MAX_TRACES {
+            return None;
+        }
+        let generation = self.next_api_generation.fetch_add(1, Ordering::Relaxed);
+        match self.traces.entry(hash) {
+            Entry::Occupied(_) => None,
+            Entry::Vacant(entry) => {
+                entry.insert(TransactionTrace::new_at_api(
+                    hash,
+                    sender,
+                    handler_enter_usecs,
+                    generation,
+                ));
+                Some(ApiTraceToken { hash, generation })
+            },
+        }
+    }
+
     /// Called at mempool insertion. Checks if sender is in allowlist + txn sampling,
-    /// creates trace if matched. Returns true if trace was started.
+    /// creates a trace if matched, or continues one started by the API.
+    /// Returns true if the mempool-relative timeline was started.
     pub fn maybe_start_trace(
         &self,
         hash: HashValue,
         sender: AccountAddress,
         now_usecs: u64,
     ) -> bool {
-        let filter = self.filter.load();
-        if !filter.should_trace(&sender, &hash) {
-            return false;
+        let should_start_new =
+            self.filter.load().should_trace(&sender, &hash) && self.traces.len() < MAX_TRACES;
+        match self.traces.entry(hash) {
+            Entry::Occupied(mut entry) => {
+                let trace = entry.get_mut();
+                if trace.sender != sender || !trace.start_at_mempool(now_usecs) {
+                    return false;
+                }
+                observe_stage_latency(
+                    now_usecs,
+                    &trace.sender_str,
+                    TransactionStage::MempoolInsert.as_ref(),
+                );
+                true
+            },
+            Entry::Vacant(entry) => {
+                if !should_start_new {
+                    return false;
+                }
+                let mut trace = TransactionTrace::new(hash, sender, now_usecs);
+                trace.record(TransactionStage::MempoolInsert, now_usecs);
+                observe_stage_latency(
+                    now_usecs,
+                    &trace.sender_str,
+                    TransactionStage::MempoolInsert.as_ref(),
+                );
+                entry.insert(trace);
+                true
+            },
         }
-        // Cap concurrent traces to prevent unbounded memory growth.
-        if self.traces.len() >= MAX_TRACES {
-            return false;
+    }
+
+    /// Records an API stage only for a trace started at API handler entry.
+    /// Each API stage is idempotent so duplicate submissions cannot append
+    /// ambiguous timestamps to an already-active trace.
+    pub fn record_api_stage(&self, token: &ApiTraceToken, stage: TransactionStage) -> bool {
+        self.record_api_stage_at(token, stage, now_usecs())
+    }
+
+    pub fn record_api_stage_at(
+        &self,
+        token: &ApiTraceToken,
+        stage: TransactionStage,
+        timestamp_usecs: u64,
+    ) -> bool {
+        debug_assert!(stage.is_api_stage());
+        if let Some(mut trace) = self.traces.get_mut(&token.hash)
+            && trace.api_generation == Some(token.generation)
+            && !trace.has_stage(stage)
+        {
+            trace.record(stage, timestamp_usecs);
+            return true;
         }
-        let mut trace = TransactionTrace::new(hash, sender, now_usecs);
-        trace.record(TransactionStage::MempoolInsert, now_usecs);
-        observe_stage_latency(
-            now_usecs,
-            &trace.sender_str,
-            TransactionStage::MempoolInsert.as_ref(),
-        );
-        self.traces.insert(hash, trace);
-        true
+        false
+    }
+
+    /// Removes a pre-mempool trace when its owning API request is rejected or
+    /// cancelled. Once mempool has promoted the trace, cleanup is a no-op.
+    pub fn cancel_api_trace(&self, token: ApiTraceToken) -> bool {
+        if let Entry::Occupied(entry) = self.traces.entry(token.hash) {
+            let trace = entry.get();
+            if trace.api_generation == Some(token.generation)
+                && trace.insertion_time_usecs.is_none()
+            {
+                entry.remove();
+                self.maybe_gc();
+                return true;
+            }
+        }
+        false
     }
 
     /// Record a stage for a traced transaction using the local clock.
@@ -118,11 +218,12 @@ impl TransactionTraceStore {
     /// Record a stage with an explicit timestamp (e.g., block.timestamp_usecs).
     pub fn record_stage_at(&self, hash: &HashValue, stage: TransactionStage, timestamp_usecs: u64) {
         if let Some(mut trace) = self.traces.get_mut(hash) {
-            observe_stage_latency(
-                trace.insertion_time_usecs,
-                &trace.sender_str,
-                stage.as_ref(),
-            );
+            let Some(insertion_time_usecs) = trace.insertion_time_usecs else {
+                return;
+            };
+            if !stage.is_api_stage() {
+                observe_stage_latency(insertion_time_usecs, &trace.sender_str, stage.as_ref());
+            }
             trace.record(stage, timestamp_usecs);
         }
     }
@@ -146,6 +247,9 @@ impl TransactionTraceStore {
         timestamp_usecs: u64,
     ) {
         if let Some(mut trace) = self.traces.get_mut(hash) {
+            let Some(insertion_time_usecs) = trace.insertion_time_usecs else {
+                return;
+            };
             let stage_label = match &metadata {
                 StageMetadata::Execution(status) => {
                     format!("{}({})", stage.as_ref(), status.as_ref())
@@ -156,7 +260,7 @@ impl TransactionTraceStore {
                 StageMetadata::BatchPull(_) => stage.as_ref().to_string(),
                 StageMetadata::BlockProposal(_) => stage.as_ref().to_string(),
             };
-            observe_stage_latency(trace.insertion_time_usecs, &trace.sender_str, &stage_label);
+            observe_stage_latency(insertion_time_usecs, &trace.sender_str, &stage_label);
             trace.record_with_metadata(stage, timestamp_usecs, metadata);
         }
     }
@@ -229,7 +333,7 @@ impl TransactionTraceStore {
     pub fn register_batch(&self, batch_digest: HashValue, txn_hashes: &[HashValue]) {
         let traced: Vec<HashValue> = txn_hashes
             .iter()
-            .filter(|h| self.traces.contains_key(*h))
+            .filter(|h| self.is_traced(h))
             .copied()
             .collect();
         if !traced.is_empty() {
@@ -380,21 +484,26 @@ impl TransactionTraceStore {
 
     /// Check if a transaction hash has an active trace.
     pub fn is_traced(&self, hash: &HashValue) -> bool {
-        self.traces.contains_key(hash)
+        self.traces
+            .get(hash)
+            .is_some_and(|trace| trace.insertion_time_usecs.is_some())
     }
 
     /// Record the gas unit price for a traced transaction (set once at first pull).
     pub fn set_gas_unit_price(&self, hash: &HashValue, gas_unit_price: u64) {
-        if let Some(mut trace) = self.traces.get_mut(hash) {
-            if trace.gas_unit_price.is_none() {
-                trace.gas_unit_price = Some(gas_unit_price);
-            }
+        if let Some(mut trace) = self.traces.get_mut(hash)
+            && trace.insertion_time_usecs.is_some()
+            && trace.gas_unit_price.is_none()
+        {
+            trace.gas_unit_price = Some(gas_unit_price);
         }
     }
 
     /// Mark a transaction for retry: increment its attempt counter.
     pub fn mark_retry(&self, hash: &HashValue) {
-        if let Some(mut trace) = self.traces.get_mut(hash) {
+        if let Some(mut trace) = self.traces.get_mut(hash)
+            && trace.insertion_time_usecs.is_some()
+        {
             trace.current_attempt += 1;
         }
     }
@@ -432,6 +541,7 @@ impl TransactionTraceStore {
     pub fn get_all_traces(&self) -> Vec<(HashValue, TransactionTrace)> {
         self.traces
             .iter()
+            .filter(|entry| entry.value().insertion_time_usecs.is_some())
             .map(|entry| (*entry.key(), entry.value().clone()))
             .collect()
     }
@@ -452,14 +562,14 @@ impl TransactionTraceStore {
         let cutoff = now_usecs().saturating_sub(ttl_usecs);
         let mut evicted = 0u64;
         self.traces.retain(|_, trace| {
-            if trace.insertion_time_usecs > cutoff {
+            if trace.trace_start_time_usecs > cutoff {
                 return true;
             }
             // Log the orphaned trace before evicting so partial pipeline data is visible.
             warn!(LogSchema::new(LogEvent::TxnTraceEvicted)
                 .hash(trace.hash)
                 .sender(trace.sender)
-                .age_ms(now_usecs().saturating_sub(trace.insertion_time_usecs) / 1000)
+                .age_ms(now_usecs().saturating_sub(trace.trace_start_time_usecs) / 1000)
                 .num_stages(trace.stages.len()));
             evicted += 1;
             false
@@ -655,7 +765,9 @@ fn build_wait_summary(
 }
 
 fn log_trace(trace: &TransactionTrace) {
-    let base = trace.insertion_time_usecs;
+    let base = trace
+        .insertion_time_usecs
+        .unwrap_or(trace.trace_start_time_usecs);
 
     // Sort stages by timestamp so concurrent pipeline stages appear in order.
     let mut sorted_stages = trace.stages.clone();
@@ -680,10 +792,10 @@ fn log_trace(trace: &TransactionTrace) {
     let mut first_pull_per_attempt: std::collections::HashMap<u32, &crate::types::BatchPullInfo> =
         std::collections::HashMap::new();
     for record in &sorted_stages {
-        if record.stage == TransactionStage::QsBatchPull {
-            if let Some(StageMetadata::BatchPull(info)) = &record.metadata {
-                first_pull_per_attempt.entry(record.attempt).or_insert(info);
-            }
+        if record.stage == TransactionStage::QsBatchPull
+            && let Some(StageMetadata::BatchPull(info)) = &record.metadata
+        {
+            first_pull_per_attempt.entry(record.attempt).or_insert(info);
         }
     }
     for record in &sorted_stages {
@@ -701,20 +813,20 @@ fn log_trace(trace: &TransactionTrace) {
             }
             // Emit wait() at the start of the new attempt (using the first
             // QsBatchPull's metadata), before whatever stage comes first.
-            if display_attempt > shown_wait_for_attempt {
-                if let Some(info) = first_pull_per_attempt.get(&display_attempt) {
-                    // Find the QsBatchPull timestamp for this attempt.
-                    if let Some(pull_record) = sorted_stages.iter().find(|r| {
-                        r.stage == TransactionStage::QsBatchPull && r.attempt == display_attempt
-                    }) {
-                        stage_parts.push(build_wait_summary(
-                            info,
-                            prev_stage_usecs,
-                            pull_record.timestamp_usecs,
-                        ));
-                    }
-                    shown_wait_for_attempt = display_attempt;
+            if display_attempt > shown_wait_for_attempt
+                && let Some(info) = first_pull_per_attempt.get(&display_attempt)
+            {
+                // Find the QsBatchPull timestamp for this attempt.
+                if let Some(pull_record) = sorted_stages.iter().find(|r| {
+                    r.stage == TransactionStage::QsBatchPull && r.attempt == display_attempt
+                }) {
+                    stage_parts.push(build_wait_summary(
+                        info,
+                        prev_stage_usecs,
+                        pull_record.timestamp_usecs,
+                    ));
                 }
+                shown_wait_for_attempt = display_attempt;
             }
         }
 
@@ -785,7 +897,27 @@ fn log_trace(trace: &TransactionTrace) {
         }
     };
 
-    let scalars = build_first_attempt_scalars(&sorted_stages, base);
+    let mut scalars = build_first_attempt_scalars(&sorted_stages, base);
+    let api_handler_enter_timestamp_usecs = sorted_stages
+        .iter()
+        .find(|record| record.stage == TransactionStage::ApiHandlerEnter)
+        .map(|record| record.timestamp_usecs);
+    let api_transaction_decoded_timestamp_usecs = sorted_stages
+        .iter()
+        .find(|record| record.stage == TransactionStage::ApiTransactionDecoded)
+        .map(|record| record.timestamp_usecs);
+    let api_mempool_submit_timestamp_usecs = sorted_stages
+        .iter()
+        .find(|record| record.stage == TransactionStage::ApiMempoolSubmit)
+        .map(|record| record.timestamp_usecs);
+    let api_mempool_accepted_timestamp_usecs = sorted_stages
+        .iter()
+        .find(|record| record.stage == TransactionStage::ApiMempoolAccepted)
+        .map(|record| record.timestamp_usecs);
+    let mempool_insert_timestamp_usecs = trace.insertion_time_usecs;
+    scalars.api_to_mempool_ms = api_handler_enter_timestamp_usecs
+        .zip(mempool_insert_timestamp_usecs)
+        .map(|(api_usecs, mempool_usecs)| mempool_usecs.saturating_sub(api_usecs) as i64 / 1000);
 
     let mut schema = LogSchema::new(LogEvent::TxnTrace)
         .hash(trace.hash)
@@ -807,8 +939,28 @@ fn log_trace(trace: &TransactionTrace) {
         };
     }
     set_if_some!(trace, gas_unit_price);
+    if let Some(timestamp_usecs) = api_handler_enter_timestamp_usecs {
+        schema = schema.api_handler_enter_timestamp_usecs(timestamp_usecs);
+    }
+    if let Some(timestamp_usecs) = api_transaction_decoded_timestamp_usecs {
+        schema = schema.api_transaction_decoded_timestamp_usecs(timestamp_usecs);
+    }
+    if let Some(timestamp_usecs) = api_mempool_submit_timestamp_usecs {
+        schema = schema.api_mempool_submit_timestamp_usecs(timestamp_usecs);
+    }
+    if let Some(timestamp_usecs) = api_mempool_accepted_timestamp_usecs {
+        schema = schema.api_mempool_accepted_timestamp_usecs(timestamp_usecs);
+    }
+    if let Some(timestamp_usecs) = mempool_insert_timestamp_usecs {
+        schema = schema.mempool_insert_timestamp_usecs(timestamp_usecs);
+    }
     set_if_some!(
         scalars,
+        api_handler_enter_ms,
+        api_transaction_decoded_ms,
+        api_mempool_submit_ms,
+        api_mempool_accepted_ms,
+        api_to_mempool_ms,
         mempool_insert_ms,
         qs_batch_pull_ms,
         qs_batch_created_ms,
@@ -838,6 +990,11 @@ fn log_trace(trace: &TransactionTrace) {
 /// detail lives in the `stages` text string.
 #[derive(Debug, Default)]
 struct StageScalars {
+    api_handler_enter_ms: Option<i64>,
+    api_transaction_decoded_ms: Option<i64>,
+    api_mempool_submit_ms: Option<i64>,
+    api_mempool_accepted_ms: Option<i64>,
+    api_to_mempool_ms: Option<i64>,
     mempool_insert_ms: Option<i64>,
     qs_batch_pull_ms: Option<i64>,
     qs_batch_created_ms: Option<i64>,
@@ -893,10 +1050,14 @@ fn build_first_attempt_scalars(
         if effective_attempt != 1 {
             continue;
         }
-        // Absolute latency in ms from `base` (MempoolInsert time). Can be
-        // negative for `BlockProposed` (proposer's clock).
+        // Absolute latency in ms from `base` (MempoolInsert time). API stages
+        // and BlockProposed (on the proposer's clock) can be negative.
         let abs_ms = (record.timestamp_usecs as i64 - base as i64) / 1000;
         let slot: &mut Option<i64> = match record.stage {
+            TransactionStage::ApiHandlerEnter => &mut scalars.api_handler_enter_ms,
+            TransactionStage::ApiTransactionDecoded => &mut scalars.api_transaction_decoded_ms,
+            TransactionStage::ApiMempoolSubmit => &mut scalars.api_mempool_submit_ms,
+            TransactionStage::ApiMempoolAccepted => &mut scalars.api_mempool_accepted_ms,
             TransactionStage::MempoolInsert => &mut scalars.mempool_insert_ms,
             TransactionStage::QsBatchPull => &mut scalars.qs_batch_pull_ms,
             TransactionStage::QsBatchCreated => &mut scalars.qs_batch_created_ms,
@@ -960,6 +1121,100 @@ mod tests {
         let other = AccountAddress::random();
         let other_hash = HashValue::random();
         assert!(!store.maybe_start_trace(other_hash, other, 1000));
+    }
+
+    #[test]
+    fn test_api_trace_continues_at_mempool_without_changing_base_semantics() {
+        let store = TransactionTraceStore::new();
+        let sender = AccountAddress::random();
+        let hash = HashValue::random();
+
+        let mut allowlist = std::collections::HashSet::new();
+        allowlist.insert(sender);
+        store.update_filter(TransactionFilter::new(true, allowlist, 1.0, 1.0));
+
+        let token = store
+            .maybe_start_api_trace(hash, sender, 100_000)
+            .expect("API trace should start");
+        assert!(store.record_api_stage_at(
+            &token,
+            TransactionStage::ApiTransactionDecoded,
+            105_000
+        ));
+        assert!(store.record_api_stage_at(&token, TransactionStage::ApiMempoolSubmit, 110_000));
+
+        let api_trace = store.get_trace(&hash).unwrap();
+        assert_eq!(api_trace.trace_start_time_usecs, 100_000);
+        assert_eq!(api_trace.insertion_time_usecs, None);
+        assert!(!store.is_traced(&hash));
+        assert!(store.maybe_start_api_trace(hash, sender, 120_000).is_none());
+        store.record_stage_at(&hash, TransactionStage::QsBatchPull, 125_000);
+        assert!(!store
+            .get_trace(&hash)
+            .unwrap()
+            .has_stage(TransactionStage::QsBatchPull));
+
+        assert!(store.maybe_start_trace(hash, sender, 215_000));
+        assert!(store.record_api_stage_at(&token, TransactionStage::ApiMempoolAccepted, 220_000));
+        assert!(store.is_traced(&hash));
+
+        let trace = store.get_trace(&hash).unwrap();
+        assert_eq!(trace.insertion_time_usecs, Some(215_000));
+        assert_eq!(
+            trace
+                .stages
+                .iter()
+                .map(|record| record.stage)
+                .collect::<Vec<_>>(),
+            vec![
+                TransactionStage::ApiHandlerEnter,
+                TransactionStage::ApiTransactionDecoded,
+                TransactionStage::ApiMempoolSubmit,
+                TransactionStage::MempoolInsert,
+                TransactionStage::ApiMempoolAccepted,
+            ]
+        );
+
+        let mut sorted = trace.stages.clone();
+        sorted.sort_by_key(|record| record.timestamp_usecs);
+        let scalars = build_first_attempt_scalars(&sorted, 215_000);
+        assert_eq!(scalars.api_handler_enter_ms, Some(-115));
+        assert_eq!(scalars.api_transaction_decoded_ms, Some(-110));
+        assert_eq!(scalars.api_mempool_submit_ms, Some(-105));
+        assert_eq!(scalars.mempool_insert_ms, Some(0));
+        assert_eq!(scalars.api_mempool_accepted_ms, Some(5));
+
+        // A duplicate insertion must not reset the original mempool base.
+        assert!(!store.maybe_start_trace(hash, sender, 300_000));
+        assert_eq!(
+            store.get_trace(&hash).unwrap().insertion_time_usecs,
+            Some(215_000)
+        );
+    }
+
+    #[test]
+    fn test_api_rejection_cleans_up_only_the_owning_pending_trace() {
+        let store = TransactionTraceStore::new();
+        let sender = AccountAddress::random();
+        let hash = HashValue::random();
+
+        let mut allowlist = std::collections::HashSet::new();
+        allowlist.insert(sender);
+        store.update_filter(TransactionFilter::new(true, allowlist, 1.0, 1.0));
+
+        let token = store
+            .maybe_start_api_trace(hash, sender, now_usecs())
+            .expect("API trace should start");
+        let stale_token = ApiTraceToken {
+            hash,
+            generation: token.generation.wrapping_add(1),
+        };
+        assert!(!store.record_api_stage(&stale_token, TransactionStage::ApiTransactionDecoded));
+        assert!(!store.cancel_api_trace(stale_token));
+        assert!(store.get_trace(&hash).is_some());
+
+        assert!(store.cancel_api_trace(token));
+        assert!(store.get_trace(&hash).is_none());
     }
 
     #[test]

--- a/crates/aptos-transaction-tracing/src/store.rs
+++ b/crates/aptos-transaction-tracing/src/store.rs
@@ -39,6 +39,24 @@ const MAX_TRACES: usize = 10_000;
 pub struct ApiTraceToken {
     hash: HashValue,
     generation: u64,
+    /// When true, dropping the token removes a still-pending pre-mempool trace.
+    /// Disarmed after mempool accepts so the trace can be promoted asynchronously.
+    cancel_on_drop: bool,
+}
+
+impl ApiTraceToken {
+    /// Prevents drop-time cleanup for traces handed off to mempool successfully.
+    pub fn disarm(&mut self) {
+        self.cancel_on_drop = false;
+    }
+}
+
+impl Drop for ApiTraceToken {
+    fn drop(&mut self) {
+        if self.cancel_on_drop {
+            GLOBAL_STORE.remove_pending_api_trace(self.hash, self.generation);
+        }
+    }
 }
 
 /// Global store for transaction lifecycle traces.
@@ -124,7 +142,11 @@ impl TransactionTraceStore {
                     handler_enter_usecs,
                     generation,
                 ));
-                Some(ApiTraceToken { hash, generation })
+                Some(ApiTraceToken {
+                    hash,
+                    generation,
+                    cancel_on_drop: true,
+                })
             },
         }
     }
@@ -196,12 +218,15 @@ impl TransactionTraceStore {
 
     /// Removes a pre-mempool trace when its owning API request is rejected or
     /// cancelled. Once mempool has promoted the trace, cleanup is a no-op.
-    pub fn cancel_api_trace(&self, token: ApiTraceToken) -> bool {
-        if let Entry::Occupied(entry) = self.traces.entry(token.hash) {
+    pub fn cancel_api_trace(&self, mut token: ApiTraceToken) -> bool {
+        token.disarm();
+        self.remove_pending_api_trace(token.hash, token.generation)
+    }
+
+    fn remove_pending_api_trace(&self, hash: HashValue, generation: u64) -> bool {
+        if let Entry::Occupied(entry) = self.traces.entry(hash) {
             let trace = entry.get();
-            if trace.api_generation == Some(token.generation)
-                && trace.insertion_time_usecs.is_none()
-            {
+            if trace.api_generation == Some(generation) && trace.insertion_time_usecs.is_none() {
                 entry.remove();
                 self.maybe_gc();
                 return true;
@@ -1208,6 +1233,7 @@ mod tests {
         let stale_token = ApiTraceToken {
             hash,
             generation: token.generation.wrapping_add(1),
+            cancel_on_drop: true,
         };
         assert!(!store.record_api_stage(&stale_token, TransactionStage::ApiTransactionDecoded));
         assert!(!store.cancel_api_trace(stale_token));
@@ -1215,6 +1241,52 @@ mod tests {
 
         assert!(store.cancel_api_trace(token));
         assert!(store.get_trace(&hash).is_none());
+    }
+
+    #[test]
+    fn test_dropped_api_trace_token_cleans_up_abandoned_pending_trace() {
+        let store = TransactionTraceStore::global();
+        let sender = AccountAddress::random();
+        let hash = HashValue::random();
+
+        let mut allowlist = std::collections::HashSet::new();
+        allowlist.insert(sender);
+        store.update_filter(TransactionFilter::new(true, allowlist, 1.0, 1.0));
+
+        let token = store
+            .maybe_start_api_trace(hash, sender, 100_000)
+            .expect("API trace should start");
+        drop(token);
+        assert!(store.get_trace(&hash).is_none());
+
+        let retry_token = store
+            .maybe_start_api_trace(hash, sender, 200_000)
+            .expect("retry should start a fresh API trace");
+        assert!(store.maybe_start_trace(hash, sender, 300_000));
+        assert_eq!(
+            store.get_trace(&hash).unwrap().trace_start_time_usecs,
+            200_000
+        );
+        drop(retry_token);
+        store.finalize_trace(&hash);
+    }
+
+    #[test]
+    fn test_disarmed_api_trace_token_keeps_pending_trace_on_drop() {
+        let store = TransactionTraceStore::new();
+        let sender = AccountAddress::random();
+        let hash = HashValue::random();
+
+        let mut allowlist = std::collections::HashSet::new();
+        allowlist.insert(sender);
+        store.update_filter(TransactionFilter::new(true, allowlist, 1.0, 1.0));
+
+        let mut token = store
+            .maybe_start_api_trace(hash, sender, 100_000)
+            .expect("API trace should start");
+        token.disarm();
+        drop(token);
+        assert!(store.get_trace(&hash).is_some());
     }
 
     #[test]

--- a/crates/aptos-transaction-tracing/src/types.rs
+++ b/crates/aptos-transaction-tracing/src/types.rs
@@ -8,6 +8,10 @@ use std::sync::Arc;
 /// Lifecycle stages a transaction passes through.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::AsRefStr)]
 pub enum TransactionStage {
+    ApiHandlerEnter,
+    ApiTransactionDecoded,
+    ApiMempoolSubmit,
+    ApiMempoolAccepted,
     MempoolInsert,
     QsBatchPull,
     QsBatchCreated,
@@ -30,6 +34,18 @@ pub enum TransactionStage {
     Committed,
     MempoolCommit,
     MempoolReject,
+}
+
+impl TransactionStage {
+    pub fn is_api_stage(self) -> bool {
+        matches!(
+            self,
+            Self::ApiHandlerEnter
+                | Self::ApiTransactionDecoded
+                | Self::ApiMempoolSubmit
+                | Self::ApiMempoolAccepted
+        )
+    }
 }
 
 /// Batch inclusion type in a block proposal.
@@ -144,7 +160,16 @@ pub struct TransactionTrace {
     /// Pre-computed sender hex string to avoid repeated allocations in
     /// `observe_stage_latency` (called ~10 times per trace lifecycle).
     pub sender_str: String,
-    pub insertion_time_usecs: u64,
+    /// Time when this trace first became active. For API-submitted transactions,
+    /// this precedes mempool insertion and is used for orphan cleanup.
+    pub trace_start_time_usecs: u64,
+    /// Mempool insertion remains the base for existing pipeline latency fields.
+    /// API-started traces leave this unset until core mempool accepts the txn.
+    pub insertion_time_usecs: Option<u64>,
+    /// Identifies the API request that created a pending trace. This remains set
+    /// after mempool promotion so that only the owning request can append its
+    /// terminal API stage.
+    pub(crate) api_generation: Option<u64>,
     pub current_attempt: u32,
     /// Gas unit price of this transaction, recorded at first QsBatchPull.
     /// Used to diagnose prioritization: mempool sorts by gas price descending.
@@ -159,11 +184,49 @@ impl TransactionTrace {
             hash,
             sender,
             sender_str,
-            insertion_time_usecs: now_usecs,
+            trace_start_time_usecs: now_usecs,
+            insertion_time_usecs: Some(now_usecs),
+            api_generation: None,
             current_attempt: 1,
             gas_unit_price: None,
             stages: Vec::new(),
         }
+    }
+
+    pub fn new_at_api(
+        hash: HashValue,
+        sender: AccountAddress,
+        now_usecs: u64,
+        api_generation: u64,
+    ) -> Self {
+        let sender_str = sender.to_string();
+        let mut trace = Self {
+            hash,
+            sender,
+            sender_str,
+            trace_start_time_usecs: now_usecs,
+            insertion_time_usecs: None,
+            api_generation: Some(api_generation),
+            current_attempt: 1,
+            gas_unit_price: None,
+            stages: Vec::new(),
+        };
+        trace.record(TransactionStage::ApiHandlerEnter, now_usecs);
+        trace
+    }
+
+    /// Initializes the existing mempool-relative timeline exactly once.
+    pub fn start_at_mempool(&mut self, now_usecs: u64) -> bool {
+        if self.insertion_time_usecs.is_some() {
+            return false;
+        }
+        self.insertion_time_usecs = Some(now_usecs);
+        self.record(TransactionStage::MempoolInsert, now_usecs);
+        true
+    }
+
+    pub fn has_stage(&self, stage: TransactionStage) -> bool {
+        self.stages.iter().any(|record| record.stage == stage)
     }
 
     pub fn record(&mut self, stage: TransactionStage, timestamp_usecs: u64) {

--- a/testsuite/smoke-test/src/transaction_tracing.rs
+++ b/testsuite/smoke-test/src/transaction_tracing.rs
@@ -179,9 +179,10 @@ async fn test_transaction_tracing() {
 
         // Every populated `*_ms` per-stage field must be a plain JSON number
         // (not an array — the schema emits scalars for the first pipeline
-        // pass only). Most stages use the local clock and are non-negative;
-        // `block_proposed_ms` can be negative due to cross-validator clock
-        // skew. We also assert no value exceeds `total_latency_ms` (the
+        // pass only). Most stages use the local clock and are non-negative.
+        // API stages before MempoolInsert are negative by definition, while
+        // block proposal timestamps can be negative due to cross-validator
+        // clock skew. We also assert no stage value exceeds `total_latency_ms` (the
         // structured scalars only cover attempt 1; for a retried trace,
         // total_latency reflects later attempts and stays >= scalar max).
         for (key, val) in trace.as_object().expect("trace must be object").iter() {
@@ -192,22 +193,31 @@ async fn test_transaction_tracing() {
                 Some(n) => n,
                 None => panic!("{} must be i64, got {}", key, val),
             };
-            // Most stages use local clocks and are non-negative;
-            // `block_proposed_ms` and `parent_block_proposed_ms` record
-            // foreign-block timestamps (proposer's clock for the child and
-            // parent blocks) and can be negative due to cross-validator
-            // clock skew.
-            if key != "block_proposed_ms" && key != "parent_block_proposed_ms" {
+            // API stages before MempoolInsert and foreign block timestamps
+            // are the only absolute stage latencies allowed to be negative.
+            let can_be_negative = matches!(
+                key.as_str(),
+                "api_handler_enter_ms"
+                    | "api_transaction_decoded_ms"
+                    | "api_mempool_submit_ms"
+                    | "block_proposed_ms"
+                    | "parent_block_proposed_ms"
+            );
+            if !can_be_negative {
                 assert!(d >= 0, "abs latency {} for {} must be non-negative", d, key);
             }
-            assert!(
-                d <= total_latency_ms,
-                "{} = {} exceeds total_latency_ms = {} (hash={})",
-                key,
-                d,
-                total_latency_ms,
-                hash
-            );
+            // api_to_mempool_ms is an interval preceding the mempool-relative
+            // total and can legitimately be larger than that total.
+            if key != "api_to_mempool_ms" {
+                assert!(
+                    d <= total_latency_ms,
+                    "{} = {} exceeds total_latency_ms = {} (hash={})",
+                    key,
+                    d,
+                    total_latency_ms,
+                    hash
+                );
+            }
         }
 
         if outcome == "committed" {


### PR DESCRIPTION
## Summary

Cherry-pick of #20323 onto `aptos-release-v1.48` so it can be canaried on testnet validators (fleet runs v1.48.x).

Context: the original PR build (based on `main`) was deployed to `testnet-validator-euwe4-0` on 2026-08-11 and crash-looped with `executed_state_id` mismatches (`buffer_item.rs:342`, `chunk_executor/mod.rs:126`) because main has diverged from release-1.48 in execution semantics (different write sets/gas for the same transactions). This port puts the same API-tracing diff on the release base so a canary build is execution-compatible with the rest of the fleet.

Cherry-picked commits (from #20323, `-x` annotated):
- `117aafcf31` [api] Add API-layer stages to transaction tracing
- `877f389552` [api] Clean up abandoned API traces on token drop

One conflict in `api/src/transactions.rs`: on main the submit-guards run before `data.verify()`; on v1.48 they run after. Resolved by keeping v1.48's original guard ordering and adding only the `api_handler_enter_usecs` capture at handler entry — no behavior change to submission gating. All 7 instrumentation call sites match the original PR.

## Test plan

On this branch (rustc 1.94.1, the branch's pinned toolchain):
- [x] `cargo test -p aptos-transaction-tracing` — 17/17 passed
- [x] `cargo test -p aptos-api test_submit_transaction_records_api_trace_stages` — passed
- [x] `cargo check -p smoke-test --tests` — clean
- [x] `cargo clippy --no-deps` on the four changed crates with xclippy flags — clean
- [x] `cargo +nightly fmt --check`, `cargo sort --check` (api), `cargo machete` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot transaction submission path and shared trace store concurrency, but work is filter-gated and submission gating is unchanged on v1.48; main risk is observability overhead or trace-store edge cases under load.
> 
> **Overview**
> **Extends per-transaction tracing to cover REST submission**, so latency can be measured from API handler entry through mempool acceptance, not only from mempool insert onward.
> 
> The API `POST /transactions` path now captures a handler-entry timestamp, optionally starts a trace via `TransactionTraceStore::maybe_start_api_trace`, records **ApiHandlerEnter → ApiTransactionDecoded → ApiMempoolSubmit → ApiMempoolAccepted**, and hands off to existing mempool tracing at **MempoolInsert**. **`ApiTraceToken`** ties stages to a single request (generation id), **disarms** after mempool accept, and **drops/cancels** pending pre-mempool traces on rejection or abandoned futures.
> 
> **`aptos-transaction-tracing`** gains API stages, optional `insertion_time_usecs` until mempool promotion, and richer **`TxnTrace` logs** (API timestamps and `api_*_ms` / `api_to_mempool_ms`). Batch submit still passes **no** API trace token. Config/docs now describe the pipeline as **API → mempool → …**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46aee15d703a7e69fe8be7c006e6f823f00c006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->