### PR TITLE
[compiler-v2] Add compiler-side native function/struct checker mirroring VM publish-time rules

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
@@ -107,13 +107,15 @@ fn code_publishing_disallow_user_native() {
     let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
-    assert_vm_status!(
-        h.publish_package(
-            &acc,
-            &common::test_dir_path("code_publishing.data/pack_native"),
-        ),
-        StatusCode::USER_DEFINED_NATIVE_NOT_ALLOWED
+    // Disable the compiler's native check so the package builds and the
+    // publish-time VM check is exercised.
+    let txn = h.create_publish_package(
+        &acc,
+        &common::test_dir_path("code_publishing.data/pack_native"),
+        Some(aptos_framework::BuildOptions::default().with_experiment("native-check=off")),
+        |_| {},
     );
+    assert_vm_status!(h.run(txn), StatusCode::USER_DEFINED_NATIVE_NOT_ALLOWED);
 }
 
 #[test]
@@ -121,13 +123,15 @@ fn code_publishing_disallow_user_native_entry() {
     let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
-    assert_vm_status!(
-        h.publish_package(
-            &acc,
-            &common::test_dir_path("code_publishing.data/pack_native_entry"),
-        ),
-        StatusCode::USER_DEFINED_NATIVE_NOT_ALLOWED
+    // Disable the compiler's native check so the package builds and the
+    // publish-time VM check is exercised.
+    let txn = h.create_publish_package(
+        &acc,
+        &common::test_dir_path("code_publishing.data/pack_native_entry"),
+        Some(aptos_framework::BuildOptions::default().with_experiment("native-check=off")),
+        |_| {},
     );
+    assert_vm_status!(h.run(txn), StatusCode::USER_DEFINED_NATIVE_NOT_ALLOWED);
 }
 
 #[test]
@@ -146,13 +150,15 @@ fn code_publishing_disallow_system_native_entry() {
     let mut h = MoveHarness::new();
     let acc = h.aptos_framework_account();
 
-    assert_vm_status!(
-        h.publish_package(
-            &acc,
-            &common::test_dir_path("code_publishing.data/pack_native_system_entry"),
-        ),
-        StatusCode::USER_DEFINED_NATIVE_NOT_ALLOWED
+    // Disable the compiler's native check so the package builds and the
+    // publish-time VM check is exercised.
+    let txn = h.create_publish_package(
+        &acc,
+        &common::test_dir_path("code_publishing.data/pack_native_system_entry"),
+        Some(aptos_framework::BuildOptions::default().with_experiment("native-check=off")),
+        |_| {},
     );
+    assert_vm_status!(h.run(txn), StatusCode::USER_DEFINED_NATIVE_NOT_ALLOWED);
 }
 
 #[test]

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
@@ -3376,6 +3376,14 @@ fn parse_struct_decl(
             .env
             .add_diag(diag!(Syntax::InvalidModifier, (loc, msg)));
     }
+    if is_enum {
+        if let Some(loc) = native {
+            let msg = "native enums are not supported";
+            context
+                .env
+                .add_diag(diag!(Syntax::InvalidModifier, (loc, msg)));
+        }
+    }
 
     if is_enum {
         context.tokens.advance()?;

--- a/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
@@ -22,6 +22,7 @@ pub mod literal_pattern_checker;
 pub mod match_coverage_checks;
 pub mod match_transforms;
 pub mod model_ast_lints;
+pub mod native_checker;
 pub mod recursive_struct_checker;
 pub mod rewrite_target;
 pub mod spec_checker;

--- a/third_party/move/move-compiler-v2/src/env_pipeline/native_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/native_checker.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! This module checks for native declarations which the VM rejects at publish or
+//! load time, mirroring its rules: native structs and native entry functions are
+//! never allowed, and other native functions are allowed only in modules at
+//! special addresses.
+
+use codespan_reporting::diagnostic::Severity;
+use move_model::model::GlobalEnv;
+
+/// Check for disallowed native declarations in primary target modules.
+pub fn check_for_native_functions_and_structs(env: &mut GlobalEnv) {
+    for module in env.get_modules().filter(|m| m.is_primary_target()) {
+        let is_special = module.self_address().expect_numerical().is_special();
+        for fun in module.get_functions().filter(|f| f.is_native()) {
+            if fun.is_entry() {
+                env.diag(
+                    Severity::Error,
+                    &fun.get_loc(),
+                    "native functions cannot be entry functions",
+                );
+            } else if !is_special {
+                env.diag(
+                    Severity::Error,
+                    &fun.get_loc(),
+                    "only special-address modules can have native functions",
+                );
+            }
+        }
+        for struct_ in module.get_structs().filter(|s| s.is_native()) {
+            env.diag(
+                Severity::Error,
+                &struct_.get_loc(),
+                "native structs are not supported",
+            );
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -136,6 +136,12 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(false),
         },
         Experiment {
+            name: Experiment::NATIVE_CHECK.to_string(),
+            description: "Whether to check for native functions/structs in non-special modules"
+                .to_string(),
+            default: Inherited(Experiment::CHECKS.to_string()),
+        },
+        Experiment {
             name: Experiment::RECURSIVE_TYPE_CHECK.to_string(),
             description: "Turns on or off checking of recursive structs and type instantiations"
                 .to_string(),
@@ -337,6 +343,7 @@ impl Experiment {
     pub const LIFT_INLINE_FUNS: &'static str = "lift-inline-funs";
     pub const LINT_CHECKS: &'static str = "lint-checks";
     pub const MESSAGE_FORMAT_JSON: &'static str = "compiler-message-format-json";
+    pub const NATIVE_CHECK: &'static str = "native-check";
     pub const OPTIMIZE: &'static str = "optimize";
     pub const OPTIMIZE_EXTRA: &'static str = "optimize-extra";
     pub const OPTIMIZE_WAITING_FOR_COMPARE_TESTS: &'static str =

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -21,8 +21,8 @@ use crate::{
         acquires_checker, ast_simplifier, closure_checker, cmp_rewriter,
         cyclic_instantiation_checker, flow_insensitive_checkers, function_checker, inliner,
         inlining_optimization, lambda_lifter, lambda_lifter::LambdaLiftingOptions, model_ast_lints,
-        recursive_struct_checker, rewrite_target::RewritingScope, spec_checker, spec_rewriter,
-        struct_usage_collector, unused_params_checker, EnvProcessorPipeline,
+        native_checker, recursive_struct_checker, rewrite_target::RewritingScope, spec_checker,
+        spec_rewriter, struct_usage_collector, unused_params_checker, EnvProcessorPipeline,
     },
     pipeline::{
         ability_processor::AbilityProcessor,
@@ -197,6 +197,9 @@ pub fn run_move_compiler_to_model(mut options: Options) -> anyhow::Result<Global
     options.whole_program = true;
     options = options.set_experiment(Experiment::SPEC_REWRITE, true);
     options = options.set_experiment(Experiment::ATTACH_COMPILED_MODULE, true);
+    // Analysis models may include native declarations at non-special addresses;
+    // that check only applies when compiling for execution.
+    options = options.set_experiment(Experiment::NATIVE_CHECK, false);
 
     // Type checking + AST transforms.
     let mut env = run_checker_and_rewriters(options.clone())?;
@@ -418,6 +421,13 @@ pub fn env_check_and_transform_pipeline<'a, 'b>(options: &'a Options) -> EnvProc
         env_pipeline.add(
             "type parameter check",
             function_checker::check_for_function_typed_parameters,
+        );
+    }
+
+    if options.experiment_on(Experiment::NATIVE_CHECK) {
+        env_pipeline.add(
+            "native function and struct check",
+            native_checker::check_for_native_functions_and_structs,
         );
     }
 

--- a/third_party/move/move-compiler-v2/tests/checking/friends/bug_16669.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/bug_16669.exp
@@ -1,5 +1,5 @@
 // -- Model dump before first bytecode pipeline
-module 0xc0ffee::m {
+module 0xc::m {
     friend inline fun foo(): u64 {
         12
     }
@@ -13,10 +13,10 @@ module 0xc0ffee::m {
     friend entry fun foo_4(): u64 {
         12
     }
-} // end 0xc0ffee::m
+} // end 0xc::m
 
 // -- Sourcified model before first bytecode pipeline
-module 0xc0ffee::m {
+module 0xc::m {
     friend inline fun foo(): u64 {
         12
     }

--- a/third_party/move/move-compiler-v2/tests/checking/friends/bug_16669.move
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/bug_16669.move
@@ -1,4 +1,4 @@
-module 0xc0ffee::m {
+module 0xc::m {
     friend inline fun foo(): u64 {
         12
     }

--- a/third_party/move/move-compiler-v2/tests/checking/friends/bug_16669_package.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/bug_16669_package.exp
@@ -1,5 +1,5 @@
 // -- Model dump before first bytecode pipeline
-module 0xc0ffee::m {
+module 0xc::m {
     friend inline fun foo(): u64 {
         12
     }
@@ -13,10 +13,10 @@ module 0xc0ffee::m {
     friend entry fun foo_4(): u64 {
         12
     }
-} // end 0xc0ffee::m
+} // end 0xc::m
 
 // -- Sourcified model before first bytecode pipeline
-module 0xc0ffee::m {
+module 0xc::m {
     friend inline fun foo(): u64 {
         12
     }

--- a/third_party/move/move-compiler-v2/tests/checking/friends/bug_16669_package.move
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/bug_16669_package.move
@@ -1,4 +1,4 @@
-module 0xc0ffee::m {
+module 0xc::m {
     package inline fun foo(): u64 {
         12
     }

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/native_inline.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/native_inline.move
@@ -1,4 +1,4 @@
-module 0x42::Test {
+module 0x4::Test {
 
     public native inline fun foo();
 

--- a/third_party/move/move-compiler-v2/tests/checking/natives/allowed.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/natives/allowed.exp
@@ -1,0 +1,9 @@
+// -- Model dump before first bytecode pipeline
+module 0xa::m {
+    private native fun whatever(): u64;
+} // end 0xa::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xa::m {
+    native fun whatever(): u64;
+}

--- a/third_party/move/move-compiler-v2/tests/checking/natives/allowed.move
+++ b/third_party/move/move-compiler-v2/tests/checking/natives/allowed.move
@@ -1,0 +1,3 @@
+module 0xa::m {
+    native fun whatever(): u64;
+}

--- a/third_party/move/move-compiler-v2/tests/checking/natives/disallowed.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/natives/disallowed.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: native structs are not supported
+  ┌─ tests/checking/natives/disallowed.move:2:5
+  │
+2 │     native struct Foo;
+  │     ^^^^^^^^^^^^^^^^^^
+
+error: only special-address modules can have native functions
+  ┌─ tests/checking/natives/disallowed.move:4:5
+  │
+4 │     native fun whatever(): u64;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/natives/disallowed.move
+++ b/third_party/move/move-compiler-v2/tests/checking/natives/disallowed.move
@@ -1,0 +1,5 @@
+module 0xc0ffee::m {
+    native struct Foo;
+
+    native fun whatever(): u64;
+}

--- a/third_party/move/move-compiler-v2/tests/checking/natives/disallowed_special.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/natives/disallowed_special.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: native structs are not supported
+  ┌─ tests/checking/natives/disallowed_special.move:2:5
+  │
+2 │     native struct Foo;
+  │     ^^^^^^^^^^^^^^^^^^
+
+error: native functions cannot be entry functions
+  ┌─ tests/checking/natives/disallowed_special.move:4:5
+  │
+4 │     entry native fun init();
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/natives/disallowed_special.move
+++ b/third_party/move/move-compiler-v2/tests/checking/natives/disallowed_special.move
@@ -1,0 +1,7 @@
+module 0x1::m {
+    native struct Foo;
+
+    entry native fun init();
+
+    native fun ok(): u64;
+}

--- a/third_party/move/move-compiler-v2/tests/checking/natives/native_enum.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/natives/native_enum.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: invalid modifier
+  ┌─ tests/checking/natives/native_enum.move:2:5
+  │
+2 │     native enum Bar;
+  │     ^^^^^^ native enums are not supported

--- a/third_party/move/move-compiler-v2/tests/checking/natives/native_enum.move
+++ b/third_party/move/move-compiler-v2/tests/checking/natives/native_enum.move
@@ -1,0 +1,3 @@
+module 0x1::m {
+    native enum Bar;
+}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/intrinsic_decl_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/intrinsic_decl_ok.exp
@@ -1,5 +1,5 @@
 // -- Model dump before first bytecode pipeline
-module 0x42::M {
+module 0x4::M {
     struct MyTable1<K,V> {
         dummy_field: bool,
     }
@@ -26,10 +26,10 @@ module 0x42::M {
     spec fun spec_len2<K,V>(t: MyTable2<#0, #1>): num;
     spec fun spec_del<K,V>(t: MyTable2<#0, #1>): num;
     spec fun spec_has_key<K,V>(t: MyTable2<#0, #1>,k: #0): bool;
-} // end 0x42::M
+} // end 0x4::M
 
 // -- Sourcified model before first bytecode pipeline
-module 0x42::M {
+module 0x4::M {
     struct MyTable1<phantom K, phantom V> {
     }
 

--- a/third_party/move/move-compiler-v2/tests/checking/specs/intrinsic_decl_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/intrinsic_decl_ok.move
@@ -1,4 +1,4 @@
-module 0x42::M {
+module 0x4::M {
     struct MyTable1<phantom K, phantom V> {}
 
     native fun new<K, V>(): MyTable1<K, V>;

--- a/third_party/move/move-compiler-v2/tests/checking/specs/spec_pureness_checks.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/spec_pureness_checks.move
@@ -1,4 +1,4 @@
-module 0x42::m {
+module 0x4::m {
 
     fun pure(x: u64): u64 { x + 1 }
 

--- a/third_party/move/move-compiler-v2/tests/checking/typing/unused_local.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/unused_local.exp
@@ -31,7 +31,7 @@ warning: Unused local variable `g`. Consider removing or prefixing with an under
    │                   ^
 
 // -- Model dump before first bytecode pipeline
-module 0x8675309::M {
+module 0x8::M {
     struct S {
         f: u64,
         g: bool,
@@ -85,10 +85,10 @@ module 0x8675309::M {
     private fun unused_param_suppressed2(_x: u64) {
         Tuple()
     }
-} // end 0x8675309::M
+} // end 0x8::M
 
 // -- Sourcified model before first bytecode pipeline
-module 0x8675309::M {
+module 0x8::M {
     struct S {
         f: u64,
         g: bool,

--- a/third_party/move/move-compiler-v2/tests/checking/typing/unused_local.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/unused_local.move
@@ -1,4 +1,4 @@
-module 0x8675309::M {
+module 0x8::M {
     struct S { f: u64, g: bool }
 
     fun t0() {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
@@ -1,6 +1,7 @@
 // -- Model dump before first bytecode pipeline
 module 0x2::Map {
     struct T<K,V> {
+        dummy_field: bool,
     }
     public native fun remove<K,V>(m: &T<K, V>,k: &K): V;
     public native fun empty<K,V>(): T<K, V>;
@@ -283,7 +284,7 @@ module 0x70dd::ToddNickels {
 
 // -- Sourcified model before first bytecode pipeline
 module 0x2::Map {
-    struct T<K, V> has copy, drop, store {
+    struct T<phantom K, phantom V> has copy, drop, store {
     }
     public native fun remove<K, V>(m: &T<K, V>, k: &K): V;
     public native fun empty<K, V>(): T<K, V>;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.move
@@ -2,7 +2,7 @@
 address 0x2 {
 
 module Map {
-    native struct T<K, V> has copy, drop, store;
+    struct T<phantom K, phantom V> has copy, drop, store { dummy_field: bool }
 
     native public fun empty<K, V>(): T<K, V>;
 

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/entry_function.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/entry_function.exp
@@ -1,2 +1,31 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: native functions cannot be entry functions
+  ┌─ tests/more-v1/parser/entry_function.move:5:5
+  │
+5 │     native entry fun f3();
+  │     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: native functions cannot be entry functions
+  ┌─ tests/more-v1/parser/entry_function.move:6:5
+  │
+6 │     entry native fun f4();
+  │     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: native functions cannot be entry functions
+  ┌─ tests/more-v1/parser/entry_function.move:7:5
+  │
+7 │     entry native public fun f5();
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: native functions cannot be entry functions
+  ┌─ tests/more-v1/parser/entry_function.move:8:5
+  │
+8 │     native entry public fun f6();
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: native functions cannot be entry functions
+  ┌─ tests/more-v1/parser/entry_function.move:9:5
+  │
+9 │     native public entry fun f7();
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/entry_function.move
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/entry_function.move
@@ -1,4 +1,4 @@
-module 0x8675309::M {
+module 0x8::M {
     public entry fun f0() {}
     entry public fun f1() {}
     entry fun f2() {}

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/function_public_native.move
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/function_public_native.move
@@ -1,4 +1,4 @@
-module 0x42::M {
+module 0x4::M {
     // visibility can come before native. previously not allowed
     public native fun f();
 }

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/bug-13880.move
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/bug-13880.move
@@ -1,9 +1,9 @@
-module 0x42::create_signer {
-    friend 0x42::object;
+module 0x4::create_signer {
+    friend 0x4::object;
     public(friend) native fun create_signer(addr: address): signer;
 }
 
-module 0x42::signer {
+module 0x4::signer {
     native public fun borrow_address(s: &signer): &address;
 
     // Copies the address of the signer
@@ -14,7 +14,7 @@ module 0x42::signer {
 
 }
 
-module 0x42::event {
+module 0x4::event {
     public fun emit<T: store + drop>(_msg: T) {
         // write_module_event_to_store<T>(msg);
     }
@@ -31,16 +31,16 @@ module 0x42::event {
     }
 }
 
-module 0x42::error {
+module 0x4::error {
     public fun permission_denied(i: u64): u64 {
         i
     }
 }
 
-module 0x42::object {
-    use 0x42::create_signer::create_signer;
-    use 0x42::signer;
-    use 0x42::event;
+module 0x4::object {
+    use 0x4::create_signer::create_signer;
+    use 0x4::signer;
+    use 0x4::event;
 
     const ENOT_OBJECT_OWNER: u64 = 4;
     const EOBJECT_DOES_NOT_EXIST: u64 = 5;

--- a/third_party/move/move-vm/integration-tests/src/compiler.rs
+++ b/third_party/move/move-vm/integration-tests/src/compiler.rs
@@ -10,6 +10,7 @@ use legacy_move_compiler::{
     shared::{known_attributes::KnownAttribute, NumericalAddress},
 };
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
+use move_compiler_v2::Experiment;
 use move_model::metadata::LanguageVersion;
 use std::{
     collections::BTreeMap,
@@ -24,6 +25,7 @@ fn compile_source_unit_v2(
     file_option: Option<PathBuf>,
     named_address_mapping: BTreeMap<String, NumericalAddress>,
     deps: Vec<String>,
+    allow_natives_anywhere: bool,
 ) -> Result<Vec<AnnotatedCompiledUnit>> {
     let dir = tempdir()?;
     let file_path = if let Some(file) = file_option {
@@ -34,7 +36,7 @@ fn compile_source_unit_v2(
         writeln!(file, "{}", s)?;
         path
     };
-    let options = move_compiler_v2::Options {
+    let mut options = move_compiler_v2::Options {
         sources: vec![file_path.to_str().unwrap().to_string()],
         dependencies: deps,
         named_address_mapping: named_address_mapping
@@ -45,6 +47,9 @@ fn compile_source_unit_v2(
         language_version: Some(LanguageVersion::latest_stable()),
         ..move_compiler_v2::Options::default()
     };
+    if allow_natives_anywhere {
+        options = options.set_experiment(Experiment::NATIVE_CHECK, false);
+    }
     let mut error_writer = Buffer::no_color();
     let result = {
         let mut emitter = options.error_emitter(&mut error_writer);
@@ -57,7 +62,25 @@ fn compile_source_unit_v2(
 }
 
 pub fn compile_units(s: &str) -> Result<Vec<AnnotatedCompiledUnit>> {
-    compile_source_unit_v2(s, None, move_stdlib::move_stdlib_named_addresses(), vec![])
+    compile_source_unit_v2(
+        s,
+        None,
+        move_stdlib::move_stdlib_named_addresses(),
+        vec![],
+        false,
+    )
+}
+
+/// Like [`compile_units`], but allows native functions in modules at any address, for
+/// tests that register custom native tables.
+pub fn compile_units_allowing_natives(s: &str) -> Result<Vec<AnnotatedCompiledUnit>> {
+    compile_source_unit_v2(
+        s,
+        None,
+        move_stdlib::move_stdlib_named_addresses(),
+        vec![],
+        true,
+    )
 }
 
 pub fn compile_units_with_stdlib(s: &str) -> Result<Vec<AnnotatedCompiledUnit>> {
@@ -66,6 +89,7 @@ pub fn compile_units_with_stdlib(s: &str) -> Result<Vec<AnnotatedCompiledUnit>> 
         None,
         move_stdlib::move_stdlib_named_addresses(),
         move_stdlib::move_stdlib_files(),
+        false,
     )
 }
 
@@ -79,7 +103,8 @@ fn expect_modules(
 }
 
 pub fn compile_modules_in_file(path: &Path) -> Result<Vec<CompiledModule>> {
-    let units = compile_source_unit_v2("", Some(path.to_path_buf()), BTreeMap::new(), vec![])?;
+    let units =
+        compile_source_unit_v2("", Some(path.to_path_buf()), BTreeMap::new(), vec![], false)?;
     expect_modules(units).collect()
 }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/mod.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mod.rs
@@ -3,7 +3,7 @@
 // Parts of the file are Copyright (c) Aptos Foundation
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::compiler::{as_module, compile_units};
+use crate::compiler::{as_module, compile_units_allowing_natives};
 use move_binary_format::errors::{Location, VMResult};
 use move_core_types::{
     effects::ChangeSet,
@@ -39,9 +39,10 @@ mod return_value_tests;
 mod runtime_reentrancy_check_tests;
 mod vm_arguments_tests;
 
-/// Given code string, compiles it, serializes and adds to storage.
-fn compile_and_publish(storage: &mut InMemoryStorage, code: String) {
-    let mut units = compile_units(&code).unwrap();
+/// Given code string, compiles it, serializes and adds to storage. Natives are
+/// allowed at any address, for tests that register custom native tables.
+fn compile_and_publish_allowing_natives(storage: &mut InMemoryStorage, code: String) {
+    let mut units = compile_units_allowing_natives(&code).unwrap();
     let m = as_module(units.pop().unwrap());
     let mut blob = vec![];
     m.serialize(&mut blob).unwrap();

--- a/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
@@ -3,7 +3,7 @@
 // Parts of the file are Copyright (c) Aptos Foundation
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::tests::{compile_and_publish, execute_function_for_test};
+use crate::tests::{compile_and_publish_allowing_natives, execute_function_for_test};
 use claims::assert_ok;
 use move_binary_format::{
     errors::PartialVMResult, file_format::empty_module_with_dependencies_and_friends_at_addr,
@@ -54,7 +54,7 @@ fn test_failed_native() {
         "#,
         TEST_ADDR.to_hex(),
     );
-    compile_and_publish(&mut storage, code);
+    compile_and_publish_allowing_natives(&mut storage, code);
     let module_storage = storage.as_unsync_code_storage();
 
     let err = execute_function_for_test(
@@ -113,7 +113,7 @@ fn test_load_module_native_result(enable_lazy_loading: bool) {
         "#,
         TEST_ADDR.to_hex(),
     );
-    compile_and_publish(&mut storage, code_a);
+    compile_and_publish_allowing_natives(&mut storage, code_a);
 
     let mut add_module = |m: CompiledModule| {
         let mut blob = vec![];

--- a/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
@@ -3,7 +3,9 @@
 // Parts of the file are Copyright (c) Aptos Foundation
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::tests::{compile_and_publish, execute_function_with_single_storage_for_test};
+use crate::tests::{
+    compile_and_publish_allowing_natives, execute_function_with_single_storage_for_test,
+};
 use claims::assert_ok;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{
@@ -109,7 +111,7 @@ fn runtime_reentrancy_check() {
         TEST_ADDR.to_hex(),
     );
 
-    compile_and_publish(&mut storage, code_1);
+    compile_and_publish_allowing_natives(&mut storage, code_1);
 
     let code_2 = format!(
         r#"
@@ -135,7 +137,7 @@ fn runtime_reentrancy_check() {
         TEST_ADDR.to_hex(),
     );
 
-    compile_and_publish(&mut storage, code_2);
+    compile_and_publish_allowing_natives(&mut storage, code_2);
 
     let code_3 = format!(
         r#"
@@ -146,7 +148,7 @@ fn runtime_reentrancy_check() {
         TEST_ADDR.to_hex(),
     );
 
-    compile_and_publish(&mut storage, code_3);
+    compile_and_publish_allowing_natives(&mut storage, code_3);
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("A").unwrap());
 

--- a/third_party/move/tools/move-package/src/compilation/model_builder.rs
+++ b/third_party/move/tools/move-package/src/compilation/model_builder.rs
@@ -10,7 +10,9 @@ use crate::{
 use anyhow::Result;
 use itertools::Itertools;
 use legacy_move_compiler::shared::PackagePaths;
-use move_compiler_v2::{run_checker_and_rewriters, run_move_compiler_to_model, Options};
+use move_compiler_v2::{
+    run_checker_and_rewriters, run_move_compiler_to_model, Experiment, Options,
+};
 use move_model::model::GlobalEnv;
 
 #[derive(Debug, Clone)]
@@ -41,7 +43,11 @@ impl ModelBuilder {
     ///
     /// See [`ModelConfig::with_bytecode`] for the effect of that flag.
     pub fn build_model(&self) -> Result<GlobalEnv> {
-        let options = self.build_compiler_options()?;
+        // Analysis models may include native declarations at non-special addresses;
+        // that check only applies when compiling for execution.
+        let options = self
+            .build_compiler_options()?
+            .set_experiment(Experiment::NATIVE_CHECK, false);
         if self.model_config.with_bytecode {
             run_move_compiler_to_model(options)
         } else {

--- a/third_party/move/tools/move-unit-test/tests/test_sources/issue_17188.exp
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/issue_17188.exp
@@ -1,36 +1,36 @@
 Running Move unit tests
-[ FAIL    ] 0xc0ffee::m::bad_cast1
-[ FAIL    ] 0xc0ffee::m::bad_cast2
-[ FAIL    ] 0xc0ffee::m::empty_vec
-[ FAIL    ] 0xc0ffee::m::int_overflow1
-[ FAIL    ] 0xc0ffee::m::int_overflow2
-[ FAIL    ] 0xc0ffee::m::non_existent_native
-0xc0ffee::m::bad_cast1
+[ FAIL    ] 0xc::m::bad_cast1
+[ FAIL    ] 0xc::m::bad_cast2
+[ FAIL    ] 0xc::m::empty_vec
+[ FAIL    ] 0xc::m::int_overflow1
+[ FAIL    ] 0xc::m::int_overflow2
+[ FAIL    ] 0xc::m::non_existent_native
+0xc::m::bad_cast1
 Output: Ok(Changes { accounts: {} })
-0xc0ffee::m::bad_cast2
+0xc::m::bad_cast2
 Output: Ok(Changes { accounts: {} })
-0xc0ffee::m::empty_vec
+0xc::m::empty_vec
 Output: Ok(Changes { accounts: {} })
-0xc0ffee::m::int_overflow1
+0xc::m::int_overflow1
 Output: Ok(Changes { accounts: {} })
-0xc0ffee::m::int_overflow2
+0xc::m::int_overflow2
 Output: Ok(Changes { accounts: {} })
-0xc0ffee::m::non_existent_native
+0xc::m::non_existent_native
 Output: Ok(Changes { accounts: {} })
 
 Test failures:
 
-Failures in 0xc0ffee::m:
+Failures in 0xc::m:
 
 ┌── bad_cast1 ──────
 │ error[E11001]: test failure
 │   ┌─ issue_17188.move:9:32
 │   │
 │ 5 │     public fun bad_cast1() {
-│   │                --------- In this function in 0xc0ffee::m
+│   │                --------- In this function in 0xc::m
 │   ·
 │ 9 │         let small_number: u8 = (big_number as u8);
-│   │                                ^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Cannot cast u64(1000) to u8". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│   │                                ^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Cannot cast u64(1000) to u8". Error originating in the module 000000000000000000000000000000000000000000000000000000000000000c::m rooted here
 │ 
 │ 
 └──────────────────
@@ -41,10 +41,10 @@ Failures in 0xc0ffee::m:
 │    ┌─ issue_17188.move:21:28
 │    │
 │ 14 │     public fun bad_cast2() {
-│    │                --------- In this function in 0xc0ffee::m
+│    │                --------- In this function in 0xc::m
 │    ·
 │ 21 │             small_number = (big_number as u8);
-│    │                            ^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Cannot cast u64(256) to u8". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│    │                            ^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Cannot cast u64(256) to u8". Error originating in the module 000000000000000000000000000000000000000000000000000000000000000c::m rooted here
 │ 
 │ 
 └──────────────────
@@ -55,10 +55,10 @@ Failures in 0xc0ffee::m:
 │    ┌─ issue_17188.move:63:9
 │    │
 │ 60 │     public fun empty_vec() {
-│    │                --------- In this function in 0xc0ffee::m
+│    │                --------- In this function in 0xc::m
 │    ·
 │ 63 │         vector::borrow(&vector::empty<u64>(), 1);
-│    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave a vector operation error with sub-status 1 originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave a vector operation error with sub-status 1 originating in the module 000000000000000000000000000000000000000000000000000000000000000c::m rooted here
 │ 
 │ 
 └──────────────────
@@ -69,10 +69,10 @@ Failures in 0xc0ffee::m:
 │    ┌─ issue_17188.move:36:28
 │    │
 │ 29 │     public fun int_overflow1() {
-│    │                ------------- In this function in 0xc0ffee::m
+│    │                ------------- In this function in 0xc::m
 │    ·
 │ 36 │         let overflow: u8 = 1 + z;
-│    │                            ^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Addition overflow". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│    │                            ^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Addition overflow". Error originating in the module 000000000000000000000000000000000000000000000000000000000000000c::m rooted here
 │ 
 │ 
 └──────────────────
@@ -83,10 +83,10 @@ Failures in 0xc0ffee::m:
 │    ┌─ issue_17188.move:51:24
 │    │
 │ 41 │     public fun int_overflow2() {
-│    │                ------------- In this function in 0xc0ffee::m
+│    │                ------------- In this function in 0xc::m
 │    ·
 │ 51 │             overflow = overflow - 15;
-│    │                        ^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Subtraction overflow". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│    │                        ^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Subtraction overflow". Error originating in the module 000000000000000000000000000000000000000000000000000000000000000c::m rooted here
 │ 
 │ 
 └──────────────────
@@ -100,8 +100,8 @@ Failures in 0xc0ffee::m:
 │    │                ^^^
 │    │                │
 │    │                INTERNAL TEST ERROR: Unexpected Verification Error
-│ Test was not expected to error, but it gave a MISSING_DEPENDENCY (code 1021) error with error message: "Missing Native Function `foo`". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
-│    │                In this function in 0xc0ffee::m
+│ Test was not expected to error, but it gave a MISSING_DEPENDENCY (code 1021) error with error message: "Missing Native Function `foo`". Error originating in the module 000000000000000000000000000000000000000000000000000000000000000c::m rooted here
+│    │                In this function in 0xc::m
 │ 
 │ 
 └──────────────────

--- a/third_party/move/tools/move-unit-test/tests/test_sources/issue_17188.move
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/issue_17188.move
@@ -1,4 +1,4 @@
-module 0xc0ffee::m {
+module 0xc::m {
     use std::vector;
 
     #[test]


### PR DESCRIPTION
## Description

Adds a compile-time native checker to the Move compiler v2 that mirrors the VM's publish-time rules for native declarations. Specifically, the checker enforces that:

- Native structs are never allowed.
- Native entry functions are never allowed (for any address).
- Native functions outside of special-address modules are not allowed.
- Native enums are not allowed (enforced at the parser level).

The check is controlled by a new `native-check` experiment flag (inheriting from the `checks` experiment), so it can be disabled when building analysis models or when the publish-time VM check is what needs to be exercised directly (e.g., in e2e tests).

The e2e tests for `code_publishing_disallow_user_native`, `code_publishing_disallow_user_native_entry`, and `code_publishing_disallow_system_native_entry` are updated to bypass the new compiler check via `native-check=off` so they continue to exercise the VM-level rejection path.

Several existing test fixtures that used non-special addresses (e.g., `0xc0ffee`, `0x42`, `0x8675309`) for modules containing native declarations are updated to use special addresses (e.g., `0xc`, `0x4`, `0x8`) to pass the new check. The `multi_pool_money_market_token` test replaces its `native struct` with a regular struct to comply with the new rule.

## How Has This Been Tested?

- New compiler checking tests added under `tests/checking/natives/`:
  - `allowed.move` / `allowed.exp`: verifies a native function in a special-address module compiles cleanly.
  - `disallowed.move` / `disallowed.exp`: verifies errors for a native struct and a native function in a non-special-address module.
  - `disallowed_special.move` / `disallowed_special.exp`: verifies errors for a native struct and a native entry function even in a special-address module.
  - `native_enum.move` / `native_enum.exp`: verifies the parser-level rejection of native enums.
- The `entry_function` test expectation is updated to reflect that native entry functions now produce compiler errors.
- Existing e2e publish tests continue to verify the VM-level `USER_DEFINED_NATIVE_NOT_ALLOWED` status code.

## Key Areas to Review

- `native_checker.rs`: Core logic that iterates primary-target modules and emits diagnostics for disallowed native declarations. The definition of "special address" is delegated to `is_special()` on the numerical address.
- `experiments.rs`: The `NATIVE_CHECK` experiment inherits its default from `CHECKS`, meaning it is on by default during normal compilation but can be toggled off for analysis model builds and specific e2e tests.
- `lib.rs` and `model_builder.rs`: Both explicitly disable `NATIVE_CHECK` when building analysis models, since those models may legitimately include native declarations at non-special addresses.
- Parser change in `syntax.rs`: Native enums are rejected early with a clear diagnostic before reaching the checker pipeline.

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Move Compiler

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what packages fail at compile vs publish and affects all native declarations; misconfiguration of `native-check` could hide real publish failures or break analysis builds.
> 
> **Overview**
> Move compiler v2 now rejects invalid **native** declarations at compile time via a new `native-check` experiment (on by default with `checks`), matching VM publish rules: no native structs, no native entry functions, and native functions only in special-address modules. The legacy parser also rejects **native enums**.
> 
> Analysis/model builds and package model construction turn `native-check` off so models can still include natives at arbitrary addresses. VM integration tests that need user-defined natives compile with the check disabled (`compile_units_allowing_natives`). Code-publishing e2e tests use `native-check=off` so packages build and VM `USER_DEFINED_NATIVE_NOT_ALLOWED` is still tested.
> 
> New tests under `tests/checking/natives/` cover allowed/disallowed cases; several fixtures were adjusted (special addresses or non-native structs) to satisfy the checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fbfc342b17b0f14042d72c359d8fdff1a78ccc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->