### PR TITLE
[vm] Defer MeterBcsByValueSize on TESTING chains to unbreak forge framework upgrade

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/bcs.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bcs.rs
@@ -190,7 +190,6 @@ fn test_bcs_to_bytes_value_size_metering() {
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     publish_deep_wrapper(&mut h, &acc, 120, 100, 30);
 
-    h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, false);
     let gas_off = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
     h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, true);
     let gas_on = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
@@ -208,7 +207,6 @@ fn test_bcs_to_bytes_execution_limit() {
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     publish_deep_wrapper(&mut h, &acc, 120, 200, 100);
 
-    h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, false);
     assert_success!(h.run_entry_function(&acc, run_id(), vec![], vec![]));
 
     // Enable timed feature flag.

--- a/aptos-move/e2e-move-tests/src/tests/bcs.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bcs.rs
@@ -7,6 +7,7 @@ use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
 use aptos_package_builder::PackageBuilder;
 use aptos_types::{
     move_utils::MemberId,
+    on_chain_config::TimedFeatureFlag,
     transaction::{ExecutionStatus, TransactionStatus},
 };
 use claims::assert_ok;
@@ -189,8 +190,9 @@ fn test_bcs_to_bytes_value_size_metering() {
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     publish_deep_wrapper(&mut h, &acc, 120, 100, 30);
 
+    h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, false);
     let gas_off = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
-    h.new_epoch();
+    h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, true);
     let gas_on = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
 
     println!("bcs::to_bytes gas  off={gas_off}  on={gas_on}");
@@ -206,10 +208,11 @@ fn test_bcs_to_bytes_execution_limit() {
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     publish_deep_wrapper(&mut h, &acc, 120, 200, 100);
 
+    h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, false);
     assert_success!(h.run_entry_function(&acc, run_id(), vec![], vec![]));
 
     // Enable timed feature flag.
-    h.new_epoch();
+    h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, true);
 
     let status = h.run_entry_function(&acc, run_id(), vec![], vec![]);
     assert!(matches!(

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -270,7 +270,15 @@ impl TimedFeatureFlag {
                 .unwrap()
                 .with_timezone(&Utc),
 
-            (MeterBcsByValueSize, TESTING) => Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap(),
+            // Note: Forge's framework upgrade and compatibility suites run half the validators on
+            //       the last released node image, which does not charge for value traversals. A
+            //       validator set split across this activation charges different gas for the same
+            //       transaction, which forks execution and stalls consensus, so the TESTING
+            //       activation has to stay in the future until a released image carries it.
+            (MeterBcsByValueSize, TESTING) => Los_Angeles
+                .with_ymd_and_hms(2026, 10, 1, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
             (MeterBcsByValueSize, TESTNET) => Los_Angeles
                 .with_ymd_and_hms(2026, 8, 4, 14, 0, 0)
                 .unwrap()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`forge-framework-upgrade-test` has hard-failed on every PR since #20336 landed on main (2026-08-11 18:06 UTC), always at the same place:

```
Voting proposal id 0
Error: API error: Unknown error Ledger on endpoint (http://aptos-node-3-validator...:8080/v1/)
is more than 60s behind current time, timing out waiting for the transaction.
```

Root cause: #20336 added `MeterBcsByValueSize` with a `TESTING` activation of `1970-01-01 01:00`, so the flag is on from genesis on every forge network (chain id 4 = `TESTING`). The framework upgrade suite deliberately runs a mixed-version validator set: two validators stay on the last released image (`aptos-release-v1.49`, which does not carry the metering) while two run the PR image (which charges `BCS_PER_VALUE_TRAVERSAL_BASE + BCS_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT * value_size` in `bcs::to_bytes`). The two halves therefore compute different gas for the same transaction, the state roots diverge 2-2, no quorum is reachable, and the chain stops committing. `voting::vote` calls `bcs::to_bytes` twice, so the governance vote transaction is the one that never lands, and forge reports the stalled ledger rather than the divergence.

Supporting evidence:
- The last green `forge-framework-upgrade-test` run is from before #20336 merged; every run after it fails identically, on both main-based PRs and on `aptos-release-v1.48` (which received the same cherry-picks in v1.48.6).
- #20336 itself hard-failed `framework_upgrade` three times before being force-landed, while `compat` and `realistic_env_max_load` passed (their traffic does not exercise `bcs::to_bytes`).
- `test_bcs_to_bytes_value_size_metering` prints `off=155 on=6254` for the same entry function, which is the size of the disagreement between the two halves of the validator set for bcs-heavy code.

The fix moves the `TESTING` activation into the future, which is the approach `UseFullTransactionSizeForGasCheck` already takes with the note about letting forge undergo a gated transition. Both halves of a mixed-version network then agree until a released image carries the metering. Testnet (2026-08-04) and mainnet (2026-08-06) activations are untouched, so the security fix stays live on real networks.

Follow-up worth considering separately: cherry-pick #20336 into `aptos-release-v1.49` so the released image forge pairs against also carries the metering, and then the `TESTING` date can be revisited.

## How Has This Been Tested?

- `cargo check -p aptos-types`, `cargo test -p aptos-types timed_feature`
- `cargo test -p e2e-move-tests tests::bcs::test_bcs_to_bytes` passes. The two tests that exercise the flag (`test_bcs_to_bytes_value_size_metering`, `test_bcs_to_bytes_execution_limit`) relied on `new_epoch()` crossing the 1970 boundary and now enable it through the existing `MoveHarness::set_timed_feature` helper, which jumps the chain to the flag's activation time and works for any date. The disabled case stays at genesis time, since two `set_timed_feature` calls in a row land too close together to trigger a second reconfiguration.
- Real verification is the `forge-framework-upgrade-test` run on this PR.

## Key Areas to Review

- The choice of `2026-10-01` for the `TESTING` activation. It needs to stay in the future until a released node image carries the metering, otherwise the same mixed-version divergence returns.
- Whether deferring the metering on `TESTING` (forge, local, smoke tests) for that window is acceptable, given testnet and mainnet already have it enabled.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [x] Move/Aptos Virtual Machine
- [x] Developer Infrastructure
- [ ] Full Node (API, Indexer, etc.)
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C03PKBQM2RY/p1786566198292249?thread_ts=1786566198.292249&cid=C03PKBQM2RY)

<div><a href="https://cursor.com/agents/bc-ee0cb56b-187d-577f-a058-8f34091af369?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee0cb56b-187d-577f-a058-8f34091af369&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

