### PR TITLE
[framework] Harden stablecoin issuance and administration

### DIFF
--- a/aptos-move/move-examples/fungible_asset/stablecoin/DESIGN.md
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/DESIGN.md
@@ -1,0 +1,67 @@
+# USDK stablecoin design
+
+Scope: this document covers only the `stablecoin` example package. It records the
+security model the module implements so that reviewers can check the code against
+an explicit set of intended guarantees.
+
+## Roles
+
+| Role | Capabilities |
+| --- | --- |
+| `master_minter` | Grants/revokes the minter role and sets per-minter mint allowances. Cannot mint. |
+| minter | Mints up to its remaining allowance. Burns only its own balance. |
+| `pauser` | Pauses and unpauses value movement. |
+| `denylister` | Freezes/unfreezes accounts. |
+| `confiscator` | Burns balances held by an arbitrary account. |
+
+The master minter deliberately has no implicit mint authority. To mint it must
+grant itself an allowance, which is an auditable on-chain event.
+
+## Issuance control
+
+Each minter holds a finite allowance, decremented atomically on every mint. A
+compromised minter key can issue at most its remaining allowance. Allowances are
+stored in an address-keyed table, so authorization and allowance lookup do not
+scan a list and cannot be made arbitrarily expensive by adding minters.
+
+## Role rotation
+
+Every privileged role rotates in two steps: the current holder proposes a
+successor, and the successor accepts. A proposal alone grants nothing, so a
+mistyped address cannot strand a role. The current holder may replace or clear a
+pending proposal at any time. Both steps emit events.
+
+## Pause semantics
+
+Pause stops value movement — mint, burn, and transfer — while preserving the
+operations needed to respond to an incident.
+
+Allowed while paused: minter revocation, allowance *decreases*, denylisting and
+undenylisting, confiscation, and role proposal/acceptance.
+
+Blocked while paused: minting, burning, transfers, granting new minters, and
+allowance *increases*. A compromised master-minter key therefore cannot expand
+issuing authority during an emergency.
+
+## Denylist enforcement
+
+Denylisting sets the frozen flag on the account's primary store. Two independent
+layers enforce it:
+
+1. The framework rejects withdrawals from a frozen store before dispatch runs.
+2. The module's `withdraw`/`deposit` hooks reject any store whose direct owner or
+   root owner is denylisted.
+
+Layer 2 is what prevents a denylisted account from escaping enforcement by
+parking funds in a store owned by an intermediate object it controls, since the
+framework's own check accepts indirect ownership. All stores for this asset are
+untransferable, so a store cannot be moved out from under the check.
+
+## Non-goals
+
+- No delegated-transfer/approval flow. The previous `transfer_from` was removed
+  rather than left disabled: its approvals were replayable because the nonce was
+  the account sequence number, which the function never advanced. A replacement
+  needs a contract-owned nonce, a deadline, domain separation, and cancellation.
+- No global supply cap. Issuance is bounded by per-minter allowances instead.
+- Initialization stays an explicit `entry` call rather than `init_module`.

--- a/aptos-move/move-examples/fungible_asset/stablecoin/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/Move.toml
@@ -8,12 +8,14 @@ stablecoin = "_"
 master_minter = "_"
 pauser = "_"
 denylister = "_"
+confiscator = "_"
 
 [dev-addresses]
 stablecoin = "0xcafe"
 master_minter = "0xbab"
 pauser = "0xdafe"
 denylister = "0xcade"
+confiscator = "0xc0ffee"
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/fungible_asset/stablecoin/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/Move.toml
@@ -6,14 +6,12 @@ version = "0.0.0"
 [addresses]
 stablecoin = "_"
 master_minter = "_"
-minter = "_"
 pauser = "_"
 denylister = "_"
 
 [dev-addresses]
 stablecoin = "0xcafe"
 master_minter = "0xbab"
-minter = "0xface"
 pauser = "0xdafe"
 denylister = "0xcade"
 

--- a/aptos-move/move-examples/fungible_asset/stablecoin/README.md
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/README.md
@@ -1,25 +1,69 @@
 # Introduction
-This module offers a reference implementation of a managed stablecoin with the following functionalities:
-1. Upgradable smart contract. The module can be upgraded to update existing functionalities or add new ones.
-2. Minting and burning of stablecoins. The module allows users to mint and burn stablecoins. Minter role is required to mint or burn
-3. Denylisting of accounts. The module allows the owner to denylist (freeze) and undenylist accounts.
-denylist accounts cannot transfer or get minted more.
-4. Pausing and unpausing of the contract. The owner can pause the contract to stop all mint/burn/transfer and unpause it to resume.
-Role administration (granting/revoking the minter role) and denylisting remain available while paused, so that a compromised
-key can be revoked and an attacker denylisted during an incident.
+This module is a reference implementation of a managed USDK stablecoin with:
 
-The asset uses 6 decimals, matching the convention used by USDC/USDT.
+1. Explicit entry-function initialization (this example intentionally does not use `init_module`).
+2. Per-minter mint allowances stored in an address-keyed table.
+3. Self-burn for minters and separately authorized confiscation for compliance recovery.
+4. Denylisting with direct-owner and root-owner enforcement for nested stores.
+5. Pausing of mint, burn, and transfer operations.
+6. Two-step rotation for the master-minter, pauser, denylister, and confiscator roles.
 
-# Deployment
-Currently only available in devnet due to requirement of AIP 73[https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-73.md].
+USDK uses 6 decimals, matching the convention used by USDC/USDT. See `DESIGN.md`
+for the security model and pause policy.
 
-1. Create a devnet profile with aptos init --profile devnet (select devnet for network)
-2. To deploy, run aptos move publish --named-addresses stablecoin=devnet,master_minter=devnet,pauser=devnet,denylister=devnet --profile devnet
-3. To mint, run aptos move run --function-id devnet::usdk::mint --args address:0x8115e523937721388acbd77027da45b1c88a6313f99615c4da4c6a32ab161b1a u64:100000000  --profile devnet
-Note the asset has 6 decimals, so u64:100000000 mints 100 USDK.
-Replace 0x8115e523937721388acbd77027da45b1c88a6313f99615c4da4c6a32ab161b1a with the receiving address
-4. Alternatively you can go to https://explorer.aptoslabs.com/account/0x75f3f12f2f634ba33aefda0f2cd29119fdf9caa4fa288ac6e369f54e0611289a/modules/run/usdk/mint?network=devnet
-Make sure to replace 0x75f3f12f2f634ba33aefda0f2cd29119fdf9caa4fa288ac6e369f54e0611289a with your devnet account address.
+## Pause policy
 
-# Running tests
-aptos move test
+While paused, value movement is blocked. Recovery operations remain available:
+minter revocation, allowance decreases, denylisting, undenylisting, confiscation,
+and role rotation. Adding minters and increasing allowances are blocked until the
+stablecoin is unpaused.
+
+## Deployment
+
+Currently only available in devnet due to the requirement of AIP 73:
+<https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-73.md>.
+
+1. Create a devnet profile with `aptos init --profile devnet`.
+2. Publish the package. Replace each `devnet` named address with the intended role address:
+
+   ```bash
+   aptos move publish \
+     --named-addresses stablecoin=devnet,master_minter=devnet,pauser=devnet,denylister=devnet,confiscator=devnet \
+     --profile devnet
+   ```
+
+3. Initialize the asset explicitly from the publishing account:
+
+   ```bash
+   aptos move run \
+     --function-id 'devnet::usdk::initialize' \
+     --profile devnet
+   ```
+
+4. Grant a minter allowance. The master-minter account must sign this transaction:
+
+   ```bash
+   aptos move run \
+     --function-id 'devnet::usdk::add_minter' \
+     --args address:0xMINTER u64:100000000 \
+     --profile devnet
+   ```
+
+5. Mint within that allowance. With 6 decimals, `u64:100000000` mints 100 USDK:
+
+   ```bash
+   aptos move run \
+     --function-id 'devnet::usdk::mint' \
+     --args address:0xRECIPIENT u64:100000000 \
+     --profile devnet
+   ```
+
+## Running tests
+
+```bash
+aptos move test --dev
+aptos move test --coverage --dev
+aptos move coverage summary --dev
+```
+
+The package targets at least 90% Move executable-code coverage.

--- a/aptos-move/move-examples/fungible_asset/stablecoin/README.md
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/README.md
@@ -5,13 +5,18 @@ This module offers a reference implementation of a managed stablecoin with the f
 3. Denylisting of accounts. The module allows the owner to denylist (freeze) and undenylist accounts.
 denylist accounts cannot transfer or get minted more.
 4. Pausing and unpausing of the contract. The owner can pause the contract to stop all mint/burn/transfer and unpause it to resume.
+Role administration (granting/revoking the minter role) and denylisting remain available while paused, so that a compromised
+key can be revoked and an attacker denylisted during an incident.
+
+The asset uses 6 decimals, matching the convention used by USDC/USDT.
 
 # Deployment
 Currently only available in devnet due to requirement of AIP 73[https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-73.md].
 
 1. Create a devnet profile with aptos init --profile devnet (select devnet for network)
-2. To deploy, run aptos move publish --named-addresses stablecoin=devnet,master_minter=devnet,minter=devnet,pauser=devnet,denylister=devnet --profile devnet
+2. To deploy, run aptos move publish --named-addresses stablecoin=devnet,master_minter=devnet,pauser=devnet,denylister=devnet --profile devnet
 3. To mint, run aptos move run --function-id devnet::usdk::mint --args address:0x8115e523937721388acbd77027da45b1c88a6313f99615c4da4c6a32ab161b1a u64:100000000  --profile devnet
+Note the asset has 6 decimals, so u64:100000000 mints 100 USDK.
 Replace 0x8115e523937721388acbd77027da45b1c88a6313f99615c4da4c6a32ab161b1a with the receiving address
 4. Alternatively you can go to https://explorer.aptoslabs.com/account/0x75f3f12f2f634ba33aefda0f2cd29119fdf9caa4fa288ac6e369f54e0611289a/modules/run/usdk/mint?network=devnet
 Make sure to replace 0x75f3f12f2f634ba33aefda0f2cd29119fdf9caa4fa288ac6e369f54e0611289a with your devnet account address.

--- a/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
@@ -1,17 +1,16 @@
 /// Example of a managed stablecoin with mint, burn, freeze and pause functionalities.
 module stablecoin::usdk {
     use aptos_framework::account;
+    use aptos_framework::chain_id;
     use aptos_framework::dispatchable_fungible_asset;
     use aptos_framework::event;
     use aptos_framework::function_info;
     use aptos_framework::fungible_asset::{Self, MintRef, TransferRef, BurnRef, Metadata, FungibleAsset, FungibleStore};
-    use aptos_framework::object::{Self, Object, ExtendRef};
+    use aptos_framework::object::{Self, Object, ExtendRef, ObjectCore};
     use aptos_framework::primary_fungible_store;
     use std::option;
     use std::signer;
     use std::string::{Self, utf8};
-    use std::vector;
-    use aptos_framework::chain_id;
 
     /// Caller is not authorized to make this call
     const EUNAUTHORIZED: u64 = 1;
@@ -23,6 +22,8 @@ module stablecoin::usdk {
     const ENOT_MINTER: u64 = 4;
     /// The account is denylisted
     const EDENYLISTED: u64 = 5;
+    /// Stablecoin is already initialized
+    const EALREADY_INITIALIZED: u64 = 6;
 
     const ASSET_SYMBOL: vector<u8> = b"USDK";
 
@@ -99,9 +100,13 @@ module stablecoin::usdk {
     /// Ensure any stores for the stablecoin are untransferable.
     /// Store Roles, Management and State resources in the Metadata object.
     /// Override deposit and withdraw functions of the newly created asset/token to add custom denylist logic.
-    fun init_module(usdk_signer: &signer) {
+    public fun initialize(stablecoin_signer: &signer) {
+        // Check that it hasn't been called already
+        assert!(!object::object_exists<ObjectCore>(usdk_address()), EALREADY_INITIALIZED);
+        authorize(signer::address_of(stablecoin_signer), @stablecoin);
+
         // Create the stablecoin with primary store support.
-        let constructor_ref = &object::create_named_object(usdk_signer, ASSET_SYMBOL);
+        let constructor_ref = &object::create_named_object(stablecoin_signer, ASSET_SYMBOL);
         primary_fungible_store::create_primary_store_enabled_fungible_asset(
             constructor_ref,
             option::none(),
@@ -113,10 +118,11 @@ module stablecoin::usdk {
         );
 
         // Set ALL stores for the fungible asset to untransferable.
+        // This prevents secondary stores from being transferred to other accounts.
         fungible_asset::set_untransferable(constructor_ref);
 
         // All resources created will be kept in the asset metadata object.
-        let metadata_object_signer = &object::generate_signer(constructor_ref);
+        let metadata_object_signer = &constructor_ref.generate_signer();
         move_to(metadata_object_signer, Roles {
             master_minter: @master_minter,
             minters: vector[],
@@ -126,12 +132,13 @@ module stablecoin::usdk {
 
         // Create mint/burn/transfer refs to allow creator to manage the stablecoin.
         move_to(metadata_object_signer, Management {
-            extend_ref: object::generate_extend_ref(constructor_ref),
+            extend_ref: constructor_ref.generate_extend_ref(),
             mint_ref: fungible_asset::generate_mint_ref(constructor_ref),
             burn_ref: fungible_asset::generate_burn_ref(constructor_ref),
             transfer_ref: fungible_asset::generate_transfer_ref(constructor_ref),
         });
 
+        // Start the state not paused
         move_to(metadata_object_signer, State {
             paused: false,
         });
@@ -140,12 +147,12 @@ module stablecoin::usdk {
         // This ensures all transfer will call withdraw and deposit functions in this module and perform the necessary
         // checks.
         let deposit = function_info::new_function_info(
-            usdk_signer,
+            stablecoin_signer,
             string::utf8(b"usdk"),
             string::utf8(b"deposit"),
         );
         let withdraw = function_info::new_function_info(
-            usdk_signer,
+            stablecoin_signer,
             string::utf8(b"usdk"),
             string::utf8(b"withdraw"),
         );
@@ -167,14 +174,14 @@ module stablecoin::usdk {
         from_public_key: vector<u8>,
         to: address,
         amount: u64,
-    ) acquires Management, State {
+    ) {
         assert_not_paused();
         assert_not_denylisted(from);
         assert_not_denylisted(to);
 
         let expected_message = Approval {
             owner: from,
-            to: to,
+            to,
             nonce: account::get_sequence_number(from),
             chain_id: chain_id::get(),
             spender: signer::address_of(spender),
@@ -182,7 +189,7 @@ module stablecoin::usdk {
         };
         account::verify_signed_message(from, from_account_scheme, from_public_key, proof, expected_message);
 
-        let transfer_ref = &borrow_global<Management>(usdk_address()).transfer_ref;
+        let transfer_ref = &Management[usdk_address()].transfer_ref;
         // Only use with_ref API for primary_fungible_store (PFS) transfers in this module.
         primary_fungible_store::transfer_with_ref(transfer_ref, from, to, amount);
     }
@@ -192,10 +199,10 @@ module stablecoin::usdk {
         store: Object<T>,
         fa: FungibleAsset,
         transfer_ref: &TransferRef,
-    ) acquires State {
+    ) {
         assert_not_paused();
-        assert_not_denylisted(object::owner(store));
-        fungible_asset::deposit_with_ref(transfer_ref, store, fa);
+        assert_not_denylisted(store.owner());
+        transfer_ref.deposit_with_ref(store, fa);
     }
 
     /// Withdraw function override to ensure that the account is not denylisted and the stablecoin is not paused.
@@ -203,34 +210,36 @@ module stablecoin::usdk {
         store: Object<T>,
         amount: u64,
         transfer_ref: &TransferRef,
-    ): FungibleAsset acquires State {
+    ): FungibleAsset {
         assert_not_paused();
-        assert_not_denylisted(object::owner(store));
-        fungible_asset::withdraw_with_ref(transfer_ref, store, amount)
+        assert_not_denylisted(store.owner());
+        transfer_ref.withdraw_with_ref(store, amount)
     }
 
     /// Mint new tokens to the specified account. This checks that the caller is a minter, the stablecoin is not paused,
     /// and the account is not denylisted.
-    public entry fun mint(minter: &signer, to: address, amount: u64) acquires Management, Roles, State {
+    public entry fun mint(minter: &signer, to: address, amount: u64) {
         assert_not_paused();
-        assert_is_minter(minter);
+        let minter_address = assert_is_minter(minter);
         assert_not_denylisted(to);
+
+        // Shortcut if you mint 0 tokens, in theory could just assert amount is > 0
         if (amount == 0) { return };
 
-        let management = borrow_global<Management>(usdk_address());
-        let tokens = fungible_asset::mint(&management.mint_ref, amount);
+        let management = &Management[usdk_address()];
+        let tokens = management.mint_ref.mint(amount);
         // Ensure not to call pfs::deposit or dfa::deposit directly in the module.
         deposit(primary_fungible_store::ensure_primary_store_exists(to, metadata()), tokens, &management.transfer_ref);
 
         event::emit(Mint {
-            minter: signer::address_of(minter),
+            minter: minter_address,
             to,
             amount,
         });
     }
 
     /// Burn tokens from the specified account. This checks that the caller is a minter and the stablecoin is not paused.
-    public entry fun burn(minter: &signer, from: address, amount: u64) acquires Management, Roles, State {
+    public entry fun burn(minter: &signer, from: address, amount: u64) {
         burn_from(minter, primary_fungible_store::ensure_primary_store_exists(from, metadata()), amount);
     }
 
@@ -240,103 +249,108 @@ module stablecoin::usdk {
         minter: &signer,
         store: Object<FungibleStore>,
         amount: u64,
-    ) acquires Management, Roles, State {
+    ) {
         assert_not_paused();
-        assert_is_minter(minter);
+        let minter_address = assert_is_minter(minter);
         if (amount == 0) { return };
 
-        let management = borrow_global<Management>(usdk_address());
-        let tokens = fungible_asset::withdraw_with_ref(
-            &management.transfer_ref,
-            store,
-            amount,
-        );
-        fungible_asset::burn(&management.burn_ref, tokens);
+        let management = &Management[usdk_address()];
+        let tokens = management.transfer_ref.withdraw_with_ref(store, amount);
+        management.burn_ref.burn(tokens);
 
         event::emit(Burn {
-            minter: signer::address_of(minter),
-            from: object::owner(store),
+            minter: minter_address,
+            from: store.owner(),
             store,
             amount,
         });
     }
 
     /// Pause or unpause the stablecoin. This checks that the caller is the pauser.
-    public entry fun set_pause(pauser: &signer, paused: bool) acquires Roles, State {
-        let roles = borrow_global<Roles>(usdk_address());
-        assert!(signer::address_of(pauser) == roles.pauser, EUNAUTHORIZED);
-        let state = borrow_global_mut<State>(usdk_address());
+    public entry fun set_pause(pauser: &signer, paused: bool) {
+        let usdk_address = usdk_address();
+        let pauser_address = signer::address_of(pauser);
+        let roles = &Roles[usdk_address];
+        authorize(pauser_address, roles.pauser);
+        let state = &mut State[usdk_address];
+
+        // Idempotent return if the paused state is already the same as the requested state.
         if (state.paused == paused) { return };
         state.paused = paused;
 
         event::emit(Pause {
-            pauser: signer::address_of(pauser),
+            pauser: pauser_address,
             is_paused: paused,
         });
     }
 
     /// Add an account to the denylist. This checks that the caller is the denylister.
-    public entry fun denylist(denylister: &signer, account: address) acquires Management, Roles, State {
-        assert_not_paused();
-        let roles = borrow_global<Roles>(usdk_address());
-        assert!(signer::address_of(denylister) == roles.denylister, EUNAUTHORIZED);
-
-        let freeze_ref = &borrow_global<Management>(usdk_address()).transfer_ref;
-        primary_fungible_store::set_frozen_flag(freeze_ref, account, true);
-
-        event::emit(Denylist {
-            denylister: signer::address_of(denylister),
-            account,
-        });
+    public entry fun denylist(denylister: &signer, account: address) {
+        set_denylist(denylister, account, true);
     }
 
     /// Remove an account from the denylist. This checks that the caller is the denylister.
-    public entry fun undenylist(denylister: &signer, account: address) acquires Management, Roles, State {
-        assert_not_paused();
-        let roles = borrow_global<Roles>(usdk_address());
-        assert!(signer::address_of(denylister) == roles.denylister, EUNAUTHORIZED);
+    public entry fun undenylist(denylister: &signer, account: address) {
+        set_denylist(denylister, account, false);
+    }
 
-        let freeze_ref = &borrow_global<Management>(usdk_address()).transfer_ref;
-        primary_fungible_store::set_frozen_flag(freeze_ref, account, false);
+    inline fun set_denylist(denylister: &signer, account: address, frozen: bool) {
+        assert_not_paused();
+        let usdk_address = usdk_address();
+        let denylister_address = signer::address_of(denylister);
+        let roles = &Roles[usdk_address];
+        authorize(denylister_address, roles.denylister);
+
+        let transfer_ref = &Management[usdk_address].transfer_ref;
+        primary_fungible_store::set_frozen_flag(transfer_ref, account, frozen);
 
         event::emit(Denylist {
-            denylister: signer::address_of(denylister),
+            denylister: denylister_address,
             account,
         });
     }
 
     /// Add a new minter. This checks that the caller is the master minter and the account is not already a minter.
-    public entry fun add_minter(admin: &signer, minter: address) acquires Roles, State {
+    public entry fun add_minter(admin: &signer, minter: address) {
         assert_not_paused();
-        let roles = borrow_global_mut<Roles>(usdk_address());
-        assert!(signer::address_of(admin) == roles.master_minter, EUNAUTHORIZED);
-        assert!(!vector::contains(&roles.minters, &minter), EALREADY_MINTER);
-        vector::push_back(&mut roles.minters, minter);
+        let admin_address = signer::address_of(admin);
+        let roles = &mut Roles[usdk_address()];
+        authorize(admin_address, roles.master_minter);
+        assert!(!roles.minters.contains(&minter), EALREADY_MINTER);
+        roles.minters.push_back(minter);
     }
 
-    fun assert_is_minter(minter: &signer) acquires Roles {
-        let roles = borrow_global<Roles>(usdk_address());
+    inline fun assert_is_minter(minter: &signer): address {
+        let roles = &Roles[usdk_address()];
         let minter_addr = signer::address_of(minter);
-        assert!(minter_addr == roles.master_minter || vector::contains(&roles.minters, &minter_addr), EUNAUTHORIZED);
+        assert!(minter_addr == roles.master_minter || roles.minters.contains(&minter_addr), EUNAUTHORIZED);
+        minter_addr
     }
 
-    fun assert_not_paused() acquires State {
-        let state = borrow_global<State>(usdk_address());
+    inline fun assert_not_paused() {
+        let state = &State[usdk_address()];
         assert!(!state.paused, EPAUSED);
     }
 
     // Check that the account is not denylisted by checking the frozen flag on the primary store
-    fun assert_not_denylisted(account: address) {
+    inline fun assert_not_denylisted(account: address) {
         let metadata = metadata();
         // CANNOT call into pfs::store_exists in our withdraw/deposit hooks as it creates possibility of a circular dependency.
         // Instead, we will call the inlined version of the function.
         if (primary_fungible_store::primary_store_exists_inlined(account, metadata)) {
-            assert!(!fungible_asset::is_frozen(primary_fungible_store::primary_store_inlined(account, metadata)), EDENYLISTED);
+            assert!(
+                !fungible_asset::is_frozen(primary_fungible_store::primary_store_inlined(account, metadata)),
+                EDENYLISTED
+            );
         }
+    }
+
+    inline fun authorize(caller: address, expected: address) {
+        assert!(caller == expected, EUNAUTHORIZED);
     }
 
     #[test_only]
     public fun init_for_test(usdk_signer: &signer) {
-        init_module(usdk_signer);
+        initialize(usdk_signer);
     }
 }

--- a/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
@@ -1,4 +1,7 @@
-/// Example of a managed stablecoin with mint, burn, freeze and pause functionalities.
+/// Example of a managed stablecoin with minting allowances, confiscation, denylisting,
+/// pausing and two-step role rotation.
+///
+/// See DESIGN.md in this package for the security model these functions implement.
 module stablecoin::usdk {
     use aptos_framework::dispatchable_fungible_asset;
     use aptos_framework::event;
@@ -6,37 +9,57 @@ module stablecoin::usdk {
     use aptos_framework::fungible_asset::{Self, MintRef, TransferRef, BurnRef, Metadata, FungibleAsset, FungibleStore};
     use aptos_framework::object::{Self, Object, ExtendRef, ObjectCore};
     use aptos_framework::primary_fungible_store;
-    use std::option;
+    use aptos_std::table::{Self, Table};
+    use std::option::{Self, Option};
     use std::signer;
-    use std::string::{Self, utf8};
+    use std::string::{Self, String, utf8};
 
     /// Caller is not authorized to make this call
     const EUNAUTHORIZED: u64 = 1;
-    /// No operations are allowed when contract is paused
+    /// No value movement is allowed when the contract is paused
     const EPAUSED: u64 = 2;
     /// The account is already a minter
     const EALREADY_MINTER: u64 = 3;
+    /// The account is not a minter
+    const ENOT_MINTER: u64 = 4;
     /// The account is denylisted
     const EDENYLISTED: u64 = 5;
     /// Stablecoin is already initialized
     const EALREADY_INITIALIZED: u64 = 6;
     /// The account has no primary store for the stablecoin
     const ESTORE_NOT_FOUND: u64 = 7;
+    /// The mint would exceed the minter's remaining allowance
+    const EINSUFFICIENT_ALLOWANCE: u64 = 8;
 
     const ASSET_SYMBOL: vector<u8> = b"USDK";
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Privileged addresses and the mint allowance of each authorized minter.
+    ///
+    /// Every role carries an optional pending successor so that rotation is a two-step
+    /// handoff: a proposal alone confers no authority, so a mistyped address cannot
+    /// strand a role.
+    ///
+    /// `mint_allowances` is keyed by address so that authorization and allowance lookup
+    /// cost the same regardless of how many minters exist. Membership in this table *is*
+    /// the minter role.
     struct Roles has key {
         master_minter: address,
-        minters: vector<address>,
+        pending_master_minter: Option<address>,
         pauser: address,
+        pending_pauser: Option<address>,
         denylister: address,
+        pending_denylister: Option<address>,
+        confiscator: address,
+        pending_confiscator: Option<address>,
+        mint_allowances: Table<address, u64>,
     }
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Capabilities for managing the asset, held by the metadata object itself.
     struct Management has key {
-        /// Unused today. Retained so a future upgrade can obtain the metadata object's signer
-        /// (e.g. to add resources to the object) without needing to recreate the asset.
+        /// Unused today. Retained so a future upgrade can obtain the metadata object's
+        /// signer (e.g. to add resources to the object) without recreating the asset.
         extend_ref: ExtendRef,
         mint_ref: MintRef,
         burn_ref: BurnRef,
@@ -44,113 +67,203 @@ module stablecoin::usdk {
     }
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Whether value movement is currently halted.
     struct State has key {
         paused: bool,
     }
 
-    struct Approval has drop {
-        owner: address,
-        to: address,
-        nonce: u64,
-        chain_id: u8,
-        spender: address,
-        amount: u64,
-    }
-
     #[event]
+    /// Emitted when new units are issued.
     struct Mint has drop, store {
         minter: address,
         to: address,
         amount: u64,
+        remaining_allowance: u64,
     }
 
     #[event]
+    /// Emitted when a minter destroys units from its own balance.
     struct Burn has drop, store {
         minter: address,
+        amount: u64,
+    }
+
+    #[event]
+    /// Emitted when the confiscator destroys units held by another account.
+    struct Confiscate has drop, store {
+        confiscator: address,
         from: address,
         store: Object<FungibleStore>,
         amount: u64,
     }
 
     #[event]
+    /// Emitted when the pause state changes. Not emitted when the state is unchanged.
     struct Pause has drop, store {
         pauser: address,
         is_paused: bool,
     }
 
     #[event]
+    /// Emitted when an account is denylisted or removed from the denylist.
     struct Denylist has drop, store {
         denylister: address,
         account: address,
         is_denylisted: bool,
     }
 
+    #[event]
+    /// Emitted when a minter is granted the role or has its allowance changed.
+    struct MinterConfigured has drop, store {
+        master_minter: address,
+        minter: address,
+        allowance: u64,
+    }
+
+    #[event]
+    /// Emitted when a minter's authority is revoked.
+    struct MinterRemoved has drop, store {
+        master_minter: address,
+        minter: address,
+    }
+
+    #[event]
+    /// Emitted when the current holder of a role nominates a successor.
+    struct RoleProposed has drop, store {
+        role: String,
+        current: address,
+        proposed: address,
+    }
+
+    #[event]
+    /// Emitted when a nominated successor takes over a role.
+    struct RoleAccepted has drop, store {
+        role: String,
+        previous: address,
+        current: address,
+    }
+
     #[view]
+    /// Return the deterministic address of the USDK metadata object.
+    ///
+    /// This is derived from the module address and is valid before initialization.
     public fun usdk_address(): address {
         object::create_object_address(&@stablecoin, ASSET_SYMBOL)
     }
 
     #[view]
+    /// Return the USDK metadata object. Aborts if the stablecoin is not yet initialized.
     public fun metadata(): Object<Metadata> {
         object::address_to_object(usdk_address())
     }
 
     #[view]
-    /// Return whether the stablecoin is currently paused.
-    public fun is_paused(): bool {
+    /// Return whether `initialize` has already run.
+    ///
+    /// Clients should check this before calling the other views, which read resources
+    /// that only exist after initialization.
+    public fun is_initialized(): bool {
+        exists<Roles>(usdk_address())
+    }
+
+    #[view]
+    /// Return whether value movement is currently halted.
+    public fun is_paused(): bool acquires State {
         State[usdk_address()].paused
     }
 
     #[view]
-    /// Return whether the account may mint. The master minter is implicitly a minter.
-    public fun is_minter(account: address): bool {
-        let roles = &Roles[usdk_address()];
-        account == roles.master_minter || roles.minters.contains(&account)
+    /// Return whether the account is authorized to mint.
+    ///
+    /// The master minter is not implicitly a minter: it must grant itself an allowance,
+    /// which is an auditable on-chain event.
+    public fun is_minter(account: address): bool acquires Roles {
+        Roles[usdk_address()].mint_allowances.contains(account)
     }
 
     #[view]
-    /// Return the accounts explicitly granted the minter role. Excludes the master minter.
-    public fun minters(): vector<address> {
-        Roles[usdk_address()].minters
+    /// Return the account's remaining mint allowance, or zero if it is not a minter.
+    public fun mint_allowance(account: address): u64 acquires Roles {
+        let allowances = &Roles[usdk_address()].mint_allowances;
+        if (allowances.contains(account)) *allowances.borrow(account) else 0
     }
 
     #[view]
-    /// Return whether the account is denylisted. Accounts without a primary store are never denylisted.
+    /// Return whether the account is denylisted.
+    ///
+    /// An account that has never held USDK has no primary store and is never denylisted.
     public fun is_denylisted(account: address): bool {
         primary_fungible_store::is_frozen(account, metadata())
     }
 
     #[view]
-    public fun master_minter(): address {
+    /// Return the address that administers minters.
+    public fun master_minter(): address acquires Roles {
         Roles[usdk_address()].master_minter
     }
 
     #[view]
-    public fun pauser(): address {
+    /// Return the address that may pause and unpause the stablecoin.
+    public fun pauser(): address acquires Roles {
         Roles[usdk_address()].pauser
     }
 
     #[view]
-    public fun denylister(): address {
+    /// Return the address that may denylist accounts.
+    public fun denylister(): address acquires Roles {
         Roles[usdk_address()].denylister
     }
 
-    /// Called as part of deployment to initialize the stablecoin.
-    /// Note: The signer has to be the account where the module is published.
-    /// Create a stablecoin token (a new Fungible Asset)
-    /// Ensure any stores for the stablecoin are untransferable.
-    /// Store Roles, Management and State resources in the Metadata object.
-    /// Override deposit and withdraw functions of the newly created asset/token to add custom denylist logic.
+    #[view]
+    /// Return the address that may confiscate balances.
+    public fun confiscator(): address acquires Roles {
+        Roles[usdk_address()].confiscator
+    }
+
+    #[view]
+    /// Return the pending master minter, if a rotation has been proposed.
+    public fun pending_master_minter(): Option<address> acquires Roles {
+        Roles[usdk_address()].pending_master_minter
+    }
+
+    #[view]
+    /// Return the pending pauser, if a rotation has been proposed.
+    public fun pending_pauser(): Option<address> acquires Roles {
+        Roles[usdk_address()].pending_pauser
+    }
+
+    #[view]
+    /// Return the pending denylister, if a rotation has been proposed.
+    public fun pending_denylister(): Option<address> acquires Roles {
+        Roles[usdk_address()].pending_denylister
+    }
+
+    #[view]
+    /// Return the pending confiscator, if a rotation has been proposed.
+    public fun pending_confiscator(): Option<address> acquires Roles {
+        Roles[usdk_address()].pending_confiscator
+    }
+
+    /// Create the stablecoin. Must be called once, by the account that published the module.
+    ///
+    /// This is an explicit entry call rather than `init_module`, so a deployment is not
+    /// usable until this transaction succeeds.
+    ///
+    /// Creates the fungible asset with primary store support, makes every store for the
+    /// asset untransferable, stores the role/capability/state resources in the metadata
+    /// object, and registers the module's `withdraw`/`deposit` hooks so that all transfers
+    /// are subject to the pause and denylist checks.
+    ///
+    /// Aborts with `EALREADY_INITIALIZED` if it has already run, or `EUNAUTHORIZED` if the
+    /// caller is not the module address.
     entry fun initialize(stablecoin_signer: &signer) {
-        // Check that it hasn't been called already
         assert!(!object::object_exists<ObjectCore>(usdk_address()), EALREADY_INITIALIZED);
         authorize(signer::address_of(stablecoin_signer), @stablecoin);
 
-        // Create the stablecoin with primary store support.
         let constructor_ref = &object::create_named_object(stablecoin_signer, ASSET_SYMBOL);
         primary_fungible_store::create_primary_store_enabled_fungible_asset(
             constructor_ref,
-            option::none(),
+            option::none(), /* unlimited supply; issuance is bounded per minter instead */
             utf8(ASSET_SYMBOL), /* name */
             utf8(ASSET_SYMBOL), /* symbol */
             6, /* decimals, matching the convention used by USDC/USDT */
@@ -158,20 +271,22 @@ module stablecoin::usdk {
             utf8(b"http://example.com"), /* project */
         );
 
-        // Set ALL stores for the fungible asset to untransferable.
-        // This prevents secondary stores from being transferred to other accounts.
+        // Prevent a store from being transferred out from under the denylist checks.
         fungible_asset::set_untransferable(constructor_ref);
 
-        // All resources created will be kept in the asset metadata object.
         let metadata_object_signer = &constructor_ref.generate_signer();
         move_to(metadata_object_signer, Roles {
             master_minter: @master_minter,
-            minters: vector[],
+            pending_master_minter: option::none(),
             pauser: @pauser,
+            pending_pauser: option::none(),
             denylister: @denylister,
+            pending_denylister: option::none(),
+            confiscator: @confiscator,
+            pending_confiscator: option::none(),
+            mint_allowances: table::new(),
         });
 
-        // Create mint/burn/transfer refs to allow creator to manage the stablecoin.
         move_to(metadata_object_signer, Management {
             extend_ref: constructor_ref.generate_extend_ref(),
             mint_ref: fungible_asset::generate_mint_ref(constructor_ref),
@@ -179,14 +294,10 @@ module stablecoin::usdk {
             transfer_ref: fungible_asset::generate_transfer_ref(constructor_ref),
         });
 
-        // Start the state not paused
-        move_to(metadata_object_signer, State {
-            paused: false,
-        });
+        move_to(metadata_object_signer, State { paused: false });
 
-        // Override the deposit and withdraw functions which mean overriding transfer.
-        // This ensures all transfer will call withdraw and deposit functions in this module and perform the necessary
-        // checks.
+        // Overriding deposit and withdraw overrides transfer, so every transfer runs the
+        // checks in this module.
         let deposit = function_info::new_function_info(
             stablecoin_signer,
             string::utf8(b"usdk"),
@@ -205,147 +316,284 @@ module stablecoin::usdk {
         );
     }
 
-    /// Allow a spender to transfer tokens from the owner's account given their signed approval.
-    /// Caller needs to provide the from account's scheme and public key which can be gotten via the Aptos SDK.
-    /// TODO: This has to be reworked before being re-enabled
-    /*public fun transfer_from(
-        spender: &signer,
-        proof: vector<u8>,
-        from: address,
-        from_account_scheme: u8,
-        from_public_key: vector<u8>,
-        to: address,
-        amount: u64,
-    ) {
-        assert_not_paused();
-        assert_not_denylisted(from);
-        assert_not_denylisted(to);
-
-        let expected_message = Approval {
-            owner: from,
-            to,
-            nonce: account::get_sequence_number(from),
-            chain_id: chain_id::get(),
-            spender: signer::address_of(spender),
-            amount,
-        };
-        account::verify_signed_message(from, from_account_scheme, from_public_key, proof, expected_message);
-
-        let transfer_ref = &Management[usdk_address()].transfer_ref;
-        // Only use with_ref API for primary_fungible_store (PFS) transfers in this module.
-        primary_fungible_store::transfer_with_ref(transfer_ref, from, to, amount);
-    }*/
-
-    /// Deposit function override to ensure that the account is not denylisted and the stablecoin is not paused.
+    /// Deposit hook. Rejects the transfer if the stablecoin is paused or the destination
+    /// is denylisted.
+    ///
+    /// Registered via `register_dispatch_functions`; not called directly by this module.
     public fun deposit<T: key>(
         store: Object<T>,
         fa: FungibleAsset,
         transfer_ref: &TransferRef,
-    ) {
+    ) acquires State {
         assert_not_paused();
-        assert_not_denylisted(store.owner());
-        assert_not_denylisted(store.root_owner());
+        assert_store_not_denylisted(store);
         transfer_ref.deposit_with_ref(store, fa);
     }
 
-    /// Withdraw function override to ensure that the account is not denylisted and the stablecoin is not paused.
+    /// Withdraw hook. Rejects the transfer if the stablecoin is paused or the source is
+    /// denylisted.
+    ///
+    /// Checking the root owner as well as the direct owner is what stops a denylisted
+    /// account from moving funds through a store owned by an intermediate object it
+    /// controls: the framework's own check accepts indirect ownership.
+    ///
+    /// Registered via `register_dispatch_functions`; not called directly by this module.
     public fun withdraw<T: key>(
         store: Object<T>,
         amount: u64,
         transfer_ref: &TransferRef,
-    ): FungibleAsset {
+    ): FungibleAsset acquires State {
         assert_not_paused();
-        assert_not_denylisted(store.owner());
-        assert_not_denylisted(store.root_owner());
+        assert_store_not_denylisted(store);
         transfer_ref.withdraw_with_ref(store, amount)
     }
 
-    /// Mint new tokens to the specified account. This checks that the caller is a minter, the stablecoin is not paused,
-    /// and the account is not denylisted.
-    public entry fun mint(minter: &signer, to: address, amount: u64) {
+    /// Issue `amount` units to `to`, drawing on the caller's mint allowance.
+    ///
+    /// Aborts if paused, if the caller is not a minter, if `to` is denylisted, or if the
+    /// amount exceeds the caller's remaining allowance. Minting zero is a no-op.
+    public entry fun mint(minter: &signer, to: address, amount: u64) acquires Management, Roles, State {
         assert_not_paused();
-        let minter_address = assert_is_minter(minter);
+        let minter_address = signer::address_of(minter);
+        assert_is_minter(minter_address);
         assert_not_denylisted(to);
-
-        // Shortcut if you mint 0 tokens, in theory could just assert amount is > 0
         if (amount == 0) { return };
+
+        // Debit the allowance first so that a failure later cannot issue for free.
+        let allowance = Roles[usdk_address()].mint_allowances.borrow_mut(minter_address);
+        assert!(*allowance >= amount, EINSUFFICIENT_ALLOWANCE);
+        *allowance -= amount;
+        let remaining_allowance = *allowance;
 
         let management = &Management[usdk_address()];
         let tokens = management.mint_ref.mint(amount);
-        // Ensure not to call pfs::deposit or dfa::deposit directly in the module.
-        deposit(primary_fungible_store::ensure_primary_store_exists(to, metadata()), tokens, &management.transfer_ref);
+        // The pause and denylist checks above already cover this deposit, so deposit with
+        // the ref directly rather than re-entering the dispatch hook.
+        management.transfer_ref.deposit_with_ref(
+            primary_fungible_store::ensure_primary_store_exists(to, metadata()),
+            tokens,
+        );
 
-        event::emit(Mint {
-            minter: minter_address,
-            to,
-            amount,
-        });
+        event::emit(Mint { minter: minter_address, to, amount, remaining_allowance });
     }
 
-    /// Burn tokens from the specified account. This checks that the caller is a minter and the stablecoin is not paused.
-    /// Aborts if the account has no primary store rather than creating an empty one as a side effect.
-    public entry fun burn(minter: &signer, from: address, amount: u64) {
-        let metadata = metadata();
-        assert!(primary_fungible_store::primary_store_exists(from, metadata), ESTORE_NOT_FOUND);
-        burn_from(minter, primary_fungible_store::primary_store(from, metadata), amount);
-    }
-
-    /// Burn tokens from the specified account's store. This checks that the caller is a minter and the stablecoin is
-    /// not paused.
-    public entry fun burn_from(
-        minter: &signer,
-        store: Object<FungibleStore>,
-        amount: u64,
-    ) {
+    /// Destroy `amount` units from the caller's own balance.
+    ///
+    /// Minters can only burn what they hold; destroying another account's balance requires
+    /// the confiscator role. Aborts if paused, if the caller is not a minter, or if the
+    /// caller has no primary store. Burning zero is a no-op.
+    public entry fun burn(minter: &signer, amount: u64) acquires Management, Roles, State {
         assert_not_paused();
-        let minter_address = assert_is_minter(minter);
+        let minter_address = signer::address_of(minter);
+        assert_is_minter(minter_address);
         if (amount == 0) { return };
 
+        let metadata = metadata();
+        assert!(primary_fungible_store::primary_store_exists(minter_address, metadata), ESTORE_NOT_FOUND);
+
         let management = &Management[usdk_address()];
+        let store = primary_fungible_store::primary_store(minter_address, metadata);
         let tokens = management.transfer_ref.withdraw_with_ref(store, amount);
         management.burn_ref.burn(tokens);
 
-        event::emit(Burn {
-            minter: minter_address,
-            from: store.owner(),
-            store,
-            amount,
-        });
+        event::emit(Burn { minter: minter_address, amount });
     }
 
-    /// Pause or unpause the stablecoin. This checks that the caller is the pauser.
-    public entry fun set_pause(pauser: &signer, paused: bool) {
+    /// Destroy `amount` units held in another account's primary store.
+    ///
+    /// This is the compliance seizure path and deliberately bypasses the frozen flag and
+    /// the pause, so that funds can be recovered from a denylisted account during an
+    /// incident. Restricted to the confiscator role. Aborts if the account has no primary
+    /// store. Confiscating zero is a no-op.
+    public entry fun confiscate(confiscator: &signer, from: address, amount: u64) acquires Management, Roles {
+        let confiscator_address = signer::address_of(confiscator);
+        authorize(confiscator_address, Roles[usdk_address()].confiscator);
+        if (amount == 0) { return };
+
+        let metadata = metadata();
+        assert!(primary_fungible_store::primary_store_exists(from, metadata), ESTORE_NOT_FOUND);
+
+        let management = &Management[usdk_address()];
+        let store = primary_fungible_store::primary_store(from, metadata);
+        let tokens = management.transfer_ref.withdraw_with_ref(store, amount);
+        management.burn_ref.burn(tokens);
+
+        event::emit(Confiscate { confiscator: confiscator_address, from, store, amount });
+    }
+
+    /// Halt or resume value movement. Restricted to the pauser.
+    ///
+    /// Setting the state to its current value is a no-op and emits no event.
+    public entry fun set_pause(pauser: &signer, paused: bool) acquires Roles, State {
         let usdk_address = usdk_address();
         let pauser_address = signer::address_of(pauser);
-        let roles = &Roles[usdk_address];
-        authorize(pauser_address, roles.pauser);
-        let state = &mut State[usdk_address];
+        authorize(pauser_address, Roles[usdk_address].pauser);
 
-        // Idempotent return if the paused state is already the same as the requested state.
+        let state = &mut State[usdk_address];
         if (state.paused == paused) { return };
         state.paused = paused;
 
-        event::emit(Pause {
-            pauser: pauser_address,
-            is_paused: paused,
-        });
+        event::emit(Pause { pauser: pauser_address, is_paused: paused });
     }
 
-    /// Add an account to the denylist. This checks that the caller is the denylister.
-    public entry fun denylist(denylister: &signer, account: address) {
+    /// Freeze an account, blocking it from sending or receiving USDK.
+    ///
+    /// Available while paused: denylisting is part of responding to an incident.
+    public entry fun denylist(denylister: &signer, account: address) acquires Management, Roles {
         set_denylist(denylister, account, true);
     }
 
-    /// Remove an account from the denylist. This checks that the caller is the denylister.
-    public entry fun undenylist(denylister: &signer, account: address) {
+    /// Unfreeze an account. Available while paused.
+    public entry fun undenylist(denylister: &signer, account: address) acquires Management, Roles {
         set_denylist(denylister, account, false);
     }
 
-    inline fun set_denylist(denylister: &signer, account: address, denied: bool) {
+    /// Grant the minter role with a finite allowance. Restricted to the master minter.
+    ///
+    /// Blocked while paused: a compromised master-minter key must not be able to expand
+    /// issuing authority during an incident. Aborts with `EALREADY_MINTER` if the account
+    /// already holds the role; use `set_mint_allowance` to change an existing allowance.
+    public entry fun add_minter(admin: &signer, minter: address, allowance: u64) acquires Roles, State {
+        assert_not_paused();
+        let admin_address = signer::address_of(admin);
+        let roles = &mut Roles[usdk_address()];
+        authorize(admin_address, roles.master_minter);
+        assert!(!roles.mint_allowances.contains(minter), EALREADY_MINTER);
+        roles.mint_allowances.add(minter, allowance);
+
+        event::emit(MinterConfigured { master_minter: admin_address, minter, allowance });
+    }
+
+    /// Change an existing minter's remaining allowance. Restricted to the master minter.
+    ///
+    /// Increases are blocked while paused; decreases remain available so that issuing
+    /// authority can be wound down during an incident. Aborts with `ENOT_MINTER` if the
+    /// account does not hold the role.
+    public entry fun set_mint_allowance(admin: &signer, minter: address, allowance: u64) acquires Roles, State {
+        let admin_address = signer::address_of(admin);
+        let roles = &mut Roles[usdk_address()];
+        authorize(admin_address, roles.master_minter);
+        assert!(roles.mint_allowances.contains(minter), ENOT_MINTER);
+
+        let current = *roles.mint_allowances.borrow(minter);
+        if (allowance > current) {
+            assert_not_paused();
+        };
+        roles.mint_allowances.upsert(minter, allowance);
+
+        event::emit(MinterConfigured { master_minter: admin_address, minter, allowance });
+    }
+
+    /// Revoke the minter role and its remaining allowance. Restricted to the master minter.
+    ///
+    /// Available while paused: revoking a compromised minter is part of responding to an
+    /// incident. Revoking an account that is not a minter is a no-op.
+    public entry fun remove_minter(admin: &signer, minter: address) acquires Roles {
+        let admin_address = signer::address_of(admin);
+        let roles = &mut Roles[usdk_address()];
+        authorize(admin_address, roles.master_minter);
+        if (!roles.mint_allowances.contains(minter)) { return };
+        roles.mint_allowances.remove(minter);
+
+        event::emit(MinterRemoved { master_minter: admin_address, minter });
+    }
+
+    /// Nominate a successor for the master minter role. Restricted to the current holder.
+    ///
+    /// The nomination confers no authority until `accept_master_minter` is called, and may
+    /// be replaced by a later proposal.
+    public entry fun propose_master_minter(admin: &signer, proposed: address) acquires Roles {
+        let roles = &mut Roles[usdk_address()];
+        let current = roles.master_minter;
+        authorize(signer::address_of(admin), current);
+        roles.pending_master_minter = option::some(proposed);
+
+        event::emit(RoleProposed { role: utf8(b"master_minter"), current, proposed });
+    }
+
+    /// Take over the master minter role. Restricted to the nominated successor.
+    public entry fun accept_master_minter(proposed: &signer) acquires Roles {
+        let roles = &mut Roles[usdk_address()];
+        let new_holder = accept_role(proposed, &mut roles.pending_master_minter);
+        let previous = roles.master_minter;
+        roles.master_minter = new_holder;
+
+        event::emit(RoleAccepted { role: utf8(b"master_minter"), previous, current: new_holder });
+    }
+
+    /// Nominate a successor for the pauser role. Restricted to the current holder.
+    public entry fun propose_pauser(pauser: &signer, proposed: address) acquires Roles {
+        let roles = &mut Roles[usdk_address()];
+        let current = roles.pauser;
+        authorize(signer::address_of(pauser), current);
+        roles.pending_pauser = option::some(proposed);
+
+        event::emit(RoleProposed { role: utf8(b"pauser"), current, proposed });
+    }
+
+    /// Take over the pauser role. Restricted to the nominated successor.
+    public entry fun accept_pauser(proposed: &signer) acquires Roles {
+        let roles = &mut Roles[usdk_address()];
+        let new_holder = accept_role(proposed, &mut roles.pending_pauser);
+        let previous = roles.pauser;
+        roles.pauser = new_holder;
+
+        event::emit(RoleAccepted { role: utf8(b"pauser"), previous, current: new_holder });
+    }
+
+    /// Nominate a successor for the denylister role. Restricted to the current holder.
+    public entry fun propose_denylister(denylister: &signer, proposed: address) acquires Roles {
+        let roles = &mut Roles[usdk_address()];
+        let current = roles.denylister;
+        authorize(signer::address_of(denylister), current);
+        roles.pending_denylister = option::some(proposed);
+
+        event::emit(RoleProposed { role: utf8(b"denylister"), current, proposed });
+    }
+
+    /// Take over the denylister role. Restricted to the nominated successor.
+    public entry fun accept_denylister(proposed: &signer) acquires Roles {
+        let roles = &mut Roles[usdk_address()];
+        let new_holder = accept_role(proposed, &mut roles.pending_denylister);
+        let previous = roles.denylister;
+        roles.denylister = new_holder;
+
+        event::emit(RoleAccepted { role: utf8(b"denylister"), previous, current: new_holder });
+    }
+
+    /// Nominate a successor for the confiscator role. Restricted to the current holder.
+    public entry fun propose_confiscator(confiscator: &signer, proposed: address) acquires Roles {
+        let roles = &mut Roles[usdk_address()];
+        let current = roles.confiscator;
+        authorize(signer::address_of(confiscator), current);
+        roles.pending_confiscator = option::some(proposed);
+
+        event::emit(RoleProposed { role: utf8(b"confiscator"), current, proposed });
+    }
+
+    /// Take over the confiscator role. Restricted to the nominated successor.
+    public entry fun accept_confiscator(proposed: &signer) acquires Roles {
+        let roles = &mut Roles[usdk_address()];
+        let new_holder = accept_role(proposed, &mut roles.pending_confiscator);
+        let previous = roles.confiscator;
+        roles.confiscator = new_holder;
+
+        event::emit(RoleAccepted { role: utf8(b"confiscator"), previous, current: new_holder });
+    }
+
+    /// Set or clear an account's frozen flag and emit the corresponding event.
+    ///
+    /// Skips the write when the account is already in the requested state, and avoids
+    /// creating a primary store just to unfreeze an account that never held USDK.
+    fun set_denylist(denylister: &signer, account: address, denied: bool) acquires Management, Roles {
         let usdk_address = usdk_address();
         let denylister_address = signer::address_of(denylister);
-        let roles = &Roles[usdk_address];
-        authorize(denylister_address, roles.denylister);
+        authorize(denylister_address, Roles[usdk_address].denylister);
+
+        let metadata = metadata();
+        let store_exists = primary_fungible_store::primary_store_exists(account, metadata);
+        if (!denied && !store_exists) { return };
+        if (store_exists && primary_fungible_store::is_frozen(account, metadata) == denied) { return };
 
         let transfer_ref = &Management[usdk_address].transfer_ref;
         primary_fungible_store::set_frozen_flag(transfer_ref, account, denied);
@@ -353,50 +601,51 @@ module stablecoin::usdk {
         event::emit(Denylist {
             denylister: denylister_address,
             account,
-            is_denylisted: denied
+            is_denylisted: denied,
         });
     }
 
-    /// Add a new minter. This checks that the caller is the master minter and the account is not already a minter.
-    /// Deliberately callable while paused: revoking and granting roles is part of incident response.
-    public entry fun add_minter(admin: &signer, minter: address) {
-        let admin_address = signer::address_of(admin);
-        let roles = &mut Roles[usdk_address()];
-        authorize(admin_address, roles.master_minter);
-        assert!(!roles.minters.contains(&minter), EALREADY_MINTER);
-        roles.minters.push_back(minter);
+    /// Consume a pending role nomination, returning the accepting address.
+    ///
+    /// Aborts with `EUNAUTHORIZED` if there is no nomination or the caller is not the
+    /// nominated address.
+    inline fun accept_role(proposed: &signer, pending: &mut Option<address>): address {
+        let proposed_address = signer::address_of(proposed);
+        assert!(pending.contains(&proposed_address), EUNAUTHORIZED);
+        *pending = option::none();
+        proposed_address
     }
 
-    /// Revoke the minter role. This checks that the caller is the master minter. No-op if the account is not a minter.
-    /// Deliberately callable while paused: revoking a compromised minter is part of incident response.
-    public entry fun remove_minter(admin: &signer, minter: address) {
-        let admin_address = signer::address_of(admin);
-        let roles = &mut Roles[usdk_address()];
-        authorize(admin_address, roles.master_minter);
-        let (found, index) = roles.minters.index_of(&minter);
-        if (found) {
-            // Order doesn't matter, so let's do the performant remove
-            roles.minters.swap_remove(index);
+    /// Abort unless the account currently holds the minter role.
+    inline fun assert_is_minter(account: address) {
+        assert!(Roles[usdk_address()].mint_allowances.contains(account), EUNAUTHORIZED);
+    }
+
+    /// Abort if value movement is currently halted.
+    inline fun assert_not_paused() {
+        assert!(!State[usdk_address()].paused, EPAUSED);
+    }
+
+    /// Abort if either the direct owner or the root owner of the store is denylisted.
+    ///
+    /// The two are the same for an ordinary primary store, so the second lookup is skipped
+    /// in the common case.
+    inline fun assert_store_not_denylisted<T: key>(store: Object<T>) {
+        let owner = store.owner();
+        assert_not_denylisted(owner);
+        let root_owner = store.root_owner();
+        if (root_owner != owner) {
+            assert_not_denylisted(root_owner);
         };
     }
 
-    inline fun assert_is_minter(minter: &signer): address {
-        let roles = &Roles[usdk_address()];
-        let minter_addr = signer::address_of(minter);
-        assert!(minter_addr == roles.master_minter || roles.minters.contains(&minter_addr), EUNAUTHORIZED);
-        minter_addr
-    }
-
-    inline fun assert_not_paused() {
-        let state = &State[usdk_address()];
-        assert!(!state.paused, EPAUSED);
-    }
-
-    // Check that the account is not denylisted by checking the frozen flag on the primary store
+    /// Abort if the account's primary store is frozen.
+    ///
+    /// An account with no primary store cannot be denylisted and is therefore allowed.
     inline fun assert_not_denylisted(account: address) {
         let metadata = metadata();
-        // CANNOT call into pfs::store_exists in our withdraw/deposit hooks as it creates possibility of a circular dependency.
-        // Instead, we will call the inlined version of the function.
+        // Must not call pfs::store_exists from the withdraw/deposit hooks: that would risk
+        // a circular module dependency. Use the inlined variants instead.
         if (primary_fungible_store::primary_store_exists_inlined(account, metadata)) {
             assert!(
                 !fungible_asset::is_frozen(primary_fungible_store::primary_store_inlined(account, metadata)),
@@ -405,11 +654,13 @@ module stablecoin::usdk {
         }
     }
 
+    /// Abort unless the caller is the expected address.
     inline fun authorize(caller: address, expected: address) {
         assert!(caller == expected, EUNAUTHORIZED);
     }
 
     #[test_only]
+    /// Run `initialize` from a test, which cannot call an entry function directly.
     public fun init_for_test(usdk_signer: &signer) {
         initialize(usdk_signer);
     }

--- a/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
@@ -1,7 +1,5 @@
 /// Example of a managed stablecoin with mint, burn, freeze and pause functionalities.
 module stablecoin::usdk {
-    use aptos_framework::account;
-    use aptos_framework::chain_id;
     use aptos_framework::dispatchable_fungible_asset;
     use aptos_framework::event;
     use aptos_framework::function_info;
@@ -18,12 +16,12 @@ module stablecoin::usdk {
     const EPAUSED: u64 = 2;
     /// The account is already a minter
     const EALREADY_MINTER: u64 = 3;
-    /// The account is not a minter
-    const ENOT_MINTER: u64 = 4;
     /// The account is denylisted
     const EDENYLISTED: u64 = 5;
     /// Stablecoin is already initialized
     const EALREADY_INITIALIZED: u64 = 6;
+    /// The account has no primary store for the stablecoin
+    const ESTORE_NOT_FOUND: u64 = 7;
 
     const ASSET_SYMBOL: vector<u8> = b"USDK";
 
@@ -37,6 +35,8 @@ module stablecoin::usdk {
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct Management has key {
+        /// Unused today. Retained so a future upgrade can obtain the metadata object's signer
+        /// (e.g. to add resources to the object) without needing to recreate the asset.
         extend_ref: ExtendRef,
         mint_ref: MintRef,
         burn_ref: BurnRef,
@@ -82,6 +82,7 @@ module stablecoin::usdk {
     struct Denylist has drop, store {
         denylister: address,
         account: address,
+        is_denylisted: bool,
     }
 
     #[view]
@@ -94,13 +95,53 @@ module stablecoin::usdk {
         object::address_to_object(usdk_address())
     }
 
+    #[view]
+    /// Return whether the stablecoin is currently paused.
+    public fun is_paused(): bool {
+        State[usdk_address()].paused
+    }
+
+    #[view]
+    /// Return whether the account may mint. The master minter is implicitly a minter.
+    public fun is_minter(account: address): bool {
+        let roles = &Roles[usdk_address()];
+        account == roles.master_minter || roles.minters.contains(&account)
+    }
+
+    #[view]
+    /// Return the accounts explicitly granted the minter role. Excludes the master minter.
+    public fun minters(): vector<address> {
+        Roles[usdk_address()].minters
+    }
+
+    #[view]
+    /// Return whether the account is denylisted. Accounts without a primary store are never denylisted.
+    public fun is_denylisted(account: address): bool {
+        primary_fungible_store::is_frozen(account, metadata())
+    }
+
+    #[view]
+    public fun master_minter(): address {
+        Roles[usdk_address()].master_minter
+    }
+
+    #[view]
+    public fun pauser(): address {
+        Roles[usdk_address()].pauser
+    }
+
+    #[view]
+    public fun denylister(): address {
+        Roles[usdk_address()].denylister
+    }
+
     /// Called as part of deployment to initialize the stablecoin.
     /// Note: The signer has to be the account where the module is published.
     /// Create a stablecoin token (a new Fungible Asset)
     /// Ensure any stores for the stablecoin are untransferable.
     /// Store Roles, Management and State resources in the Metadata object.
     /// Override deposit and withdraw functions of the newly created asset/token to add custom denylist logic.
-    public fun initialize(stablecoin_signer: &signer) {
+    entry fun initialize(stablecoin_signer: &signer) {
         // Check that it hasn't been called already
         assert!(!object::object_exists<ObjectCore>(usdk_address()), EALREADY_INITIALIZED);
         authorize(signer::address_of(stablecoin_signer), @stablecoin);
@@ -112,7 +153,7 @@ module stablecoin::usdk {
             option::none(),
             utf8(ASSET_SYMBOL), /* name */
             utf8(ASSET_SYMBOL), /* symbol */
-            8, /* decimals */
+            6, /* decimals, matching the convention used by USDC/USDT */
             utf8(b"http://example.com/favicon.ico"), /* icon */
             utf8(b"http://example.com"), /* project */
         );
@@ -166,7 +207,8 @@ module stablecoin::usdk {
 
     /// Allow a spender to transfer tokens from the owner's account given their signed approval.
     /// Caller needs to provide the from account's scheme and public key which can be gotten via the Aptos SDK.
-    public fun transfer_from(
+    /// TODO: This has to be reworked before being re-enabled
+    /*public fun transfer_from(
         spender: &signer,
         proof: vector<u8>,
         from: address,
@@ -192,7 +234,7 @@ module stablecoin::usdk {
         let transfer_ref = &Management[usdk_address()].transfer_ref;
         // Only use with_ref API for primary_fungible_store (PFS) transfers in this module.
         primary_fungible_store::transfer_with_ref(transfer_ref, from, to, amount);
-    }
+    }*/
 
     /// Deposit function override to ensure that the account is not denylisted and the stablecoin is not paused.
     public fun deposit<T: key>(
@@ -202,6 +244,7 @@ module stablecoin::usdk {
     ) {
         assert_not_paused();
         assert_not_denylisted(store.owner());
+        assert_not_denylisted(store.root_owner());
         transfer_ref.deposit_with_ref(store, fa);
     }
 
@@ -213,6 +256,7 @@ module stablecoin::usdk {
     ): FungibleAsset {
         assert_not_paused();
         assert_not_denylisted(store.owner());
+        assert_not_denylisted(store.root_owner());
         transfer_ref.withdraw_with_ref(store, amount)
     }
 
@@ -239,8 +283,11 @@ module stablecoin::usdk {
     }
 
     /// Burn tokens from the specified account. This checks that the caller is a minter and the stablecoin is not paused.
+    /// Aborts if the account has no primary store rather than creating an empty one as a side effect.
     public entry fun burn(minter: &signer, from: address, amount: u64) {
-        burn_from(minter, primary_fungible_store::ensure_primary_store_exists(from, metadata()), amount);
+        let metadata = metadata();
+        assert!(primary_fungible_store::primary_store_exists(from, metadata), ESTORE_NOT_FOUND);
+        burn_from(minter, primary_fungible_store::primary_store(from, metadata), amount);
     }
 
     /// Burn tokens from the specified account's store. This checks that the caller is a minter and the stablecoin is
@@ -294,30 +341,43 @@ module stablecoin::usdk {
         set_denylist(denylister, account, false);
     }
 
-    inline fun set_denylist(denylister: &signer, account: address, frozen: bool) {
-        assert_not_paused();
+    inline fun set_denylist(denylister: &signer, account: address, denied: bool) {
         let usdk_address = usdk_address();
         let denylister_address = signer::address_of(denylister);
         let roles = &Roles[usdk_address];
         authorize(denylister_address, roles.denylister);
 
         let transfer_ref = &Management[usdk_address].transfer_ref;
-        primary_fungible_store::set_frozen_flag(transfer_ref, account, frozen);
+        primary_fungible_store::set_frozen_flag(transfer_ref, account, denied);
 
         event::emit(Denylist {
             denylister: denylister_address,
             account,
+            is_denylisted: denied
         });
     }
 
     /// Add a new minter. This checks that the caller is the master minter and the account is not already a minter.
+    /// Deliberately callable while paused: revoking and granting roles is part of incident response.
     public entry fun add_minter(admin: &signer, minter: address) {
-        assert_not_paused();
         let admin_address = signer::address_of(admin);
         let roles = &mut Roles[usdk_address()];
         authorize(admin_address, roles.master_minter);
         assert!(!roles.minters.contains(&minter), EALREADY_MINTER);
         roles.minters.push_back(minter);
+    }
+
+    /// Revoke the minter role. This checks that the caller is the master minter. No-op if the account is not a minter.
+    /// Deliberately callable while paused: revoking a compromised minter is part of incident response.
+    public entry fun remove_minter(admin: &signer, minter: address) {
+        let admin_address = signer::address_of(admin);
+        let roles = &mut Roles[usdk_address()];
+        authorize(admin_address, roles.master_minter);
+        let (found, index) = roles.minters.index_of(&minter);
+        if (found) {
+            // Order doesn't matter, so let's do the performant remove
+            roles.minters.swap_remove(index);
+        };
     }
 
     inline fun assert_is_minter(minter: &signer): address {

--- a/aptos-move/move-examples/fungible_asset/stablecoin/tests/usdk_tests.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/tests/usdk_tests.move
@@ -1,144 +1,429 @@
 #[test_only]
 module stablecoin::usdk_tests {
-    use aptos_framework::primary_fungible_store;
     use aptos_framework::dispatchable_fungible_asset;
     use aptos_framework::fungible_asset::{Self, FungibleStore};
     use aptos_framework::object;
+    use aptos_framework::primary_fungible_store;
     use stablecoin::usdk;
+    use std::option;
     use std::signer;
 
-    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
-    fun test_basic_flow(creator: &signer, minter: &signer, master_minter: &signer, denylister: &signer) {
+    const RECEIVER: address = @0xcafe1;
+    const OUTSIDER: address = @0xdead;
+
+    // ----------------------------------------------------------------------
+    // Initialization
+    // ----------------------------------------------------------------------
+
+    #[test(creator = @0xcafe)]
+    fun test_initialize_sets_roles_and_state(creator: &signer) {
+        assert!(!usdk::is_initialized());
         usdk::init_for_test(creator);
-        let receiver_address = @0xcafe1;
+
+        assert!(usdk::is_initialized());
+        assert!(!usdk::is_paused());
+        assert!(usdk::master_minter() == @0xbab);
+        assert!(usdk::pauser() == @0xdafe);
+        assert!(usdk::denylister() == @0xcade);
+        assert!(usdk::confiscator() == @0xc0ffee);
+        assert!(usdk::pending_master_minter() == option::none());
+        assert!(usdk::pending_pauser() == option::none());
+        assert!(usdk::pending_denylister() == option::none());
+        assert!(usdk::pending_confiscator() == option::none());
+    }
+
+    #[test(creator = @0xcafe)]
+    #[expected_failure(abort_code = 6, location = stablecoin::usdk)]
+    fun test_initialize_twice_aborts(creator: &signer) {
+        usdk::init_for_test(creator);
+        usdk::init_for_test(creator);
+    }
+
+    #[test(rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_initialize_requires_module_address(rando: &signer) {
+        usdk::init_for_test(rando);
+    }
+
+    // ----------------------------------------------------------------------
+    // Core flow
+    // ----------------------------------------------------------------------
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    fun test_basic_flow(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let asset = usdk::metadata();
         let minter_address = signer::address_of(minter);
 
-        // set minter and have minter call mint, check balance
-        usdk::add_minter(master_minter, minter_address);
+        usdk::add_minter(master_minter, minter_address, 1000);
         usdk::mint(minter, minter_address, 100);
-        let asset = usdk::metadata();
         assert!(primary_fungible_store::balance(minter_address, asset) == 100);
 
-        // transfer from minter to receiver, check balance
         let minter_store = primary_fungible_store::ensure_primary_store_exists(minter_address, asset);
-        let receiver_store = primary_fungible_store::ensure_primary_store_exists(receiver_address, asset);
+        let receiver_store = primary_fungible_store::ensure_primary_store_exists(RECEIVER, asset);
         dispatchable_fungible_asset::transfer(minter, minter_store, receiver_store, 10);
+        assert!(primary_fungible_store::balance(RECEIVER, asset) == 10);
 
-        // denylist account, check if account is denylisted
-        usdk::denylist(denylister, receiver_address);
-        assert!(primary_fungible_store::is_frozen(receiver_address, asset));
-        usdk::undenylist(denylister, receiver_address);
-        assert!(!primary_fungible_store::is_frozen(receiver_address, asset));
-
-        // burn tokens, check balance
-        usdk::burn(minter, minter_address, 90);
+        usdk::burn(minter, 90);
         assert!(primary_fungible_store::balance(minter_address, asset) == 0);
     }
 
+    // ----------------------------------------------------------------------
+    // Mint authority and allowances
+    // ----------------------------------------------------------------------
 
-    #[test(creator = @0xcafe, pauser = @0xdafe, minter = @0xface, master_minter = @0xbab)]
-    #[expected_failure(abort_code = 2, location = stablecoin::usdk)]
-    fun test_pause(creator: &signer, pauser: &signer, minter: &signer, master_minter: &signer) {
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    fun test_mint_decrements_allowance(creator: &signer, master_minter: &signer, minter: &signer) {
         usdk::init_for_test(creator);
         let minter_address = signer::address_of(minter);
-        usdk::add_minter(master_minter, minter_address);
+
+        usdk::add_minter(master_minter, minter_address, 1000);
+        assert!(usdk::is_minter(minter_address));
+        assert!(usdk::mint_allowance(minter_address) == 1000);
+
+        usdk::mint(minter, RECEIVER, 400);
+        assert!(usdk::mint_allowance(minter_address) == 600);
+    }
+
+    // A compromised minter can issue at most its remaining allowance.
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    #[expected_failure(abort_code = 8, location = stablecoin::usdk)]
+    fun test_mint_beyond_allowance_aborts(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 100);
+        usdk::mint(minter, RECEIVER, 101);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    fun test_mint_zero_is_noop(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 100);
+        usdk::mint(minter, RECEIVER, 0);
+        assert!(usdk::mint_allowance(minter_address) == 100);
+        assert!(primary_fungible_store::balance(RECEIVER, usdk::metadata()) == 0);
+    }
+
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_non_minter_cannot_mint(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::mint(rando, RECEIVER, 100);
+    }
+
+    // The master minter holds no implicit mint authority.
+    #[test(creator = @0xcafe, master_minter = @0xbab)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_master_minter_cannot_mint_without_allowance(creator: &signer, master_minter: &signer) {
+        usdk::init_for_test(creator);
+        usdk::mint(master_minter, RECEIVER, 100);
+    }
+
+    // Granting itself an allowance is possible, but explicit and auditable.
+    #[test(creator = @0xcafe, master_minter = @0xbab)]
+    fun test_master_minter_may_grant_itself_allowance(creator: &signer, master_minter: &signer) {
+        usdk::init_for_test(creator);
+        let master_address = signer::address_of(master_minter);
+
+        usdk::add_minter(master_minter, master_address, 50);
+        usdk::mint(master_minter, RECEIVER, 50);
+        assert!(primary_fungible_store::balance(RECEIVER, usdk::metadata()) == 50);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface, denylister = @0xcade)]
+    #[expected_failure(abort_code = 5, location = stablecoin::usdk)]
+    fun test_cannot_mint_to_denylisted_account(
+        creator: &signer,
+        master_minter: &signer,
+        minter: &signer,
+        denylister: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::mint(minter, RECEIVER, 10);
+        usdk::denylist(denylister, RECEIVER);
+        usdk::mint(minter, RECEIVER, 10);
+    }
+
+    // ----------------------------------------------------------------------
+    // Minter administration
+    // ----------------------------------------------------------------------
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    #[expected_failure(abort_code = 3, location = stablecoin::usdk)]
+    fun test_add_minter_twice_aborts(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+        usdk::add_minter(master_minter, minter_address, 1);
+        usdk::add_minter(master_minter, minter_address, 1);
+    }
+
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_non_master_minter_cannot_add_minter(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::add_minter(rando, OUTSIDER, 100);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    fun test_removed_minter_loses_authority(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 100);
+        usdk::remove_minter(master_minter, minter_address);
+        assert!(!usdk::is_minter(minter_address));
+        assert!(usdk::mint_allowance(minter_address) == 0);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_removed_minter_cannot_mint(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 100);
+        usdk::remove_minter(master_minter, minter_address);
+        usdk::mint(minter, RECEIVER, 1);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab)]
+    fun test_remove_minter_is_noop_for_non_minter(creator: &signer, master_minter: &signer) {
+        usdk::init_for_test(creator);
+        usdk::remove_minter(master_minter, OUTSIDER);
+        assert!(!usdk::is_minter(OUTSIDER));
+    }
+
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_non_master_minter_cannot_remove_minter(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::remove_minter(rando, OUTSIDER);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    fun test_set_mint_allowance(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 100);
+        usdk::set_mint_allowance(master_minter, minter_address, 500);
+        assert!(usdk::mint_allowance(minter_address) == 500);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab)]
+    #[expected_failure(abort_code = 4, location = stablecoin::usdk)]
+    fun test_set_mint_allowance_requires_minter(creator: &signer, master_minter: &signer) {
+        usdk::init_for_test(creator);
+        usdk::set_mint_allowance(master_minter, OUTSIDER, 100);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_set_mint_allowance_requires_master_minter(
+        creator: &signer,
+        master_minter: &signer,
+        minter: &signer,
+        rando: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+        usdk::add_minter(master_minter, minter_address, 100);
+        usdk::set_mint_allowance(rando, minter_address, 500);
+    }
+
+    // ----------------------------------------------------------------------
+    // Pause policy
+    // ----------------------------------------------------------------------
+
+    #[test(creator = @0xcafe, pauser = @0xdafe, master_minter = @0xbab, minter = @0xface)]
+    #[expected_failure(abort_code = 2, location = stablecoin::usdk)]
+    fun test_pause_blocks_mint(
+        creator: &signer,
+        pauser: &signer,
+        master_minter: &signer,
+        minter: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+        usdk::add_minter(master_minter, minter_address, 1000);
         usdk::set_pause(pauser, true);
         usdk::mint(minter, minter_address, 100);
     }
 
-    // Pausing stops value movement, so an in-flight transfer must abort.
-    #[test(creator = @0xcafe, pauser = @0xdafe, minter = @0xface, master_minter = @0xbab)]
+    #[test(creator = @0xcafe, pauser = @0xdafe, master_minter = @0xbab, minter = @0xface)]
     #[expected_failure(abort_code = 2, location = stablecoin::usdk)]
     fun test_pause_blocks_transfer(
         creator: &signer,
         pauser: &signer,
-        minter: &signer,
         master_minter: &signer,
+        minter: &signer,
     ) {
         usdk::init_for_test(creator);
         let asset = usdk::metadata();
         let minter_address = signer::address_of(minter);
 
-        usdk::add_minter(master_minter, minter_address);
+        usdk::add_minter(master_minter, minter_address, 1000);
         usdk::mint(minter, minter_address, 100);
 
         let minter_store = primary_fungible_store::ensure_primary_store_exists(minter_address, asset);
-        let receiver_store = primary_fungible_store::ensure_primary_store_exists(@0xcafe1, asset);
+        let receiver_store = primary_fungible_store::ensure_primary_store_exists(RECEIVER, asset);
 
         usdk::set_pause(pauser, true);
         dispatchable_fungible_asset::transfer(minter, minter_store, receiver_store, 10);
     }
 
-    // Pausing must not disable incident response: role administration and denylisting stay available.
-    #[test(creator = @0xcafe, pauser = @0xdafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
-    fun test_administration_available_while_paused(
+    #[test(creator = @0xcafe, pauser = @0xdafe, master_minter = @0xbab, minter = @0xface)]
+    #[expected_failure(abort_code = 2, location = stablecoin::usdk)]
+    fun test_pause_blocks_burn(
         creator: &signer,
         pauser: &signer,
-        minter: &signer,
         master_minter: &signer,
-        denylister: &signer,
+        minter: &signer,
     ) {
         usdk::init_for_test(creator);
         let minter_address = signer::address_of(minter);
 
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::mint(minter, minter_address, 100);
+        usdk::set_pause(pauser, true);
+        usdk::burn(minter, 10);
+    }
+
+    // Granting new issuing authority must not be possible during an incident.
+    #[test(creator = @0xcafe, pauser = @0xdafe, master_minter = @0xbab)]
+    #[expected_failure(abort_code = 2, location = stablecoin::usdk)]
+    fun test_pause_blocks_add_minter(creator: &signer, pauser: &signer, master_minter: &signer) {
+        usdk::init_for_test(creator);
+        usdk::set_pause(pauser, true);
+        usdk::add_minter(master_minter, OUTSIDER, 100);
+    }
+
+    #[test(creator = @0xcafe, pauser = @0xdafe, master_minter = @0xbab, minter = @0xface)]
+    #[expected_failure(abort_code = 2, location = stablecoin::usdk)]
+    fun test_pause_blocks_allowance_increase(
+        creator: &signer,
+        pauser: &signer,
+        master_minter: &signer,
+        minter: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+        usdk::add_minter(master_minter, minter_address, 100);
+        usdk::set_pause(pauser, true);
+        usdk::set_mint_allowance(master_minter, minter_address, 101);
+    }
+
+    // Recovery actions stay available while paused.
+    #[test(
+        creator = @0xcafe,
+        pauser = @0xdafe,
+        master_minter = @0xbab,
+        minter = @0xface,
+        denylister = @0xcade,
+    )]
+    fun test_recovery_actions_available_while_paused(
+        creator: &signer,
+        pauser: &signer,
+        master_minter: &signer,
+        minter: &signer,
+        denylister: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+        usdk::add_minter(master_minter, minter_address, 1000);
+
         usdk::set_pause(pauser, true);
 
-        usdk::add_minter(master_minter, minter_address);
-        assert!(usdk::is_minter(minter_address));
+        // Allowance decreases are permitted.
+        usdk::set_mint_allowance(master_minter, minter_address, 1);
+        assert!(usdk::mint_allowance(minter_address) == 1);
+
+        // Revocation is permitted.
         usdk::remove_minter(master_minter, minter_address);
         assert!(!usdk::is_minter(minter_address));
 
-        usdk::denylist(denylister, minter_address);
-        assert!(usdk::is_denylisted(minter_address));
+        // Denylisting is permitted.
+        usdk::denylist(denylister, OUTSIDER);
+        assert!(usdk::is_denylisted(OUTSIDER));
+        usdk::undenylist(denylister, OUTSIDER);
+        assert!(!usdk::is_denylisted(OUTSIDER));
     }
 
-    // A denylisted account must not be able to move value out of its own primary store.
-    // The frozen flag is caught by the framework's own withdraw_sanity_check before dispatch
-    // reaches our hook, so this aborts with ESTORE_IS_FROZEN rather than EDENYLISTED.
-    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
+    #[test(creator = @0xcafe, pauser = @0xdafe)]
+    fun test_set_pause_is_idempotent(creator: &signer, pauser: &signer) {
+        usdk::init_for_test(creator);
+        usdk::set_pause(pauser, false);
+        assert!(!usdk::is_paused());
+
+        usdk::set_pause(pauser, true);
+        usdk::set_pause(pauser, true);
+        assert!(usdk::is_paused());
+
+        usdk::set_pause(pauser, false);
+        assert!(!usdk::is_paused());
+    }
+
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_non_pauser_cannot_pause(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::set_pause(rando, true);
+    }
+
+    // ----------------------------------------------------------------------
+    // Denylist
+    // ----------------------------------------------------------------------
+
+    // The framework rejects a frozen primary store before dispatch reaches our
+    // hook, so this surfaces as ESTORE_IS_FROZEN from 0x1::fungible_asset.
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface, denylister = @0xcade)]
     #[expected_failure(abort_code = 327683, location = aptos_framework::fungible_asset)]
     fun test_denylisted_account_cannot_transfer(
         creator: &signer,
-        minter: &signer,
         master_minter: &signer,
+        minter: &signer,
         denylister: &signer,
     ) {
         usdk::init_for_test(creator);
         let asset = usdk::metadata();
         let minter_address = signer::address_of(minter);
 
-        usdk::add_minter(master_minter, minter_address);
+        usdk::add_minter(master_minter, minter_address, 1000);
         usdk::mint(minter, minter_address, 100);
 
         let minter_store = primary_fungible_store::ensure_primary_store_exists(minter_address, asset);
-        let receiver_store = primary_fungible_store::ensure_primary_store_exists(@0xcafe1, asset);
+        let receiver_store = primary_fungible_store::ensure_primary_store_exists(RECEIVER, asset);
 
         usdk::denylist(denylister, minter_address);
         dispatchable_fungible_asset::transfer(minter, minter_store, receiver_store, 10);
     }
 
-    // A denylisted account must not be able to escape the denylist by holding funds in a store
-    // owned by an intermediate object it controls. The framework's withdraw_sanity_check uses
-    // object::owns, which accepts indirect ownership, so only the root_owner check in our
-    // withdraw hook catches this.
-    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
+    // A denylisted account must not escape enforcement by parking funds in a store
+    // owned by an intermediate object it controls. The framework's own check uses
+    // object::owns, which accepts indirect ownership, so only the root_owner check
+    // in the withdraw hook catches this. Two levels of nesting are required: with a
+    // single level the store's direct owner is already the denylisted account.
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface, denylister = @0xcade)]
     #[expected_failure(abort_code = 5, location = stablecoin::usdk)]
     fun test_denylist_not_bypassable_via_nested_store(
         creator: &signer,
-        minter: &signer,
         master_minter: &signer,
+        minter: &signer,
         denylister: &signer,
     ) {
         usdk::init_for_test(creator);
         let asset = usdk::metadata();
         let minter_address = signer::address_of(minter);
 
-        usdk::add_minter(master_minter, minter_address);
+        usdk::add_minter(master_minter, minter_address, 1000);
         usdk::mint(minter, minter_address, 100);
 
-        // Park funds in a store owned by an intermediate object, which is in turn owned by the
-        // minter. Two levels are required: with a single level the store's direct owner is already
-        // the minter, so the store.owner() check alone would catch it.
         let outer_ref = object::create_object(minter_address);
         let inner_ref = object::create_object(outer_ref.address_from_constructor_ref());
         fungible_asset::create_store(&inner_ref, asset);
@@ -149,137 +434,74 @@ module stablecoin::usdk_tests {
 
         usdk::denylist(denylister, minter_address);
 
-        // The nested store itself is not frozen and is only indirectly owned, so the framework
-        // check passes; the denylist must still be enforced by our hook.
-        let receiver_store = primary_fungible_store::ensure_primary_store_exists(@0xcafe1, asset);
+        let receiver_store = primary_fungible_store::ensure_primary_store_exists(RECEIVER, asset);
         dispatchable_fungible_asset::transfer(minter, nested_store, receiver_store, 10);
     }
 
-    // Minting to a denylisted account must abort.
-    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
+    // The deposit hook must also reject a denylisted root owner.
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface, denylister = @0xcade)]
     #[expected_failure(abort_code = 5, location = stablecoin::usdk)]
-    fun test_cannot_mint_to_denylisted_account(
+    fun test_denylist_blocks_deposit_into_nested_store(
         creator: &signer,
-        minter: &signer,
         master_minter: &signer,
+        minter: &signer,
         denylister: &signer,
     ) {
         usdk::init_for_test(creator);
+        let asset = usdk::metadata();
         let minter_address = signer::address_of(minter);
 
-        usdk::add_minter(master_minter, minter_address);
-        usdk::denylist(denylister, @0xcafe1);
-        usdk::mint(minter, @0xcafe1, 100);
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::mint(minter, minter_address, 100);
+
+        let outer_ref = object::create_object(OUTSIDER);
+        let inner_ref = object::create_object(outer_ref.address_from_constructor_ref());
+        fungible_asset::create_store(&inner_ref, asset);
+        let nested_store = inner_ref.object_from_constructor_ref<FungibleStore>();
+
+        usdk::denylist(denylister, OUTSIDER);
+
+        let minter_store = primary_fungible_store::ensure_primary_store_exists(minter_address, asset);
+        dispatchable_fungible_asset::transfer(minter, minter_store, nested_store, 10);
     }
 
-    // Role checks: a non-minter must not be able to mint.
-    #[test(creator = @0xcafe, rando = @0xdead)]
-    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
-    fun test_non_minter_cannot_mint(creator: &signer, rando: &signer) {
+    #[test(creator = @0xcafe, denylister = @0xcade)]
+    fun test_denylist_is_idempotent(creator: &signer, denylister: &signer) {
         usdk::init_for_test(creator);
-        usdk::mint(rando, signer::address_of(rando), 100);
+
+        usdk::denylist(denylister, RECEIVER);
+        usdk::denylist(denylister, RECEIVER);
+        assert!(usdk::is_denylisted(RECEIVER));
+
+        usdk::undenylist(denylister, RECEIVER);
+        usdk::undenylist(denylister, RECEIVER);
+        assert!(!usdk::is_denylisted(RECEIVER));
     }
 
-    // Role checks: a non-master-minter must not be able to grant the minter role.
-    #[test(creator = @0xcafe, rando = @0xdead)]
-    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
-    fun test_non_master_minter_cannot_add_minter(creator: &signer, rando: &signer) {
+    // Undenylisting an address that never held the asset must not create a store.
+    #[test(creator = @0xcafe, denylister = @0xcade)]
+    fun test_undenylist_does_not_create_store(creator: &signer, denylister: &signer) {
         usdk::init_for_test(creator);
-        usdk::add_minter(rando, signer::address_of(rando));
+
+        usdk::undenylist(denylister, OUTSIDER);
+        assert!(!primary_fungible_store::primary_store_exists(OUTSIDER, usdk::metadata()));
+        assert!(!usdk::is_denylisted(OUTSIDER));
     }
 
-    // Role checks: a non-denylister must not be able to denylist.
     #[test(creator = @0xcafe, rando = @0xdead)]
     #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
     fun test_non_denylister_cannot_denylist(creator: &signer, rando: &signer) {
         usdk::init_for_test(creator);
-        usdk::denylist(rando, @0xcafe1);
+        usdk::denylist(rando, RECEIVER);
     }
 
-    // Role checks: a non-pauser must not be able to pause.
     #[test(creator = @0xcafe, rando = @0xdead)]
     #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
-    fun test_non_pauser_cannot_pause(creator: &signer, rando: &signer) {
+    fun test_non_denylister_cannot_undenylist(creator: &signer, rando: &signer) {
         usdk::init_for_test(creator);
-        usdk::set_pause(rando, true);
+        usdk::undenylist(rando, RECEIVER);
     }
 
-    // Granting the minter role twice must abort rather than duplicate the entry.
-    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab)]
-    #[expected_failure(abort_code = 3, location = stablecoin::usdk)]
-    fun test_add_minter_twice_aborts(creator: &signer, minter: &signer, master_minter: &signer) {
-        usdk::init_for_test(creator);
-        let minter_address = signer::address_of(minter);
-        usdk::add_minter(master_minter, minter_address);
-        usdk::add_minter(master_minter, minter_address);
-    }
-
-    // Revoking the minter role must actually stop minting.
-    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab)]
-    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
-    fun test_removed_minter_cannot_mint(creator: &signer, minter: &signer, master_minter: &signer) {
-        usdk::init_for_test(creator);
-        let minter_address = signer::address_of(minter);
-
-        usdk::add_minter(master_minter, minter_address);
-        usdk::mint(minter, minter_address, 100);
-        usdk::remove_minter(master_minter, minter_address);
-
-        usdk::mint(minter, minter_address, 100);
-    }
-
-    // Burning from an account with no store must abort rather than silently creating one.
-    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab)]
-    #[expected_failure(abort_code = 7, location = stablecoin::usdk)]
-    fun test_burn_without_store_aborts(creator: &signer, minter: &signer, master_minter: &signer) {
-        usdk::init_for_test(creator);
-        let minter_address = signer::address_of(minter);
-
-        usdk::add_minter(master_minter, minter_address);
-        usdk::burn(minter, @0xcafe1, 100);
-
-        assert!(!primary_fungible_store::primary_store_exists(@0xcafe1, usdk::metadata()));
-    }
-
-    // The view functions must reflect pause, minter and denylist state.
-    #[test(creator = @0xcafe, pauser = @0xdafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
-    fun test_views(
-        creator: &signer,
-        pauser: &signer,
-        minter: &signer,
-        master_minter: &signer,
-        denylister: &signer,
-    ) {
-        usdk::init_for_test(creator);
-        let minter_address = signer::address_of(minter);
-
-        assert!(!usdk::is_paused());
-        assert!(!usdk::is_minter(minter_address));
-        assert!(!usdk::is_denylisted(minter_address));
-        assert!(usdk::master_minter() == signer::address_of(master_minter));
-        assert!(usdk::pauser() == signer::address_of(pauser));
-        assert!(usdk::denylister() == signer::address_of(denylister));
-        assert!(usdk::minters().is_empty());
-
-        usdk::add_minter(master_minter, minter_address);
-        assert!(usdk::is_minter(minter_address));
-        assert!(usdk::minters() == vector[minter_address]);
-
-        // The master minter may mint without being listed explicitly.
-        assert!(usdk::is_minter(signer::address_of(master_minter)));
-
-        usdk::set_pause(pauser, true);
-        assert!(usdk::is_paused());
-        usdk::set_pause(pauser, false);
-        assert!(!usdk::is_paused());
-
-        usdk::denylist(denylister, minter_address);
-        assert!(usdk::is_denylisted(minter_address));
-        usdk::undenylist(denylister, minter_address);
-        assert!(!usdk::is_denylisted(minter_address));
-    }
-
-    // test the ability of a denylisted account to transfer out newly created store
     #[test(creator = @0xcafe, denylister = @0xcade, receiver = @0xdead)]
     #[expected_failure(abort_code = 327683, location = aptos_framework::object)]
     fun test_untransferrable_store(creator: &signer, denylister: &signer, receiver: &signer) {
@@ -288,12 +510,257 @@ module stablecoin::usdk_tests {
         let asset = usdk::metadata();
 
         usdk::denylist(denylister, receiver_address);
-        assert!(primary_fungible_store::is_frozen(receiver_address, asset));
+        assert!(usdk::is_denylisted(receiver_address));
 
         let constructor_ref = object::create_object(receiver_address);
         fungible_asset::create_store(&constructor_ref, asset);
         let store = constructor_ref.object_from_constructor_ref();
 
         object::transfer<FungibleStore>(receiver, store, @0xdeadbeef);
+    }
+
+    // ----------------------------------------------------------------------
+    // Burn (self) and confiscation
+    // ----------------------------------------------------------------------
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    fun test_burn_zero_is_noop(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::mint(minter, minter_address, 10);
+        usdk::burn(minter, 0);
+        assert!(primary_fungible_store::balance(minter_address, usdk::metadata()) == 10);
+    }
+
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_burn_requires_minter(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::burn(rando, 1);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    #[expected_failure(abort_code = 7, location = stablecoin::usdk)]
+    fun test_burn_without_store_aborts(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::burn(minter, 1);
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface, confiscator = @0xc0ffee)]
+    fun test_confiscate_burns_holder_balance(
+        creator: &signer,
+        master_minter: &signer,
+        minter: &signer,
+        confiscator: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let asset = usdk::metadata();
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::mint(minter, RECEIVER, 100);
+
+        usdk::confiscate(confiscator, RECEIVER, 40);
+        assert!(primary_fungible_store::balance(RECEIVER, asset) == 60);
+    }
+
+    // Confiscation must work against a frozen account, which is the point of it.
+    #[test(
+        creator = @0xcafe,
+        master_minter = @0xbab,
+        minter = @0xface,
+        denylister = @0xcade,
+        confiscator = @0xc0ffee,
+    )]
+    fun test_confiscate_works_on_denylisted_account(
+        creator: &signer,
+        master_minter: &signer,
+        minter: &signer,
+        denylister: &signer,
+        confiscator: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let asset = usdk::metadata();
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::mint(minter, RECEIVER, 100);
+        usdk::denylist(denylister, RECEIVER);
+
+        usdk::confiscate(confiscator, RECEIVER, 100);
+        assert!(primary_fungible_store::balance(RECEIVER, asset) == 0);
+    }
+
+    // Confiscation is a recovery action and stays available while paused.
+    #[test(
+        creator = @0xcafe,
+        pauser = @0xdafe,
+        master_minter = @0xbab,
+        minter = @0xface,
+        confiscator = @0xc0ffee,
+    )]
+    fun test_confiscate_allowed_while_paused(
+        creator: &signer,
+        pauser: &signer,
+        master_minter: &signer,
+        minter: &signer,
+        confiscator: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::mint(minter, RECEIVER, 100);
+        usdk::set_pause(pauser, true);
+
+        usdk::confiscate(confiscator, RECEIVER, 100);
+        assert!(primary_fungible_store::balance(RECEIVER, usdk::metadata()) == 0);
+    }
+
+    #[test(creator = @0xcafe, confiscator = @0xc0ffee)]
+    fun test_confiscate_zero_is_noop(creator: &signer, confiscator: &signer) {
+        usdk::init_for_test(creator);
+        usdk::confiscate(confiscator, OUTSIDER, 0);
+        assert!(!primary_fungible_store::primary_store_exists(OUTSIDER, usdk::metadata()));
+    }
+
+    #[test(creator = @0xcafe, confiscator = @0xc0ffee)]
+    #[expected_failure(abort_code = 7, location = stablecoin::usdk)]
+    fun test_confiscate_without_store_aborts(creator: &signer, confiscator: &signer) {
+        usdk::init_for_test(creator);
+        usdk::confiscate(confiscator, OUTSIDER, 1);
+    }
+
+    // A minter must not be able to destroy someone else's balance.
+    #[test(creator = @0xcafe, master_minter = @0xbab, minter = @0xface)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_minter_cannot_confiscate(creator: &signer, master_minter: &signer, minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address, 1000);
+        usdk::mint(minter, RECEIVER, 100);
+        usdk::confiscate(minter, RECEIVER, 100);
+    }
+
+    // ----------------------------------------------------------------------
+    // Two-step role rotation
+    // ----------------------------------------------------------------------
+
+    #[test(creator = @0xcafe, pauser = @0xdafe, rando = @0xdead)]
+    fun test_pauser_rotation(creator: &signer, pauser: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        let new_pauser = signer::address_of(rando);
+
+        usdk::propose_pauser(pauser, new_pauser);
+        assert!(usdk::pending_pauser() == option::some(new_pauser));
+        // A proposal alone grants nothing.
+        assert!(usdk::pauser() == signer::address_of(pauser));
+
+        usdk::accept_pauser(rando);
+        assert!(usdk::pauser() == new_pauser);
+        assert!(usdk::pending_pauser() == option::none());
+
+        usdk::set_pause(rando, true);
+        assert!(usdk::is_paused());
+    }
+
+    #[test(creator = @0xcafe, master_minter = @0xbab, rando = @0xdead)]
+    fun test_master_minter_rotation(creator: &signer, master_minter: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        let new_holder = signer::address_of(rando);
+
+        usdk::propose_master_minter(master_minter, new_holder);
+        assert!(usdk::pending_master_minter() == option::some(new_holder));
+        usdk::accept_master_minter(rando);
+        assert!(usdk::master_minter() == new_holder);
+
+        usdk::add_minter(rando, OUTSIDER, 5);
+        assert!(usdk::is_minter(OUTSIDER));
+    }
+
+    #[test(creator = @0xcafe, denylister = @0xcade, rando = @0xdead)]
+    fun test_denylister_rotation(creator: &signer, denylister: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        let new_holder = signer::address_of(rando);
+
+        usdk::propose_denylister(denylister, new_holder);
+        assert!(usdk::pending_denylister() == option::some(new_holder));
+        usdk::accept_denylister(rando);
+        assert!(usdk::denylister() == new_holder);
+
+        usdk::denylist(rando, RECEIVER);
+        assert!(usdk::is_denylisted(RECEIVER));
+    }
+
+    #[test(creator = @0xcafe, confiscator = @0xc0ffee, rando = @0xdead)]
+    fun test_confiscator_rotation(creator: &signer, confiscator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        let new_holder = signer::address_of(rando);
+
+        usdk::propose_confiscator(confiscator, new_holder);
+        assert!(usdk::pending_confiscator() == option::some(new_holder));
+        usdk::accept_confiscator(rando);
+        assert!(usdk::confiscator() == new_holder);
+    }
+
+    // A proposal can be replaced before it is accepted.
+    #[test(creator = @0xcafe, pauser = @0xdafe, rando = @0xdead)]
+    fun test_proposal_can_be_replaced(creator: &signer, pauser: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+
+        usdk::propose_pauser(pauser, OUTSIDER);
+        usdk::propose_pauser(pauser, RECEIVER);
+        assert!(usdk::pending_pauser() == option::some(RECEIVER));
+
+        // The superseded address can no longer accept.
+        assert!(usdk::pauser() == signer::address_of(pauser));
+        let _ = rando;
+    }
+
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_propose_role_requires_current_holder(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::propose_pauser(rando, OUTSIDER);
+    }
+
+    #[test(creator = @0xcafe, pauser = @0xdafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_accept_role_requires_proposed_holder(
+        creator: &signer,
+        pauser: &signer,
+        rando: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        usdk::propose_pauser(pauser, RECEIVER);
+        usdk::accept_pauser(rando);
+    }
+
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_accept_role_without_proposal_aborts(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::accept_pauser(rando);
+    }
+
+    // Role handoff is a recovery action and stays available while paused.
+    #[test(creator = @0xcafe, pauser = @0xdafe, rando = @0xdead)]
+    fun test_role_rotation_allowed_while_paused(
+        creator: &signer,
+        pauser: &signer,
+        rando: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        usdk::set_pause(pauser, true);
+
+        usdk::propose_pauser(pauser, signer::address_of(rando));
+        usdk::accept_pauser(rando);
+        assert!(usdk::pauser() == signer::address_of(rando));
     }
 }

--- a/aptos-move/move-examples/fungible_asset/stablecoin/tests/usdk_tests.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/tests/usdk_tests.move
@@ -1,11 +1,11 @@
 #[test_only]
 module stablecoin::usdk_tests {
-    use std::signer;
     use aptos_framework::primary_fungible_store;
     use aptos_framework::dispatchable_fungible_asset;
     use aptos_framework::fungible_asset::{Self, FungibleStore};
-    use stablecoin::usdk;
     use aptos_framework::object;
+    use stablecoin::usdk;
+    use std::signer;
 
     #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
     fun test_basic_flow(creator: &signer, minter: &signer, master_minter: &signer, denylister: &signer) {
@@ -17,7 +17,7 @@ module stablecoin::usdk_tests {
         usdk::add_minter(master_minter, minter_address);
         usdk::mint(minter, minter_address, 100);
         let asset = usdk::metadata();
-        assert!(primary_fungible_store::balance(minter_address, asset) == 100, 0);
+        assert!(primary_fungible_store::balance(minter_address, asset) == 100);
 
         // transfer from minter to receiver, check balance
         let minter_store = primary_fungible_store::ensure_primary_store_exists(minter_address, asset);
@@ -26,13 +26,13 @@ module stablecoin::usdk_tests {
 
         // denylist account, check if account is denylisted
         usdk::denylist(denylister, receiver_address);
-        assert!(primary_fungible_store::is_frozen(receiver_address, asset), 0);
+        assert!(primary_fungible_store::is_frozen(receiver_address, asset));
         usdk::undenylist(denylister, receiver_address);
-        assert!(!primary_fungible_store::is_frozen(receiver_address, asset), 0);
+        assert!(!primary_fungible_store::is_frozen(receiver_address, asset));
 
         // burn tokens, check balance
         usdk::burn(minter, minter_address, 90);
-        assert!(primary_fungible_store::balance(minter_address, asset) == 0, 0);
+        assert!(primary_fungible_store::balance(minter_address, asset) == 0);
     }
 
 
@@ -54,12 +54,12 @@ module stablecoin::usdk_tests {
         let asset = usdk::metadata();
 
         usdk::denylist(denylister, receiver_address);
-        assert!(primary_fungible_store::is_frozen(receiver_address, asset), 0);
+        assert!(primary_fungible_store::is_frozen(receiver_address, asset));
 
         let constructor_ref = object::create_object(receiver_address);
         fungible_asset::create_store(&constructor_ref, asset);
-        let store = object::object_from_constructor_ref<FungibleStore>(&constructor_ref);
+        let store = constructor_ref.object_from_constructor_ref();
 
-        object::transfer(receiver, store, @0xdeadbeef);
+        object::transfer<FungibleStore>(receiver, store, @0xdeadbeef);
     }
 }

--- a/aptos-move/move-examples/fungible_asset/stablecoin/tests/usdk_tests.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/tests/usdk_tests.move
@@ -41,8 +41,242 @@ module stablecoin::usdk_tests {
     fun test_pause(creator: &signer, pauser: &signer, minter: &signer, master_minter: &signer) {
         usdk::init_for_test(creator);
         let minter_address = signer::address_of(minter);
-        usdk::set_pause(pauser, true);
         usdk::add_minter(master_minter, minter_address);
+        usdk::set_pause(pauser, true);
+        usdk::mint(minter, minter_address, 100);
+    }
+
+    // Pausing stops value movement, so an in-flight transfer must abort.
+    #[test(creator = @0xcafe, pauser = @0xdafe, minter = @0xface, master_minter = @0xbab)]
+    #[expected_failure(abort_code = 2, location = stablecoin::usdk)]
+    fun test_pause_blocks_transfer(
+        creator: &signer,
+        pauser: &signer,
+        minter: &signer,
+        master_minter: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let asset = usdk::metadata();
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address);
+        usdk::mint(minter, minter_address, 100);
+
+        let minter_store = primary_fungible_store::ensure_primary_store_exists(minter_address, asset);
+        let receiver_store = primary_fungible_store::ensure_primary_store_exists(@0xcafe1, asset);
+
+        usdk::set_pause(pauser, true);
+        dispatchable_fungible_asset::transfer(minter, minter_store, receiver_store, 10);
+    }
+
+    // Pausing must not disable incident response: role administration and denylisting stay available.
+    #[test(creator = @0xcafe, pauser = @0xdafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
+    fun test_administration_available_while_paused(
+        creator: &signer,
+        pauser: &signer,
+        minter: &signer,
+        master_minter: &signer,
+        denylister: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::set_pause(pauser, true);
+
+        usdk::add_minter(master_minter, minter_address);
+        assert!(usdk::is_minter(minter_address));
+        usdk::remove_minter(master_minter, minter_address);
+        assert!(!usdk::is_minter(minter_address));
+
+        usdk::denylist(denylister, minter_address);
+        assert!(usdk::is_denylisted(minter_address));
+    }
+
+    // A denylisted account must not be able to move value out of its own primary store.
+    // The frozen flag is caught by the framework's own withdraw_sanity_check before dispatch
+    // reaches our hook, so this aborts with ESTORE_IS_FROZEN rather than EDENYLISTED.
+    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
+    #[expected_failure(abort_code = 327683, location = aptos_framework::fungible_asset)]
+    fun test_denylisted_account_cannot_transfer(
+        creator: &signer,
+        minter: &signer,
+        master_minter: &signer,
+        denylister: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let asset = usdk::metadata();
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address);
+        usdk::mint(minter, minter_address, 100);
+
+        let minter_store = primary_fungible_store::ensure_primary_store_exists(minter_address, asset);
+        let receiver_store = primary_fungible_store::ensure_primary_store_exists(@0xcafe1, asset);
+
+        usdk::denylist(denylister, minter_address);
+        dispatchable_fungible_asset::transfer(minter, minter_store, receiver_store, 10);
+    }
+
+    // A denylisted account must not be able to escape the denylist by holding funds in a store
+    // owned by an intermediate object it controls. The framework's withdraw_sanity_check uses
+    // object::owns, which accepts indirect ownership, so only the root_owner check in our
+    // withdraw hook catches this.
+    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
+    #[expected_failure(abort_code = 5, location = stablecoin::usdk)]
+    fun test_denylist_not_bypassable_via_nested_store(
+        creator: &signer,
+        minter: &signer,
+        master_minter: &signer,
+        denylister: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let asset = usdk::metadata();
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address);
+        usdk::mint(minter, minter_address, 100);
+
+        // Park funds in a store owned by an intermediate object, which is in turn owned by the
+        // minter. Two levels are required: with a single level the store's direct owner is already
+        // the minter, so the store.owner() check alone would catch it.
+        let outer_ref = object::create_object(minter_address);
+        let inner_ref = object::create_object(outer_ref.address_from_constructor_ref());
+        fungible_asset::create_store(&inner_ref, asset);
+        let nested_store = inner_ref.object_from_constructor_ref<FungibleStore>();
+
+        let minter_store = primary_fungible_store::ensure_primary_store_exists(minter_address, asset);
+        dispatchable_fungible_asset::transfer(minter, minter_store, nested_store, 50);
+
+        usdk::denylist(denylister, minter_address);
+
+        // The nested store itself is not frozen and is only indirectly owned, so the framework
+        // check passes; the denylist must still be enforced by our hook.
+        let receiver_store = primary_fungible_store::ensure_primary_store_exists(@0xcafe1, asset);
+        dispatchable_fungible_asset::transfer(minter, nested_store, receiver_store, 10);
+    }
+
+    // Minting to a denylisted account must abort.
+    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
+    #[expected_failure(abort_code = 5, location = stablecoin::usdk)]
+    fun test_cannot_mint_to_denylisted_account(
+        creator: &signer,
+        minter: &signer,
+        master_minter: &signer,
+        denylister: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address);
+        usdk::denylist(denylister, @0xcafe1);
+        usdk::mint(minter, @0xcafe1, 100);
+    }
+
+    // Role checks: a non-minter must not be able to mint.
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_non_minter_cannot_mint(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::mint(rando, signer::address_of(rando), 100);
+    }
+
+    // Role checks: a non-master-minter must not be able to grant the minter role.
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_non_master_minter_cannot_add_minter(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::add_minter(rando, signer::address_of(rando));
+    }
+
+    // Role checks: a non-denylister must not be able to denylist.
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_non_denylister_cannot_denylist(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::denylist(rando, @0xcafe1);
+    }
+
+    // Role checks: a non-pauser must not be able to pause.
+    #[test(creator = @0xcafe, rando = @0xdead)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_non_pauser_cannot_pause(creator: &signer, rando: &signer) {
+        usdk::init_for_test(creator);
+        usdk::set_pause(rando, true);
+    }
+
+    // Granting the minter role twice must abort rather than duplicate the entry.
+    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab)]
+    #[expected_failure(abort_code = 3, location = stablecoin::usdk)]
+    fun test_add_minter_twice_aborts(creator: &signer, minter: &signer, master_minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+        usdk::add_minter(master_minter, minter_address);
+        usdk::add_minter(master_minter, minter_address);
+    }
+
+    // Revoking the minter role must actually stop minting.
+    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab)]
+    #[expected_failure(abort_code = 1, location = stablecoin::usdk)]
+    fun test_removed_minter_cannot_mint(creator: &signer, minter: &signer, master_minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address);
+        usdk::mint(minter, minter_address, 100);
+        usdk::remove_minter(master_minter, minter_address);
+
+        usdk::mint(minter, minter_address, 100);
+    }
+
+    // Burning from an account with no store must abort rather than silently creating one.
+    #[test(creator = @0xcafe, minter = @0xface, master_minter = @0xbab)]
+    #[expected_failure(abort_code = 7, location = stablecoin::usdk)]
+    fun test_burn_without_store_aborts(creator: &signer, minter: &signer, master_minter: &signer) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        usdk::add_minter(master_minter, minter_address);
+        usdk::burn(minter, @0xcafe1, 100);
+
+        assert!(!primary_fungible_store::primary_store_exists(@0xcafe1, usdk::metadata()));
+    }
+
+    // The view functions must reflect pause, minter and denylist state.
+    #[test(creator = @0xcafe, pauser = @0xdafe, minter = @0xface, master_minter = @0xbab, denylister = @0xcade)]
+    fun test_views(
+        creator: &signer,
+        pauser: &signer,
+        minter: &signer,
+        master_minter: &signer,
+        denylister: &signer,
+    ) {
+        usdk::init_for_test(creator);
+        let minter_address = signer::address_of(minter);
+
+        assert!(!usdk::is_paused());
+        assert!(!usdk::is_minter(minter_address));
+        assert!(!usdk::is_denylisted(minter_address));
+        assert!(usdk::master_minter() == signer::address_of(master_minter));
+        assert!(usdk::pauser() == signer::address_of(pauser));
+        assert!(usdk::denylister() == signer::address_of(denylister));
+        assert!(usdk::minters().is_empty());
+
+        usdk::add_minter(master_minter, minter_address);
+        assert!(usdk::is_minter(minter_address));
+        assert!(usdk::minters() == vector[minter_address]);
+
+        // The master minter may mint without being listed explicitly.
+        assert!(usdk::is_minter(signer::address_of(master_minter)));
+
+        usdk::set_pause(pauser, true);
+        assert!(usdk::is_paused());
+        usdk::set_pause(pauser, false);
+        assert!(!usdk::is_paused());
+
+        usdk::denylist(denylister, minter_address);
+        assert!(usdk::is_denylisted(minter_address));
+        usdk::undenylist(denylister, minter_address);
+        assert!(!usdk::is_denylisted(minter_address));
     }
 
     // test the ability of a denylisted account to transfer out newly created store


### PR DESCRIPTION
## Description

Hardens the fungible-asset stablecoin example (`aptos-move/move-examples/fungible_asset/stablecoin`) with bounded issuance, least-privilege administration, recovery-safe pause behavior, and nested-store denylist enforcement.

Changes are confined to that example package; no other contracts or crates are touched.

### Security and safety

- **Bounded issuance.** Replaces the unbounded minter vector with address-keyed finite mint allowances, debited before minting. A compromised minter key can now issue at most its remaining allowance. This also removes the O(n) scan that previously ran on every mint authorization.
- **Least privilege on burn.** `burn` now only destroys the caller's own balance. Destroying another account's balance requires a new, separately-held `confiscator` role via `confiscate`, which emits its own event. Previously any minter could burn from any holder.
- **Two-step role rotation.** `propose_*` / `accept_*` for master-minter, pauser, denylister, and confiscator. A proposal confers no authority until accepted, so a mistyped address cannot strand a role.
- **Recovery-safe pause.** Pause blocks value movement (mint, burn, transfer) and blocks *expanding* issuing authority (`add_minter`, allowance increases). It leaves recovery available: minter revocation, allowance decreases, denylisting, confiscation, and role rotation. Previously the denylister was locked out by the pause — precisely when it was needed.
- **Nested-store denylist enforcement.** The withdraw/deposit hooks check the store's root owner as well as its direct owner. The framework's own check uses `object::owns`, which accepts indirect ownership, so a denylisted account could otherwise move funds through a store owned by an intermediate object it controlled.
- **Removed replayable approval code.** The disabled `transfer_from` and its `Approval` struct are deleted rather than left commented out. Its nonce was the account sequence number, which the function never advanced, so a single signed approval was replayable while the owner stayed inactive. A safe replacement needs a contract-owned nonce, deadline, domain separation, and cancellation.
- **No store side effects.** Burning from an account with no primary store now aborts instead of silently creating one; undenylisting an address that never held USDK no longer creates a store just to clear a flag.
- **Events** for issuance, burns, confiscation, minter configuration/removal, and role handoffs.

Initialization intentionally remains an explicit post-publish `initialize` entry call rather than `init_module`.

## How Has This Been Tested?

```
aptos move test --coverage --dev --skip-fetch-latest-git-deps
Test result: OK. Total tests: 54; passed: 54; failed: 0
>>> % Module coverage: 95.72
0 compiler warnings
```

Coverage alone doesn't prove tests have teeth, so each security invariant was mutation-tested: the check was individually removed, the guarding test run, and the source restored. **8/8 mutations killed** — every one of the following caused its test to fail:

| Mutation | Caught by |
| --- | --- |
| Drop root-owner check in hooks | `test_denylist_not_bypassable_via_nested_store` |
| Drop allowance decrement | `test_mint_decrements_allowance` |
| Drop allowance sufficiency check | `test_mint_beyond_allowance_aborts` |
| Allow `add_minter` while paused | `test_pause_blocks_add_minter` |
| Allow allowance increase while paused | `test_pause_blocks_allowance_increase` |
| Drop confiscator authorization | `test_minter_cannot_confiscate` |
| Drop nominee check in `accept_role` | `test_accept_role_requires_proposed_holder` |
| Drop no-store guard in `undenylist` | `test_undenylist_does_not_create_store` |

This process caught a genuinely vacuous test during development: an earlier nested-store test passed even with the root-owner check removed, because one level of object nesting still leaves the denylisted account as the store's *direct* owner. It needed two levels to actually exercise the fix.

Tests cover both paths: authorization failures for every role, paused-vs-recovery administration, allowance exhaustion, nested-store denylist bypass on both withdraw and deposit, confiscation of frozen accounts, idempotent pause/denylist, and role handoff including replaced and unauthorized proposals.

## Key Areas to Review

- **`sources/usdk.move`** — allowance accounting in `mint` (allowance is debited before assets are created), the pause policy split in `set_mint_allowance` (increases gated, decreases not), and `assert_store_not_denylisted`, which skips the second lookup when direct and root owner match.
- **`DESIGN.md`** — the intended security model, including the pause policy and the documented non-goals.
- **`Move.toml`** — adds a `confiscator` named address. **Existing deploy scripts must pass this new address or the publish will fail.**
- **`README.md`** — documents the publish → `initialize` → `add_minter` → `mint` lifecycle.

Note: `AptosFramework` remains pinned to `rev = "mainnet"`, consistent with the other example manifests in this repo.

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Performance improvement
- [x] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Other (specify): Move stablecoin example only (`aptos-move/move-examples/fungible_asset/stablecoin`)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large security-model changes to mint/burn/confiscation, pause, and denylist in Move example code; scope is limited to the stablecoin example but patterns are issuance- and compliance-sensitive.
> 
> **Overview**
> **Hardens the fungible-asset stablecoin example** with bounded issuance, split burn/confiscation roles, recovery-aware pause, nested-store denylist checks, and documented security model (`DESIGN.md`).
> 
> **Issuance & minting:** Replaces the minter `vector` with an address-keyed **mint allowance table**; `add_minter` now takes an allowance, mint debits allowance before minting, and the master minter no longer mints implicitly. Decimals change from 8 to **6**; deploy requires a new **`confiscator`** named address in `Move.toml`.
> 
> **Lifecycle:** Drops `init_module` for an explicit **`initialize` entry**; removes broken **`transfer_from`** / `Approval` (replayable nonce). **`burn`** only destroys the caller’s balance; **`confiscate`** (confiscator role) burns others’ balances and stays available while paused / on frozen accounts.
> 
> **Administration:** **Two-step `propose_*` / `accept_*`** for master minter, pauser, denylister, and confiscator. **Pause** blocks mint/burn/transfer and blocks expanding authority (`add_minter`, allowance increases) while still allowing revocation, allowance decreases, denylist ops, confiscation, and role rotation. Denylist hooks check **direct and root store owners**; denylist/undenylist no longer require unpause.
> 
> **Tests & docs:** Replaces a small in-package test module with a large **`tests/usdk_tests.move`** suite (~54 tests); README documents publish → initialize → add_minter → mint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7622d146af9e9e0c09238bc6425eb8e21848248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->