### PR TITLE
[state-sync] Serve hot state snapshots

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,7 +38,6 @@ xclippy = [
   "-Aclippy::unnecessary_sort_by",
   "-Aclippy::unneeded_wildcard_pattern",
   "-Aclippy::useless_borrows_in_formatting",
-  "-Aclippy::useless_conversion",
   "-Aclippy::useless_format",
   "-Aclippy::while_let_loop",
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,7 +30,6 @@ xclippy = [
   "-Aclippy::manual_filter",
   "-Aclippy::map_or_identity",
   "-Aclippy::missing_spin_loop",
-  "-Aclippy::needless_late_init",
   "-Aclippy::needless_return_with_question_mark",
   "-Aclippy::question_mark",
   "-Aclippy::single_range_in_vec_init",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,6 +19,30 @@ xclippy = [
   "-Aclippy::result-large-err",
   "-Aclippy::sliced-string-as-bytes",
   "-Aclippy::upper_case_acronyms",
+  # New/expanded lints surfaced by the Rust 1.98 upgrade, suppressed to keep the
+  # toolchain bump mechanical. TODO: clean these up separately.
+  "-Aclippy::chunks_exact_to_as_chunks",
+  "-Aclippy::cloned_ref_to_slice_refs",
+  "-Aclippy::drain_collect",
+  "-Aclippy::explicit_counter_loop",
+  "-Aclippy::extra_unused_lifetimes",
+  "-Aclippy::for_kv_map",
+  "-Aclippy::iter_kv_map",
+  "-Aclippy::manual_checked_ops",
+  "-Aclippy::manual_clear",
+  "-Aclippy::manual_filter",
+  "-Aclippy::map_or_identity",
+  "-Aclippy::missing_spin_loop",
+  "-Aclippy::needless_late_init",
+  "-Aclippy::needless_return_with_question_mark",
+  "-Aclippy::question_mark",
+  "-Aclippy::single_range_in_vec_init",
+  "-Aclippy::unnecessary_sort_by",
+  "-Aclippy::unneeded_wildcard_pattern",
+  "-Aclippy::useless_borrows_in_formatting",
+  "-Aclippy::useless_conversion",
+  "-Aclippy::useless_format",
+  "-Aclippy::while_let_loop",
 ]
 x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 build-perf = ["build", "--profile", "performance", "--config", ".cargo/performance.toml"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,7 +26,6 @@ xclippy = [
   "-Aclippy::drain_collect",
   "-Aclippy::explicit_counter_loop",
   "-Aclippy::extra_unused_lifetimes",
-  "-Aclippy::for_kv_map",
   "-Aclippy::iter_kv_map",
   "-Aclippy::manual_checked_ops",
   "-Aclippy::manual_clear",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,7 +26,6 @@ xclippy = [
   "-Aclippy::drain_collect",
   "-Aclippy::explicit_counter_loop",
   "-Aclippy::extra_unused_lifetimes",
-  "-Aclippy::iter_kv_map",
   "-Aclippy::manual_checked_ops",
   "-Aclippy::manual_clear",
   "-Aclippy::manual_filter",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,7 +27,6 @@ xclippy = [
   "-Aclippy::explicit_counter_loop",
   "-Aclippy::extra_unused_lifetimes",
   "-Aclippy::manual_checked_ops",
-  "-Aclippy::manual_clear",
   "-Aclippy::manual_filter",
   "-Aclippy::map_or_identity",
   "-Aclippy::missing_spin_loop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ license = "LicenseRef-Aptos"
 license-file = "LICENSE"
 publish = false
 repository = "https://github.com/aptos-labs/aptos-core"
-rust-version = "1.88"
+rust-version = "1.93"
 
 [workspace.dependencies]
 # Internal crate dependencies.

--- a/api/src/view_function.rs
+++ b/api/src/view_function.rs
@@ -211,7 +211,7 @@ fn view_request(
 
             let move_vals = values
                 .into_iter()
-                .zip(return_types.into_iter())
+                .zip(return_types)
                 .map(|(v, ty)| {
                     state_view
                         .as_converter(context.db.clone(), context.indexer_reader.clone())

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -346,7 +346,7 @@ impl AptosDebugger {
         let mut cur = vec![];
         let mut cur_aux_infos = vec![];
         let mut cur_version = begin;
-        for (txn, aux_info) in txns.into_iter().zip(auxiliary_infos.into_iter()) {
+        for (txn, aux_info) in txns.into_iter().zip(auxiliary_infos) {
             if txn.is_block_start() && !cur.is_empty() {
                 let to_execute = std::mem::take(&mut cur);
                 let to_execute_aux_infos = std::mem::take(&mut cur_aux_infos);

--- a/aptos-move/aptos-sdk-builder/src/rust.rs
+++ b/aptos-move/aptos-sdk-builder/src/rust.rs
@@ -1004,7 +1004,7 @@ pub fn replace_keywords(registry: &mut BTreeMap<String, ContainerFormat>) {
 fn swap_keyworded_fields(fields: Option<&mut ContainerFormat>) {
     match fields {
         Some(ContainerFormat::Enum(fields)) => {
-            for (_, val) in fields.iter_mut() {
+            for val in fields.values_mut() {
                 match val.name.as_str() {
                     "struct" => val.name = String::from("Struct"),
                     "bool" => val.name = String::from("Bool"),

--- a/aptos-move/aptos-vm-types/Cargo.toml
+++ b/aptos-move/aptos-vm-types/Cargo.toml
@@ -39,3 +39,6 @@ aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-transaction-simulation = { workspace = true }
 aptos-vm = { workspace = true }
 test-case = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -250,7 +250,7 @@ where
                                 group_key,
                                 idx_to_execute,
                                 incarnation,
-                                group_ops.into_iter(),
+                                group_ops,
                                 group_size,
                                 prev_tags,
                             )?,
@@ -293,7 +293,7 @@ where
                 group_key,
                 idx_to_execute,
                 incarnation,
-                group_ops.into_iter(),
+                group_ops,
                 group_size,
                 HashSet::new(), // No previous tags since this is a new group write
             )?)?;
@@ -602,7 +602,7 @@ where
                     group_key,
                     idx_to_execute,
                     incarnation,
-                    group_ops.into_iter(),
+                    group_ops,
                     group_size,
                     prev_tags,
                 )? {

--- a/aptos-move/e2e-benchmark/src/gas_profiling.rs
+++ b/aptos-move/e2e-benchmark/src/gas_profiling.rs
@@ -318,7 +318,7 @@ async fn initialize_workflow_workload(
 fn execute_block_expect_success(txns: Vec<SignedTransaction>, harness: &mut MoveHarnessSend) {
     let outputs = harness.run_block_with_current_metadata(txns.clone());
 
-    for (idx, (status, txn)) in outputs.into_iter().zip(txns.into_iter()).enumerate() {
+    for (idx, (status, txn)) in outputs.into_iter().zip(txns).enumerate() {
         assert!(
             status.is_kept(),
             "[{idx}] status {:?} for txn {:.2000?}",

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
@@ -472,7 +472,7 @@ fn test_module_publishing_does_not_fallback() {
     for (output, maybe_abort_code) in h
         .run_block_get_output(txns)
         .into_iter()
-        .zip(expected_abort_codes.into_iter())
+        .zip(expected_abort_codes)
     {
         let status = output.status().clone();
         match maybe_abort_code {
@@ -574,7 +574,7 @@ fn test_module_publishing_does_not_leak_speculative_information() {
     for (output, maybe_abort_code) in h
         .run_block_get_output(txns)
         .into_iter()
-        .zip(expected_abort_codes.into_iter())
+        .zip(expected_abort_codes)
     {
         let status = output.status().clone();
         match maybe_abort_code {

--- a/aptos-move/framework/natives/src/string_utils.rs
+++ b/aptos-move/framework/natives/src/string_utils.rs
@@ -113,7 +113,7 @@ fn format_vector<'a>(
         return Ok(());
     }
     print_space_or_newline(newline, out, depth + 1);
-    for (i, (ty, val)) in fields.zip(values.into_iter()).enumerate() {
+    for (i, (ty, val)) in fields.zip(values).enumerate() {
         if i > 0 {
             out.push(',');
             print_space_or_newline(newline, out, depth + 1);

--- a/aptos-move/framework/src/release_builder.rs
+++ b/aptos-move/framework/src/release_builder.rs
@@ -56,8 +56,8 @@ impl ReleaseOptions {
         let mut source_paths = vec![];
         for ((package_path, rust_binding_path), use_latest_language) in packages
             .into_iter()
-            .zip(rust_bindings.into_iter())
-            .zip(package_use_latest_language.into_iter())
+            .zip(rust_bindings)
+            .zip(package_use_latest_language)
         {
             let cur_build_options = if use_latest_language {
                 build_options.clone().set_latest_language()

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -626,7 +626,7 @@ mod test {
         );
 
         // Verify the ordered blocks don't have any commit decisions
-        for (_, (_, commit_decision)) in all_ordered_blocks.iter() {
+        for (_, commit_decision) in all_ordered_blocks.values() {
             assert!(commit_decision.is_none());
         }
 

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -1260,7 +1260,7 @@ mod test {
     /// Returns the number of unverified payloads in the block payload store
     fn get_num_unverified_payloads(block_payload_store: &BlockPayloadStore) -> usize {
         let mut num_unverified_payloads = 0;
-        for (_, block_payload_status) in block_payload_store.block_payloads.lock().iter() {
+        for block_payload_status in block_payload_store.block_payloads.lock().values() {
             if let BlockPayloadStatus::AvailableAndUnverified(_) = block_payload_status {
                 num_unverified_payloads += 1;
             }
@@ -1271,7 +1271,7 @@ mod test {
     /// Returns the number of verified payloads in the block payload store
     fn get_num_verified_payloads(block_payload_store: &BlockPayloadStore) -> usize {
         let mut num_verified_payloads = 0;
-        for (_, block_payload_status) in block_payload_store.block_payloads.lock().iter() {
+        for block_payload_status in block_payload_store.block_payloads.lock().values() {
             if let BlockPayloadStatus::AvailableAndVerified(_) = block_payload_status {
                 num_verified_payloads += 1;
             }

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -539,8 +539,8 @@ impl DagStore {
         let to_prune = self.dag.write().commit_callback(commit_round);
         if let Some(to_prune) = to_prune {
             let digests = to_prune
-                .iter()
-                .flat_map(|(_, round_ref)| round_ref.iter().flatten())
+                .values()
+                .flat_map(|round_ref| round_ref.iter().flatten())
                 .map(|node_status| *node_status.as_node().metadata().digest())
                 .collect();
             if let Err(e) = self.storage.delete_certified_nodes(digests) {

--- a/consensus/src/pipeline/tests/buffer_manager_tests.rs
+++ b/consensus/src/pipeline/tests/buffer_manager_tests.rs
@@ -257,7 +257,7 @@ async fn assert_results(
     let mut blocks: Vec<Arc<PipelinedBlock>> = Vec::new();
     while blocks.len() < total_batches {
         let OrderedBlocks { ordered_blocks, .. } = result_rx.next().await.unwrap();
-        blocks.extend(ordered_blocks.into_iter());
+        blocks.extend(ordered_blocks);
     }
 
     for (i, batch) in enumerate(batches) {

--- a/crates/aptos-crypto/src/blstrs/polynomials.rs
+++ b/crates/aptos-crypto/src/blstrs/polynomials.rs
@@ -303,7 +303,7 @@ pub fn poly_mul_assign_slow(f: &[Scalar], g: &[Scalar], out: &mut Vec<Scalar>) {
     let g_len = g.len();
 
     // Set `out` to all zeros.
-    out.truncate(0); // Rust docs say "Note that this method has no effect on the allocated capacity of the vector."
+    out.clear(); // Rust docs say "Note that this method has no effect on the allocated capacity of the vector."
     out.resize(f_len + g_len - 1, Scalar::ZERO);
     for (i1, a) in f.iter().enumerate() {
         for (i2, b) in g.iter().enumerate() {
@@ -339,7 +339,7 @@ pub fn poly_mul_slow(f: &[Scalar], g: &[Scalar]) -> Vec<Scalar> {
 pub fn poly_mul_assign_less_slow(f: &Vec<Scalar>, g: &Vec<Scalar>, out: &mut Vec<Scalar>) {
     let mut result = poly_mul_less_slow(f.as_slice(), g.as_slice());
 
-    out.truncate(0);
+    out.clear();
     out.append(&mut result);
 }
 

--- a/crates/aptos-inspection-service/src/server/utils.rs
+++ b/crates/aptos-inspection-service/src/server/utils.rs
@@ -121,7 +121,7 @@ fn get_metrics_map(metric_families: Vec<MetricFamily>) -> HashMap<String, String
             format!("{}{}", metric_family.get_name(), labels_string)
         });
 
-        for (name, value) in metric_names.zip(values.into_iter()) {
+        for (name, value) in metric_names.zip(values) {
             all_metrics.insert(name, value);
         }
     }

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -357,10 +357,8 @@ impl<'t> AccountMinter<'t> {
         let txn_factory = self.txn_factory.clone();
 
         // For each seed account, create a future and transfer coins from that seed account to new accounts
-        let account_futures = seed_accounts
-            .into_iter()
-            .zip(local_accounts_by_seed.into_iter())
-            .map(|(seed_account, accounts)| {
+        let account_futures = seed_accounts.into_iter().zip(local_accounts_by_seed).map(
+            |(seed_account, accounts)| {
                 // Spawn new threads
                 create_and_fund_new_accounts(
                     seed_account,
@@ -371,7 +369,8 @@ impl<'t> AccountMinter<'t> {
                     &txn_factory,
                     &request_counters,
                 )
-            });
+            },
+        );
 
         // Each future creates 10 accounts, limit concurrency to 1000.
         let stream = futures::stream::iter(account_futures).buffer_unordered(CREATION_PARALLELISM);

--- a/crates/transaction-generator-lib/src/call_custom_modules.rs
+++ b/crates/transaction-generator-lib/src/call_custom_modules.rs
@@ -310,7 +310,7 @@ impl CustomModulesDelegationGeneratorCreator {
         )
         .await;
 
-        packages.into_iter().zip(accounts.into_iter()).collect()
+        packages.into_iter().zip(accounts).collect()
     }
 
     pub async fn publish_package_to_accounts(

--- a/crates/transaction-workloads-lib/src/args.rs
+++ b/crates/transaction-workloads-lib/src/args.rs
@@ -567,7 +567,7 @@ impl TransactionTypeArg {
         for (transaction_type, (weight, phase)) in arg_transaction_types.into_iter().zip(
             arg_transaction_weights
                 .into_iter()
-                .zip(arg_transaction_phases.into_iter()),
+                .zip(arg_transaction_phases),
         ) {
             assert!(
                 phase <= transaction_mix_per_phase.len(),

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -82,8 +82,8 @@ target "builder-base" {
   target     = "builder-base"
   context    = "."
   contexts = {
-    # Run `docker buildx imagetools inspect rust:1.94.1-trixie` to find the latest multi-platform hash
-    rust = "docker-image://rust:1.94.1-trixie@sha256:652612f07bfbbdfa3af34761c1e435094c00dde4a98036132fca28c7bb2b165c"
+    # Run `docker buildx imagetools inspect rust:1.98.0-trixie` to find the latest multi-platform hash
+    rust = "docker-image://rust:1.98.0-trixie@sha256:271849e998ffce5776454bbf98c5dc21baafc854ff8e566197908d3aca9a81e8"
   }
   args = {
     PROFILE            = "${PROFILE}"

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/src/config.rs
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/src/config.rs
@@ -249,7 +249,7 @@ impl TransactionImporterConfig {
     fn validate(&self) -> anyhow::Result<()> {
         // Validate the configuration. This is to make sure that no output file shares the same name.
         let mut output_files = HashSet::new();
-        for (_, network_config) in self.configs.iter() {
+        for network_config in self.configs.values() {
             for output_file in network_config.versions_to_import.values() {
                 if !output_files.insert(output_file) {
                     return Err(anyhow::anyhow!(

--- a/execution/executor-benchmark/src/native/native_transaction.rs
+++ b/execution/executor-benchmark/src/native/native_transaction.rs
@@ -134,10 +134,7 @@ pub fn compute_deltas_for_batch(
     sender_address: AccountAddress,
 ) -> (HashMap<AccountAddress, i64>, u64) {
     let mut deltas = HashMap::new();
-    for (recipient, amount) in recipient_addresses
-        .into_iter()
-        .zip(transfer_amounts.into_iter())
-    {
+    for (recipient, amount) in recipient_addresses.into_iter().zip(transfer_amounts) {
         let amount = amount as i64;
         deltas
             .entry(recipient)

--- a/experimental/bulk-txn-submit/src/coordinator.rs
+++ b/experimental/bulk-txn-submit/src/coordinator.rs
@@ -345,7 +345,7 @@ pub async fn execute_txn_list<T: Clone, B: SignedTransactionBuilder<T>>(
 
     let accounts_with_work = work_chunks
         .into_iter()
-        .zip(accounts.into_iter())
+        .zip(accounts)
         .map(|(work, account)| AccountWork::new(account, work))
         .collect::<Vec<_>>();
     let txn_factory = &txn_factory;

--- a/experimental/storage/layered-map/benches/maps.rs
+++ b/experimental/storage/layered-map/benches/maps.rs
@@ -101,7 +101,7 @@ fn insert_in_batches(
             |batches| {
                 let mut map = HashMap::new();
                 for batch in batches {
-                    map.extend(batch.into_iter());
+                    map.extend(batch);
                 }
                 map
             },
@@ -116,7 +116,7 @@ fn insert_in_batches(
             |batches| {
                 let mut map = BTreeMap::new();
                 for batch in batches {
-                    map.extend(batch.into_iter());
+                    map.extend(batch);
                 }
                 map
             },

--- a/network/framework/src/application/storage.rs
+++ b/network/framework/src/application/storage.rs
@@ -88,7 +88,7 @@ impl PeersAndMetadata {
         // Collect all peers
         let mut all_peers = Vec::new();
         for (network_id, peers_and_metadata) in cached_peers_and_metadata.iter() {
-            for (peer_id, _) in peers_and_metadata.iter() {
+            for peer_id in peers_and_metadata.keys() {
                 let peer_network_id = PeerNetworkId::new(*network_id, *peer_id);
                 all_peers.push(peer_network_id);
             }

--- a/network/framework/src/connectivity_manager/mod.rs
+++ b/network/framework/src/connectivity_manager/mod.rs
@@ -893,7 +893,7 @@ where
     /// Updates the metrics for tracking pre-dial and connected peer ping latencies
     fn update_ping_latency_metrics(&self) {
         // Update the pre-dial peer ping latencies
-        for (_, peer) in self.discovered_peers.read().peer_set.iter() {
+        for peer in self.discovered_peers.read().peer_set.values() {
             if let Some(ping_latency_secs) = peer.ping_latency_secs {
                 counters::observe_pre_dial_ping_time(&self.network_context, ping_latency_secs);
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.98.0"
 
 # Note: we don't specify cargofmt in our toolchain because we rely on
 # the nightly version of cargofmt and verify formatting in CI/CD.

--- a/scripts/update_docker_images.py
+++ b/scripts/update_docker_images.py
@@ -10,7 +10,7 @@ OS = "linux"
 
 IMAGES = {
     "debian": "debian:trixie",
-    "rust": "rust:1.94.1-trixie",
+    "rust": "rust:1.98.0-trixie",
 }
 
 

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -267,7 +267,7 @@ impl EventSubscriptionService {
         }
 
         let new_configs = self.read_on_chain_configs(version)?;
-        for (_, reconfig_subscription) in self.reconfig_subscriptions.iter_mut() {
+        for reconfig_subscription in self.reconfig_subscriptions.values_mut() {
             reconfig_subscription.notify_subscriber_of_configs(version, new_configs.clone())?;
         }
 

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -237,7 +237,7 @@ impl VerifiedEpochStates {
     /// exists).
     pub fn next_epoch_ending_version(&self, version: Version) -> Option<Version> {
         // BTreeMap keys are iterated through in increasing key orders (i.e., versions)
-        for (epoch_ending_version, _) in self.new_epoch_ending_ledger_infos.iter() {
+        for epoch_ending_version in self.new_epoch_ending_ledger_infos.keys() {
             if *epoch_ending_version > version {
                 return Some(*epoch_ending_version);
             }

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -23,8 +23,8 @@ use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{
     requests::{
         DataRequest, EpochEndingLedgerInfoRequest, GetTransactionDataWithProofRequest,
-        NumberOfStatesRequestV2, StateValuesWithProofRequest, StateValuesWithProofRequestV2,
-        StorageServiceRequest, TransactionOutputsWithProofRequest,
+        HotStateValuesWithProofRequest, NumberOfStatesRequestV2, StateValuesWithProofRequest,
+        StateValuesWithProofRequestV2, StorageServiceRequest, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
     },
     responses::{
@@ -415,6 +415,9 @@ impl<T: StorageReaderInterface> Handler<T> {
             DataRequest::GetStateValuesWithProofV2(request) => {
                 self.get_state_value_chunk_with_proof_v2(request)
             },
+            DataRequest::GetHotStateValuesWithProof(request) => {
+                self.get_hot_state_value_chunk_with_proof(request)
+            },
             DataRequest::GetEpochEndingLedgerInfos(request) => {
                 self.get_epoch_ending_ledger_infos(request)
             },
@@ -423,6 +426,9 @@ impl<T: StorageReaderInterface> Handler<T> {
             },
             DataRequest::GetNumberOfStatesAtVersionV2(request) => {
                 self.get_number_of_states_at_version_v2(request)
+            },
+            DataRequest::GetNumberOfHotStatesAtVersion(version) => {
+                self.get_number_of_hot_states_at_version(*version)
             },
             DataRequest::GetTransactionOutputsWithProof(request) => {
                 self.get_transaction_outputs_with_proof(request)
@@ -486,6 +492,21 @@ impl<T: StorageReaderInterface> Handler<T> {
         ))
     }
 
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        request: &HotStateValuesWithProofRequest,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let hot_state_value_chunk_with_proof = self.storage.get_hot_state_value_chunk_with_proof(
+            request.version,
+            request.start_index,
+            request.end_index,
+        )?;
+
+        Ok(DataResponse::HotStateValueChunkWithProof(
+            hot_state_value_chunk_with_proof,
+        ))
+    }
+
     fn get_state_value_chunk_with_proof_v2(
         &self,
         request: &StateValuesWithProofRequestV2,
@@ -525,6 +546,16 @@ impl<T: StorageReaderInterface> Handler<T> {
             .get_number_of_states(version, StateKind::MainState)?;
 
         Ok(DataResponse::NumberOfStatesAtVersion(number_of_states))
+    }
+
+    fn get_number_of_hot_states_at_version(
+        &self,
+        version: Version,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let number_of_hot_states = self.storage.get_number_of_hot_states(version)?;
+        Ok(DataResponse::NumberOfHotStatesAtVersion(
+            number_of_hot_states,
+        ))
     }
 
     fn get_number_of_states_at_version_v2(

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -23,8 +23,8 @@ use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{
     requests::{
         DataRequest, EpochEndingLedgerInfoRequest, GetTransactionDataWithProofRequest,
-        NumberOfStatesRequestV2, StateValuesWithProofRequest, StateValuesWithProofRequestV2,
-        StorageServiceRequest, TransactionOutputsWithProofRequest,
+        HotStateValuesWithProofRequest, NumberOfStatesRequestV2, StateValuesWithProofRequest,
+        StateValuesWithProofRequestV2, StorageServiceRequest, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
     },
     responses::{
@@ -409,6 +409,9 @@ impl<T: StorageReaderInterface> Handler<T> {
 
         // Otherwise, fetch the data from storage and time the operation
         let fetch_data_response = || match &request.data_request {
+            DataRequest::GetHotStateValuesWithProof(request) => {
+                self.get_hot_state_value_chunk_with_proof(request)
+            },
             DataRequest::GetStateValuesWithProof(request) => {
                 self.get_state_value_chunk_with_proof(request)
             },
@@ -423,6 +426,9 @@ impl<T: StorageReaderInterface> Handler<T> {
             },
             DataRequest::GetNumberOfStatesAtVersionV2(request) => {
                 self.get_number_of_states_at_version_v2(request)
+            },
+            DataRequest::GetNumberOfHotStatesAtVersion(version) => {
+                self.get_number_of_hot_states_at_version(*version)
             },
             DataRequest::GetTransactionOutputsWithProof(request) => {
                 self.get_transaction_outputs_with_proof(request)
@@ -486,6 +492,21 @@ impl<T: StorageReaderInterface> Handler<T> {
         ))
     }
 
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        request: &HotStateValuesWithProofRequest,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let hot_state_value_chunk_with_proof = self.storage.get_hot_state_value_chunk_with_proof(
+            request.version,
+            request.start_index,
+            request.end_index,
+        )?;
+
+        Ok(DataResponse::HotStateValueChunkWithProof(
+            hot_state_value_chunk_with_proof,
+        ))
+    }
+
     fn get_state_value_chunk_with_proof_v2(
         &self,
         request: &StateValuesWithProofRequestV2,
@@ -525,6 +546,16 @@ impl<T: StorageReaderInterface> Handler<T> {
             .get_number_of_states(version, StateKind::MainState)?;
 
         Ok(DataResponse::NumberOfStatesAtVersion(number_of_states))
+    }
+
+    fn get_number_of_hot_states_at_version(
+        &self,
+        version: Version,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let number_of_hot_states = self.storage.get_number_of_hot_states(version)?;
+        Ok(DataResponse::NumberOfHotStatesAtVersion(
+            number_of_hot_states,
+        ))
     }
 
     fn get_number_of_states_at_version_v2(

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -910,13 +910,11 @@ impl StorageReader {
         use_size_and_time_aware_chunking: bool,
         kind: StateKind,
     ) -> Result<StateValueChunkWithProof, Error> {
-        // Calculate the number of state values to fetch
-        let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
-        let max_num_state_values = self.config.max_state_chunk_size;
-        let num_state_values_to_fetch = min(expected_num_state_values, max_num_state_values);
-
         // If size and time-aware chunking are disabled, use the legacy implementation
         if !use_size_and_time_aware_chunking {
+            let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
+            let num_state_values_to_fetch =
+                min(expected_num_state_values, self.config.max_state_chunk_size);
             return self.get_state_value_chunk_with_proof_by_size_legacy(
                 version,
                 start_index,
@@ -927,71 +925,85 @@ impl StorageReader {
             );
         }
 
-        // Get the state value chunk iterator
-        let mut state_value_iterator = self.storage.get_state_value_chunk_iter(
+        self.get_value_chunk_with_proof_by_size(
             version,
-            start_index as usize,
-            num_state_values_to_fetch as usize,
-            kind,
-        )?;
+            start_index,
+            end_index,
+            max_response_size,
+            "state value",
+            DataResponse::get_state_value_chunk_with_proof_label(),
+            |first_index, chunk_size| {
+                self.storage
+                    .get_state_value_chunk_iter(version, first_index, chunk_size, kind)
+            },
+            |first_index, state_values| {
+                self.storage
+                    .get_state_value_chunk_proof(version, first_index, state_values, kind)
+            },
+        )
+    }
 
-        // Initialize the fetched state values
-        let mut state_values = vec![];
-
-        // Create a response progress tracker
+    /// Fetches a proof-carrying value chunk, bounded by the configured item, byte, and time limits.
+    fn get_value_chunk_with_proof_by_size<T, C, I, GetValues, GetProof>(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        max_response_size: u64,
+        value_label: &'static str,
+        data_response_label: &'static str,
+        get_values: GetValues,
+        get_proof: GetProof,
+    ) -> Result<C, Error>
+    where
+        T: Serialize,
+        I: Iterator<Item = StorageResult<T>>,
+        GetValues: FnOnce(usize, usize) -> StorageResult<I>,
+        GetProof: FnOnce(usize, Vec<T>) -> StorageResult<C>,
+    {
+        let expected_num_values = inclusive_range_len(start_index, end_index)?;
+        let num_values_to_fetch = min(expected_num_values, self.config.max_state_chunk_size);
+        let mut value_iterator = get_values(start_index as usize, num_values_to_fetch as usize)?;
+        let mut values = vec![];
         let mut response_progress_tracker = ResponseDataProgressTracker::new(
-            num_state_values_to_fetch,
+            num_values_to_fetch,
             max_response_size,
             self.config.max_storage_read_wait_time_ms,
             self.time_service.clone(),
         );
 
-        // Fetch as many state values as possible
         while !response_progress_tracker.is_response_complete() {
-            match state_value_iterator.next() {
-                Some(Ok(state_value)) => {
-                    // Calculate the number of serialized bytes for the state value
-                    let num_serialized_bytes = get_num_serialized_bytes(&state_value)
+            match value_iterator.next() {
+                Some(Ok(value)) => {
+                    let num_serialized_bytes = get_num_serialized_bytes(&value)
                         .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?;
-
-                    // Add the state value to the list
                     if response_progress_tracker
                         .data_items_fits_in_response(true, num_serialized_bytes)
                     {
-                        state_values.push(state_value);
+                        values.push(value);
                         response_progress_tracker.add_data_item(num_serialized_bytes);
                     } else {
-                        break; // Cannot add any more data items
+                        break;
                     }
                 },
                 Some(Err(error)) => {
                     return Err(Error::StorageErrorEncountered(error.to_string()));
                 },
                 None => {
-                    // Log a warning that the iterator did not contain all the expected data
                     warn!(
-                        "The state value iterator is missing data! Version: {:?}, \
-                        start index: {:?}, end index: {:?}, num state values to fetch: {:?}",
-                        version, start_index, end_index, num_state_values_to_fetch
+                        "The {} iterator is missing data! Version: {:?}, start index: {:?}, \
+                        end index: {:?}, num values to fetch: {:?}",
+                        value_label, version, start_index, end_index, num_values_to_fetch
                     );
                     break;
                 },
             }
         }
 
-        // Create the state value chunk with proof
-        let state_value_chunk_with_proof = self.storage.get_state_value_chunk_proof(
-            version,
-            start_index as usize,
-            state_values,
-            kind,
-        )?;
+        let chunk_with_proof = get_proof(start_index as usize, values)?;
+        response_progress_tracker.update_data_truncation_metrics(data_response_label);
 
-        // Update the data truncation metrics
-        response_progress_tracker
-            .update_data_truncation_metrics(DataResponse::get_state_value_chunk_with_proof_label());
-
-        Ok(state_value_chunk_with_proof)
+        Ok(chunk_with_proof)
     }
 
     /// Returns a state value chunk with proof response (bound by the max response size in bytes).

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -21,6 +21,7 @@ use aptos_types::{
         AccumulatorRangeProof, TransactionAccumulatorRangeProof, TransactionInfoListWithProof,
     },
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -106,6 +107,12 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
         kind: StateKind,
     ) -> aptos_storage_service_types::Result<u64, Error>;
 
+    /// Returns the number of hot states at the specified version.
+    fn get_number_of_hot_states(
+        &self,
+        version: u64,
+    ) -> aptos_storage_service_types::Result<u64, Error>;
+
     /// Returns a chunk holding a list of state values starting at the
     /// specified `start_index` and ending at `end_index` (inclusive). In
     /// some cases, less state values may be returned (e.g., due to network
@@ -117,6 +124,14 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
         end_index: u64,
         kind: StateKind,
     ) -> aptos_storage_service_types::Result<StateValueChunkWithProof, Error>;
+
+    /// Returns a chunk holding hot state values and their range proof.
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> aptos_storage_service_types::Result<HotStateValueChunkWithProof, Error>;
 }
 
 /// The underlying implementation of the StorageReaderInterface, used by the
@@ -1022,6 +1037,32 @@ impl StorageReader {
         Ok(chunk_with_proof)
     }
 
+    /// Returns a hot state value chunk with proof, bounded by the configured item, byte, and time
+    /// limits. Hot state only supports the iterator and proof construction path.
+    fn get_hot_state_value_chunk_with_proof_by_size(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> Result<HotStateValueChunkWithProof, Error> {
+        self.get_value_chunk_with_proof_by_size(
+            version,
+            start_index,
+            end_index,
+            self.config.max_network_chunk_bytes,
+            "hot state value",
+            DataResponse::get_hot_state_value_chunk_with_proof_label(),
+            |first_index, chunk_size| {
+                self.storage
+                    .get_hot_state_value_chunk_iter(version, first_index, chunk_size)
+            },
+            |first_index, hot_state_values| {
+                self.storage
+                    .get_hot_state_value_chunk_proof(version, first_index, hot_state_values)
+            },
+        )
+    }
+
     /// Returns a state value chunk with proof response (bound by the max response size in bytes).
     /// This is the legacy implementation (that does not use size and time-aware chunking).
     fn get_state_value_chunk_with_proof_by_size_legacy(
@@ -1238,6 +1279,14 @@ impl StorageReaderInterface for StorageReader {
         Ok(number_of_states as u64)
     }
 
+    fn get_number_of_hot_states(
+        &self,
+        version: u64,
+    ) -> aptos_storage_service_types::Result<u64, Error> {
+        let number_of_hot_states = self.storage.get_hot_state_item_count(version)?;
+        Ok(number_of_hot_states as u64)
+    }
+
     fn get_state_value_chunk_with_proof(
         &self,
         version: u64,
@@ -1253,6 +1302,15 @@ impl StorageReaderInterface for StorageReader {
             self.config.enable_size_and_time_aware_chunking,
             kind,
         )
+    }
+
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> aptos_storage_service_types::Result<HotStateValueChunkWithProof, Error> {
+        self.get_hot_state_value_chunk_with_proof_by_size(version, start_index, end_index)
     }
 }
 
@@ -1328,6 +1386,8 @@ impl DbReader for TimedStorageReader {
 
         fn get_state_item_count(&self, version: Version, kind: StateKind) -> StorageResult<usize>;
 
+        fn get_hot_state_item_count(&self, version: Version) -> StorageResult<usize>;
+
         fn get_state_value_chunk_with_proof(
             &self,
             version: Version,
@@ -1388,6 +1448,20 @@ impl DbReader for TimedStorageReader {
             state_key_values: Vec<(StateKey, StateValue)>,
             kind: StateKind,
         ) -> StorageResult<StateValueChunkWithProof>;
+
+        fn get_hot_state_value_chunk_iter(
+            &self,
+            version: Version,
+            first_index: usize,
+            chunk_size: usize,
+        ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(StateKey, HotStateValue)>> + '_>>;
+
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> StorageResult<HotStateValueChunkWithProof>;
 
         fn get_persisted_auxiliary_info_iterator(
             &self,

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -910,13 +910,12 @@ impl StorageReader {
         use_size_and_time_aware_chunking: bool,
         kind: StateKind,
     ) -> Result<StateValueChunkWithProof, Error> {
-        // Calculate the number of state values to fetch
-        let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
-        let max_num_state_values = self.config.max_state_chunk_size;
-        let num_state_values_to_fetch = min(expected_num_state_values, max_num_state_values);
-
         // If size and time-aware chunking are disabled, use the legacy implementation
         if !use_size_and_time_aware_chunking {
+            // Calculate the number of state values to fetch
+            let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
+            let num_state_values_to_fetch =
+                min(expected_num_state_values, self.config.max_state_chunk_size);
             return self.get_state_value_chunk_with_proof_by_size_legacy(
                 version,
                 start_index,
@@ -927,38 +926,73 @@ impl StorageReader {
             );
         }
 
-        // Get the state value chunk iterator
-        let mut state_value_iterator = self.storage.get_state_value_chunk_iter(
+        self.get_value_chunk_with_proof_by_size(
             version,
-            start_index as usize,
-            num_state_values_to_fetch as usize,
-            kind,
-        )?;
+            start_index,
+            end_index,
+            max_response_size,
+            "state value",
+            DataResponse::get_state_value_chunk_with_proof_label(),
+            |first_index, chunk_size| {
+                self.storage
+                    .get_state_value_chunk_iter(version, first_index, chunk_size, kind)
+            },
+            |first_index, state_values| {
+                self.storage
+                    .get_state_value_chunk_proof(version, first_index, state_values, kind)
+            },
+        )
+    }
 
-        // Initialize the fetched state values
-        let mut state_values = vec![];
+    /// Fetches a proof-carrying value chunk, bounded by the configured item, byte, and time limits.
+    fn get_value_chunk_with_proof_by_size<T, C, I, GetValues, GetProof>(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        max_response_size: u64,
+        value_label: &'static str,
+        data_response_label: &'static str,
+        get_values: GetValues,
+        get_proof: GetProof,
+    ) -> Result<C, Error>
+    where
+        T: Serialize,
+        I: Iterator<Item = StorageResult<T>>,
+        GetValues: FnOnce(usize, usize) -> StorageResult<I>,
+        GetProof: FnOnce(usize, Vec<T>) -> StorageResult<C>,
+    {
+        // Calculate the number of values to fetch
+        let expected_num_values = inclusive_range_len(start_index, end_index)?;
+        let num_values_to_fetch = min(expected_num_values, self.config.max_state_chunk_size);
+
+        // Get the value iterator
+        let mut value_iterator = get_values(start_index as usize, num_values_to_fetch as usize)?;
+
+        // Initialize the fetched values
+        let mut values = vec![];
 
         // Create a response progress tracker
         let mut response_progress_tracker = ResponseDataProgressTracker::new(
-            num_state_values_to_fetch,
+            num_values_to_fetch,
             max_response_size,
             self.config.max_storage_read_wait_time_ms,
             self.time_service.clone(),
         );
 
-        // Fetch as many state values as possible
+        // Fetch as many values as possible
         while !response_progress_tracker.is_response_complete() {
-            match state_value_iterator.next() {
-                Some(Ok(state_value)) => {
-                    // Calculate the number of serialized bytes for the state value
-                    let num_serialized_bytes = get_num_serialized_bytes(&state_value)
+            match value_iterator.next() {
+                Some(Ok(value)) => {
+                    // Calculate the number of serialized bytes for the value
+                    let num_serialized_bytes = get_num_serialized_bytes(&value)
                         .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?;
 
-                    // Add the state value to the list
+                    // Add the value to the list
                     if response_progress_tracker
                         .data_items_fits_in_response(true, num_serialized_bytes)
                     {
-                        state_values.push(state_value);
+                        values.push(value);
                         response_progress_tracker.add_data_item(num_serialized_bytes);
                     } else {
                         break; // Cannot add any more data items
@@ -970,28 +1004,22 @@ impl StorageReader {
                 None => {
                     // Log a warning that the iterator did not contain all the expected data
                     warn!(
-                        "The state value iterator is missing data! Version: {:?}, \
-                        start index: {:?}, end index: {:?}, num state values to fetch: {:?}",
-                        version, start_index, end_index, num_state_values_to_fetch
+                        "The {} iterator is missing data! Version: {:?}, start index: {:?}, \
+                        end index: {:?}, num values to fetch: {:?}",
+                        value_label, version, start_index, end_index, num_values_to_fetch
                     );
                     break;
                 },
             }
         }
 
-        // Create the state value chunk with proof
-        let state_value_chunk_with_proof = self.storage.get_state_value_chunk_proof(
-            version,
-            start_index as usize,
-            state_values,
-            kind,
-        )?;
+        // Create the value chunk with proof
+        let chunk_with_proof = get_proof(start_index as usize, values)?;
 
         // Update the data truncation metrics
-        response_progress_tracker
-            .update_data_truncation_metrics(DataResponse::get_state_value_chunk_with_proof_label());
+        response_progress_tracker.update_data_truncation_metrics(data_response_label);
 
-        Ok(state_value_chunk_with_proof)
+        Ok(chunk_with_proof)
     }
 
     /// Returns a state value chunk with proof response (bound by the max response size in bytes).

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -21,6 +21,7 @@ use aptos_types::{
         AccumulatorRangeProof, TransactionAccumulatorRangeProof, TransactionInfoListWithProof,
     },
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -106,6 +107,12 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
         kind: StateKind,
     ) -> aptos_storage_service_types::Result<u64, Error>;
 
+    /// Returns the number of hot states at the specified version.
+    fn get_number_of_hot_states(
+        &self,
+        version: u64,
+    ) -> aptos_storage_service_types::Result<u64, Error>;
+
     /// Returns a chunk holding a list of state values starting at the
     /// specified `start_index` and ending at `end_index` (inclusive). In
     /// some cases, less state values may be returned (e.g., due to network
@@ -117,6 +124,14 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
         end_index: u64,
         kind: StateKind,
     ) -> aptos_storage_service_types::Result<StateValueChunkWithProof, Error>;
+
+    /// Returns a chunk holding hot state values and their range proof.
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> aptos_storage_service_types::Result<HotStateValueChunkWithProof, Error>;
 }
 
 /// The underlying implementation of the StorageReaderInterface, used by the
@@ -1006,6 +1021,32 @@ impl StorageReader {
         Ok(chunk_with_proof)
     }
 
+    /// Returns a hot state value chunk with proof, bounded by the configured item, byte, and time
+    /// limits. Hot state only supports the iterator and proof construction path.
+    fn get_hot_state_value_chunk_with_proof_by_size(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> Result<HotStateValueChunkWithProof, Error> {
+        self.get_value_chunk_with_proof_by_size(
+            version,
+            start_index,
+            end_index,
+            self.config.max_network_chunk_bytes,
+            "hot state value",
+            DataResponse::get_hot_state_value_chunk_with_proof_label(),
+            |first_index, chunk_size| {
+                self.storage
+                    .get_hot_state_value_chunk_iter(version, first_index, chunk_size)
+            },
+            |first_index, hot_state_values| {
+                self.storage
+                    .get_hot_state_value_chunk_proof(version, first_index, hot_state_values)
+            },
+        )
+    }
+
     /// Returns a state value chunk with proof response (bound by the max response size in bytes).
     /// This is the legacy implementation (that does not use size and time-aware chunking).
     fn get_state_value_chunk_with_proof_by_size_legacy(
@@ -1222,6 +1263,14 @@ impl StorageReaderInterface for StorageReader {
         Ok(number_of_states as u64)
     }
 
+    fn get_number_of_hot_states(
+        &self,
+        version: u64,
+    ) -> aptos_storage_service_types::Result<u64, Error> {
+        let number_of_hot_states = self.storage.get_hot_state_item_count(version)?;
+        Ok(number_of_hot_states as u64)
+    }
+
     fn get_state_value_chunk_with_proof(
         &self,
         version: u64,
@@ -1237,6 +1286,15 @@ impl StorageReaderInterface for StorageReader {
             self.config.enable_size_and_time_aware_chunking,
             kind,
         )
+    }
+
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> aptos_storage_service_types::Result<HotStateValueChunkWithProof, Error> {
+        self.get_hot_state_value_chunk_with_proof_by_size(version, start_index, end_index)
     }
 }
 
@@ -1312,6 +1370,8 @@ impl DbReader for TimedStorageReader {
 
         fn get_state_item_count(&self, version: Version, kind: StateKind) -> StorageResult<usize>;
 
+        fn get_hot_state_item_count(&self, version: Version) -> StorageResult<usize>;
+
         fn get_state_value_chunk_with_proof(
             &self,
             version: Version,
@@ -1372,6 +1432,20 @@ impl DbReader for TimedStorageReader {
             state_key_values: Vec<(StateKey, StateValue)>,
             kind: StateKind,
         ) -> StorageResult<StateValueChunkWithProof>;
+
+        fn get_hot_state_value_chunk_iter(
+            &self,
+            version: Version,
+            first_index: usize,
+            chunk_size: usize,
+        ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(StateKey, HotStateValue)>> + '_>>;
+
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> StorageResult<HotStateValueChunkWithProof>;
 
         fn get_persisted_auxiliary_info_iterator(
             &self,

--- a/state-sync/storage-service/server/src/tests/hot_state_values.rs
+++ b/state-sync/storage-service/server/src/tests/hot_state_values.rs
@@ -1,0 +1,225 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::tests::{mock, mock::MockClient, utils};
+use aptos_config::config::StorageServiceConfig;
+use aptos_crypto::HashValue;
+use aptos_storage_service_types::{
+    responses::{DataResponse, StorageServiceResponse},
+    StorageServiceError,
+};
+use aptos_types::{
+    proof::definition::SparseMerkleRangeProof,
+    state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
+        state_key::StateKey,
+        state_value::StateValue,
+    },
+};
+use bytes::Bytes;
+use claims::assert_matches;
+use mockall::predicate::eq;
+
+#[tokio::test]
+async fn test_get_hot_states_with_proof_and_cache() {
+    let version = 101;
+    let start_index = 100;
+    let chunk_size = 10;
+    let raw_values = create_hot_state_values(chunk_size, 10, version);
+
+    let mut db_reader = mock::create_mock_db_reader();
+    expect_get_hot_state_values_with_proof(
+        &mut db_reader,
+        version,
+        start_index,
+        chunk_size,
+        raw_values.clone(),
+        2, // One storage fetch for each compression setting.
+    );
+
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
+    utils::update_storage_server_summary(&mut service, version, 10);
+    tokio::spawn(service.start());
+
+    for use_compression in [false, true] {
+        // The second identical request should be served from the response cache.
+        for _ in 0..2 {
+            let response = utils::get_hot_state_values_with_proof(
+                &mut mock_client,
+                version,
+                start_index,
+                start_index + chunk_size - 1,
+                use_compression,
+            )
+            .await
+            .unwrap();
+            assert_eq!(response.is_compressed(), use_compression);
+            assert_hot_state_response(response, start_index, &raw_values);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_hot_states_with_proof_chunk_limit() {
+    let config = StorageServiceConfig::default();
+    let version = 101;
+    let start_index = 100;
+    let requested_chunk_size = config.max_state_chunk_size + 10;
+    let raw_values = create_hot_state_values(config.max_state_chunk_size, 1, version);
+
+    let mut db_reader = mock::create_mock_db_reader();
+    expect_get_hot_state_values_with_proof(
+        &mut db_reader,
+        version,
+        start_index,
+        config.max_state_chunk_size,
+        raw_values.clone(),
+        1,
+    );
+
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), Some(config));
+    utils::update_storage_server_summary(&mut service, version, 10);
+    tokio::spawn(service.start());
+
+    let response = utils::get_hot_state_values_with_proof(
+        &mut mock_client,
+        version,
+        start_index,
+        start_index + requested_chunk_size - 1,
+        false,
+    )
+    .await
+    .unwrap();
+    assert_hot_state_response(response, start_index, &raw_values);
+}
+
+#[tokio::test]
+async fn test_get_hot_states_with_proof_network_limit() {
+    let network_limit_bytes = 2500;
+    let version = 101;
+    let start_index = 100;
+    let chunk_size = 10;
+    let raw_values = create_hot_state_values(chunk_size, 1000, version);
+    let config = StorageServiceConfig {
+        max_network_chunk_bytes: network_limit_bytes,
+        ..Default::default()
+    };
+
+    let mut db_reader = mock::create_mock_db_reader();
+    expect_get_hot_state_values_with_proof(
+        &mut db_reader,
+        version,
+        start_index,
+        chunk_size,
+        raw_values,
+        1,
+    );
+
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), Some(config));
+    utils::update_storage_server_summary(&mut service, version, 10);
+    tokio::spawn(service.start());
+
+    let response = utils::get_hot_state_values_with_proof(
+        &mut mock_client,
+        version,
+        start_index,
+        start_index + chunk_size - 1,
+        false,
+    )
+    .await
+    .unwrap();
+    let response_size = bcs::serialized_size(&response).unwrap() as u64;
+    let DataResponse::HotStateValueChunkWithProof(chunk) = response.get_data_response().unwrap()
+    else {
+        panic!("expected hot state values with proof response")
+    };
+    assert!(chunk.raw_values.len() < chunk_size as usize);
+    if response_size > network_limit_bytes {
+        assert_eq!(chunk.raw_values.len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn test_get_hot_states_with_proof_invalid_range() {
+    let version = 101;
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
+    utils::update_storage_server_summary(&mut service, version, 10);
+    tokio::spawn(service.start());
+
+    let response =
+        utils::get_hot_state_values_with_proof(&mut mock_client, version, 100, 99, false)
+            .await
+            .unwrap_err();
+    assert_matches!(response, StorageServiceError::InvalidRequest(_));
+}
+
+fn create_hot_state_values(
+    num_values: u64,
+    value_size: usize,
+    hot_since_version: u64,
+) -> Vec<(StateKey, HotStateValue)> {
+    (0..num_values)
+        .map(|index| {
+            let state_key = StateKey::raw(&index.to_le_bytes());
+            let state_value = StateValue::new_legacy(Bytes::from(vec![index as u8; value_size]));
+            (
+                state_key,
+                HotStateValue::new(Some(state_value), hot_since_version),
+            )
+        })
+        .collect()
+}
+
+fn expect_get_hot_state_values_with_proof(
+    db_reader: &mut mock::MockDatabaseReader,
+    version: u64,
+    start_index: u64,
+    chunk_size: u64,
+    raw_values: Vec<(StateKey, HotStateValue)>,
+    times: usize,
+) {
+    let iterator_values = raw_values.clone();
+    db_reader
+        .expect_get_hot_state_value_chunk_iter()
+        .times(times)
+        .with(
+            eq(version),
+            eq(start_index as usize),
+            eq(chunk_size as usize),
+        )
+        .returning(move |_, _, _| Ok(Box::new(iterator_values.clone().into_iter().map(Ok))));
+
+    db_reader
+        .expect_get_hot_state_value_chunk_proof()
+        .times(times)
+        .with(
+            eq(version),
+            eq(start_index as usize),
+            mockall::predicate::always(),
+        )
+        .returning(move |_, first_index, raw_values| {
+            let last_index = first_index + raw_values.len() - 1;
+            Ok(HotStateValueChunkWithProof {
+                first_index: first_index as u64,
+                last_index: last_index as u64,
+                first_key: HashValue::random(),
+                last_key: HashValue::random(),
+                raw_values,
+                proof: SparseMerkleRangeProof::new(vec![]),
+                root_hash: HashValue::random(),
+            })
+        });
+}
+
+fn assert_hot_state_response(
+    response: StorageServiceResponse,
+    start_index: u64,
+    expected_raw_values: &[(StateKey, HotStateValue)],
+) {
+    let DataResponse::HotStateValueChunkWithProof(chunk) = response.get_data_response().unwrap()
+    else {
+        panic!("expected hot state values with proof response")
+    };
+    assert_eq!(chunk.first_index, start_index);
+    assert_eq!(chunk.raw_values, expected_raw_values);
+}

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -40,6 +40,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -322,6 +323,8 @@ mock! {
 
         fn get_state_item_count(&self, version: Version, kind: StateKind) -> aptos_storage_interface::Result<usize>;
 
+        fn get_hot_state_item_count(&self, version: Version) -> aptos_storage_interface::Result<usize>;
+
         fn get_state_value_chunk_with_proof(
             &self,
             version: Version,
@@ -392,6 +395,20 @@ mock! {
             state_key_values: Vec<(StateKey, StateValue)>,
             kind: StateKind,
         ) -> aptos_storage_interface::Result<StateValueChunkWithProof>;
+
+        fn get_hot_state_value_chunk_iter(
+            &self,
+            version: Version,
+            first_index: usize,
+            chunk_size: usize,
+        ) -> aptos_storage_interface::Result<Box<dyn Iterator<Item = aptos_storage_interface::Result<(StateKey, HotStateValue)>>>>;
+
+        fn get_hot_state_value_chunk_proof(
+            &self,
+            version: Version,
+            first_index: usize,
+            raw_values: Vec<(StateKey, HotStateValue)>,
+        ) -> aptos_storage_interface::Result<HotStateValueChunkWithProof>;
     }
 }
 

--- a/state-sync/storage-service/server/src/tests/mod.rs
+++ b/state-sync/storage-service/server/src/tests/mod.rs
@@ -5,6 +5,7 @@
 
 mod cache;
 mod epoch_ending;
+mod hot_state_values;
 mod mock;
 mod new_transaction_outputs;
 mod new_transactions;

--- a/state-sync/storage-service/server/src/tests/number_of_states.rs
+++ b/state-sync/storage-service/server/src/tests/number_of_states.rs
@@ -44,6 +44,70 @@ async fn test_get_number_of_states_at_version() {
 }
 
 #[tokio::test]
+async fn test_get_number_of_hot_states_at_version() {
+    let version = 101;
+    let number_of_hot_states = 560;
+
+    let mut db_reader = mock::create_mock_db_reader();
+    db_reader
+        .expect_get_hot_state_item_count()
+        .times(1)
+        .with(eq(version))
+        .returning(move |_| Ok(number_of_hot_states as usize));
+
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
+    utils::update_storage_server_summary(&mut service, version, 10);
+    tokio::spawn(service.start());
+
+    let response = utils::get_number_of_hot_states(&mut mock_client, version, false)
+        .await
+        .unwrap();
+
+    assert_matches!(response, StorageServiceResponse::RawResponse(_));
+    assert_eq!(
+        response.get_data_response().unwrap(),
+        DataResponse::NumberOfHotStatesAtVersion(number_of_hot_states)
+    );
+}
+
+#[tokio::test]
+async fn test_get_number_of_hot_states_at_version_not_serviceable() {
+    let version = 101;
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
+    utils::update_storage_server_summary(&mut service, version - 1, 10);
+    tokio::spawn(service.start());
+
+    let response = utils::get_number_of_hot_states(&mut mock_client, version, false)
+        .await
+        .unwrap_err();
+    assert_matches!(response, StorageServiceError::InvalidRequest(_));
+}
+
+#[tokio::test]
+async fn test_get_number_of_hot_states_at_version_invalid() {
+    let version = 1;
+    let mut db_reader = mock::create_mock_db_reader();
+    db_reader
+        .expect_get_hot_state_item_count()
+        .times(1)
+        .with(eq(version))
+        .returning(move |_| {
+            Err(AptosDbError::NotFound(
+                format_err!("Version does not exist!").to_string(),
+            ))
+        });
+
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
+    utils::update_storage_server_summary(&mut service, version, 10);
+    tokio::spawn(service.start());
+
+    let response = utils::get_number_of_hot_states(&mut mock_client, version, false)
+        .await
+        .unwrap_err();
+    assert_matches!(response, StorageServiceError::InternalError(_));
+}
+
+#[tokio::test]
 async fn test_get_number_of_states_at_version_not_serviceable() {
     // Create test data
     let version = 101;

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -20,8 +20,8 @@ use aptos_storage_service_notifications::{
 };
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, StateValuesWithProofRequest, StorageServiceRequest,
-        SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, HotStateValuesWithProofRequest, StateValuesWithProofRequest,
+        StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionsWithProofRequest,
     },
@@ -816,6 +816,16 @@ pub async fn get_number_of_states(
     send_storage_request(mock_client, use_compression, data_request).await
 }
 
+/// Sends a request for the number of hot states at a version.
+pub async fn get_number_of_hot_states(
+    mock_client: &mut MockClient,
+    version: u64,
+    use_compression: bool,
+) -> Result<StorageServiceResponse, StorageServiceError> {
+    let data_request = DataRequest::GetNumberOfHotStatesAtVersion(version);
+    send_storage_request(mock_client, use_compression, data_request).await
+}
+
 /// Generates and returns a random number (u64)
 pub fn get_random_u64() -> u64 {
     OsRng.r#gen()
@@ -830,6 +840,22 @@ pub async fn get_state_values_with_proof(
     use_compression: bool,
 ) -> Result<StorageServiceResponse, StorageServiceError> {
     let data_request = DataRequest::GetStateValuesWithProof(StateValuesWithProofRequest {
+        version,
+        start_index,
+        end_index,
+    });
+    send_storage_request(mock_client, use_compression, data_request).await
+}
+
+/// Sends a hot state values with proof request and processes the response.
+pub async fn get_hot_state_values_with_proof(
+    mock_client: &mut MockClient,
+    version: u64,
+    start_index: u64,
+    end_index: u64,
+    use_compression: bool,
+) -> Result<StorageServiceResponse, StorageServiceError> {
+    let data_request = DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
         version,
         start_index,
         end_index,

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -63,6 +63,10 @@ pub enum DataRequest {
     // V1 `GetStateValuesWithProof` / `GetNumberOfStatesAtVersion` variants.
     GetStateValuesWithProofV2(StateValuesWithProofRequestV2), // Fetches a list of states (of the given kind) with a proof
     GetNumberOfStatesAtVersionV2(NumberOfStatesRequestV2), // Fetches the number of states (of the given kind) at the specified version
+
+    // Hot state has a different value type, so it cannot use the state V2 variants above.
+    GetHotStateValuesWithProof(HotStateValuesWithProofRequest), // Fetches a list of hot state values with a proof
+    GetNumberOfHotStatesAtVersion(Version), // Fetches the number of hot states at the specified version
 }
 
 impl DataRequest {
@@ -77,6 +81,8 @@ impl DataRequest {
             Self::GetStateValuesWithProof(_) => "get_state_values_with_proof",
             Self::GetStateValuesWithProofV2(_) => "get_state_values_with_proof_v2",
             Self::GetNumberOfStatesAtVersionV2(_) => "get_number_of_states_at_version_v2",
+            Self::GetHotStateValuesWithProof(_) => "get_hot_state_values_with_proof",
+            Self::GetNumberOfHotStatesAtVersion(_) => "get_number_of_hot_states_at_version",
             Self::GetStorageServerSummary => "get_storage_server_summary",
             Self::GetTransactionOutputsWithProof(_) => "get_transaction_outputs_with_proof",
             Self::GetTransactionsWithProof(_) => "get_transactions_with_proof",
@@ -367,6 +373,14 @@ pub struct StateValuesWithProofRequestV2 {
     pub start_index: u64,      // The index to start fetching state values (inclusive)
     pub end_index: u64,        // The index to stop fetching state values (inclusive)
     pub state_kind: StateKind, // Which snapshot store to fetch from
+}
+
+/// A storage service request for fetching hot state values at a specified version.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct HotStateValuesWithProofRequest {
+    pub version: u64,     // The version to fetch the hot state values at
+    pub start_index: u64, // The index to start fetching hot state values (inclusive)
+    pub end_index: u64,   // The index to stop fetching hot state values (inclusive)
 }
 
 /// A storage service request for fetching the number of state values (of the

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -4,14 +4,15 @@
 use crate::{
     requests::{
         DataRequest::{
-            GetEpochEndingLedgerInfos, GetNewTransactionDataWithProof,
+            GetEpochEndingLedgerInfos, GetHotStateValuesWithProof, GetNewTransactionDataWithProof,
             GetNewTransactionOutputsWithProof, GetNewTransactionsOrOutputsWithProof,
-            GetNewTransactionsWithProof, GetNumberOfStatesAtVersion, GetNumberOfStatesAtVersionV2,
-            GetServerProtocolVersion, GetStateValuesWithProof, GetStateValuesWithProofV2,
-            GetStorageServerSummary, GetTransactionDataWithProof, GetTransactionOutputsWithProof,
-            GetTransactionsOrOutputsWithProof, GetTransactionsWithProof,
-            SubscribeTransactionDataWithProof, SubscribeTransactionOutputsWithProof,
-            SubscribeTransactionsOrOutputsWithProof, SubscribeTransactionsWithProof,
+            GetNewTransactionsWithProof, GetNumberOfHotStatesAtVersion, GetNumberOfStatesAtVersion,
+            GetNumberOfStatesAtVersionV2, GetServerProtocolVersion, GetStateValuesWithProof,
+            GetStateValuesWithProofV2, GetStorageServerSummary, GetTransactionDataWithProof,
+            GetTransactionOutputsWithProof, GetTransactionsOrOutputsWithProof,
+            GetTransactionsWithProof, SubscribeTransactionDataWithProof,
+            SubscribeTransactionOutputsWithProof, SubscribeTransactionsOrOutputsWithProof,
+            SubscribeTransactionsWithProof,
         },
         TransactionDataRequestType,
     },
@@ -26,7 +27,9 @@ use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::{state_value::StateValueChunkWithProof, StateKind},
+    state_store::{
+        hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof, StateKind,
+    },
     transaction::{
         TransactionListWithProof, TransactionListWithProofV2, TransactionOutputListWithProof,
         TransactionOutputListWithProofV2, Version,
@@ -163,6 +166,10 @@ pub enum DataResponse {
     // V2 state responses carry the `StateKind`, so one variant serves any snapshot kind.
     StateValueChunkWithProofV2(StateValueChunkWithProofResponseV2),
     NumberOfStatesAtVersionV2(NumberOfStatesResponseV2),
+
+    // Hot state response variants must remain at the end for BCS wire compatibility.
+    HotStateValueChunkWithProof(HotStateValueChunkWithProof),
+    NumberOfHotStatesAtVersion(u64),
 }
 
 /// A state value chunk response (of the given kind) with a proof.
@@ -210,7 +217,13 @@ impl DataResponse {
             },
             Self::NewTransactionsWithProof(_) => Self::get_new_transactions_with_proof_label(),
             Self::NumberOfStatesAtVersion(_) => Self::get_number_of_states_at_version_label(),
+            Self::NumberOfHotStatesAtVersion(_) => {
+                Self::get_number_of_hot_states_at_version_label()
+            },
             Self::ServerProtocolVersion(_) => Self::get_server_protocol_version_label(),
+            Self::HotStateValueChunkWithProof(_) => {
+                Self::get_hot_state_value_chunk_with_proof_label()
+            },
             Self::StateValueChunkWithProof(_) => Self::get_state_value_chunk_with_proof_label(),
             Self::StateValueChunkWithProofV2(_) => {
                 Self::get_state_value_chunk_with_proof_v2_label()
@@ -272,6 +285,11 @@ impl DataResponse {
         "number_of_states_at_version"
     }
 
+    /// Returns a label for the number of hot states at version response
+    pub fn get_number_of_hot_states_at_version_label() -> &'static str {
+        "number_of_hot_states_at_version"
+    }
+
     /// Returns a label for the server protocol version response
     pub fn get_server_protocol_version_label() -> &'static str {
         "server_protocol_version"
@@ -280,6 +298,11 @@ impl DataResponse {
     /// Returns a label for the state value chunk with proof response
     pub fn get_state_value_chunk_with_proof_label() -> &'static str {
         "state_value_chunk_with_proof"
+    }
+
+    /// Returns a label for the hot state value chunk with proof response
+    pub fn get_hot_state_value_chunk_with_proof_label() -> &'static str {
+        "hot_state_value_chunk_with_proof"
     }
 
     /// Returns a label for the v2 state value chunk with proof response
@@ -365,6 +388,21 @@ impl TryFrom<StorageServiceResponse> for StateValueChunkWithProof {
             DataResponse::StateValueChunkWithProof(inner) => Ok(inner),
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected state_value_chunk_with_proof, found {}",
+                data_response.get_label()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for HotStateValueChunkWithProof {
+    type Error = crate::responses::Error;
+
+    fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
+        let data_response = response.get_data_response()?;
+        match data_response {
+            DataResponse::HotStateValueChunkWithProof(inner) => Ok(inner),
+            _ => Err(Error::UnexpectedResponseError(format!(
+                "expected hot_state_value_chunk_with_proof, found {}",
                 data_response.get_label()
             ))),
         }
@@ -500,7 +538,8 @@ impl TryFrom<StorageServiceResponse> for u64 {
     fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
         let data_response = response.get_data_response()?;
         match data_response {
-            DataResponse::NumberOfStatesAtVersion(inner) => Ok(inner),
+            DataResponse::NumberOfStatesAtVersion(inner)
+            | DataResponse::NumberOfHotStatesAtVersion(inner) => Ok(inner),
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected number_of_states_at_version, found {}",
                 data_response.get_label()
@@ -793,8 +832,13 @@ impl DataSummary {
                 .states
                 .map(|range| range.contains(request.version))
                 .unwrap_or(false),
+            GetNumberOfHotStatesAtVersion(version) => self
+                .states
+                .map(|range| range.contains(*version))
+                .unwrap_or(false),
             GetStateValuesWithProof(request) => self.can_service_state_values(request.version),
             GetStateValuesWithProofV2(request) => self.can_service_state_values(request.version),
+            GetHotStateValuesWithProof(request) => self.can_service_state_values(request.version),
             GetTransactionOutputsWithProof(request) => self
                 .can_service_transaction_outputs_with_proof(
                     request.start_version,

--- a/state-sync/storage-service/types/src/tests.rs
+++ b/state-sync/storage-service/types/src/tests.rs
@@ -3,9 +3,10 @@
 
 use crate::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
-        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, HotStateValuesWithProofRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+        NewTransactionsWithProofRequest, StateValuesWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
@@ -515,12 +516,14 @@ fn test_protocol_metadata_service() {
         assert!(metadata.can_service(&create_epoch_ending_request(100, 199, compression)));
         assert!(metadata.can_service(&create_outputs_request(200, 100, 100, compression)));
         assert!(metadata.can_service(&create_state_values_request(200, 100, 199, compression)));
+        assert!(metadata.can_service(&create_hot_state_values_request(200, 100, 199, compression)));
 
         // Requests with larger chunk sizes (beyond the max) can also be serviced
         assert!(metadata.can_service(&create_transactions_request(200, 100, 1000, compression)));
         assert!(metadata.can_service(&create_epoch_ending_request(100, 10000, compression)));
         assert!(metadata.can_service(&create_outputs_request(200, 100, 9999989, compression)));
         assert!(metadata.can_service(&create_state_values_request(200, 100, 200, compression)));
+        assert!(metadata.can_service(&create_hot_state_values_request(200, 100, 200, compression)));
     }
 }
 
@@ -871,6 +874,21 @@ fn create_state_values_request(
     StorageServiceRequest::new(data_request, use_compression)
 }
 
+/// Creates a request for hot state values.
+fn create_hot_state_values_request(
+    version: Version,
+    start_index: u64,
+    end_index: u64,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    let data_request = DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
+        version,
+        start_index,
+        end_index,
+    });
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
 /// Creates a request for state values at a given version
 fn create_state_values_request_at_version(
     version: Version,
@@ -951,17 +969,19 @@ fn verify_can_service_state_chunk_requests(
     expect_service: bool,
 ) {
     for version in versions {
-        // Create the state chunk request
-        let request = create_state_values_request_at_version(version, use_compression);
-
-        // Verify the serviceability of the request
-        verify_serviceability(
-            data_client_config,
-            data_summary,
-            None,
-            request,
-            expect_service,
-        );
+        let requests = [
+            create_state_values_request_at_version(version, use_compression),
+            create_hot_state_values_request(version, 0, 1000, use_compression),
+        ];
+        for request in requests {
+            verify_serviceability(
+                data_client_config,
+                data_summary,
+                None,
+                request,
+                expect_service,
+            );
+        }
     }
 }
 

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -375,10 +375,8 @@ pub fn test_state_merkle_pruning_impl(
 
         // Check strictly that all trees in the window accessible and all those nodes not needed
         // must be gone.
-        let non_pruned_versions: HashSet<_> = snapshots
-            .into_iter()
-            .chain(epoch_snapshots.into_iter())
-            .collect();
+        let non_pruned_versions: HashSet<_> =
+            snapshots.into_iter().chain(epoch_snapshots).collect();
 
         let expected_nodes: HashSet<_> = non_pruned_versions
             .iter()

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -55,7 +55,7 @@ impl HotStateAccumulator {
         target: &mut [HotStateShardUpdates; NUM_STATE_SHARDS],
         incoming: [HotStateShardUpdates; NUM_STATE_SHARDS],
     ) {
-        for (t, i) in target.iter_mut().zip_eq(incoming.into_iter()) {
+        for (t, i) in target.iter_mut().zip_eq(incoming) {
             t.merge(i);
         }
     }

--- a/storage/aptosdb/src/state_store/tests/mod.rs
+++ b/storage/aptosdb/src/state_store/tests/mod.rs
@@ -216,7 +216,7 @@ proptest! {
             prop_assert!(
                 itertools::equal(
                     actual.iter(),
-                    expected.iter().filter_map(|(_h, kv)| kv.as_ref())
+                    expected.values().filter_map(|kv| kv.as_ref())
                 )
             );
         }

--- a/storage/backup/backup-cli/src/metadata/cache.rs
+++ b/storage/backup/backup-cli/src/metadata/cache.rs
@@ -201,8 +201,7 @@ pub async fn sync_and_load(
                 .err_notes(&cached_file)?
                 .load_metadata_lines()
                 .await
-                .err_notes(&cached_file)?
-                .into_iter(),
+                .err_notes(&cached_file)?,
         )
     }
     info!(

--- a/storage/backup/backup-cli/src/storage/test_util.rs
+++ b/storage/backup/backup-cli/src/storage/test_util.rs
@@ -82,8 +82,7 @@ pub async fn test_save_and_list_metadata_files_impl(
             buf.lines()
                 .map(TextLine::new)
                 .collect::<Result<Vec<_>>>()
-                .unwrap()
-                .into_iter(),
+                .unwrap(),
         )
     }
     read_back.sort();

--- a/storage/jellyfish-merkle/src/test_helper.rs
+++ b/storage/jellyfish-merkle/src/test_helper.rs
@@ -359,25 +359,29 @@ fn compute_root_hash_impl(kvs: Vec<(&[bool], HashValue)>) -> HashValue {
     // Otherwise the tree has more than one leaves, which means we can find which ones are in the
     // left subtree and which ones are in the right subtree. So we find the first key that starts
     // with a 1-bit.
-    let left_hash;
-    let right_hash;
-    match kvs.iter().position(|(key, _value)| key[0]) {
+    let (left_hash, right_hash) = match kvs.iter().position(|(key, _value)| key[0]) {
         Some(0) => {
             // Every key starts with a 1-bit, i.e., they are all in the right subtree.
-            left_hash = *SPARSE_MERKLE_PLACEHOLDER_HASH;
-            right_hash = compute_root_hash_impl(reduce(&kvs));
+            (
+                *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                compute_root_hash_impl(reduce(&kvs)),
+            )
         },
         Some(index) => {
             // Both left subtree and right subtree have some keys.
-            left_hash = compute_root_hash_impl(reduce(&kvs[..index]));
-            right_hash = compute_root_hash_impl(reduce(&kvs[index..]));
+            (
+                compute_root_hash_impl(reduce(&kvs[..index])),
+                compute_root_hash_impl(reduce(&kvs[index..])),
+            )
         },
         None => {
             // Every key starts with a 0-bit, i.e., they are all in the left subtree.
-            left_hash = compute_root_hash_impl(reduce(&kvs));
-            right_hash = *SPARSE_MERKLE_PLACEHOLDER_HASH;
+            (
+                compute_root_hash_impl(reduce(&kvs)),
+                *SPARSE_MERKLE_PLACEHOLDER_HASH,
+            )
         },
-    }
+    };
 
     SparseMerkleInternalNode::new(left_hash, right_hash).hash()
 }

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -1130,7 +1130,7 @@ async fn parse_block_transactions(
         )
         .await;
 
-        for (_, account_balance) in balances.iter() {
+        for account_balance in balances.values() {
             if let Some(amount) = account_balance.get(&cur_version) {
                 assert!(*amount >= 0, "Amount shouldn't be negative!")
             }

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -1833,7 +1833,7 @@ impl Generator<'_> {
                         .iter()
                         .map(|exp| self.gen_escape_auto_ref_arg(exp, true))
                         .collect::<Vec<_>>();
-                    for (pat, temp) in pats.iter().zip(temps.into_iter()) {
+                    for (pat, temp) in pats.iter().zip(temps) {
                         self.gen_match_from_temp(
                             id,
                             pat,

--- a/third_party/move/move-compiler-v2/src/env_pipeline/acquires_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/acquires_checker.rs
@@ -150,7 +150,7 @@ impl AcquiredResources {
     /// Joins the resources acquired by `other_fun`
     fn join(&mut self, other_fun: FunId, other_fun_called_at: Loc, other_acquries: &Self) -> bool {
         let mut changed = false;
-        for (sid, _) in other_acquries.0.iter() {
+        for sid in other_acquries.0.keys() {
             use std::collections::btree_map::Entry::*;
             match self.0.entry(*sid) {
                 Vacant(e) => {
@@ -217,7 +217,7 @@ impl<'a> AcquireChecker<'a> {
         let reversed_call_graph = call_graph.iter().fold(
             BTreeMap::new(),
             |mut reversed: BTreeMap<FunId, BTreeSet<FunId>>, (caller, callees)| {
-                for (callee, _) in callees.iter() {
+                for callee in callees.keys() {
                     reversed.entry(*callee).or_default().insert(*caller);
                 }
                 reversed

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
@@ -215,7 +215,7 @@ fn find_cycles_in_call_graph(
     for scc in kosaraju_scc(&graph) {
         if scc.len() > 1 {
             // cycle involving non-self-recursion
-            cycle_nodes.extend(scc.into_iter());
+            cycle_nodes.extend(scc);
         }
     }
     cycle_nodes
@@ -357,7 +357,7 @@ fn pick_from_eligible_and_compute_cost(
             locals_budget_remaining.checked_sub(callee_info.locals_per_site),
             code_size_budget_remaining.checked_sub(callee_info.code_size * sites.len()),
         ) {
-            call_sites_to_inline.extend(sites.into_iter());
+            call_sites_to_inline.extend(sites);
             // Note that we reduce the remaining budget for number of locals once for
             // all the callsites of a callee, because we expect to coalesce the locals at
             // different callsites.

--- a/third_party/move/move-compiler-v2/src/pipeline/control_flow_graph_simplifier.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/control_flow_graph_simplifier.rs
@@ -554,7 +554,7 @@ impl ControlFlowGraphCodeGenerator {
         // check invariant 7
         assert!(self.entry_block != self.exit_block);
         // check invariant 8
-        for (_, succs) in self.successors.iter() {
+        for succs in self.successors.values() {
             succs.iter().all_unique();
         }
         // check invariant 9

--- a/third_party/move/move-prover/boogie-backend/src/lib.rs
+++ b/third_party/move/move-prover/boogie-backend/src/lib.rs
@@ -426,8 +426,8 @@ pub fn add_prelude(
     context.insert("tuple_instances", &tuple_instances);
     let table_key_instances = mono_info
         .table_inst
-        .iter()
-        .flat_map(|(_, ty_args)| ty_args.iter().map(|(kty, _)| kty))
+        .values()
+        .flat_map(|ty_args| ty_args.iter().map(|(kty, _)| kty))
         .unique()
         .map(|ty| TypeInfo::new(env, options, ty, false))
         .collect_vec();

--- a/third_party/move/move-prover/boogie-backend/src/options.rs
+++ b/third_party/move/move-prover/boogie-backend/src/options.rs
@@ -523,7 +523,7 @@ impl BoogieOptions {
             ));
         }
 
-        for (l, g) in lesser_parts.into_iter().zip(greater_parts.into_iter()) {
+        for (l, g) in lesser_parts.into_iter().zip(greater_parts) {
             let ln = l.parse::<usize>()?;
             let gn = g.parse::<usize>()?;
             if gn < ln {

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -1121,10 +1121,7 @@ impl Analyzer<'_> {
             }
         }
         if let Some(option_qid) = option_qid {
-            for ty in option_v_to_register
-                .into_iter()
-                .chain(option_k_to_register.into_iter())
-            {
+            for ty in option_v_to_register.into_iter().chain(option_k_to_register) {
                 self.add_type(&Type::Struct(option_qid.module_id, option_qid.id, vec![ty]));
             }
         }

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -203,10 +203,7 @@ pub fn verify_pack_closure(
     let expected_capture_tys = mask.extract(func.param_tys(), true);
 
     let given_capture_tys = operand_stack.popn_tys(expected_capture_tys.len() as u16)?;
-    for (expected, given) in expected_capture_tys
-        .into_iter()
-        .zip(given_capture_tys.into_iter())
-    {
+    for (expected, given) in expected_capture_tys.into_iter().zip(given_capture_tys) {
         expected.paranoid_check_is_no_ref("Captured argument type")?;
         with_instantiation(ty_builder, func, expected, |expected| {
             // Intersect the captured type with the accumulated abilities

--- a/third_party/move/tools/move-asm/src/assembler.rs
+++ b/third_party/move/tools/move-asm/src/assembler.rs
@@ -414,8 +414,8 @@ impl<'a> Assembler<'a> {
                 .require_resolution_context()
                 .local_map
                 .clone()
-                .into_iter()
-                .filter_map(|(_, r)| {
+                .into_values()
+                .filter_map(|r| {
                     if r.0 as usize >= locals_start {
                         Some(r)
                     } else {

--- a/third_party/move/tools/move-coverage/src/coverage_map.rs
+++ b/third_party/move/tools/move-coverage/src/coverage_map.rs
@@ -132,7 +132,7 @@ impl CoverageMap {
 
     pub fn to_unified_exec_map(&self) -> ExecCoverageMap {
         let mut unified_map = ExecCoverageMap::new(String::new());
-        for (_, exec_map) in self.exec_maps.iter() {
+        for exec_map in self.exec_maps.values() {
             for ((module_addr, module_name), module_map) in exec_map.module_maps.iter() {
                 for (func_name, func_map) in module_map.function_maps.iter() {
                     for (pc, count) in func_map.iter() {

--- a/third_party/move/tools/move-coverage/src/coverage_map.rs
+++ b/third_party/move/tools/move-coverage/src/coverage_map.rs
@@ -267,12 +267,8 @@ impl ExecCoverageMap {
             .collect();
 
         let compiled_modules = modules
-            .into_iter()
-            .flat_map(|(_, module_map)| {
-                module_map
-                    .into_iter()
-                    .map(|(_, (module_path, compiled_module))| (module_path, compiled_module))
-            })
+            .into_values()
+            .flat_map(|module_map| module_map.into_values())
             .collect();
 
         ExecCoverageMapWithModules {

--- a/third_party/move/tools/move-coverage/src/source_coverage.rs
+++ b/third_party/move/tools/move-coverage/src/source_coverage.rs
@@ -320,13 +320,10 @@ impl<'a> SourceCoverageBuilder<'a> {
                                 minimize_locations(fun_uncov.iter().map(|(loc, _)| *loc).collect());
                             // If any uncovered locations are the same as covered locations,
                             // remove them from uncovered locations.
-                            let uncovered_locations =
-                                BTreeSet::from_iter(uncovered_locations.into_iter())
-                                    .difference(&BTreeSet::from_iter(
-                                        covered_locations.iter().cloned(),
-                                    ))
-                                    .cloned()
-                                    .collect();
+                            let uncovered_locations = BTreeSet::from_iter(uncovered_locations)
+                                .difference(&BTreeSet::from_iter(covered_locations.iter().cloned()))
+                                .cloned()
+                                .collect();
                             // Covered locations may be an over-approximation, so uncovered
                             // locations are subtracted from covered locations.
                             let covered_locations = subtract_locations(

--- a/third_party/move/tools/move-coverage/src/summary.rs
+++ b/third_party/move/tools/move-coverage/src/summary.rs
@@ -329,7 +329,7 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
         BTreeMap<BTreeSet<(CodeOffset, CodeOffset)>, u64>,
     > = BTreeMap::new();
 
-    for (_, trace) in trace_map.exec_maps.iter() {
+    for trace in trace_map.exec_maps.values() {
         let mut call_stack: Vec<&FunctionInfo> = Vec::new();
         let mut path_stack: Vec<BTreeSet<(CodeOffset, CodeOffset)>> = Vec::new();
         let mut path_store: Vec<(Identifier, BTreeSet<(CodeOffset, CodeOffset)>)> = Vec::new();

--- a/third_party/move/tools/move-package-resolver/src/resolver.rs
+++ b/third_party/move/tools/move-package-resolver/src/resolver.rs
@@ -276,7 +276,7 @@ async fn resolve_package(
                     package_manifest
                         .dependencies
                         .into_iter()
-                        .chain(package_manifest.dev_dependencies.into_iter()),
+                        .chain(package_manifest.dev_dependencies),
                 )
             } else {
                 Either::Right(package_manifest.dependencies.into_iter())

--- a/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -769,8 +769,8 @@ impl ResolvedGraph {
 
     pub fn file_sources(&self) -> BTreeMap<FileHash, (Symbol, String)> {
         self.package_table
-            .iter()
-            .flat_map(|(_, rpkg)| {
+            .values()
+            .flat_map(|rpkg| {
                 rpkg.get_sources(&self.build_options)
                     .unwrap()
                     .iter()

--- a/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -279,7 +279,7 @@ impl ResolvingGraph {
             .dependencies
             .clone()
             .into_iter()
-            .chain(additional_deps.into_iter())
+            .chain(additional_deps)
         {
             if let Some(std_version) = &override_std {
                 if let Some(std_lib) = StdLib::from_package_name(dep_name) {

--- a/third_party/move/tools/move-package/tests/test_runner.rs
+++ b/third_party/move/tools/move-package/tests/test_runner.rs
@@ -113,7 +113,7 @@ fn run_test_impl(
                 Err(error) => format!("{:#}\n", error),
             },
             (_, _) => {
-                for (_, package) in resolved_package.package_table.iter_mut() {
+                for package in resolved_package.package_table.values_mut() {
                     package.package_path = PathBuf::from("ELIDED_FOR_TEST");
                     package.source_digest = PackageDigest::from("ELIDED_FOR_TEST");
                 }

--- a/third_party/move/tools/move-unit-test/src/package_test.rs
+++ b/third_party/move/tools/move-unit-test/src/package_test.rs
@@ -73,8 +73,8 @@ pub fn build_test_plan_for_package<W: Write + Send>(
     // messages.
     let dep_file_map: HashMap<_, _> = resolution_graph
         .package_table
-        .iter()
-        .flat_map(|(_, rpkg)| {
+        .values()
+        .flat_map(|rpkg| {
             rpkg.get_sources(&resolution_graph.build_options)
                 .unwrap()
                 .iter()

--- a/third_party/move/tools/move-unit-test/src/test_reporter.rs
+++ b/third_party/move/tools/move-unit-test/src/test_reporter.rs
@@ -480,15 +480,15 @@ impl TestStatistics {
     pub fn combine(mut self, other: Self) -> Self {
         for (module_id, test_result) in other.passed {
             let entry = self.passed.entry(module_id).or_default();
-            entry.extend(test_result.into_iter());
+            entry.extend(test_result);
         }
         for (module_id, test_result) in other.failed {
             let entry = self.failed.entry(module_id).or_default();
-            entry.extend(test_result.into_iter());
+            entry.extend(test_result);
         }
         for (module_id, test_output) in other.output {
             let entry = self.output.entry(module_id).or_default();
-            entry.extend(test_output.into_iter());
+            entry.extend(test_output);
         }
         self
     }

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -98,7 +98,7 @@ fn test_accumulator_append() {
     let mut accumulator = InMemoryAccumulator::<TestOnlyHasher>::default();
     // Append the leaves one at a time and check the root hashes match.
     for (i, (leaf, expected_root_hash)) in
-        itertools::zip_eq(leaves.into_iter(), expected_root_hashes).enumerate()
+        itertools::zip_eq(leaves, expected_root_hashes).enumerate()
     {
         assert_eq!(accumulator.root_hash(), expected_root_hash);
         assert_eq!(accumulator.num_leaves(), i as LeafCount);

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -30,7 +30,8 @@ pub mod table;
 
 pub const NUM_STATE_SHARDS: usize = 16;
 
-/// Identifies which snapshot store an operation targets.
+/// Identifies a snapshot store whose leaves use the standard `StateValue` representation.
+/// Hot state uses `HotStateValue` leaves and separate APIs, so it is not a variant of this enum.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum StateKind {
     MainState,


### PR DESCRIPTION

Expose the existing AptosDB hot-state snapshot readers through the storage service so fast-sync clients can fetch bounded, authenticated chunks in a follow-up change.

Reuse the existing state availability range and response progress tracking, preserving wire compatibility by appending the new request and response variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes state-sync RPC types and storage-server read paths used during sync; variants are append-only for BCS compatibility, but mixed-fleet behavior depends on peers understanding the new requests.
> 
> **Overview**
> **Bumps the Rust toolchain to 1.98.0** (Docker bake, `rust-toolchain.toml`, workspace `rust-version`) and applies widespread Clippy-driven cleanups (`zip` without redundant `into_iter()`, map `values`/`keys` iteration, `clear` vs `truncate(0)`). New Clippy lints from the upgrade are **suppressed in `.cargo/config.toml`** with a TODO to address separately; `aptos-vm-types` adds `unexpected_cfgs` for `fuzzing`.
> 
> **Adds hot-state support to the storage service** so peers can sync `HotStateValue` chunks with proofs, separate from main-state `StateKind` APIs. Wire-compatible **request/response variants** are appended: `GetHotStateValuesWithProof`, `GetNumberOfHotStatesAtVersion`, and matching responses. The server **handlers** delegate to AptosDB via new `StorageReaderInterface` / `DbReader` methods (`get_hot_state_item_count`, chunk iter + proof).
> 
> Chunk serving **refactors** size/time-aware fetching into a shared `get_value_chunk_with_proof_by_size` helper reused for main state and hot state. **Serviceability** reuses the existing state availability range; tests cover caching, chunk limits, network byte caps, and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114710d297b4ccca7dd5bc34b1e3b124263c2db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->