### PR TITLE
[cli] Clean up CLI documentation and help text

### DIFF
--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -1,5 +1,111 @@
-# Aptos Command Line Interface (CLI) Tool
+# Aptos Command Line Interface (CLI)
 
-The `aptos` tool is a command line interface (CLI) for debugging, development, and node operation.
+The `aptos` CLI is a command line tool for developing Move smart contracts, interacting with the
+Aptos blockchain, and operating Aptos nodes.
 
-See [Aptos CLI Documentation](https://aptos.dev/tools/aptos-cli/) for how to install the `aptos` CLI tool and how to use it.
+This crate builds the `aptos` binary. For conceptual guides and tutorials, see the
+[Aptos CLI documentation](https://aptos.dev/build/cli).
+
+## Installation
+
+Prebuilt binaries are the recommended way to install the CLI:
+
+- [macOS](https://aptos.dev/build/cli/install-cli/install-cli-mac)
+- [Linux](https://aptos.dev/build/cli/install-cli/install-cli-linux)
+- [Windows](https://aptos.dev/build/cli/install-cli/install-cli-windows)
+- [asdf](https://aptos.dev/build/cli/install-cli/install-cli-asdf)
+- [A specific version](https://aptos.dev/build/cli/install-cli/install-cli-specific-version)
+
+Once installed, update the CLI in place with:
+
+```bash
+aptos update aptos
+```
+
+To build from this repository instead, see [Building from source](#building-from-source).
+
+## Getting started
+
+Initialize a profile, which stores a key pair and network settings in `.aptos/config.yaml` in the
+current directory:
+
+```bash
+aptos init
+```
+
+Then create and publish a Move package:
+
+```bash
+aptos move init --name my_package   # Scaffold a new package
+aptos move compile                  # Compile it
+aptos move test                     # Run its unit tests
+aptos move publish                  # Publish it on chain
+```
+
+Run a local network to develop against, instead of a public network:
+
+```bash
+aptos node run-localnet
+```
+
+See [Setting up the CLI](https://aptos.dev/build/cli/setup-cli) for profile and network
+configuration details.
+
+## Command groups
+
+Every command is grouped under a top-level subcommand:
+
+| Group | Purpose |
+| --- | --- |
+| `account` | Create and fund accounts, inspect resources, transfer APT, and rotate keys |
+| `config` | Manage CLI profiles, global settings, and shell completions |
+| `genesis` | Set up a genesis transaction for a new chain |
+| `governance` | Propose, vote on, and verify on-chain governance proposals |
+| `info` | Show build information about the CLI |
+| `init` | Initialize the current directory for use with the CLI |
+| `key` | Generate and inspect keys, and extract peer information |
+| `move` | Compile, test, publish, and interact with Move packages |
+| `multisig` | Create and approve transactions for multisig accounts |
+| `node` | Operate validators and full nodes, and run a local network |
+| `stake` | Manage stake, staking contracts, and delegated voters |
+| `update` | Update the CLI and the tools it depends on |
+
+## Discovering commands
+
+The CLI is self-documenting. Append `--help` at any level to list the available subcommands and
+arguments:
+
+```bash
+aptos --help                # All command groups
+aptos move --help           # Commands within a group
+aptos move publish --help   # Arguments for a single command
+```
+
+Use `-h` for a short summary and `--help` for the full description of each argument.
+
+Shell completions make the commands easier to explore interactively:
+
+```bash
+aptos config generate-shell-completions --shell zsh --output-file <path>
+```
+
+Supported shells are `bash`, `elvish`, `fish`, `powershell`, and `zsh`.
+
+## Building from source
+
+Build the CLI from a checkout of `aptos-core`:
+
+```bash
+cargo build -p aptos            # Debug binary at target/debug/aptos
+cargo build -p aptos --release  # Release binary at target/release/aptos
+```
+
+Helper scripts for release and minimal builds live in [`scripts/cli`](../../scripts/cli) at the
+repository root.
+
+## Further reading
+
+- [`CHANGELOG.md`](CHANGELOG.md) — released versions and their changes
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — design decisions and guidelines for adding commands
+- [`e2e/README.md`](e2e/README.md) — the CLI end-to-end test suite
+- [`homebrew/README.md`](homebrew/README.md) — the Homebrew formula for the CLI

--- a/crates/aptos/src/account/multisig_account.rs
+++ b/crates/aptos/src/account/multisig_account.rs
@@ -232,7 +232,7 @@ impl CliCommand<serde_json::Value> for VerifyProposal {
                 "Transaction mismatch: The transaction you provided has a payload hash of \
                 {expected_payload_hash}, but the on-chain transaction proposal you specified has \
                 a payload hash of {actual_payload_hash}. For more info, see \
-                https://aptos.dev/move/move-on-aptos/cli#multisig-governance"
+                https://aptos.dev/build/cli/working-with-move-contracts/multi-signature-tutorial"
             )))
         }
     }
@@ -512,7 +512,7 @@ impl CliCommand<serde_json::Value> for VerifyScriptProposal {
                 "Transaction mismatch: The transaction you provided has a payload hash of \
                 {expected_payload_hash}, but the on-chain transaction proposal you specified has \
                 a payload hash of {actual_payload_hash}. For more info, see \
-                https://aptos.dev/move/move-on-aptos/cli#multisig-governance"
+                https://aptos.dev/build/cli/working-with-move-contracts/multi-signature-tutorial"
             )))
         }
     }

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -83,6 +83,10 @@ impl FromStr for GithubRepo {
     }
 }
 
+/// Shared options for locating the genesis configuration repository
+///
+/// Genesis inputs can be read either from a GitHub repository or from a local
+/// directory. Exactly one of the two sources must be provided.
 #[derive(Clone, Default, Parser)]
 pub struct GitOptions {
     /// Github repository e.g. 'aptos-labs/aptos-core'

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -288,6 +288,7 @@ pub struct SubmitProposal {
     pub(crate) args: SubmitProposalArgs,
 }
 
+/// Shared options for submitting a governance proposal
 #[derive(Parser)]
 pub struct SubmitProposalArgs {
     /// Location of the JSON metadata of the proposal
@@ -305,6 +306,11 @@ pub struct SubmitProposalArgs {
     #[clap(long)]
     pub(crate) metadata_path: Option<PathBuf>,
 
+    /// Submit the proposal as a multi-step proposal
+    ///
+    /// A multi-step proposal executes a sequence of scripts, where each script
+    /// commits to the hash of the next one. Without this flag the proposal is
+    /// submitted as a single-step proposal that executes exactly one script.
     #[clap(long)]
     pub(crate) is_multi_step: bool,
 
@@ -492,6 +498,9 @@ pub struct SubmitVote {
     pub(crate) args: SubmitVoteArgs,
 }
 
+/// Shared options for voting on a governance proposal
+///
+/// Exactly one of `--yes` or `--no` must be provided.
 #[derive(Parser)]
 #[group(id = "vote", required = true, multiple = false)]
 pub struct SubmitVoteArgs {
@@ -831,6 +840,11 @@ pub struct GenerateUpgradeProposal {
     #[clap(long)]
     pub(crate) testnet: bool,
 
+    /// Execution hash of the next script in a multi-step proposal
+    ///
+    /// Leave this empty to generate a single-step proposal. When set, the
+    /// generated script becomes part of a multi-step proposal and commits to
+    /// the next script to be executed.
     #[clap(long, default_value = "")]
     pub(crate) next_execution_hash: String,
 
@@ -884,8 +898,13 @@ impl CliCommand<()> for GenerateUpgradeProposal {
 /// Generate execution hash for a specified script.
 #[derive(Parser)]
 pub struct GenerateExecutionHash {
+    /// Path to the Move script to compile and hash
     #[clap(long)]
     pub script_path: Option<PathBuf>,
+
+    /// Local directory of the `aptos-framework` package to compile against
+    ///
+    /// Defaults to the copy of `aptos-framework` bundled with this CLI.
     #[clap(long)]
     pub framework_local_dir: Option<PathBuf>,
 }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -116,6 +116,10 @@ impl NodeTool {
     }
 }
 
+/// Shared option for supplying validator settings from an operator config file
+///
+/// Values loaded from the file are used as defaults for the corresponding
+/// command line arguments, which take precedence when set explicitly.
 #[derive(Parser)]
 pub struct OperatorConfigFileArgs {
     /// Operator Configuration file
@@ -137,6 +141,10 @@ impl OperatorConfigFileArgs {
     }
 }
 
+/// Shared options for a validator's BLS12-381 consensus key
+///
+/// Both the public key and its proof of possession may instead be supplied
+/// through an operator config file.
 #[derive(Parser)]
 pub struct ValidatorConsensusKeyArgs {
     /// Hex encoded Consensus public key
@@ -187,6 +195,10 @@ impl ValidatorConsensusKeyArgs {
     }
 }
 
+/// Shared options for a validator's network addresses and network keys
+///
+/// These describe how the validator and its optional full node are reached by
+/// peers. They may instead be supplied through an operator config file.
 #[derive(Parser)]
 pub struct ValidatorNetworkAddressesArgs {
     /// Host and port pair for the validator

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -116,6 +116,9 @@ impl CliCommand<HashMap<AccountAddress, Peer>> for ExtractPeer {
     }
 }
 
+/// Shared options for supplying an x25519 network private key
+///
+/// The key may be given directly or read from a file, but not both.
 #[derive(Debug, Default, Parser)]
 pub struct NetworkKeyInputOptions {
     /// x25519 Private key input file name
@@ -393,6 +396,10 @@ impl CliCommand<HashMap<&'static str, PathBuf>> for ExtractPublicKey {
     }
 }
 
+/// Shared options for writing a generated key pair to disk
+///
+/// The private key is written to the given output file and the public key to
+/// the same path with a `.pub` extension, both in the selected encoding.
 #[derive(Debug, Parser, Clone)]
 pub struct SaveKey {
     #[clap(flatten)]


### PR DESCRIPTION
## Description

The `aptos` crate README was a five-line stub that deferred entirely to the website, and several user-facing help strings were missing or stale. This consolidates the CLI's user-facing documentation under `crates/aptos` and fixes the gaps in generated `--help` output.

### Help output (user-visible)

- Document `--is-multi-step` and `--next-execution-hash` on governance proposals. Both previously rendered in `--help` with no description at all.

### Dead link

- Repoint the multisig payload mismatch error at the current tutorial. The old URL (`/move/move-on-aptos/cli#multisig-governance`) returned 404, so it failed users exactly when they were already blocked by a mismatch.

### Readability

- Add doc comments to the flattened argument-group structs shared by the genesis, governance, node, and key commands. Clap ignores struct-level docs on `#[clap(flatten)]` groups, so these aid readers of the code rather than changing `--help` output.

### README

- Expand `crates/aptos/README.md` into a CLI overview: installation, getting started, a command-group table, help discovery, building from source, and links to the existing changelog, contributing, e2e, and homebrew docs.

Specialized docs (`CONTRIBUTING.md`, `e2e/`, `homebrew/`, `CHANGELOG.md`) were intentionally left in place and are now linked from the README.

## Test Plan

- `cargo check -p aptos` — passes
- `cargo test -p aptos --lib verify_tool` — passes (clap `debug_assert`, catches malformed help/arg definitions)
- `cargo +nightly fmt -p aptos -- --check` — clean
- Rendered `--help` inspected directly for each changed argument
- All README links and relative paths verified reachable

Documentation-only; no functional or behavioral changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and Clap field descriptions only; no logic, API, or security behavior changes.
> 
> **Overview**
> **Documentation-only** refresh of the `aptos` crate’s user-facing docs and Clap help strings; runtime behavior is unchanged.
> 
> The **`crates/aptos/README.md`** stub is replaced with a full CLI overview: install paths, quick start (`init`, Move workflow, localnet), a command-group table, `--help`/completions discovery, build-from-source, and links to changelog, contributing, e2e, and homebrew docs (with updated aptos.dev URLs).
> 
> **`--help` output** gains descriptions for governance flags that were previously blank: **`--is-multi-step`** on proposal submit, **`--next-execution-hash`** on upgrade proposal generation, and **`script_path` / `framework_local_dir`** on execution-hash generation.
> 
> Multisig **payload mismatch** errors now point at the current multi-signature tutorial instead of a **404** aptos.dev anchor.
> 
> **Rust doc comments** were added on shared `#[clap(flatten)]` argument structs in genesis, governance, node, and key modules; these improve source readability only and do not alter `--help`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c42b402fe0d8de333a9c69162f5f05306461b63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->