### PR TITLE
[repo] Ignore .atlas/ agent state directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ genesis_antithesis_*/
 # ignore cursor rules / claude settings
 .cursor/rules
 .claude
+.atlas/
 
 #ignore proptest regressions
 **/proptest_regressions/*


### PR DESCRIPTION
## Description

Atlas writes per-workspace state into `.atlas/` directories. Each one carries a self-ignoring `.gitignore` (`*` plus `!.gitignore`) that hides its contents but deliberately keeps that one file visible, so the directories still surfaced as untracked in `git status`.

This ignores them at the root, alongside the existing agent and IDE tooling entries (`.cursor/rules`, `.claude`).

## Test Plan

Before the change, `git status` showed:

```
?? .atlas/
?? aptos-move/move-examples/fungible_asset/stablecoin/.atlas/
```

After, both resolve to the new rule and `git status` is clean:

```
$ git check-ignore -v .atlas/history \
    aptos-move/move-examples/fungible_asset/stablecoin/.atlas/history
.gitignore:148:.atlas/	.atlas/history
.gitignore:148:.atlas/	aptos-move/move-examples/fungible_asset/stablecoin/.atlas/history
```

One line added to `.gitignore`; no code or build changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `.gitignore` line with no runtime or security impact.
> 
> **Overview**
> Adds a root `.gitignore` entry for **`.atlas/`** so Atlas per-workspace state (repo root and nested paths such as under `move-examples`) no longer shows up as untracked in `git status`, consistent with existing ignores for `.cursor/rules` and `.claude`.
> 
> No application, build, or test code is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65452b44624d0c2ac41c06c0fa415c7d9745343d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->