### PR TITLE
[prover] add bv internal pragma

### DIFF
--- a/third_party/move/move-model/src/pragmas.rs
+++ b/third_party/move/move-model/src/pragmas.rs
@@ -681,6 +681,7 @@ pub fn is_pragma_valid_for_block(
                 | DELEGATE_INVARIANTS_TO_CALLER_PRAGMA
                 | BV_PARAM_PROP
                 | BV_RET_PROP
+                | BV_INTERNAL_PRAGMA
                 | UNROLL_PRAGMA
                 | INFERENCE_PRAGMA
         ),
@@ -780,6 +781,11 @@ pub const BV_PARAM_PROP: &str = "bv";
 /// to explicitly specify which return value will be translated into a bv type in the boogie file
 /// example: bv_ret=b"0,1"
 pub const BV_RET_PROP: &str = "bv_ret";
+
+/// A pragma declaring a function's bitwise representation internal: the body verifies
+/// with bitvectors, while parameters, results and the contract are integers at the
+/// boundary. Requires `pragma opaque`.
+pub const BV_INTERNAL_PRAGMA: &str = "bv_internal";
 
 /// A function which determines whether a property is valid for a given condition kind.
 pub fn is_property_valid_for_condition(kind: &ConditionKind, prop: &str) -> bool {

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -1733,7 +1733,7 @@ impl SpecTranslator<'_> {
                 // as int and the conversion is the identity. The base comes
                 // from the instantiated type (a raw node type can still be a
                 // type parameter, which has no numeric base).
-                let wrap = self.node_bv_flag(node_id) && !self.node_bv_flag(args[0].node_id());
+                let wrap = self.node_bv_flag(node_id) && !self.operand_bv_flag(&args[0]);
                 if wrap {
                     let arg_node_type = self.get_node_type(args[0].node_id());
                     let literal = boogie_num_type_base(
@@ -1751,15 +1751,14 @@ impl SpecTranslator<'_> {
             },
             Operation::Bv2Int => {
                 // See `Int2Bv`: convert only when the argument renders as a
-                // bitvector; under the signed clamp it renders as int and the
-                // conversion is the identity.
-                let wrap = self.node_bv_flag(args[0].node_id());
+                // bitvector; a severed contract leaves the node unclassified
+                // where the temporary itself still renders bv.
+                let (wrap, arg_ty) = self.operand_rendering(&args[0]);
                 if wrap {
-                    let arg_node_type = self.get_node_type(args[0].node_id());
                     let literal = boogie_num_type_base(
                         self.env,
                         Some(self.env.get_node_loc(args[0].node_id())),
-                        &arg_node_type,
+                        &arg_ty,
                         false,
                     );
                     emit!(self.writer, "$bv2int.{}(", literal);
@@ -2894,6 +2893,22 @@ impl SpecTranslator<'_> {
         // spec-function checks compare state S against entry/exit (or one labeled state
         // against another) rather than collapsing to entry-vs-exit via the `Old(arg)`-routed
         // function-entry snapshots.
+        // Mirrors the declaration in `translate_spec_fun`; `None` for native templates,
+        // whose parameters follow the call's flag-node suffix.
+        let boundary_global_state = self.env.get_extension::<GlobalNumberOperationState>();
+        let param_renders_bv = |i: usize, ty: &Type| -> Option<bool> {
+            if is_vector_table_cmp_module {
+                return None;
+            }
+            Some(
+                boundary_global_state
+                    .as_ref()
+                    .and_then(|gs| gs.spec_fun_operation_map.get(&(module_id, fun_id)))
+                    .and_then(|(params, _)| params.get(i))
+                    .map(|oper| bv_flag_for_type(self.env, oper, ty))
+                    .unwrap_or(false),
+            )
+        };
         let mut_count = fun_decl
             .params
             .iter()
@@ -2925,7 +2940,7 @@ impl SpecTranslator<'_> {
         if is_doubled {
             let mut arg_iter = args.iter();
             let mut mut_idx: usize = 0;
-            for move_model::model::Parameter(_, ty, _) in &fun_decl.params {
+            for (i, move_model::model::Parameter(_, ty, _)) in fun_decl.params.iter().enumerate() {
                 if ty.is_mutable_reference() {
                     let pre_arg = arg_iter.next().expect("doubled args missing pre slot");
                     let post_arg = arg_iter.next().expect("doubled args missing post slot");
@@ -2946,7 +2961,9 @@ impl SpecTranslator<'_> {
                     let arg = arg_iter.next().expect("missing arg for non-mut param");
                     maybe_comma();
                     // Instantiated type, as in the non-doubled branch below.
-                    self.translate_spec_fun_arg(arg, &ty.instantiate(inst));
+                    let ity = ty.instantiate(inst);
+                    let param_is_bv = param_renders_bv(i, &ity);
+                    self.translate_spec_fun_arg(arg, &ity, param_is_bv);
                 }
             }
         } else {
@@ -2972,7 +2989,7 @@ impl SpecTranslator<'_> {
             };
             let mut arg_iter = args.iter();
             let mut mut_idx: usize = 0;
-            for move_model::model::Parameter(_, ty, _) in &fun_decl.params {
+            for (i, move_model::model::Parameter(_, ty, _)) in fun_decl.params.iter().enumerate() {
                 let arg = arg_iter.next().expect("missing arg");
                 maybe_comma();
                 if ty.is_mutable_reference() {
@@ -2983,35 +3000,33 @@ impl SpecTranslator<'_> {
                     }
                     mut_idx += 1;
                 } else {
-                    // The `num`-boundary check must see the instantiated
-                    // parameter type: a generic parameter instantiated at
-                    // `num` converts like a declared `num` parameter.
-                    self.translate_spec_fun_arg(arg, &ty.instantiate(inst));
+                    // Instantiated type: a generic parameter at `num` converts like a
+                    // declared `num` one.
+                    let ity = ty.instantiate(inst);
+                    let param_is_bv = param_renders_bv(i, &ity);
+                    self.translate_spec_fun_arg(arg, &ity, param_is_bv);
                 }
             }
         }
         emit!(self.writer, ")");
     }
 
-    /// Emit a spec fun argument for a by-value parameter, converting at the
-    /// representational boundary of widthless `num` parameters: a `num`
-    /// parameter always renders as int, while a bitwise-classified argument
-    /// renders as a bitvector (the number-operation analysis clamps `num`
-    /// parameter slots to `Arithmetic`, so the two sides legitimately
-    /// disagree exactly here). Other parameter types keep the propagated
-    /// classification and need no conversion (see the comment at the
-    /// argument-emission site).
-    fn translate_spec_fun_arg(&self, arg: &Exp, param_ty: &Type) {
+    /// Emit a by-value spec fun argument, converting a bitvector argument that meets an
+    /// int-rendered parameter. `param_is_bv == None` keeps the argument's own rendering.
+    fn translate_spec_fun_arg(&self, arg: &Exp, param_ty: &Type, param_is_bv: Option<bool>) {
         // The operand's own rendering is authoritative (a schema binding
         // can substitute a bitvector-rendered temporary under a node
         // rewritten to `num`), and the conversion width comes from the
         // same type that decided that rendering.
         let (arg_is_bv, arg_ty) = self.operand_rendering(arg);
-        if matches!(
+        let is_num_param = matches!(
             param_ty.skip_reference(),
             Type::Primitive(PrimitiveType::Num)
-        ) && arg_is_bv
-        {
+        );
+        // `$bv2int.N` exists only for concrete unsigned widths; aggregates and type
+        // parameters have no scalar conversion.
+        let arg_is_convertible = arg_ty.skip_reference().is_unsigned_int();
+        if arg_is_bv && arg_is_convertible && (is_num_param || param_is_bv == Some(false)) {
             let base = boogie_num_type_base(
                 self.env,
                 Some(self.env.get_node_loc(arg.node_id())),
@@ -3022,6 +3037,19 @@ impl SpecTranslator<'_> {
             self.translate_exp(arg);
             emit!(self.writer, ")");
         } else {
+            // Renderings disagree with no conversion available; types rendering the same
+            // under both flags are not a disagreement.
+            if arg_is_bv
+                && param_is_bv == Some(false)
+                && boogie_type(self.env, arg_ty.skip_reference(), true)
+                    != boogie_type(self.env, arg_ty.skip_reference(), false)
+            {
+                self.env.error(
+                    &self.env.get_node_loc(arg.node_id()),
+                    "argument renders as a bitvector but the spec function parameter \
+                     renders as an integer, and no conversion exists for this type",
+                );
+            }
             self.translate_exp(arg);
         }
     }
@@ -4157,15 +4185,22 @@ impl SpecTranslator<'_> {
             }
         }
 
-        let global_state = &self
-            .env
-            .get_extension::<GlobalNumberOperationState>()
-            .expect("global number operation state");
-        let num_oper = global_state.get_node_num_oper(args[0].node_id());
-        // (`Num` never carries a bv rendering; `bv_flag_for_type` clamps it.)
-        let bv_flag = bv_flag_for_type(self.env, &num_oper, ty);
+        // A scalar comparison converts its operands below, so the node decides and a
+        // severed contract stays in integer world. An aggregate has no conversion, so
+        // there the operands' own rendering must pick the helper.
+        let is_scalar = ty.skip_reference().is_number();
+        let bv_flag = if is_scalar {
+            let global_state = &self
+                .env
+                .get_extension::<GlobalNumberOperationState>()
+                .expect("global number operation state");
+            let num_oper = global_state.get_node_num_oper(args[0].node_id());
+            bv_flag_for_type(self.env, &num_oper, ty)
+        } else {
+            self.operand_bv_flag(&args[0])
+        };
         let suffix = boogie_type_suffix(self.env, ty, bv_flag);
-        if ty.skip_reference().is_number() {
+        if is_scalar {
             let op_base = if bv_flag {
                 boogie_num_type_base(
                     self.env,
@@ -4437,14 +4472,17 @@ impl SpecTranslator<'_> {
         // `$bv2int.N(...)`. We must NOT propagate `cast_oper` (Arithmetic) onto
         // the source first — a bv-classified literal arg would otherwise lose
         // its bv suffix in `translate_value` and feed an `int` into `$bv2int.N`.
-        if source_oper == Bitwise
-            && source_type.is_unsigned_int()
+        // The operand's rendering decides, not the node's: in a boundary condition the
+        // node is integer-world while the temporary it reads renders as a bitvector.
+        let (source_renders_bv, source_render_ty) = self.operand_rendering(&arg);
+        if source_renders_bv
+            && source_render_ty.is_unsigned_int()
             && !bv_flag_for_type(self.env, &cast_oper, &target_type)
         {
             let source_base = boogie_num_type_base(
                 self.env,
                 Some(self.env.get_node_loc(arg.node_id())),
-                &source_type,
+                &source_render_ty,
                 false,
             );
             emit!(self.writer, "$bv2int.{}(", source_base);
@@ -4689,10 +4727,38 @@ impl SpecTranslator<'_> {
         emit!(self.writer, ")");
     }
 
+    /// Emit a native vector primitive specialized on the element type. The aggregate
+    /// operand picks the template (a vector has no conversion); elements convert to match.
     fn translate_primitive_inst_call(&self, node_id: NodeId, fun: &str, args: &[Exp]) {
-        let suffix = boogie_inst_suffix(self.env, &self.get_node_instantiation(node_id), &[]);
+        let inst = self.get_node_instantiation(node_id);
+        // Only concrete unsigned elements have both templates and a conversion.
+        let elem_convertible = inst
+            .first()
+            .is_some_and(|ty| ty.skip_reference().is_unsigned_int());
+        let elem_is_bv = elem_convertible
+            && match args.first() {
+                Some(aggregate) => self.operand_rendering(aggregate).0,
+                None => self.node_bv_flag(node_id),
+            };
+        let suffix = boogie_inst_suffix(self.env, &inst, &[elem_is_bv]);
         emit!(self.writer, "{}{}(", fun, suffix);
-        self.translate_seq(args.iter(), ", ", |e| self.translate_exp(e));
+        let elem_base = if elem_is_bv {
+            boogie_num_type_base(
+                self.env,
+                Some(self.env.get_node_loc(node_id)),
+                inst.first().expect("element type"),
+                false,
+            )
+        } else {
+            String::new()
+        };
+        self.translate_seq(args.iter().enumerate(), ", ", |(i, e)| {
+            if i == 0 || !elem_convertible {
+                self.translate_exp(e)
+            } else {
+                self.translate_op_operand(e, elem_is_bv, &elem_base)
+            }
+        });
         emit!(self.writer, ")");
     }
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation.rs
@@ -55,13 +55,42 @@
 
 use itertools::Itertools;
 use move_model::{
-    ast::{PropertyValue, TempIndex, Value},
-    model::{FieldId, FunId, FunctionEnv, ModuleId, NodeId, SpecFunId, StructEnv, StructId},
-    pragmas::{BV_PARAM_PROP, BV_RET_PROP},
+    ast::{Exp, PropertyValue, Spec, TempIndex, Value},
+    model::{FieldId, FunId, FunctionEnv, Loc, ModuleId, NodeId, SpecFunId, StructEnv, StructId},
+    pragmas::{
+        BV_INTERNAL_PRAGMA, BV_PARAM_PROP, BV_RET_PROP, CONDITION_ABSTRACT_PROP,
+        CONDITION_CONCRETE_PROP,
+    },
 };
-use std::{collections::BTreeMap, ops::Deref, str};
+use move_stackless_bytecode::stackless_bytecode::AttrId;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+    str,
+};
 
 static PARSING_ERROR: &str = "error happened when parsing the bv pragma";
+
+/// Bitwise operators in a `bv_internal` contract.
+pub static BV_INTERNAL_SPEC_BITWISE_MSG: &str = "the specification of a `bv_internal` function \
+     must stay in integer world and cannot use bitwise operators or int2bv";
+
+/// Contract conditions of `bv_internal` functions, keyed by containing function and
+/// variant. The analysis classifies these in integer world regardless of context.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct BvInternalBoundaryProps {
+    props: BTreeSet<(ModuleId, FunId, bool, AttrId)>,
+}
+
+impl BvInternalBoundaryProps {
+    pub fn insert(&mut self, mid: ModuleId, fid: FunId, baseline: bool, attr_id: AttrId) {
+        self.props.insert((mid, fid, baseline, attr_id));
+    }
+
+    pub fn contains(&self, mid: ModuleId, fid: FunId, baseline: bool, attr_id: AttrId) -> bool {
+        self.props.contains(&(mid, fid, baseline, attr_id))
+    }
+}
 
 /// Represents the type of numeric operations a value participates in.
 /// This forms a lattice with Bottom < Arithmetic and Bottom < Bitwise.
@@ -321,6 +350,19 @@ impl GlobalNumberOperationState {
         let ret_idx_vec =
             Self::extract_bv_vars(spec.properties.get(&symbol_pool.make(BV_RET_PROP)));
 
+        if func_env.is_pragma_true(BV_INTERNAL_PRAGMA, || false) {
+            let env = func_env.module_env.env;
+            let loc = spec.loc.clone().unwrap_or_else(|| func_env.get_id_loc());
+            if !func_env.is_opaque() {
+                env.error(
+                    &loc,
+                    "`pragma bv_internal` requires `pragma opaque`: callers must not \
+                     see the function's bitvector representation",
+                );
+            }
+            Self::check_bv_internal_spec_stays_int(func_env, spec);
+        }
+
         // Populate operation maps using the helper
         let param_map = Self::populate_operation_map(func_env.get_parameter_count(), &para_idx_vec);
         let ret_map = Self::populate_operation_map(func_env.get_return_count(), &ret_idx_vec);
@@ -330,6 +372,63 @@ impl GlobalNumberOperationState {
         self.ret_operation_map.insert(func_key, ret_map);
         self.local_oper_baseline.insert(func_key, BTreeMap::new());
         self.local_oper.insert(func_key, BTreeMap::new());
+    }
+
+    /// Check that a `bv_internal` contract stays in integer world, transitively through
+    /// spec functions. Needed for `[abstract]` conditions, which the analysis never sees.
+    fn check_bv_internal_spec_stays_int(func_env: &FunctionEnv, spec: &Spec) {
+        use move_model::ast::{ExpData, Operation};
+        let env = func_env.module_env.env;
+        let mut visited_spec_funs = BTreeSet::new();
+        let mut worklist = vec![];
+        let collect_spec = |spec: &Spec, worklist: &mut Vec<(Exp, Loc)>| {
+            for cond in &spec.conditions {
+                // `[concrete]` is verified against the body and never assumed by a caller,
+                // so it stays in the body's bitvector world.
+                // Concrete-only conditions never reach a caller; one also marked
+                // `[abstract]` still travels and must stay integer world.
+                if env
+                    .is_property_true(&cond.properties, CONDITION_CONCRETE_PROP)
+                    .unwrap_or(false)
+                    && !env
+                        .is_property_true(&cond.properties, CONDITION_ABSTRACT_PROP)
+                        .unwrap_or(false)
+                {
+                    continue;
+                }
+                for exp in cond.all_exps() {
+                    worklist.push((exp.clone(), cond.loc.clone()));
+                }
+            }
+        };
+        // Boundary conditions only: `on_impl` holds inline body specs over bitvector
+        // locals.
+        collect_spec(spec, &mut worklist);
+        while let Some((exp, loc)) = worklist.pop() {
+            let mut nested = vec![];
+            exp.visit_pre_order(&mut |e| {
+                if let ExpData::Call(_, oper, _) = e {
+                    match oper {
+                        Operation::BitOr
+                        | Operation::BitAnd
+                        | Operation::Xor
+                        | Operation::Int2Bv => {
+                            env.error(&loc, BV_INTERNAL_SPEC_BITWISE_MSG);
+                        },
+                        Operation::SpecFunction(mid, sid, _) => {
+                            if visited_spec_funs.insert((*mid, *sid)) {
+                                if let Some(body) = &env.get_module(*mid).get_spec_fun(*sid).body {
+                                    nested.push((body.clone(), loc.clone()));
+                                }
+                            }
+                        },
+                        _ => {},
+                    }
+                }
+                true
+            });
+            worklist.append(&mut nested);
+        }
     }
 
     /// Create the initial NumOperation state for a struct.

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
@@ -42,14 +42,16 @@
 //! ```
 
 use crate::number_operation::{
-    GlobalNumberOperationState, NumOperation,
+    BvInternalBoundaryProps, GlobalNumberOperationState, NumOperation,
     NumOperation::{Arithmetic, Bitwise, Bottom},
+    BV_INTERNAL_SPEC_BITWISE_MSG,
 };
 use itertools::Either;
 use move_binary_format::file_format::CodeOffset;
 use move_model::{
     ast::{Exp, ExpData, Operation as ASTOperation, TempIndex},
-    model::{FieldId, FunId, GlobalEnv, ModuleId, Parameter, StructId},
+    model::{FieldId, FunId, FunctionEnv, GlobalEnv, ModuleId, Parameter, StructId},
+    pragmas::BV_INTERNAL_PRAGMA,
     ty::{PrimitiveType, Type},
 };
 use move_stackless_bytecode::{
@@ -66,6 +68,14 @@ use std::{collections::BTreeMap, str};
 
 /// Error message shown when a value is used in conflicting contexts (both arithmetic and bitwise).
 static CONFLICT_ERROR_MSG: &str = "cannot appear in both arithmetic and bitwise operation, please refer to https://aptos.dev/en/build/smart-contracts/prover/spec-lang#bitwise-operators for more information";
+
+/// A `bv_internal` contract depending on bitvector-classified entities.
+static BV_INTERNAL_SPEC_LEAK_MSG: &str = "the specification of a `bv_internal` function cannot \
+     depend on bitvector-classified spec functions or struct fields";
+
+/// Bitwise values escaping a `bv_internal` function through a struct field.
+static BV_INTERNAL_FIELD_MSG: &str = "inside a `bv_internal` function, bitwise-classified values \
+     cannot flow through struct fields; exchange them as plain parameters and return values";
 
 /// Main processor that orchestrates the number operation analysis.
 /// This runs as part of the bytecode pipeline and iterates until reaching a fixed point.
@@ -231,6 +241,11 @@ fn table_funs_name_propagate_to_srcs(callee_name: &str) -> bool {
         || callee_name == "upsert"
 }
 
+/// Whether the function declares its bitwise representation internal via `pragma bv_internal`.
+fn is_bv_internal(func_env: &FunctionEnv) -> bool {
+    func_env.is_pragma_true(BV_INTERNAL_PRAGMA, || false)
+}
+
 impl NumberOperationAnalysis<'_> {
     /// Helper to get current function's module and function IDs
     fn func_ids(&self) -> (ModuleId, FunId) {
@@ -243,6 +258,11 @@ impl NumberOperationAnalysis<'_> {
     /// Helper to check if this is a baseline variant
     fn is_baseline(&self) -> bool {
         self.func_target.data.variant == FunctionVariant::Baseline
+    }
+
+    /// Whether the current function declares `pragma bv_internal`.
+    fn is_cur_bv_internal(&self) -> bool {
+        is_bv_internal(self.func_target.func_env)
     }
 
     /// Helper to get the operation for a temp index
@@ -490,10 +510,21 @@ impl NumberOperationAnalysis<'_> {
         let baseline_flag = self.func_target.data.variant == FunctionVariant::Baseline;
         let cur_mid = self.func_target.func_env.module_env.get_id();
         let cur_fid = self.func_target.func_env.get_id();
+        // Boundary view: a `bv_internal` contract stays in integer world; the backend
+        // reconciles with `$bv2int` at operand positions. Keyed per Prop, so props about
+        // body locals keep the body's classification.
+        let severed = self
+            .func_target
+            .global_env()
+            .get_extension::<BvInternalBoundaryProps>()
+            .is_some_and(|ext| ext.contains(cur_mid, cur_fid, baseline_flag, attr_id));
         let update_temporary = |arg: &Exp,
                                 oper: &NumOperation,
                                 global_state: &mut GlobalNumberOperationState,
                                 state: &mut NumberOperationState| {
+            if severed {
+                return;
+            }
             if let ExpData::Temporary(_, idx) = arg.as_ref() {
                 let cur_oper = global_state
                     .get_temp_index_oper(cur_mid, cur_fid, *idx, baseline_flag)
@@ -509,6 +540,10 @@ impl NumberOperationAnalysis<'_> {
         let visitor = &mut |exp: &ExpData| {
             match exp {
                 ExpData::Temporary(id, idx) => {
+                    if severed {
+                        // The temporary still renders as a bitvector; only the node is int.
+                        return true;
+                    }
                     let baseline_flag = self.func_target.data.variant == FunctionVariant::Baseline;
                     let oper = global_state
                         .get_temp_index_oper(cur_mid, cur_fid, *idx, baseline_flag)
@@ -575,26 +610,42 @@ impl NumberOperationAnalysis<'_> {
                         },
                         // Update node for return value
                         move_model::ast::Operation::Result(i) => {
-                            let oper = global_state
-                                .get_ret_map()
-                                .get(&(cur_mid, cur_fid))
-                                .unwrap()
-                                .get(i)
-                                .unwrap_or(&Bottom);
-                            global_state.update_node_oper(*id, *oper, true);
+                            if !severed {
+                                let oper = global_state
+                                    .get_ret_map()
+                                    .get(&(cur_mid, cur_fid))
+                                    .unwrap()
+                                    .get(i)
+                                    .unwrap_or(&Bottom);
+                                global_state.update_node_oper(*id, *oper, true);
+                            }
                         },
                         // Update node for field operation
                         move_model::ast::Operation::Select(mid, sid, field_id)
                         | move_model::ast::Operation::UpdateField(mid, sid, field_id) => {
                             let field_oper =
-                                global_state.get_num_operation_field(mid, sid, field_id);
-                            global_state.update_node_oper(*id, *field_oper, true);
+                                *global_state.get_num_operation_field(mid, sid, field_id);
+                            if severed && field_oper == Bitwise {
+                                self.func_target.global_env().error(
+                                    &self.func_target.get_bytecode_loc(attr_id),
+                                    BV_INTERNAL_SPEC_LEAK_MSG,
+                                );
+                            } else {
+                                global_state.update_node_oper(*id, field_oper, true);
+                            }
                         },
                         move_model::ast::Operation::SelectVariants(mid, sid, field_ids) => {
                             for field_id in field_ids {
                                 let field_oper =
-                                    global_state.get_num_operation_field(mid, sid, field_id);
-                                global_state.update_node_oper(*id, *field_oper, true);
+                                    *global_state.get_num_operation_field(mid, sid, field_id);
+                                if severed && field_oper == Bitwise {
+                                    self.func_target.global_env().error(
+                                        &self.func_target.get_bytecode_loc(attr_id),
+                                        BV_INTERNAL_SPEC_LEAK_MSG,
+                                    );
+                                } else {
+                                    global_state.update_node_oper(*id, field_oper, true);
+                                }
                             }
                         },
                         move_model::ast::Operation::Cast => {
@@ -625,7 +676,14 @@ impl NumberOperationAnalysis<'_> {
                             global_state.update_node_oper(*id, cast_oper, true);
                         },
                         move_model::ast::Operation::Int2Bv => {
-                            global_state.update_node_oper(*id, Bitwise, true);
+                            if severed {
+                                self.func_target.global_env().error(
+                                    &self.func_target.get_bytecode_loc(attr_id),
+                                    BV_INTERNAL_SPEC_BITWISE_MSG,
+                                );
+                            } else {
+                                global_state.update_node_oper(*id, Bitwise, true);
+                            }
                         },
                         move_model::ast::Operation::Bv2Int => {
                             global_state.update_node_oper(*id, Arithmetic, true);
@@ -776,11 +834,15 @@ impl NumberOperationAnalysis<'_> {
                                     .unwrap()
                                     .1;
                                 if !ret_num_oper_vec.is_empty() {
-                                    global_state.update_node_oper(
-                                        *id,
-                                        ret_num_oper_vec[0],
-                                        allow_merge,
-                                    );
+                                    let ret_oper = ret_num_oper_vec[0];
+                                    if severed && ret_oper == Bitwise {
+                                        self.func_target.global_env().error(
+                                            &self.func_target.get_bytecode_loc(attr_id),
+                                            BV_INTERNAL_SPEC_LEAK_MSG,
+                                        );
+                                    } else {
+                                        global_state.update_node_oper(*id, ret_oper, allow_merge);
+                                    }
                                 }
                             }
                         },
@@ -834,6 +896,13 @@ impl NumberOperationAnalysis<'_> {
                             // All args must have compatible number operations
                             // TODO(tengzhang): support converting int to bv
                             if opers_for_propagation(oper) {
+                                if severed && bitwise_oper(oper) {
+                                    self.func_target.global_env().error(
+                                        &self.func_target.get_bytecode_loc(attr_id),
+                                        BV_INTERNAL_SPEC_BITWISE_MSG,
+                                    );
+                                    return true;
+                                }
                                 let mut merged = if bitwise_oper(oper) { Bitwise } else { Bottom };
                                 for num_oper in &arg_oper {
                                     if !allow_merge && num_oper.conflict(&merged) {
@@ -916,6 +985,13 @@ impl NumberOperationAnalysis<'_> {
                                             | ExpData::LocalVar(..)
                                             | ExpData::Value(..)
                                             | ExpData::Call(_, ASTOperation::Cast, _) => true,
+                                            // An empty aggregate carries no classification
+                                            // and takes that of its context.
+                                            ExpData::Call(_, ASTOperation::Vector, elems)
+                                                if elems.is_empty() =>
+                                            {
+                                                true
+                                            },
                                             ExpData::Call(
                                                 _,
                                                 ASTOperation::SpecFunction(mid, sid, _),
@@ -971,6 +1047,7 @@ impl NumberOperationAnalysis<'_> {
     /// Handle pack/unpack operations - merge field types with temporary variables
     fn handle_pack_unpack(
         &self,
+        attr_id: AttrId,
         msid: ModuleId,
         sid: StructId,
         field_id: FieldId,
@@ -980,6 +1057,16 @@ impl NumberOperationAnalysis<'_> {
     ) {
         let field_oper = *global_state.get_num_operation_field(&msid, &sid, &field_id);
         let temp_oper = self.get_temp_oper(temp_idx, global_state);
+
+        // Field slots are program-wide; raising one here would leak the representation.
+        if self.is_cur_bv_internal() && temp_oper == Bitwise && field_oper != Bitwise {
+            self.func_target.global_env().error(
+                &self.func_target.get_bytecode_loc(attr_id),
+                BV_INTERNAL_FIELD_MSG,
+            );
+            return;
+        }
+
         let merged = field_oper.merge(&temp_oper);
 
         if merged != field_oper {
@@ -1054,7 +1141,7 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                     }
                 }
             },
-            Call(_, dests, oper, srcs, _) => {
+            Call(attr_id, dests, oper, srcs, _) => {
                 match oper {
                     BorrowLoc | ReadRef | CastU8 | CastU16 | CastU32 | CastU64 | CastU128
                     | CastU256 => {
@@ -1093,6 +1180,7 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                             .into_struct(*sid);
                         for (i, field) in struct_env.get_fields().enumerate() {
                             self.handle_pack_unpack(
+                                *attr_id,
                                 *msid,
                                 *sid,
                                 field.get_id(),
@@ -1118,6 +1206,7 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                                 )));
                             if srcs.len() > i {
                                 self.handle_pack_unpack(
+                                    *attr_id,
                                     *msid,
                                     *sid,
                                     new_field_id,
@@ -1137,6 +1226,7 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                             .into_struct(*sid);
                         for (i, field) in struct_env.get_fields().enumerate() {
                             self.handle_pack_unpack(
+                                *attr_id,
                                 *msid,
                                 *sid,
                                 field.get_id(),
@@ -1162,6 +1252,7 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                                 )));
                             if dests.len() > i {
                                 self.handle_pack_unpack(
+                                    *attr_id,
                                     *msid,
                                     *sid,
                                     new_field_id,
@@ -1182,6 +1273,7 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                             .get_id();
 
                         self.handle_pack_unpack(
+                            *attr_id,
                             *msid,
                             *sid,
                             field_id,
@@ -1216,6 +1308,19 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                         let field_oper =
                             global_state.get_num_operation_field(msid, sid, &new_field_id);
 
+                        // Same field-boundary rule as `handle_pack_unpack`.
+                        if self.is_cur_bv_internal()
+                            && *dests_oper == Bitwise
+                            && *field_oper != Bitwise
+                        {
+                            self.func_target.global_env().error(
+                                &self.func_target.get_bytecode_loc(*attr_id),
+                                BV_INTERNAL_FIELD_MSG,
+                            );
+                            self.func_target.global_env().set_extension(global_state);
+                            return;
+                        }
+
                         let merged_oper = dests_oper.merge(field_oper);
                         if merged_oper != *field_oper || merged_oper != *dests_oper {
                             state.changed = true;
@@ -1249,6 +1354,9 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                         if callee_env.is_struct_api() {
                             // Struct API calls are already translated to native ops by
                             // stackless_bytecode_generator; nothing to do here.
+                        } else if is_bv_internal(&callee_env) {
+                            // `bv_internal` callee: a representation boundary, so nothing
+                            // crosses between caller temps and callee slots.
                         } else if !module_env.is_std_vector() && !module_env.is_table() {
                             for (i, src) in srcs.iter().enumerate() {
                                 let cur_oper = global_state

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -5,7 +5,9 @@
 
 // Transformation which injects specifications (Move function spec blocks) into the bytecode.
 
-use crate::{options::ProverOptions, verification_analysis};
+use crate::{
+    number_operation::BvInternalBoundaryProps, options::ProverOptions, verification_analysis,
+};
 use itertools::Itertools;
 use move_core_types::function::ClosureMask;
 use move_model::{
@@ -18,7 +20,10 @@ use move_model::{
         FunId, FunctionEnv, GlobalEnv, Loc, ModuleId, NodeId, QualifiedId, QualifiedInstId,
         SpecVarId, StructId,
     },
-    pragmas::{ABORTS_IF_IS_PARTIAL_PRAGMA, EMITS_IS_PARTIAL_PRAGMA, EMITS_IS_STRICT_PRAGMA},
+    pragmas::{
+        ABORTS_IF_IS_PARTIAL_PRAGMA, BV_INTERNAL_PRAGMA, CONDITION_ABSTRACT_PROP,
+        CONDITION_CONCRETE_PROP, EMITS_IS_PARTIAL_PRAGMA, EMITS_IS_STRICT_PRAGMA,
+    },
     spec_translator::{ProofAction, SpecTranslator, TranslatedSpec},
     symbol::Symbol,
     ty::{PrimitiveType, ReferenceKind, Type, TypeDisplayContext, BOOL_TYPE, NUM_TYPE},
@@ -442,6 +447,11 @@ struct Instrumenter<'a> {
     /// AttrIds are stable across optimization passes, unlike bytecode offsets.
     /// The optional guard is a path condition from enclosing `if` in the proof block.
     split_points: Vec<(AttrId, Exp, Option<Exp>)>,
+    /// Whether the function being instrumented declares `pragma bv_internal`.
+    self_is_bv_internal: bool,
+    /// Locations of this function's `[concrete]` conditions: verified against the body,
+    /// never assumed by a caller, so not boundary language.
+    concrete_cond_locs: BTreeSet<Loc>,
 }
 
 // =================================================================================================
@@ -626,6 +636,21 @@ impl<'a> Instrumenter<'a> {
             opaque_callee_framed_memory,
             opaque_closure_modifies,
             split_points: vec![],
+            self_is_bv_internal: fun_env.is_pragma_true(BV_INTERNAL_PRAGMA, || false),
+            concrete_cond_locs: fun_env
+                .get_spec()
+                .conditions
+                .iter()
+                .filter(|cond| {
+                    let env = &fun_env.module_env.env;
+                    env.is_property_true(&cond.properties, CONDITION_CONCRETE_PROP)
+                        .unwrap_or(false)
+                        && !env
+                            .is_property_true(&cond.properties, CONDITION_ABSTRACT_PROP)
+                            .unwrap_or(false)
+                })
+                .map(|cond| cond.loc.clone())
+                .collect(),
         };
         // Always inline spec lets in proof actions, independent of the
         // `inline_spec_lets` option. Proof-action exps are recorded in
@@ -678,15 +703,17 @@ impl<'a> Instrumenter<'a> {
         let old_code = std::mem::take(&mut self.builder.data.code);
 
         // Emit `let` bindings.
-        self.emit_lets(spec, false);
+        self.emit_lets(spec, false, self.self_is_bv_internal);
 
         // Inject preconditions as assumes. This is done for all self.variant values.
         self.builder
             .set_loc(self.builder.fun_env.get_loc().at_start()); // reset to function level
         for (loc, exp) in spec.pre_conditions(&self.builder) {
+            let is_concrete = self.is_concrete_cond(&loc);
             self.builder.set_loc(loc);
             self.builder
-                .emit_with(move |attr_id| Prop(attr_id, Assume, exp))
+                .emit_with(move |attr_id| Prop(attr_id, Assume, exp));
+            self.tag_contract_prop(self.self_is_bv_internal && !is_concrete);
         }
 
         // Emit well-formedness checks for choice expressions in let bindings.
@@ -931,6 +958,7 @@ impl<'a> Instrumenter<'a> {
 
         let callee_env = env.get_module(mid).into_function(fid);
         let callee_opaque = callee_env.is_opaque();
+        let callee_is_bv_internal = callee_env.is_pragma_true(BV_INTERNAL_PRAGMA, || false);
         let mut callee_spec = SpecTranslator::translate_fun_spec(
             self.options.auto_trace_level.functions(),
             true,
@@ -963,7 +991,7 @@ impl<'a> Instrumenter<'a> {
         }
 
         // Emit `let` assignments.
-        self.emit_lets(&callee_spec, false);
+        self.emit_lets(&callee_spec, false, callee_is_bv_internal);
         self.builder.set_loc_from_attr(id);
 
         // Emit pre conditions if this is the verification variant or if the callee
@@ -983,6 +1011,7 @@ impl<'a> Instrumenter<'a> {
                     FunctionVariant::Baseline => Assume,
                 };
                 self.builder.emit_with(|id| Prop(id, prop_kind, cond));
+                self.tag_contract_prop(callee_is_bv_internal);
             }
         }
 
@@ -1054,7 +1083,8 @@ impl<'a> Instrumenter<'a> {
             // aborts_if conditions. Uses abort_path=true to emit only the
             // defining fragment (label-defining conjuncts), not full postcondition
             // properties that reference post-havoc state.
-            let defining_indices = self.emit_state_label_assumes(&callee_spec, true);
+            let defining_indices =
+                self.emit_state_label_assumes(&callee_spec, true, callee_is_bv_internal);
             // Remove defining conditions from post so they aren't double-emitted
             // later when assumes for ensures are emitted on the non-abort path.
             if !defining_indices.is_empty() {
@@ -1076,8 +1106,11 @@ impl<'a> Instrumenter<'a> {
 
             // Translate the abort condition. If the abort_cond_temp_opt is None, it indicates
             // that the abort condition is known to be false, so we can skip the abort handling.
-            let (abort_cond_temp_opt, code_cond) =
-                self.generate_abort_opaque_cond(callee_aborts_if_is_partial, &callee_spec);
+            let (abort_cond_temp_opt, code_cond) = self.generate_abort_opaque_cond(
+                callee_aborts_if_is_partial,
+                &callee_spec,
+                callee_is_bv_internal,
+            );
             if let Some(abort_cond_temp) = abort_cond_temp_opt {
                 let abort_local = self.abort_local;
                 let abort_label = self.abort_label;
@@ -1089,6 +1122,7 @@ impl<'a> Instrumenter<'a> {
                 if let Some(cond) = code_cond {
                     self.emit_traces(&callee_spec, &cond);
                     self.builder.emit_with(move |id| Prop(id, Assume, cond));
+                    self.tag_contract_prop(callee_is_bv_internal);
                 }
                 // Aggregate `aborts_of<callee>` on the abort path so a
                 // caller's `aborts_of<callee>` assertion discharges directly.
@@ -1193,7 +1227,7 @@ impl<'a> Instrumenter<'a> {
             }
 
             // Emit `let post` assignments.
-            self.emit_lets(&callee_spec, true);
+            self.emit_lets(&callee_spec, true, callee_is_bv_internal);
 
             // Emit well-formedness checks for choice expressions in callee's post-state let bindings.
             self.emit_choice_wellformedness(&callee_spec, true);
@@ -1205,6 +1239,7 @@ impl<'a> Instrumenter<'a> {
             for (_, cond) in std::mem::take(&mut callee_spec.post) {
                 self.emit_traces(&callee_spec, &cond);
                 self.builder.emit_with(|id| Prop(id, Assume, cond));
+                self.tag_contract_prop(callee_is_bv_internal);
             }
 
             // Emit the events in the `emits` specs of the callee.
@@ -1304,6 +1339,36 @@ impl<'a> Instrumenter<'a> {
             // Generate OpaqueCallEnd instruction if invariant_v2.
             self.generate_opaque_call(dests, mid, fid, targs, srcs, aa, false);
         }
+    }
+
+    /// Mark the `Prop` just emitted as a `bv_internal` contract condition (`pre`, `post`,
+    /// `aborts`, `lets`) — the only ones proven in one context and assumed in another.
+    /// `owner_is_bv_internal` is the callee at a call site, not the enclosing function.
+    /// Whether `loc` is a `[concrete]` condition of this function.
+    fn is_concrete_cond(&self, loc: &Loc) -> bool {
+        self.concrete_cond_locs.contains(loc)
+    }
+
+    fn tag_contract_prop(&mut self, owner_is_bv_internal: bool) {
+        if !owner_is_bv_internal {
+            return;
+        }
+        let Some(Bytecode::Prop(attr_id, ..)) = self.builder.data.code.last() else {
+            return;
+        };
+        let attr_id = *attr_id;
+        let env = self.builder.global_env();
+        let mut boundary = env
+            .get_extension::<BvInternalBoundaryProps>()
+            .map(|rc| rc.as_ref().clone())
+            .unwrap_or_default();
+        boundary.insert(
+            self.builder.fun_env.module_env.get_id(),
+            self.builder.fun_env.get_id(),
+            self.builder.data.variant == FunctionVariant::Baseline,
+            attr_id,
+        );
+        env.set_extension(boundary);
     }
 }
 
@@ -1624,7 +1689,7 @@ impl<'a> Instrumenter<'a> {
         }
     }
 
-    fn emit_lets(&mut self, spec: &TranslatedSpec, post_state: bool) {
+    fn emit_lets(&mut self, spec: &TranslatedSpec, post_state: bool, owner_is_bv_internal: bool) {
         use Bytecode::*;
         let lets = spec
             .lets
@@ -1638,6 +1703,7 @@ impl<'a> Instrumenter<'a> {
                 .mk_identical(self.builder.mk_temporary(*temp), exp.clone());
             self.builder
                 .emit_with(|id| Prop(id, PropKind::Assume, assign));
+            self.tag_contract_prop(owner_is_bv_internal);
         }
     }
 
@@ -2137,6 +2203,13 @@ impl<'a> Instrumenter<'a> {
 
     /// Generates verification conditions for abort block.
     fn generate_abort_verify(&mut self, spec: &TranslatedSpec) {
+        // The aggregate is a disjunction over all `aborts_if`; it is boundary language
+        // only when some clause travels, i.e. is not `[concrete]`.
+        let aborts_travel = spec
+            .aborts
+            .iter()
+            .any(|(loc, ..)| !self.is_concrete_cond(loc));
+        let tag = self.self_is_bv_internal && aborts_travel;
         use Bytecode::*;
         use PropKind::*;
 
@@ -2147,7 +2220,7 @@ impl<'a> Instrumenter<'a> {
         // when address aliasing makes the abort condition depend on labeled state.
         // Use abort_path=true to assume only the defining fragment of each
         // condition, not extra properties that only hold on successful returns.
-        self.emit_state_label_assumes(spec, true);
+        self.emit_state_label_assumes(spec, true, self.self_is_bv_internal);
 
         let is_partial = self
             .builder
@@ -2161,6 +2234,7 @@ impl<'a> Instrumenter<'a> {
                 self.emit_traces(spec, &cond);
                 self.builder.set_loc_and_vc_info(loc, ABORT_NOT_COVERED);
                 self.builder.emit_with(move |id| Prop(id, Assert, cond));
+                self.tag_contract_prop(tag);
             }
         }
 
@@ -2174,6 +2248,7 @@ impl<'a> Instrumenter<'a> {
                     .set_loc_and_vc_info(loc, ABORTS_CODE_NOT_COVERED);
                 self.builder
                     .emit_with(move |id| Prop(id, Assert, code_cond));
+                self.tag_contract_prop(tag);
             }
         }
     }
@@ -2186,6 +2261,7 @@ impl<'a> Instrumenter<'a> {
         &mut self,
         is_partial: bool,
         spec: &TranslatedSpec,
+        owner_is_bv_internal: bool,
     ) -> (Option<TempIndex>, Option<Exp>) {
         let aborts_cond = if is_partial {
             None
@@ -2197,7 +2273,9 @@ impl<'a> Instrumenter<'a> {
                 return (None, None);
             }
             // Introduce a temporary to hold the value of the aborts condition.
-            self.builder.emit_let(cond).0
+            let t = self.builder.emit_let(cond).0;
+            self.tag_contract_prop(owner_is_bv_internal);
+            t
         } else {
             // Introduce a havoced temporary to hold an arbitrary value for the aborts
             // condition.
@@ -2227,7 +2305,7 @@ impl<'a> Instrumenter<'a> {
         // Emit specification variable updates. They are generated for both verified and inlined
         // function variants, as the evolution of state updates is always the same.
         let lets_emitted = if !spec.updates.is_empty() {
-            self.emit_lets(spec, true);
+            self.emit_lets(spec, true, self.self_is_bv_internal);
             self.emit_updates(spec, None);
             true
         } else {
@@ -2237,13 +2315,14 @@ impl<'a> Instrumenter<'a> {
         if self.is_verified() {
             // Emit `let` bindings if not already emitted.
             if !lets_emitted {
-                self.emit_lets(spec, true);
+                self.emit_lets(spec, true, self.self_is_bv_internal);
             }
 
             // Emit well-formedness checks for choice expressions in post-state let bindings.
             self.emit_choice_wellformedness(spec, true);
 
-            let defining_indices = self.emit_state_label_assumes(spec, false);
+            let defining_indices =
+                self.emit_state_label_assumes(spec, false, self.self_is_bv_internal);
 
             // Emit the negation of all aborts conditions.
             // For defining conditions (already assumed), assert the non-defining
@@ -2258,6 +2337,9 @@ impl<'a> Instrumenter<'a> {
                         self.builder
                             .set_loc_and_vc_info(loc.clone(), ABORTS_IF_FAILS_MESSAGE);
                         self.builder.emit_with(|id| Prop(id, Assert, exp));
+                        self.tag_contract_prop(
+                            self.self_is_bv_internal && !self.is_concrete_cond(loc),
+                        );
                     }
                     continue;
                 }
@@ -2265,7 +2347,8 @@ impl<'a> Instrumenter<'a> {
                 let exp = self.builder.mk_not(abort_cond.clone());
                 self.builder
                     .set_loc_and_vc_info(loc.clone(), ABORTS_IF_FAILS_MESSAGE);
-                self.builder.emit_with(|id| Prop(id, Assert, exp))
+                self.builder.emit_with(|id| Prop(id, Assert, exp));
+                self.tag_contract_prop(self.self_is_bv_internal && !self.is_concrete_cond(loc));
             }
 
             // Emit return-point proof actions (`post`-prefixed proof statements).
@@ -2285,6 +2368,9 @@ impl<'a> Instrumenter<'a> {
                         self.builder
                             .set_loc_and_vc_info(loc.clone(), ENSURES_FAILS_MESSAGE);
                         self.builder.emit_with(move |id| Prop(id, Assert, residual));
+                        self.tag_contract_prop(
+                            self.self_is_bv_internal && !self.is_concrete_cond(loc),
+                        );
                     }
                     continue;
                 }
@@ -2292,7 +2378,8 @@ impl<'a> Instrumenter<'a> {
                 self.builder
                     .set_loc_and_vc_info(loc.clone(), ENSURES_FAILS_MESSAGE);
                 self.builder
-                    .emit_with(move |id| Prop(id, Assert, cond.clone()))
+                    .emit_with(move |id| Prop(id, Assert, cond.clone()));
+                self.tag_contract_prop(self.self_is_bv_internal && !self.is_concrete_cond(loc));
             }
 
             // Emit all event `emits` checks.
@@ -2334,6 +2421,7 @@ impl<'a> Instrumenter<'a> {
         &mut self,
         spec: &TranslatedSpec,
         abort_path: bool,
+        owner_is_bv_internal: bool,
     ) -> BTreeSet<usize> {
         use Bytecode::*;
         use PropKind::*;
@@ -2351,6 +2439,14 @@ impl<'a> Instrumenter<'a> {
             .iter()
             .map(|(_, e)| e)
             .chain(spec.aborts.iter().map(|(_, e, _)| e))
+            .collect();
+        // Same index space as `all_conditions`: a `[concrete]` definer stays in
+        // body world, like its counterpart in the post and aborts loops.
+        let condition_locs: Vec<&Loc> = spec
+            .post
+            .iter()
+            .map(|(l, _)| l)
+            .chain(spec.aborts.iter().map(|(l, _, _)| l))
             .collect();
         for (idx, cond) in all_conditions.iter().enumerate() {
             for label in Self::defined_labels(cond) {
@@ -2405,6 +2501,9 @@ impl<'a> Instrumenter<'a> {
                             all_conditions[idx].clone()
                         };
                         self.builder.emit_with(move |id| Prop(id, Assume, cond));
+                        self.tag_contract_prop(
+                            owner_is_bv_internal && !self.is_concrete_cond(condition_locs[idx]),
+                        );
                         defining_indices.insert(idx);
                     }
                     emitted_labels.insert(label);

--- a/third_party/move/move-prover/tests/sources/functional/bv_internal.move
+++ b/third_party/move/move-prover/tests/sources/functional/bv_internal.move
@@ -1,0 +1,309 @@
+// exclude_for: cvc5
+module 0x42::bv_internal {
+
+    spec module {
+        axiom forall a: u16, b: u16 where a != b: spec_swap_bytes(a) != spec_swap_bytes(b);
+    }
+
+    spec fun spec_swap_bytes(x: u16): u16;
+
+    fun swap_bytes(x: u16): u16 {
+        let v = x;
+        v = ((v & 0xff) << 8) | ((v >> 8) & 0xff);
+        v
+    }
+    spec swap_bytes {
+        pragma opaque;
+        pragma bv_internal;
+        pragma bv = b"0";
+        pragma bv_ret = b"0";
+        ensures [abstract] result == spec_swap_bytes(x);
+    }
+
+    fun masked(x: u16): u16 {
+        x & 0xff
+    }
+    spec masked {
+        pragma opaque;
+        pragma bv_internal;
+        ensures (result as num) <= (x as num);
+        ensures (result as u64) <= 0xff;
+    }
+
+    fun swap_bytes_checked(x: u16): u16 {
+        assert!(x != 0, 1);
+        let v = x;
+        v = ((v & 0xff) << 8) | ((v >> 8) & 0xff);
+        v
+    }
+    spec swap_bytes_checked {
+        pragma opaque;
+        pragma bv_internal;
+        aborts_if x == 0;
+        ensures [abstract] result == spec_swap_bytes(x);
+    }
+
+    struct Holder has drop {
+        v: u16
+    }
+
+    fun consume(a: u16): u16 {
+        if (a == 0) return 0;
+        let r = swap_bytes_checked(a);
+        let h = Holder { v: r };
+        if (h.v < 0xffff) { h.v + 1 } else { 0 }
+    }
+    spec consume {
+        aborts_if false;
+        ensures a != 0 && spec_swap_bytes(a) < 0xffff ==> result == spec_swap_bytes(a) + 1;
+    }
+
+    fun bv_ret_caller(x: u16): u16 {
+        swap_bytes(x)
+    }
+    spec bv_ret_caller {
+        pragma bv_ret = b"0";
+    }
+
+    fun makes_bitwise_vector(x: u8): vector<u8> {
+        vector[x & 1]
+    }
+    spec makes_bitwise_vector {
+        ensures result != vector[];
+    }
+
+    fun bitwise_vector(x: u16): vector<u16> {
+        vector[x & 1]
+    }
+    spec bitwise_vector {
+        ensures contains(result, x & 1) || !contains(result, x & 1);
+    }
+
+    fun boundary_contains(v: vector<u16>, x: u16): u16 {
+        let _ = v;
+        x | 0
+    }
+    spec boundary_contains {
+        pragma opaque;
+        pragma bv_internal;
+        ensures contains(v, result) || !contains(v, result);
+    }
+
+    fun inverted(x: u16): u16 {
+        x ^ 0xffff
+    }
+    spec inverted {
+        pragma opaque;
+        pragma bv_internal;
+        ensures [concrete] result == x ^ 0xffff;
+        ensures [abstract] result == spec_inverted(x);
+    }
+    spec fun spec_inverted(x: u16): u16;
+
+    fun uses_inverted(x: u16): u16 {
+        inverted(x)
+    }
+    spec uses_inverted {
+        ensures result == spec_inverted(x);
+    }
+
+    spec fun spec_concrete_bv(x: u16): u16;
+
+    fun concrete_bv_body(x: u16): u16 {
+        (x ^ 0xffff) & 0x0ff0
+    }
+    spec concrete_bv_body {
+        pragma opaque;
+        pragma bv_internal;
+        pragma bv = b"0";
+        pragma bv_ret = b"0";
+        ensures [concrete] result == (x ^ 0xffff) & 0x0ff0;
+        ensures [abstract] result == spec_concrete_bv(x);
+    }
+
+    fun uses_concrete_bv(x: u16): u16 {
+        concrete_bv_body(x)
+    }
+    spec uses_concrete_bv {
+        ensures result == spec_concrete_bv(x);
+    }
+
+    fun proved_masked(x: u16): u16 {
+        x & 3
+    }
+    spec proved_masked {
+        pragma opaque;
+        pragma bv_internal;
+        ensures [abstract] result == spec_swap_bytes(x);
+    } proof {
+        assert x & 3 == x & 3;
+        post assert result == x & 3;
+    }
+
+    fun masked_opaque(x: u16): u16 {
+        x & 3
+    }
+    spec masked_opaque {
+        pragma opaque;
+        ensures result == x & 3;
+    }
+
+    fun uses_bitwise_callee(x: u16): u16 {
+        let m = masked_opaque(x);
+        m | 0
+    }
+    spec uses_bitwise_callee {
+        pragma opaque;
+        pragma bv_internal;
+        ensures [abstract] result == spec_swap_bytes(x);
+    }
+
+    fun distinct_ids(a: u16, b: u16): bool {
+        swap_bytes(a) != swap_bytes(b)
+    }
+    spec distinct_ids {
+        ensures a != b ==> result == true;
+    }
+
+    spec fun spec_sum_bytes(data: vector<u8>): u64;
+    spec fun spec_pack_bytes(data: vector<u8>): u64;
+
+    fun sum_bytes(data: &vector<u8>): u64 {
+        let value = 0u64;
+        for (i in 0..4u64) {
+            value = (value << 8) | (data[i] as u64);
+        };
+        value
+    }
+    spec sum_bytes {
+        pragma opaque;
+        pragma bv_internal;
+        ensures [abstract] result == spec_sum_bytes(data);
+    }
+
+    fun pack_bytes(data: &vector<u8>): u64 {
+        let value = 0u64;
+        let i = 0;
+        while ({
+            spec {
+                invariant value | 0 == value;
+            };
+            i < 4
+        }) {
+            value = (value << 8) | (data[i] as u64);
+            i = i + 1;
+        };
+        value
+    }
+    spec pack_bytes {
+        pragma opaque;
+        pragma bv_internal;
+        ensures [abstract] result == spec_pack_bytes(data);
+    }
+
+    fun packed_is_stable(data: &vector<u8>): bool {
+        pack_bytes(data) == pack_bytes(data)
+    }
+    spec packed_is_stable {
+        ensures result == true;
+    }
+
+    fun bitwise_caller(y: u16): u16 {
+        let x = y & 0xff;
+        let r = swap_bytes(x);
+        if (r < 0xffff) { r + 1 } else { 0 }
+    }
+    spec bitwise_caller {
+        ensures result <= 0xffff;
+    }
+
+    spec fun spec_u8(x: u8): u8;
+
+    fun aborts_concrete(x: u8): u8 {
+        assert!(x & 1 == 0, 1);
+        x | 0
+    }
+    spec aborts_concrete {
+        pragma opaque;
+        pragma bv_internal;
+        aborts_if [concrete] x & 1 != 0;
+        ensures [abstract] result == spec_u8(x);
+    }
+
+    fun bv2int_boundary(x: u8): u8 {
+        x | 0
+    }
+    spec bv2int_boundary {
+        pragma opaque;
+        pragma bv_internal;
+        ensures bv2int(result) >= 0;
+        ensures [abstract] result == spec_u8(x);
+    }
+
+    fun aborts_boundary(x: u8): u8 {
+        assert!(x < 255, 1);
+        x | 0
+    }
+    spec aborts_boundary {
+        pragma opaque;
+        pragma bv_internal;
+        aborts_if x + 1 > 255;
+        ensures [abstract] result == spec_u8(x);
+    }
+
+    fun uses_aborts_boundary(x: u8): u8 {
+        aborts_boundary(x)
+    }
+    spec uses_aborts_boundary {
+        aborts_if x + 1 > 255;
+    }
+
+    spec fun spec_generic<T>(x: T): T;
+
+    fun arith_opaque(x: u64): u64 {
+        x + 0
+    }
+    spec arith_opaque {
+        pragma opaque;
+        ensures [abstract] result == spec_generic(x);
+    }
+
+    fun bitwise_severed(x: u8): u8 {
+        x | 0
+    }
+    spec bitwise_severed {
+        pragma opaque;
+        pragma bv_internal;
+        ensures [abstract] result == spec_generic(x);
+    }
+
+    fun severed_vector(x: u8): vector<u8> {
+        vector[x & 1]
+    }
+    spec severed_vector {
+        pragma opaque;
+        pragma bv_internal;
+        ensures result == result;
+    }
+
+    public fun public_masked(x: u16): u16 {
+        x & 0xff
+    }
+    spec public_masked {
+        pragma opaque;
+        pragma bv_internal;
+        ensures (result as u64) <= 0xff;
+    }
+}
+
+module 0x42::bv_internal_client {
+    use 0x42::bv_internal;
+
+    fun cross_module_caller(x: u16): u16 {
+        let r = bv_internal::public_masked(x);
+        if (r < 0xffff) { r + 1 } else { 0 }
+    }
+    spec cross_module_caller {
+        ensures result <= 0x100;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/bv_internal_aggregate.exp
+++ b/third_party/move/move-prover/tests/sources/functional/bv_internal_aggregate.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with condition generation errors
+error: argument renders as a bitvector but the spec function parameter renders as an integer, and no conversion exists for this type
+   ┌─ tests/sources/functional/bv_internal_aggregate.move:14:50
+   │
+14 │         ensures [abstract] result == bytes_value(v);
+   │                                                  ^

--- a/third_party/move/move-prover/tests/sources/functional/bv_internal_aggregate.move
+++ b/third_party/move/move-prover/tests/sources/functional/bv_internal_aggregate.move
@@ -1,0 +1,24 @@
+// exclude_for: cvc5
+module 0x42::bv_internal_aggregate {
+
+    spec fun bytes_value(v: vector<u8>): u64;
+
+    fun packs_bytes(v: &vector<u8>): u64 {
+        let acc = 0u64;
+        acc = acc | (v[0] as u64);
+        acc
+    }
+    spec packs_bytes {
+        pragma opaque;
+        pragma bv_internal;
+        ensures [abstract] result == bytes_value(v);
+    }
+
+    fun feeds_bitwise_vector(x: u8): u64 {
+        let v = vector[x & 1];
+        packs_bytes(&v)
+    }
+    spec feeds_bitwise_vector {
+        ensures result == bytes_value(vector[x & 1]);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/bv_internal_invalid.exp
+++ b/third_party/move/move-prover/tests/sources/functional/bv_internal_invalid.exp
@@ -1,0 +1,26 @@
+Move prover returns: exiting with bytecode transformation errors
+error: `pragma bv_internal` requires `pragma opaque`: callers must not see the function's bitvector representation
+  ┌─ tests/sources/functional/bv_internal_invalid.move:7:5
+  │
+7 │ ╭     spec not_opaque {
+8 │ │         pragma bv_internal;
+9 │ │     }
+  │ ╰─────^
+
+error: the specification of a `bv_internal` function must stay in integer world and cannot use bitwise operators or int2bv
+   ┌─ tests/sources/functional/bv_internal_invalid.move:17:9
+   │
+17 │         ensures result == (x | 2);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the specification of a `bv_internal` function must stay in integer world and cannot use bitwise operators or int2bv
+   ┌─ tests/sources/functional/bv_internal_invalid.move:26:9
+   │
+26 │         ensures [abstract] result == or_four(x);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: inside a `bv_internal` function, bitwise-classified values cannot flow through struct fields; exchange them as plain parameters and return values
+   ┌─ tests/sources/functional/bv_internal_invalid.move:37:9
+   │
+37 │         Wrap { v: x & 3 }
+   │         ^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/bv_internal_invalid.move
+++ b/third_party/move/move-prover/tests/sources/functional/bv_internal_invalid.move
@@ -1,0 +1,43 @@
+// exclude_for: cvc5
+module 0x42::bv_internal_invalid {
+
+    fun not_opaque(x: u64): u64 {
+        x ^ 1
+    }
+    spec not_opaque {
+        pragma bv_internal;
+    }
+
+    fun bitwise_spec(x: u64): u64 {
+        x | 2
+    }
+    spec bitwise_spec {
+        pragma opaque;
+        pragma bv_internal;
+        ensures result == (x | 2);
+    }
+
+    fun bitwise_spec_fun(x: u64): u64 {
+        x | 4
+    }
+    spec bitwise_spec_fun {
+        pragma opaque;
+        pragma bv_internal;
+        ensures [abstract] result == or_four(x);
+    }
+    spec fun or_four(x: u64): u64 {
+        x | 4
+    }
+
+    struct Wrap has drop {
+        v: u64
+    }
+
+    fun escapes(x: u64): Wrap {
+        Wrap { v: x & 3 }
+    }
+    spec escapes {
+        pragma opaque;
+        pragma bv_internal;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/bv_internal_wrapping.exp
+++ b/third_party/move/move-prover/tests/sources/functional/bv_internal_wrapping.exp
@@ -1,0 +1,12 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/bv_internal_wrapping.move:10:9
+   │
+10 │         ensures result == (x as num) + 256;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/bv_internal_wrapping.move:4: f
+   =         x = <redacted>
+   =     at tests/sources/functional/bv_internal_wrapping.move:5: f
+   =         result = <redacted>
+   =     at tests/sources/functional/bv_internal_wrapping.move:10: f (spec)

--- a/third_party/move/move-prover/tests/sources/functional/bv_internal_wrapping.move
+++ b/third_party/move/move-prover/tests/sources/functional/bv_internal_wrapping.move
@@ -1,0 +1,21 @@
+// exclude_for: cvc5
+module 0x42::bv_internal_wrapping {
+
+    fun f(x: u8): u8 {
+        x | 0
+    }
+    spec f {
+        pragma opaque;
+        pragma bv_internal;
+        ensures result == (x as num) + 256;
+    }
+
+    fun g(x: u8): u8 {
+        x | 0
+    }
+    spec g {
+        pragma opaque;
+        pragma bv_internal;
+        ensures (result as num) * 2 == (x as num) * 2;
+    }
+}


### PR DESCRIPTION
## Description

Adds `pragma bv_internal`, which declares that a function's use of bitwise operations is an implementation detail.

The number-operation analysis classifies values touched by `&`, `|`, `^` as bitvectors and propagates that across function boundaries, which may produce mixed int/bv Boogie type errors where no caller needs bit-level semantics.

`bv_internal` (requires `pragma opaque`) makes the function boundary a representation boundary:

- the body verifies with native bitvectors;
- parameters and results are integers at the boundary, and callers reason only through the opaque summary;
- the specification must stay in integer world, checked statically over the contract and transitively through called spec functions, and again during the dataflow analysis;
- bitwise values may not escape through struct fields, whose slots are shared program-wide.

Callers see `ensures [abstract] result == spec_fn(args)` plus axioms for the properties they need; this introduces no `int2bv`/`bv2int`. The bit-level behaviour is stated with `ensures [concrete]` and verified against the body in bitvector world: a `[concrete]` condition is never assumed by a caller, so it does not cross contexts and may use bitwise operators directly. Plain conditions do travel, and are asserted in integer world with `$bv2int` confined to the function's own verification condition.

Combine with `pragma bv` / `bv_ret` to keep a severed body conversion-free: they set the body's rendering, `bv_internal` keeps the boundary integer. Without them the body converts its symbolic input at every bitwise operand; without `bv_internal` the bitvector classification escapes through the shared summary and drags the spec function's parameter, so the two are complementary rather than alternatives.

**Which conditions need a context-independent classification.** Exactly those proven in one representation context and assumed in another: the `pre`, `post`, `aborts` and `lets` of a `TranslatedSpec`. They are tagged at both emission sites — at the function, and at every call site that inlines them, tagged to the callee so an ordinary callee's summary keeps its own classification.

The operational test is symmetry: a clause emitted under the same rule in both contexts renders identically in both and cannot diverge, whatever its classification. `modifies`, `emits` and global invariants are in that category and are deliberately left untagged. Well-formedness assumptions, loop invariants, proof actions, body assertions and `[concrete]` conditions live in a single context and follow it.

**Rendering versus classification.** Severing deliberately makes a node's classification differ from what its temporary renders, so every emission site that selects a template or inserts a conversion consults the operand's rendering rather than the node: `Int2Bv`/`Bv2Int`, casts, spec-function arguments, native vector predicates, and the `$IsEqual` helper — whose aggregate path emits no conversion, so a mismatched suffix cannot be repaired downstream.

Two **pre-existing** defects this exercises are fixed alongside; both reproduce with no `bv_internal` present:

- native vector predicates always named the integer template even though the prelude emits the bitvector twins, so a bitwise `contains(v, e)` produced ill-typed Boogie. The aggregate operand now selects the template, and element operands convert to match.
- an empty vector literal was classified "integer" rather than "unclassified", so it could not adopt the rendering of the operand it was compared against.

## How Has This Been Tested?

- `bv_internal.move`: severed functions with abstract summaries, an axiom-transported injectivity fact, a non-abstract `aborts_if` proven against a bitvector body, and integer-world callers. Every condition class that could be misclassified is pinned separately — loop well-formedness, loop invariants, call-site destinations, nested opaque callees, proof actions, `[concrete]` conditions, a caller consuming a severed abort summary, a severed function returning a bitwise vector compared with `==`, a generic spec function shared between a severed and an unsevered function, and a cross-module severed call.
- `bv_internal_invalid.move` and `bv_internal_aggregate.move`: the diagnostics.
- Full prover suite and inference suite pass.
- On a large package where oracle decoders and an id bit-reversal utility had dragged bitvector classification program-wide (~800 bitvector-related Boogie type errors on a module-wide run), annotating 7 leaf functions eliminated all of them.

## Key Areas to Review

- `tag_contract_prop` and its call sites: the claim is that `pre`/`post`/`aborts`/`lets` are exactly the clauses that cross contexts. A clause tagged in one context but not the other would diverge; tagging something body-internal surfaces as a Boogie type error.
- The rendering-versus-classification sites listed above, in particular the `$IsEqual` suffix and native vector template selection, which change emitted names for existing code.

## Type of Change

- [x] New feature

## Which Components or Systems Does This Change Impact?

- [x] Move Prover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core prover pipelines (instrumentation, number-operation analysis, Boogie spec translation) and changes emitted templates/conversions for existing bitwise code paths, not only the new pragma.
> 
> **Overview**
> Introduces **`pragma bv_internal`** (requires **`pragma opaque`**) so a function’s bitwise implementation is verified with bitvectors while parameters, results, and the **cross-context** contract (`pre`/`post`/`aborts`/`lets`) stay in integer world. Static checks reject bitwise spec, `int2bv`, and leaking bv through struct fields; **`[concrete]`** conditions remain body-only.
> 
> **Spec instrumentation** tags boundary `Prop` bytecode with **`BvInternalBoundaryProps`**; **number-operation analysis** treats those props as “severed” (integer classification) while body locals can still be bitwise. **Boogie translation** uses **operand rendering** (not just node flags) for `Int2Bv`/`Bv2Int`, casts, spec-function args, equality, and native vector primitives—plus per-parameter bv/int conversion at spec-fun calls.
> 
> Also fixes pre-existing issues: vector natives pick bv/int templates from the aggregate operand and convert elements; empty `vector[]` can adopt contextual classification. New functional tests cover valid/invalid/aggregate/wrapping cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be2603edbdec2280bf889e4b7681a2c784205c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->