### PR TITLE
Increase testnet archival PFN size to 26Ti

### DIFF
--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -34,7 +34,7 @@ NAMESPACE = "replay-verify"
 ZONE = "us-central1-a"
 
 DEFAULT_PVC_ACCESS_MODE = "ReadOnlyMany"  # Default access mode for PVCs
-TESTNET_SNAPSHOT_DISK_SIZE = "25Ti"  # Must be >= the testnet PFN disk size (25Ti as of 2026-07)
+TESTNET_SNAPSHOT_DISK_SIZE = "26Ti"  # Must be >= the testnet PFN disk size (26Ti as of 2026-08)
 MAINNET_SNAPSHOT_DISK_SIZE = "23Ti"  # Must be >= the mainnet PFN disk size (23Ti as of 2026-07)
 
 def get_disk_size_for_snapshot(snapshot_name: str) -> str:


### PR DESCRIPTION
## Description

Tesnet disk usage is >95%.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single infrastructure sizing constant for testnet replay-verify; no application logic or security changes.
> 
> **Overview**
> Raises **`TESTNET_SNAPSHOT_DISK_SIZE`** from **25Ti** to **26Ti** in `archive_disk_utils.py` so replay-verify PVCs cloned from the testnet archive snapshot request enough capacity to match the growing testnet PFN disk (comment updated to 2026-08).
> 
> That constant drives **`get_disk_size_for_snapshot`** for testnet snapshot–based PVC creation, addressing testnet archival disk usage above **95%**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecb74d48e2134e3734ee823663c9bc4551a6910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->