### PR TITLE
[mono-move] Fix executor signer count and transaction-context seeding

### DIFF
--- a/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
@@ -136,9 +136,9 @@ pub(crate) fn place_args(
     if args.next().is_some() {
         bail!("too many arguments for the function");
     }
-    if signers.next().is_some() {
-        bail!("too many signers for the function");
-    }
+    // Unused signers are fine: like the legacy VM, a function taking fewer
+    // signer parameters than the transaction has signers ignores the rest
+    // (e.g. an entry function without a `&signer`).
     Ok(())
 }
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
@@ -66,6 +66,7 @@ pub(crate) fn place_args(
     let missing_signer = || anyhow!("not enough signers for the function");
     // Signers must lead the parameter list, as the legacy VM requires.
     let mut seen_argument = false;
+    let mut signer_params = 0;
     for (slot, ty) in func.param_slots.iter().zip(params) {
         let offset = slot.offset.0;
         let view = view_type(*ty);
@@ -76,6 +77,7 @@ pub(crate) fn place_args(
             if seen_argument {
                 bail!("a signer parameter follows an argument");
             }
+            signer_params += 1;
         } else {
             seen_argument = true;
         }
@@ -136,9 +138,11 @@ pub(crate) fn place_args(
     if args.next().is_some() {
         bail!("too many arguments for the function");
     }
-    // Unused signers are fine: like the legacy VM, a function taking fewer
-    // signer parameters than the transaction has signers ignores the rest
-    // (e.g. an entry function without a `&signer`).
+    // Like the legacy VM: a function with signer parameters requires exactly
+    // that many signers; one without ignores them.
+    if signer_params > 0 && signers.next().is_some() {
+        bail!("more signers than the function's signer parameters");
+    }
     Ok(())
 }
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -13,7 +13,9 @@ use aptos_types::{
     fee_statement::FeeStatement,
     on_chain_config::Features,
     state_store::state_storage_usage::StateStorageUsage,
-    transaction::{EntryFunction, SignedTransaction, TransactionExecutableRef},
+    transaction::{
+        EntryFunction, PersistedAuxiliaryInfo, SignedTransaction, TransactionExecutableRef,
+    },
 };
 use mono_move_core::{
     intern_type_tag, storage::module_provider::ModuleProvider, types::InternedTypeList, GasMeter,
@@ -69,10 +71,16 @@ impl<'a> AptosTransactionExecutor<'a> {
     }
 
     /// Executes one user transaction, returning its side effects unmaterialized (see [`TxnOutcome`]).
+    /// `aux_info` carries the transaction's index in its block, which seeds
+    /// `monotonically_increasing_number`.
     //
     // TODO(completeness): add logging. Should warn on unexpected errors/discards.
-    pub fn execute_user_transaction(&self, txn: &SignedTransaction) -> TxnOutcome {
-        match self.execute_user_transaction_impl(txn) {
+    pub fn execute_user_transaction(
+        &self,
+        txn: &SignedTransaction,
+        aux_info: PersistedAuxiliaryInfo,
+    ) -> TxnOutcome {
+        match self.execute_user_transaction_impl(txn, aux_info) {
             Ok(outcome) => outcome,
             Err(reason) => TxnOutcome::Discarded(reason),
         }
@@ -82,6 +90,7 @@ impl<'a> AptosTransactionExecutor<'a> {
     fn execute_user_transaction_impl(
         &self,
         txn: &SignedTransaction,
+        aux_info: PersistedAuxiliaryInfo,
     ) -> Result<TxnOutcome, DiscardReason> {
         let guard = self.guard;
 
@@ -92,7 +101,7 @@ impl<'a> AptosTransactionExecutor<'a> {
         // gas price bounds, intrinsic gas coverage. Without them a transaction
         // outside the configured bounds -- including a zero gas price -- buys a
         // full `max_gas_amount` budget for free.
-        let txn_data = TxnMetadata::new(txn);
+        let txn_data = TxnMetadata::new(txn, aux_info);
 
         let entry = match txn.payload().executable_ref() {
             Ok(TransactionExecutableRef::EntryFunction(entry)) => entry,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -13,9 +13,7 @@ use aptos_types::{
     fee_statement::FeeStatement,
     on_chain_config::Features,
     state_store::state_storage_usage::StateStorageUsage,
-    transaction::{
-        EntryFunction, PersistedAuxiliaryInfo, SignedTransaction, TransactionExecutableRef,
-    },
+    transaction::{AuxiliaryInfo, EntryFunction, SignedTransaction, TransactionExecutableRef},
 };
 use mono_move_core::{
     intern_type_tag, storage::module_provider::ModuleProvider, types::InternedTypeList, GasMeter,
@@ -78,7 +76,7 @@ impl<'a> AptosTransactionExecutor<'a> {
     pub fn execute_user_transaction(
         &self,
         txn: &SignedTransaction,
-        aux_info: PersistedAuxiliaryInfo,
+        aux_info: &AuxiliaryInfo,
     ) -> TxnOutcome {
         match self.execute_user_transaction_impl(txn, aux_info) {
             Ok(outcome) => outcome,
@@ -90,7 +88,7 @@ impl<'a> AptosTransactionExecutor<'a> {
     fn execute_user_transaction_impl(
         &self,
         txn: &SignedTransaction,
-        aux_info: PersistedAuxiliaryInfo,
+        aux_info: &AuxiliaryInfo,
     ) -> Result<TxnOutcome, DiscardReason> {
         let guard = self.guard;
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use aptos_types::transaction::{ReplayProtector, SessionId, SignedTransaction};
+use aptos_types::transaction::{
+    PersistedAuxiliaryInfo, ReplayProtector, SessionId, SignedTransaction,
+};
 use move_core_types::account_address::AccountAddress;
 
 /// The slice of transaction metadata need by the executor.
@@ -20,10 +22,32 @@ pub(crate) struct TxnMetadata {
     /// Seeds unique-address generation. Derived like the legacy VM's, from the
     /// payload session's id, so generated addresses match.
     pub txn_hash: Vec<u8>,
+    /// The payload session's counter, one term of
+    /// `monotonically_increasing_number`; matches the legacy VM's.
+    pub session_counter: u8,
+    /// The transaction's index in its block, another term of
+    /// `monotonically_increasing_number`.
+    pub transaction_index: u32,
+    /// Distinguishes block execution (0) from validation/simulation (1) in
+    /// `monotonically_increasing_number`.
+    pub reserved_byte: u8,
 }
 
 impl TxnMetadata {
-    pub fn new(txn: &SignedTransaction) -> Self {
+    pub fn new(txn: &SignedTransaction, aux_info: PersistedAuxiliaryInfo) -> Self {
+        let (transaction_index, reserved_byte) = match aux_info {
+            PersistedAuxiliaryInfo::V1 { transaction_index } => (transaction_index, 0),
+            PersistedAuxiliaryInfo::TimestampNotYetAssignedV1 { transaction_index } => {
+                (transaction_index, 1)
+            },
+            PersistedAuxiliaryInfo::None => (0, 0),
+        };
+        let session_id = SessionId::txn(
+            txn.sender(),
+            txn.replay_protector(),
+            txn.payload().script_hash(),
+            txn.expiration_timestamp_secs(),
+        );
         Self {
             sender: txn.sender(),
             fee_payer: txn.authenticator_ref().fee_payer_address(),
@@ -48,14 +72,10 @@ impl TxnMetadata {
             expiration_timestamp_secs: txn.expiration_timestamp_secs(),
             chain_id: txn.chain_id().id(),
             replay_protector: txn.replay_protector(),
-            txn_hash: SessionId::txn(
-                txn.sender(),
-                txn.replay_protector(),
-                txn.payload().script_hash(),
-                txn.expiration_timestamp_secs(),
-            )
-            .txn_hash()
-            .to_vec(),
+            txn_hash: session_id.txn_hash().to_vec(),
+            session_counter: session_id.session_counter(),
+            transaction_index,
+            reserved_byte,
         }
     }
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
@@ -21,7 +21,7 @@ pub(crate) struct TxnMetadata {
     pub replay_protector: ReplayProtector,
     /// Seeds unique-address generation. Derived like the legacy VM's, from the
     /// payload session's id, so generated addresses match.
-    pub txn_hash: Vec<u8>,
+    pub txn_hash: [u8; 32],
     /// The payload session's counter, one term of
     /// `monotonically_increasing_number`; matches the legacy VM's.
     pub session_counter: u8,
@@ -47,21 +47,19 @@ impl TxnMetadata {
             txn.payload().script_hash(),
             txn.expiration_timestamp_secs(),
         );
+        let authenticator = txn.authenticator_ref();
         Self {
             sender: txn.sender(),
-            fee_payer: txn.authenticator_ref().fee_payer_address(),
-            secondary_signers: txn.authenticator().secondary_signer_addresses(),
-            sender_auth_key: txn
-                .authenticator()
+            fee_payer: authenticator.fee_payer_address(),
+            secondary_signers: authenticator.secondary_signer_addresses(),
+            sender_auth_key: authenticator
                 .sender()
                 .authentication_proof()
                 .optional_auth_key(),
-            fee_payer_auth_key: txn
-                .authenticator()
+            fee_payer_auth_key: authenticator
                 .fee_payer_signer()
                 .and_then(|signer| signer.authentication_proof().optional_auth_key()),
-            secondary_auth_keys: txn
-                .authenticator()
+            secondary_auth_keys: authenticator
                 .secondary_signers()
                 .iter()
                 .map(|account_auth| account_auth.authentication_proof().optional_auth_key())
@@ -71,7 +69,7 @@ impl TxnMetadata {
             expiration_timestamp_secs: txn.expiration_timestamp_secs(),
             chain_id: txn.chain_id().id(),
             replay_protector: txn.replay_protector(),
-            txn_hash: session_id.txn_hash().to_vec(),
+            txn_hash: session_id.txn_hash(),
             session_counter: session_id.session_counter(),
             transaction_index,
         }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
@@ -25,22 +25,21 @@ pub(crate) struct TxnMetadata {
     /// The payload session's counter, one term of
     /// `monotonically_increasing_number`; matches the legacy VM's.
     pub session_counter: u8,
-    /// The transaction's index in its block, another term of
-    /// `monotonically_increasing_number`.
-    pub transaction_index: u32,
-    /// Distinguishes block execution (0) from validation/simulation (1) in
-    /// `monotonically_increasing_number`.
-    pub reserved_byte: u8,
+    /// The transaction's index within its block plus the counter's reserved
+    /// byte (0 for block execution, 1 for validation/simulation), or `None`
+    /// when the auxiliary info carries no index — the legacy VM aborts
+    /// `monotonically_increasing_number` in that case.
+    pub transaction_index: Option<(u32, u8)>,
 }
 
 impl TxnMetadata {
     pub fn new(txn: &SignedTransaction, aux_info: PersistedAuxiliaryInfo) -> Self {
-        let (transaction_index, reserved_byte) = match aux_info {
-            PersistedAuxiliaryInfo::V1 { transaction_index } => (transaction_index, 0),
+        let transaction_index = match aux_info {
+            PersistedAuxiliaryInfo::V1 { transaction_index } => Some((transaction_index, 0)),
             PersistedAuxiliaryInfo::TimestampNotYetAssignedV1 { transaction_index } => {
-                (transaction_index, 1)
+                Some((transaction_index, 1))
             },
-            PersistedAuxiliaryInfo::None => (0, 0),
+            PersistedAuxiliaryInfo::None => None,
         };
         let session_id = SessionId::txn(
             txn.sender(),
@@ -75,7 +74,6 @@ impl TxnMetadata {
             txn_hash: session_id.txn_hash().to_vec(),
             session_counter: session_id.session_counter(),
             transaction_index,
-            reserved_byte,
         }
     }
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_types::transaction::{
-    PersistedAuxiliaryInfo, ReplayProtector, SessionId, SignedTransaction,
+    AuxiliaryInfo, PersistedAuxiliaryInfo, ReplayProtector, SessionId, SignedTransaction,
 };
 use move_core_types::account_address::AccountAddress;
 
@@ -33,8 +33,8 @@ pub(crate) struct TxnMetadata {
 }
 
 impl TxnMetadata {
-    pub fn new(txn: &SignedTransaction, aux_info: PersistedAuxiliaryInfo) -> Self {
-        let transaction_index = match aux_info {
+    pub fn new(txn: &SignedTransaction, aux_info: &AuxiliaryInfo) -> Self {
+        let transaction_index = match *aux_info.persisted_info() {
             PersistedAuxiliaryInfo::V1 { transaction_index } => Some((transaction_index, 0)),
             PersistedAuxiliaryInfo::TimestampNotYetAssignedV1 { transaction_index } => {
                 Some((transaction_index, 1))

--- a/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
@@ -49,7 +49,6 @@ pub(crate) fn transaction_extensions(
         txn_data.txn_hash.clone(),
         txn_data.session_counter,
         txn_data.transaction_index,
-        txn_data.reserved_byte,
     ));
     extensions.add(ObjectContextExtension::new());
     extensions.add(StorageUsageAtEpochBoundary::new(

--- a/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
@@ -45,14 +45,11 @@ pub(crate) fn transaction_extensions(
     usage: StateStorageUsage,
 ) -> NativeExtensions {
     let mut extensions = NativeExtensions::new();
-    // TODO(completeness): the transaction index and the reserved byte
-    // (block execution vs. validation/simulation) come from the auxiliary
-    // info the block coordinator has to pass in; both are hardcoded here.
     extensions.add(TransactionContextExtension::new(
         txn_data.txn_hash.clone(),
-        0,
-        0,
-        0,
+        txn_data.session_counter,
+        txn_data.transaction_index,
+        txn_data.reserved_byte,
     ));
     extensions.add(ObjectContextExtension::new());
     extensions.add(StorageUsageAtEpochBoundary::new(

--- a/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
@@ -46,7 +46,7 @@ pub(crate) fn transaction_extensions(
 ) -> NativeExtensions {
     let mut extensions = NativeExtensions::new();
     extensions.add(TransactionContextExtension::new(
-        txn_data.txn_hash.clone(),
+        txn_data.txn_hash,
         txn_data.session_counter,
         txn_data.transaction_index,
     ));

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -19,8 +19,8 @@ use aptos_types::{
     on_chain_config::{Features, OnChainConfig},
     state_store::StateView,
     transaction::{
-        ExecutionStatus, PersistedAuxiliaryInfo, SignedTransaction, TransactionAuxiliaryData,
-        TransactionOutput, TransactionStatus,
+        AuxiliaryInfo, ExecutionStatus, PersistedAuxiliaryInfo, SignedTransaction,
+        TransactionAuxiliaryData, TransactionOutput, TransactionStatus,
     },
 };
 use mono_move_aptos_state_view_providers::{
@@ -62,7 +62,7 @@ fn execute_v2<S: StateView>(state: &S, txn: &SignedTransaction) -> TransactionOu
         usage,
     );
     executor
-        .execute_user_transaction(txn, PersistedAuxiliaryInfo::None)
+        .execute_user_transaction(txn, &AuxiliaryInfo::new(PersistedAuxiliaryInfo::None, None))
         .materialize(
             &guard,
             &data_provider,

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -14,7 +14,7 @@
 // covered by other tests, such as the e2e move tests. Note that the sender's
 // store is masked, so a wrong debit there is not caught.
 
-use aptos_language_e2e_tests::executor::FakeExecutor;
+use aptos_language_e2e_tests::{account::AccountData, executor::FakeExecutor};
 use aptos_types::{
     on_chain_config::{Features, OnChainConfig},
     state_store::StateView,
@@ -72,13 +72,19 @@ fn execute_v2<S: StateView>(state: &S, txn: &SignedTransaction) -> TransactionOu
         .expect("the transaction output materializes")
 }
 
-#[test]
-fn p2p_transfer_matches_v1() {
+/// Fresh genesis with a funded sender (sequence number 10) and recipient.
+fn setup() -> (FakeExecutor, AccountData, AccountData) {
     let mut fx = FakeExecutor::from_head_genesis();
     let alice = fx.create_raw_account_data(1_000_000_000, 10);
     fx.add_account_data(&alice);
     let bob = fx.create_raw_account_data(100_000_000, 0);
     fx.add_account_data(&bob);
+    (fx, alice, bob)
+}
+
+#[test]
+fn p2p_transfer_matches_v1() {
+    let (fx, alice, bob) = setup();
 
     let txn = alice
         .account()
@@ -193,11 +199,7 @@ fn compare_outputs(
 /// epilogue still charges the fee and bumps the sequence number.
 #[test]
 fn p2p_transfer_insufficient_balance_aborts_like_v1() {
-    let mut fx = FakeExecutor::from_head_genesis();
-    let alice = fx.create_raw_account_data(1_000_000_000, 10);
-    fx.add_account_data(&alice);
-    let bob = fx.create_raw_account_data(100_000_000, 0);
-    fx.add_account_data(&bob);
+    let (fx, alice, bob) = setup();
 
     let txn = alice
         .account()
@@ -245,11 +247,7 @@ fn p2p_transfer_insufficient_balance_aborts_like_v1() {
 /// failure cleanup — including the abort location.
 #[test]
 fn p2p_transfer_draining_fee_payer_aborts_like_v1() {
-    let mut fx = FakeExecutor::from_head_genesis();
-    let alice = fx.create_raw_account_data(1_000_000_000, 10);
-    fx.add_account_data(&alice);
-    let bob = fx.create_raw_account_data(100_000_000, 0);
-    fx.add_account_data(&bob);
+    let (fx, alice, bob) = setup();
 
     // Send the entire balance: nothing is left for the fee at epilogue time.
     let txn = alice
@@ -298,9 +296,7 @@ fn nonexistent_entry_function_kept_like_v1() {
     use aptos_types::transaction::{EntryFunction, TransactionPayload};
     use move_core_types::{ident_str, language_storage::ModuleId};
 
-    let mut fx = FakeExecutor::from_head_genesis();
-    let alice = fx.create_raw_account_data(1_000_000_000, 10);
-    fx.add_account_data(&alice);
+    let (fx, alice, _bob) = setup();
 
     let txn = alice
         .account()
@@ -342,11 +338,7 @@ fn nonexistent_entry_function_kept_like_v1() {
 // real status instead of an invariant violation.
 #[test]
 fn extra_signers_rejected_like_v1() {
-    let mut fx = FakeExecutor::from_head_genesis();
-    let alice = fx.create_raw_account_data(1_000_000_000, 10);
-    fx.add_account_data(&alice);
-    let bob = fx.create_raw_account_data(100_000_000, 0);
-    fx.add_account_data(&bob);
+    let (fx, alice, bob) = setup();
 
     // `aptos_account::transfer` takes one `&signer`; supply two senders.
     let txn = alice
@@ -395,11 +387,7 @@ fn extra_signers_rejected_like_v1() {
 fn sequential_execution_applies_outputs() {
     use aptos_transaction_simulation::{DeltaStateStore, SimulationStateStore};
 
-    let mut fx = FakeExecutor::from_head_genesis();
-    let alice = fx.create_raw_account_data(1_000_000_000, 10);
-    fx.add_account_data(&alice);
-    let bob = fx.create_raw_account_data(100_000_000, 0);
-    fx.add_account_data(&bob);
+    let (fx, alice, bob) = setup();
 
     let transfer = |seq| {
         alice

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -28,6 +28,7 @@ use mono_move_aptos_state_view_providers::{
 };
 use mono_move_aptos_transaction_executor::{production_natives, AptosTransactionExecutor};
 use mono_move_global_context::GlobalContext;
+use move_core_types::vm_status::StatusCode;
 use std::collections::BTreeMap;
 
 /// Event types whose payload embeds gas amounts.
@@ -332,6 +333,59 @@ fn nonexistent_entry_function_kept_like_v1() {
     assert_eq!(v1_output.status(), v2_output.status());
 
     compare_outputs(&v1_output, &v2_output, *alice.address());
+}
+
+/// A multi-agent transaction supplying two senders to a one-signer entry
+/// function is rejected, like on the legacy VM.
+//
+// TODO(correctness): compare exact statuses once argument rejection gets a
+// real status instead of an invariant violation.
+#[test]
+fn extra_signers_rejected_like_v1() {
+    let mut fx = FakeExecutor::from_head_genesis();
+    let alice = fx.create_raw_account_data(1_000_000_000, 10);
+    fx.add_account_data(&alice);
+    let bob = fx.create_raw_account_data(100_000_000, 0);
+    fx.add_account_data(&bob);
+
+    // `aptos_account::transfer` takes one `&signer`; supply two senders.
+    let txn = alice
+        .account()
+        .transaction()
+        .payload(aptos_cached_packages::aptos_stdlib::aptos_account_transfer(
+            *bob.address(),
+            1_000,
+        ))
+        .sequence_number(10)
+        .gas_unit_price(100)
+        .max_gas_amount(1_000_000)
+        .secondary_signers(vec![bob.account().clone()])
+        .sign_multi_agent();
+
+    let v1_output = fx.execute_transaction(txn.clone());
+    assert!(
+        matches!(
+            v1_output.status(),
+            TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(
+                StatusCode::NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH
+            )))
+        ),
+        "v1 did not reject the signer-count mismatch: {:?}",
+        v1_output.status()
+    );
+
+    let v2_output = execute_v2(fx.get_state_view(), &txn);
+    assert!(
+        matches!(
+            v2_output.status(),
+            TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(_))
+        ),
+        "v2 did not reject the signer-count mismatch: {:?}",
+        v2_output.status()
+    );
+
+    // Write sets are not compared: the gas divergence leaves v1 with fee
+    // writes v2 lacks.
 }
 
 /// Two dependent transfers executed sequentially, each transaction's outputs

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -19,8 +19,8 @@ use aptos_types::{
     on_chain_config::{Features, OnChainConfig},
     state_store::StateView,
     transaction::{
-        ExecutionStatus, SignedTransaction, TransactionAuxiliaryData, TransactionOutput,
-        TransactionStatus,
+        ExecutionStatus, PersistedAuxiliaryInfo, SignedTransaction, TransactionAuxiliaryData,
+        TransactionOutput, TransactionStatus,
     },
 };
 use mono_move_aptos_state_view_providers::{
@@ -61,7 +61,7 @@ fn execute_v2<S: StateView>(state: &S, txn: &SignedTransaction) -> TransactionOu
         usage,
     );
     executor
-        .execute_user_transaction(txn)
+        .execute_user_transaction(txn, PersistedAuxiliaryInfo::None)
         .materialize(
             &guard,
             &data_provider,

--- a/third_party/move/mono-move/natives/src/transaction_context.rs
+++ b/third_party/move/mono-move/natives/src/transaction_context.rs
@@ -14,9 +14,9 @@ use mono_move_core::{
 
 /// Per-transaction context backing the `transaction_context` natives.
 //
-// TODO(completeness): source `transaction_index` / `reserved_byte` from aptos-core's
-// `UserTransactionContext` rather than carrying them as plain fields, and model
-// the "transaction index not available" case.
+// TODO(completeness): the "no user transaction context at all" case (e.g. view
+// functions) is not modeled; the legacy VM aborts those natives with
+// ETRANSACTION_CONTEXT_NOT_AVAILABLE.
 pub struct TransactionContextExtension {
     txn_hash: Vec<u8>,
     /// AUIDs issued so far in this transaction.
@@ -25,11 +25,10 @@ pub struct TransactionContextExtension {
     local_counter: u16,
     /// Identifies the session within the transaction.
     session_counter: u8,
-    /// Index of the transaction within its block/chunk.
-    transaction_index: u32,
-    /// Top byte of the monotonic counter (0 for block execution, 1 for
-    /// validation/simulation).
-    reserved_byte: u8,
+    /// The transaction's index within its block plus the monotonic counter's
+    /// top byte (0 for block execution, 1 for validation/simulation), or
+    /// `None` when the execution context provides no index.
+    transaction_index: Option<(u32, u8)>,
     /// Tables created so far in this transaction; seeds the next table handle.
     table_counter: u32,
 }
@@ -38,8 +37,7 @@ impl TransactionContextExtension {
     pub fn new(
         txn_hash: Vec<u8>,
         session_counter: u8,
-        transaction_index: u32,
-        reserved_byte: u8,
+        transaction_index: Option<(u32, u8)>,
     ) -> Self {
         Self {
             txn_hash,
@@ -47,7 +45,6 @@ impl TransactionContextExtension {
             local_counter: 0,
             session_counter,
             transaction_index,
-            reserved_byte,
             table_counter: 0,
         }
     }
@@ -87,6 +84,10 @@ impl NativeExtension for TransactionContextExtension {
 /// `0x1::transaction_context` (category 3, reason 2).
 const COUNTER_OVERFLOW_ABORT_CODE: u64 = (3 << 16) | 2;
 
+/// `error::invalid_state(ETRANSACTION_INDEX_NOT_AVAILABLE)` in
+/// `0x1::transaction_context` (category 3, reason 5).
+const INDEX_NOT_AVAILABLE_ABORT_CODE: u64 = (3 << 16) | 5;
+
 /// `0x1::transaction_context::generate_unique_address(): address`
 ///
 /// Returns a freshly derived address, which is guaranteed to be unique within
@@ -123,9 +124,18 @@ pub fn native_monotonically_increasing_counter_internal<C: NativeContext>(
     }
     ext.local_counter += 1;
 
-    let counter = ((ext.reserved_byte as u128) << 120)
+    // Like the legacy VM, abort when the execution context provides no
+    // transaction index.
+    let Some((transaction_index, reserved_byte)) = ext.transaction_index else {
+        return Ok(NativeStatus::Abort {
+            code: INDEX_NOT_AVAILABLE_ABORT_CODE,
+            message: Some("transaction index is not available in this execution context".into()),
+        });
+    };
+
+    let counter = ((reserved_byte as u128) << 120)
         | ((timestamp_us as u128) << 56)
-        | ((ext.transaction_index as u128) << 24)
+        | ((transaction_index as u128) << 24)
         | ((ext.session_counter as u128) << 16)
         | (ext.local_counter as u128);
     // SAFETY: return 0 is `u128`.

--- a/third_party/move/mono-move/natives/src/transaction_context.rs
+++ b/third_party/move/mono-move/natives/src/transaction_context.rs
@@ -18,7 +18,7 @@ use mono_move_core::{
 // functions) is not modeled; the legacy VM aborts those natives with
 // ETRANSACTION_CONTEXT_NOT_AVAILABLE.
 pub struct TransactionContextExtension {
-    txn_hash: Vec<u8>,
+    txn_hash: [u8; 32],
     /// AUIDs issued so far in this transaction.
     auid_counter: u64,
     /// Per-session counter feeding the low bits of the monotonic counter.
@@ -35,7 +35,7 @@ pub struct TransactionContextExtension {
 
 impl TransactionContextExtension {
     pub fn new(
-        txn_hash: Vec<u8>,
+        txn_hash: [u8; 32],
         session_counter: u8,
         transaction_index: Option<(u32, u8)>,
     ) -> Self {

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -96,7 +96,7 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
     };
     let mut extensions = NativeExtensions::new();
     extensions.add(TransactionContextExtension::new(
-        input.session_id.txn_hash().to_vec(),
+        input.session_id.txn_hash(),
         input.session_id.session_counter(),
         transaction_index,
     ));

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -87,19 +87,18 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
         .max(MIN_ARENA_BYTES);
     let resource_provider = read_set_resource_provider(&guard, &input.read_set, arena_size)?;
 
-    let (transaction_index, reserved_byte) = match input.user_context.transaction_index_kind() {
-        TransactionIndexKind::BlockExecution { transaction_index } => (transaction_index, 0),
+    let transaction_index = match input.user_context.transaction_index_kind() {
+        TransactionIndexKind::BlockExecution { transaction_index } => Some((transaction_index, 0)),
         TransactionIndexKind::ValidationOrSimulation { transaction_index } => {
-            (transaction_index, 1)
+            Some((transaction_index, 1))
         },
-        TransactionIndexKind::NotAvailable => (0, 0),
+        TransactionIndexKind::NotAvailable => None,
     };
     let mut extensions = NativeExtensions::new();
     extensions.add(TransactionContextExtension::new(
         input.session_id.txn_hash().to_vec(),
         input.session_id.session_counter(),
         transaction_index,
-        reserved_byte,
     ));
     extensions.add(ObjectContextExtension::new());
     let usage = input.read_set.get_usage()?;

--- a/third_party/move/mono-move/testsuite/src/extensions.rs
+++ b/third_party/move/mono-move/testsuite/src/extensions.rs
@@ -26,8 +26,7 @@ pub(crate) fn seed_extensions() -> NativeExtensions {
     extensions.add(TransactionContextExtension::new(
         TEST_TXN_HASH.to_vec(),
         TEST_SESSION_COUNTER,
-        TEST_TXN_INDEX,
-        TEST_RESERVED_BYTE,
+        Some((TEST_TXN_INDEX, TEST_RESERVED_BYTE)),
     ));
     extensions.add(ObjectContextExtension::new());
     extensions.add(StorageUsageAtEpochBoundary::new(

--- a/third_party/move/mono-move/testsuite/src/extensions.rs
+++ b/third_party/move/mono-move/testsuite/src/extensions.rs
@@ -24,7 +24,7 @@ pub(crate) const TEST_RESERVED_BYTE: u8 = 0;
 pub(crate) fn seed_extensions() -> NativeExtensions {
     let mut extensions = NativeExtensions::new();
     extensions.add(TransactionContextExtension::new(
-        TEST_TXN_HASH.to_vec(),
+        TEST_TXN_HASH,
         TEST_SESSION_COUNTER,
         Some((TEST_TXN_INDEX, TEST_RESERVED_BYTE)),
     ));


### PR DESCRIPTION
## Description

Two bugs in the Aptos transaction executor, surfaced by replaying real mainnet transactions (via the reworked replay benchmark in #20370, where this commit is also included; whichever lands second rebases):

1. **`place_args` rejected transactions carrying more signers than the entry function takes.** The legacy VM ignores extra signers — that's what makes signer-less entry functions (e.g. permissionless maintenance functions like `process_pending_requests`) callable by any sender. On the executor they failed with an `UNKNOWN_INVARIANT_VIOLATION_ERROR`.

2. **The transaction context extension hardcoded `session_counter`, `transaction_index`, and `reserved_byte` to zero** (a known `TODO(completeness)`). The legacy VM seeds `monotonically_increasing_number` with the payload session's counter (35/40) and the transaction's block-level index from the auxiliary info. Since Decibel derives order IDs from that native, every derived ID diverged from on-chain execution: placed orders were stored under different IDs (byte-diverging write sets and events), and lookups of on-chain IDs missed (`BorrowGlobalMut` on absent resources, `0x1::table` NOT_FOUND aborts). `TxnMetadata` now derives all three the way the legacy VM seeds `NativeTransactionContext`, and `execute_user_transaction` takes the transaction's `PersistedAuxiliaryInfo` as a parameter, like `AptosVM` does.

With both fixes, 16 of the 22 captured mainnet transactions replay **byte-for-byte identical** to the legacy AptosVM (up from 3); the remaining 6 hit the known function-value dispatch gaps.


### Review follow-ups

- **Exact signer count when the function takes signers**: the legacy VM ignores extra senders only for signer-less functions; with one or more signer params it requires an exact count (`NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH`). Restored the check for that case, with a multi-agent e2e test.
- **Cleanups**: `TxnMetadata` no longer deep-clones the authenticator four times per transaction, the 32-byte transaction hash is carried as `[u8; 32]` instead of three heap round-trips, and the e2e tests share a `setup()` helper.
- **Transaction-index availability**: with `PersistedAuxiliaryInfo::None`, the context extension now models "index unavailable" and `monotonically_increasing_counter` aborts with `ETRANSACTION_INDEX_NOT_AVAILABLE` like the legacy VM, instead of silently seeding index zero (a gap predating this PR, which used to hardcode zero for every transaction). The no-user-context layer (`ETRANSACTION_CONTEXT_NOT_AVAILABLE`) remains a `TODO(completeness)`.

- **`execute_user_transaction` takes `&AuxiliaryInfo`** like `AptosVM`, extracting the persisted part itself.

## How Has This Been Tested?

- `cargo test -p mono-move-aptos-transaction-executor` (5 e2e tests, call sites updated for the new parameter)
- Differential replay of the 22 captured mainnet transactions on the #20370 branch: 16/22 strict output matches, stable across 12+ runs
- clippy + nightly fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect entry-function argument validation and natives that derive on-chain IDs (e.g. order IDs); incorrect seeding would diverge from mainnet, but behavior is explicitly aligned with the legacy VM and covered by differential tests.
> 
> **Overview**
> **Signer placement** in `place_args` now matches the legacy VM: extra senders are ignored for signer-less entry functions, but functions with signer parameters require an exact count (new e2e: multi-agent extra signers rejected).
> 
> **Transaction context** is no longer hardcoded to zero. `execute_user_transaction` accepts `AuxiliaryInfo`; `TxnMetadata` derives `session_counter`, block index, and reserved byte from `PersistedAuxiliaryInfo` and `SessionId`, and wires them into `TransactionContextExtension` (txn hash as `[u8; 32]`). `monotonically_increasing_counter` aborts with `ETRANSACTION_INDEX_NOT_AVAILABLE` when no index is present instead of using index 0. Replay benchmark and test harness call sites updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d4d39b586488ff0dacdc08288a06fe8eba8560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





