### PR TITLE
[mono-move] Guard copy coalescing and propagation on bitwise-copy types

### DIFF
--- a/third_party/move/mono-move/core/src/prepared_module.rs
+++ b/third_party/move/mono-move/core/src/prepared_module.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     interner::{InternedIdentifier, InternedModuleId, Interner, TypeSubstitutionError},
-    types::{InternedType, InternedTypeList, EMPTY_TYPE_LIST},
+    types::{view_type, view_type_list, InternedType, InternedTypeList, Type, EMPTY_TYPE_LIST},
     ExecutionErrorKind, IntoExecutionError,
 };
 use move_binary_format::{
@@ -215,6 +215,113 @@ impl PreparedModule {
     pub fn interned_field_types(&self, name: InternedIdentifier) -> Option<&FieldTypes> {
         let idx = self.interned_nominal_type_def_idx(name)?;
         Some(&self.field_types[idx.0 as usize])
+    }
+
+    /// Whether a byte copy of `ty`'s frame bytes is by itself a complete,
+    /// faithful copy. False when the value owns heap storage (vectors,
+    /// closures, heap-boxed enums): both copies would then own the same
+    /// allocation, so a faithful copy must also clone that storage. True for
+    /// references: a copied reference must alias the same target, so copying
+    /// the fat pointer bytes is correct.
+    ///
+    /// Conservatively `false` whenever this cannot be established from this
+    /// module alone: type parameters, imported nominals, and type arguments
+    /// that are not directly substitutable.
+    ///
+    /// The last case makes the `false` answer an over-approximation. Given
+    ///
+    /// ```move
+    /// struct C<V> has copy { z: V }
+    /// struct B<U> has copy { y: U }
+    /// struct A<T> has copy { x: B<C<T>> }
+    /// ```
+    ///
+    /// `is_bitwise_copy_type(A<u64>)` returns `false`: `B`'s type argument
+    /// `C<T>` is a nominal rather than a bare type parameter, so `T` is never
+    /// bound to `u64` and answers `false` once `C`'s field is reached.
+    ///
+    /// Inherits safety contract of [`view_type`].
+    /// TODO(metering, perf): the uncached recursion revisits shared subtypes,
+    /// so an all-bitwise struct DAG is traversed exponentially at module load,
+    /// and every caller repeats the walk. Fix: return `false` for non-closed
+    /// types, substitute field types via the interner, and iterate instead of
+    /// recursing, caching the `InternedType -> bool` answer in the global
+    /// context beside the other type-keyed caches. Substitution makes every
+    /// key closed and hence module-independent (a free [`Type::TypeParam`] is
+    /// not a valid key: equal indices at different scopes intern to the same
+    /// pointer). Answering from the global context also gives the imported
+    /// nominal arm below the cross-module field types it lacks today, and
+    /// removes the over-approximation above.
+    pub fn is_bitwise_copy_type(&self, ty: InternedType) -> bool {
+        self.is_bitwise_copy_type_in_ty_env(ty, &[])
+    }
+
+    /// `ty_env` binds [`Type::TypeParam`] nodes to the enclosing nominal's type
+    /// arguments, and is empty at top level. A binding may itself contain type
+    /// parameters; those are looked up in an empty `ty_env`, so they answer
+    /// `false` instead of binding to the wrong parameter.
+    fn is_bitwise_copy_type_in_ty_env(&self, ty: InternedType, ty_env: &[InternedType]) -> bool {
+        match view_type(ty) {
+            Type::Bool
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::U128
+            | Type::U256
+            | Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::I128
+            | Type::I256
+            | Type::Address
+            | Type::Signer
+            | Type::ImmutRef { .. }
+            | Type::MutRef { .. } => true,
+
+            // Owned heap pointers.
+            Type::Vector { .. } | Type::Function { .. } => false,
+
+            Type::TypeParam { idx } => ty_env
+                .get(*idx as usize)
+                .is_some_and(|arg| self.is_bitwise_copy_type_in_ty_env(*arg, &[])),
+
+            Type::Nominal {
+                module_id,
+                name,
+                ty_args,
+            } => {
+                if *module_id != self.id {
+                    // An imported module's field types are not reachable from
+                    // here; see the TODO(metering, perf) on
+                    // [`Self::is_bitwise_copy_type`].
+                    return false;
+                }
+                let Some(FieldTypes::Struct(fields)) = self.interned_field_types(*name) else {
+                    // Enums are heap-boxed regardless of payload.
+                    return false;
+                };
+                // Resolve type arguments that are directly a type parameter of
+                // the current environment; anything deeper stays unresolved and
+                // fails conservatively inside the recursion (a precision loss
+                // removed by the substitution rewrite in the
+                // TODO(metering, perf) on [`Self::is_bitwise_copy_type`]).
+                let args: Vec<InternedType> = view_type_list(*ty_args)
+                    .iter()
+                    .map(|arg| {
+                        if let Type::TypeParam { idx } = view_type(*arg) {
+                            ty_env.get(*idx as usize).copied().unwrap_or(*arg)
+                        } else {
+                            *arg
+                        }
+                    })
+                    .collect();
+                fields
+                    .iter()
+                    .all(|field| self.is_bitwise_copy_type_in_ty_env(*field, &args))
+            },
+        }
     }
 
     /// Returns interned type corresponding to the compiled module's struct

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -176,7 +176,9 @@ pub fn strip_ref(ref_ty: InternedType) -> Option<InternedType> {
 /// Whether `ty` contains no [`Type::TypeParam`] node.
 ///
 /// Inherits safety contract of [`view_type`].
-/// TODO(metering): convert to non-recursive.
+/// TODO(metering): memoize by interned type and convert to non-recursive.
+/// The recursion has no cache and `.all()` short-circuits only on `false`,
+/// so a type whose interned tree shares subtypes is traversed exponentially.
 pub fn is_closed_type(ty: InternedType) -> bool {
     match view_type(ty) {
         Type::TypeParam { .. } => false,

--- a/third_party/move/mono-move/specializer/src/destack/analysis.rs
+++ b/third_party/move/mono-move/specializer/src/destack/analysis.rs
@@ -105,7 +105,10 @@ pub(crate) struct BlockAnalysis {
     pub stloc_targets: UnorderedMap<SsaSlot, HomeIndex>,
     /// `ValueId` → Home slot index of the local it was copied/moved out of,
     /// when the local is neither redefined nor mut-borrowed during the
-    /// `ValueId`'s live range.
+    /// `ValueId`'s live range. A `Copy` coalesces only when its type is
+    /// bitwise-copy: coalescing elides the copy, which is unsound for a value
+    /// owning heap storage (see the equivalence rules on
+    /// [`Instr::Copy`]/[`Instr::Move`]).
     pub coalesce_to_local: UnorderedMap<SsaSlot, HomeIndex>,
     /// `ValueId` → `Transfer` position, for call args or rets whose live
     /// range doesn't cross any other call. See the file-header section
@@ -121,6 +124,10 @@ pub(crate) struct BlockAnalysis {
 impl BlockAnalysis {
     /// Analyze a basic block and produce hint maps for slot allocation.
     ///
+    /// `is_bitwise_copy_value(id)` reports whether `ValueId(id)`'s type is
+    /// bitwise-copy (fully captured by its frame bytes); gates `Copy`
+    /// coalescing.
+    ///
     /// Pre: `instrs` is one basic block's SSA slice; each `ValueId` is
     /// defined exactly once.
     ///
@@ -131,7 +138,10 @@ impl BlockAnalysis {
     /// ValueIds already in either earlier map. (`coalesce_to_local` ∩ call
     /// rets is empty by SSA: a ValueId defined by a `Call` is never the
     /// `dst` of `Copy`/`Move { dst: value_id, src: Home }`.)
-    pub(crate) fn analyze(instrs: &[Instr<SsaSlot>]) -> Self {
+    pub(crate) fn analyze(
+        instrs: &[Instr<SsaSlot>],
+        is_bitwise_copy_value: impl Fn(u16) -> bool,
+    ) -> Self {
         // Forward scan: build per-`ValueId` and per-`Home` position indices.
         // `ValueId` -> last instruction index where it appears as def or use.
         let mut live_end: UnorderedMap<SsaSlot, usize> = UnorderedMap::new();
@@ -213,9 +223,14 @@ impl BlockAnalysis {
         let mut coalesce_to_local: UnorderedMap<SsaSlot, HomeIndex> = UnorderedMap::new();
         for (i, instr) in instrs.iter().enumerate() {
             if let Instr::Copy { dst, src } | Instr::Move { dst, src } = instr
-                && dst.is_value_id()
+                && let SsaSlot::ValueId(id) = dst
                 && let SsaSlot::Home(home_idx) = src
             {
+                // A `Copy` of a value owning heap storage must materialize an
+                // independent object; coalescing would elide the deep copy.
+                if matches!(instr, Instr::Copy { .. }) && !is_bitwise_copy_value(*id) {
+                    continue;
+                }
                 let value_id = *dst;
                 if let Some(&lu) = live_end.get(&value_id)
                     && lu > i
@@ -736,7 +751,7 @@ mod tests {
                 args,
             }),
         }];
-        let analysis = BlockAnalysis::analyze(&instrs);
+        let analysis = BlockAnalysis::analyze(&instrs, |_| true);
         assert_eq!(analysis.max_transfer_positions, 200);
     }
 }

--- a/third_party/move/mono-move/specializer/src/destack/optimize.rs
+++ b/third_party/move/mono-move/specializer/src/destack/optimize.rs
@@ -1,12 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Post-slot allocation optimization passes.
-//!
-//! Pass: Copy propagation
-//! Pass: Identity move elimination
-//! Pass: Dead instruction elimination
-//! Pass: Slot renumbering
+//! Post-slot-allocation optimization passes over the named-slot IR; see
+//! [`optimize_module`] for the pass pipeline.
 
 use crate::stackless_exec_ir::{
     instr_utils::{
@@ -15,15 +11,16 @@ use crate::stackless_exec_ir::{
     },
     FunctionIR, HomeIndex, Instr, ModuleIR, NamedSlot,
 };
+use mono_move_core::PreparedModule;
 use shared_dsa::{UnorderedMap, UnorderedSet};
 
 /// Optimize all functions in a module IR.
-/// Operates on the slot-allocated (named-slot) IR.
 pub fn optimize_module(module_ir: &mut ModuleIR) {
-    for func in module_ir.functions.iter_mut().flatten() {
-        eliminate_identity_moves(func);
-        copy_propagation(func);
-        eliminate_identity_moves(func);
+    let ModuleIR { module, functions } = module_ir;
+    for func in functions.iter_mut().flatten() {
+        eliminate_identity_moves(func, module);
+        copy_propagation(func, module);
+        eliminate_identity_moves(func, module);
         dead_instruction_elimination(func);
         renumber_slots(func);
     }
@@ -36,72 +33,94 @@ pub fn optimize_module(module_ir: &mut ModuleIR) {
 ///
 /// # Correctness
 ///
-/// ## Move verifier guarantees we rely on
-/// - **StLoc(L) forbidden while L is borrowed** (immutably or mutably)
-/// - **MoveLoc(L) forbidden while L is borrowed**
-/// - **CopyLoc(L) forbidden while L is mutably borrowed**
-///
-/// ## Two kinds of slot use
-/// 1. **Value use** — reads the slot's current value (e.g., `Add(dst, r, #5)`)
-/// 2. **Place use** — takes a reference to the slot's place
-///    (only `ImmBorrowLoc` and `MutBorrowLoc`)
-///
-/// Copy propagation is sound for value uses (value equality suffices) but
-/// unsound for place uses (identity of the slot matters).
+/// ## Value uses vs. place uses
+/// Propagation is sound for value uses (value equality suffices) but unsound
+/// for place uses (slot identity matters) — see "Operand roles" on [`Instr`].
 /// `remap_source_slots_with` skips BorrowLoc sources to enforce this.
 ///
 /// ## The MutBorrowLoc hidden-write problem
 /// Once a slot is mutably borrowed, it can be silently modified through the
 /// reference (via `WriteRef`, function calls, etc.) without appearing as a
-/// def in `get_defs_uses`. So we kill subst entries for the borrowed slot
-/// at `MutBorrowLoc` — conservatively assuming hidden writes may follow.
-/// `MutBorrowLocField` and `WriteLocField` have the same hazard.
-///
-/// `ImmBorrowLoc` does NOT need this kill — the verifier guarantees the
-/// borrowed slot cannot be modified while immutably borrowed. The same
-/// holds for `ImmBorrowLocField` and `ReadLocField`.
+/// def. So we kill subst entries for the borrowed slot at `MutBorrowLoc` and
+/// `MutBorrowLocField` — conservatively assuming hidden writes may follow. A
+/// mut borrow cannot predate an entry: the verifier forbids `MoveLoc` on a
+/// borrowed local and `CopyLoc` on a mutably borrowed one. `ImmBorrowLoc`,
+/// `ImmBorrowLocField`, and `ReadLocField` need no kill: `StLoc`/`MoveLoc`
+/// on a borrowed local are forbidden, so a slot cannot change while
+/// immutably borrowed.
 ///
 /// ## Why cross-block mutable borrows are safe
-///
 /// Subst is reset at every block boundary. If `MutBorrowLoc` is in the same
 /// block as the copy, the kill fires before any hidden write. If it's in a
 /// different block, that block's subst is empty — no stale propagation occurs.
-fn copy_propagation(func: &mut FunctionIR) {
-    for block in &mut func.blocks {
-        // TODO(perf): `retain` scans all entries to kill by value, making each kill O(|subst|).
-        // For typical small blocks this is fine, but if subst grows large, consider a
-        // reverse index (value → keys) for O(1) value-based kills.
+///
+/// ## Why `Move` sources are safe but `Copy` sources need a type guard
+/// See the interchangeability rules on [`Instr::Copy`]/[`Instr::Move`].
+/// Applied here: a `Move` entry can never go stale — the verifier makes the
+/// source unusable until redefinition, which kills the entry. A `Copy` entry
+/// for a heap-owning type has no such protection: the source stays usable, so
+/// remapping a consuming use of `dst` would transfer the wrong object, and the
+/// source's object may be consumed or mutated while the entry is live. `Copy`
+/// entries are therefore only created for bitwise-copy types.
+fn copy_propagation(func: &mut FunctionIR, module: &PreparedModule) {
+    let FunctionIR {
+        blocks,
+        home_slot_types,
+        ..
+    } = func;
+    for block in blocks {
+        // TODO(perf): value-based kills `retain`-scan all entries; a reverse
+        // index (value → keys) would make them O(1).
         let mut subst: UnorderedMap<NamedSlot, NamedSlot> = UnorderedMap::new();
 
         for instr in block.instrs.iter_mut() {
-            remap_source_slots_with(instr, |s| *subst.get(&s).unwrap_or(&s));
-
-            // Kill subst for locals whose storage may be mutated without a
-            // full def: mut borrows (writes go through the ref) and
-            // `WriteLocField` (partial write). `WriteLocFieldChain`
-            // reports its root local as a def, so it is covered by the
-            // `for_each_def` kill below; the ref-rooted `WriteFieldChain`
-            // writes through a reference whose originating mut borrow was
-            // already killed here.
-            let mut hidden_write = mut_local_borrow_target(instr);
-            if let Instr::WriteLocField { local, .. } = instr {
-                hidden_write = Some(*local);
-            }
-            if let Some(src) = hidden_write {
-                subst.remove(&src);
-                subst.retain(|_, v| *v != src);
-            }
-
+            // Kill entries invalidated by this def before remapping sources
+            // (see the interchangeability rules on `Instr::Copy`/`Instr::Move`):
+            // remapping through a stale entry would rewrite a source onto this
+            // instruction's own def, manufacturing `dst == src` `Copy` shapes
+            // whose elimination is unsound for heap-owning types (see
+            // `eliminate_identity_moves`). `WriteLocField`/`WriteLocFieldChain`
+            // report the partially written local as a def, so they are covered.
             for_each_def(instr, |d| {
                 subst.remove(&d);
                 subst.retain(|_, v| *v != d);
             });
 
+            // Mut borrows allow hidden writes that never appear as defs (see
+            // the hidden-write section above). The ref-rooted `WriteFieldChain`
+            // writes through a reference whose originating mut borrow was
+            // already killed here.
+            if let Some(src) = mut_local_borrow_target(instr) {
+                subst.remove(&src);
+                subst.retain(|_, v| *v != src);
+            }
+
+            remap_source_slots_with(instr, |s| *subst.get(&s).unwrap_or(&s));
+
+            // Record new entries. Transfer slot values don't survive a call
+            // boundary, so never propagate from them; `Copy` additionally
+            // needs the bitwise-copy type guard (see "Why `Move` sources are
+            // safe but `Copy` sources need a type guard" above).
             match instr {
-                Instr::Copy { dst, src } | Instr::Move { dst, src } => {
-                    // Transfer slot values don't survive a call boundary,
-                    // so don't copy propagate from them.
+                Instr::Move { dst, src } => {
                     if !matches!(src, NamedSlot::Transfer(_)) {
+                        subst.insert(*dst, *src);
+                    }
+                },
+                Instr::Copy { dst, src } => {
+                    // TODO(perf): a non-capturing closure has a null
+                    // captured-data pointer, so its deep copy is pure overhead
+                    // — but the type-based guard can't tell it from a capturing
+                    // one. Recover the propagation by tracking slots defined in
+                    // this block by a `PackClosure` with an empty `captured`
+                    // list.
+                    let interchangeable = match src {
+                        NamedSlot::Home(idx) => {
+                            module.is_bitwise_copy_type(home_slot_types[idx.0 as usize])
+                        },
+                        NamedSlot::Transfer(_) => false,
+                    };
+                    if interchangeable {
                         subst.insert(*dst, *src);
                     }
                 },
@@ -111,14 +130,41 @@ fn copy_propagation(func: &mut FunctionIR) {
     }
 }
 
-/// Pass: Remove `Move` and `Copy` instructions whose `dst == src`.
-fn eliminate_identity_moves(func: &mut FunctionIR) {
-    for block in &mut func.blocks {
-        block
-            .instrs
-            .retain(|instr| {
-                !matches!(instr, Instr::Move { dst, src } | Instr::Copy { dst, src } if dst == src)
-            });
+/// Pass: Remove `Move` and `Copy` instructions whose `dst == src`, except
+/// `Copy`s of heap-owning types.
+///
+/// An identity `Move` is a no-op for every type, and so is an identity
+/// `Copy` of a bitwise-copy type (no deep copy is emitted). An identity
+/// `Copy` of a heap-owning type is a real effect — an in-place deep copy,
+/// "replace the slot's object with a fresh copy" — whose deletion is sound
+/// only when no other slot co-owns the object, which is not locally
+/// checkable. Thus, it is kept.
+fn eliminate_identity_moves(func: &mut FunctionIR, module: &PreparedModule) {
+    let FunctionIR {
+        blocks,
+        home_slot_types,
+        ..
+    } = func;
+    for block in blocks {
+        block.instrs.retain(|instr| {
+            let (is_copy, dst) = match instr {
+                Instr::Move { dst, src } if dst == src => (false, dst),
+                Instr::Copy { dst, src } if dst == src => (true, dst),
+                _ => return true,
+            };
+            // A Transfer identity can't currently arise: SSA `Copy`/`Move`
+            // always carry a Home slot on one side, and copy propagation
+            // never remaps a source onto a Transfer slot.
+            let NamedSlot::Home(idx) = dst else {
+                // A Transfer identity would resolve to distinct frame offsets
+                // at lowering, so deleting one would be wrong: keep it.
+                debug_assert!(false, "identity Copy/Move on a Transfer slot");
+                return true;
+            };
+            let removable =
+                !is_copy || module.is_bitwise_copy_type(home_slot_types[idx.0 as usize]);
+            !removable
+        });
     }
 }
 
@@ -129,6 +175,10 @@ fn eliminate_identity_moves(func: &mut FunctionIR) {
 ///
 /// Slots that appear in more than one basic block are excluded from
 /// removal — their liveness cannot be determined by block-local analysis.
+///
+/// Deleting a *dead* Copy is sound for every type, including a heap-typed
+/// identity Copy kept by `eliminate_identity_moves`: a Copy's only effect
+/// is its dst slot, and dead means no instruction reads it.
 fn dead_instruction_elimination(func: &mut FunctionIR) {
     // Pre-scan: identify Home slots that appear in more than one block.
     // (Transfer slots are intra-block and never cross block boundaries.)
@@ -204,7 +254,6 @@ fn renumber_slots(func: &mut FunctionIR) {
     }
 
     // Build remap[old_index] = Some(new_index) or None if unused.
-    // Params keep their ABI indices; non-params are compacted sequentially.
     let mut remap: Vec<Option<u16>> = vec![None; old_num_home as usize];
     let mut next_slot = num_params;
     let mut num_surviving_locals: u16 = 0;

--- a/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
+++ b/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
@@ -14,7 +14,8 @@ use crate::stackless_exec_ir::{
     BasicBlock, HomeIndex, NamedSlot, SsaSlot,
 };
 use mono_move_core::{
-    types::InternedType, ExecutionErrorKind, IntoExecutionError, VMInternalError, VMResult,
+    types::InternedType, ExecutionErrorKind, IntoExecutionError, PreparedModule, VMInternalError,
+    VMResult,
 };
 use shared_dsa::UnorderedMap;
 use thiserror::Error;
@@ -199,14 +200,23 @@ impl SlotTable {
 ///      `ValueId(i)` to its type at index `i`.
 /// Post: all `ValueId`s replaced with `Home`/`Transfer` slots
 ///       (guaranteed by the output type).
-pub(crate) fn allocate_slots(ssa: SSAFunction) -> VMResult<AllocatedFunction> {
+pub(crate) fn allocate_slots(
+    ssa: SSAFunction,
+    module: &PreparedModule,
+) -> VMResult<AllocatedFunction> {
     let mut table = SlotTable::new(&ssa.local_types, ssa.value_id_types.len());
     let mut result_blocks = Vec::with_capacity(ssa.blocks.len());
     let mut num_transfer_positions: u16 = 0;
     let mut free_pool: UnorderedMap<InternedType, Vec<NamedSlot>> = UnorderedMap::new();
 
+    let is_bitwise_copy_value = |id: u16| -> bool {
+        ssa.value_id_types
+            .get(id as usize)
+            .is_some_and(|ty| module.is_bitwise_copy_type(*ty))
+    };
+
     for block in ssa.blocks {
-        let analysis = BlockAnalysis::analyze(&block.instrs);
+        let analysis = BlockAnalysis::analyze(&block.instrs, is_bitwise_copy_value);
         num_transfer_positions = num_transfer_positions.max(analysis.max_transfer_positions);
         result_blocks.push(allocate_block(
             block,

--- a/third_party/move/mono-move/specializer/src/destack/translate.rs
+++ b/third_party/move/mono-move/specializer/src/destack/translate.rs
@@ -64,7 +64,7 @@ pub fn translate_module(module: PreparedModule, interner: &impl Interner) -> VMR
             let ssa = ssa.with_fusion_passes()?.with_test_utils_passes(&module)?;
 
             // Pass: Greedy Slot Allocation (consumes SSA, produces named-slot IR)
-            let alloc = super::slot_alloc::allocate_slots(ssa)?;
+            let alloc = super::slot_alloc::allocate_slots(ssa, &module)?;
 
             Ok(Some(FunctionIR {
                 name_idx,

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -262,6 +262,21 @@ pub enum Instr<SlotForm> {
     LdImm { dst: SlotForm, imm: ImmValue },
 
     // --- Slot ops ---
+    //
+    // For transformation passes: when may `dst` and `src` be treated as
+    // interchangeable names for one value?
+    //
+    // - `Move`: always — both name the same object, and `src` is unusable
+    //   until redefined (bytecode verifier).
+    // - `Copy`: only for bitwise-copy types
+    //   (`PreparedModule::is_bitwise_copy_type`). Otherwise the lowering
+    //   deep-copies, so `dst` is a different object: the `Copy` must not be
+    //   substituted through, coalesced, or elided unless its result is
+    //   provably unobserved.
+    //
+    // Either claim holds only until `dst` or `src` is redefined (frame slots
+    // are recycled); invalidate before rewriting the redefining instruction
+    // itself.
     /// `dst = copy(src)`, source remains valid.
     Copy { dst: SlotForm, src: SlotForm },
     /// `dst = move(src)`, source invalidated.

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/noncapturing.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/noncapturing.exp
@@ -43,18 +43,20 @@ fun identity(l0: u64): u64
 // module 0x99::noncapturing
 
 fun call_double_twice(r0): u64 {
-  slots: params(1), locals(1), temps(2)
+  slots: params(1), locals(1), temps(3)
     r0: u64
     r1: |u64|u64
-    r2: u64
+    r2: |u64|u64
     r3: u64
+    r4: u64
   code:
   L0:
     0: r1 := pack_closure double, 0, [] @0
-    1: [r2] := call_closure [|u64|u64], [r0, r1] @4
-    2: [r3] := call_closure [|u64|u64], [r0, r1] @7
-    3: r3 := add r2, r3 @8
-    4: ret [r3] @9
+    1: r2 := copy r1 @3
+    2: [r3] := call_closure [|u64|u64], [r0, r2] @4
+    3: [r4] := call_closure [|u64|u64], [r0, r1] @7
+    4: r4 := add r3, r4 @8
+    5: ret [r4] @9
 }
 
 fun call_identity(r0): u64 {
@@ -90,19 +92,22 @@ fun identity(r0): u64 {
 // module 0x99::noncapturing
 
 fun call_double_twice() {
-  frame_data_size: 32
-  entry_gas: 244
+  frame_data_size: 40
+  entry_gas: 270
   code:
     0: PackClosure [8] <- func_ref=Unresolved(double), mask=0, captured_desc=<none>, captured=[] @0
-    1: CallClosure closure=[8], provided_args=[[0](8)] @4
-    2: Move8 [16] <- [56] @4
-    3: CallClosure closure=[8], provided_args=[[0](8)] @7
-    4: Move8 [24] <- [56] @7
-    5: AddU64 [24] <- [16] + [24] @8
-    6: Move8 [0] <- [24] @9
-    7: Return @9
+    1: Move8 [16] <- [8] @3
+    2: DeepCopyHeapPtrs [16] deep-copy ptrs at [0] @3
+    3: CallClosure closure=[16], provided_args=[[0](8)] @4
+    4: Move8 [24] <- [64] @4
+    5: CallClosure closure=[8], provided_args=[[0](8)] @7
+    6: Move8 [32] <- [64] @7
+    7: AddU64 [32] <- [24] + [32] @8
+    8: Move8 [0] <- [32] @9
+    9: Return @9
   safe_point_layouts:
     0: []
+    2: []
 }
 
 fun call_identity() {

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/copy_xfer_gc.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/enums/copy_xfer_gc.move
@@ -31,4 +31,4 @@ module 0x42::copy_xfer_gc {
 
 // RUN: execute 0x42::copy_xfer_gc::churn --args 200 --heap-size 96
 // CHECK: results: 4829
-// CHECK-GC-COUNT: 198
+// CHECK-GC-COUNT: 398

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_enum_option.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_enum_option.exp
@@ -6,23 +6,27 @@ fun none(): skipped (generic function not instantiated)
 fun some(): skipped (generic function not instantiated)
 
 fun copy_some() {
-  frame_data_size: 32
-  entry_gas: 301
+  frame_data_size: 40
+  entry_gas: 327
   code:
-    0: Move8 [56] <- [0] @1
+    0: Move8 [64] <- [0] @1
     1: CallIndirect 0x42::generic_enum_option::some<u64> @1
-    2: Move8 [8] <- [56] @1
-    3: StoreImm8 [64] <- #0 @5
-    4: Move8 [56] <- [8] @6
-    5: CallIndirect 0x42::generic_enum_option::unwrap_or<u64> @6
-    6: Move8 [0] <- [56] @6
-    7: StoreImm8 [64] <- #0 @8
-    8: Move8 [56] <- [8] @9
-    9: CallIndirect 0x42::generic_enum_option::unwrap_or<u64> @9
-    10: Move8 [16] <- [56] @9
-    11: AddU64 [24] <- [0] + [16] @13
-    12: Move8 [0] <- [24] @14
-    13: Return @14
+    2: Move8 [8] <- [64] @1
+    3: Move8 [24] <- [8] @3
+    4: DeepCopyHeapPtrs [24] deep-copy ptrs at [0] @3
+    5: StoreImm8 [72] <- #0 @5
+    6: Move8 [64] <- [8] @6
+    7: CallIndirect 0x42::generic_enum_option::unwrap_or<u64> @6
+    8: Move8 [0] <- [64] @6
+    9: StoreImm8 [72] <- #0 @8
+    10: Move8 [64] <- [24] @9
+    11: CallIndirect 0x42::generic_enum_option::unwrap_or<u64> @9
+    12: Move8 [16] <- [64] @9
+    13: AddU64 [32] <- [0] + [16] @13
+    14: Move8 [0] <- [32] @14
+    15: Return @14
+  safe_point_layouts:
+    4: []
 }
 
 fun run_bool() {

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/coalesce_copy_bypass.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/coalesce_copy_bypass.exp
@@ -1,0 +1,65 @@
+=== stackless ===
+// module 0x42::coalesce_copy_bypass
+
+fun direct_arg_copy(r0): u64 {
+  slots: params(1), locals(1), temps(3), transfer(1)
+    r0: u64
+    r1: vector<u64>
+    r2: &vector<u64>
+    r3: u64
+    r4: &u64
+  code:
+  L0:
+    0: [r1] := call make, [r0] @1
+    1: x0 := copy r1 @3
+    2: [r0] := call mutate_first, [x0] @4
+    3: r2 := imm_borrow_loc r1 @6
+    4: r3 := ld_u64 0 @7
+    5: r4 := vec_imm_borrow u64, r2, r3 @8
+    6: r3 := read_ref r4 @9
+    7: r3 := mul r3, #100 @11
+    8: r3 := add r3, r0 @13
+    9: ret [r3] @14
+}
+
+fun make(r0): vector<u64> {
+  slots: params(1), locals(1), temps(2)
+    r0: u64
+    r1: vector<u64>
+    r2: &mut vector<u64>
+    r3: u64
+  code:
+  L0:
+    0: r1 := vec_pack u64, 0, [] @0
+    1: r2 := mut_borrow_loc r1 @2
+    2: vec_push_back u64, r2, r0 @4
+    3: r2 := mut_borrow_loc r1 @5
+    4: r3 := add r0, #1 @8
+    5: vec_push_back u64, r2, r3 @9
+    6: r2 := mut_borrow_loc r1 @10
+    7: r3 := add r0, #2 @13
+    8: vec_push_back u64, r2, r3 @14
+    9: ret [r1] @16
+}
+
+fun mutate_first(r0): u64 {
+  slots: params(1), locals(1), temps(5)
+    r0: vector<u64>
+    r1: vector<u64>
+    r2: u64
+    r3: &mut vector<u64>
+    r4: u64
+    r5: &mut u64
+    r6: &vector<u64>
+  code:
+  L0:
+    0: r1 := move r0 @0
+    1: r2 := ld_u64 99 @2
+    2: r3 := mut_borrow_loc r1 @3
+    3: r4 := ld_u64 0 @4
+    4: r5 := vec_mut_borrow u64, r3, r4 @5
+    5: write_ref r5, r2 @6
+    6: r6 := imm_borrow_loc r1 @7
+    7: r2 := vec_len u64, r6 @8
+    8: ret [r2] @9
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/coalesce_copy_bypass.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/coalesce_copy_bypass.move
@@ -1,0 +1,28 @@
+// RUN: publish --print(stackless)
+module 0x42::coalesce_copy_bypass {
+    use std::vector;
+
+    fun make(seed: u64): vector<u64> {
+        let items = vector::empty<u64>();
+        vector::push_back(&mut items, seed);
+        vector::push_back(&mut items, seed + 1);
+        vector::push_back(&mut items, seed + 2);
+        items
+    }
+
+    // Takes ownership and mutates element 0 in place (no realloc).
+    fun mutate_first(items: vector<u64>): u64 {
+        let owned = items;
+        *vector::borrow_mut(&mut owned, 0) = 99;
+        vector::length(&owned)
+    }
+
+    fun direct_arg_copy(seed: u64): u64 {
+        let v = make(seed);
+        let len = mutate_first(copy v);
+        *vector::borrow(&v, 0) * 100 + len
+    }
+}
+
+// RUN: execute 0x42::coalesce_copy_bypass::direct_arg_copy --args 1
+// CHECK: results: 103

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_allowed.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_allowed.exp
@@ -1,0 +1,90 @@
+=== stackless ===
+// module 0x42::copy_prop_allowed
+
+fun bump(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := add r0, #1 @2
+    1: ret [r1] @3
+}
+
+fun consume_len(r0): u64 {
+  slots: params(1), locals(0), temps(2)
+    r0: vector<u64>
+    r1: &vector<u64>
+    r2: u64
+  code:
+  L0:
+    0: r1 := imm_borrow_loc r0 @0
+    1: r2 := vec_len u64, r1 @1
+    2: ret [r2] @2
+}
+
+fun make(r0): vector<u64> {
+  slots: params(1), locals(1), temps(2)
+    r0: u64
+    r1: vector<u64>
+    r2: &mut vector<u64>
+    r3: u64
+  code:
+  L0:
+    0: r1 := vec_pack u64, 0, [] @0
+    1: r2 := mut_borrow_loc r1 @2
+    2: vec_push_back u64, r2, r0 @4
+    3: r2 := mut_borrow_loc r1 @5
+    4: r3 := add r0, #1 @8
+    5: vec_push_back u64, r2, r3 @9
+    6: ret [r1] @11
+}
+
+fun pair_sum(r0): u64 {
+  slots: params(1), locals(0), temps(2)
+    r0: 0x42::copy_prop_allowed::Pair
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r1 := read_loc_field Pair::a, r0 @0
+    1: r2 := read_loc_field Pair::b, r0 @3
+    2: r2 := add r1, r2 @6
+    3: ret [r2] @7
+}
+
+fun scalar_copy(r0): u64 {
+  slots: params(1), locals(0), temps(1), transfer(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: [x0] := call bump, [r0] @1
+    1: r1 := add x0, r0 @3
+    2: ret [r1] @4
+}
+
+fun struct_copy(r0): u64 {
+  slots: params(1), locals(1), temps(1), transfer(1)
+    r0: u64
+    r1: 0x42::copy_prop_allowed::Pair
+    r2: u64
+  code:
+  L0:
+    0: r2 := ld_u64 2 @1
+    1: r1 := pack 0x42::copy_prop_allowed::Pair, [r0, r2] @2
+    2: [x0] := call pair_sum, [r1] @5
+    3: r2 := read_loc_field Pair::a, r1 @6
+    4: r2 := add x0, r2 @9
+    5: ret [r2] @10
+}
+
+fun vector_move(r0): u64 {
+  slots: params(1), locals(0), temps(0), transfer(1)
+    r0: u64
+  code:
+  L0:
+    0: [x0] := call make, [r0] @1
+    1: [x0] := call consume_len, [x0] @2
+    2: ret [x0] @3
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_allowed.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_allowed.move
@@ -1,0 +1,50 @@
+// RUN: publish --print(stackless)
+module 0x42::copy_prop_allowed {
+    use std::vector;
+
+    struct Pair has copy, drop { a: u64, b: u64 }
+
+    fun make(seed: u64): vector<u64> {
+        let items = vector::empty<u64>();
+        vector::push_back(&mut items, seed);
+        vector::push_back(&mut items, seed + 1);
+        items
+    }
+
+    fun bump(x: u64): u64 { x + 1 }
+
+    fun pair_sum(p: Pair): u64 { p.a + p.b }
+
+    fun consume_len(items: vector<u64>): u64 { vector::length(&items) }
+
+    // Copy of a scalar: the copy and the original are interchangeable bits;
+    // propagation may collapse the copy.
+    fun scalar_copy(v: u64): u64 {
+        let d = copy v;
+        bump(d) + v
+    }
+
+    // Move of a vector: dst and src name the same object; the move chain may
+    // collapse even though the type owns heap storage.
+    fun vector_move(seed: u64): u64 {
+        let v = make(seed);
+        let d = v;
+        consume_len(d)
+    }
+
+    // Copy of a pointer-free local struct: still propagatable.
+    fun struct_copy(seed: u64): u64 {
+        let p = Pair { a: seed, b: 2 };
+        let d = copy p;
+        pair_sum(d) + p.a
+    }
+}
+
+// RUN: execute 0x42::copy_prop_allowed::scalar_copy --args 5
+// CHECK: results: 11
+
+// RUN: execute 0x42::copy_prop_allowed::vector_move --args 5
+// CHECK: results: 2
+
+// RUN: execute 0x42::copy_prop_allowed::struct_copy --args 5
+// CHECK: results: 12

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_deep_copy_bypass.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_deep_copy_bypass.exp
@@ -1,0 +1,146 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x42::copy_prop_deep_copy_bypass
+// Function definition at index 0
+fun deep_copy_bypass(): u64
+    local l0: vector<u64>
+    local l1: vector<u64>
+    local l2: u64
+    local l3: u64
+    ld_u64 1
+    call make
+    st_loc l0
+    copy_loc l0
+    st_loc l1
+    // @5
+    borrow_loc l1
+    vec_len <u64>
+    st_loc l2
+    move_loc l1
+    call mutate_first
+    // @10
+    st_loc l3
+    borrow_loc l0
+    ld_u64 0
+    vec_borrow <u64>
+    read_ref
+    // @15
+    ld_u64 100
+    mul
+    move_loc l3
+    add
+    move_loc l2
+    // @20
+    add
+    ret
+
+// Function definition at index 1
+fun make(l0: u64): vector<u64>
+    local l1: vector<u64>
+    vec_pack <u64>, 0
+    st_loc l1
+    mut_borrow_loc l1
+    copy_loc l0
+    vec_push_back <u64>
+    // @5
+    mut_borrow_loc l1
+    copy_loc l0
+    ld_u64 1
+    add
+    vec_push_back <u64>
+    // @10
+    mut_borrow_loc l1
+    move_loc l0
+    ld_u64 2
+    add
+    vec_push_back <u64>
+    // @15
+    move_loc l1
+    ret
+
+// Function definition at index 2
+fun mutate_first(l0: vector<u64>): u64
+    local l1: vector<u64>
+    move_loc l0
+    st_loc l1
+    ld_u64 99
+    mut_borrow_loc l1
+    ld_u64 0
+    // @5
+    vec_mut_borrow <u64>
+    write_ref
+    borrow_loc l1
+    vec_len <u64>
+    ret
+
+=== stackless ===
+// module 0x42::copy_prop_deep_copy_bypass
+
+fun deep_copy_bypass(): u64 {
+  slots: params(0), locals(4), temps(3), transfer(1)
+    r0: vector<u64>
+    r1: vector<u64>
+    r2: u64
+    r3: u64
+    r4: &vector<u64>
+    r5: u64
+    r6: &u64
+  code:
+  L0:
+    0: x0 := ld_u64 1 @0
+    1: [r0] := call make, [x0] @1
+    2: r1 := copy r0 @3
+    3: r4 := imm_borrow_loc r1 @5
+    4: r2 := vec_len u64, r4 @6
+    5: [r3] := call mutate_first, [r1] @9
+    6: r4 := imm_borrow_loc r0 @11
+    7: r5 := ld_u64 0 @12
+    8: r6 := vec_imm_borrow u64, r4, r5 @13
+    9: r5 := read_ref r6 @14
+    10: r5 := mul r5, #100 @16
+    11: r5 := add r5, r3 @18
+    12: r5 := add r5, r2 @20
+    13: ret [r5] @21
+}
+
+fun make(r0): vector<u64> {
+  slots: params(1), locals(1), temps(2)
+    r0: u64
+    r1: vector<u64>
+    r2: &mut vector<u64>
+    r3: u64
+  code:
+  L0:
+    0: r1 := vec_pack u64, 0, [] @0
+    1: r2 := mut_borrow_loc r1 @2
+    2: vec_push_back u64, r2, r0 @4
+    3: r2 := mut_borrow_loc r1 @5
+    4: r3 := add r0, #1 @8
+    5: vec_push_back u64, r2, r3 @9
+    6: r2 := mut_borrow_loc r1 @10
+    7: r3 := add r0, #2 @13
+    8: vec_push_back u64, r2, r3 @14
+    9: ret [r1] @16
+}
+
+fun mutate_first(r0): u64 {
+  slots: params(1), locals(1), temps(5)
+    r0: vector<u64>
+    r1: vector<u64>
+    r2: u64
+    r3: &mut vector<u64>
+    r4: u64
+    r5: &mut u64
+    r6: &vector<u64>
+  code:
+  L0:
+    0: r1 := move r0 @0
+    1: r2 := ld_u64 99 @2
+    2: r3 := mut_borrow_loc r1 @3
+    3: r4 := ld_u64 0 @4
+    4: r5 := vec_mut_borrow u64, r3, r4 @5
+    5: write_ref r5, r2 @6
+    6: r6 := imm_borrow_loc r1 @7
+    7: r2 := vec_len u64, r6 @8
+    8: ret [r2] @9
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_deep_copy_bypass.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_deep_copy_bypass.move
@@ -1,0 +1,30 @@
+// RUN: publish --print(bytecode,stackless)
+module 0x42::copy_prop_deep_copy_bypass {
+    use std::vector;
+
+    fun make(seed: u64): vector<u64> {
+        let items = vector::empty<u64>();
+        vector::push_back(&mut items, seed);
+        vector::push_back(&mut items, seed + 1);
+        vector::push_back(&mut items, seed + 2);
+        items
+    }
+
+    // Takes ownership and mutates element 0 in place (no realloc).
+    fun mutate_first(items: vector<u64>): u64 {
+        let owned = items;
+        *vector::borrow_mut(&mut owned, 0) = 99;
+        vector::length(&owned)
+    }
+
+    fun deep_copy_bypass(): u64 {
+        let v = make(1);
+        let d = copy v;
+        let pin = vector::length(&d); // borrow pins `d` in a home slot
+        let len = mutate_first(d);
+        *vector::borrow(&v, 0) * 100 + len + pin
+    }
+}
+
+// RUN: execute 0x42::copy_prop_deep_copy_bypass::deep_copy_bypass
+// CHECK: results: 106

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_enum_bypass.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_enum_bypass.exp
@@ -1,0 +1,53 @@
+=== stackless ===
+// module 0x42::copy_prop_enum_bypass
+
+fun bypass(r0): u64 {
+  slots: params(1), locals(3), temps(2), transfer(1)
+    r0: u64
+    r1: 0x42::copy_prop_enum_bypass::Holder
+    r2: 0x42::copy_prop_enum_bypass::Holder
+    r3: u64
+    r4: &0x42::copy_prop_enum_bypass::Holder
+    r5: u64
+  code:
+  L0:
+    0: [r1] := call make, [r0] @1
+    1: r2 := copy r1 @3
+    2: r4 := imm_borrow_loc r2 @5
+    3: r0 := read_variant_field Holder::V::n, r4 @6
+    4: [r3] := call set_payload, [r2] @10
+    5: r4 := imm_borrow_loc r1 @12
+    6: r5 := read_variant_field Holder::V::n, r4 @13
+    7: r5 := mul r5, #100 @16
+    8: r5 := add r5, r3 @18
+    9: r5 := add r5, r0 @20
+    10: ret [r5] @21
+}
+
+fun make(r0): Holder {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: 0x42::copy_prop_enum_bypass::Holder
+  code:
+  L0:
+    0: r1 := pack_variant 0x42::copy_prop_enum_bypass::Holder@0, [r0] @1
+    1: ret [r1] @2
+}
+
+fun set_payload(r0): u64 {
+  slots: params(1), locals(1), temps(3)
+    r0: 0x42::copy_prop_enum_bypass::Holder
+    r1: 0x42::copy_prop_enum_bypass::Holder
+    r2: u64
+    r3: &mut 0x42::copy_prop_enum_bypass::Holder
+    r4: &0x42::copy_prop_enum_bypass::Holder
+  code:
+  L0:
+    0: r1 := move r0 @0
+    1: r2 := ld_u64 99 @2
+    2: r3 := mut_borrow_loc r1 @3
+    3: write_variant_field Holder::V::n, r3, r2 @4
+    4: r4 := imm_borrow_loc r1 @6
+    5: r2 := read_variant_field Holder::V::n, r4 @7
+    6: ret [r2] @9
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_enum_bypass.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_enum_bypass.move
@@ -1,0 +1,28 @@
+// RUN: publish --print(stackless)
+module 0x42::copy_prop_enum_bypass {
+    enum Holder has copy, drop { V { n: u64 } }
+
+    fun make(seed: u64): Holder {
+        Holder::V { n: seed }
+    }
+
+    // Takes ownership and mutates the payload in place.
+    fun set_payload(h: Holder): u64 {
+        let owned = h;
+        owned.n = 99;
+        owned.n
+    }
+
+    // Enum values are heap-boxed: `d` is a deep copy of `a`, and the callee's
+    // in-place write must not be visible through `a`.
+    fun bypass(seed: u64): u64 {
+        let a = make(seed);
+        let d = copy a;
+        let pin = d.n; // field borrow pins `d` in a home slot
+        let got = set_payload(d);
+        a.n * 100 + got + pin
+    }
+}
+
+// RUN: execute 0x42::copy_prop_enum_bypass::bypass --args 1
+// CHECK: results: 200

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_stale_read.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_stale_read.exp
@@ -1,0 +1,162 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x42::copy_prop_stale_read
+// Function definition at index 0
+fun first(l0: vector<u64>): u64
+    borrow_loc l0
+    ld_u64 0
+    vec_borrow <u64>
+    read_ref
+    ret
+
+// Function definition at index 1
+fun make(l0: u64): vector<u64>
+    local l1: vector<u64>
+    vec_pack <u64>, 0
+    st_loc l1
+    mut_borrow_loc l1
+    copy_loc l0
+    vec_push_back <u64>
+    // @5
+    mut_borrow_loc l1
+    copy_loc l0
+    ld_u64 1
+    add
+    vec_push_back <u64>
+    // @10
+    mut_borrow_loc l1
+    move_loc l0
+    ld_u64 2
+    add
+    vec_push_back <u64>
+    // @15
+    move_loc l1
+    ret
+
+// Function definition at index 2
+fun mutate_first(l0: vector<u64>): u64
+    local l1: vector<u64>
+    move_loc l0
+    st_loc l1
+    ld_u64 99
+    mut_borrow_loc l1
+    ld_u64 0
+    // @5
+    vec_mut_borrow <u64>
+    write_ref
+    borrow_loc l1
+    vec_len <u64>
+    ret
+
+// Function definition at index 3
+fun stale_read_after_consume(): u64
+    local l0: vector<u64>
+    local l1: vector<u64>
+    local l2: u64
+    local l3: u64
+    ld_u64 7
+    call make
+    st_loc l0
+    copy_loc l0
+    st_loc l1
+    // @5
+    borrow_loc l1
+    vec_len <u64>
+    st_loc l2
+    move_loc l0
+    call mutate_first
+    // @10
+    st_loc l3
+    move_loc l1
+    call first
+    ld_u64 100
+    mul
+    // @15
+    move_loc l3
+    add
+    move_loc l2
+    add
+    ret
+
+=== stackless ===
+// module 0x42::copy_prop_stale_read
+
+fun first(r0): u64 {
+  slots: params(1), locals(0), temps(3)
+    r0: vector<u64>
+    r1: &vector<u64>
+    r2: u64
+    r3: &u64
+  code:
+  L0:
+    0: r1 := imm_borrow_loc r0 @0
+    1: r2 := ld_u64 0 @1
+    2: r3 := vec_imm_borrow u64, r1, r2 @2
+    3: r2 := read_ref r3 @3
+    4: ret [r2] @4
+}
+
+fun make(r0): vector<u64> {
+  slots: params(1), locals(1), temps(2)
+    r0: u64
+    r1: vector<u64>
+    r2: &mut vector<u64>
+    r3: u64
+  code:
+  L0:
+    0: r1 := vec_pack u64, 0, [] @0
+    1: r2 := mut_borrow_loc r1 @2
+    2: vec_push_back u64, r2, r0 @4
+    3: r2 := mut_borrow_loc r1 @5
+    4: r3 := add r0, #1 @8
+    5: vec_push_back u64, r2, r3 @9
+    6: r2 := mut_borrow_loc r1 @10
+    7: r3 := add r0, #2 @13
+    8: vec_push_back u64, r2, r3 @14
+    9: ret [r1] @16
+}
+
+fun mutate_first(r0): u64 {
+  slots: params(1), locals(1), temps(5)
+    r0: vector<u64>
+    r1: vector<u64>
+    r2: u64
+    r3: &mut vector<u64>
+    r4: u64
+    r5: &mut u64
+    r6: &vector<u64>
+  code:
+  L0:
+    0: r1 := move r0 @0
+    1: r2 := ld_u64 99 @2
+    2: r3 := mut_borrow_loc r1 @3
+    3: r4 := ld_u64 0 @4
+    4: r5 := vec_mut_borrow u64, r3, r4 @5
+    5: write_ref r5, r2 @6
+    6: r6 := imm_borrow_loc r1 @7
+    7: r2 := vec_len u64, r6 @8
+    8: ret [r2] @9
+}
+
+fun stale_read_after_consume(): u64 {
+  slots: params(0), locals(4), temps(2), transfer(1)
+    r0: vector<u64>
+    r1: vector<u64>
+    r2: u64
+    r3: u64
+    r4: &vector<u64>
+    r5: u64
+  code:
+  L0:
+    0: x0 := ld_u64 7 @0
+    1: [r0] := call make, [x0] @1
+    2: r1 := copy r0 @3
+    3: r4 := imm_borrow_loc r1 @5
+    4: r2 := vec_len u64, r4 @6
+    5: [r3] := call mutate_first, [r0] @9
+    6: [x0] := call first, [r1] @12
+    7: r5 := mul x0, #100 @14
+    8: r5 := add r5, r3 @16
+    9: r5 := add r5, r2 @18
+    10: ret [r5] @19
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_stale_read.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/copy_prop_stale_read.move
@@ -1,0 +1,37 @@
+// RUN: publish --print(bytecode,stackless)
+module 0x42::copy_prop_stale_read {
+    use std::vector;
+
+    fun make(seed: u64): vector<u64> {
+        let items = vector::empty<u64>();
+        vector::push_back(&mut items, seed);
+        vector::push_back(&mut items, seed + 1);
+        vector::push_back(&mut items, seed + 2);
+        items
+    }
+
+    // Takes ownership and mutates element 0 in place (no realloc).
+    fun mutate_first(items: vector<u64>): u64 {
+        let owned = items;
+        *vector::borrow_mut(&mut owned, 0) = 99;
+        vector::length(&owned)
+    }
+
+    // Reads element 0 of an owned vector.
+    fun first(items: vector<u64>): u64 {
+        *vector::borrow(&items, 0)
+    }
+
+    // `v` is consumed (and its buffer mutated in place) before `d` is read
+    // by value; the read of `d` must see the pristine copy.
+    fun stale_read_after_consume(): u64 {
+        let v = make(7);
+        let d = copy v;
+        let pin = vector::length(&d);
+        let len = mutate_first(v);
+        first(d) * 100 + len + pin
+    }
+}
+
+// RUN: execute 0x42::copy_prop_stale_read::stale_read_after_consume
+// CHECK: results: 706

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/recycled_slot_identity_copy.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/recycled_slot_identity_copy.exp
@@ -1,0 +1,69 @@
+=== stackless ===
+// module 0x42::recycled_slot_identity_copy
+
+fun assign_through_call(r0): u64 {
+  slots: params(1), locals(2), temps(7), transfer(1)
+    r0: u64
+    r1: vector<u64>
+    r2: 0x42::recycled_slot_identity_copy::Wrap
+    r3: vector<u64>
+    r4: u64
+    r5: &mut vector<u64>
+    r6: u64
+    r7: &mut u64
+    r8: &vector<u64>
+    r9: &u64
+  code:
+  L0:
+    0: [r1] := call make, [r0] @1
+    1: x0 := add r0, #10 @5
+    2: [r3] := call make, [x0] @6
+    3: [r0] := call consume_len, [r1] @8
+    4: r1 := move r3 @10
+    5: r3 := copy r1 @11
+    6: r2 := pack 0x42::recycled_slot_identity_copy::Wrap, [r3] @12
+    7: r4 := ld_u64 99 @14
+    8: r5 := mut_borrow_loc_field Wrap::v, r2 @15
+    9: r6 := ld_u64 0 @17
+    10: r7 := vec_mut_borrow u64, r5, r6 @18
+    11: write_ref r7, r4 @19
+    12: r8 := imm_borrow_loc r1 @20
+    13: r4 := ld_u64 0 @21
+    14: r9 := vec_imm_borrow u64, r8, r4 @22
+    15: r4 := read_ref r9 @23
+    16: r4 := mul r4, #100 @25
+    17: r4 := add r4, r0 @27
+    18: ret [r4] @28
+}
+
+fun consume_len(r0): u64 {
+  slots: params(1), locals(0), temps(2)
+    r0: vector<u64>
+    r1: &vector<u64>
+    r2: u64
+  code:
+  L0:
+    0: r1 := imm_borrow_loc r0 @0
+    1: r2 := vec_len u64, r1 @1
+    2: ret [r2] @2
+}
+
+fun make(r0): vector<u64> {
+  slots: params(1), locals(1), temps(2)
+    r0: u64
+    r1: vector<u64>
+    r2: &mut vector<u64>
+    r3: u64
+  code:
+  L0:
+    0: r1 := vec_pack u64, 0, [] @0
+    1: r2 := mut_borrow_loc r1 @2
+    2: vec_push_back u64, r2, r0 @4
+    3: r2 := mut_borrow_loc r1 @5
+    4: r3 := add r0, #1 @8
+    5: vec_push_back u64, r2, r3 @9
+    6: r2 := mut_borrow_loc r1 @10
+    7: r3 := add r0, #2 @13
+    8: vec_push_back u64, r2, r3 @14
+    9: ret [r1] @16
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/recycled_slot_identity_copy.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/recycled_slot_identity_copy.move
@@ -1,0 +1,30 @@
+// RUN: publish --print(stackless)
+module 0x42::recycled_slot_identity_copy {
+    use std::vector;
+
+    struct Wrap has drop { v: vector<u64> }
+
+    fun make(seed: u64): vector<u64> {
+        let items = vector::empty<u64>();
+        vector::push_back(&mut items, seed);
+        vector::push_back(&mut items, seed + 1);
+        vector::push_back(&mut items, seed + 2);
+        items
+    }
+
+    fun consume_len(items: vector<u64>): u64 {
+        vector::length(&items)
+    }
+
+    fun assign_through_call(seed: u64): u64 {
+        let h = make(seed);
+        let len;
+        (h, len) = (make(seed + 10), consume_len(h));
+        let wrapped = Wrap { v: copy h };
+        *vector::borrow_mut(&mut wrapped.v, 0) = 99;
+        *vector::borrow(&h, 0) * 100 + len
+    }
+}
+
+// RUN: execute 0x42::recycled_slot_identity_copy::assign_through_call --args 1
+// CHECK: results: 1103

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/recycled_slot_identity_masm.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/recycled_slot_identity_masm.exp
@@ -1,0 +1,71 @@
+=== stackless ===
+// module 0x66::recycled_slot_identity_copy_masm
+
+fun bonus7(): u64 {
+  slots: params(0), locals(0), temps(1)
+    r0: u64
+  code:
+  L0:
+    0: r0 := ld_u64 7 @0
+    1: ret [r0] @1
+}
+
+fun mutate_first(r0, r1): u64 {
+  slots: params(2), locals(0), temps(6)
+    r0: vector<u64>
+    r1: u64
+    r2: u64
+    r3: &mut vector<u64>
+    r4: u64
+    r5: &mut u64
+    r6: &vector<u64>
+    r7: &u64
+  code:
+  L0:
+    0: r2 := ld_u64 99 @0
+    1: r3 := mut_borrow_loc r0 @1
+    2: r4 := ld_u64 0 @2
+    3: r5 := vec_mut_borrow u64, r3, r4 @3
+    4: write_ref r5, r2 @4
+    5: r6 := imm_borrow_loc r0 @5
+    6: r2 := ld_u64 0 @6
+    7: r7 := vec_imm_borrow u64, r6, r2 @7
+    8: r2 := read_ref r7 @8
+    9: r2 := add r2, r1 @10
+    10: ret [r2] @11
+}
+
+fun trigger(): u64 {
+  slots: params(0), locals(2), temps(6), transfer(2)
+    r0: vector<u64>
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: u64
+    r5: vector<u64>
+    r6: &vector<u64>
+    r7: &u64
+  code:
+  L0:
+    0: r2 := ld_u64 1 @0
+    1: r3 := ld_u64 2 @1
+    2: r4 := ld_u64 3 @2
+    3: r0 := vec_pack u64, 3, [r2, r3, r4] @3
+    4: r4 := ld_u64 11 @5
+    5: r3 := ld_u64 12 @6
+    6: r2 := ld_u64 13 @7
+    7: r5 := vec_pack u64, 3, [r4, r3, r2] @8
+    8: r6 := imm_borrow_loc r0 @9
+    9: r1 := vec_len u64, r6 @10
+    10: r0 := move r5 @12
+    11: r5 := copy r0 @13
+    12: [x1] := call bonus7, [] @14
+    13: [r1] := call mutate_first, [r5, x1] @15
+    14: r6 := imm_borrow_loc r0 @17
+    15: r2 := ld_u64 0 @18
+    16: r7 := vec_imm_borrow u64, r6, r2 @19
+    17: r2 := read_ref r7 @20
+    18: r2 := mul r2, #100 @22
+    19: r2 := add r2, r1 @24
+    20: ret [r2] @25
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/recycled_slot_identity_masm.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/optimizer/recycled_slot_identity_masm.masm
@@ -1,0 +1,57 @@
+// RUN: publish --print(stackless)
+module 0x66::recycled_slot_identity_copy_masm
+
+fun bonus7(): u64
+    ld_u64 7
+    ret
+
+// Takes the vector by value, writes 99 into element 0 in place, and
+// returns elem0_after + bonus.
+fun mutate_first(items: vector<u64>, bonus: u64): u64
+    ld_u64 99
+    mut_borrow_loc items
+    ld_u64 0
+    vec_mut_borrow <u64>
+    write_ref
+    borrow_loc items
+    ld_u64 0
+    vec_borrow <u64>
+    read_ref
+    move_loc bonus
+    add
+    ret
+
+fun trigger(): u64
+    local h: vector<u64>
+    local sink: u64
+    ld_u64 1
+    ld_u64 2
+    ld_u64 3
+    vec_pack <u64>, 3
+    st_loc h
+    ld_u64 11
+    ld_u64 12
+    ld_u64 13
+    vec_pack <u64>, 3
+    borrow_loc h
+    vec_len <u64>
+    st_loc sink
+    st_loc h
+    copy_loc h
+    call bonus7
+    call mutate_first
+    st_loc sink
+    borrow_loc h
+    ld_u64 0
+    vec_borrow <u64>
+    read_ref
+    ld_u64 100
+    mul
+    move_loc sink
+    add
+    ret
+
+// h[0] must still be 11 after the callee mutates its copy:
+// 11*100 + (99 + 7) = 1206.
+// RUN: execute 0x66::recycled_slot_identity_copy_masm::trigger
+// CHECK: results: 1206


### PR DESCRIPTION
## Description

Fixes unsound `Copy` coalescing and copy propagation for heap-owning types (vectors, closures, heap-boxed enums) in the mono-move specializer's slot allocator and optimizer passes.

Previously, `BlockAnalysis::analyze` would coalesce a `Copy` instruction's destination slot directly onto the source home slot, effectively eliding the deep copy. Similarly, `copy_propagation` would substitute through `Copy` entries regardless of whether the type owned heap storage. Both optimizations are only valid when a byte-for-byte copy of the frame slot is a faithful, independent copy — i.e., for bitwise-copy types (scalars, references, pointer-free structs).

The fix introduces `PreparedModule::is_bitwise_copy_type`, which walks a type's structure within the current module to determine whether its frame representation is self-contained. It returns `false` conservatively for vectors, closures, enums (heap-boxed regardless of payload), imported nominals, and unresolved type parameters. This predicate is threaded into:

- `BlockAnalysis::analyze` via an `is_bitwise_copy_value` callback, which gates `Copy` coalescing.
- `copy_propagation`, which now only records `Copy` substitution entries for bitwise-copy types, and correctly orders the def-kill before source remapping to prevent stale-entry rewrites.
- `eliminate_identity_moves`, which now retains identity `Copy` instructions on heap-owning types, since such a copy is a real in-place deep-copy effect that cannot be safely deleted without alias analysis.

The ordering of kills and remaps in `copy_propagation` was also corrected: defs are now killed before sources are remapped, preventing a stale entry from rewriting a source onto the instruction's own def and producing a spurious identity `Copy` that `eliminate_identity_moves` would then incorrectly delete.

## How Has This Been Tested?

Several new differential test cases were added to cover the fixed scenarios:

- `coalesce_copy_bypass`: verifies that a `Copy` of a vector passed to a consuming, mutating callee is not coalesced away, so the original slot retains its pre-mutation value.
- `copy_prop_allowed`: verifies that propagation still fires correctly for scalars, pointer-free structs, and `Move` of heap-owning types.
- `copy_prop_deep_copy_bypass`: verifies that copy propagation does not substitute through a `Copy` of a vector when the copy's destination is later consumed by a mutating callee.
- `copy_prop_stale_read`: verifies that after a `Copy` of a vector, consuming the original does not corrupt the copy's observable value.
- `copy_prop_enum_bypass`: verifies that heap-boxed enum copies are not propagated through.
- `recycled_slot_identity_copy` and `recycled_slot_identity_masm`: verify that identity `Copy` on a heap-owning type in a recycled slot is preserved and produces the correct result.

Existing tests `noncapturing`, `generic_enum_option`, and `copy_xfer_gc` have updated expected outputs reflecting the corrected behavior (additional `DeepCopyHeapPtrs` instructions, adjusted frame sizes, and corrected GC counts).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler correctness for value copying and lowering of Move programs; wrong guards would corrupt heap-owned data at runtime, but behavior is heavily covered by new differential tests.
> 
> **Overview**
> Fixes **unsound `Copy` optimizations** in the mono-move specializer that treated heap-owning values (vectors, closures, heap-boxed enums) like bitwise-copy data.
> 
> Adds **`PreparedModule::is_bitwise_copy_type`** to decide when frame bytes alone are a faithful copy, and threads it through **slot allocation** (`BlockAnalysis` skips `Copy` coalescing when false), **copy propagation** (only records `Copy` subst entries for bitwise-copy home slots), and **identity move elimination** (keeps `dst == src` `Copy` for heap types because that is a real deep-copy effect). **Copy propagation** also **kills substitution entries before remapping sources**, avoiding stale rewrites that manufactured bogus identity copies.
> 
> Documents when `Instr::Copy` vs `Move` operands may be treated as interchangeable. New differential tests cover vector/enum bypass and recycled-slot cases; existing expectations pick up extra **`DeepCopyHeapPtrs`** and adjusted frame/GC counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340a5514c0afbfa107373527dc3251c17cb5d96f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->