### PR TITLE
[mono-move] Ristretto255 scalar natives

### DIFF
--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -26,6 +26,7 @@ pub mod hash;
 pub mod mem;
 pub mod multi_ed25519;
 pub mod object;
+pub mod ristretto255_scalar;
 pub mod secp256k1;
 pub mod signer;
 pub mod state_storage;
@@ -56,6 +57,9 @@ pub use multi_ed25519::make_all_multi_ed25519_natives;
 #[cfg(feature = "testing")]
 pub use multi_ed25519::make_all_multi_ed25519_test_natives;
 pub use object::{make_all_object_natives, ObjectContextExtension};
+pub use ristretto255_scalar::make_all_ristretto255_scalar_natives;
+#[cfg(feature = "testing")]
+pub use ristretto255_scalar::make_all_ristretto255_scalar_test_natives;
 pub use secp256k1::make_all_secp256k1_natives;
 pub use signer::make_all_signer_natives;
 pub use state_storage::{make_all_state_storage_natives, StorageUsageAtEpochBoundary};
@@ -115,6 +119,7 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
     natives.extend(make_all_ed25519_natives::<F>());
     natives.extend(make_all_multi_ed25519_natives::<F>());
     natives.extend(make_all_bls12381_natives::<F>());
+    natives.extend(make_all_ristretto255_scalar_natives::<F>());
     natives.extend(make_all_vector_natives::<F>());
     natives
 }

--- a/third_party/move/mono-move/natives/src/ristretto255_scalar.rs
+++ b/third_party/move/mono-move/natives/src/ristretto255_scalar.rs
@@ -1,0 +1,275 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Scalar natives for the `ristretto255` module (`aptos_std::ristretto255`).
+
+use crate::{monomorphic_natives, NativeEntry};
+use curve25519_dalek::scalar::Scalar;
+use mono_move_core::{
+    native::{
+        native_invariant_violation, NativeContext, NativeContextFamily, NativeStatus, Vector,
+    },
+    VMResult,
+};
+#[cfg(feature = "testing")]
+use rand_core::{OsRng, RngCore};
+use sha2::Sha512;
+
+/// A Move `Scalar`'s encoding is exactly 32 bytes.
+const SCALAR_NUM_BYTES: usize = 32;
+
+/// Builds a scalar from its 32-byte encoding. `Scalar::from_bits` clears the
+/// high bit, matching V1's `scalar_from_valid_bytes`. The Move `Scalar` type
+/// guarantees the length, so a mismatch is an invariant violation, not a user
+/// abort.
+fn scalar_from_bytes(bytes: &[u8]) -> VMResult<Scalar> {
+    let slice = <[u8; SCALAR_NUM_BYTES]>::try_from(bytes)
+        .map_err(|_| native_invariant_violation("ristretto255 scalar must be 32 bytes".into()))?;
+    Ok(Scalar::from_bits(slice))
+}
+
+/// `0x1::ristretto255::scalar_is_canonical_internal(s: vector<u8>): bool`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_is_canonical<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let s: Vector<u8> = unsafe { ctx.arg(0)? };
+
+    // SAFETY: byte slice consumed before any allocation.
+    let is_canonical = match <[u8; SCALAR_NUM_BYTES]>::try_from(unsafe { s.as_bytes() }) {
+        Ok(bytes) => Scalar::from_canonical_bytes(bytes).is_some(),
+        // A wrong length is not canonical; return `false` rather than aborting.
+        Err(_) => false,
+    };
+
+    // SAFETY: return slot 0 is `bool`.
+    unsafe { ctx.set_return(0, is_canonical)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_invert_internal(bytes: vector<u8>): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_invert<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let s: Vector<u8> = unsafe { ctx.arg(0)? };
+
+    // SAFETY: byte slice consumed into an owned scalar before any allocation.
+    let s = scalar_from_bytes(unsafe { s.as_bytes() })?;
+    let out = ctx.new_byte_vector(&s.invert().to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_from_sha512_internal(sha2_512_input: vector<u8>): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_from_sha512<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let input: Vector<u8> = unsafe { ctx.arg(0)? };
+
+    // SAFETY: byte slice consumed into an owned scalar before any allocation.
+    let s = Scalar::hash_from_bytes::<Sha512>(unsafe { input.as_bytes() });
+    let out = ctx.new_byte_vector(&s.to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_mul_internal(a_bytes: vector<u8>, b_bytes: vector<u8>): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_mul<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: args 0 and 1 are `vector<u8>`.
+    let a: Vector<u8> = unsafe { ctx.arg(0)? };
+    let b: Vector<u8> = unsafe { ctx.arg(1)? };
+
+    // SAFETY: byte slices consumed into owned scalars before any allocation.
+    let a = scalar_from_bytes(unsafe { a.as_bytes() })?;
+    let b = scalar_from_bytes(unsafe { b.as_bytes() })?;
+    let out = ctx.new_byte_vector(&(a * b).to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_add_internal(a_bytes: vector<u8>, b_bytes: vector<u8>): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_add<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: args 0 and 1 are `vector<u8>`.
+    let a: Vector<u8> = unsafe { ctx.arg(0)? };
+    let b: Vector<u8> = unsafe { ctx.arg(1)? };
+
+    // SAFETY: byte slices consumed into owned scalars before any allocation.
+    let a = scalar_from_bytes(unsafe { a.as_bytes() })?;
+    let b = scalar_from_bytes(unsafe { b.as_bytes() })?;
+    let out = ctx.new_byte_vector(&(a + b).to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_sub_internal(a_bytes: vector<u8>, b_bytes: vector<u8>): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_sub<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: args 0 and 1 are `vector<u8>`.
+    let a: Vector<u8> = unsafe { ctx.arg(0)? };
+    let b: Vector<u8> = unsafe { ctx.arg(1)? };
+
+    // SAFETY: byte slices consumed into owned scalars before any allocation.
+    let a = scalar_from_bytes(unsafe { a.as_bytes() })?;
+    let b = scalar_from_bytes(unsafe { b.as_bytes() })?;
+    let out = ctx.new_byte_vector(&(a - b).to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_neg_internal(a_bytes: vector<u8>): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_neg<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let a: Vector<u8> = unsafe { ctx.arg(0)? };
+
+    // SAFETY: byte slice consumed into an owned scalar before any allocation.
+    let a = scalar_from_bytes(unsafe { a.as_bytes() })?;
+    let out = ctx.new_byte_vector(&(-a).to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_from_u64_internal(num: u64): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_from_u64<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `u64`.
+    let num: u64 = unsafe { ctx.arg(0)? };
+
+    let out = ctx.new_byte_vector(&Scalar::from(num).to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_from_u128_internal(num: u128): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_from_u128<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `u128`.
+    let num: u128 = unsafe { ctx.arg(0)? };
+
+    let out = ctx.new_byte_vector(&Scalar::from(num).to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_reduced_from_32_bytes_internal(bytes: vector<u8>): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_reduced_from_32_bytes<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let bytes: Vector<u8> = unsafe { ctx.arg(0)? };
+
+    // SAFETY: byte slice copied into an owned array before any allocation.
+    let slice = <[u8; 32]>::try_from(unsafe { bytes.as_bytes() })
+        .map_err(|_| native_invariant_violation("expected 32 bytes".into()))?;
+    let out = ctx.new_byte_vector(&Scalar::from_bytes_mod_order(slice).to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::scalar_uniform_from_64_bytes_internal(bytes: vector<u8>): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_scalar_uniform_from_64_bytes<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let bytes: Vector<u8> = unsafe { ctx.arg(0)? };
+
+    // SAFETY: byte slice copied into an owned array before any allocation.
+    let slice = <[u8; 64]>::try_from(unsafe { bytes.as_bytes() })
+        .map_err(|_| native_invariant_violation("expected 64 bytes".into()))?;
+    let out = ctx.new_byte_vector(&Scalar::from_bytes_mod_order_wide(&slice).to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Production scalar natives for the `ristretto255` module.
+pub fn make_all_ristretto255_scalar_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![
+        (
+            "0x1::ristretto255::scalar_is_canonical_internal",
+            native_scalar_is_canonical
+        ),
+        (
+            "0x1::ristretto255::scalar_invert_internal",
+            native_scalar_invert
+        ),
+        (
+            "0x1::ristretto255::scalar_from_sha512_internal",
+            native_scalar_from_sha512
+        ),
+        ("0x1::ristretto255::scalar_mul_internal", native_scalar_mul),
+        ("0x1::ristretto255::scalar_add_internal", native_scalar_add),
+        ("0x1::ristretto255::scalar_sub_internal", native_scalar_sub),
+        ("0x1::ristretto255::scalar_neg_internal", native_scalar_neg),
+        (
+            "0x1::ristretto255::scalar_from_u64_internal",
+            native_scalar_from_u64
+        ),
+        (
+            "0x1::ristretto255::scalar_from_u128_internal",
+            native_scalar_from_u128
+        ),
+        (
+            "0x1::ristretto255::scalar_reduced_from_32_bytes_internal",
+            native_scalar_reduced_from_32_bytes
+        ),
+        (
+            "0x1::ristretto255::scalar_uniform_from_64_bytes_internal",
+            native_scalar_uniform_from_64_bytes
+        ),
+    ]
+}
+
+/// `0x1::ristretto255::random_scalar_internal(): vector<u8>`
+///
+/// Test-only native. No need to charge gas.
+#[cfg(feature = "testing")]
+pub fn native_scalar_random<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let mut scalar_bytes = [0u8; 64];
+    let mut rng = OsRng;
+    rng.fill_bytes(&mut scalar_bytes);
+    let s = Scalar::from_bytes_mod_order_wide(&scalar_bytes);
+    let out = ctx.new_byte_vector(&s.to_bytes())?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Test-only scalar natives for the `ristretto255` module.
+#[cfg(feature = "testing")]
+pub fn make_all_ristretto255_scalar_test_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![(
+        "0x1::ristretto255::random_scalar_internal",
+        native_scalar_random
+    ),]
+}

--- a/third_party/move/mono-move/testsuite/src/engine.rs
+++ b/third_party/move/mono-move/testsuite/src/engine.rs
@@ -17,8 +17,9 @@ use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
 use mono_move_natives::{
     make_all_bls12381_test_natives, make_all_ed25519_test_natives,
-    make_all_multi_ed25519_test_natives, make_all_production_natives, make_all_test_natives,
-    make_all_unit_test_natives, Dispatch,
+    make_all_multi_ed25519_test_natives, make_all_production_natives,
+    make_all_ristretto255_scalar_test_natives, make_all_test_natives, make_all_unit_test_natives,
+    Dispatch,
 };
 use mono_move_runtime::{
     InterpreterContext, ProductionContextFamily, ProductionNativeRegistry, RuntimeStatus,
@@ -125,6 +126,9 @@ pub fn build_natives(guard: &ExecutionGuard<'_>) -> ProductionNativeRegistry {
                 .chain(make_all_ed25519_test_natives::<ProductionContextFamily>())
                 .chain(make_all_multi_ed25519_test_natives::<ProductionContextFamily>())
                 .chain(make_all_bls12381_test_natives::<ProductionContextFamily>())
+                .chain(make_all_ristretto255_scalar_test_natives::<
+                    ProductionContextFamily,
+                >())
                 .chain(make_all_production_natives::<ProductionContextFamily>())
                 .map(|(addr, module, function, dispatch, func)| {
                     let module = guard.module_id_of(&addr, &module);

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/ristretto255_scalar.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/ristretto255_scalar.move
@@ -1,0 +1,151 @@
+// Differential test for the ristretto255 scalar natives.
+
+// RUN: publish
+module 0x1::ristretto255 {
+    native fun scalar_is_canonical_internal(s: vector<u8>): bool;
+
+    native fun scalar_invert_internal(bytes: vector<u8>): vector<u8>;
+
+    native fun scalar_from_sha512_internal(sha2_512_input: vector<u8>): vector<u8>;
+
+    native fun scalar_mul_internal(a_bytes: vector<u8>, b_bytes: vector<u8>): vector<u8>;
+
+    native fun scalar_add_internal(a_bytes: vector<u8>, b_bytes: vector<u8>): vector<u8>;
+
+    native fun scalar_sub_internal(a_bytes: vector<u8>, b_bytes: vector<u8>): vector<u8>;
+
+    native fun scalar_neg_internal(a_bytes: vector<u8>): vector<u8>;
+
+    native fun scalar_from_u64_internal(num: u64): vector<u8>;
+
+    native fun scalar_from_u128_internal(num: u128): vector<u8>;
+
+    native fun scalar_reduced_from_32_bytes_internal(bytes: vector<u8>): vector<u8>;
+
+    native fun scalar_uniform_from_64_bytes_internal(bytes: vector<u8>): vector<u8>;
+
+    // scalar_from_u64(0) is the 32-byte zero encoding.
+    public fun from_u64_zero(): vector<u8> {
+        scalar_from_u64_internal(0)
+    }
+
+    // scalar_from_u64(1) is little-endian: a leading 0x01 then zeros.
+    public fun from_u64_one(): vector<u8> {
+        scalar_from_u64_internal(1)
+    }
+
+    public fun from_u64_42(): vector<u8> {
+        scalar_from_u64_internal(42)
+    }
+
+    // scalar_from_u128 agrees with scalar_from_u64 on small values.
+    public fun from_u128_42(): vector<u8> {
+        scalar_from_u128_internal(42)
+    }
+
+    // 2 + 3 == 5.
+    public fun add_small(): vector<u8> {
+        scalar_add_internal(scalar_from_u64_internal(2), scalar_from_u64_internal(3))
+    }
+
+    // 10 - 3 == 7.
+    public fun sub_small(): vector<u8> {
+        scalar_sub_internal(scalar_from_u64_internal(10), scalar_from_u64_internal(3))
+    }
+
+    // 6 * 7 == 42.
+    public fun mul_small(): vector<u8> {
+        scalar_mul_internal(scalar_from_u64_internal(6), scalar_from_u64_internal(7))
+    }
+
+    // a + (-a) == 0.
+    public fun neg_to_zero(): vector<u8> {
+        let a = scalar_from_u64_internal(9);
+        scalar_add_internal(a, scalar_neg_internal(a))
+    }
+
+    // a * a^{-1} == 1.
+    public fun invert_roundtrip(): vector<u8> {
+        let a = scalar_from_u64_internal(7);
+        scalar_mul_internal(a, scalar_invert_internal(a))
+    }
+
+    // reduced_from_32_bytes on a small canonical value is that value.
+    public fun reduced_small(): vector<u8> {
+        scalar_reduced_from_32_bytes_internal(
+            x"0500000000000000000000000000000000000000000000000000000000000000",
+        )
+    }
+
+    public fun from_sha512_fixed(): vector<u8> {
+        scalar_from_sha512_internal(b"ristretto255 scalar test")
+    }
+
+    public fun uniform_fixed(): vector<u8> {
+        scalar_uniform_from_64_bytes_internal(
+            x"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+        )
+    }
+
+    // A freshly built scalar is canonical.
+    public fun is_canonical_valid(): bool {
+        scalar_is_canonical_internal(scalar_from_u64_internal(5))
+    }
+
+    // A wrong-length input is not canonical (returns false, does not abort).
+    public fun is_canonical_wrong_length(): bool {
+        scalar_is_canonical_internal(x"00")
+    }
+
+    // A 32-byte value above the group order is not canonical.
+    public fun is_canonical_too_large(): bool {
+        scalar_is_canonical_internal(
+            x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        )
+    }
+}
+
+// RUN: execute 0x1::ristretto255::from_u64_zero
+// CHECK: results: 0x0000000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::from_u64_one
+// CHECK: results: 0x0100000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::from_u64_42
+// CHECK: results: 0x2a00000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::from_u128_42
+// CHECK: results: 0x2a00000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::add_small
+// CHECK: results: 0x0500000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::sub_small
+// CHECK: results: 0x0700000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::mul_small
+// CHECK: results: 0x2a00000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::neg_to_zero
+// CHECK: results: 0x0000000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::invert_roundtrip
+// CHECK: results: 0x0100000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::reduced_small
+// CHECK: results: 0x0500000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::from_sha512_fixed
+// CHECK: results: 0x794a276e00e3a3af70f3a8a409fa8a34b20a7f01bc5ecc50afa4dac191e80205
+
+// RUN: execute 0x1::ristretto255::uniform_fixed
+// CHECK: results: 0x7a3c6282f02d37a05023b60d5428e6cc5961d4c31221937adae0b574e4d07205
+
+// RUN: execute 0x1::ristretto255::is_canonical_valid
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::is_canonical_wrong_length
+// CHECK: results: false
+
+// RUN: execute 0x1::ristretto255::is_canonical_too_large
+// CHECK: results: false


### PR DESCRIPTION
## Description

Ports the ristretto255 **scalar** natives from the legacy MoveVM to mono-move, in
a new `natives/src/ristretto255_scalar.rs`.

ristretto255 splits along a clean seam. The scalar natives are stateless — every
argument and result is `vector<u8>` / `u64` / `u128` / `bool` — so they fold in
following the existing `ed25519.rs` / `bls12381.rs` pattern with **no new
value-model machinery**. The point natives (which need a session-scoped handle
store as a `NativeExtension`) are a separate follow-up PR.

### Natives

Eleven production natives:

- `scalar_is_canonical_internal(vector<u8>): bool`
- `scalar_invert_internal(vector<u8>): vector<u8>`
- `scalar_from_sha512_internal(vector<u8>): vector<u8>`
- `scalar_mul_internal` / `scalar_add_internal` / `scalar_sub_internal(vector<u8>, vector<u8>): vector<u8>`
- `scalar_neg_internal(vector<u8>): vector<u8>`
- `scalar_from_u64_internal(u64): vector<u8>`
- `scalar_from_u128_internal(u128): vector<u8>`
- `scalar_reduced_from_32_bytes_internal(vector<u8>): vector<u8>`
- `scalar_uniform_from_64_bytes_internal(vector<u8>): vector<u8>`

Plus the test-only `random_scalar_internal(): vector<u8>` behind the `testing`
feature (non-deterministic, so not value-checked).

### Parity notes

- Scalars are built with `Scalar::from_bits` (matching V1's
  `scalar_from_valid_bytes`, which clears the high bit) over the same
  `curve25519-dalek-ng` backend, so replay produces byte-identical results.
- The Move `Scalar { data: vector<u8> }` type guarantees a 32-byte canonical
  encoding by construction, so the arithmetic natives never abort on valid input.
  A wrong length is an invariant violation (`native_invariant_violation`), not a
  user abort — matching V1, where it is an `InvariantViolation`.
  `scalar_is_canonical` returns `false` on a wrong-length or non-canonical input
  rather than aborting, also matching V1.
- No abort codes in any scalar native.

Gas metering is deferred as elsewhere in mono-move; each native carries
`// TODO(metering): charge gas.`

## Testing

Differential test cases in
`testsuite/.../natives/ristretto255_scalar.move` — 16 cases run on both the
legacy VM (v1) and mono-move (v2) and checked for byte-for-byte agreement:

- `from_u64` / `from_u128` known encodings (0, 1, 42).
- `add` / `sub` / `mul` on small values, pinned to their known results.
- `neg` (`a + (-a) == 0`) and `invert` (`a * a^{-1} == 1`) reduced to known
  constants.
- `reduced_from_32_bytes` on a small canonical value.
- `from_sha512` and `uniform_from_64_bytes` on fixed inputs (golden byte output).
- `is_canonical`: true for a valid scalar, `false` for wrong-length input, `false`
  for a 32-byte value above the group order.

Stacked on #20339 (bls12381 aggregate natives); base branch `george/natives-3`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Crypto VM natives affect on-chain behavior and must match legacy semantics; scope is limited to scalar ops with strong differential coverage, but gas is not yet metered.
> 
> **Overview**
> Adds **mono-move** support for legacy `0x1::ristretto255` **scalar** natives by introducing `ristretto255_scalar.rs` and registering eleven production entry points (canonical check, invert, SHA-512 derivation, add/sub/mul/neg, `u64`/`u128` encoding, and 32/64-byte reduction) plus a **`testing`**-only `random_scalar_internal`.
> 
> Scalars are handled as **32-byte `vector<u8>`** via `curve25519_dalek`, with **`Scalar::from_bits`** and invariant-violation semantics aligned to V1; gas metering is left as TODOs like other crypto natives. Production natives are folded into **`make_all_production_natives`**, and the testsuite wires test natives and a **differential** `ristretto255_scalar.move` suite for byte-for-byte parity with the legacy VM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd56eb9c529239bd5e886744fc1f4ffc46637c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->