### PR TITLE
[mono-move] Chain ID and consensus config natives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12985,6 +12985,8 @@ name = "mono-move-natives"
 version = "0.1.0"
 dependencies = [
  "aptos-crypto",
+ "aptos-types",
+ "bcs 0.1.4",
  "blake2-rfc",
  "curve25519-dalek-ng",
  "libsecp256k1",

--- a/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
@@ -47,6 +47,7 @@ pub(crate) fn transaction_extensions(
     let mut extensions = NativeExtensions::new();
     extensions.add(TransactionContextExtension::new(
         txn_data.txn_hash,
+        txn_data.chain_id,
         txn_data.session_counter,
         txn_data.transaction_index,
     ));

--- a/third_party/move/mono-move/natives/Cargo.toml
+++ b/third_party/move/mono-move/natives/Cargo.toml
@@ -13,6 +13,8 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-crypto = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
 blake2-rfc = { workspace = true }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4" }
 libsecp256k1 = { workspace = true }

--- a/third_party/move/mono-move/natives/src/address_derivation.rs
+++ b/third_party/move/mono-move/natives/src/address_derivation.rs
@@ -1,35 +1,18 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Address derivations replicated from
-//! `aptos_types::transaction::authenticator::AuthenticationKey`.
-//
-// TODO(completeness, cleanup): unify with aptos-core's `AuthenticationKey` so we don't end up having two
-// duplicate implementation of the same scheme and derivation algorithm.
+//! Address derivations, delegating to
+//! `aptos_types::transaction::authenticator::AuthenticationKey` so the scheme
+//! bytes and hashing stay in one place.
 
+use aptos_types::transaction::authenticator::AuthenticationKey;
 use mono_move_core::native::TableHandle;
 use move_core_types::account_address::AccountAddress;
 use sha3::{Digest, Sha3_256};
 
-/// `Scheme::DeriveAuid` discriminant.
-const DERIVE_AUID_SCHEME: u8 = 251;
-/// `Scheme::DeriveObjectAddressFromObject` discriminant.
-const DERIVE_OBJECT_FROM_OBJECT_SCHEME: u8 = 252;
-
-/// `sha3_256(preimage || scheme)` as an address, mirroring
-/// `AuthenticationKey::from_preimage`.
-fn address_from_preimage(mut preimage: Vec<u8>, scheme: u8) -> AccountAddress {
-    preimage.push(scheme);
-    let digest = Sha3_256::digest(&preimage);
-    AccountAddress::new(digest.into())
-}
-
 /// AUID address: `sha3_256(txn_hash || auid_counter_le || DeriveAuid)`.
 pub(crate) fn auid_address(txn_hash: &[u8], auid_counter: u64) -> AccountAddress {
-    let mut preimage = Vec::with_capacity(txn_hash.len() + 8);
-    preimage.extend_from_slice(txn_hash);
-    preimage.extend_from_slice(&auid_counter.to_le_bytes());
-    address_from_preimage(preimage, DERIVE_AUID_SCHEME)
+    AuthenticationKey::auid(txn_hash.to_vec(), auid_counter).account_address()
 }
 
 /// Object-from-object address:
@@ -38,9 +21,7 @@ pub(crate) fn object_address_from_object(
     source: &AccountAddress,
     derive_from: &AccountAddress,
 ) -> AccountAddress {
-    let mut preimage = source.to_vec();
-    preimage.extend_from_slice(derive_from.as_ref());
-    address_from_preimage(preimage, DERIVE_OBJECT_FROM_OBJECT_SCHEME)
+    AuthenticationKey::object_address_from_object(source, derive_from).account_address()
 }
 
 /// Table handle: `sha3_256(txn_hash || table_count_be_u32)`. Unlike the AUID and
@@ -55,13 +36,6 @@ pub(crate) fn table_handle(txn_hash: &[u8], table_count: u32) -> TableHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // Pin the on-chain-frozen scheme discriminants.
-    #[test]
-    fn scheme_bytes_are_frozen() {
-        assert_eq!(DERIVE_AUID_SCHEME, 251);
-        assert_eq!(DERIVE_OBJECT_FROM_OBJECT_SCHEME, 252);
-    }
 
     // Known-answer tests, also cross-checked end-to-end against the legacy VM's
     // `AuthenticationKey` in the differential suite.

--- a/third_party/move/mono-move/natives/src/consensus_config.rs
+++ b/third_party/move/mono-move/natives/src/consensus_config.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `consensus_config` module.
+
+use crate::{monomorphic_natives, NativeEntry};
+use aptos_types::on_chain_config::OnChainConsensusConfig;
+use mono_move_core::{
+    native::{NativeContext, NativeContextFamily, NativeStatus, Vector},
+    VMResult,
+};
+
+/// `0x1::consensus_config::validator_txn_enabled_internal(config_bytes: vector<u8>): bool`
+///
+/// BCS-decodes an `OnChainConsensusConfig` from `config_bytes` and returns
+/// whether validator transactions are enabled. A malformed encoding falls back
+/// to the default config, matching the legacy VM's `unwrap_or_default()`.
+//
+// TODO(metering): charge gas.
+pub fn native_validator_txn_enabled<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`, passed by value.
+    let v: Vector<u8> = unsafe { ctx.arg(0)? };
+    // Copy off the VM heap first: deserialization allocates and may relocate it.
+    // SAFETY: the bytes are copied immediately, before any allocation.
+    let bytes = unsafe { v.as_bytes() }.to_vec();
+    let config = bcs::from_bytes::<OnChainConsensusConfig>(&bytes).unwrap_or_default();
+    // SAFETY: return 0 is `bool`.
+    unsafe { ctx.set_return(0, config.is_vtxn_enabled())? };
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `consensus_config` module.
+pub fn make_all_consensus_config_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![(
+        "0x1::consensus_config::validator_txn_enabled_internal",
+        native_validator_txn_enabled
+    )]
+}

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -18,6 +18,7 @@ pub mod aptos_hash;
 pub mod bcs;
 pub mod bls12381;
 pub mod cmp;
+pub mod consensus_config;
 pub mod ed25519;
 pub mod event;
 pub mod from_bytes;
@@ -45,6 +46,7 @@ pub use bls12381::make_all_bls12381_natives;
 #[cfg(feature = "testing")]
 pub use bls12381::make_all_bls12381_test_natives;
 pub use cmp::make_all_cmp_natives;
+pub use consensus_config::make_all_consensus_config_natives;
 pub use ed25519::make_all_ed25519_natives;
 #[cfg(feature = "testing")]
 pub use ed25519::make_all_ed25519_test_natives;
@@ -113,6 +115,7 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
     natives.extend(make_all_string_natives::<F>());
     natives.extend(make_all_bcs_natives::<F>());
     natives.extend(make_all_cmp_natives::<F>());
+    natives.extend(make_all_consensus_config_natives::<F>());
     natives.extend(make_all_from_bytes_natives::<F>());
     natives.extend(make_all_table_natives::<F>());
     natives.extend(make_all_secp256k1_natives::<F>());

--- a/third_party/move/mono-move/natives/src/transaction_context.rs
+++ b/third_party/move/mono-move/natives/src/transaction_context.rs
@@ -19,6 +19,8 @@ use mono_move_core::{
 // ETRANSACTION_CONTEXT_NOT_AVAILABLE.
 pub struct TransactionContextExtension {
     txn_hash: [u8; 32],
+    /// Chain id of the network the transaction runs on.
+    chain_id: u8,
     /// AUIDs issued so far in this transaction.
     auid_counter: u64,
     /// Per-session counter feeding the low bits of the monotonic counter.
@@ -36,11 +38,13 @@ pub struct TransactionContextExtension {
 impl TransactionContextExtension {
     pub fn new(
         txn_hash: [u8; 32],
+        chain_id: u8,
         session_counter: u8,
         transaction_index: Option<(u32, u8)>,
     ) -> Self {
         Self {
             txn_hash,
+            chain_id,
             auid_counter: 0,
             local_counter: 0,
             session_counter,
@@ -143,6 +147,19 @@ pub fn native_monotonically_increasing_counter_internal<C: NativeContext>(
     Ok(NativeStatus::Success)
 }
 
+/// `0x1::transaction_context::chain_id_internal(): u8` and the identical
+/// `0x1::type_info::chain_id_internal(): u8`.
+///
+/// Returns the chain id of the network the transaction runs on.
+//
+// TODO(metering): charge gas.
+pub fn native_chain_id<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let ext = ctx.get_extension::<TransactionContextExtension>()?;
+    // SAFETY: return 0 is `u8`.
+    unsafe { ctx.set_return(0, ext.chain_id)? };
+    Ok(NativeStatus::Success)
+}
+
 /// Natives for the `transaction_context` module.
 pub fn make_all_transaction_context_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
     monomorphic_natives![
@@ -153,6 +170,10 @@ pub fn make_all_transaction_context_natives<F: NativeContextFamily>() -> Vec<Nat
         (
             "0x1::transaction_context::monotonically_increasing_counter_internal",
             native_monotonically_increasing_counter_internal
+        ),
+        (
+            "0x1::transaction_context::chain_id_internal",
+            native_chain_id
         ),
     ]
 }

--- a/third_party/move/mono-move/natives/src/type_info.rs
+++ b/third_party/move/mono-move/natives/src/type_info.rs
@@ -3,7 +3,9 @@
 
 //! Natives for the `type_info` module.
 
-use crate::{polymorphic_natives, NativeEntry};
+use crate::{
+    monomorphic_natives, polymorphic_natives, transaction_context::native_chain_id, NativeEntry,
+};
 use mono_move_core::{
     native::{NativeContext, NativeContextFamily, NativeStatus, RootPool, VMValue, Vector},
     types::{type_to_string, view_name, view_type, view_type_list, Type},
@@ -137,8 +139,16 @@ pub fn native_type_of<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
 
 /// Natives for the `type_info` module.
 pub fn make_all_type_info_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
-    polymorphic_natives![
+    let mut natives = polymorphic_natives![
         ("0x1::type_info::type_name", native_type_name),
         ("0x1::type_info::type_of", native_type_of),
-    ]
+    ];
+    // `chain_id_internal` is non-generic, so it registers as a monomorphic entry
+    // with empty type arguments. It shares its implementation with
+    // `transaction_context::chain_id_internal`.
+    natives.extend(monomorphic_natives![(
+        "0x1::type_info::chain_id_internal",
+        native_chain_id
+    )]);
+    natives
 }

--- a/third_party/move/mono-move/testsuite/src/extensions.rs
+++ b/third_party/move/mono-move/testsuite/src/extensions.rs
@@ -12,6 +12,7 @@ use mono_move_natives::{
 // natives (AUID generation, state-storage usage, ...) produce matching output
 // across the two engines.
 pub(crate) const TEST_TXN_HASH: [u8; 32] = [7u8; 32];
+pub(crate) const TEST_CHAIN_ID: u8 = 4;
 pub(crate) const TEST_STATE_ITEMS: u64 = 100;
 pub(crate) const TEST_STATE_BYTES: u64 = 2000;
 // Inputs to the monotonically-increasing counter. The reserved byte is 0,
@@ -25,6 +26,7 @@ pub(crate) fn seed_extensions() -> NativeExtensions {
     let mut extensions = NativeExtensions::new();
     extensions.add(TransactionContextExtension::new(
         TEST_TXN_HASH,
+        TEST_CHAIN_ID,
         TEST_SESSION_COUNTER,
         Some((TEST_TXN_INDEX, TEST_RESERVED_BYTE)),
     ));

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -8,8 +8,8 @@ use crate::{
     compile::{compile, compile_move_path, compile_move_stdlib, SourceKind},
     engine::RunResult,
     extensions::{
-        seed_extensions, TEST_SESSION_COUNTER, TEST_STATE_BYTES, TEST_STATE_ITEMS, TEST_TXN_HASH,
-        TEST_TXN_INDEX,
+        seed_extensions, TEST_CHAIN_ID, TEST_SESSION_COUNTER, TEST_STATE_BYTES, TEST_STATE_ITEMS,
+        TEST_TXN_HASH, TEST_TXN_INDEX,
     },
     matcher::check_output,
     module_provider::InMemoryModuleProvider,
@@ -470,7 +470,7 @@ fn execute_function_v1(
         AccountAddress::ZERO,
         0,
         0,
-        0,
+        TEST_CHAIN_ID, // chain_id, read by transaction_context::chain_id_internal
         None,
         None,
         TransactionIndexKind::BlockExecution {
@@ -482,7 +482,7 @@ fn execute_function_v1(
     extensions.add(NativeTransactionContext::new(
         TEST_TXN_HASH.to_vec(),
         vec![],
-        0,
+        TEST_CHAIN_ID,
         Some(user_transaction_context),
         TEST_SESSION_COUNTER,
     ));

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/chain_id.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/chain_id.move
@@ -1,0 +1,27 @@
+// Differential test for `type_info::chain_id_internal` and
+// `transaction_context::chain_id_internal`.
+//
+// Both natives return the chain id carried by the transaction-context
+// extension, which both VMs seed with the same fixed value (TEST_CHAIN_ID = 4).
+
+// RUN: publish
+module 0x1::type_info {
+    public native fun chain_id_internal(): u8;
+
+    public fun get(): u8 {
+        chain_id_internal()
+    }
+}
+module 0x1::transaction_context {
+    public native fun chain_id_internal(): u8;
+
+    public fun get(): u8 {
+        chain_id_internal()
+    }
+}
+
+// RUN: execute 0x1::type_info::get
+// CHECK: results: 4
+
+// RUN: execute 0x1::transaction_context::get
+// CHECK: results: 4

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/consensus_config.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/consensus_config.move
@@ -1,0 +1,26 @@
+// Differential test for `consensus_config::validator_txn_enabled_internal`.
+//
+// The native BCS-decodes an `OnChainConsensusConfig` from its argument and
+// returns whether validator transactions are enabled. It reads no VM context,
+// so both VMs agree on any input. Empty bytes fail to decode and fall back to
+// the default config (validator txns disabled); the `enabled` blob is a V3
+// config whose `vtxn` field is `V1`.
+
+// RUN: publish
+module 0x1::consensus_config {
+    native fun validator_txn_enabled_internal(config_bytes: vector<u8>): bool;
+
+    public fun disabled(): bool {
+        validator_txn_enabled_internal(vector[])
+    }
+
+    public fun enabled(): bool {
+        validator_txn_enabled_internal(x"02010000000000000000000100000000000000000000000000000000")
+    }
+}
+
+// RUN: execute 0x1::consensus_config::disabled
+// CHECK: results: false
+
+// RUN: execute 0x1::consensus_config::enabled
+// CHECK: results: true


### PR DESCRIPTION
## Description

Adds two Aptos framework natives to mono-move so differential replay matches the legacy MoveVM:

- `0x1::type_info::chain_id_internal(): u8`, also registered under `0x1::transaction_context::chain_id_internal` (legacy exposes both). Returns the transaction's chain id, now carried on `TransactionContextExtension` and threaded through every construction site.
- `0x1::consensus_config::validator_txn_enabled_internal(config_bytes: vector<u8>): bool`. BCS-decodes an `OnChainConsensusConfig` (via `aptos-types`) and returns `is_vtxn_enabled()`. A malformed encoding falls back to the default config, matching the legacy `unwrap_or_default()`.

Also resolves the `address_derivation.rs` TODO: `auid_address` and `object_address_from_object` now delegate to `aptos_types::transaction::authenticator::AuthenticationKey` instead of a duplicate scheme/hashing implementation. Only `table_handle` stays local (it appends no scheme byte).

## How Has This Been Tested?

New differential tests (run on both the legacy VM and mono-move; both must agree):

- `testsuite/tests/test_cases/differential/natives/chain_id.move` — `type_info::get` and `transaction_context::get` both return `TEST_CHAIN_ID` (4).
- `testsuite/tests/test_cases/differential/natives/consensus_config.move` — `disabled()` (empty bytes → default config) → `false`; `enabled()` (a V3 config whose `vtxn` field is `V1`) → `true`.

The V1 test side is seeded with the same chain id in `runner.rs` for both the `NativeTransactionContext` (read by `type_info`) and the `UserTransactionContext` (read by `transaction_context`).

Address-derivation known-answer tests (`address_derivation`) confirm the `AuthenticationKey` reuse is byte-identical to the previous implementation. The `transaction_context.move` (AUID) and `object.move` differential tests still pass end-to-end.

```
RUST_MIN_STACK=1073741824 cargo nextest run -p mono-move-testsuite --test differential chain_id consensus_config transaction_context object
RUST_MIN_STACK=1073741824 cargo nextest run -p mono-move-natives address_derivation
```

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM native behavior and on-chain address derivation paths; changes are aligned with legacy semantics and covered by differential tests, but consensus decoding and shared auth-key logic affect framework-visible behavior.
> 
> **Overview**
> Brings mono-move in line with the legacy MoveVM for **chain id** and **validator-txn consensus config** natives, and deduplicates address derivation.
> 
> **Chain id:** `TransactionContextExtension` now holds `chain_id`, wired from transaction metadata in the Aptos executor and from `TEST_CHAIN_ID` in differential tests. A shared `native_chain_id` backs `0x1::transaction_context::chain_id_internal` and `0x1::type_info::chain_id_internal`.
> 
> **Consensus config:** New `0x1::consensus_config::validator_txn_enabled_internal` BCS-decodes `OnChainConsensusConfig` via `aptos-types` and returns whether validator transactions are enabled; bad bytes use `unwrap_or_default()` like the legacy VM.
> 
> **Address derivation:** AUID and object-from-object addresses call `AuthenticationKey` in `aptos-types` instead of local scheme-byte hashing (`table_handle` stays local).
> 
> Differential `.move` tests cover chain id (both entry points) and consensus config (empty vs enabled V3 blob).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b3ebe30083969fbd06c5ed1dec7555c1640ef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->