### PR TITLE
[mono-move] Initialization natives

### DIFF
--- a/third_party/move/mono-move/natives/src/init.rs
+++ b/third_party/move/mono-move/natives/src/init.rs
@@ -4,6 +4,7 @@
 //! Natives for the `init` module, backing lazy module initialization.
 
 use crate::{monomorphic_natives, NativeEntry};
+use aptos_types::error;
 use mono_move_core::{
     native::{NativeContext, NativeContextFamily, NativeStatus},
     types::view_name,
@@ -11,15 +12,15 @@ use mono_move_core::{
 };
 use sha3::{Digest, Sha3_256};
 
-/// `error::invalid_argument(EINVALID_INITIALIZE_CALLER)`, where the Move-side
-/// constant is `0x1` (category 1, reason 1).
-const EINVALID_INITIALIZE_CALLER: u64 = (1 << 16) | 1;
+/// Matches the Move-side `EINVALID_INITIALIZE_CALLER` in `0x1::init.move`.
+const EINVALID_INITIALIZE_CALLER: u64 = error::invalid_argument(1);
 
 /// `0x1::init::get_caller_address_and_module_id(): (address, ModuleId)`
 ///
-/// Returns module ID of the module calling this function. Aborts if caller is
-/// not a module. The module id is the sha3-256 of the module name, trimmed to
-/// 16 bytes. INVARIANT: Must match implemention in `0x1::init.move`.
+/// Returns the address and module id of the module that directly called the
+/// function invoking this native. Aborts if there is no such module (e.g. a
+/// script). The module id is the sha3-256 of the module name, trimmed to 16
+/// bytes. INVARIANT: Must match implemention in `0x1::init.move`.
 //
 // TODO(metering): charge gas.
 pub fn native_get_caller_address_and_module_id<C: NativeContext>(

--- a/third_party/move/mono-move/natives/src/init.rs
+++ b/third_party/move/mono-move/natives/src/init.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `init` module, backing lazy module initialization.
+
+use crate::{monomorphic_natives, NativeEntry};
+use mono_move_core::{
+    native::{NativeContext, NativeContextFamily, NativeStatus},
+    types::view_name,
+    view_module_id, VMResult,
+};
+use sha3::{Digest, Sha3_256};
+
+/// `error::invalid_argument(EINVALID_INITIALIZE_CALLER)`, where the Move-side
+/// constant is `0x1` (category 1, reason 1).
+const EINVALID_INITIALIZE_CALLER: u64 = (1 << 16) | 1;
+
+/// `0x1::init::get_caller_address_and_module_id(): (address, ModuleId)`
+///
+/// Returns module ID of the module calling this function. Aborts if caller is
+/// not a module. The module id is the sha3-256 of the module name, trimmed to
+/// 16 bytes. INVARIANT: Must match implemention in `0x1::init.move`.
+//
+// TODO(metering): charge gas.
+pub fn native_get_caller_address_and_module_id<C: NativeContext>(
+    ctx: &C,
+) -> VMResult<NativeStatus> {
+    let Some(module_id) = ctx.caller_module() else {
+        return Ok(NativeStatus::Abort {
+            code: EINVALID_INITIALIZE_CALLER,
+            message: Some("caller has no associated module (e.g. a script)".into()),
+        });
+    };
+    let module_id = view_module_id(module_id);
+    let address = *module_id.address();
+    let name = view_name(module_id.name());
+    let hash = Sha3_256::digest(name.as_bytes());
+    let module_id_hash = u128::from_le_bytes(
+        hash[..16]
+            .try_into()
+            .expect("sha3-256 digest has at least 16 bytes"),
+    );
+
+    // SAFETY: return 0 is `address`; return 1 is `ModuleId { hash: u128 }`,
+    // which has same representation as u128.
+    unsafe { ctx.set_return(0, address)? };
+    unsafe { ctx.set_return(1, module_id_hash)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `init` module.
+pub fn make_all_init_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![(
+        "0x1::init::get_caller_address_and_module_id",
+        native_get_caller_address_and_module_id
+    ),]
+}

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -24,6 +24,7 @@ pub mod event;
 pub mod from_bytes;
 pub mod function_info;
 pub mod hash;
+pub mod init;
 pub mod mem;
 pub mod multi_ed25519;
 pub mod object;
@@ -54,6 +55,7 @@ pub use event::{make_all_event_natives, EventEntry, EventKind, EventStore};
 pub use from_bytes::make_all_from_bytes_natives;
 pub use function_info::make_all_function_info_natives;
 pub use hash::make_all_hash_natives;
+pub use init::make_all_init_natives;
 pub use mem::make_all_mem_natives;
 pub use multi_ed25519::make_all_multi_ed25519_natives;
 #[cfg(feature = "testing")]
@@ -112,6 +114,7 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
     natives.extend(make_all_event_natives::<F>());
     natives.extend(make_all_hash_natives::<F>());
     natives.extend(make_all_aptos_hash_natives::<F>());
+    natives.extend(make_all_init_natives::<F>());
     natives.extend(make_all_string_natives::<F>());
     natives.extend(make_all_bcs_natives::<F>());
     natives.extend(make_all_cmp_natives::<F>());

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/init.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/init.move
@@ -1,0 +1,34 @@
+// Differential test for the init::get_caller_address_and_module_id native.
+
+// RUN: publish
+module 0x1::init {
+    struct ModuleId has copy, drop, store {
+        hash: u128
+    }
+
+    native fun get_caller_address_and_module_id(): (address, ModuleId);
+
+    // Indirection so the native's caller is this module, not the entry frame.
+    fun call_native(): (address, ModuleId) {
+        get_caller_address_and_module_id()
+    }
+
+    // Caller module is 0x1::init: returns (0x1, hash("init")).
+    public fun caller_addr_and_hash(): (address, u128) {
+        let (addr, id) = call_native();
+        (addr, id.hash)
+    }
+
+    // Native called directly from the entry frame: its caller has no module,
+    // so the native aborts.
+    public fun caller_is_entry(): (address, u128) {
+        let (addr, id) = get_caller_address_and_module_id();
+        (addr, id.hash)
+    }
+}
+
+// RUN: execute 0x1::init::caller_addr_and_hash
+// CHECK: results: 0x1, 294358983490175456809003430205152366618
+
+// RUN: execute 0x1::init::caller_is_entry
+// CHECK-SUBSTR: aborted: code 65537

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -152,7 +152,7 @@ pub const NOT_IMPLEMENTED: u64 = 0xC;
 pub const UNAVAILABLE: u64 = 0xD;
 
 /// Construct a canonical error code from a category and a reason.
-pub fn canonical(category: u64, reason: u64) -> u64 {
+pub const fn canonical(category: u64, reason: u64) -> u64 {
     (category << 16) + reason
 }
 
@@ -162,40 +162,40 @@ pub fn split_canonical(code: u64) -> (u64, u64) {
 }
 
 /// Functions to construct a canonical error code of the given category.
-pub fn invalid_argument(r: u64) -> u64 {
+pub const fn invalid_argument(r: u64) -> u64 {
     canonical(INVALID_ARGUMENT, r)
 }
-pub fn out_of_range(r: u64) -> u64 {
+pub const fn out_of_range(r: u64) -> u64 {
     canonical(OUT_OF_RANGE, r)
 }
-pub fn invalid_state(r: u64) -> u64 {
+pub const fn invalid_state(r: u64) -> u64 {
     canonical(INVALID_STATE, r)
 }
-pub fn unauthenticated(r: u64) -> u64 {
+pub const fn unauthenticated(r: u64) -> u64 {
     canonical(UNAUTHENTICATED, r)
 }
-pub fn permission_denied(r: u64) -> u64 {
+pub const fn permission_denied(r: u64) -> u64 {
     canonical(PERMISSION_DENIED, r)
 }
-pub fn not_found(r: u64) -> u64 {
+pub const fn not_found(r: u64) -> u64 {
     canonical(NOT_FOUND, r)
 }
-pub fn aborted(r: u64) -> u64 {
+pub const fn aborted(r: u64) -> u64 {
     canonical(ABORTED, r)
 }
-pub fn already_exists(r: u64) -> u64 {
+pub const fn already_exists(r: u64) -> u64 {
     canonical(ALREADY_EXISTS, r)
 }
-pub fn resource_exhausted(r: u64) -> u64 {
+pub const fn resource_exhausted(r: u64) -> u64 {
     canonical(RESOURCE_EXHAUSTED, r)
 }
-pub fn internal(r: u64) -> u64 {
+pub const fn internal(r: u64) -> u64 {
     canonical(INTERNAL, r)
 }
-pub fn not_implemented(r: u64) -> u64 {
+pub const fn not_implemented(r: u64) -> u64 {
     canonical(NOT_IMPLEMENTED, r)
 }
-pub fn unavailable(r: u64) -> u64 {
+pub const fn unavailable(r: u64) -> u64 {
     canonical(UNAVAILABLE, r)
 }
 


### PR DESCRIPTION
## Description

Adds the `init::get_caller_address_and_module_id` native to mono-move, reaching
parity with the legacy VM.

The `init` module (`0x1::init`, `aptos_framework::init`) backs lazy module
initialization: `internal_maybe_initialize` calls this native to learn which
module is asking to self-initialize. The native returns:

- the caller module's address, and
- its module id — `sha3_256(module_name)` trimmed to the first 16 bytes, read as
  a little-endian `u128` (the in-frame representation of the single-field
  `ModuleId { hash: u128 }`).

It aborts with `error::invalid_argument(EINVALID_INITIALIZE_CALLER)` (65537) when
the caller has no module (e.g. a script / the entry frame).

No new VM infrastructure was needed. `NativeContext::caller_module()` is the
exact analog of the legacy VM's `context.stack_frames(1)`, and the interner and
sha3 helpers already exist. This change is the native itself, its registration
in `make_all_production_natives`, and a differential test.

Gas is not charged: mono-move natives have no gas-charging API on the context
yet (tracked by an existing `TODO(metering)`). A doc comment records what the
legacy native charges so it can be added once the API lands.

## How Has This Been Tested?

New differential test
`third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/init.move`,
which runs on both the legacy MoveVM (v1) and mono-move (v2) and checks they
agree:

- Success: a two-level call (`caller_addr_and_hash` -> `call_native` -> native)
  so the native's caller has a module. Both VMs return
  `0x1, 294358983490175456809003430205152366618`
  (= `u128::from_le_bytes(sha3_256(b"init")[..16])`).
- Abort: a direct entry-frame call whose caller has no module. Both VMs abort
  with code `65537`.

```
RUST_MIN_STACK=1073741824 cargo nextest run -p mono-move-testsuite \
  --test differential -- init
```

## Key Areas to Review

- `natives/src/init.rs` — the abort code (`0x1_0001`), the sha3 trimming and
  little-endian decode, and the two `set_return` slots. These must match
  `init.move::module_id_from_name` and the legacy native
  (`aptos-move/framework/natives/src/init.rs`).
- The `caller_module()` semantics: it returns the module of the caller of the
  function that invoked the native, which is why the success-case test needs a
  two-level call and the abort case calls the native directly from the entry
  frame.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM native behavior for framework lazy initialization; incorrect caller or hash semantics would break self-init, though scope is narrow and covered by differential tests.
> 
> **Overview**
> Adds mono-move support for **`0x1::init::get_caller_address_and_module_id`**, matching the legacy VM so lazy module initialization can identify the direct caller module.
> 
> The native uses **`NativeContext::caller_module()`** to return the caller address and a **`ModuleId`** hash (`sha3-256` of the module name, first 16 bytes as little-endian **`u128`**). It aborts with **`error::invalid_argument(1)`** (65537) when the caller has no module (e.g. entry frame / script). It is wired into **`make_all_production_natives`**.
> 
> A differential test covers the success path (indirect call from **`0x1::init`**) and the abort path (native invoked from the entry frame). **`aptos_types::error`** canonical helpers are marked **`const fn`** so the abort code can be a **`const`** in the native module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bea5c2e76273f66436b0e2058d5113b486632cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->