### PR TITLE
[mono-move] Ristretto255 point native extension

### DIFF
--- a/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
@@ -8,7 +8,7 @@ use mono_move_core::{
 };
 use mono_move_global_context::ExecutionGuard;
 use mono_move_natives::{
-    make_all_production_natives, Dispatch, EventStore, ObjectContextExtension,
+    make_all_production_natives, Dispatch, EventStore, ObjectContextExtension, RistrettoPointStore,
     StorageUsageAtEpochBoundary, TransactionContextExtension,
 };
 use mono_move_runtime::{ProductionContextFamily, ProductionNativeRegistry};
@@ -52,5 +52,6 @@ pub(crate) fn extensions_with(
         usage.bytes() as u64,
     ));
     extensions.add(EventStore::new());
+    extensions.add(RistrettoPointStore::new());
     extensions
 }

--- a/third_party/move/mono-move/core/src/native/mod.rs
+++ b/third_party/move/mono-move/core/src/native/mod.rs
@@ -18,5 +18,5 @@ pub use registry::{
     NativeContextFamily, NativeFunction, NativeIdx, NativeName, NativeRegistry,
     NativeRegistryError, NativeResolver, NoNatives,
 };
-pub use result::{native_invariant_violation, NativeStatus};
+pub use result::{native_invariant_violation, native_vector_index_out_of_bounds, NativeStatus};
 pub use value::{Boxed, Opaque, Ref, TableHandle, VMValue, Vector};

--- a/third_party/move/mono-move/core/src/native/result.rs
+++ b/third_party/move/mono-move/core/src/native/result.rs
@@ -25,3 +25,22 @@ impl IntoExecutionError for NativeInvariantViolation {
 pub fn native_invariant_violation(message: String) -> VMInternalError {
     VMInternalError::new(NativeInvariantViolation(message))
 }
+
+#[derive(Debug, Error)]
+#[error("vector index out of bounds: index {idx}, length {len}")]
+struct NativeVectorIndexOutOfBounds {
+    idx: u64,
+    len: u64,
+}
+
+impl IntoExecutionError for NativeVectorIndexOutOfBounds {
+    fn kind(&self) -> ExecutionErrorKind {
+        ExecutionErrorKind::InvalidOperation
+    }
+}
+
+// TODO(cleanup): move runtime errors to core to reuse
+// `RuntimeError::VectorIndexOutOfBounds` instead of this native-specific error.
+pub fn native_vector_index_out_of_bounds(idx: u64, len: u64) -> VMInternalError {
+    VMInternalError::new(NativeVectorIndexOutOfBounds { idx, len })
+}

--- a/third_party/move/mono-move/core/src/native/value.rs
+++ b/third_party/move/mono-move/core/src/native/value.rs
@@ -6,8 +6,9 @@
 use crate::{
     align::MAX_ALIGN,
     memory::{read_fat_ptr, read_ptr, read_u64, write_fat_ptr, write_ptr},
+    native::native_vector_index_out_of_bounds,
     root_pool::{ObjectHandle, ReferenceHandle, RootPool},
-    VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
+    VMResult, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -331,21 +332,27 @@ impl<'a, V> Vector<'a, V> {
     // TODO(completeness): Other vector APIs, added on-demand.
 }
 
-impl<'a, V> Vector<'a, Vector<'a, V>> {
-    /// Returns element `i` of a `vector<vector<V>>` -- the inner `vector<V>` --
-    /// as a handle rooted for the rest of the native call.
-    ///
-    /// Each element of a nested vector is an 8-byte heap pointer to the inner
-    /// vector object, so this reads that pointer and roots it, mirroring
-    /// [`Ref::borrow`]. The caller must ensure `i < len()`.
+impl<'a, V: VMValue<'a>> Vector<'a, V> {
+    /// Reads element `i` by value, using `V`'s in-frame representation. Any heap
+    /// pointer the element carries is rooted for the rest of the native call, so
+    /// the result survives GC. Returns an invalid-operation error if `i` is out
+    /// of bounds.
     #[inline]
-    pub fn get(&self, i: u64) -> Vector<'a, V> {
-        // SAFETY: element `i` (within bounds) of a `vector<vector<V>>` is an
-        // 8-byte heap pointer to the inner vector object.
-        let inner_ptr = unsafe { read_ptr(self.ptr(), VEC_DATA_OFFSET + i as usize * 8) };
-        // Root the inner vector so it survives GC for the rest of the call,
-        // even if the outer slot is later overwritten.
-        Vector::from_handle(unsafe { self.handle.pool().root_object(inner_ptr) })
+    pub fn get_element(&self, i: u64) -> VMResult<V> {
+        let len = self.len();
+        if i >= len {
+            return Err(native_vector_index_out_of_bounds(i, len));
+        }
+        // SAFETY: element `i` (bounds-checked above) lives at `VEC_DATA_OFFSET +
+        // i * FRAME_SLOT_SIZE` in the vector object; `read_from_frame` reads it
+        // and roots any heap pointer it carries.
+        Ok(unsafe {
+            V::read_from_frame(
+                self.handle.pool(),
+                self.ptr(),
+                VEC_DATA_OFFSET + i as usize * <V as VMValue<'a>>::FRAME_SLOT_SIZE,
+            )
+        })
     }
 }
 
@@ -500,8 +507,8 @@ mod tests {
         buf
     }
 
-    /// `Vector::<Vector<u8>>::get` reads each inner byte vector back by value,
-    /// including an empty inner vector.
+    /// `Vector::<Vector<u8>>::get_element` reads each inner byte vector back by
+    /// value, including an empty inner vector.
     #[test]
     fn nested_byte_vector_get_reads_elements() {
         let pool = RootPool::new();
@@ -530,11 +537,53 @@ mod tests {
 
         assert_eq!(vec.len(), 3);
         // Bind each inner handle so its bytes outlive the borrow.
-        let e0 = vec.get(0);
-        let e1 = vec.get(1);
-        let e2 = vec.get(2);
+        let e0 = vec.get_element(0).unwrap();
+        let e1 = vec.get_element(1).unwrap();
+        let e2 = vec.get_element(2).unwrap();
         assert_eq!(unsafe { e0.as_bytes() }, b"hello");
         assert_eq!(unsafe { e1.as_bytes() }, b"");
         assert_eq!(unsafe { e2.as_bytes() }, b"world!!");
+    }
+
+    /// `get_element` fails with an invalid-operation error on an out-of-bounds
+    /// index rather than reading past the vector object.
+    #[test]
+    fn get_element_out_of_bounds_errors() {
+        let pool = RootPool::new();
+
+        // Outer object holding two inner byte vectors.
+        let inners = [
+            byte_vec_object_for_test(b"a"),
+            byte_vec_object_for_test(b"b"),
+        ];
+        let mut outer = vec![0u64; 1 + inners.len()];
+        outer[0] = inners.len() as u64;
+        for (i, inner) in inners.iter().enumerate() {
+            outer[1 + i] = inner.as_ptr() as u64;
+        }
+
+        // SAFETY: `outer` is a valid `vector<vector<u8>>` object.
+        let vec: Vector<Vector<u8>> =
+            Vector::from_handle(unsafe { pool.root_object(outer.as_ptr() as *mut u8) });
+
+        assert_eq!(vec.len(), 2);
+        assert!(vec.get_element(0).is_ok());
+        // Index == len and beyond both fail.
+        match vec.get_element(2) {
+            Ok(_) => panic!("out-of-bounds index must not read an element"),
+            Err(err) => assert_eq!(err.kind(), crate::ExecutionErrorKind::InvalidOperation),
+        }
+        assert!(vec.get_element(u64::MAX).is_err());
+    }
+
+    /// `get_element` on an empty vector errors for every index.
+    #[test]
+    fn get_element_empty_vector_errors() {
+        let pool = RootPool::new();
+        // A null-backed vector reads as empty.
+        let vec: Vector<u64> =
+            Vector::from_handle(unsafe { pool.root_object(std::ptr::null_mut()) });
+        assert_eq!(vec.len(), 0);
+        assert!(vec.get_element(0).is_err());
     }
 }

--- a/third_party/move/mono-move/natives/src/bls12381.rs
+++ b/third_party/move/mono-move/natives/src/bls12381.rs
@@ -164,7 +164,7 @@ pub fn native_aggregate_pubkeys<C: NativeContext>(ctx: &C) -> VMResult<NativeSta
     // Deserialize every public key, stopping at the first that fails.
     let mut deserialized = Vec::with_capacity(num_pks as usize);
     for i in 0..num_pks {
-        let pk = pks.get(i);
+        let pk = pks.get_element(i)?;
         // SAFETY: byte slice consumed before any allocation.
         let Ok(pk) = PublicKey::try_from(unsafe { pk.as_bytes() }) else {
             break;
@@ -205,7 +205,7 @@ pub fn native_aggregate_signatures<C: NativeContext>(ctx: &C) -> VMResult<Native
     // Deserialize every signature, stopping at the first that fails.
     let mut deserialized = Vec::with_capacity(num_sigs as usize);
     for i in 0..num_sigs {
-        let sig = sigs.get(i);
+        let sig = sigs.get_element(i)?;
         // SAFETY: byte slice consumed before any allocation.
         let Ok(sig) = bls12381::Signature::try_from(unsafe { sig.as_bytes() }) else {
             break;
@@ -251,7 +251,7 @@ pub fn native_verify_aggregate_signature<C: NativeContext>(ctx: &C) -> VMResult<
     // Deserialize every public key, stopping at the first that fails.
     let mut pk_vals = Vec::with_capacity(num_pks as usize);
     for i in 0..num_pks {
-        let pk = pks.get(i);
+        let pk = pks.get_element(i)?;
         // SAFETY: byte slice consumed before any allocation.
         let Ok(pk) = PublicKey::try_from(unsafe { pk.as_bytes() }) else {
             break;
@@ -275,8 +275,8 @@ pub fn native_verify_aggregate_signature<C: NativeContext>(ctx: &C) -> VMResult<
     // verify call. No VM allocation happens in between, so the slices stay
     // valid.
     let msg_vecs = (0..messages.len())
-        .map(|i| messages.get(i))
-        .collect::<Vec<_>>();
+        .map(|i| messages.get_element(i))
+        .collect::<VMResult<Vec<_>>>()?;
     // SAFETY: byte slices consumed before any allocation.
     let msg_refs = msg_vecs
         .iter()

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -28,6 +28,7 @@ pub mod init;
 pub mod mem;
 pub mod multi_ed25519;
 pub mod object;
+pub mod ristretto255_point;
 pub mod ristretto255_scalar;
 pub mod secp256k1;
 pub mod signer;
@@ -61,6 +62,7 @@ pub use multi_ed25519::make_all_multi_ed25519_natives;
 #[cfg(feature = "testing")]
 pub use multi_ed25519::make_all_multi_ed25519_test_natives;
 pub use object::{make_all_object_natives, ObjectContextExtension};
+pub use ristretto255_point::{make_all_ristretto255_point_natives, RistrettoPointStore};
 pub use ristretto255_scalar::make_all_ristretto255_scalar_natives;
 #[cfg(feature = "testing")]
 pub use ristretto255_scalar::make_all_ristretto255_scalar_test_natives;
@@ -126,6 +128,7 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
     natives.extend(make_all_multi_ed25519_natives::<F>());
     natives.extend(make_all_bls12381_natives::<F>());
     natives.extend(make_all_ristretto255_scalar_natives::<F>());
+    natives.extend(make_all_ristretto255_point_natives::<F>());
     natives.extend(make_all_vector_natives::<F>());
     natives
 }

--- a/third_party/move/mono-move/natives/src/ristretto255_point.rs
+++ b/third_party/move/mono-move/natives/src/ristretto255_point.rs
@@ -1,0 +1,622 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Point natives for the `ristretto255` module (`aptos_std::ristretto255`).
+//!
+//! A `RistrettoPoint` never crosses the Move/native boundary as bytes. Instead
+//! each point lives in a per-transaction Rust store ([`RistrettoPointStore`]) and
+//! Move holds a `u64` handle (a dense index into the store). Point natives take
+//! and return handles, either as a bare `u64` or as a `&RistrettoPoint { handle:
+//! u64 }` struct reference.
+//!
+//! The handle indirection is not about garbage collection. It matches Move
+//! struct layout (`RistrettoPoint { handle: u64 }`) and keeps the decompressed
+//! curve point in the store, so a chain of operations does not pay a field
+//! square root to re-decompress between each step.
+
+use crate::{
+    monomorphic_natives, polymorphic_natives, ristretto255_scalar::scalar_from_bytes, NativeEntry,
+};
+use curve25519_dalek::{
+    constants::RISTRETTO_BASEPOINT_TABLE,
+    ristretto::{CompressedRistretto, RistrettoPoint},
+    traits::{Identity, VartimeMultiscalarMul},
+};
+use mono_move_core::{
+    native::{
+        native_invariant_violation, NativeContext, NativeContextFamily, NativeExtension,
+        NativeStatus, Ref, Vector,
+    },
+    VMResult,
+};
+use sha2::Sha512;
+
+/// A compressed ristretto point is exactly 32 bytes.
+const COMPRESSED_POINT_NUM_BYTES: usize = 32;
+
+/// Upper bound on points created within a single execution. Caps the store at
+/// roughly 1.6 MB (~160 bytes per point).
+const NUM_POINTS_LIMIT: usize = 10000;
+
+/// Abort code returned when a native tries to allocate past [`NUM_POINTS_LIMIT`].
+const TOO_MANY_POINTS_CREATED: u64 = aptos_types::error::resource_exhausted(4);
+
+/// Abort code returned when an in-place point operation is given the same
+/// handle for both operands.
+const DUPLICATE_POINT_HANDLE: u64 = aptos_types::error::cancelled(3);
+
+/// Per-transaction store of ristretto points, indexed by handle.
+///
+/// TODO(perf, security): points are held in a Rust `Vec` here; they should
+/// eventually live on the VM's own heap.
+#[derive(Default)]
+pub struct RistrettoPointStore {
+    points: Vec<RistrettoPoint>,
+    checkpoints: Vec<usize>,
+}
+
+impl RistrettoPointStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocates a new handle for `point`, or aborts if too many points have
+    /// been created.
+    fn add(&mut self, point: RistrettoPoint) -> Result<u64, NativeStatus> {
+        let id = self.points.len();
+        if id >= NUM_POINTS_LIMIT {
+            Err(NativeStatus::Abort {
+                code: TOO_MANY_POINTS_CREATED,
+                message: Some(format!(
+                    "Too many points created: {}, limit is {}",
+                    id, NUM_POINTS_LIMIT
+                )),
+            })
+        } else {
+            self.points.push(point);
+            Ok(id as u64)
+        }
+    }
+
+    /// Reads the point at `handle`.
+    fn get(&self, handle: u64) -> VMResult<RistrettoPoint> {
+        self.points.get(handle as usize).copied().ok_or_else(|| {
+            native_invariant_violation(format!("invalid ristretto255 point handle: {handle}"))
+        })
+    }
+
+    /// Updates the point at `handle`.
+    fn set(&mut self, handle: u64, point: RistrettoPoint) -> VMResult<()> {
+        match self.points.get_mut(handle as usize) {
+            Some(slot) => {
+                *slot = point;
+                Ok(())
+            },
+            None => Err(native_invariant_violation(format!(
+                "invalid ristretto255 point handle: {handle}"
+            ))),
+        }
+    }
+}
+
+impl NativeExtension for RistrettoPointStore {
+    unsafe fn relocate_roots(&mut self, _relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {
+        // Points are referenced by handle and hold no VM heap pointers.
+    }
+
+    fn on_checkpoint(&mut self) {
+        self.checkpoints.push(self.points.len());
+    }
+
+    fn on_rollback(&mut self, n: usize) -> VMResult<()> {
+        if n > self.checkpoints.len() {
+            return Err(native_invariant_violation(format!(
+                "ristretto255 point rollback({n}): only {} checkpoint(s)",
+                self.checkpoints.len(),
+            )));
+        }
+        let snapshot = self.checkpoints[self.checkpoints.len() - n];
+        self.checkpoints.truncate(self.checkpoints.len() - n);
+        self.points.truncate(snapshot);
+        Ok(())
+    }
+}
+
+/// Reads the `handle` field of a `&RistrettoPoint { handle: u64 }` argument.
+///
+/// `RistrettoPoint` is a single inline `u64`, so the reference points straight
+/// at that `u64`. Nothing needs GC rooting here: the field holds no VM heap
+/// pointer and the handle is read immediately.
+fn point_handle(point: &Ref<u64>) -> u64 {
+    // SAFETY: `handle` is the 0th (and only) field of `RistrettoPoint`, so the
+    // reference points at that `u64`.
+    unsafe { core::ptr::read_unaligned(point.ptr() as *const u64) }
+}
+
+/// `0x1::ristretto255::point_identity_internal(): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_identity<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let handle = match store.add(RistrettoPoint::identity()) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_is_canonical_internal(bytes: vector<u8>): bool`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_is_canonical<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let bytes: Vector<u8> = unsafe { ctx.arg(0)? };
+
+    // SAFETY: byte slice consumed before any allocation. A wrong length is not
+    // canonical, so it yields `false` rather than aborting.
+    let is_canonical =
+        match <[u8; COMPRESSED_POINT_NUM_BYTES]>::try_from(unsafe { bytes.as_bytes() }) {
+            Ok(slice) => CompressedRistretto(slice).decompress().is_some(),
+            Err(_) => false,
+        };
+
+    // SAFETY: return slot 0 is `bool`.
+    unsafe { ctx.set_return(0, is_canonical)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_decompress_internal(bytes: vector<u8>): (u64, bool)`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_decompress<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let bytes: Vector<u8> = unsafe { ctx.arg(0)? };
+
+    // SAFETY: byte slice consumed before any allocation.
+    let point = match <[u8; COMPRESSED_POINT_NUM_BYTES]>::try_from(unsafe { bytes.as_bytes() }) {
+        Ok(slice) => CompressedRistretto(slice).decompress(),
+        Err(_) => None,
+    };
+
+    let Some(point) = point else {
+        // An invalid encoding yields `(u64::MAX, false)`.
+        // SAFETY: return slots 0 and 1 are `u64` and `bool`.
+        unsafe {
+            ctx.set_return(0, u64::MAX)?;
+            ctx.set_return(1, false)?;
+        }
+        return Ok(NativeStatus::Success);
+    };
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let handle = match store.add(point) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slots 0 and 1 are `u64` and `bool`.
+    unsafe {
+        ctx.set_return(0, handle)?;
+        ctx.set_return(1, true)?;
+    }
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_clone_internal(point_handle: u64): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_clone<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `u64`.
+    let handle_in = unsafe { ctx.arg::<u64>(0)? };
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let point = store.get(handle_in)?;
+    let handle = match store.add(point) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_compress_internal(point: &RistrettoPoint): vector<u8>`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_compress<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `&RistrettoPoint`.
+    let point = unsafe { ctx.arg::<Ref<u64>>(0)? };
+    let handle = point_handle(&point);
+
+    let bytes = {
+        let store = ctx.get_extension::<RistrettoPointStore>()?;
+        store.get(handle)?.compress().to_bytes()
+    };
+    let out = ctx.new_byte_vector(&bytes)?;
+
+    // SAFETY: return slot 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, out)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_mul_internal(point: &RistrettoPoint, a: vector<u8>, in_place: bool): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_mul<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `&RistrettoPoint`, arg 1 is `vector<u8>`, arg 2 is `bool`.
+    let point = unsafe { ctx.arg::<Ref<u64>>(0)? };
+    let scalar_vec: Vector<u8> = unsafe { ctx.arg(1)? };
+    let in_place = unsafe { ctx.arg::<bool>(2)? };
+    let handle = point_handle(&point);
+    // SAFETY: byte slice consumed into an owned scalar before any allocation.
+    let scalar = scalar_from_bytes(unsafe { scalar_vec.as_bytes() })?;
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let result = store.get(handle)? * scalar;
+    let result_handle = if in_place {
+        store.set(handle, result)?;
+        handle
+    } else {
+        match store.add(result) {
+            Ok(handle) => handle,
+            Err(abort) => return Ok(abort),
+        }
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, result_handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_equals(a: &RistrettoPoint, b: &RistrettoPoint): bool`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_equals<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: args 0 and 1 are `&RistrettoPoint`.
+    let a = unsafe { ctx.arg::<Ref<u64>>(0)? };
+    let b = unsafe { ctx.arg::<Ref<u64>>(1)? };
+    let a_handle = point_handle(&a);
+    let b_handle = point_handle(&b);
+
+    let equals = {
+        let store = ctx.get_extension::<RistrettoPointStore>()?;
+        store.get(a_handle)? == store.get(b_handle)?
+    };
+
+    // SAFETY: return slot 0 is `bool`.
+    unsafe { ctx.set_return(0, equals)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_neg_internal(a: &RistrettoPoint, in_place: bool): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_neg<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `&RistrettoPoint`, arg 1 is `bool`.
+    let point = unsafe { ctx.arg::<Ref<u64>>(0)? };
+    let in_place = unsafe { ctx.arg::<bool>(1)? };
+    let handle = point_handle(&point);
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let result = -store.get(handle)?;
+    let result_handle = if in_place {
+        store.set(handle, result)?;
+        handle
+    } else {
+        match store.add(result) {
+            Ok(handle) => handle,
+            Err(abort) => return Ok(abort),
+        }
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, result_handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_add_internal(a: &RistrettoPoint, b: &RistrettoPoint, in_place: bool): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_add<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: args 0 and 1 are `&RistrettoPoint`, arg 2 is `bool`.
+    let a = unsafe { ctx.arg::<Ref<u64>>(0)? };
+    let b = unsafe { ctx.arg::<Ref<u64>>(1)? };
+    let in_place = unsafe { ctx.arg::<bool>(2)? };
+    let a_handle = point_handle(&a);
+    let b_handle = point_handle(&b);
+
+    // In-place add requires two distinct points; aliasing both operands aborts.
+    if in_place && a_handle == b_handle {
+        return Ok(NativeStatus::Abort {
+            code: DUPLICATE_POINT_HANDLE,
+            message: Some("Duplicate Ristretto point handle".to_string()),
+        });
+    }
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let result = store.get(a_handle)? + store.get(b_handle)?;
+    let result_handle = if in_place {
+        store.set(a_handle, result)?;
+        a_handle
+    } else {
+        match store.add(result) {
+            Ok(handle) => handle,
+            Err(abort) => return Ok(abort),
+        }
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, result_handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::point_sub_internal(a: &RistrettoPoint, b: &RistrettoPoint, in_place: bool): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_point_sub<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: args 0 and 1 are `&RistrettoPoint`, arg 2 is `bool`.
+    let a = unsafe { ctx.arg::<Ref<u64>>(0)? };
+    let b = unsafe { ctx.arg::<Ref<u64>>(1)? };
+    let in_place = unsafe { ctx.arg::<bool>(2)? };
+    let a_handle = point_handle(&a);
+    let b_handle = point_handle(&b);
+
+    // In-place sub requires two distinct points; aliasing both operands aborts.
+    if in_place && a_handle == b_handle {
+        return Ok(NativeStatus::Abort {
+            code: DUPLICATE_POINT_HANDLE,
+            message: Some("Duplicate Ristretto point handle".to_string()),
+        });
+    }
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let result = store.get(a_handle)? - store.get(b_handle)?;
+    let result_handle = if in_place {
+        store.set(a_handle, result)?;
+        a_handle
+    } else {
+        match store.add(result) {
+            Ok(handle) => handle,
+            Err(abort) => return Ok(abort),
+        }
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, result_handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::basepoint_mul_internal(a: vector<u8>): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_basepoint_mul<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let scalar_vec: Vector<u8> = unsafe { ctx.arg(0)? };
+    // SAFETY: byte slice consumed into an owned scalar before any allocation.
+    let scalar = scalar_from_bytes(unsafe { scalar_vec.as_bytes() })?;
+
+    let result = &RISTRETTO_BASEPOINT_TABLE * &scalar;
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let handle = match store.add(result) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::basepoint_double_mul_internal(a: vector<u8>, some_point: &RistrettoPoint, b: vector<u8>): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_basepoint_double_mul<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`, arg 1 is `&RistrettoPoint`, arg 2 is `vector<u8>`.
+    let a_vec: Vector<u8> = unsafe { ctx.arg(0)? };
+    let point = unsafe { ctx.arg::<Ref<u64>>(1)? };
+    let b_vec: Vector<u8> = unsafe { ctx.arg(2)? };
+    let handle = point_handle(&point);
+    // SAFETY: byte slices consumed into owned scalars before any allocation.
+    let a = scalar_from_bytes(unsafe { a_vec.as_bytes() })?;
+    let b = scalar_from_bytes(unsafe { b_vec.as_bytes() })?;
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let point = store.get(handle)?;
+    let result = RistrettoPoint::vartime_double_scalar_mul_basepoint(&a, &point, &b);
+    let result_handle = match store.add(result) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, result_handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::new_point_from_sha512_internal(sha2_512_input: vector<u8>): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_new_point_from_sha512<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let input: Vector<u8> = unsafe { ctx.arg(0)? };
+    // SAFETY: byte slice consumed into an owned point before any allocation.
+    let point = RistrettoPoint::hash_from_bytes::<Sha512>(unsafe { input.as_bytes() });
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let handle = match store.add(point) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::new_point_from_64_uniform_bytes_internal(bytes: vector<u8>): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_new_point_from_64_uniform_bytes<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `vector<u8>`.
+    let bytes: Vector<u8> = unsafe { ctx.arg(0)? };
+    // SAFETY: byte slice copied into an owned array before any allocation. The
+    // Move caller guarantees 64 bytes, so a mismatch is an invariant violation.
+    let slice = <[u8; 64]>::try_from(unsafe { bytes.as_bytes() })
+        .map_err(|_| native_invariant_violation("expected 64 bytes".into()))?;
+    let point = RistrettoPoint::from_uniform_bytes(&slice);
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let handle = match store.add(point) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::double_scalar_mul_internal(point1: u64, point2: u64, scalar1: vector<u8>, scalar2: vector<u8>): u64`
+///
+/// TODO(metering): charge gas.
+pub fn native_double_scalar_mul<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: args 0, 1 are `u64`; args 2, 3 are `vector<u8>`.
+    let handle1 = unsafe { ctx.arg::<u64>(0)? };
+    let handle2 = unsafe { ctx.arg::<u64>(1)? };
+    let scalar1_vec: Vector<u8> = unsafe { ctx.arg(2)? };
+    let scalar2_vec: Vector<u8> = unsafe { ctx.arg(3)? };
+    // SAFETY: byte slices consumed into owned scalars before any allocation.
+    let scalar1 = scalar_from_bytes(unsafe { scalar1_vec.as_bytes() })?;
+    let scalar2 = scalar_from_bytes(unsafe { scalar2_vec.as_bytes() })?;
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let point1 = store.get(handle1)?;
+    let point2 = store.get(handle2)?;
+    let result = RistrettoPoint::vartime_multiscalar_mul([scalar1, scalar2], [point1, point2]);
+    let result_handle = match store.add(result) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, result_handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::ristretto255::multi_scalar_mul_internal<P, S>(points: &vector<P>, scalars: &vector<S>): u64`
+///
+/// Computes `sum_i scalars[i] * points[i]`. The `<P, S>` generics are a Move
+/// borrow-checker workaround; the implementation ignores the type arguments and
+/// reads the arguments at their fixed runtime layout (`vector<RistrettoPoint>`
+/// as inline `u64` handles, `vector<Scalar>` as `vector<vector<u8>>`). The
+/// non-empty and equal-length preconditions are enforced by the Move caller.
+///
+/// TODO(metering): charge gas.
+pub fn native_multi_scalar_mul<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: arg 0 is `&vector<RistrettoPoint>` (inline `u64` handles); arg 1
+    // is `&vector<Scalar>` (layout-identical to `vector<vector<u8>>`).
+    let points_ref = unsafe { ctx.arg::<Ref<Vector<u64>>>(0)? };
+    let scalars_ref = unsafe { ctx.arg::<Ref<Vector<Vector<u8>>>>(1)? };
+    let points_vec = points_ref.borrow();
+    let scalars_vec = scalars_ref.borrow();
+
+    let num = scalars_vec.len();
+    // Parse scalars into owned values before touching the store.
+    let mut scalars = Vec::with_capacity(num as usize);
+    for i in 0..num {
+        let data = scalars_vec.get_element(i)?;
+        // SAFETY: byte slice consumed into an owned scalar before the next read.
+        scalars.push(scalar_from_bytes(unsafe { data.as_bytes() })?);
+    }
+
+    let mut store = ctx.get_extension::<RistrettoPointStore>()?;
+    let mut points = Vec::with_capacity(num as usize);
+    for i in 0..num {
+        points.push(store.get(points_vec.get_element(i)?)?);
+    }
+    let result = RistrettoPoint::vartime_multiscalar_mul(scalars.iter(), points);
+    let handle = match store.add(result) {
+        Ok(handle) => handle,
+        Err(abort) => return Ok(abort),
+    };
+    drop(store);
+
+    // SAFETY: return slot 0 is `u64`.
+    unsafe { ctx.set_return(0, handle)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Production point natives for the `ristretto255` module.
+pub fn make_all_ristretto255_point_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    let mut natives = monomorphic_natives![
+        (
+            "0x1::ristretto255::point_identity_internal",
+            native_point_identity
+        ),
+        (
+            "0x1::ristretto255::point_is_canonical_internal",
+            native_point_is_canonical
+        ),
+        (
+            "0x1::ristretto255::point_decompress_internal",
+            native_point_decompress
+        ),
+        (
+            "0x1::ristretto255::point_clone_internal",
+            native_point_clone
+        ),
+        (
+            "0x1::ristretto255::point_compress_internal",
+            native_point_compress
+        ),
+        ("0x1::ristretto255::point_mul_internal", native_point_mul),
+        ("0x1::ristretto255::point_equals", native_point_equals),
+        ("0x1::ristretto255::point_neg_internal", native_point_neg),
+        ("0x1::ristretto255::point_add_internal", native_point_add),
+        ("0x1::ristretto255::point_sub_internal", native_point_sub),
+        (
+            "0x1::ristretto255::basepoint_mul_internal",
+            native_basepoint_mul
+        ),
+        (
+            "0x1::ristretto255::basepoint_double_mul_internal",
+            native_basepoint_double_mul
+        ),
+        (
+            "0x1::ristretto255::new_point_from_sha512_internal",
+            native_new_point_from_sha512
+        ),
+        (
+            "0x1::ristretto255::new_point_from_64_uniform_bytes_internal",
+            native_new_point_from_64_uniform_bytes
+        ),
+        (
+            "0x1::ristretto255::double_scalar_mul_internal",
+            native_double_scalar_mul
+        ),
+    ];
+    // `multi_scalar_mul_internal` is generic in Move (`<P, S>`), so it is
+    // registered as a polymorphic native, even though the Move caller only ever
+    // instantiates it with `<RistrettoPoint, Scalar>`.
+    natives.extend(polymorphic_natives![(
+        "0x1::ristretto255::multi_scalar_mul_internal",
+        native_multi_scalar_mul
+    )]);
+    natives
+}

--- a/third_party/move/mono-move/natives/src/ristretto255_point.rs
+++ b/third_party/move/mono-move/natives/src/ristretto255_point.rs
@@ -48,7 +48,7 @@ const DUPLICATE_POINT_HANDLE: u64 = aptos_types::error::cancelled(3);
 /// Per-transaction store of ristretto points, indexed by handle.
 ///
 /// TODO(perf, security): points are held in a Rust `Vec` here; they should
-/// eventually live on the VM's own heap.
+/// eventually live on the VM's own heap as a single rooted vector.
 #[derive(Default)]
 pub struct RistrettoPointStore {
     points: Vec<RistrettoPoint>,
@@ -63,6 +63,9 @@ impl RistrettoPointStore {
     /// Allocates a new handle for `point`, or aborts if too many points have
     /// been created.
     fn add(&mut self, point: RistrettoPoint) -> Result<u64, NativeStatus> {
+        // Points are never deduplicated, not even identity: `*_assign` natives
+        // mutate the slot at a handle in place, so sharing a slot between callers
+        // would let one caller's mutation corrupt another's point.
         let id = self.points.len();
         if id >= NUM_POINTS_LIMIT {
             Err(NativeStatus::Abort {
@@ -108,6 +111,14 @@ impl NativeExtension for RistrettoPointStore {
         self.checkpoints.push(self.points.len());
     }
 
+    /// Rolls back by truncating the point vector to the checkpoint length.
+    ///
+    /// Correct despite in-place `set`: a `RistrettoPoint` never crosses a
+    /// checkpoint boundary (it is `drop`-only and each phase is a separate
+    /// top-level call), so a phase only mutates points it created above the
+    /// watermark. Truncation drops exactly those; points below were never
+    /// touched. Handles never leave the store, so a rolled-back point is
+    /// unobservable regardless.
     fn on_rollback(&mut self, n: usize) -> VMResult<()> {
         if n > self.checkpoints.len() {
             return Err(native_invariant_violation(format!(

--- a/third_party/move/mono-move/natives/src/ristretto255_scalar.rs
+++ b/third_party/move/mono-move/natives/src/ristretto255_scalar.rs
@@ -22,7 +22,7 @@ const SCALAR_NUM_BYTES: usize = 32;
 /// high bit, matching V1's `scalar_from_valid_bytes`. The Move `Scalar` type
 /// guarantees the length, so a mismatch is an invariant violation, not a user
 /// abort.
-fn scalar_from_bytes(bytes: &[u8]) -> VMResult<Scalar> {
+pub(crate) fn scalar_from_bytes(bytes: &[u8]) -> VMResult<Scalar> {
     let slice = <[u8; SCALAR_NUM_BYTES]>::try_from(bytes)
         .map_err(|_| native_invariant_violation("ristretto255 scalar must be 32 bytes".into()))?;
     Ok(Scalar::from_bits(slice))

--- a/third_party/move/mono-move/testsuite/src/extensions.rs
+++ b/third_party/move/mono-move/testsuite/src/extensions.rs
@@ -8,7 +8,8 @@ use aptos_types::transaction::user_transaction_context::{
 };
 use mono_move_core::native::NativeExtensions;
 use mono_move_natives::{
-    EventStore, ObjectContextExtension, StorageUsageAtEpochBoundary, TransactionContextExtension,
+    EventStore, ObjectContextExtension, RistrettoPointStore, StorageUsageAtEpochBoundary,
+    TransactionContextExtension,
 };
 use move_core_types::account_address::AccountAddress;
 
@@ -40,6 +41,7 @@ pub(crate) fn seed_extensions(user_transaction_context: bool) -> NativeExtension
         TEST_STATE_BYTES,
     ));
     extensions.add(EventStore::new());
+    extensions.add(RistrettoPointStore::new());
     extensions
 }
 

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -18,8 +18,9 @@ use crate::{
 };
 use anyhow::{anyhow, bail};
 use aptos_framework_natives::{
-    event::NativeEventContext, object::NativeObjectContext,
-    state_storage::NativeStateStorageContext, transaction_context::NativeTransactionContext,
+    cryptography::ristretto255_point::NativeRistrettoPointContext, event::NativeEventContext,
+    object::NativeObjectContext, state_storage::NativeStateStorageContext,
+    transaction_context::NativeTransactionContext,
 };
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
 use aptos_types::{
@@ -457,6 +458,7 @@ fn execute_function_v1(
     extensions.add(NativeObjectContext::default());
     extensions.add(NativeStateStorageContext::new(&state_storage_view));
     extensions.add(NativeEventContext::default());
+    extensions.add(NativeRistrettoPointContext::new());
 
     let mut data_cache = TransactionDataCache::empty();
     let output = match MoveVM::execute_loaded_function(

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/ristretto255_point.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/ristretto255_point.move
@@ -1,0 +1,288 @@
+// Differential test for the ristretto255 point natives and the point-handle store.
+//
+// Points never cross the Move/native boundary as bytes: a native returns a `u64`
+// handle, wrapped into a `RistrettoPoint`. Most checks compute a point two ways
+// and compare with `point_equals` (v1 is the oracle); a couple pin known
+// compressed encodings.
+
+// RUN: publish
+module 0x1::ristretto255 {
+    struct Scalar has copy, store, drop {
+        data: vector<u8>
+    }
+
+    struct RistrettoPoint has drop {
+        handle: u64
+    }
+
+    native fun scalar_from_u64_internal(num: u64): vector<u8>;
+
+    native fun point_identity_internal(): u64;
+
+    native fun point_is_canonical_internal(bytes: vector<u8>): bool;
+
+    native fun point_decompress_internal(maybe_non_canonical_bytes: vector<u8>): (u64, bool);
+
+    native fun point_clone_internal(point_handle: u64): u64;
+
+    native fun point_compress_internal(point: &RistrettoPoint): vector<u8>;
+
+    native fun point_mul_internal(point: &RistrettoPoint, a: vector<u8>, in_place: bool): u64;
+
+    native fun point_equals(a: &RistrettoPoint, b: &RistrettoPoint): bool;
+
+    native fun point_neg_internal(a: &RistrettoPoint, in_place: bool): u64;
+
+    native fun point_add_internal(a: &RistrettoPoint, b: &RistrettoPoint, in_place: bool): u64;
+
+    native fun point_sub_internal(a: &RistrettoPoint, b: &RistrettoPoint, in_place: bool): u64;
+
+    native fun basepoint_mul_internal(a: vector<u8>): u64;
+
+    native fun basepoint_double_mul_internal(
+        a: vector<u8>, some_point: &RistrettoPoint, b: vector<u8>
+    ): u64;
+
+    native fun new_point_from_sha512_internal(sha2_512_input: vector<u8>): u64;
+
+    native fun new_point_from_64_uniform_bytes_internal(bytes: vector<u8>): u64;
+
+    native fun double_scalar_mul_internal(
+        point1: u64, point2: u64, scalar1: vector<u8>, scalar2: vector<u8>
+    ): u64;
+
+    native fun multi_scalar_mul_internal<P, S>(points: &vector<P>, scalars: &vector<S>): u64;
+
+    // `k * basepoint`, as a RistrettoPoint.
+    fun basepoint_times(k: u64): RistrettoPoint {
+        RistrettoPoint { handle: basepoint_mul_internal(scalar_from_u64_internal(k)) }
+    }
+
+    // point_identity compressed is the 32-byte zero encoding.
+    public fun identity_compressed(): vector<u8> {
+        let id = RistrettoPoint { handle: point_identity_internal() };
+        point_compress_internal(&id)
+    }
+
+    // basepoint (1 * B) compressed is a fixed known encoding.
+    public fun basepoint_compressed(): vector<u8> {
+        let b = basepoint_times(1);
+        point_compress_internal(&b)
+    }
+
+    // (5B + 3B) - 3B == 5B.
+    public fun add_sub_roundtrip(): bool {
+        let five_b = basepoint_times(5);
+        let three_b = basepoint_times(3);
+        let sum = RistrettoPoint { handle: point_add_internal(&five_b, &three_b, false) };
+        let diff = RistrettoPoint { handle: point_sub_internal(&sum, &three_b, false) };
+        let expected = basepoint_times(5);
+        point_equals(&diff, &expected)
+    }
+
+    // In-place add/sub compute the same result as the out-of-place forms.
+    public fun add_sub_in_place(): bool {
+        let acc = basepoint_times(5);
+        let three_b = basepoint_times(3);
+        // acc = acc + 3B (== 8B), reusing acc's handle.
+        acc = RistrettoPoint { handle: point_add_internal(&acc, &three_b, true) };
+        // acc = acc - 3B (== 5B), reusing acc's handle.
+        acc = RistrettoPoint { handle: point_sub_internal(&acc, &three_b, true) };
+        let expected = basepoint_times(5);
+        point_equals(&acc, &expected)
+    }
+
+    // P + (-P) == identity, out-of-place and in-place.
+    public fun neg_roundtrip(): bool {
+        let p = basepoint_times(7);
+        let neg = RistrettoPoint { handle: point_neg_internal(&p, false) };
+        let sum = RistrettoPoint { handle: point_add_internal(&p, &neg, false) };
+        let id = RistrettoPoint { handle: point_identity_internal() };
+        point_equals(&sum, &id)
+    }
+
+    public fun neg_in_place(): bool {
+        let p = basepoint_times(7);
+        let neg = RistrettoPoint { handle: point_neg_internal(&p, true) };
+        let expected = RistrettoPoint {
+            handle: point_neg_internal(&basepoint_times(7), false)
+        };
+        point_equals(&neg, &expected)
+    }
+
+    // point_mul(B, 5) == 5B, out-of-place and in-place.
+    public fun mul_matches_basepoint(): bool {
+        let b = basepoint_times(1);
+        let p = RistrettoPoint { handle: point_mul_internal(&b, scalar_from_u64_internal(5), false) };
+        let expected = basepoint_times(5);
+        point_equals(&p, &expected)
+    }
+
+    public fun mul_in_place(): bool {
+        let b = basepoint_times(1);
+        let p = RistrettoPoint { handle: point_mul_internal(&b, scalar_from_u64_internal(5), true) };
+        let expected = basepoint_times(5);
+        point_equals(&p, &expected)
+    }
+
+    // double_scalar_mul(B, B, 2, 3) == 2B + 3B == 5B.
+    public fun double_scalar_mul_matches(): bool {
+        let p1 = basepoint_times(1);
+        let p2 = basepoint_times(1);
+        let h = double_scalar_mul_internal(
+            p1.handle, p2.handle, scalar_from_u64_internal(2), scalar_from_u64_internal(3)
+        );
+        let result = RistrettoPoint { handle: h };
+        let expected = basepoint_times(5);
+        point_equals(&result, &expected)
+    }
+
+    // basepoint_double_mul(2, B, 3) == 2*B + 3*B == 5B.
+    public fun basepoint_double_mul_matches(): bool {
+        let b = basepoint_times(1);
+        let h = basepoint_double_mul_internal(
+            scalar_from_u64_internal(2), &b, scalar_from_u64_internal(3)
+        );
+        let result = RistrettoPoint { handle: h };
+        let expected = basepoint_times(5);
+        point_equals(&result, &expected)
+    }
+
+    // multi_scalar_mul([B, B], [2, 3]) == 2B + 3B == 5B.
+    public fun multi_scalar_mul_matches(): bool {
+        let points = vector[basepoint_times(1), basepoint_times(1)];
+        let scalars = vector[
+            Scalar { data: scalar_from_u64_internal(2) },
+            Scalar { data: scalar_from_u64_internal(3) },
+        ];
+        let result = RistrettoPoint {
+            handle: multi_scalar_mul_internal<RistrettoPoint, Scalar>(&points, &scalars)
+        };
+        let expected = basepoint_times(5);
+        point_equals(&result, &expected)
+    }
+
+    // A cloned handle refers to an equal point.
+    public fun clone_equal(): bool {
+        let b = basepoint_times(3);
+        let c = RistrettoPoint { handle: point_clone_internal(b.handle) };
+        point_equals(&b, &c)
+    }
+
+    // decompress(compress(B)) == B, and reports success.
+    public fun compress_decompress_roundtrip(): bool {
+        let b = basepoint_times(1);
+        let bytes = point_compress_internal(&b);
+        let (handle, ok) = point_decompress_internal(bytes);
+        let decompressed = RistrettoPoint { handle };
+        ok && point_equals(&decompressed, &b)
+    }
+
+    // A valid compressed point is canonical.
+    public fun is_canonical_true(): bool {
+        let b = basepoint_times(1);
+        point_is_canonical_internal(point_compress_internal(&b))
+    }
+
+    // All-ones 32 bytes is not a canonical point encoding.
+    public fun is_canonical_false(): bool {
+        point_is_canonical_internal(
+            x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        )
+    }
+
+    // Decompressing invalid bytes reports failure.
+    public fun decompress_invalid_ok(): bool {
+        let (_handle, ok) = point_decompress_internal(
+            x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        );
+        ok
+    }
+
+    // Distinct points are not equal.
+    public fun equals_false(): bool {
+        let b = basepoint_times(1);
+        let two_b = basepoint_times(2);
+        point_equals(&b, &two_b)
+    }
+
+    // new_point_from_sha512 and new_point_from_64_uniform_bytes just need to run
+    // and agree across VMs; compare their compressed encodings for equality of
+    // outputs by round-tripping through decompress.
+    public fun from_sha512_roundtrips(): bool {
+        let p = RistrettoPoint { handle: new_point_from_sha512_internal(b"ristretto255 point test") };
+        let bytes = point_compress_internal(&p);
+        let (handle, ok) = point_decompress_internal(bytes);
+        let q = RistrettoPoint { handle };
+        ok && point_equals(&p, &q)
+    }
+
+    public fun from_64_uniform_roundtrips(): bool {
+        let p = RistrettoPoint {
+            handle: new_point_from_64_uniform_bytes_internal(
+                x"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+            )
+        };
+        let bytes = point_compress_internal(&p);
+        let (handle, ok) = point_decompress_internal(bytes);
+        let q = RistrettoPoint { handle };
+        ok && point_equals(&p, &q)
+    }
+}
+
+// RUN: execute 0x1::ristretto255::identity_compressed
+// CHECK: results: 0x0000000000000000000000000000000000000000000000000000000000000000
+
+// RUN: execute 0x1::ristretto255::basepoint_compressed
+// CHECK: results: 0xe2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76
+
+// RUN: execute 0x1::ristretto255::add_sub_roundtrip
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::add_sub_in_place
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::neg_roundtrip
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::neg_in_place
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::mul_matches_basepoint
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::mul_in_place
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::double_scalar_mul_matches
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::basepoint_double_mul_matches
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::multi_scalar_mul_matches
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::clone_equal
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::compress_decompress_roundtrip
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::is_canonical_true
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::is_canonical_false
+// CHECK: results: false
+
+// RUN: execute 0x1::ristretto255::decompress_invalid_ok
+// CHECK: results: false
+
+// RUN: execute 0x1::ristretto255::equals_false
+// CHECK: results: false
+
+// RUN: execute 0x1::ristretto255::from_sha512_roundtrips
+// CHECK: results: true
+
+// RUN: execute 0x1::ristretto255::from_64_uniform_roundtrips
+// CHECK: results: true

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -189,6 +189,9 @@ pub const fn already_exists(r: u64) -> u64 {
 pub const fn resource_exhausted(r: u64) -> u64 {
     canonical(RESOURCE_EXHAUSTED, r)
 }
+pub const fn cancelled(r: u64) -> u64 {
+    canonical(CANCELLED, r)
+}
 pub const fn internal(r: u64) -> u64 {
     canonical(INTERNAL, r)
 }


### PR DESCRIPTION
## Description

Ports the 16 ristretto255 **point** natives from the legacy Aptos MoveVM to
mono-move, including `multi_scalar_mul_internal`. Stacked on the ristretto255
scalar natives PR.

Unlike scalars, a `RistrettoPoint` never crosses the Move/native boundary as
bytes. A new `RistrettoPointStore` `NativeExtension` holds the points in a
per-transaction `Vec<RistrettoPoint>` and hands Move back a `u64` handle (a
dense index). The handle indirection matches V1's Move-visible struct layout
(`RistrettoPoint { handle: u64 }`) and keeps the decompressed curve point in the
store, so a chain of point operations does not pay a field square root to
re-decompress between steps.

### What this adds

- **`natives/src/ristretto255_point.rs`** (new)
  - `RistrettoPointStore` extension: `add` / `get` / `set` over the handle Vec.
    Mirrors `EventStore` for sub-session semantics — `on_checkpoint` snapshots
    the length, `on_rollback` truncates back to it, `relocate_roots` is a no-op
    (points hold no VM heap pointers).
  - `NUM_POINTS_LIMIT` (10000) and the too-many-points abort (code + message)
    match V1 exactly, so the differential harness comparison holds even though
    the limit is never hit in tests.
  - A `&RistrettoPoint` argument is read as a plain `Ref<u64>`: the struct is a
    single inline `u64`, so the reference points straight at the handle. No
    reference wrapper or GC rooting is needed on the read side.
  - All 16 point natives: identity, is_canonical, (de)compress, clone, equals,
    mul / neg / add / sub (out-of-place and in-place), basepoint_mul,
    basepoint_double_mul, from_sha512, from_64_uniform_bytes, double_scalar_mul,
    and polymorphic `multi_scalar_mul_internal<P, S>`.
  - Backend reuses the existing `curve25519-dalek` and `sha2` deps. No new
    dependencies.
- **`core/src/native/value.rs`**: one generic `Vector::get_element` accessor
  (subsuming the old nested-vector `get`) so `multi_scalar_mul` can read point
  handles and inline `Scalar` byte vectors structurally.
- **Registration / install**: `natives/src/lib.rs` registers the natives;
  `RistrettoPointStore` is installed in the production, testsuite, and
  replay-benchmark extension sets; `NativeRistrettoPointContext` is added to the
  legacy VM harness so both VMs run with the extension present.

## How Has This Been Tested?

- New differential test
  `testsuite/tests/test_cases/differential/natives/ristretto255_point.move`
  runs on both the legacy MoveVM (v1) and mono-move (v2) and checks they agree:
  2 byte goldens (identity and basepoint compressed encodings) plus 18 bool
  self-checks covering every point native (round-trips, in-place vs out-of-place,
  clone, compress/decompress, is_canonical true/false, decompress-invalid,
  equals true/false, sha512 and 64-uniform round-trips). All 20 cases pass; v1
  and v2 produce byte-identical output.
- `mono-move-core` unit tests pass (`get_element` change).

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the Move VM cryptography surface (Ristretto point store and natives) and changes vector indexing errors for BLS aggregation; behavior is aligned with V1 and covered by differential tests.
> 
> **Overview**
> Ports **16 legacy `ristretto255` point natives** (including polymorphic `multi_scalar_mul_internal`) into mono-move. Curve points live in a new per-transaction **`RistrettoPointStore`** extension (dense `u64` handles, checkpoint/rollback, 10k-point cap); the store is wired into production execution, testsuite fixtures, and the legacy VM side of differential tests.
> 
> **`ristretto255_point.rs`** implements identity, (de)compress, clone, equals, mul/neg/add/sub (in-place and out-of-place), basepoint ops, SHA-512 / uniform point creation, and multiscalar mul—reusing **`scalar_from_bytes`** from the scalar module. Adds **`aptos_types::error::cancelled`** for duplicate-handle in-place add/sub aborts.
> 
> **Native vector API:** replaces nested-only **`Vector::get`** with generic **`Vector::get_element`** (bounds-checked, `InvalidOperation` on OOB via **`native_vector_index_out_of_bounds`**). **BLS12-381** aggregate/verify paths now propagate those errors.
> 
> New differential test **`ristretto255_point.move`** compares v1 vs v2 across all point operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0503c85e18235b33ba28027ce39fe3fcbec6107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->