### PR TITLE
[gas] Revert LATEST_GAS_FEATURE_VERSION to RELEASE_V1_49 on v1.49 branch

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -86,7 +86,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_50;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_49;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.exp
@@ -1,4 +1,4 @@
 processed 3 tasks
-task 1 lines 8-29:  publish --private-key Alice [module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check]
-task 2 lines 32-32:  run --signers Alice -- 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check::closure_type_rejected
+task 1 lines 9-30:  publish --private-key Alice [module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check]
+task 2 lines 33-33:  run --signers Alice -- 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check::closure_type_rejected
 Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: 0000000000000000000000000000000000000000000000000000000000000001::object, function: 2, code_offset: 0 }

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.exp
@@ -1,4 +1,4 @@
 processed 3 tasks
-task 1 lines 7-28:  publish --private-key Alice [module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check]
-task 2 lines 31-31:  run --signers Alice -- 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check::closure_type_rejected
-Error: Failed to execute transaction. ExecutionStatus: MoveAbort { location: 0000000000000000000000000000000000000000000000000000000000000001::object, code: 11, info: Some(AbortInfo { reason_name: "ENOT_A_RESOURCE_TYPE", description: "Object type argument must be a resource (struct) type" }) }
+task 1 lines 8-29:  publish --private-key Alice [module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check]
+task 2 lines 32-32:  run --signers Alice -- 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check::closure_type_rejected
+Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: 0000000000000000000000000000000000000000000000000000000000000001::object, function: 2, code_offset: 0 }

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.masm
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.masm
@@ -1,8 +1,10 @@
 //# init --addresses Alice=0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6 --private-keys Alice=56a26140eb233750cd14fb168c3eb4bd0782b099cde626ec8aff7f3cceb6364f
 
-// A closure type can have `key` and thus satisfy `T: key`, so object natives must
-// check that the type argument is a struct: `address_to_object<||u64 has key>` aborts
-// with ENOT_A_RESOURCE_TYPE.
+// A closure type can have `key` and thus satisfy `T: key`. Calling
+// `address_to_object<||u64 has key>` must still fail.
+// Note: On gas feature versions before RELEASE_V1_50 the exists_at native
+// does not yet emit ENOT_A_RESOURCE_TYPE, so this surfaces as an ExecutionFailure
+// instead.
 
 //# publish --private-key Alice
 module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After the v1.49 re-cut, the release branch inherited `LATEST_GAS_FEATURE_VERSION = RELEASE_V1_50`. Per alignment with Victor/Sharon/Josh, this PR releases v1.49 with the 1_49 gas version while keeping new binary code from the re-cut.

## Change
- Set `LATEST_GAS_FEATURE_VERSION` back to `RELEASE_V1_49` in `aptos-move/aptos-gas-schedule/src/ver.rs`
- Leave `RELEASE_V1_50` defined in `ver.rs` and all existing `RELEASE_V1_50` feature gates untouched, so those Move/gas changes stay dormant until the next release (v1.50) and we avoid compile errors

## Context
See [Branch-Cut Debug](https://www.notion.so/3bf8b846eb72802caf29e738597b2013) option 1.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/D0ABFLTFBLM/p1787000432005969?thread_ts=1787000432.005969&cid=D0ABFLTFBLM)

<div><a href="https://cursor.com/agents/bc-ca6e92c8-cbf9-56e9-8c2c-7dd125b57a90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca6e92c8-cbf9-56e9-8c2c-7dd125b57a90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

