### PR TITLE
[mono-move] User context natives

### DIFF
--- a/aptos-move/framework/natives/src/transaction_context.rs
+++ b/aptos-move/framework/natives/src/transaction_context.rs
@@ -10,9 +10,7 @@ use aptos_types::{
     error,
     transaction::{
         authenticator::AuthenticationKey,
-        user_transaction_context::{
-            EntryFunctionPayload, TransactionIndexKind, UserTransactionContext,
-        },
+        user_transaction_context::{EntryFunctionPayload, UserTransactionContext},
     },
 };
 use better_any::{Tid, TidAble};
@@ -186,22 +184,15 @@ fn native_monotonically_increasing_counter_internal(
         // monotonically_increasing_counter (128 bits) = `<reserved_byte (8 bits)> || timestamp_us (64 bits) || transaction_index (32 bits) || session counter (8 bits) || local_counter (16 bits)`
         // reserved_byte: 0 for block/chunk execution (V1), 1 for validation/simulation (TimestampNotYetAssignedV1)
         let timestamp_us = safely_pop_arg!(args, u64);
-        let transaction_index_kind = user_transaction_context.transaction_index_kind();
-
-        let (reserved_byte, transaction_index) = match transaction_index_kind {
-            TransactionIndexKind::BlockExecution { transaction_index } => {
-                (0u128, transaction_index)
-            },
-            TransactionIndexKind::ValidationOrSimulation { transaction_index } => {
-                (1u128, transaction_index)
-            },
-            TransactionIndexKind::NotAvailable => {
-                return Err(SafeNativeError::abort_with_message(
+        let (reserved_byte, transaction_index) = user_transaction_context
+            .transaction_index_kind()
+            .reserved_byte_and_transaction_index()
+            .ok_or_else(|| {
+                SafeNativeError::abort_with_message(
                     error::invalid_state(abort_codes::ETRANSACTION_INDEX_NOT_AVAILABLE),
                     "Transaction index is not available in this execution context",
-                ));
-            },
-        };
+                )
+            })?;
 
         let mut monotonically_increasing_counter: u128 = reserved_byte << 120;
         monotonically_increasing_counter |= (timestamp_us as u128) << 56;
@@ -374,7 +365,9 @@ fn native_chain_id_internal(
 
     let user_transaction_context_opt = get_user_transaction_context_opt_from_context(context);
     if let Some(transaction_context) = user_transaction_context_opt {
-        Ok(smallvec![Value::u8(transaction_context.chain_id())])
+        Ok(smallvec![Value::u8(
+            transaction_context.user_txn_chain_id()
+        )])
     } else {
         Err(SafeNativeError::abort_with_message(
             error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),

--- a/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/metadata.rs
@@ -2,7 +2,8 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_types::transaction::{
-    AuxiliaryInfo, PersistedAuxiliaryInfo, ReplayProtector, SessionId, SignedTransaction,
+    user_transaction_context::{TransactionIndexKind, UserTransactionContext},
+    AuxiliaryInfo, ReplayProtector, SessionId, SignedTransaction,
 };
 use move_core_types::account_address::AccountAddress;
 
@@ -18,33 +19,30 @@ pub(crate) struct TxnMetadata {
     pub max_gas_amount: u64,
     pub expiration_timestamp_secs: u64,
     pub chain_id: u8,
+    /// Whether the transaction carries an encrypted payload.
+    pub is_encrypted_txn: bool,
     pub replay_protector: ReplayProtector,
     /// Seeds unique-address generation. Derived like the legacy VM's, from the
     /// payload session's id, so generated addresses match.
     pub txn_hash: [u8; 32],
+    /// Hash of the executed script, or empty when the payload is not a script.
+    pub script_hash: Vec<u8>,
     /// The payload session's counter, one term of
     /// `monotonically_increasing_number`; matches the legacy VM's.
     pub session_counter: u8,
-    /// The transaction's index within its block plus the counter's reserved
-    /// byte (0 for block execution, 1 for validation/simulation), or `None`
-    /// when the auxiliary info carries no index — the legacy VM aborts
-    /// `monotonically_increasing_number` in that case.
-    pub transaction_index: Option<(u32, u8)>,
+    /// The transaction's index within its block and whether it comes from block
+    /// execution or validation/simulation.
+    pub transaction_index_kind: TransactionIndexKind,
 }
 
 impl TxnMetadata {
     pub fn new(txn: &SignedTransaction, aux_info: &AuxiliaryInfo) -> Self {
-        let transaction_index = match *aux_info.persisted_info() {
-            PersistedAuxiliaryInfo::V1 { transaction_index } => Some((transaction_index, 0)),
-            PersistedAuxiliaryInfo::TimestampNotYetAssignedV1 { transaction_index } => {
-                Some((transaction_index, 1))
-            },
-            PersistedAuxiliaryInfo::None => None,
-        };
+        let transaction_index_kind = aux_info.transaction_index_kind();
+        let script_hash = txn.payload().script_hash();
         let session_id = SessionId::txn(
             txn.sender(),
             txn.replay_protector(),
-            txn.payload().script_hash(),
+            script_hash.clone(),
             txn.expiration_timestamp_secs(),
         );
         let authenticator = txn.authenticator_ref();
@@ -68,14 +66,36 @@ impl TxnMetadata {
             max_gas_amount: txn.max_gas_amount(),
             expiration_timestamp_secs: txn.expiration_timestamp_secs(),
             chain_id: txn.chain_id().id(),
+            is_encrypted_txn: txn.is_encrypted_txn(),
             replay_protector: txn.replay_protector(),
             txn_hash: session_id.txn_hash(),
+            script_hash,
             session_counter: session_id.session_counter(),
-            transaction_index,
+            transaction_index_kind,
         }
     }
 
     pub fn is_orderless(&self) -> bool {
         matches!(self.replay_protector, ReplayProtector::Nonce(_))
+    }
+
+    /// Builds the user transaction context used by some native functions.
+    //
+    // TODO(completeness): `entry_function_payload` and `multisig_payload` are
+    // left `None`; no implemented mono-move native reads them yet.
+    pub(crate) fn as_user_transaction_context(&self) -> UserTransactionContext {
+        UserTransactionContext::new(
+            self.sender,
+            self.secondary_signers.clone(),
+            self.fee_payer.unwrap_or(self.sender),
+            self.max_gas_amount,
+            self.gas_unit_price,
+            self.chain_id,
+            None,
+            None,
+            self.transaction_index_kind,
+            self.is_encrypted_txn,
+            self.is_orderless(),
+        )
     }
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
@@ -47,9 +47,10 @@ pub(crate) fn transaction_extensions(
     let mut extensions = NativeExtensions::new();
     extensions.add(TransactionContextExtension::new(
         txn_data.txn_hash,
+        txn_data.script_hash.clone(),
         txn_data.chain_id,
         txn_data.session_counter,
-        txn_data.transaction_index,
+        Some(txn_data.as_user_transaction_context()),
     ));
     extensions.add(ObjectContextExtension::new());
     extensions.add(StorageUsageAtEpochBoundary::new(

--- a/third_party/move/mono-move/natives/src/from_bytes.rs
+++ b/third_party/move/mono-move/natives/src/from_bytes.rs
@@ -15,7 +15,7 @@ use mono_move_core::{
 const EFROM_BYTES: u64 = 0x01_0001;
 
 /// `0x1::from_bcs::from_bytes<T>(bytes: vector<u8>): T`, and the identical
-/// `0x1::util::from_bytes<T>`.
+/// `0x1::util::from_bytes<T>`
 ///
 /// Deserializes `bytes` as a value of type `T`, aborting with `EFROM_BYTES` if
 /// `bytes` is not a valid encoding.

--- a/third_party/move/mono-move/natives/src/transaction_context.rs
+++ b/third_party/move/mono-move/natives/src/transaction_context.rs
@@ -7,50 +7,59 @@ use crate::{
     address_derivation::{auid_address, table_handle},
     monomorphic_natives, NativeEntry,
 };
+use aptos_types::{error, transaction::user_transaction_context::UserTransactionContext};
 use mono_move_core::{
-    native::{NativeContext, NativeContextFamily, NativeExtension, NativeStatus, TableHandle},
+    native::{
+        NativeContext, NativeContextFamily, NativeExtension, NativeStatus, TableHandle, VMValue,
+    },
     VMResult,
 };
+use move_core_types::account_address::AccountAddress;
 
-/// Per-transaction context backing the `transaction_context` natives.
-//
-// TODO(completeness): the "no user transaction context at all" case (e.g. view
-// functions) is not modeled; the legacy VM aborts those natives with
-// ETRANSACTION_CONTEXT_NOT_AVAILABLE.
+/// Carries transaction context information, such as transaction hashes or chain
+/// ID.
 pub struct TransactionContextExtension {
     txn_hash: [u8; 32],
-    /// Chain id of the network the transaction runs on.
-    chain_id: u8,
+    /// Hash of the script executed by the transaction, or empty when the payload
+    /// is not a script.
+    script_hash: Vec<u8>,
+    /// Chain ID of the network the transaction runs on.
+    network_chain_id: u8,
     /// AUIDs issued so far in this transaction.
     auid_counter: u64,
     /// Per-session counter feeding the low bits of the monotonic counter.
     local_counter: u16,
     /// Identifies the session within the transaction.
     session_counter: u8,
-    /// The transaction's index within its block plus the monotonic counter's
-    /// top byte (0 for block execution, 1 for validation/simulation), or
-    /// `None` when the execution context provides no index.
-    transaction_index: Option<(u32, u8)>,
     /// Tables created so far in this transaction; seeds the next table handle.
     table_counter: u32,
+    /// Set to [`None`] when not a user transaction, and set otherwise.
+    user_transaction_context: Option<UserTransactionContext>,
 }
 
 impl TransactionContextExtension {
     pub fn new(
         txn_hash: [u8; 32],
-        chain_id: u8,
+        script_hash: Vec<u8>,
+        network_chain_id: u8,
         session_counter: u8,
-        transaction_index: Option<(u32, u8)>,
+        user_transaction_context: Option<UserTransactionContext>,
     ) -> Self {
         Self {
             txn_hash,
-            chain_id,
+            script_hash,
+            network_chain_id,
             auid_counter: 0,
             local_counter: 0,
             session_counter,
-            transaction_index,
             table_counter: 0,
+            user_transaction_context,
         }
+    }
+
+    /// Chain ID of the network the transaction runs on.
+    pub(crate) fn network_chain_id(&self) -> u8 {
+        self.network_chain_id
     }
 
     /// Mints the next table handle, advancing the per-transaction counter.
@@ -84,13 +93,11 @@ impl NativeExtension for TransactionContextExtension {
     }
 }
 
-/// `error::invalid_state(EMONOTONICALLY_INCREASING_COUNTER_OVERFLOW)` in
-/// `0x1::transaction_context` (category 3, reason 2).
-const COUNTER_OVERFLOW_ABORT_CODE: u64 = (3 << 16) | 2;
+const MONOTONICALLY_INCREASING_COUNTER_OVERFLOW: u64 = error::invalid_state(2);
 
-/// `error::invalid_state(ETRANSACTION_INDEX_NOT_AVAILABLE)` in
-/// `0x1::transaction_context` (category 3, reason 5).
-const INDEX_NOT_AVAILABLE_ABORT_CODE: u64 = (3 << 16) | 5;
+const TRANSACTION_CONTEXT_NOT_AVAILABLE: u64 = error::invalid_state(1);
+
+const TXN_INDEX_NOT_AVAILABLE: u64 = error::invalid_state(5);
 
 /// `0x1::transaction_context::generate_unique_address(): address`
 ///
@@ -122,22 +129,35 @@ pub fn native_monotonically_increasing_counter_internal<C: NativeContext>(
     let mut ext = ctx.get_extension::<TransactionContextExtension>()?;
     if ext.local_counter == u16::MAX {
         return Ok(NativeStatus::Abort {
-            code: COUNTER_OVERFLOW_ABORT_CODE,
-            message: Some("monotonically increasing counter overflow".into()),
+            code: MONOTONICALLY_INCREASING_COUNTER_OVERFLOW,
+            message: Some(
+                "Monotonically increasing counter has reached maximum value (too many calls in this session)".into(),
+            ),
         });
     }
     ext.local_counter += 1;
 
-    // Like the legacy VM, abort when the execution context provides no
-    // transaction index.
-    let Some((transaction_index, reserved_byte)) = ext.transaction_index else {
+    let Some(user_transaction_context) = &ext.user_transaction_context else {
         return Ok(NativeStatus::Abort {
-            code: INDEX_NOT_AVAILABLE_ABORT_CODE,
-            message: Some("transaction index is not available in this execution context".into()),
+            code: TRANSACTION_CONTEXT_NOT_AVAILABLE,
+            message: Some(
+                "Transaction context is not available (must be called during transaction execution)"
+                    .into(),
+            ),
         });
     };
 
-    let counter = ((reserved_byte as u128) << 120)
+    let Some((reserved_byte, transaction_index)) = user_transaction_context
+        .transaction_index_kind()
+        .reserved_byte_and_transaction_index()
+    else {
+        return Ok(NativeStatus::Abort {
+            code: TXN_INDEX_NOT_AVAILABLE,
+            message: Some("Transaction index is not available in this execution context".into()),
+        });
+    };
+
+    let counter = (reserved_byte << 120)
         | ((timestamp_us as u128) << 56)
         | ((transaction_index as u128) << 24)
         | ((ext.session_counter as u128) << 16)
@@ -147,16 +167,214 @@ pub fn native_monotonically_increasing_counter_internal<C: NativeContext>(
     Ok(NativeStatus::Success)
 }
 
-/// `0x1::transaction_context::chain_id_internal(): u8` and the identical
-/// `0x1::type_info::chain_id_internal(): u8`.
+/// `0x1::transaction_context::chain_id_internal(): u8`
 ///
-/// Returns the chain id of the network the transaction runs on.
+/// Returns the chain ID specified for the current user transaction. This might
+/// be different from the network chain ID.
+pub fn native_transaction_context_chain_id<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: `chain_id` returns `u8`, matching the native's `u8` return.
+    unsafe {
+        return_user_transaction_context_field(
+            ctx,
+            "Transaction context is not available (chain ID can only be accessed during transaction execution)",
+            UserTransactionContext::user_txn_chain_id,
+        )
+    }
+}
+
+/// `0x1::transaction_context::sender_internal(): address`
+pub fn native_sender<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: `sender` returns `AccountAddress`, matching the native's `address` return.
+    unsafe {
+        return_user_transaction_context_field(
+            ctx,
+            "Transaction context is not available (sender information can only be accessed during transaction execution)",
+            UserTransactionContext::sender,
+        )
+    }
+}
+
+/// `0x1::transaction_context::gas_payer_internal(): address`
+pub fn native_gas_payer<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: `gas_payer` returns `AccountAddress`, matching the native's `address` return.
+    unsafe {
+        return_user_transaction_context_field(
+            ctx,
+            "Transaction context is not available (gas payer information can only be accessed during transaction execution)",
+            UserTransactionContext::gas_payer,
+        )
+    }
+}
+
+/// `0x1::transaction_context::max_gas_amount_internal(): u64`
+pub fn native_max_gas_amount<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: `max_gas_amount` returns `u64`, matching the native's `u64` return.
+    unsafe {
+        return_user_transaction_context_field(
+            ctx,
+            "Transaction context is not available (max gas amount can only be accessed during transaction execution)",
+            UserTransactionContext::max_gas_amount,
+        )
+    }
+}
+
+/// `0x1::transaction_context::gas_unit_price_internal(): u64`
+pub fn native_gas_unit_price<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: `gas_unit_price` returns `u64`, matching the native's `u64` return.
+    unsafe {
+        return_user_transaction_context_field(
+            ctx,
+            "Transaction context is not available (gas unit price can only be accessed during transaction execution)",
+            UserTransactionContext::gas_unit_price,
+        )
+    }
+}
+
+/// `0x1::transaction_context::is_encrypted_txn_internal(): bool`
+pub fn native_is_encrypted_txn<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: `is_encrypted_txn` returns `bool`, matching the native's `bool` return.
+    unsafe {
+        return_user_transaction_context_field(
+            ctx,
+            "Transaction context is not available (is_encrypted_txn can only be accessed during transaction execution)",
+            UserTransactionContext::is_encrypted_txn,
+        )
+    }
+}
+
+/// `0x1::transaction_context::get_txn_hash(): vector<u8>`
 //
 // TODO(metering): charge gas.
-pub fn native_chain_id<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+pub fn native_get_txn_hash<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let txn_hash = ctx.get_extension::<TransactionContextExtension>()?.txn_hash;
+    let bytes = ctx.new_byte_vector(&txn_hash)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, bytes)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::transaction_context::get_script_hash(): vector<u8>`
+//
+// TODO(metering): charge gas.
+pub fn native_get_script_hash<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let script_hash = ctx
+        .get_extension::<TransactionContextExtension>()?
+        .script_hash
+        .clone();
+    let bytes = ctx.new_byte_vector(&script_hash)?;
+    // SAFETY: return 0 is `vector<u8>`.
+    unsafe { ctx.set_return(0, bytes)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::transaction_context::secondary_signers_internal(): vector<address>`
+//
+// TODO(metering): charge gas.
+pub fn native_secondary_signers<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let signers = {
+        let ext = ctx.get_extension::<TransactionContextExtension>()?;
+        let Some(user_transaction_context) = &ext.user_transaction_context else {
+            return Ok(NativeStatus::Abort {
+                code: TRANSACTION_CONTEXT_NOT_AVAILABLE,
+                message: Some(
+                    "Transaction context is not available (secondary signers can only be accessed during transaction execution)".into(),
+                ),
+            });
+        };
+        user_transaction_context.secondary_signers()
+    };
+    let mut data = Vec::with_capacity(signers.len() * AccountAddress::LENGTH);
+    for signer in &signers {
+        data.extend_from_slice(signer.as_ref());
+    }
+    let vector =
+        ctx.new_vector_no_pointers(AccountAddress::LENGTH as u32, signers.len() as u64, &data)?;
+    // SAFETY: return 0 is `vector<address>`; addresses are pointer-free.
+    unsafe { ctx.set_return(0, vector)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::transaction_context::is_orderless_txn_internal(): bool`
+pub fn native_is_orderless_txn<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    // SAFETY: `is_orderless_txn` returns `bool`, matching the native's `bool` return.
+    unsafe {
+        return_user_transaction_context_field(
+            ctx,
+            "Transaction context is not available (is_orderless_txn can only be accessed during transaction execution)",
+            UserTransactionContext::is_orderless_txn,
+        )
+    }
+}
+
+/// `0x1::transaction_context::is_orderless_txn_internal_for_test_only(): bool`
+///
+/// This is a test-only function but not gated behind `#[test_only]`. So it has
+/// to stay with other production natives.
+//
+// TODO(metering): charge gas.
+pub fn native_is_orderless_txn_for_test_only<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
     let ext = ctx.get_extension::<TransactionContextExtension>()?;
-    // SAFETY: return 0 is `u8`.
-    unsafe { ctx.set_return(0, ext.chain_id)? };
+    let is_orderless = ext
+        .user_transaction_context
+        .as_ref()
+        .is_some_and(UserTransactionContext::is_orderless_txn);
+    // SAFETY: return 0 is `bool`.
+    unsafe { ctx.set_return(0, is_orderless)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::transaction_context::monotonically_increasing_counter_internal_for_test_only(): u128`
+///
+/// This is a test-only function but not gated behind `#[test_only]`. So it has
+/// to stay with other production natives.
+//
+// TODO(metering): charge gas.
+pub fn native_monotonically_increasing_counter_for_test_only<C: NativeContext>(
+    ctx: &C,
+) -> VMResult<NativeStatus> {
+    let mut ext = ctx.get_extension::<TransactionContextExtension>()?;
+    if ext.local_counter == u16::MAX {
+        return Ok(NativeStatus::Abort {
+            code: MONOTONICALLY_INCREASING_COUNTER_OVERFLOW,
+            message: Some(
+                "Monotonically increasing counter has reached maximum value (too many calls in this session)".into(),
+            ),
+        });
+    }
+    ext.local_counter += 1;
+    let counter = ext.local_counter as u128;
+    // SAFETY: return 0 is `u128`.
+    unsafe { ctx.set_return(0, counter)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Reads one field from the user transaction context and returns it. Aborts if
+/// user transaction context is not available.
+///
+/// # Safety
+///
+/// Caller should guarantee the return type is correct.
+//
+// TODO(metering): charge gas.
+unsafe fn return_user_transaction_context_field<'a, C, T>(
+    ctx: &'a C,
+    not_available_message: &'static str,
+    read: impl FnOnce(&UserTransactionContext) -> T,
+) -> VMResult<NativeStatus>
+where
+    C: NativeContext,
+    T: VMValue<'a>,
+{
+    let ext = ctx.get_extension::<TransactionContextExtension>()?;
+    let Some(user_transaction_context) = &ext.user_transaction_context else {
+        return Ok(NativeStatus::Abort {
+            code: TRANSACTION_CONTEXT_NOT_AVAILABLE,
+            message: Some(not_available_message.into()),
+        });
+    };
+    let value = read(user_transaction_context);
+    // SAFETY: the caller ensures return type and field type match.
+    unsafe { ctx.set_return(0, value)? };
     Ok(NativeStatus::Success)
 }
 
@@ -173,7 +391,48 @@ pub fn make_all_transaction_context_natives<F: NativeContextFamily>() -> Vec<Nat
         ),
         (
             "0x1::transaction_context::chain_id_internal",
-            native_chain_id
+            native_transaction_context_chain_id
+        ),
+        ("0x1::transaction_context::sender_internal", native_sender),
+        (
+            "0x1::transaction_context::gas_payer_internal",
+            native_gas_payer
+        ),
+        (
+            "0x1::transaction_context::max_gas_amount_internal",
+            native_max_gas_amount
+        ),
+        (
+            "0x1::transaction_context::gas_unit_price_internal",
+            native_gas_unit_price
+        ),
+        (
+            "0x1::transaction_context::is_encrypted_txn_internal",
+            native_is_encrypted_txn
+        ),
+        (
+            "0x1::transaction_context::get_txn_hash",
+            native_get_txn_hash
+        ),
+        (
+            "0x1::transaction_context::get_script_hash",
+            native_get_script_hash
+        ),
+        (
+            "0x1::transaction_context::secondary_signers_internal",
+            native_secondary_signers
+        ),
+        (
+            "0x1::transaction_context::is_orderless_txn_internal",
+            native_is_orderless_txn
+        ),
+        (
+            "0x1::transaction_context::is_orderless_txn_internal_for_test_only",
+            native_is_orderless_txn_for_test_only
+        ),
+        (
+            "0x1::transaction_context::monotonically_increasing_counter_internal_for_test_only",
+            native_monotonically_increasing_counter_for_test_only
         ),
     ]
 }

--- a/third_party/move/mono-move/natives/src/transaction_context.rs
+++ b/third_party/move/mono-move/natives/src/transaction_context.rs
@@ -99,6 +99,12 @@ const TRANSACTION_CONTEXT_NOT_AVAILABLE: u64 = error::invalid_state(1);
 
 const TXN_INDEX_NOT_AVAILABLE: u64 = error::invalid_state(5);
 
+fn txn_context_unavailable_msg(subject: &str) -> String {
+    format!(
+        "Transaction context is not available ({subject} can only be accessed during transaction execution)"
+    )
+}
+
 /// `0x1::transaction_context::generate_unique_address(): address`
 ///
 /// Returns a freshly derived address, which is guaranteed to be unique within
@@ -176,7 +182,7 @@ pub fn native_transaction_context_chain_id<C: NativeContext>(ctx: &C) -> VMResul
     unsafe {
         return_user_transaction_context_field(
             ctx,
-            "Transaction context is not available (chain ID can only be accessed during transaction execution)",
+            "chain ID",
             UserTransactionContext::user_txn_chain_id,
         )
     }
@@ -188,7 +194,7 @@ pub fn native_sender<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
     unsafe {
         return_user_transaction_context_field(
             ctx,
-            "Transaction context is not available (sender information can only be accessed during transaction execution)",
+            "sender information",
             UserTransactionContext::sender,
         )
     }
@@ -200,7 +206,7 @@ pub fn native_gas_payer<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
     unsafe {
         return_user_transaction_context_field(
             ctx,
-            "Transaction context is not available (gas payer information can only be accessed during transaction execution)",
+            "gas payer information",
             UserTransactionContext::gas_payer,
         )
     }
@@ -212,7 +218,7 @@ pub fn native_max_gas_amount<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus
     unsafe {
         return_user_transaction_context_field(
             ctx,
-            "Transaction context is not available (max gas amount can only be accessed during transaction execution)",
+            "max gas amount",
             UserTransactionContext::max_gas_amount,
         )
     }
@@ -224,7 +230,7 @@ pub fn native_gas_unit_price<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus
     unsafe {
         return_user_transaction_context_field(
             ctx,
-            "Transaction context is not available (gas unit price can only be accessed during transaction execution)",
+            "gas unit price",
             UserTransactionContext::gas_unit_price,
         )
     }
@@ -236,7 +242,7 @@ pub fn native_is_encrypted_txn<C: NativeContext>(ctx: &C) -> VMResult<NativeStat
     unsafe {
         return_user_transaction_context_field(
             ctx,
-            "Transaction context is not available (is_encrypted_txn can only be accessed during transaction execution)",
+            "is_encrypted_txn",
             UserTransactionContext::is_encrypted_txn,
         )
     }
@@ -276,9 +282,7 @@ pub fn native_secondary_signers<C: NativeContext>(ctx: &C) -> VMResult<NativeSta
         let Some(user_transaction_context) = &ext.user_transaction_context else {
             return Ok(NativeStatus::Abort {
                 code: TRANSACTION_CONTEXT_NOT_AVAILABLE,
-                message: Some(
-                    "Transaction context is not available (secondary signers can only be accessed during transaction execution)".into(),
-                ),
+                message: Some(txn_context_unavailable_msg("secondary signers")),
             });
         };
         user_transaction_context.secondary_signers()
@@ -300,7 +304,7 @@ pub fn native_is_orderless_txn<C: NativeContext>(ctx: &C) -> VMResult<NativeStat
     unsafe {
         return_user_transaction_context_field(
             ctx,
-            "Transaction context is not available (is_orderless_txn can only be accessed during transaction execution)",
+            "is_orderless_txn",
             UserTransactionContext::is_orderless_txn,
         )
     }
@@ -358,7 +362,7 @@ pub fn native_monotonically_increasing_counter_for_test_only<C: NativeContext>(
 // TODO(metering): charge gas.
 unsafe fn return_user_transaction_context_field<'a, C, T>(
     ctx: &'a C,
-    not_available_message: &'static str,
+    subject: &str,
     read: impl FnOnce(&UserTransactionContext) -> T,
 ) -> VMResult<NativeStatus>
 where
@@ -369,7 +373,7 @@ where
     let Some(user_transaction_context) = &ext.user_transaction_context else {
         return Ok(NativeStatus::Abort {
             code: TRANSACTION_CONTEXT_NOT_AVAILABLE,
-            message: Some(not_available_message.into()),
+            message: Some(txn_context_unavailable_msg(subject)),
         });
     };
     let value = read(user_transaction_context);

--- a/third_party/move/mono-move/natives/src/type_info.rs
+++ b/third_party/move/mono-move/natives/src/type_info.rs
@@ -4,7 +4,8 @@
 //! Natives for the `type_info` module.
 
 use crate::{
-    monomorphic_natives, polymorphic_natives, transaction_context::native_chain_id, NativeEntry,
+    monomorphic_natives, polymorphic_natives, transaction_context::TransactionContextExtension,
+    NativeEntry,
 };
 use mono_move_core::{
     native::{NativeContext, NativeContextFamily, NativeStatus, RootPool, VMValue, Vector},
@@ -137,6 +138,20 @@ pub fn native_type_of<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
     Ok(NativeStatus::Success)
 }
 
+/// `0x1::type_info::chain_id_internal(): u8`
+///
+/// Returns the chain ID of the network, and is therefore always available. This
+/// is NOT the chain ID of the user transaction, which may be different and not
+/// even available for some transaction types.
+//
+// TODO(metering): charge gas.
+pub fn native_type_info_chain_id<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
+    let ext = ctx.get_extension::<TransactionContextExtension>()?;
+    // SAFETY: return 0 is `u8`.
+    unsafe { ctx.set_return(0, ext.network_chain_id())? };
+    Ok(NativeStatus::Success)
+}
+
 /// Natives for the `type_info` module.
 pub fn make_all_type_info_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
     let mut natives = polymorphic_natives![
@@ -144,11 +159,12 @@ pub fn make_all_type_info_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F
         ("0x1::type_info::type_of", native_type_of),
     ];
     // `chain_id_internal` is non-generic, so it registers as a monomorphic entry
-    // with empty type arguments. It shares its implementation with
-    // `transaction_context::chain_id_internal`.
+    // with empty type arguments. Unlike `transaction_context::chain_id_internal`,
+    // it is always available and never aborts on a missing user transaction
+    // context.
     natives.extend(monomorphic_natives![(
         "0x1::type_info::chain_id_internal",
-        native_chain_id
+        native_type_info_chain_id
     )]);
     natives
 }

--- a/third_party/move/mono-move/testsuite/src/extensions.rs
+++ b/third_party/move/mono-move/testsuite/src/extensions.rs
@@ -3,32 +3,36 @@
 
 //! Shared native-extension fixtures for the mono-move test harnesses.
 
+use aptos_types::transaction::user_transaction_context::{
+    TransactionIndexKind, UserTransactionContext,
+};
 use mono_move_core::native::NativeExtensions;
 use mono_move_natives::{
     EventStore, ObjectContextExtension, StorageUsageAtEpochBoundary, TransactionContextExtension,
 };
+use move_core_types::account_address::AccountAddress;
 
 // Fixed inputs seeded into both VMs' native extensions, so extension-backed
 // natives (AUID generation, state-storage usage, ...) produce matching output
 // across the two engines.
 pub(crate) const TEST_TXN_HASH: [u8; 32] = [7u8; 32];
+pub(crate) const TEST_SCRIPT_HASH: [u8; 1] = [1u8];
 pub(crate) const TEST_CHAIN_ID: u8 = 4;
 pub(crate) const TEST_STATE_ITEMS: u64 = 100;
 pub(crate) const TEST_STATE_BYTES: u64 = 2000;
-// Inputs to the monotonically-increasing counter. The reserved byte is 0,
-// matching `TransactionIndexKind::BlockExecution`.
 pub(crate) const TEST_SESSION_COUNTER: u8 = 2;
 pub(crate) const TEST_TXN_INDEX: u32 = 5;
-pub(crate) const TEST_RESERVED_BYTE: u8 = 0;
 
-/// Builds the per-transaction native extensions seeded with the fixed inputs above.
-pub(crate) fn seed_extensions() -> NativeExtensions {
+/// Builds the per-transaction native extensions initialized with the fixed
+/// dummy inputs.
+pub(crate) fn seed_extensions(user_transaction_context: bool) -> NativeExtensions {
     let mut extensions = NativeExtensions::new();
     extensions.add(TransactionContextExtension::new(
         TEST_TXN_HASH,
+        TEST_SCRIPT_HASH.to_vec(),
         TEST_CHAIN_ID,
         TEST_SESSION_COUNTER,
-        Some((TEST_TXN_INDEX, TEST_RESERVED_BYTE)),
+        user_transaction_context.then(test_user_transaction_context),
     ));
     extensions.add(ObjectContextExtension::new());
     extensions.add(StorageUsageAtEpochBoundary::new(
@@ -37,4 +41,23 @@ pub(crate) fn seed_extensions() -> NativeExtensions {
     ));
     extensions.add(EventStore::new());
     extensions
+}
+
+/// The user transaction context both VMs use.
+pub(crate) fn test_user_transaction_context() -> UserTransactionContext {
+    UserTransactionContext::new(
+        AccountAddress::ZERO,
+        vec![],
+        AccountAddress::ZERO,
+        0,
+        0,
+        TEST_CHAIN_ID,
+        None,
+        None,
+        TransactionIndexKind::BlockExecution {
+            transaction_index: TEST_TXN_INDEX,
+        },
+        false,
+        false,
+    )
 }

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -8,8 +8,8 @@ use crate::{
     compile::{compile, compile_move_path, compile_move_stdlib, SourceKind},
     engine::RunResult,
     extensions::{
-        seed_extensions, TEST_CHAIN_ID, TEST_SESSION_COUNTER, TEST_STATE_BYTES, TEST_STATE_ITEMS,
-        TEST_TXN_HASH, TEST_TXN_INDEX,
+        seed_extensions, test_user_transaction_context, TEST_CHAIN_ID, TEST_SCRIPT_HASH,
+        TEST_SESSION_COUNTER, TEST_STATE_BYTES, TEST_STATE_ITEMS, TEST_TXN_HASH,
     },
     matcher::check_output,
     module_provider::InMemoryModuleProvider,
@@ -30,7 +30,6 @@ use aptos_types::{
         errors::StateViewError, state_key::StateKey, state_storage_usage::StateStorageUsage,
         StateViewId,
     },
-    transaction::user_transaction_context::{TransactionIndexKind, UserTransactionContext},
 };
 use aptos_vm::natives::aptos_natives;
 use aptos_vm_types::resolver::StateStorageView;
@@ -464,26 +463,11 @@ fn execute_function_v1(
         usage: StateStorageUsage::new(TEST_STATE_ITEMS as usize, TEST_STATE_BYTES as usize),
     };
     let mut extensions = NativeContextExtensions::default();
-    let user_transaction_context = UserTransactionContext::new(
-        AccountAddress::ZERO,
-        vec![],
-        AccountAddress::ZERO,
-        0,
-        0,
-        TEST_CHAIN_ID, // chain_id, read by transaction_context::chain_id_internal
-        None,
-        None,
-        TransactionIndexKind::BlockExecution {
-            transaction_index: TEST_TXN_INDEX,
-        },
-        false, // is_encrypted_txn
-        false, // is_orderless_txn
-    );
     extensions.add(NativeTransactionContext::new(
         TEST_TXN_HASH.to_vec(),
-        vec![],
+        TEST_SCRIPT_HASH.to_vec(),
         TEST_CHAIN_ID,
-        Some(user_transaction_context),
+        Some(test_user_transaction_context()),
         TEST_SESSION_COUNTER,
     ));
     extensions.add(NativeObjectContext::default());
@@ -558,8 +542,8 @@ fn execute_function_v2(
     return_kinds: &[PrimitiveKind],
     heap_size: Option<usize>,
 ) -> (Output, usize) {
-    // Seed extensions with the same fixed inputs as the legacy side.
-    let extensions = seed_extensions();
+    // For differential tests, treat transaction as a user transaction.
+    let extensions = seed_extensions(true);
 
     // Run through the shared pipeline engine. Argument placement and result
     // reading mirror mono-move's frame slot layout.

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -185,7 +185,8 @@ fn execute(
         natives,
         function,
     )
-    .with_extensions(seed_extensions());
+    // For Move unit tests, there is no user transaction context.
+    .with_extensions(seed_extensions(false));
 
     // Reference arguments point into this storage, so it must outlive `run()`.
     let _ref_args = marshal_args(&mut interpreter, function, &test.arguments);

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/user_transaction_context.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/user_transaction_context.move
@@ -1,0 +1,77 @@
+// RUN: publish
+module 0x1::transaction_context {
+    native fun sender_internal(): address;
+    native fun gas_payer_internal(): address;
+    native fun max_gas_amount_internal(): u64;
+    native fun gas_unit_price_internal(): u64;
+    native fun is_encrypted_txn_internal(): bool;
+    native fun is_orderless_txn_internal(): bool;
+    native fun secondary_signers_internal(): vector<address>;
+    native fun get_txn_hash(): vector<u8>;
+    native fun get_script_hash(): vector<u8>;
+
+    public fun sender(): address {
+        sender_internal()
+    }
+
+    public fun gas_payer(): address {
+        gas_payer_internal()
+    }
+
+    public fun max_gas_amount(): u64 {
+        max_gas_amount_internal()
+    }
+
+    public fun gas_unit_price(): u64 {
+        gas_unit_price_internal()
+    }
+
+    public fun is_encrypted_txn(): bool {
+        is_encrypted_txn_internal()
+    }
+
+    public fun is_orderless_txn(): bool {
+        is_orderless_txn_internal()
+    }
+
+    // `vector<address>` is not a renderable return type, so return the count.
+    public fun num_secondary_signers(): u64 {
+        let signers = secondary_signers_internal();
+        std::vector::length(&signers)
+    }
+
+    public fun txn_hash(): vector<u8> {
+        get_txn_hash()
+    }
+
+    public fun script_hash(): vector<u8> {
+        get_script_hash()
+    }
+}
+
+// RUN: execute 0x1::transaction_context::sender
+// CHECK: results: 0x0
+
+// RUN: execute 0x1::transaction_context::gas_payer
+// CHECK: results: 0x0
+
+// RUN: execute 0x1::transaction_context::max_gas_amount
+// CHECK: results: 0
+
+// RUN: execute 0x1::transaction_context::gas_unit_price
+// CHECK: results: 0
+
+// RUN: execute 0x1::transaction_context::is_encrypted_txn
+// CHECK: results: false
+
+// RUN: execute 0x1::transaction_context::is_orderless_txn
+// CHECK: results: false
+
+// RUN: execute 0x1::transaction_context::num_secondary_signers
+// CHECK: results: 0
+
+// RUN: execute 0x1::transaction_context::txn_hash
+// CHECK: results: 0x0707070707070707070707070707070707070707070707070707070707070707
+
+// RUN: execute 0x1::transaction_context::script_hash
+// CHECK: results: 0x01

--- a/third_party/move/mono-move/testsuite/tests/unit_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/unit_tests.rs
@@ -43,7 +43,6 @@ fn aptos_stdlib_on_mono_move() {
 }
 
 #[test]
-#[ignore]
 fn aptos_framework_on_mono_move() {
     run_tests_for_pkg("aptos-framework", false);
 }

--- a/types/src/transaction/user_transaction_context.rs
+++ b/types/src/transaction/user_transaction_context.rs
@@ -18,6 +18,23 @@ pub enum TransactionIndexKind {
     NotAvailable,
 }
 
+impl TransactionIndexKind {
+    /// Returns the monotonic counter's reserved byte (0 for block execution, 1
+    /// for validation/simulation) and the transaction index, or [`None`] when
+    /// no transaction index is available.
+    pub fn reserved_byte_and_transaction_index(&self) -> Option<(u128, u32)> {
+        match self {
+            TransactionIndexKind::BlockExecution { transaction_index } => {
+                Some((0, *transaction_index))
+            },
+            TransactionIndexKind::ValidationOrSimulation { transaction_index } => {
+                Some((1, *transaction_index))
+            },
+            TransactionIndexKind::NotAvailable => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct UserTransactionContext {
     sender: AccountAddress,
@@ -25,7 +42,7 @@ pub struct UserTransactionContext {
     gas_payer: AccountAddress,
     max_gas_amount: u64,
     gas_unit_price: u64,
-    chain_id: u8,
+    user_txn_chain_id: u8,
     entry_function_payload: Option<EntryFunctionPayload>,
     multisig_payload: Option<MultisigPayload>,
     /// The transaction index context for the monotonically increasing counter.
@@ -41,7 +58,7 @@ impl UserTransactionContext {
         gas_payer: AccountAddress,
         max_gas_amount: u64,
         gas_unit_price: u64,
-        chain_id: u8,
+        user_txn_chain_id: u8,
         entry_function_payload: Option<EntryFunctionPayload>,
         multisig_payload: Option<MultisigPayload>,
         transaction_index_kind: TransactionIndexKind,
@@ -54,7 +71,7 @@ impl UserTransactionContext {
             gas_payer,
             max_gas_amount,
             gas_unit_price,
-            chain_id,
+            user_txn_chain_id,
             entry_function_payload,
             multisig_payload,
             transaction_index_kind,
@@ -83,8 +100,8 @@ impl UserTransactionContext {
         self.gas_unit_price
     }
 
-    pub fn chain_id(&self) -> u8 {
-        self.chain_id
+    pub fn user_txn_chain_id(&self) -> u8 {
+        self.user_txn_chain_id
     }
 
     pub fn entry_function_payload(&self) -> Option<EntryFunctionPayload> {


### PR DESCRIPTION
## Description

Mirrors the legacy VM's transaction context model in mono-move so the
`transaction_context` and `type_info::chain_id` natives behave identically on
both engines.

The `TransactionContextExtension` now keeps always-present top-level `chain_id`,
`txn_hash`, and `script_hash`, and groups user-transaction-only state under
`Option<UserTransactionContext>` (the canonical `aptos_types` type). This split
lets the two chain-id natives diverge, and lets the monotonic counter separate
"no user context" from "no transaction index".

Natives added or corrected:
- `type_info::chain_id_internal` — reads the top-level chain id; always
  available, never aborts.
- `transaction_context::chain_id_internal` — reads the user context; aborts
  `ETRANSACTION_CONTEXT_NOT_AVAILABLE` (code 1) when absent.
- `sender`, `gas_payer`, `max_gas_amount`, `gas_unit_price`, `is_encrypted_txn`,
  `secondary_signers_internal` — read the user context; abort code 1 when absent.
- `get_txn_hash`, `get_script_hash` — always available.
- `monotonically_increasing_counter_internal` — separates a missing user context
  (code 1) from a missing transaction index (code 5); overflow uses code 2.
- `is_orderless_txn_internal_for_test_only`,
  `monotonically_increasing_counter_internal_for_test_only` — unit-test shims
  that return safe defaults instead of aborting when no user context is present.

Three chain-id sources are now distinct and documented:
- `aptos_framework::chain_id::chain_id()` — a Move function reading the on-chain
  `ChainId` resource in global storage. Not a native; out of scope.
- `aptos_std::type_info::chain_id()` — native returning the transaction-carried
  chain id; always available.
- `aptos_framework::transaction_context::chain_id()` — native returning the user
  transaction's chain id; aborts when there is no user transaction.

## How Has This Been Tested?

- Differential harness (legacy MoveVM v1 vs mono-move v2): 216/216 pass.
- Framework unit tests on mono-move: 628 pass, 13 fail, 131 unsupported.
  `transaction_context` is 9 pass / 0 fail / 2 unsupported and `type_info` passes.
  The 13 failures are the pre-existing, out-of-scope specializer bug (unsound
  copy coalescing for heap types, fixed by #20390): `big_ordered_map`,
  `sigma_protocol_proof_tests`, `sui_derivable_account`.
- The unit-test harness seeds `script_hash = vec![1]` to match the legacy
  unit-test hook (`aptos-vm` `unit_test_extensions_hook`), so the framework
  voting and governance tests, which assert `get_script_hash()` matches their
  registered execution hash, behave identically on both engines.

## Key Areas to Review

- The two-tier `TransactionContextExtension` layout (always-present top-level
  fields vs `Option<UserTransactionContext>`), mirroring legacy
  `NativeTransactionContext`.
- Abort-code parity: counter overflow uses `error::invalid_state(2)` (native
  parity, not the Move module's const 4); a missing context is code 1; a missing
  index is code 5.
- Test fixtures in `extensions.rs` / `runner.rs` seeded identically across v1
  and v2, and the unit-test harness matching the legacy unit-test hook.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VM native transaction-context semantics and abort codes, which can affect Move execution results. Scope is mainly mono-move plus a small shared type rename; production consensus path is largely untouched.
> 
> **Overview**
> Aligns mono-move `transaction_context` natives with the legacy VM by storing always-available fields (`txn_hash`, `script_hash`, network chain ID) separately from optional `UserTransactionContext`.
> 
> **`type_info::chain_id_internal`** now always returns the network chain ID. **`transaction_context::chain_id_internal`** reads the user txn chain ID and aborts when there is no user context. Sender, gas payer, gas limits, encrypted/orderless flags, and secondary signers abort the same way; txn/script hashes stay always available. The monotonic counter distinguishes missing user context (abort 1) from missing txn index (abort 5).
> 
> Executor metadata now builds `UserTransactionContext` (including script hash and encrypted-txn). Test harnesses seed that context for differential runs and omit it for unit tests. Unignores aptos-framework unit tests on mono-move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ba5bbbb3ee2551befef7d5b9d0f6c2755a68b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->