### PR TITLE
use archive in url for package tests

### DIFF
--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/Move.lock
@@ -1,4 +1,4 @@
 [git]
 
 [on_chain]
-"fullnode.mainnet.aptoslabs.com" = 3152151156
+"archive.mainnet.aptoslabs.com" = 3152151156

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/Move.toml
@@ -3,4 +3,4 @@ name = "Pack"
 version = "0.1.2"
 
 [dependencies]
-MoveStdlib = { aptos = "https://fullnode.mainnet.aptoslabs.com", address = "0x10" }
+MoveStdlib = { aptos = "https://archive.mainnet.aptoslabs.com", address = "0x10" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/Move.lock
@@ -1,4 +1,4 @@
 [git]
 
 [on_chain]
-"fullnode.mainnet.aptoslabs.com" = 3152151123
+"archive.mainnet.aptoslabs.com" = 3152151123

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/Move.toml
@@ -3,4 +3,4 @@ name = "Pack"
 version = "0.1.2"
 
 [dependencies]
-DoesNotExist = { aptos = "https://fullnode.mainnet.aptoslabs.com", address = "0x1" }
+DoesNotExist = { aptos = "https://archive.mainnet.aptoslabs.com", address = "0x1" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/output.md
@@ -1,3 +1,3 @@
 error
 
-package not found: https://fullnode.mainnet.aptoslabs.com///0x1::DoesNotExist
+package not found: https://archive.mainnet.aptoslabs.com///0x1::DoesNotExist

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/Move.lock
@@ -1,4 +1,4 @@
 [git]
 
 [on_chain]
-"fullnode.mainnet.aptoslabs.com" = 3152151123
+"archive.mainnet.aptoslabs.com" = 3152151123

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/Move.toml
@@ -3,5 +3,5 @@ name = "Pack"
 version = "0.1.2"
 
 [dependencies]
-MoveStdlib = { aptos = "https://fullnode.mainnet.aptoslabs.com", address = "0x1" }
-AptosStdlib = { aptos = "https://fullnode.mainnet.aptoslabs.com", address = "0x1" }
+MoveStdlib = { aptos = "https://archive.mainnet.aptoslabs.com", address = "0x1" }
+AptosStdlib = { aptos = "https://archive.mainnet.aptoslabs.com", address = "0x1" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/output.md
@@ -3,8 +3,8 @@ success
 ```mermaid
 flowchart TD
     N0["Pack<br><br>local:testsuite-online/on-chain<br><br>testsuite-online/on-chain"]
-    N1["AptosStdlib<br><br>onchain:fullnode.mainnet.aptoslabs.com::0x1<br><br>cache/on-chain/fullnode.mainnet.aptoslabs.com+3152151123+0x1+AptosStdlib"]
-    N2["MoveStdlib<br><br>onchain:fullnode.mainnet.aptoslabs.com::0x1<br><br>cache/on-chain/fullnode.mainnet.aptoslabs.com+3152151123+0x1+MoveStdlib"]
+    N1["AptosStdlib<br><br>onchain:archive.mainnet.aptoslabs.com::0x1<br><br>cache/on-chain/archive.mainnet.aptoslabs.com+3152151123+0x1+AptosStdlib"]
+    N2["MoveStdlib<br><br>onchain:archive.mainnet.aptoslabs.com::0x1<br><br>cache/on-chain/archive.mainnet.aptoslabs.com+3152151123+0x1+MoveStdlib"]
     N0 --> N1
     N0 --> N2
 


### PR DESCRIPTION
## Description

Four `resolver_tests_online` on-chain tests started failing with:

```
API error Error(VersionPruned): Ledger version(3152151123) has been pruned
```

These tests pin a mainnet ledger version in `Move.lock` so resolution is reproducible. `fullnode.mainnet.aptoslabs.com` retains only ~2 weeks of state history, so the pinned versions were eventually pruned.

This switches the on-chain tests to `archive.mainnet.aptoslabs.com`, which serves full history (`oldest_ledger_version: 0`). The pinned versions are unchanged — the diff is a host rename — so the lock keeps exercising the pin-honoring path and the baselines no longer expire.

## How Has This Been Tested?

`cargo test -p move-package-resolver`. The on-chain tests pass again at their original pinned versions; `on-chain-bad-addr` needed no baseline change at all.

## Key Areas to Review

The diff should contain no version changes — only `fullnode.` → `archive.` in the three manifests, their locks, and the two baselines that embed the host in cache keys and error text. Note that CI now fetches these packages from the archive endpoint.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify) — Move package resolver test suite

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only URL and baseline updates for move-package-resolver online tests; no production resolver or node behavior changes.
> 
> **Overview**
> **Fixes flaky/failing online on-chain resolver tests** that pinned old mainnet ledger versions in `Move.lock` but fetched them via `fullnode.mainnet.aptoslabs.com`, which no longer serves those pruned versions.
> 
> The three `testsuite-online` on-chain fixtures (`on-chain`, `on-chain-bad-addr`, `on-chain-bad-package-name`) now declare Aptos dependencies against **`https://archive.mainnet.aptoslabs.com`**. `Move.lock` on-chain keys and the expected `output.md` baselines (mermaid cache paths and the “package not found” URL) are updated to match the archive host. **Pinned ledger versions are unchanged**—only the RPC host in URLs and golden output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1712cbd52d354a4412dfd30dd000a1322944c9c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->