### PR TITLE
[indexer-grpc] Fix recovered file store version tracking

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-manager/src/data_manager.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-manager/src/data_manager.rs
@@ -32,6 +32,22 @@ use std::{
 use tokio::sync::{mpsc::channel, oneshot::Receiver, RwLock, RwLockReadGuard};
 use tracing::{debug, error, info, trace, warn};
 
+fn update_cached_file_store_version(
+    cached_version: &AtomicU64,
+    file_store_version: u64,
+    version_can_go_backward: bool,
+) {
+    if version_can_go_backward {
+        cached_version.store(file_store_version, Ordering::SeqCst);
+    } else {
+        let file_store_version_before_update =
+            cached_version.fetch_max(file_store_version, Ordering::SeqCst);
+        if file_store_version_before_update > file_store_version {
+            panic!("File store version is going backward, data might be corrupted. {file_store_version_before_update} v.s. {file_store_version}");
+        }
+    }
+}
+
 struct Cache {
     start_version: u64,
     file_store_version: AtomicU64,
@@ -407,14 +423,44 @@ impl DataManager {
     ) {
         let file_store_version = self.file_store_reader.get_latest_version().await;
         if let Some(file_store_version) = file_store_version {
-            let file_store_version_before_update = cache
-                .file_store_version
-                .fetch_max(file_store_version, Ordering::SeqCst);
+            update_cached_file_store_version(
+                &cache.file_store_version,
+                file_store_version,
+                version_can_go_backward,
+            );
             FILE_STORE_VERSION_IN_CACHE.set(file_store_version as i64);
             info!("Updated file_store_version in cache to {file_store_version}.");
-            if !version_can_go_backward && file_store_version_before_update > file_store_version {
-                panic!("File store version is going backward, data might be corrupted. {file_store_version_before_update} v.s. {file_store_version}");
-            };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_cached_file_store_version_allows_backward_update() {
+        let cached_version = AtomicU64::new(100);
+
+        update_cached_file_store_version(&cached_version, 90, true);
+
+        assert_eq!(cached_version.load(Ordering::SeqCst), 90);
+    }
+
+    #[test]
+    fn test_update_cached_file_store_version_moves_forward() {
+        let cached_version = AtomicU64::new(90);
+
+        update_cached_file_store_version(&cached_version, 100, false);
+
+        assert_eq!(cached_version.load(Ordering::SeqCst), 100);
+    }
+
+    #[test]
+    #[should_panic(expected = "File store version is going backward")]
+    fn test_update_cached_file_store_version_rejects_backward_update() {
+        let cached_version = AtomicU64::new(100);
+
+        update_cached_file_store_version(&cached_version, 90, false);
     }
 }


### PR DESCRIPTION
## Description

During master startup, the DataManager updates the cached file store version after the FileStoreUploader finishes recovery.

The current implementation always uses `fetch_max`, even when `version_can_go_backward` is true. As a result, if recovery produces a lower file store version, the cached value remains stale and higher than the recovered version. The flag only suppresses the panic; it does not actually allow the version to move backward.

This change updates the cached version directly when backward movement is allowed. For normal runtime updates, it preserves the existing monotonic `fetch_max` behavior and continues to panic if the file store version moves backward unexpectedly.

## How Has This Been Tested?

- `cargo test -p aptos-indexer-grpc-manager update_cached_file_store_version --lib`
- 3 focused unit tests covering:
  - backward update when allowed
  - forward update
  - backward update rejection

## Type of Change

- [x] Bug fix

## Which Components or Systems Does This Change Impact?

- [x] Full Node (API, Indexer, etc.)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches version tracking used for cache GC and serving in the indexer-grpc manager; behavior change is narrow and covered by new unit tests.
> 
> **Overview**
> Fixes **stale cached file store version** on indexer-grpc manager master startup when **FileStoreUploader recovery** reports a **lower** version than what was read at init.
> 
> Previously `update_file_store_version_in_cache` always used **`fetch_max`**, so with `version_can_go_backward=true` the flag only avoided a panic—the cache could stay **above** the recovered file store version and skew **GC** / version metrics.
> 
> The logic is moved into **`update_cached_file_store_version`**: when backward movement is allowed it **`store`s** the reader version; otherwise it keeps monotonic **`fetch_max`** and panics on unexpected regression. Three unit tests cover allowed backward, forward, and rejected backward paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc845fe22a1c46d886e1357da0ca055bb9a028d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->