### PR TITLE
[config] Keep hot state across restarts on devnet

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -712,6 +712,12 @@ impl ConfigOptimizer for StorageConfig {
                 config.assert_rlimit_nofile = true;
                 modified_config = true;
             }
+            if chain_id.is_devnet()
+                && config_yaml["hot_state_config"]["delete_on_restart"].is_null()
+            {
+                config.hot_state_config.delete_on_restart = false;
+                modified_config = true;
+            }
         }
 
         Ok(modified_config)
@@ -834,7 +840,7 @@ impl ConfigSanitizer for StorageConfig {
 mod test {
     use super::{ShardPathConfig, ShardedDbPathConfig, StorageConfig};
     use crate::config::{config_optimizer::ConfigOptimizer, NodeConfig, NodeType, PrunerConfig};
-    use aptos_types::chain_id::ChainId;
+    use aptos_types::chain_id::{ChainId, NamedChain};
 
     #[test]
     pub fn test_default_prune_window() {
@@ -948,5 +954,65 @@ mod test {
 
         assert_eq!(node_config.storage.ensure_rlimit_nofile, 999_999);
         assert!(node_config.storage.assert_rlimit_nofile);
+    }
+
+    #[test]
+    fn test_optimize_delete_on_restart() {
+        let yaml = serde_yaml::from_str(
+            r#"
+            storage:
+              rocksdb_configs:
+                enable_storage_sharding: true
+            "#,
+        )
+        .unwrap();
+
+        // Devnet disables it, including for the chain IDs devnet actually rotates through.
+        for chain_id in [
+            ChainId::new(NamedChain::DEVNET.id()),
+            ChainId::new(30),
+            ChainId::new(240),
+        ] {
+            let mut node_config = NodeConfig::default();
+            assert!(node_config.storage.hot_state_config.delete_on_restart);
+
+            let modified_config = StorageConfig::optimize(
+                &mut node_config,
+                &yaml,
+                NodeType::Validator,
+                Some(chain_id),
+            )
+            .unwrap();
+            assert!(modified_config);
+            assert!(!node_config.storage.hot_state_config.delete_on_restart);
+        }
+
+        // Other chains keep the default.
+        for chain_id in [ChainId::mainnet(), ChainId::testnet(), ChainId::test()] {
+            let mut node_config = NodeConfig::default();
+            StorageConfig::optimize(&mut node_config, &yaml, NodeType::Validator, Some(chain_id))
+                .unwrap();
+            assert!(node_config.storage.hot_state_config.delete_on_restart);
+        }
+
+        // An explicit setting in the local config wins over the optimizer.
+        let yaml = serde_yaml::from_str(
+            r#"
+            storage:
+              hot_state_config:
+                delete_on_restart: true
+            "#,
+        )
+        .unwrap();
+        let mut node_config = NodeConfig::default();
+        let modified_config = StorageConfig::optimize(
+            &mut node_config,
+            &yaml,
+            NodeType::Validator,
+            Some(ChainId::new(NamedChain::DEVNET.id())),
+        )
+        .unwrap();
+        assert!(!modified_config);
+        assert!(node_config.storage.hot_state_config.delete_on_restart);
     }
 }

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -86,6 +86,12 @@ impl ChainId {
         self.matches_named_chain(NamedChain::MAINNET)
     }
 
+    /// Returns true iff the chain ID matches devnet
+    pub fn is_devnet(&self) -> bool {
+        // NOTE: hardcoded in internal-ops. ID 3 is kept for compatibility with NamedChain::DEVNET.
+        matches!(self.id(), 3 | 10..=49 | 225..=249)
+    }
+
     /// Returns true iff the chain ID matches the given named chain
     fn matches_named_chain(&self, expected_chain: NamedChain) -> bool {
         if let Ok(named_chain) = NamedChain::from_chain_id(self) {
@@ -214,5 +220,28 @@ mod test {
         assert!(ChainId::from_str("255255").is_err());
         assert_eq!(ChainId::from_str("TESTING").unwrap(), ChainId::test());
         assert_eq!(ChainId::from_str("255").unwrap(), ChainId::new(255));
+    }
+
+    #[test]
+    fn test_chain_id_display_roundtrip() {
+        for id in 1..=u8::MAX {
+            let chain_id = ChainId::new(id);
+            assert_eq!(ChainId::from_str(&chain_id.to_string()).unwrap(), chain_id);
+        }
+    }
+
+    #[test]
+    fn test_chain_id_is_devnet() {
+        for id in [3, 10, 49, 225, 249] {
+            assert!(ChainId::new(id).is_devnet(), "{} should be devnet", id);
+        }
+        // Reserved named chains and IDs outside the devnet ranges.
+        for id in [1, 2, 4, 5, 9, 50, 224, 250, 255] {
+            assert!(!ChainId::new(id).is_devnet(), "{} should not be devnet", id);
+        }
+
+        assert!(!ChainId::mainnet().is_devnet());
+        assert!(!ChainId::testnet().is_devnet());
+        assert!(!ChainId::test().is_devnet());
     }
 }


### PR DESCRIPTION

We have enabled hot state on devnet, and `delete_on_restart = false`
is a requirement for it to work. Previous we manually set this in
`internal-ops`, but it's easy to forget. Now that we have added
`ChainId::is_devnet` to help determine if the network is devnet, we
can set it automatically in code.

Have the storage config optimizer clear the flag when the chain ID is
devnet. As with the other rules in this optimizer, an explicit
`delete_on_restart` in the local config yaml still wins.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Devnet-only default tuning for hot-state persistence; explicit YAML overrides remain, and other networks are unchanged.
> 
> **Overview**
> Adds **`ChainId::is_devnet()`** so devnet is recognized by numeric ID ranges (3, 10–49, 225–249), not only `NamedChain::DEVNET`.
> 
> The **storage config optimizer** now sets **`hot_state_config.delete_on_restart = false`** when the chain is devnet and the local YAML does not set that field—so hot state survives restarts without manual internal-ops overrides. An explicit `delete_on_restart` in config still wins.
> 
> Tests cover devnet vs other chains, rotated devnet IDs, and the YAML override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f2cd2a3144061030e6d6c830150da31634547e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->