### PR TITLE
[mono-move] Ability computation and assignability for interned types, with correct closure ability derivation

### DIFF
--- a/third_party/move/mono-move/core/src/abilities.rs
+++ b/third_party/move/mono-move/core/src/abilities.rs
@@ -1,0 +1,321 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Ability computation over interned types.
+//!
+//! A [`Type::Nominal`] carries no abilities, so they are looked up.
+//!
+//! Resolve through the *asking* module's own declaration, which may carry fewer
+//! abilities and fewer phantom markers than the definition. Only that
+//! declaration governs what the module may do with the type, and it can narrow
+//! the definition's set but never widen it.
+//!
+//! TODO(correctness): this relies on the declaration being compatible with the
+//! definition. Revisit whether that reliance is acceptable, and whether
+//! abilities should also be confirmed against the definition somewhere it is
+//! already resolved.
+//!
+//! Note: this is an independent implementation, used in translation validation.
+//! So, it should not reuse existing bytecode verifier implementations.
+
+use crate::{
+    interner::{InternedIdentifier, InternedModuleId},
+    types::{view_type, view_type_list, InternedType, Type},
+    ExecutionErrorKind, IntoExecutionError, PreparedModule,
+};
+use move_binary_format::file_format::StructHandle;
+use move_core_types::ability::AbilitySet;
+use shared_dsa::UnorderedMap;
+use thiserror::Error;
+
+/// Computes abilities of interned types under a fixed type-parameter scope.
+///
+/// `lookup` resolves a nominal to the [`StructHandle`] declaring it, which
+/// carries the abilities and phantom markers this computation needs.
+///
+/// The memo is keyed on the interned type alone. That is sound only because
+/// `ty_param_ctx` and `lookup` are fixed for the calculator's lifetime: both
+/// change the abilities of the same type. Construct a new calculator whenever
+/// either changes.
+pub struct AbilityCalculator<'a, L> {
+    lookup: L,
+    /// Constraints of the enclosing scope's type parameters, indexed by
+    /// [`Type::TypeParam`]'s `idx`.
+    ty_param_ctx: &'a [AbilitySet],
+    memo: UnorderedMap<InternedType, AbilitySet>,
+}
+
+impl<'a, L> AbilityCalculator<'a, L>
+where
+    L: FnMut(InternedModuleId, InternedIdentifier) -> Result<&'a StructHandle, AbilityError>,
+{
+    pub fn new(lookup: L, ty_param_ctx: &'a [AbilitySet]) -> Self {
+        Self {
+            lookup,
+            ty_param_ctx,
+            memo: UnorderedMap::new(),
+        }
+    }
+
+    /// Abilities of `ty` in this calculator's scope.
+    ///
+    /// Inherits safety contract of [`view_type`].
+    ///
+    /// TODO(metering): the memo bounds repeated work but not stack depth, which
+    /// is still linear in type nesting. Same family as the `TODO(metering)` on
+    /// `is_closed_type`.
+    pub fn abilities_of(&mut self, ty: InternedType) -> Result<AbilitySet, AbilityError> {
+        if let Some(cached) = self.memo.get(&ty) {
+            return Ok(*cached);
+        }
+        let abilities = self.compute(ty)?;
+        self.memo.insert(ty, abilities);
+        Ok(abilities)
+    }
+
+    fn compute(&mut self, ty: InternedType) -> Result<AbilitySet, AbilityError> {
+        Ok(match view_type(ty) {
+            Type::Bool
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::U128
+            | Type::U256
+            | Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::I128
+            | Type::I256
+            | Type::Address => AbilitySet::PRIMITIVES,
+
+            Type::Signer => AbilitySet::SIGNER,
+
+            Type::ImmutRef { .. } | Type::MutRef { .. } => AbilitySet::REFERENCES,
+
+            Type::Function { abilities, .. } => *abilities,
+
+            Type::TypeParam { idx } => {
+                *self
+                    .ty_param_ctx
+                    .get(*idx as usize)
+                    .ok_or(AbilityError::TypeParamOutOfRange {
+                        idx: *idx,
+                        num_params: self.ty_param_ctx.len(),
+                    })?
+            },
+
+            // A vector is copy/drop/store exactly when its element is; the
+            // element is stored inside it, so it is never phantom.
+            Type::Vector { elem } => {
+                let elem_abilities = self.abilities_of(*elem)?;
+                instantiated_abilities(AbilitySet::VECTOR, [(false, elem_abilities)])
+            },
+
+            Type::Nominal {
+                module_id,
+                name,
+                ty_args,
+            } => {
+                let handle = (self.lookup)(*module_id, *name)?;
+                let ty_args = view_type_list(*ty_args);
+                if handle.type_parameters.len() != ty_args.len() {
+                    return Err(AbilityError::TypeArgumentArityMismatch {
+                        declared: handle.type_parameters.len(),
+                        actual: ty_args.len(),
+                    });
+                }
+                let mut arg_abilities = Vec::with_capacity(ty_args.len());
+                for ty_arg in ty_args {
+                    arg_abilities.push(self.abilities_of(*ty_arg)?);
+                }
+                instantiated_abilities(
+                    handle.abilities,
+                    handle
+                        .type_parameters
+                        .iter()
+                        .map(|param| param.is_phantom)
+                        .zip(arg_abilities),
+                )
+            },
+        })
+    }
+}
+
+/// Abilities of a polymorphic type once instantiated.
+///
+/// Each declared ability imposes a requirement on every non-phantom argument:
+/// copy, drop, and store require themselves; key requires store. The ability is
+/// kept only if every such argument meets it. Phantom arguments are not part of
+/// the value, so they impose nothing.
+///
+/// Callers must pass one argument per declared type parameter.
+fn instantiated_abilities(
+    declared: AbilitySet,
+    type_arguments: impl IntoIterator<Item = (bool, AbilitySet)>,
+) -> AbilitySet {
+    let mut result = declared;
+    for (is_phantom, argument) in type_arguments {
+        if is_phantom {
+            continue;
+        }
+        for ability in declared.iter() {
+            if !argument.has_ability(ability.requires()) {
+                result = result.remove(ability);
+            }
+        }
+    }
+    result
+}
+
+/// Builds a lookup closure backed by one [`PreparedModule`]'s handle table.
+///
+/// The table holds every nominal the module can name, so a miss is
+/// [`AbilityError::UnknownNominal`].
+pub fn module_nominal_lookup<'m>(
+    module: &'m PreparedModule,
+) -> impl FnMut(InternedModuleId, InternedIdentifier) -> Result<&'m StructHandle, AbilityError> + 'm
+{
+    |module_id, name| {
+        module
+            .nominal_handle(module_id, name)
+            .ok_or(AbilityError::UnknownNominal)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AbilityError {
+    #[error("no ability information for nominal type in scope")]
+    UnknownNominal,
+
+    #[error("type parameter {idx} out of range: {num_params} parameter(s) in scope")]
+    TypeParamOutOfRange { idx: u16, num_params: usize },
+
+    #[error("nominal declares {declared} type parameter(s) but the type carries {actual}")]
+    TypeArgumentArityMismatch { declared: usize, actual: usize },
+}
+
+impl IntoExecutionError for AbilityError {
+    fn kind(&self) -> ExecutionErrorKind {
+        use AbilityError::*;
+        match self {
+            // Each is established before translation: nominal resolution,
+            // type-parameter scoping, and instantiation arity.
+            UnknownNominal | TypeParamOutOfRange { .. } | TypeArgumentArityMismatch { .. } => {
+                ExecutionErrorKind::InvariantViolation
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_core_types::ability::Ability;
+
+    /// Every `AbilitySet`: the domain is 4 bits, so "exhaustive" is 16 values.
+    fn all_ability_sets() -> Vec<AbilitySet> {
+        (0u8..16)
+            .map(|bits| AbilitySet::from_u8(bits).expect("4-bit set"))
+            .collect()
+    }
+
+    /// Pins the derivation to `polymorphic_abilities` over the entire input
+    /// domain for arities 0..=2: all 16 declared sets against every
+    /// `(phantom, argument)` pair drawn from 2 x 16.
+    #[test]
+    fn agrees_with_the_verifier_on_every_input() {
+        let sets = all_ability_sets();
+        let mut checked = 0usize;
+
+        for &declared in &sets {
+            // Arity 0.
+            assert_eq!(
+                instantiated_abilities(declared, []),
+                AbilitySet::polymorphic_abilities(declared, [], []).expect("arity 0"),
+            );
+            checked += 1;
+
+            for &phantom_a in &[false, true] {
+                for &arg_a in &sets {
+                    assert_eq!(
+                        instantiated_abilities(declared, [(phantom_a, arg_a)]),
+                        AbilitySet::polymorphic_abilities(declared, [phantom_a], [arg_a])
+                            .expect("arity 1"),
+                        "declared={declared:?} phantom={phantom_a} arg={arg_a:?}",
+                    );
+                    checked += 1;
+
+                    for &phantom_b in &[false, true] {
+                        for &arg_b in &sets {
+                            assert_eq!(
+                                instantiated_abilities(declared, [
+                                    (phantom_a, arg_a),
+                                    (phantom_b, arg_b)
+                                ]),
+                                AbilitySet::polymorphic_abilities(
+                                    declared,
+                                    [phantom_a, phantom_b],
+                                    [arg_a, arg_b]
+                                )
+                                .expect("arity 2"),
+                                "declared={declared:?} args=[{arg_a:?}, {arg_b:?}]",
+                            );
+                            checked += 1;
+                        }
+                    }
+                }
+            }
+        }
+        // 16 * (1 + 32 * (1 + 32)) = 16 * 1057
+        assert_eq!(checked, 16 * (1 + 32 * (1 + 32)));
+    }
+
+    #[test]
+    fn key_is_predicated_on_store_not_on_key() {
+        // The one asymmetric rule: `a.requires()` is `a` for copy/drop/store
+        // but `store` for key, so a `key` struct needs `store` arguments.
+        let key_only = AbilitySet::EMPTY | Ability::Key;
+        let store_only = AbilitySet::EMPTY | Ability::Store;
+
+        assert_eq!(
+            instantiated_abilities(key_only, [(false, store_only)]),
+            key_only,
+            "a store-only argument keeps key"
+        );
+        assert_eq!(
+            instantiated_abilities(key_only, [(false, key_only)]),
+            AbilitySet::EMPTY,
+            "a key-only argument does not supply store, so key is stripped"
+        );
+    }
+
+    #[test]
+    fn phantom_arguments_never_predicate() {
+        // A phantom parameter holds no runtime value, so even the empty set
+        // takes nothing away.
+        for &declared in &all_ability_sets() {
+            assert_eq!(
+                instantiated_abilities(declared, [(true, AbilitySet::EMPTY)]),
+                declared,
+            );
+        }
+    }
+
+    #[test]
+    fn abilities_are_only_ever_removed() {
+        // Instantiation is monotone downward: an argument can strip a declared
+        // ability but never add one.
+        let sets = all_ability_sets();
+        for &declared in &sets {
+            for &arg in &sets {
+                let result = instantiated_abilities(declared, [(false, arg)]);
+                assert!(
+                    result.is_subset(declared),
+                    "{result:?} not subset {declared:?}"
+                );
+            }
+        }
+    }
+}

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+pub mod abilities;
 pub mod align;
 mod error;
 mod function;
@@ -57,7 +58,7 @@ pub use storage::{
     nominal_tag, ModuleProvider, NoModuleProvider, NoResourceProvider, ResourceProvider,
     ResourceProviderError, StorageRead,
 };
-pub use types::{convert_mut_to_immut_ref, strip_ref};
+pub use types::{convert_mut_to_immut_ref, is_assignable, strip_ref};
 pub use value_layout::{
     reserved_layout_id, reserved_layouts, FieldValueLayout, LayoutFlags, LayoutId, LayoutKind,
     LayoutProvider, ValueLayout, ValueLayoutTable,

--- a/third_party/move/mono-move/core/src/prepared_module.rs
+++ b/third_party/move/mono-move/core/src/prepared_module.rs
@@ -62,6 +62,15 @@ pub struct PreparedModule {
     ///
     /// Indexed by [`StructHandleIndex`].
     nominal_types: Vec<InternedType>,
+    /// Interned identity -> the [`StructHandle`] declaring it, for every
+    /// nominal this module can name, local or imported.
+    ///
+    /// We just need an index: the handle already lives in [`Self::module`] and
+    /// carries both the declared abilities and the phantom markers. A module may
+    /// declare an imported nominal with fewer of each than its definition, and
+    /// that narrower declaration governs the module's own code, so it is the
+    /// right basis for checking it.
+    nominal_handles: UnorderedMap<(InternedModuleId, InternedIdentifier), StructHandleIndex>,
     /// Maps struct or enum name to its local [`StructDefinitionIndex`].
     nominal_definitions: UnorderedMap<InternedIdentifier, StructDefinitionIndex>,
     /// Interned struct or enum field types from compiled module. Only for
@@ -208,6 +217,19 @@ impl PreparedModule {
             FieldTypes::Enum(variants) => Some(variants[variant_idx as usize].as_slice()),
             FieldTypes::Struct(..) => None,
         }
+    }
+
+    /// The [`StructHandle`] by which this module declares a nominal type,
+    /// carrying its abilities and type-parameter metadata. Resolves local and
+    /// imported nominals alike; returns [`None`] for a nominal this module
+    /// cannot name.
+    pub fn nominal_handle(
+        &self,
+        module_id: InternedModuleId,
+        name: InternedIdentifier,
+    ) -> Option<&StructHandle> {
+        let idx = self.nominal_handles.get(&(module_id, name))?;
+        Some(self.module.struct_handle_at(*idx))
     }
 
     /// Looks up a struct or enum definition by its interned name, and returns
@@ -416,22 +438,29 @@ impl PreparedModule {
         // index, to intern_sig_token. That way, we could avoid re-interning the nominal in the
         // Struct case, or the module_id + struct_name in the StructInstantiation case. It saves
         // a few hashmap lookups per struct reference, which may add up across the signature.
-        let nominal_types = module
-            .struct_handles
-            .iter()
-            .map(|handle| {
-                let (module_id, name) = intern_struct_handle(handle, &module, interner);
-                let ty_args = if handle.type_parameters.is_empty() {
-                    EMPTY_TYPE_LIST
-                } else {
-                    let params = (0..handle.type_parameters.len())
-                        .map(|idx| interner.type_param_of(idx as u16))
-                        .collect::<Vec<_>>();
-                    interner.type_list_of(&params)
-                };
-                interner.nominal_of(module_id, name, ty_args)
-            })
-            .collect();
+        let mut nominal_types = Vec::with_capacity(module.struct_handles.len());
+        let mut nominal_handles = UnorderedMap::with_capacity(module.struct_handles.len());
+        for (handle_idx, handle) in module.struct_handles.iter().enumerate() {
+            let (module_id, name) = intern_struct_handle(handle, &module, interner);
+            let ty_args = if handle.type_parameters.is_empty() {
+                EMPTY_TYPE_LIST
+            } else {
+                let params = (0..handle.type_parameters.len())
+                    .map(|idx| interner.type_param_of(idx as u16))
+                    .collect::<Vec<_>>();
+                interner.type_list_of(&params)
+            };
+            nominal_types.push(interner.nominal_of(module_id, name, ty_args));
+
+            // Uniqueness is a trusted bytecode-verification result.
+            // Debug-asserted rather than re-checked.
+            let previous =
+                nominal_handles.insert((module_id, name), StructHandleIndex(handle_idx as u16));
+            debug_assert!(
+                previous.is_none(),
+                "duplicate struct handle for one (module, name)"
+            );
+        }
 
         let mut nominal_definitions = UnorderedMap::with_capacity(module.struct_defs().len());
         let field_types = module
@@ -508,6 +537,7 @@ impl PreparedModule {
             id,
             signatures,
             nominal_types,
+            nominal_handles,
             nominal_definitions,
             field_types,
             constant_types,

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -173,6 +173,74 @@ pub fn strip_ref(ref_ty: InternedType) -> Option<InternedType> {
     Some(*inner)
 }
 
+/// Whether a value of type `actual` may be used where `expected` is required.
+///
+/// - Identical types are assignable.
+/// - Two [`Type::Function`]s are assignable when their argument and result
+///   lists are identical and `expected`'s abilities are a subset of `actual`'s.
+/// - Two [`Type::ImmutRef`]s are assignable when their pointees are.
+/// - Nothing else is assignable; in particular, `&mut T` and `&T` are not.
+///
+/// # Preconditions
+///
+/// Both types must come from the same interner, and from the same
+/// type-parameter scope: a [`Type::TypeParam`] is interned by index alone, so
+/// parameters sharing an index across scopes are the same pointer.
+///
+/// Inherits safety contract of [`view_type`].
+///
+/// TODO(metering): unbounded recursion on reference nesting; same family as the
+/// `TODO(metering)` on [`is_closed_type`]. Depth is 1 in practice because
+/// nested references are not expressible.
+pub fn is_assignable(expected: InternedType, actual: InternedType) -> bool {
+    // Interning makes pointer equality structural equality, which settles every
+    // invariant constructor: below, only the two variant positions do work.
+    if expected == actual {
+        return true;
+    }
+    match view_type(expected) {
+        Type::Function {
+            args,
+            results,
+            abilities,
+        } => matches!(
+            view_type(actual),
+            Type::Function {
+                args: actual_args,
+                results: actual_results,
+                abilities: actual_abilities,
+            } if args == actual_args
+                && results == actual_results
+                && abilities.is_subset(*actual_abilities)
+        ),
+        Type::ImmutRef { inner } => matches!(
+            view_type(actual),
+            Type::ImmutRef { inner: actual_inner } if is_assignable(*inner, *actual_inner)
+        ),
+        // Invariant: pointer inequality above already decided these. Listed
+        // explicitly so a new `Type` variant forces a variance decision.
+        Type::Bool
+        | Type::U8
+        | Type::U16
+        | Type::U32
+        | Type::U64
+        | Type::U128
+        | Type::U256
+        | Type::I8
+        | Type::I16
+        | Type::I32
+        | Type::I64
+        | Type::I128
+        | Type::I256
+        | Type::Address
+        | Type::Signer
+        | Type::MutRef { .. }
+        | Type::Vector { .. }
+        | Type::Nominal { .. }
+        | Type::TypeParam { .. } => false,
+    }
+}
+
 /// Whether `ty` contains no [`Type::TypeParam`] node.
 ///
 /// Inherits safety contract of [`view_type`].
@@ -442,12 +510,16 @@ pub fn display_type(f: &mut fmt::Formatter<'_>, ty: InternedType) -> fmt::Result
             }
             Ok(())
         },
-        Type::Function { args, results, .. } => {
+        Type::Function {
+            args,
+            results,
+            abilities,
+        } => {
             write!(f, "|")?;
             display_type_list(f, *args)?;
             write!(f, "|")?;
             display_type_list(f, *results)?;
-            Ok(())
+            write!(f, "{}", abilities.display_postfix())
         },
     }
 }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -16,6 +16,7 @@ use crate::{
     validate::TranslationWitness,
 };
 use mono_move_core::{
+    abilities::{module_nominal_lookup, AbilityCalculator, AbilityError},
     convert_mut_to_immut_ref, strip_ref,
     types::{self as ty, view_type, view_type_list, InternedType, InternedTypeList, Type},
     ExecutionErrorKind, IntTy, Interner, IntoExecutionError, PreparedModule, VMInternalError,
@@ -24,12 +25,14 @@ use mono_move_core::{
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
-        Bytecode, CodeOffset, FieldHandleIndex, FieldInstantiationIndex, FunctionHandleIndex,
-        FunctionInstantiationIndex, StructDefInstantiationIndex, StructDefinitionIndex,
-        StructFieldInformation, StructVariantInstantiationIndex, VariantFieldHandleIndex,
-        VariantFieldInstantiationIndex, VariantIndex,
+        Bytecode, CodeOffset, FieldHandleIndex, FieldInstantiationIndex, FunctionAttribute,
+        FunctionHandle, FunctionHandleIndex, FunctionInstantiationIndex,
+        StructDefInstantiationIndex, StructDefinitionIndex, StructFieldInformation,
+        StructVariantInstantiationIndex, VariantFieldHandleIndex, VariantFieldInstantiationIndex,
+        VariantIndex,
     },
 };
+use move_core_types::{ability::AbilitySet, function::ClosureMask};
 use shared_dsa::{Entry, UnorderedMap};
 use std::ops::Range;
 use thiserror::Error;
@@ -48,6 +51,15 @@ enum SsaConversionError {
 
     #[error("ValueId {value_id} out of range")]
     ValueIdOutOfRange { value_id: u16 },
+
+    #[error("closure mask captures parameter {max_captured} of a {num_params}-parameter function")]
+    ClosureMaskOutOfRange {
+        max_captured: usize,
+        num_params: usize,
+    },
+
+    #[error("closure captured value abilities: {0}")]
+    CapturedAbilities(#[from] AbilityError),
 
     #[error("expected a ValueId slot on the operand stack")]
     ExpectedValueIdOnStack,
@@ -88,8 +100,10 @@ impl IntoExecutionError for SsaConversionError {
             | ExpectedEnumType
             | ClosureSignatureEmpty
             | ClosureSignatureNotFunction
+            | ClosureMaskOutOfRange { .. }
             | ExpectedReferenceType
             | ExpectedMutableReference => ExecutionErrorKind::InvariantViolation,
+            CapturedAbilities(err) => err.kind(),
         }
     }
 }
@@ -145,6 +159,9 @@ pub(crate) struct SsaConverter<'a, I: Interner> {
     local_types: Vec<InternedType>,
     /// Types of value IDs, indexed directly by value ID number.
     value_id_types: Vec<InternedType>,
+    /// Ability constraints on the enclosing function's type parameters, indexed
+    /// by [`Type::TypeParam`]'s `idx`.
+    ty_param_constraints: &'a [AbilitySet],
     /// Interner for composite type construction.
     interner: &'a I,
     /// Completed basic blocks.
@@ -162,12 +179,17 @@ pub(crate) struct SsaConverter<'a, I: Interner> {
 }
 
 impl<'a, I: Interner> SsaConverter<'a, I> {
-    pub(crate) fn new(local_types: Vec<InternedType>, interner: &'a I) -> Self {
+    pub(crate) fn new(
+        local_types: Vec<InternedType>,
+        ty_param_constraints: &'a [AbilitySet],
+        interner: &'a I,
+    ) -> Self {
         Self {
             next_value_id: 0,
             stack: Vec::new(),
             local_types,
             value_id_types: Vec::new(),
+            ty_param_constraints,
             interner,
             blocks: Vec::new(),
             current_block_instrs: InstrSeq::new(),
@@ -193,6 +215,67 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             .ok_or(SsaConversionError::TooManySsaValues)?;
         self.value_id_types.push(ty);
         Ok(value_id)
+    }
+
+    /// Interned type of the value produced by `PackClosure`: the callee's
+    /// non-captured parameters (what a caller must still supply), its
+    /// returns, and the closure's own abilities.
+    ///
+    /// The abilities begin as the callee's: copy and drop, plus store when the
+    /// function is persistent. That set is intersected with the abilities of
+    /// every captured value.
+    ///
+    /// `params` must already be instantiated at the call site's type
+    /// arguments, if any.
+    ///
+    /// Note: we should not share this derivation with code that validates its
+    /// result.
+    fn closure_type(
+        &self,
+        module: &PreparedModule,
+        handle: &FunctionHandle,
+        params: &[InternedType],
+        returns: InternedTypeList,
+        mask: ClosureMask,
+        captured: &[SsaSlot],
+    ) -> VMResult<InternedType> {
+        if let Some(max_captured) = mask.max_captured()
+            && max_captured >= params.len()
+        {
+            return Err(VMInternalError::new(
+                SsaConversionError::ClosureMaskOutOfRange {
+                    max_captured,
+                    num_params: params.len(),
+                },
+            ));
+        }
+        let not_captured = params
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, ty)| (!mask.is_captured(idx)).then_some(*ty))
+            .collect::<Vec<_>>();
+        let not_captured = self.interner.type_list_of(&not_captured);
+
+        let mut abilities = if handle.attributes.contains(&FunctionAttribute::Persistent) {
+            AbilitySet::PUBLIC_FUNCTIONS
+        } else {
+            AbilitySet::PRIVATE_FUNCTIONS
+        };
+        // TODO(perf): both bindings are fixed for the whole conversion, so this
+        // could be hoisted to `convert_bytecode` and threaded down, letting the
+        // memo survive across closures. Needs a `&mut` parameter rather than a
+        // field, since `closure_type` borrows `self` for `value_id_type`.
+        let mut calculator =
+            AbilityCalculator::new(module_nominal_lookup(module), self.ty_param_constraints);
+        for slot in captured {
+            let captured_ty = self.value_id_type(*slot)?;
+            let captured_abilities = calculator
+                .abilities_of(captured_ty)
+                .map_err(SsaConversionError::CapturedAbilities)?;
+            abilities = abilities.intersect(captured_abilities);
+        }
+
+        Ok(self.interner.function_of(not_captured, returns, abilities))
     }
 
     fn push_slot(&mut self, r: SsaSlot) {
@@ -1021,17 +1104,15 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
                 let captured_count = mask.captured_count() as usize;
                 let captured = self.pop_n_reverse(captured_count)?;
                 let handle = module.function_handle_at(*fhi);
-                let params = self
-                    .interner
-                    .type_list_of(module.interned_types_at(handle.parameters));
-                let returns = self
-                    .interner
-                    .type_list_of(module.interned_types_at(handle.return_));
-                let ty = self.interner.function_of(
-                    params,
-                    returns,
-                    move_core_types::ability::AbilitySet::EMPTY,
-                );
+                let signature = module.function_signature_at(*fhi);
+                let ty = self.closure_type(
+                    module,
+                    handle,
+                    ty::view_type_list(signature.params),
+                    signature.returns,
+                    *mask,
+                    &captured,
+                )?;
                 let dst = self.alloc_value_id(ty)?;
                 self.emit(Instr::PackClosure {
                     data: Box::new(PackClosureData {
@@ -1047,28 +1128,24 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::PackClosureGeneric(fii, mask) => {
                 let captured_count = mask.captured_count() as usize;
                 let captured = self.pop_n_reverse(captured_count)?;
-                let (handle_idx, ty_args) = self.fun_inst_parts(module, *fii);
+                let handle_idx = module.function_instantiation_at(*fii).handle;
                 let handle = module.function_handle_at(handle_idx);
-                let params = self
-                    .interner
-                    .type_list_of(module.interned_types_at(handle.parameters));
-                let returns = self
-                    .interner
-                    .type_list_of(module.interned_types_at(handle.return_));
-
-                let params = self.interner.subst_type_list(params, ty_args)?;
-                let returns = self.interner.subst_type_list(returns, ty_args)?;
-                let ty = self.interner.function_of(
-                    params,
-                    returns,
-                    move_core_types::ability::AbilitySet::EMPTY,
-                );
+                // Already substituted under the instantiation's type arguments.
+                let signature = module.function_instantiation_signature_at(*fii);
+                let ty = self.closure_type(
+                    module,
+                    handle,
+                    ty::view_type_list(signature.params),
+                    signature.returns,
+                    *mask,
+                    &captured,
+                )?;
                 let dst = self.alloc_value_id(ty)?;
                 self.emit(Instr::PackClosure {
                     data: Box::new(PackClosureData {
                         dst,
                         function_handle: handle_idx,
-                        ty_args,
+                        ty_args: signature.ty_args,
                         mask: *mask,
                         captured,
                     }),

--- a/third_party/move/mono-move/specializer/src/destack/translate.rs
+++ b/third_party/move/mono-move/specializer/src/destack/translate.rs
@@ -59,7 +59,7 @@ pub fn translate_module(module: PreparedModule, interner: &impl Interner) -> VMR
                 .collect::<Vec<_>>();
 
             // Pass: Bytecode -> Intra-Block SSA -> Fusion
-            let converter = SsaConverter::new(local_types, interner);
+            let converter = SsaConverter::new(local_types, &handle.type_parameters, interner);
             let (ssa, witness) = converter.convert_function(&module, &code.code)?;
             let ssa = ssa.with_fusion_passes()?.with_test_utils_passes(&module)?;
 

--- a/third_party/move/mono-move/testsuite/src/engine.rs
+++ b/third_party/move/mono-move/testsuite/src/engine.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Result};
 use mono_move_core::{
-    native::{NativeExtensions, NativeName},
+    native::{NativeExtensions, NativeName, NoNatives},
     types::EMPTY_TYPE_LIST,
     Function, GasMeter, Interner, NoResourceProvider,
 };
@@ -27,6 +27,7 @@ use mono_move_runtime::{
 use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, vm_status::AbortLocation,
 };
+use specializer::ModuleIR;
 
 /// Gas budget for engine runs. Effectively unbounded.
 const GAS_BUDGET: u64 = u64::MAX;
@@ -217,6 +218,37 @@ pub fn with_mono_function<'guard, 'ctx, R>(
         gc_count: 0,
     };
     Ok(body(&mut runner))
+}
+
+/// Compile `source`, load `0x1::module_name`, and hand its IR to `body`
+/// alongside the live execution guard.
+///
+/// `R` must not contain an `InternedType`: those are arena pointers that
+/// dangle once the guard is dropped.
+pub fn with_loaded_module<R>(
+    source: &str,
+    module_name: &IdentStr,
+    body: impl FnOnce(&ExecutionGuard, &ModuleIR) -> R,
+) -> Result<R> {
+    let modules = compile(source, SourceKind::Move)?;
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx
+        .try_execution_context(0)
+        .ok_or_else(|| anyhow!("failed to acquire execution guard 0"))?;
+    let mut module_provider = InMemoryModuleProvider::new();
+    module_provider.add_modules(&modules);
+
+    let loader = Loader::new_with_policy(
+        &guard,
+        &module_provider,
+        LoadingPolicy::Lazy(LoweringPolicy::Eager),
+        &NoNatives,
+    );
+    let mut read_set = ModuleReadSet::new();
+    let mut gas_meter = GasMeter::with_max_budget();
+    let id = guard.intern_address_name(&AccountAddress::ONE, module_name);
+    let module_ir = loader.load_module(&mut read_set, &mut gas_meter, id)?.ir();
+    Ok(body(&guard, module_ir))
 }
 
 /// Compile/assemble `source`, build a fresh [`GlobalContext`] + module

--- a/third_party/move/mono-move/testsuite/src/lib.rs
+++ b/third_party/move/mono-move/testsuite/src/lib.rs
@@ -20,7 +20,8 @@ pub use compile::{
     assemble_masm_source, compile, compile_move_path, compile_move_source, SourceKind,
 };
 pub use engine::{
-    build_natives, with_loaded_mono_function, with_mono_function, MonoRunner, RunResult,
+    build_natives, with_loaded_module, with_loaded_mono_function, with_mono_function, MonoRunner,
+    RunResult,
 };
 pub use module_provider::InMemoryModuleProvider;
 pub use resource_provider::InMemoryResourceProvider;

--- a/third_party/move/mono-move/testsuite/tests/abilities_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/abilities_tests.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `AbilityCalculator` behavior that valid Move cannot exercise: malformed
+//! inputs, and rules whose callers do not exist yet.
+
+use mono_move_core::{
+    abilities::{module_nominal_lookup, AbilityCalculator, AbilityError},
+    types::{InternedType, EMPTY_TYPE_LIST, U64_TY},
+    Interner, PreparedModule,
+};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_testsuite::with_loaded_module;
+use move_core_types::{
+    ability::{Ability, AbilitySet},
+    account_address::AccountAddress,
+    ident_str,
+    identifier::IdentStr,
+};
+
+const SOURCE: &str = r#"
+module 0x1::a {
+    struct Res has key, store { x: u64 }
+    struct Box<T> has copy, drop, store { x: T }
+    // Constraint recorded on the parameter, not on the nominal.
+    struct Constrained<T: copy + drop> has copy, drop { x: T }
+
+    public fun touch(_b: &Box<u64>, _c: &Constrained<u64>, _r: &Res) {}
+}
+"#;
+
+/// Loads the shared test module and runs `check` on its prepared form.
+fn with_module(check: impl FnOnce(&ExecutionGuard, &PreparedModule)) {
+    with_loaded_module(SOURCE, ident_str!("a"), |guard, module_ir| {
+        check(guard, &module_ir.module)
+    })
+    .expect("module load failed");
+}
+
+/// Abilities of `ty` under `module`'s view, with `ty_param_ctx` in scope.
+fn abilities_in(
+    module: &PreparedModule,
+    ty: InternedType,
+    ty_param_ctx: &[AbilitySet],
+) -> Result<AbilitySet, AbilityError> {
+    AbilityCalculator::new(module_nominal_lookup(module), ty_param_ctx).abilities_of(ty)
+}
+
+/// Interned type of the nominal named `name`, instantiated at `ty_args`.
+fn nominal(
+    guard: &ExecutionGuard,
+    module: &PreparedModule,
+    name: &IdentStr,
+    ty_args: &[InternedType],
+) -> InternedType {
+    guard.nominal_of(
+        module.id(),
+        guard.identifier_of(name),
+        guard.type_list_of(ty_args),
+    )
+}
+
+/// A reference is copy and drop but never store, whatever it points to.
+///
+/// Unreachable today: a captured value may not be a reference, and captures are
+/// the only caller. It becomes live once slot types are checked.
+#[test]
+fn references_are_copy_drop_but_never_store() {
+    with_module(|guard, module| {
+        let res = nominal(guard, module, ident_str!("Res"), &[]);
+        for ty in [
+            guard.immut_ref_of(U64_TY),
+            guard.mut_ref_of(U64_TY),
+            // The pointee does not predicate: `&Res` is copy+drop even though
+            // `Res` is neither.
+            guard.immut_ref_of(res),
+        ] {
+            assert_eq!(
+                abilities_in(module, ty, &[]).expect("reference must resolve"),
+                set(&[Ability::Copy, Ability::Drop]),
+            );
+        }
+    });
+}
+
+/// A nominal whose argument count disagrees with its declaration is rejected
+/// rather than derived from the shorter of the two.
+///
+/// The derivation zips parameters against arguments, and `zip` stops at the
+/// shorter side, so without this check a mismatch would silently yield
+/// abilities computed from a prefix.
+#[test]
+fn type_argument_arity_mismatch_is_rejected_not_truncated() {
+    with_module(|guard, module| {
+        // `Box` declares one parameter; hand it two.
+        let bogus = nominal(guard, module, ident_str!("Box"), &[U64_TY, U64_TY]);
+        let err = abilities_in(module, bogus, &[]).unwrap_err();
+        assert!(
+            matches!(err, AbilityError::TypeArgumentArityMismatch {
+                declared: 1,
+                actual: 2
+            }),
+            "unexpected error: {err}"
+        );
+    });
+}
+
+/// A nominal the module cannot name, and a type parameter outside the bound
+/// scope, are both errors rather than defaults.
+#[test]
+fn unresolvable_inputs_are_errors() {
+    with_module(|guard, module| {
+        let elsewhere = guard.module_id_of(&AccountAddress::TWO, ident_str!("elsewhere"));
+        let foreign = guard.nominal_of(
+            elsewhere,
+            guard.identifier_of(ident_str!("Res")),
+            EMPTY_TYPE_LIST,
+        );
+        assert!(matches!(
+            abilities_in(module, foreign, &[]).unwrap_err(),
+            AbilityError::UnknownNominal
+        ));
+
+        let one_param = [set(&[Ability::Copy])];
+        assert!(matches!(
+            abilities_in(module, guard.type_param_of(3), &one_param).unwrap_err(),
+            AbilityError::TypeParamOutOfRange {
+                idx: 3,
+                num_params: 1
+            }
+        ));
+        assert!(matches!(
+            abilities_in(module, guard.type_param_of(0), &[]).unwrap_err(),
+            AbilityError::TypeParamOutOfRange { .. }
+        ));
+    });
+}
+
+/// Per-parameter ability constraints are recorded on the handle.
+///
+/// Ability derivation reads only `is_phantom`, so nothing else would notice if
+/// these were dropped; they are stored for type-argument constraint checking.
+#[test]
+fn type_parameter_constraints_are_recorded() {
+    with_module(|guard, module| {
+        let handle = module
+            .nominal_handle(module.id(), guard.identifier_of(ident_str!("Constrained")))
+            .expect("nominal not in table");
+        assert_eq!(
+            handle.type_parameters[0].constraints,
+            set(&[Ability::Copy, Ability::Drop])
+        );
+    });
+}
+
+fn set(abilities: &[Ability]) -> AbilitySet {
+    abilities
+        .iter()
+        .fold(AbilitySet::EMPTY, |acc, ability| acc | *ability)
+}

--- a/third_party/move/mono-move/testsuite/tests/assignability_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/assignability_tests.rs
@@ -1,0 +1,241 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Integration tests for `is_assignable` on interned types.
+
+use mono_move_core::{
+    intern_sig_token, is_assignable,
+    types::{BOOL_TY, EMPTY_TYPE_LIST, U64_TY},
+    Interner, PreparedModule,
+};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_testsuite::with_loaded_module;
+use move_binary_format::file_format::SignatureToken;
+use move_core_types::{
+    ability::{Ability, AbilitySet},
+    account_address::AccountAddress,
+    ident_str,
+};
+
+/// A trivial module, used only to satisfy `intern_sig_token`'s signature. Every
+/// token generated below is struct-free, so the module is never consulted.
+const HOST_MODULE: &str = r#"
+module 0x1::a {
+    struct S has copy, drop, store { x: u64 }
+    public fun f(_s: &S) {}
+}
+"#;
+
+fn with_context(check: impl FnOnce(&ExecutionGuard, &PreparedModule)) {
+    with_loaded_module(HOST_MODULE, ident_str!("a"), |guard, module_ir| {
+        check(guard, &module_ir.module)
+    })
+    .expect("module load failed");
+}
+
+fn func(
+    args: Vec<SignatureToken>,
+    results: Vec<SignatureToken>,
+    abilities: &[Ability],
+) -> SignatureToken {
+    let abilities = abilities
+        .iter()
+        .fold(AbilitySet::EMPTY, |acc, ability| acc | *ability);
+    SignatureToken::Function(args, results, abilities)
+}
+
+/// Struct-free tokens (interning a struct token needs a module) covering every
+/// constructor, plus the shapes where disagreement is plausible: differing
+/// abilities and arities, references over function types, and nesting.
+///
+/// Enumerate rather than generate: generators omit function types, without
+/// which every pair reduces to equality.
+fn token_pool() -> Vec<SignatureToken> {
+    use SignatureToken::*;
+
+    let copy_drop = &[Ability::Copy, Ability::Drop][..];
+    let drop_only = &[Ability::Drop][..];
+    let all = &[Ability::Copy, Ability::Drop, Ability::Store][..];
+
+    let f_none = func(vec![U64], vec![U64], &[]);
+    let f_drop = func(vec![U64], vec![U64], drop_only);
+    let f_copy_drop = func(vec![U64], vec![U64], copy_drop);
+    let f_all = func(vec![U64], vec![U64], all);
+    // Same abilities, different shapes.
+    let f_other_arg = func(vec![Bool], vec![U64], copy_drop);
+    let f_other_ret = func(vec![U64], vec![Bool], copy_drop);
+    let f_extra_arg = func(vec![U64, U64], vec![U64], copy_drop);
+    let f_no_ret = func(vec![U64], vec![], copy_drop);
+    // Function types nested inside a function's own signature.
+    let f_nested_arg = func(vec![f_drop.clone()], vec![], copy_drop);
+    let f_nested_arg_strong = func(vec![f_copy_drop.clone()], vec![], copy_drop);
+
+    vec![
+        Bool,
+        U8,
+        U64,
+        U128,
+        I64,
+        I128,
+        Address,
+        Signer,
+        TypeParameter(0),
+        TypeParameter(1),
+        Vector(Box::new(U64)),
+        Vector(Box::new(Bool)),
+        Vector(Box::new(f_drop.clone())),
+        Vector(Box::new(f_copy_drop.clone())),
+        Reference(Box::new(U64)),
+        Reference(Box::new(f_none.clone())),
+        Reference(Box::new(f_drop.clone())),
+        Reference(Box::new(f_copy_drop.clone())),
+        Reference(Box::new(Reference(Box::new(f_drop.clone())))),
+        Reference(Box::new(Reference(Box::new(f_copy_drop.clone())))),
+        MutableReference(Box::new(U64)),
+        MutableReference(Box::new(f_none.clone())),
+        MutableReference(Box::new(f_drop.clone())),
+        MutableReference(Box::new(f_copy_drop.clone())),
+        f_none,
+        f_drop,
+        f_copy_drop,
+        f_all,
+        f_other_arg,
+        f_other_ret,
+        f_extra_arg,
+        f_no_ret,
+        f_nested_arg,
+        f_nested_arg_strong,
+    ]
+}
+
+/// Every ordered pair from the pool must get the same answer from the derived
+/// rule and from `is_assignable_from`.
+#[test]
+fn agrees_with_the_verifier_on_all_pairs() {
+    with_context(|guard, module| {
+        let pool = token_pool();
+        let interned = pool
+            .iter()
+            .map(|tok| intern_sig_token(tok, module, guard))
+            .collect::<Vec<_>>();
+
+        let mut assignable_unequal = 0;
+        for (i, expected_tok) in pool.iter().enumerate() {
+            for (j, actual_tok) in pool.iter().enumerate() {
+                let oracle = expected_tok.is_assignable_from(actual_tok);
+                let derived = is_assignable(interned[i], interned[j]);
+                assert_eq!(
+                    oracle, derived,
+                    "disagreement on expected={expected_tok:?}, actual={actual_tok:?}"
+                );
+                if i != j && derived {
+                    assignable_unequal += 1;
+                }
+            }
+        }
+        // Guard against a vacuous sweep: the pool must contain pairs that are
+        // assignable without being identical, i.e. the ability-widening arm.
+        assert!(
+            assignable_unequal > 0,
+            "pool exercises no non-trivial assignability"
+        );
+    });
+}
+
+#[test]
+fn function_abilities_widen_but_do_not_narrow() {
+    with_context(|guard, _module| {
+        let args = guard.type_list_of(&[U64_TY]);
+        let weak = guard.function_of(args, EMPTY_TYPE_LIST, AbilitySet::EMPTY);
+        let strong = guard.function_of(args, EMPTY_TYPE_LIST, AbilitySet::PUBLIC_FUNCTIONS);
+
+        // A context wanting fewer abilities accepts a value that has more.
+        assert!(is_assignable(weak, strong));
+        // The reverse is not sound.
+        assert!(!is_assignable(strong, weak));
+    });
+}
+
+#[test]
+fn immutable_references_recurse_but_mutable_ones_do_not() {
+    with_context(|guard, _module| {
+        let args = guard.type_list_of(&[U64_TY]);
+        let weak = guard.function_of(args, EMPTY_TYPE_LIST, AbilitySet::EMPTY);
+        let strong = guard.function_of(args, EMPTY_TYPE_LIST, AbilitySet::PUBLIC_FUNCTIONS);
+
+        // Covariant: reading through `&` yields a value usable as `weak`.
+        assert!(is_assignable(
+            guard.immut_ref_of(weak),
+            guard.immut_ref_of(strong)
+        ));
+        assert!(!is_assignable(
+            guard.immut_ref_of(strong),
+            guard.immut_ref_of(weak)
+        ));
+
+        // Invariant: writing through `&mut` could install a weaker value that
+        // the original holder would then use at the stronger type.
+        assert!(!is_assignable(
+            guard.mut_ref_of(weak),
+            guard.mut_ref_of(strong)
+        ));
+        assert!(!is_assignable(
+            guard.mut_ref_of(strong),
+            guard.mut_ref_of(weak)
+        ));
+
+        // No implicit freeze: `&mut T` is not usable where `&T` is required,
+        // in either direction. Move converts explicitly.
+        assert!(!is_assignable(
+            guard.immut_ref_of(U64_TY),
+            guard.mut_ref_of(U64_TY)
+        ));
+        assert!(!is_assignable(
+            guard.mut_ref_of(U64_TY),
+            guard.immut_ref_of(U64_TY)
+        ));
+
+        // Nested immutable references keep recursing.
+        assert!(is_assignable(
+            guard.immut_ref_of(guard.immut_ref_of(weak)),
+            guard.immut_ref_of(guard.immut_ref_of(strong))
+        ));
+    });
+}
+
+#[test]
+fn nominals_from_different_modules_are_distinct() {
+    // Interned nominal identity is `(module, name, ty_args)`, which is strictly
+    // stronger than the verifier's module-local `StructHandleIndex`: a
+    // same-named struct in another module cannot be confused for this one.
+    with_context(|guard, module| {
+        let name = guard.identifier_of(ident_str!("S"));
+        let here = guard.nominal_of(module.id(), name, EMPTY_TYPE_LIST);
+        let elsewhere_id = guard.module_id_of(&AccountAddress::TWO, ident_str!("a"));
+        let elsewhere = guard.nominal_of(elsewhere_id, name, EMPTY_TYPE_LIST);
+
+        assert!(is_assignable(here, here));
+        assert!(!is_assignable(here, elsewhere));
+        assert!(!is_assignable(elsewhere, here));
+    });
+}
+
+#[test]
+fn interned_type_list_pointer_equality_is_structural() {
+    // `is_assignable` compares a function's arguments and results as whole
+    // interned list pointers rather than elementwise; that O(1) path is only
+    // sound if list interning deduplicates structurally equal lists.
+    with_context(|guard, _module| {
+        let first = guard.type_list_of(&[U64_TY, BOOL_TY]);
+        let second = guard.type_list_of(&[U64_TY, BOOL_TY]);
+        let different = guard.type_list_of(&[BOOL_TY, U64_TY]);
+        assert!(
+            first == second,
+            "structurally equal lists must intern equal"
+        );
+        assert!(
+            first != different,
+            "different lists must intern differently"
+        );
+    });
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_alignment.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_alignment.exp
@@ -70,7 +70,7 @@ fun run(r0): u64 {
   slots: params(1), locals(2), temps(2)
     r0: bool
     r1: vector<u64>
-    r2: |u64|u64
+    r2: |u64|u64 has drop
     r3: &mut vector<u64>
     r4: u64
   code:
@@ -84,7 +84,7 @@ fun run(r0): u64 {
     6: vec_push_back u64, r3, r4 @7
     7: r2 := pack_closure combine, 11, [r0, r1] @10
     8: r4 := ld_u64 100 @12
-    9: [r4] := call_closure [|u64|u64], [r4, r2] @14
+    9: [r4] := call_closure [|u64|u64 has drop], [r4, r2] @14
     10: ret [r4] @15
 }
 === micro-ops ===

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_middle_interleave.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_middle_interleave.exp
@@ -32,7 +32,7 @@ fun g(r0, r1, r2): u64 {
 
 fun caller(): u64 {
   slots: params(0), locals(1), temps(3), transfer(3)
-    r0: |u64, u64|u64
+    r0: |u64, u64|u64 has drop
     r1: u64
     r2: u64
     r3: u64
@@ -41,7 +41,7 @@ fun caller(): u64 {
     0: r1 := ld_u64 7 @0
     1: r0 := pack_closure g, 10, [r1] @1
     2: [r1, r2, r3] := call three_rets, [] @3
-    3: [r2] := call_closure [|u64, u64|u64], [r1, r2, r0] @6
+    3: [r2] := call_closure [|u64, u64|u64 has drop], [r1, r2, r0] @6
     4: ret [r2] @7
 }
 === micro-ops ===

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_vector.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_vector.exp
@@ -92,7 +92,7 @@ fun capture_one(r0): u64 {
   slots: params(1), locals(2), temps(2)
     r0: u64
     r1: vector<u64>
-    r2: |u64|u64
+    r2: |u64|u64 has drop
     r3: &mut vector<u64>
     r4: u64
   code:
@@ -108,7 +108,7 @@ fun capture_one(r0): u64 {
     8: r4 := ld_u64 30 @9
     9: vec_push_back u64, r3, r4 @10
     10: r2 := pack_closure len_plus, 1, [r1] @12
-    11: [r4] := call_closure [|u64|u64], [r0, r2] @16
+    11: [r4] := call_closure [|u64|u64 has drop], [r0, r2] @16
     12: ret [r4] @17
 }
 
@@ -117,7 +117,7 @@ fun capture_two(r0): u64 {
     r0: u64
     r1: vector<u64>
     r2: vector<u64>
-    r3: |u64|u64
+    r3: |u64|u64 has drop
     r4: &mut vector<u64>
     r5: u64
   code:
@@ -140,7 +140,7 @@ fun capture_two(r0): u64 {
     15: r5 := ld_u64 5 @17
     16: vec_push_back u64, r4, r5 @18
     17: r3 := pack_closure len_sum, 11, [r1, r2] @21
-    18: [r5] := call_closure [|u64|u64], [r0, r3] @25
+    18: [r5] := call_closure [|u64|u64 has drop], [r0, r3] @25
     19: ret [r5] @26
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capturing.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capturing.exp
@@ -138,13 +138,13 @@ fun add_u64(r0, r1): u64 {
 fun adder(r0): u64 {
   slots: params(1), locals(1), temps(1)
     r0: u64
-    r1: |u64|u64
+    r1: |u64|u64 has drop
     r2: u64
   code:
   L0:
     0: r1 := pack_closure __lambda__1__adder, 1, [r0] @1
     1: r2 := ld_u64 8 @3
-    2: [r2] := call_closure [|u64|u64], [r2, r1] @5
+    2: [r2] := call_closure [|u64|u64 has drop], [r2, r1] @5
     3: ret [r2] @6
 }
 
@@ -152,12 +152,12 @@ fun all_captured(r0, r1): u64 {
   slots: params(2), locals(0), temps(2)
     r0: u64
     r1: u64
-    r2: |u64, u64|u64
+    r2: ||u64 has copy + drop
     r3: u64
   code:
   L0:
     0: r2 := pack_closure add_u64, 11, [r0, r1] @2
-    1: [r3] := call_closure [||u64], [r2] @3
+    1: [r3] := call_closure [||u64 has drop], [r2] @3
     2: ret [r3] @4
 }
 
@@ -165,26 +165,26 @@ fun capture_ends(r0, r1): u64 {
   slots: params(2), locals(1), temps(1)
     r0: u64
     r1: u64
-    r2: |u64|u64
+    r2: |u64|u64 has drop
     r3: u64
   code:
   L0:
     0: r2 := pack_closure add3, 101, [r0, r1] @2
     1: r3 := ld_u64 100 @4
-    2: [r3] := call_closure [|u64|u64], [r3, r2] @6
+    2: [r3] := call_closure [|u64|u64 has drop], [r3, r2] @6
     3: ret [r3] @7
 }
 
 fun capture_second(r0): u64 {
   slots: params(1), locals(1), temps(1)
     r0: u64
-    r1: |u64|u64
+    r1: |u64|u64 has drop
     r2: u64
   code:
   L0:
     0: r1 := pack_closure add_u64, 10, [r0] @1
     1: r2 := ld_u64 7 @3
-    2: [r2] := call_closure [|u64|u64], [r2, r1] @5
+    2: [r2] := call_closure [|u64|u64 has drop], [r2, r1] @5
     3: ret [r2] @6
 }
 
@@ -192,20 +192,20 @@ fun capture_two(r0, r1): u64 {
   slots: params(2), locals(1), temps(1)
     r0: u64
     r1: u64
-    r2: |u64|u64
+    r2: |u64|u64 has drop
     r3: u64
   code:
   L0:
     0: r2 := pack_closure add3, 11, [r0, r1] @2
     1: r3 := ld_u64 1 @4
-    2: [r3] := call_closure [|u64|u64], [r3, r2] @6
+    2: [r3] := call_closure [|u64|u64 has drop], [r3, r2] @6
     3: ret [r3] @7
 }
 
 fun make_adder(r0): |u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: u64
-    r1: |u64, u64|u64
+    r1: |u64|u64 has copy + drop
   code:
   L0:
     0: r1 := pack_closure __lambda__1__make_adder, 1, [r0] @1
@@ -216,12 +216,12 @@ fun use_adder(r0, r1): u64 {
   slots: params(2), locals(1), temps(1), transfer(1)
     r0: u64
     r1: u64
-    r2: |u64|u64
+    r2: |u64|u64 has drop
     r3: u64
   code:
   L0:
     0: [r2] := call make_adder, [r0] @1
-    1: [r3] := call_closure [|u64|u64], [r1, r2] @5
+    1: [r3] := call_closure [|u64|u64 has drop], [r1, r2] @5
     2: ret [r3] @6
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_abilities.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_abilities.exp
@@ -1,0 +1,282 @@
+=== stackless ===
+// module 0x99::closure_abilities
+
+fun add3(r0, r1, r2): u64 {
+  slots: params(3), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+  code:
+  L0:
+    0: r3 := add r0, r1 @2
+    1: r3 := add r3, r2 @4
+    2: ret [r3] @5
+}
+
+fun all_captured(r0, r1, r2): ||u64 {
+  slots: params(3), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: ||u64 has copy + drop
+  code:
+  L0:
+    0: r3 := pack_closure add3, 111, [r0, r1, r2] @3
+    1: ret [r3] @4
+}
+
+fun captures_box2_res(r0): |u64|u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: 0x99::closure_abilities::Box2<0x99::closure_abilities::Res>
+    r1: |u64|u64 has copy + drop + store
+  code:
+  L0:
+    0: r1 := pack_closure drop_box2, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun captures_box_res(r0): |u64|Box<Res> {
+  slots: params(1), locals(0), temps(1)
+    r0: 0x99::closure_abilities::Box<0x99::closure_abilities::Res>
+    r1: |u64|0x99::closure_abilities::Box<0x99::closure_abilities::Res> has store
+  code:
+  L0:
+    0: r1 := pack_closure keep_box_res, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun captures_box_u64(r0): |u64|Box<u64> {
+  slots: params(1), locals(0), temps(1)
+    r0: 0x99::closure_abilities::Box<u64>
+    r1: |u64|0x99::closure_abilities::Box<u64> has copy + drop + store
+  code:
+  L0:
+    0: r1 := pack_closure keep_box_u64, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun captures_enum(r0): |u64|u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: 0x99::closure_abilities::E
+    r1: |u64|u64 has copy + drop
+  code:
+  L0:
+    0: r1 := pack_closure drop_enum, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun captures_plain(r0): |u64|u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: 0x99::closure_abilities::Plain
+    r1: |u64|u64 has copy + drop
+  code:
+  L0:
+    0: r1 := pack_closure takes_plain, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun captures_resource(r0): |u64|u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: 0x99::closure_abilities::Res
+    r1: |u64|u64
+  code:
+  L0:
+    0: r1 := pack_closure takes_res, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun captures_signer(r0): |u64|u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: signer
+    r1: |u64|u64 has drop
+  code:
+  L0:
+    0: r1 := pack_closure drop_signer, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun captures_vec_res(r0): |u64|vector<Res> {
+  slots: params(1), locals(0), temps(1)
+    r0: vector<0x99::closure_abilities::Res>
+    r1: |u64|vector<0x99::closure_abilities::Res> has store
+  code:
+  L0:
+    0: r1 := pack_closure keep_vec_res, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun captures_vec_u64(r0): |u64|vector<u64> {
+  slots: params(1), locals(0), temps(1)
+    r0: vector<u64>
+    r1: |u64|vector<u64> has copy + drop + store
+  code:
+  L0:
+    0: r1 := pack_closure keep_vec_u64, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun drop_box2(r0, r1): u64 {
+  slots: params(2), locals(0), temps(0)
+    r0: 0x99::closure_abilities::Box2<0x99::closure_abilities::Res>
+    r1: u64
+  code:
+  L0:
+    0: ret [r1] @1
+}
+
+fun drop_enum(r0, r1): u64 {
+  slots: params(2), locals(0), temps(0)
+    r0: 0x99::closure_abilities::E
+    r1: u64
+  code:
+  L0:
+    0: ret [r1] @1
+}
+
+fun drop_signer(r0, r1): u64 {
+  slots: params(2), locals(0), temps(0)
+    r0: signer
+    r1: u64
+  code:
+  L0:
+    0: ret [r1] @1
+}
+
+fun generic_captured(r0): |_0, bool|_0 {
+  slots: params(1), locals(0), temps(1)
+    r0: _0
+    r1: |_0, bool|_0 has drop
+  code:
+  L0:
+    0: r1 := pack_closure generic_pick<_0>, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun generic_pick(r0, r1, r2): _0 {
+  slots: params(3), locals(0), temps(0)
+    r0: _0
+    r1: _0
+    r2: bool
+  code:
+  L2:
+    0: br_false L0, r2 @1
+  L1:
+    1: ret [r0] @3
+  L0:
+    2: ret [r1] @5
+}
+
+fun keep_box_res(r0, r1): Box<Res> {
+  slots: params(2), locals(0), temps(0)
+    r0: 0x99::closure_abilities::Box<0x99::closure_abilities::Res>
+    r1: u64
+  code:
+  L0:
+    0: ret [r0] @1
+}
+
+fun keep_box_u64(r0, r1): Box<u64> {
+  slots: params(2), locals(0), temps(0)
+    r0: 0x99::closure_abilities::Box<u64>
+    r1: u64
+  code:
+  L0:
+    0: ret [r0] @1
+}
+
+fun keep_vec_res(r0, r1): vector<Res> {
+  slots: params(2), locals(0), temps(0)
+    r0: vector<0x99::closure_abilities::Res>
+    r1: u64
+  code:
+  L0:
+    0: ret [r0] @1
+}
+
+fun keep_vec_u64(r0, r1): vector<u64> {
+  slots: params(2), locals(0), temps(0)
+    r0: vector<u64>
+    r1: u64
+  code:
+  L0:
+    0: ret [r0] @1
+}
+
+fun none_captured(): |u64, u64, u64|u64 {
+  slots: params(0), locals(0), temps(1)
+    r0: |u64, u64, u64|u64 has copy + drop
+  code:
+  L0:
+    0: r0 := pack_closure add3, 0, [] @0
+    1: ret [r0] @1
+}
+
+fun one_captured(r0): |u64, u64|u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: |u64, u64|u64 has copy + drop
+  code:
+  L0:
+    0: r1 := pack_closure add3, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun private_callee(r0): |u64|u64 {
+  slots: params(1), locals(0), temps(2)
+    r0: u64
+    r1: u64
+    r2: |u64|u64 has copy + drop
+  code:
+  L0:
+    0: r1 := ld_u64 0 @1
+    1: r2 := pack_closure add3, 11, [r0, r1] @2
+    2: ret [r2] @3
+}
+
+fun public_add(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r2 := add r0, r1 @2
+    1: ret [r2] @3
+}
+
+fun public_callee(r0): |u64|u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: |u64|u64 has copy + drop + store
+  code:
+  L0:
+    0: r1 := pack_closure public_add, 1, [r0] @1
+    1: ret [r1] @2
+}
+
+fun takes_plain(r0, r1): u64 {
+  slots: params(2), locals(1), temps(1)
+    r0: 0x99::closure_abilities::Plain
+    r1: u64
+    r2: u64
+    r3: u64
+  code:
+  L0:
+    0: [r2] := unpack 0x99::closure_abilities::Plain, r0 @1
+    1: r3 := add r1, r2 @5
+    2: ret [r3] @6
+}
+
+fun takes_res(r0, r1): u64 {
+  slots: params(2), locals(1), temps(1)
+    r0: 0x99::closure_abilities::Res
+    r1: u64
+    r2: u64
+    r3: u64
+  code:
+  L0:
+    0: [r2] := unpack 0x99::closure_abilities::Res, r0 @1
+    1: r3 := add r1, r2 @5
+    2: ret [r3] @6
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_abilities.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_abilities.move
@@ -1,0 +1,82 @@
+// RUN: publish --print(stackless)
+
+module 0x99::closure_abilities {
+    struct Res has store { x: u64 }
+    struct Plain has copy, drop, store { x: u64 }
+    // Non-phantom: abilities are predicated on T.
+    struct Box<T> has copy, drop, store { x: T }
+    // Phantom: T never predicates Box2's abilities.
+    struct Box2<phantom T> has copy, drop, store { x: u64 }
+    enum E has copy, drop { V1 { x: u64 }, V2 { x: bool } }
+
+    fun add3(a: u64, b: u64, c: u64): u64 { a + b + c }
+    public fun public_add(a: u64, b: u64): u64 { a + b }
+    fun takes_res(r: Res, x: u64): u64 { let Res { x: y } = r; x + y }
+    fun takes_plain(p: Plain, x: u64): u64 { let Plain { x: y } = p; x + y }
+    fun generic_pick<T: drop>(t: T, other: T, flag: bool): T { if (flag) t else other }
+
+    // Captures nothing: all three parameters remain.
+    public fun none_captured(): |u64, u64, u64|u64 has copy + drop { add3 }
+
+    // Captures the leading parameter: two remain.
+    public fun one_captured(a: u64): |u64, u64|u64 has copy + drop { |b, c| add3(a, b, c) }
+
+    // Captures every parameter: none remain.
+    public fun all_captured(a: u64, b: u64, c: u64): ||u64 has copy + drop { || add3(a, b, c) }
+
+    // Private callee is not storable, so the closure is copy+drop only.
+    public fun private_callee(a: u64): |u64|u64 has copy + drop { |b| add3(a, 0, b) }
+
+    // Public callee is storable, so the closure gains store.
+    public fun public_callee(a: u64): |u64|u64 has copy + drop + store { |b| public_add(a, b) }
+
+    // Capturing a non-copy, non-drop resource strips both; intersected with a
+    // private callee's copy+drop this leaves no abilities at all.
+    public fun captures_resource(r: Res): |u64|u64 { |x| takes_res(r, x) }
+
+    // Capturing a fully-abled struct cannot *add* abilities.
+    public fun captures_plain(p: Plain): |u64|u64 has copy + drop { |x| takes_plain(p, x) }
+
+    // Generic: `T: drop` resolves through the enclosing function's constraint
+    // slice, so the closure is drop-only.
+    public fun generic_captured<T: drop>(t: T): |T, bool|T {
+        |other, flag| generic_pick(t, other, flag)
+    }
+
+    // Below, every callee is public, so the closure's abilities are exactly the
+    // captured value's.
+    public fun keep_vec_u64(v: vector<u64>, _y: u64): vector<u64> { v }
+    public fun keep_vec_res(v: vector<Res>, _y: u64): vector<Res> { v }
+    public fun keep_box_u64(b: Box<u64>, _y: u64): Box<u64> { b }
+    public fun keep_box_res(b: Box<Res>, _y: u64): Box<Res> { b }
+    public fun drop_box2(_b: Box2<Res>, y: u64): u64 { y }
+    public fun drop_enum(_e: E, y: u64): u64 { y }
+    public fun drop_signer(_s: signer, y: u64): u64 { y }
+
+    // A vector is as able as its element.
+    public fun captures_vec_u64(v: vector<u64>): |u64|vector<u64> has copy + drop + store {
+        |y| keep_vec_u64(v, y)
+    }
+    public fun captures_vec_res(v: vector<Res>): |u64|vector<Res> has store {
+        |y| keep_vec_res(v, y)
+    }
+
+    // A non-phantom argument predicates; `Box<Res>` keeps only store.
+    public fun captures_box_u64(b: Box<u64>): |u64|Box<u64> has copy + drop + store {
+        |y| keep_box_u64(b, y)
+    }
+    public fun captures_box_res(b: Box<Res>): |u64|Box<Res> has store {
+        |y| keep_box_res(b, y)
+    }
+
+    // A phantom argument does not predicate, so `Box2<Res>` keeps everything.
+    public fun captures_box2_res(b: Box2<Res>): |u64|u64 has copy + drop + store {
+        |y| drop_box2(b, y)
+    }
+
+    // Enums resolve like structs.
+    public fun captures_enum(e: E): |u64|u64 has copy + drop { |y| drop_enum(e, y) }
+
+    // Signer is drop-only.
+    public fun captures_signer(s: signer): |u64|u64 has drop { |y| drop_signer(s, y) }
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/noncapturing.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/noncapturing.exp
@@ -45,16 +45,16 @@ fun identity(l0: u64): u64
 fun call_double_twice(r0): u64 {
   slots: params(1), locals(1), temps(3)
     r0: u64
-    r1: |u64|u64
-    r2: |u64|u64
+    r1: |u64|u64 has copy + drop
+    r2: |u64|u64 has copy + drop
     r3: u64
     r4: u64
   code:
   L0:
     0: r1 := pack_closure double, 0, [] @0
     1: r2 := copy r1 @3
-    2: [r3] := call_closure [|u64|u64], [r0, r2] @4
-    3: [r4] := call_closure [|u64|u64], [r0, r1] @7
+    2: [r3] := call_closure [|u64|u64 has copy + drop], [r0, r2] @4
+    3: [r4] := call_closure [|u64|u64 has copy + drop], [r0, r1] @7
     4: r4 := add r3, r4 @8
     5: ret [r4] @9
 }
@@ -62,12 +62,12 @@ fun call_double_twice(r0): u64 {
 fun call_identity(r0): u64 {
   slots: params(1), locals(1), temps(1)
     r0: u64
-    r1: |u64|u64
+    r1: |u64|u64 has drop
     r2: u64
   code:
   L0:
     0: r1 := pack_closure identity, 0, [] @0
-    1: [r2] := call_closure [|u64|u64], [r0, r1] @4
+    1: [r2] := call_closure [|u64|u64 has drop], [r0, r1] @4
     2: ret [r2] @5
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_closure_pack.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_closure_pack.exp
@@ -4,20 +4,20 @@
 fun call_identity(r0): u64 {
   slots: params(1), locals(1), temps(1)
     r0: u64
-    r1: |u64|u64
+    r1: |u64|u64 has drop
     r2: u64
   code:
   L0:
     0: r1 := pack_closure identity<u64>, 0, [] @0
-    1: [r2] := call_closure [|u64|u64], [r0, r1] @4
+    1: [r2] := call_closure [|u64|u64 has drop], [r0, r1] @4
     2: ret [r2] @5
 }
 
 fun call_pick(r0): u64 {
   slots: params(1), locals(2), temps(3), transfer(1)
     r0: u64
-    r1: |u64, bool|u64
-    r2: |u64, bool|u64
+    r1: |u64, bool|u64 has drop
+    r2: |u64, bool|u64 has drop
     r3: u64
     r4: bool
     r5: u64
@@ -27,11 +27,11 @@ fun call_pick(r0): u64 {
     1: [r2] := call make_pick<u64>, [r0] @4
     2: r3 := add r0, #1 @8
     3: r4 := ld_true @9
-    4: [r3] := call_closure [|u64, bool|u64], [r3, r4, r1] @11
+    4: [r3] := call_closure [|u64, bool|u64 has drop], [r3, r4, r1] @11
     5: r3 := mul r3, #1000 @13
     6: r5 := add r0, #1 @16
     7: r4 := ld_false @17
-    8: [r5] := call_closure [|u64, bool|u64], [r5, r4, r2] @19
+    8: [r5] := call_closure [|u64, bool|u64 has drop], [r5, r4, r2] @19
     9: r5 := add r3, r5 @20
     10: ret [r5] @21
 }
@@ -47,7 +47,7 @@ fun identity(r0): _0 {
 fun make_pick(r0): |_0, bool|_0 {
   slots: params(1), locals(0), temps(1)
     r0: _0
-    r1: |_0, _0, bool|_0
+    r1: |_0, bool|_0 has drop
   code:
   L0:
     0: r1 := pack_closure pick<_0>, 1, [r0] @1


### PR DESCRIPTION
## Description

Adds ability computation over interned types to the mono-move runtime, used in translation validation. This introduces an `AbilityCalculator` in `mono_move_core::abilities` that computes `AbilitySet` for any interned type given a type-parameter constraint context and a lookup closure for nominal (struct/enum) handles.

Key additions:
- `AbilityCalculator`: a memoized calculator that resolves abilities for all `Type` variants, including nominals (via a caller-supplied lookup), vectors, references, function types, and type parameters. Phantom type parameters are correctly excluded from ability predication.
- `module_nominal_lookup`: a helper that builds a lookup closure backed by a `PreparedModule`'s handle table.
- `PreparedModule::nominal_handles`: a new map from `(InternedModuleId, InternedIdentifier)` to `StructHandleIndex`, populated during module preparation, enabling the lookup above.
- `is_assignable`: a new function on interned types implementing subtyping for function types (covariant in abilities) and immutable references (covariant in pointee), with all other constructors invariant.
- Correct closure ability derivation in `SsaConverter::closure_type`: the closure's abilities now start from the callee's declared abilities (copy+drop for private, copy+drop+store for persistent/public) and are intersected with the abilities of every captured value. Previously, all closures were assigned `AbilitySet::EMPTY`.
- `display_type` now renders function type abilities as a postfix (e.g. `|u64|u64 has drop`), matching the updated expected outputs across all closure differential tests.
- A new `with_loaded_module` test helper in the testsuite for loading a module IR without running a function.

## How Has This Been Tested?

- `abilities.rs` unit tests exhaustively verify `instantiated_abilities` against `AbilitySet::polymorphic_abilities` across all 16 possible declared ability sets and arities 0–2 (16 × 1057 cases), plus targeted tests for the `key`/`store` asymmetry, phantom parameters, and monotonicity.
- `abilities_tests.rs` integration tests cover: references being copy+drop but never store, type-argument arity mismatch rejection, unresolvable nominals and out-of-range type parameters returning errors, and type-parameter constraints being recorded on handles.
- `assignability_tests.rs` integration tests verify `is_assignable` against the bytecode verifier's `is_assignable_from` oracle on all ordered pairs from a hand-crafted token pool covering every constructor and ability combination, plus targeted tests for ability widening, reference variance, nominal identity across modules, and interned list pointer equality.
- Differential test `.exp` files for all existing closure tests have been updated to reflect the corrected ability annotations on closure types.
- A new `closure_abilities.move` differential test exercises the full matrix of captured-value ability interactions: primitives, resources, plain structs, generic type parameters, vectors, non-phantom and phantom struct arguments, enums, signers, and the private-vs-public callee distinction.

## Key Areas to Review

- **`instantiated_abilities` vs. `AbilitySet::polymorphic_abilities`**: The independent implementation intentionally does not reuse the bytecode verifier's logic. The exhaustive unit test is the primary assurance that both agree.
- **Memo soundness in `AbilityCalculator`**: The memo is keyed on `InternedType` alone. This is sound only because `ty_param_ctx` and `lookup` are fixed for the calculator's lifetime; the doc comment calls this out explicitly.
- **`is_assignable` on function types**: Ability widening is covariant (a context wanting fewer abilities accepts a value with more). Mutable references are invariant; there is no implicit freeze between `&mut T` and `&T`.
- **Closure ability derivation**: The starting set depends on whether the callee has the `Persistent` attribute. Captured values are intersected in, not unioned. The `SsaConverter` now requires `ty_param_constraints` to be threaded through from the enclosing function's handle.
- **`nominal_handles` population**: Uniqueness of `(module_id, name)` pairs is trusted as a bytecode-verification result and only debug-asserted, not re-checked at runtime.

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Move ability and closure typing in the VM specializer: wrong copy/drop/store on closures that capture resources would be a soundness bug. Independent of the bytecode verifier, so mismatches are high-impact.
> 
> **Overview**
> Adds interned-type **ability computation** and **assignability**, and uses them so packed closures no longer get `AbilitySet::EMPTY`.
> 
> `AbilityCalculator` looks up nominals through the asking module’s `StructHandle` (abilities + phantom flags), memoizes by interned type, and instantiates like the verifier (`key` requires `store`; phantoms do not predicate). `PreparedModule` now indexes those handles by interned `(module, name)`.
> 
> `is_assignable` is pointer-equality plus covariant function abilities and covariant `&T`; `&mut T` stays invariant with no implicit freeze.
> 
> SSA `PackClosure` starts from private vs persistent callee abilities and **intersects** captured-value abilities (using the enclosing function’s type-parameter constraints). Function types print `has …` postfix; closure differential tests and a new `closure_abilities` case cover the matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6cd59ed2c434e2a88b53061ed4512a68e25bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->