### PR TITLE
[execution] Drain state sync before teardown

### DIFF
--- a/execution/executor/src/chunk_executor/mod.rs
+++ b/execution/executor/src/chunk_executor/mod.rs
@@ -5,7 +5,10 @@
 
 use crate::{
     logging::{LogEntry, LogSchema},
-    metrics::{APPLY_CHUNK, CHUNK_OTHER_TIMERS, COMMIT_CHUNK, CONCURRENCY_GAUGE, EXECUTE_CHUNK},
+    metrics::{
+        APPLY_CHUNK, CHUNK_EXECUTOR_REQUEST_REJECTED, CHUNK_OTHER_TIMERS, COMMIT_CHUNK,
+        CONCURRENCY_GAUGE, EXECUTE_CHUNK,
+    },
     types::{
         executed_chunk::ExecutedChunk, partial_state_compute_result::PartialStateComputeResult,
     },
@@ -14,14 +17,14 @@ use crate::{
         do_state_checkpoint::DoStateCheckpoint,
     },
 };
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 use aptos_executor_types::{
     ChunkCommitNotification, ChunkExecutorTrait, TransactionReplayer, VerifyExecutionMode,
 };
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
-use aptos_metrics_core::{IntGaugeVecHelper, TimerHelper};
+use aptos_metrics_core::{IntCounterVecHelper, IntGaugeVecHelper, TimerHelper};
 use aptos_storage_interface::{
     state_store::{
         state::State,
@@ -93,32 +96,92 @@ fn chunk_onchain_config(state_view: &CachedStateView) -> Result<BlockExecutorCon
     })
 }
 
+enum ChunkExecutorState<V> {
+    Uninitialized,
+    Active(ChunkExecutorInner<V>),
+    Finished,
+}
+
+impl<V> ChunkExecutorState<V> {
+    fn rejection_reason(&self) -> Option<&'static str> {
+        match self {
+            Self::Uninitialized => Some("uninitialized"),
+            Self::Active(_) => None,
+            Self::Finished => Some("finished"),
+        }
+    }
+}
+
 pub struct ChunkExecutor<V> {
     db: DbReaderWriter,
-    inner: RwLock<Option<ChunkExecutorInner<V>>>,
+    state: RwLock<ChunkExecutorState<V>>,
 }
 
 impl<V: VMBlockExecutor> ChunkExecutor<V> {
     pub fn new(db: DbReaderWriter) -> Self {
         Self {
             db,
-            inner: RwLock::new(None),
+            state: RwLock::new(ChunkExecutorState::Uninitialized),
         }
     }
 
-    fn maybe_initialize(&self) -> Result<()> {
-        if self.inner.read().is_none() {
-            self.reset()?;
+    fn maybe_initialize(&self, entry_point: &'static str) -> Result<()> {
+        {
+            let state = self.state.read();
+            match &*state {
+                ChunkExecutorState::Uninitialized => {},
+                ChunkExecutorState::Active(_) => return Ok(()),
+                ChunkExecutorState::Finished => {
+                    CHUNK_EXECUTOR_REQUEST_REJECTED.inc_with(&[entry_point, "finished"]);
+                    bail!(
+                        "Chunk executor has been finished, rejecting {} request",
+                        entry_point
+                    );
+                },
+            }
         }
-        Ok(())
+
+        let mut state = self.state.write();
+        match &*state {
+            ChunkExecutorState::Uninitialized => {
+                *state = ChunkExecutorState::Active(ChunkExecutorInner::new(self.db.clone())?);
+                Ok(())
+            },
+            ChunkExecutorState::Active(_) => Ok(()),
+            ChunkExecutorState::Finished => {
+                CHUNK_EXECUTOR_REQUEST_REJECTED.inc_with(&[entry_point, "finished"]);
+                Err(anyhow!(
+                    "Chunk executor has been finished, rejecting {} request",
+                    entry_point
+                ))
+            },
+        }
     }
 
-    fn with_inner<F, T>(&self, f: F) -> Result<T>
+    /// Runs `f` against the initialized inner executor.
+    ///
+    /// Errors out if there is no active executor. This protects handoff from late
+    /// requests after state sync calls `finish()`; the next owner resets from the
+    /// committed version.
+    fn with_inner<F, T>(&self, entry_point: &'static str, f: F) -> Result<T>
     where
         F: FnOnce(&ChunkExecutorInner<V>) -> Result<T>,
     {
-        let locked = self.inner.read();
-        let inner = locked.as_ref().expect("not reset");
+        let state = self.state.read();
+        let inner = match &*state {
+            ChunkExecutorState::Active(inner) => inner,
+            state => {
+                let reason = state
+                    .rejection_reason()
+                    .expect("The active state was handled above");
+                CHUNK_EXECUTOR_REQUEST_REJECTED.inc_with(&[entry_point, reason]);
+                return Err(anyhow!(
+                    "Chunk executor is {}, rejecting {} request",
+                    reason,
+                    entry_point
+                ));
+            },
+        };
 
         let has_pending_pre_commit = inner.has_pending_pre_commit.load(Ordering::Acquire);
         f(inner).map_err(|error| {
@@ -133,7 +196,10 @@ impl<V: VMBlockExecutor> ChunkExecutor<V> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.with_inner(|inner| Ok(inner.is_empty())).unwrap()
+        match &*self.state.read() {
+            ChunkExecutorState::Active(inner) => inner.is_empty(),
+            ChunkExecutorState::Uninitialized | ChunkExecutorState::Finished => true,
+        }
     }
 }
 
@@ -147,7 +213,7 @@ impl<V: VMBlockExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["chunk", "enqueue_by_execution"]);
         let _timer = EXECUTE_CHUNK.start_timer();
 
-        self.maybe_initialize()?;
+        self.maybe_initialize("enqueue_by_execution")?;
 
         // Verify input data.
         // In consensus-only mode, txn_list_with_proof is fake.
@@ -179,7 +245,9 @@ impl<V: VMBlockExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         });
 
         // Call the shared implementation.
-        self.with_inner(|inner| inner.enqueue_chunk(chunk, chunk_verifier, "execute"))
+        self.with_inner("enqueue_by_execution", |inner| {
+            inner.enqueue_chunk(chunk, chunk_verifier, "execute")
+        })
     }
 
     fn enqueue_chunk_by_transaction_outputs(
@@ -190,6 +258,8 @@ impl<V: VMBlockExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
     ) -> Result<()> {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["chunk", "enqueue_by_outputs"]);
         let _timer = APPLY_CHUNK.start_timer();
+
+        self.maybe_initialize("enqueue_by_outputs")?;
 
         // Verify input data.
         THREAD_MANAGER.get_exe_cpu_pool().install(|| {
@@ -223,32 +293,34 @@ impl<V: VMBlockExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         });
 
         // Call the shared implementation.
-        self.with_inner(|inner| inner.enqueue_chunk(chunk, chunk_verifier, "apply"))
+        self.with_inner("enqueue_by_outputs", |inner| {
+            inner.enqueue_chunk(chunk, chunk_verifier, "apply")
+        })
     }
 
     fn update_ledger(&self) -> Result<()> {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["chunk", "update_ledger"]);
 
-        self.with_inner(|inner| inner.update_ledger())
+        self.with_inner("update_ledger", |inner| inner.update_ledger())
     }
 
     fn commit_chunk(&self) -> Result<ChunkCommitNotification> {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["chunk", "commit_chunk"]);
 
-        self.with_inner(|inner| inner.commit_chunk())
+        self.with_inner("commit_chunk", |inner| inner.commit_chunk())
     }
 
     fn reset(&self) -> Result<()> {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["chunk", "reset"]);
 
-        *self.inner.write() = Some(ChunkExecutorInner::new(self.db.clone())?);
+        *self.state.write() = ChunkExecutorState::Active(ChunkExecutorInner::new(self.db.clone())?);
         Ok(())
     }
 
     fn finish(&self) {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["chunk", "finish"]);
 
-        *self.inner.write() = None;
+        *self.state.write() = ChunkExecutorState::Finished;
     }
 }
 
@@ -477,12 +549,9 @@ impl<V: VMBlockExecutor> TransactionReplayer for ChunkExecutor<V> {
     ) -> Result<usize> {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["replayer", "replay"]);
 
-        self.maybe_initialize()?;
-        self.inner
-            .read()
-            .as_ref()
-            .expect("not reset")
-            .enqueue_chunks(
+        self.maybe_initialize("replayer_enqueue")?;
+        self.with_inner("replayer_enqueue", |inner| {
+            inner.enqueue_chunks(
                 transactions,
                 persisted_aux_info,
                 transaction_infos,
@@ -490,12 +559,13 @@ impl<V: VMBlockExecutor> TransactionReplayer for ChunkExecutor<V> {
                 event_vecs,
                 verify_execution_mode,
             )
+        })
     }
 
     fn commit(&self) -> Result<Version> {
         let _guard = CONCURRENCY_GAUGE.concurrency_with(&["replayer", "commit"]);
 
-        self.inner.read().as_ref().expect("not reset").commit()
+        self.with_inner("replayer_commit", |inner| inner.commit())
     }
 }
 

--- a/execution/executor/src/metrics.rs
+++ b/execution/executor/src/metrics.rs
@@ -80,6 +80,15 @@ pub static EXECUTOR_ERRORS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!("aptos_executor_error_total", "Cumulative number of errors").unwrap()
 });
 
+pub static CHUNK_EXECUTOR_REQUEST_REJECTED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_executor_chunk_executor_request_rejected_total",
+        "Cumulative number of rejected chunk executor requests, by entry point and reason",
+        &["entry_point", "reason"]
+    )
+    .unwrap()
+});
+
 pub static BLOCK_EXECUTION_WORKFLOW_WHOLE: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         // metric name

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -19,7 +19,7 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     test_helpers::transaction_test_helpers::{block, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG},
-    transaction::{TransactionListWithProofV2, Version},
+    transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use rand::Rng;
 
@@ -160,6 +160,42 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
     executor.commit_chunk().unwrap();
     let li = db.reader.get_latest_ledger_info().unwrap();
     assert_eq!(li, ledger_info);
+}
+
+#[test]
+fn test_finished_executor_rejects_chunks_without_panicking() {
+    let batch_size: u64 = 10;
+    let (chunks, ledger_info) = create_transaction_chunks(vec![1..=batch_size]);
+
+    let TestExecutor {
+        _path,
+        db: _db,
+        executor,
+    } = TestExecutor::new();
+    executor.reset().unwrap();
+    executor.finish();
+
+    // The outputs path used to `.expect("not reset")` here and take the node down.
+    assert!(executor
+        .enqueue_chunk_by_transaction_outputs(
+            TransactionOutputListWithProofV2::new_empty(),
+            &ledger_info,
+            None,
+        )
+        .is_err());
+    assert!(executor
+        .enqueue_chunk_by_execution(chunks[0].clone(), &ledger_info, None)
+        .is_err());
+    assert!(executor.update_ledger().is_err());
+    assert!(executor.commit_chunk().is_err());
+    assert!(executor.is_empty());
+
+    // A reset brings it back to a usable state.
+    executor.reset().unwrap();
+    executor
+        .execute_chunk(chunks[0].clone(), &ledger_info, None)
+        .unwrap();
+    executor.commit_chunk().unwrap();
 }
 
 #[test]

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -386,9 +386,33 @@ impl<
 
     /// Marks bootstrapping as complete and notifies any listeners
     pub async fn bootstrapping_complete(&mut self) -> Result<(), Error> {
+        if self.is_bootstrapped() {
+            return Ok(());
+        }
+
+        self.reset_active_stream(None).await?;
+
+        // Chunks already handed to the storage synchronizer may still be in flight.
+        while self.storage_synchronizer.pending_storage_data() {
+            sample!(
+                SampleRate::Duration(Duration::from_secs(PENDING_DATA_LOG_FREQ_SECS)),
+                info!("Waiting for the storage synchronizer to handle pending data!")
+            );
+
+            // Yield to avoid starving the storage synchronizer threads.
+            tokio::task::yield_now().await;
+        }
+
+        if self.storage_synchronizer.pending_storage_data_error() {
+            return Err(Error::UnexpectedError(
+                "The storage synchronizer failed while draining pending data!".into(),
+            ));
+        }
+
+        self.storage_synchronizer.finish_chunk_executor();
+        self.bootstrapped = true;
         info!(LogSchema::new(LogEntry::Bootstrapper)
             .message("The node has successfully bootstrapped!"));
-        self.bootstrapped = true;
         self.notify_listeners_if_bootstrapped().await
     }
 
@@ -418,8 +442,6 @@ impl<
                     )));
                 }
             }
-            self.reset_active_stream(None).await?;
-            self.storage_synchronizer.finish_chunk_executor(); // The bootstrapper is now complete
         }
 
         Ok(())

--- a/state-sync/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-driver/src/driver.rs
@@ -530,6 +530,7 @@ impl<
                 ))
             );
         };
+        self.storage_synchronizer.acknowledge_storage_data_error();
     }
 
     /// Checks if the node has successfully reached the sync target or duration
@@ -561,6 +562,12 @@ impl<
 
             // Yield to avoid starving the storage synchronizer threads.
             yield_now().await;
+        }
+
+        if self.storage_synchronizer.pending_storage_data_error() {
+            return Err(Error::UnexpectedError(
+                "The storage synchronizer failed while draining pending data!".into(),
+            ));
         }
 
         // If the request was to sync for a specified duration, we should only

--- a/state-sync/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/storage_synchronizer.rs
@@ -88,6 +88,12 @@ pub trait StorageSynchronizerInterface {
     /// to be executed/applied or committed.
     fn pending_storage_data(&self) -> bool;
 
+    /// Returns true iff a storage data error is waiting to be handled by the driver.
+    fn pending_storage_data_error(&self) -> bool;
+
+    /// Marks one storage data error as handled by the driver.
+    fn acknowledge_storage_data_error(&self);
+
     /// Saves the given state values to storage, for whichever snapshot
     /// synchronizer was last initialized.
     async fn save_state_values(
@@ -163,6 +169,9 @@ pub struct StorageSynchronizer<ChunkExecutor, MetadataStorage> {
     // The number of storage data chunks pending execute/apply, or commit
     pending_data_chunks: Arc<AtomicU64>,
 
+    // The number of storage data errors waiting to be handled by the driver
+    pending_data_errors: Arc<AtomicU64>,
+
     // An optional runtime on which to spawn the storage synchronizer threads
     runtime: Option<Handle>,
 
@@ -190,6 +199,7 @@ impl<
             error_notification_sender: self.error_notification_sender.clone(),
             executor_notifier: self.executor_notifier.clone(),
             pending_data_chunks: self.pending_data_chunks.clone(),
+            pending_data_errors: Arc::clone(&self.pending_data_errors),
             metadata_storage: self.metadata_storage.clone(),
             runtime: self.runtime.clone(),
             state_snapshot_notifier: self.state_snapshot_notifier.clone(),
@@ -238,12 +248,14 @@ impl<
 
         // Create a shared pending data chunk counter
         let pending_data_chunks = Arc::new(AtomicU64::new(0));
+        let pending_data_errors = Arc::new(AtomicU64::new(0));
         let executor_handle = spawn_executor(
             chunk_executor.clone(),
             error_notification_sender.clone(),
             executor_listener,
             ledger_updater_notifier,
             pending_data_chunks.clone(),
+            Arc::clone(&pending_data_errors),
             runtime.clone(),
         );
 
@@ -254,6 +266,7 @@ impl<
             ledger_updater_listener,
             committer_notifier,
             pending_data_chunks.clone(),
+            Arc::clone(&pending_data_errors),
             runtime.clone(),
         );
 
@@ -264,6 +277,7 @@ impl<
             committer_listener,
             commit_post_processor_notifier,
             pending_data_chunks.clone(),
+            Arc::clone(&pending_data_errors),
             runtime.clone(),
             storage.reader.clone(),
         );
@@ -291,6 +305,7 @@ impl<
             error_notification_sender,
             executor_notifier,
             pending_data_chunks,
+            pending_data_errors,
             metadata_storage,
             runtime,
             state_snapshot_notifier: None,
@@ -398,6 +413,7 @@ impl<
             snapshot_listener,
             self.error_notification_sender.clone(),
             self.pending_data_chunks.clone(),
+            Arc::clone(&self.pending_data_errors),
             self.metadata_storage.clone(),
             self.storage.clone(),
             target_ledger_info,
@@ -411,6 +427,22 @@ impl<
 
     fn pending_storage_data(&self) -> bool {
         load_pending_data_chunks(self.pending_data_chunks.clone()) > 0
+    }
+
+    fn pending_storage_data_error(&self) -> bool {
+        self.pending_data_errors.load(Ordering::Acquire) > 0
+    }
+
+    fn acknowledge_storage_data_error(&self) {
+        if self
+            .pending_data_errors
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                count.checked_sub(1)
+            })
+            .is_err()
+        {
+            error!("Received a storage data error acknowledgement with no pending error!");
+        }
     }
 
     async fn save_state_values(
@@ -549,6 +581,7 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
     mut executor_listener: mpsc::Receiver<StorageDataChunk>,
     mut ledger_updater_notifier: mpsc::Sender<NotificationMetadata>,
     pending_data_chunks: Arc<AtomicU64>,
+    pending_data_errors: Arc<AtomicU64>,
     runtime: Option<Handle>,
 ) -> JoinHandle<()> {
     // Create an executor
@@ -625,6 +658,7 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
                             error,
                             &error_notification_sender,
                             &pending_data_chunks,
+                            &pending_data_errors,
                         )
                         .await;
                     }
@@ -641,6 +675,7 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
                         error,
                         &error_notification_sender,
                         &pending_data_chunks,
+                        &pending_data_errors,
                     )
                     .await;
                 },
@@ -677,6 +712,7 @@ fn spawn_ledger_updater<ChunkExecutor: ChunkExecutorTrait + 'static>(
     mut ledger_updater_listener: mpsc::Receiver<NotificationMetadata>,
     mut committer_notifier: mpsc::Sender<NotificationMetadata>,
     pending_data_chunks: Arc<AtomicU64>,
+    pending_data_errors: Arc<AtomicU64>,
     runtime: Option<Handle>,
 ) -> JoinHandle<()> {
     // Create a ledger updater
@@ -724,6 +760,7 @@ fn spawn_ledger_updater<ChunkExecutor: ChunkExecutorTrait + 'static>(
                             error,
                             &error_notification_sender,
                             &pending_data_chunks,
+                            &pending_data_errors,
                         )
                         .await;
                     }
@@ -736,6 +773,7 @@ fn spawn_ledger_updater<ChunkExecutor: ChunkExecutorTrait + 'static>(
                         error,
                         &error_notification_sender,
                         &pending_data_chunks,
+                        &pending_data_errors,
                     )
                     .await;
                 },
@@ -754,6 +792,7 @@ fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
     mut committer_listener: mpsc::Receiver<NotificationMetadata>,
     mut commit_post_processor_notifier: mpsc::Sender<ChunkCommitNotification>,
     pending_data_chunks: Arc<AtomicU64>,
+    pending_data_errors: Arc<AtomicU64>,
     runtime: Option<Handle>,
     storage: Arc<dyn DbReader>,
 ) -> JoinHandle<()> {
@@ -817,6 +856,7 @@ fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
                             error,
                             &error_notification_sender,
                             &pending_data_chunks,
+                            &pending_data_errors,
                         )
                         .await;
                     }
@@ -829,6 +869,7 @@ fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
                         error,
                         &error_notification_sender,
                         &pending_data_chunks,
+                        &pending_data_errors,
                     )
                     .await;
                 },
@@ -907,6 +948,7 @@ async fn apply_snapshot_chunk<MetadataStorage: MetadataStorageInterface + Clone>
     target_ledger_info: &LedgerInfoWithSignatures,
     error_notification_sender: &mpsc::UnboundedSender<ErrorNotification>,
     pending_data_chunks: &Arc<AtomicU64>,
+    pending_data_errors: &Arc<AtomicU64>,
     version: Version,
 ) -> ChunkApplyOutcome {
     let (operation, noun) = match kind {
@@ -966,6 +1008,7 @@ async fn apply_snapshot_chunk<MetadataStorage: MetadataStorageInterface + Clone>
                             error_notification_sender.clone(),
                             notification_id,
                             error,
+                            pending_data_errors,
                         )
                         .await;
                     }
@@ -977,6 +1020,7 @@ async fn apply_snapshot_chunk<MetadataStorage: MetadataStorageInterface + Clone>
                         error_notification_sender.clone(),
                         notification_id,
                         error,
+                        pending_data_errors,
                     )
                     .await;
                 },
@@ -1004,6 +1048,7 @@ fn spawn_snapshot_receiver<
     mut snapshot_listener: mpsc::Receiver<StorageDataChunk>,
     error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
     pending_data_chunks: Arc<AtomicU64>,
+    pending_data_errors: Arc<AtomicU64>,
     metadata_storage: MetadataStorage,
     storage: DbReaderWriter,
     target_ledger_info: LedgerInfoWithSignatures,
@@ -1042,6 +1087,7 @@ fn spawn_snapshot_receiver<
                                     "Failed to initialize the {:?} snapshot receiver! Error: {:?}",
                                     kind, error
                                 ),
+                                &pending_data_errors,
                             )
                             .await;
                         }
@@ -1061,6 +1107,7 @@ fn spawn_snapshot_receiver<
                 &target_ledger_info,
                 &error_notification_sender,
                 &pending_data_chunks,
+                &pending_data_errors,
                 version,
             )
             .await
@@ -1096,6 +1143,7 @@ fn spawn_snapshot_receiver<
                             error_notification_sender.clone(),
                             notification_id,
                             error,
+                            &pending_data_errors,
                         )
                         .await;
                     } else {
@@ -1150,7 +1198,7 @@ fn spawn(
 
 /// Returns the value currently held by the pending chunk counter
 fn load_pending_data_chunks(pending_data_chunks: Arc<AtomicU64>) -> u64 {
-    pending_data_chunks.load(Ordering::Relaxed)
+    pending_data_chunks.load(Ordering::Acquire)
 }
 
 /// Increments the pending data chunks
@@ -1167,7 +1215,8 @@ fn increment_pending_data_chunks(pending_data_chunks: Arc<AtomicU64>) {
 /// Decrements the pending data chunks
 fn decrement_pending_data_chunks(atomic_u64: Arc<AtomicU64>) {
     let delta = 1;
-    atomic_u64.fetch_sub(delta, Ordering::Relaxed);
+    // Publish stage completion after any pending error.
+    atomic_u64.fetch_sub(delta, Ordering::AcqRel);
     metrics::decrement_gauge(
         &metrics::STORAGE_SYNCHRONIZER_GAUGES,
         metrics::STORAGE_SYNCHRONIZER_PENDING_DATA,
@@ -1182,12 +1231,14 @@ async fn handle_storage_synchronizer_error(
     error: String,
     error_notification_sender: &mpsc::UnboundedSender<ErrorNotification>,
     pending_data_chunks: &Arc<AtomicU64>,
+    pending_data_errors: &Arc<AtomicU64>,
 ) {
     // Send an error notification to the driver
     send_storage_synchronizer_error(
         error_notification_sender.clone(),
         notification_metadata.notification_id,
         error,
+        pending_data_errors,
     )
     .await;
 
@@ -1252,6 +1303,7 @@ async fn send_storage_synchronizer_error(
     mut error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
     notification_id: NotificationId,
     error_message: String,
+    pending_data_errors: &Arc<AtomicU64>,
 ) {
     // Log the storage synchronizer error
     let error_message = format!("Storage synchronizer error: {:?}", error_message);
@@ -1260,6 +1312,8 @@ async fn send_storage_synchronizer_error(
     // Update the storage synchronizer error metrics
     let error = Error::UnexpectedError(error_message);
     metrics::increment_counter(&metrics::STORAGE_SYNCHRONIZER_ERRORS, error.get_label());
+    // Keep drain barriers closed until the driver handles this notification.
+    pending_data_errors.fetch_add(1, Ordering::Release);
 
     // Send an error notification to the driver
     let error_notification = ErrorNotification {

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -7,8 +7,9 @@ use crate::{
     error::Error,
     tests::{
         mocks::{
-            create_mock_db_reader, create_mock_streaming_client, create_ready_storage_synchronizer,
-            MockMetadataStorage, MockStorageSynchronizer, MockStreamingClient,
+            create_mock_db_reader, create_mock_storage_synchronizer, create_mock_streaming_client,
+            create_ready_storage_synchronizer, MockMetadataStorage, MockStorageSynchronizer,
+            MockStreamingClient,
         },
         utils::{
             create_data_stream_listener, create_empty_epoch_state, create_epoch_ending_ledger_info,
@@ -38,7 +39,96 @@ use mockall::{
     predicate::{always, eq},
     Sequence,
 };
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+#[tokio::test]
+async fn test_bootstrapping_waits_for_pending_storage_data() {
+    let pending_data_polls = Arc::new(AtomicUsize::new(0));
+
+    let mut storage_synchronizer = create_mock_storage_synchronizer();
+    let pending_data_polls_for_poll = Arc::clone(&pending_data_polls);
+    storage_synchronizer
+        .expect_pending_storage_data()
+        .returning(move || pending_data_polls_for_poll.fetch_add(1, Ordering::SeqCst) == 0);
+    storage_synchronizer
+        .expect_pending_storage_data_error()
+        .return_const(false);
+
+    let pending_data_polls_at_finish = Arc::clone(&pending_data_polls);
+    storage_synchronizer
+        .expect_finish_chunk_executor()
+        .times(1)
+        .returning(move || {
+            assert_eq!(pending_data_polls_at_finish.load(Ordering::SeqCst), 2);
+        });
+
+    let driver_configuration = create_full_node_driver_configuration();
+    let output_fallback_handler =
+        OutputFallbackHandler::new(driver_configuration.clone(), TimeService::mock());
+    let mut database_reader = create_mock_db_reader();
+    database_reader
+        .expect_get_latest_epoch_state()
+        .return_once(|| Ok(create_empty_epoch_state()));
+    let mut bootstrapper = Bootstrapper::new(
+        driver_configuration,
+        MockMetadataStorage::new(),
+        output_fallback_handler,
+        create_mock_streaming_client(),
+        Arc::new(database_reader),
+        storage_synchronizer,
+    );
+
+    bootstrapper.bootstrapping_complete().await.unwrap();
+
+    assert_eq!(pending_data_polls.load(Ordering::SeqCst), 2);
+    assert!(bootstrapper.is_bootstrapped());
+}
+
+#[tokio::test]
+async fn test_bootstrapping_rejects_pending_storage_error() {
+    let mut storage_synchronizer = create_mock_storage_synchronizer();
+    storage_synchronizer
+        .expect_pending_storage_data()
+        .return_const(false);
+    storage_synchronizer
+        .expect_pending_storage_data_error()
+        .return_const(true);
+    storage_synchronizer.expect_finish_chunk_executor().times(0);
+
+    let driver_configuration = create_full_node_driver_configuration();
+    let output_fallback_handler =
+        OutputFallbackHandler::new(driver_configuration.clone(), TimeService::mock());
+    let mut database_reader = create_mock_db_reader();
+    database_reader
+        .expect_get_latest_epoch_state()
+        .return_once(|| Ok(create_empty_epoch_state()));
+    let mut bootstrapper = Bootstrapper::new(
+        driver_configuration,
+        MockMetadataStorage::new(),
+        output_fallback_handler,
+        create_mock_streaming_client(),
+        Arc::new(database_reader),
+        storage_synchronizer,
+    );
+
+    let (bootstrap_notification_sender, bootstrap_notification_receiver) = oneshot::channel();
+    bootstrapper
+        .subscribe_to_bootstrap_notifications(bootstrap_notification_sender)
+        .await
+        .unwrap();
+
+    let error = bootstrapper.bootstrapping_complete().await.unwrap_err();
+
+    assert_matches!(error, Error::UnexpectedError(_));
+    assert!(!bootstrapper.is_bootstrapped());
+    assert_none!(bootstrap_notification_receiver.now_or_never());
+}
 
 #[tokio::test]
 async fn test_bootstrap_genesis_waypoint() {

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -117,6 +117,9 @@ pub fn create_ready_storage_synchronizer(expect_reset_executor: bool) -> MockSto
     mock_storage_synchronizer
         .expect_pending_storage_data()
         .return_const(false);
+    mock_storage_synchronizer
+        .expect_pending_storage_data_error()
+        .return_const(false);
     if expect_reset_executor {
         mock_storage_synchronizer
             .expect_finish_chunk_executor()
@@ -454,6 +457,10 @@ mock! {
         ) -> AnyhowResult<JoinHandle<()>, crate::error::Error>;
 
         fn pending_storage_data(&self) -> bool;
+
+        fn pending_storage_data_error(&self) -> bool;
+
+        fn acknowledge_storage_data_error(&self);
 
         async fn save_state_values(
             &mut self,

--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -144,7 +144,10 @@ async fn test_apply_outputs_error() {
 
     // Verify we get an error notification and that there's no pending data
     verify_error_notification(&mut error_listener, notification_id).await;
+    assert!(storage_synchronizer.pending_storage_data_error());
     verify_no_pending_data(&storage_synchronizer);
+    storage_synchronizer.acknowledge_storage_data_error();
+    assert!(!storage_synchronizer.pending_storage_data_error());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION

The bootstrapper could complete handoff while chunks it had already sent to the storage synchronizer were still moving through the execute, ledger-update, commit, or post-processing stages. Completing bootstrapping finished the shared chunk executor immediately. A worker that reached the executor afterward observed cleared inner state and panicked with "not reset", crashing the node.

Stop the active stream first, wait for the storage synchronizer pending-data count to reach zero, and only then finish the chunk executor and publish bootstrap completion. This prevents new work from entering while the existing pipeline drains.

Track the chunk executor lifecycle as uninitialized, active, or finished. Fresh executors can still initialize lazily, but a finished executor stays terminal until an explicit reset. Late calls return an error and increment a labeled rejection counter instead of panicking, allowing state sync to recover through its normal error path.

Cover both the handoff ordering and terminal lifecycle behavior in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2dc6feb8e7ae8353b6215b6aef69416c80499a4d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->