### PR TITLE
Replay-verify: increase Mainnet PFN snapshot size

### DIFF
--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -35,7 +35,7 @@ ZONE = "us-central1-a"
 
 DEFAULT_PVC_ACCESS_MODE = "ReadOnlyMany"  # Default access mode for PVCs
 TESTNET_SNAPSHOT_DISK_SIZE = "26Ti"  # Must be >= the testnet PFN disk size (26Ti as of 2026-08)
-MAINNET_SNAPSHOT_DISK_SIZE = "23Ti"  # Must be >= the mainnet PFN disk size (23Ti as of 2026-07)
+MAINNET_SNAPSHOT_DISK_SIZE = "25Ti"  # Must be >= the mainnet PFN disk size (25Ti as of 2026-08)
 
 def get_disk_size_for_snapshot(snapshot_name: str) -> str:
     if TESTNET_SNAPSHOT_NAME in snapshot_name:


### PR DESCRIPTION
## Description

Increase Mainnet snapshot size to match the running PFNs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single infrastructure sizing constant for replay-verify PVCs; no application logic or security changes.
> 
> **Overview**
> Raises **`MAINNET_SNAPSHOT_DISK_SIZE`** from **23Ti** to **25Ti** in `archive_disk_utils.py` so replay-verify PVCs provisioned from mainnet archive snapshots request enough storage to match current mainnet PFN disks (comment updated to 2026-08).
> 
> That value flows through **`get_disk_size_for_snapshot`** into mainnet snapshot-backed PVC creation for replay-verify; testnet sizing is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b636c4a33d5b62fdc4dbe9c05e1d12eb544b855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->