### PR TITLE
require email_verified in pepper get_uid_key_and_value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ dependencies = [
  "regex",
  "serde",
  "serde-big-array",
+ "serde_json",
  "sha2 0.10.9",
 ]
 

--- a/keyless/pepper/common/Cargo.toml
+++ b/keyless/pepper/common/Cargo.toml
@@ -33,4 +33,5 @@ rand = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde-big-array = { workspace = true }
+serde_json = { workspace = true }
 sha2_0_10_6 = { workspace = true }

--- a/keyless/pepper/common/src/jwt.rs
+++ b/keyless/pepper/common/src/jwt.rs
@@ -12,6 +12,7 @@ pub struct Claims {
     pub iss: String,
     pub sub: String,
     pub email: Option<String>,
+    pub email_verified: Option<serde_json::Value>,
     pub azp: Option<String>,
     pub aud: String,
     pub iat: u64,

--- a/keyless/pepper/service/src/dedicated_handlers/pepper_request.rs
+++ b/keyless/pepper/service/src/dedicated_handlers/pepper_request.rs
@@ -324,6 +324,22 @@ fn get_uid_key_and_value(
                 EMAIL_UID_KEY
             ))
         })?;
+        // Only issue an email-keyed pepper for a verified email, matching the
+        // on-chain rule in Claims::get_uid_val. The claim may be a boolean or a
+        // boolean-as-a-string, so accept both true forms.
+        let email_verified = claims.claims.email_verified.as_ref().ok_or_else(|| {
+            PepperServiceError::BadRequest(
+                "The email uid_key was specified, but the email_verified claim was not found in the JWT".into(),
+            )
+        })?;
+        let verified =
+            email_verified.as_bool().unwrap_or(false) || email_verified.as_str() == Some("true");
+        if !verified {
+            return Err(PepperServiceError::BadRequest(
+                "The email uid_key was specified, but the email_verified claim was not \"true\""
+                    .into(),
+            ));
+        }
         return Ok((uid_key, uid_value));
     }
 
@@ -578,6 +594,37 @@ mod tests {
     }
 
     #[test]
+    fn test_get_uid_key_and_value_email_requires_verified() {
+        // A missing email_verified claim should be rejected for the email uid_key
+        let mut claims = create_test_token_data();
+        claims.claims.email_verified = None;
+        assert!(get_uid_key_and_value(Some(EMAIL_UID_KEY.into()), &claims).is_err());
+
+        // email_verified = false (bool or string) should be rejected
+        for value in [
+            serde_json::Value::Bool(false),
+            serde_json::Value::String("false".into()),
+        ] {
+            let mut claims = create_test_token_data();
+            claims.claims.email_verified = Some(value);
+            assert!(get_uid_key_and_value(Some(EMAIL_UID_KEY.into()), &claims).is_err());
+        }
+
+        // email_verified = true (bool or string) should be accepted
+        for value in [
+            serde_json::Value::Bool(true),
+            serde_json::Value::String("true".into()),
+        ] {
+            let mut claims = create_test_token_data();
+            claims.claims.email_verified = Some(value);
+            let (uid_key, uid_val) =
+                get_uid_key_and_value(Some(EMAIL_UID_KEY.into()), &claims).unwrap();
+            assert_eq!(uid_key, EMAIL_UID_KEY);
+            assert_eq!(uid_val, TEST_TOKEN_EMAIL);
+        }
+    }
+
+    #[test]
     fn test_invalid_derivation_path() {
         let invalid_path = Some("m/44'/637'/0'/0/0'".to_string()); // Invalid because one index is not hardened
         let result = get_verified_derivation_path(invalid_path);
@@ -741,6 +788,7 @@ mod tests {
                 iat: 0,
                 nonce: TEST_TOKEN_NONCE.into(),
                 email: Some(TEST_TOKEN_EMAIL.into()),
+                email_verified: Some(serde_json::Value::Bool(true)),
                 azp: None,
             },
             header: Default::default(),

--- a/keyless/pepper/service/src/tests/federated_jwk.rs
+++ b/keyless/pepper/service/src/tests/federated_jwk.rs
@@ -31,6 +31,7 @@ impl TestJWTPayload {
             iss: issuer,
             sub: "".into(),
             email: None,
+            email_verified: None,
             azp: None,
             aud: "".into(),
             iat: 0,


### PR DESCRIPTION
## Description
The pepper service derives an email-keyed pepper from the `email` claim but never checks `email_verified`. The on-chain keyless rule, `Claims::get_uid_val` in `types/src/keyless/openid_sig.rs`, requires `email_verified` to be true before using the email as the identity. `get_uid_key_and_value` runs after `verify_jwt_signature`, so a validly signed token whose `email` names a victim while `email_verified` is `false` or absent hands that victim's pepper to a caller who never proved ownership of the address. This gates the email branch on `email_verified`, accepting both a boolean and a boolean-as-string ("true") as providers emit, so the service matches the canonical check.

## How Has This Been Tested?
Added `test_get_uid_key_and_value_email_requires_verified`: a missing, `false`, or `"false"` claim is rejected, `true`/`"true"` is accepted. `cargo test -p aptos-keyless-pepper-service -p aptos-keyless-pepper-common` is green.

## Key Areas to Review
`get_uid_key_and_value` in `keyless/pepper/service/src/dedicated_handlers/pepper_request.rs`, and the new `email_verified` field on `Claims` in `keyless/pepper/common/src/jwt.rs`. The accept/reject logic mirrors `Claims::get_uid_val` so the pepper service and on-chain verification agree.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify) — Keyless pepper service

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This closes an identity/pepper issuance bug in the keyless pepper path; behavior change for email `uid_key` requests with unverified emails is intentional and security-critical.
> 
> **Overview**
> Fixes a **security gap** where the keyless pepper service could derive an email-keyed pepper from a validly signed JWT without checking `email_verified`, allowing a caller to target another user’s email identity.
> 
> **`Claims`** now parses optional `email_verified` (as `serde_json::Value` for bool or string forms). When `uid_key` is `email`, **`get_uid_key_and_value`** rejects missing, false, or `"false"` values and only proceeds when the claim is `true` or `"true"`, matching on-chain **`Claims::get_uid_val`** in `openid_sig.rs`.
> 
> Tests cover the new gate; fixtures and federated JWT test payloads were updated for the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12bfd200f97c878db63efbfde3ec9f63e9783a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->