### PR TITLE
[mono-move] Do not zero-initialize heap

### DIFF
--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -233,7 +233,9 @@ pub struct Heap {
 
 impl Heap {
     pub fn new(size: usize) -> Self {
-        let buffer = MemoryRegion::new(size);
+        // Uninitialized is safe: `heap_alloc` zeroes each object before handing
+        // out its pointer, and nothing reads `[bump_ptr, buffer.end)`.
+        let buffer = MemoryRegion::new_uninit(size);
         Self {
             bump_ptr: buffer.as_ptr(),
             buffer,
@@ -453,6 +455,13 @@ impl<'a> RootScanner<'a> {
 ///
 /// Returns [`AllocationError::OutOfHeapMemory`] when the heap is full
 /// so the caller can trigger GC and retry.
+///
+/// # Invariants
+///
+/// Prior to allocation, the region is zeroed. This is a safety mechanism
+/// when the heap buffer is allocated uninitialized to make sure that the
+/// inter-field padding or any extra memory allocated due to alignment is
+/// always zero.
 pub(crate) fn heap_alloc(
     heap: &mut Heap,
     total_size: usize,
@@ -494,11 +503,13 @@ pub(crate) fn heap_alloc(
         // material win for large/wide-variant enums). It is not a drop-in
         // change: `gc_copy_object` / `deep_copy` copy the full object image
         // including dead-variant tail and inter-field padding, which is
-        // deterministically zero today; leaving it uninitialized makes that
-        // image carry stale heap bytes. Prefer zeroing only the
-        // tail/padding the active variant does not write (still skipping the
-        // large active body), or audit that no byte-image consumer
-        // (state commit / hashing) depends on those bytes first.
+        // deterministically zero today because this memset is the sole
+        // initializer (the backing buffer is uninitialized). Skipping it makes
+        // that image read uninitialized memory (UB), not merely stale bytes.
+        // Prefer zeroing only the tail/padding the active variant does not
+        // write (still skipping the large active body), or audit that no
+        // byte-image consumer (state commit / hashing) depends on those bytes
+        // first.
         std::ptr::write_bytes(header_start, 0, aligned_size);
         let obj_ptr = header_start.add(OBJECT_HEADER_SIZE);
         write_object_header(obj_ptr, descriptor_id, aligned_size as u32);
@@ -812,7 +823,9 @@ pub(crate) fn gc_collect<P: DescriptorProvider + ?Sized>(
 ) -> VMResult<()> {
     heap.gc_count += 1;
 
-    let to_space = MemoryRegion::new(heap.buffer.len());
+    // Uninitialized is safe: the copy below fills to-space contiguously up to
+    // `free_ptr`, and the Phase-2 scan only reads `[to_space.start, free_ptr)`.
+    let to_space = MemoryRegion::new_uninit(heap.buffer.len());
     // `free_ptr` is a raw bump cursor — it points at the start of the
     // next *header* reservation, advancing by each object's total size.
     // Treating it as a raw cursor (rather than as an "object pointer"

--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -232,9 +232,12 @@ pub struct Heap {
 }
 
 impl Heap {
+    /// Creates a heap backed by an uninitialized buffer of the given size.
+    ///
+    /// The buffer is not zeroed. This is sound only while this contract holds:
+    /// every heap object is fully written before any byte of it is read, and
+    /// nothing reads the unbumped tail `[bump_ptr, buffer.end)`.
     pub fn new(size: usize) -> Self {
-        // Uninitialized is safe: `heap_alloc` zeroes each object before handing
-        // out its pointer, and nothing reads `[bump_ptr, buffer.end)`.
         let buffer = MemoryRegion::new_uninit(size);
         Self {
             bump_ptr: buffer.as_ptr(),
@@ -458,10 +461,10 @@ impl<'a> RootScanner<'a> {
 ///
 /// # Invariants
 ///
-/// Prior to allocation, the region is zeroed. This is a safety mechanism
-/// when the heap buffer is allocated uninitialized to make sure that the
-/// inter-field padding or any extra memory allocated due to alignment is
-/// always zero.
+/// Each object's region is zeroed before it is returned. The GC and deep-copy
+/// copy the full object image, including inter-field padding and alignment
+/// gaps. Zeroing makes those bytes reproducibly zero, so the copied image is
+/// deterministic rather than arbitrary heap contents.
 pub(crate) fn heap_alloc(
     heap: &mut Heap,
     total_size: usize,
@@ -504,8 +507,11 @@ pub(crate) fn heap_alloc(
         // change: `gc_copy_object` / `deep_copy` copy the full object image
         // including dead-variant tail and inter-field padding, which is
         // deterministically zero today because this memset is the sole
-        // initializer (the backing buffer is uninitialized). Skipping it makes
-        // that image read uninitialized memory (UB), not merely stale bytes.
+        // initializer (the backing buffer is uninitialized). Skipping it leaves
+        // those bytes uninitialized. A raw byte copy of them is fine in
+        // principle, but compilers (e.g. LLVM) may lower a small copy to a
+        // typed integer load/store, and reading uninitialized bytes as a typed
+        // value is UB, not merely a stale read.
         // Prefer zeroing only the tail/padding the active variant does not
         // write (still skipping the large active body), or audit that no
         // byte-image consumer (state commit / hashing) depends on those bytes

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -243,7 +243,7 @@ impl<'guard> InterpreterContext<'guard> {
                 .join("\n")
         );
 
-        let stack = MemoryRegion::new(DEFAULT_STACK_SIZE);
+        let stack = MemoryRegion::new_zeroed(DEFAULT_STACK_SIZE);
         let base = stack.as_ptr();
 
         unsafe {
@@ -277,7 +277,7 @@ impl<'guard> InterpreterContext<'guard> {
         resource_provider: &'guard dyn ResourceProvider,
         natives: &'guard ProductionNativeRegistry,
     ) -> Self {
-        let stack = MemoryRegion::new(DEFAULT_STACK_SIZE);
+        let stack = MemoryRegion::new_zeroed(DEFAULT_STACK_SIZE);
         let base = stack.as_ptr();
 
         unsafe {

--- a/third_party/move/mono-move/runtime/src/memory.rs
+++ b/third_party/move/mono-move/runtime/src/memory.rs
@@ -22,13 +22,48 @@ pub struct MemoryRegion {
 impl MemoryRegion {
     /// Allocates a zeroed, [`MAX_ALIGN`]-aligned memory region of the given size.
     ///
+    /// Use this whenever a caller may read a slot before writing it (e.g. the
+    /// interpreter stack). For memory that is always written before it is read,
+    /// prefer [`Self::new_uninit`] to skip the zeroing.
+    ///
     /// OOM is handled by aborting via `handle_alloc_error`.
-    pub fn new(size: usize) -> Self {
+    pub fn new_zeroed(size: usize) -> Self {
+        Self::new::<true>(size)
+    }
+
+    /// Allocates an uninitialized, [`MAX_ALIGN`]-aligned memory region of the
+    /// given size. The bytes hold arbitrary values, so the region must be
+    /// written before it is read.
+    ///
+    /// # Safety
+    ///
+    /// This is safe for the heap buffer and the GC to-space because every byte
+    /// that is ever read is written first:
+    /// - `heap_alloc` zeroes each object's region before returning its pointer,
+    ///   and all reads go through object pointers within `[buffer.start, bump_ptr)`.
+    /// - The GC copies fill to-space contiguously up to `free_ptr` and only ever
+    ///   scan `[to_space.start, free_ptr)`; the unbumped tail is never touched.
+    ///
+    /// OOM is handled by aborting via `handle_alloc_error`.
+    pub fn new_uninit(size: usize) -> Self {
+        Self::new::<false>(size)
+    }
+
+    /// Shared body of [`Self::new_zeroed`] / [`Self::new_uninit`]. `ZEROED`
+    /// selects `alloc_zeroed` vs `alloc`; both paths null-check and abort via
+    /// `handle_alloc_error` on OOM.
+    fn new<const ZEROED: bool>(size: usize) -> Self {
         debug_assert!(size > 0);
         let layout = Layout::from_size_align(size, MAX_ALIGN).expect("invalid memory layout");
-        // SAFETY: layout is valid (power-of-two alignment) and `alloc_zeroed` handles
-        // zero-size layouts per the GlobalAlloc contract. Null is checked below.
-        let ptr = unsafe { alloc::alloc_zeroed(layout) };
+        // SAFETY: layout is valid (power-of-two alignment, non-zero size). Null
+        // is checked below.
+        let ptr = unsafe {
+            if ZEROED {
+                alloc::alloc_zeroed(layout)
+            } else {
+                alloc::alloc(layout)
+            }
+        };
         if ptr.is_null() {
             alloc::handle_alloc_error(layout);
         }

--- a/third_party/move/mono-move/runtime/src/memory.rs
+++ b/third_party/move/mono-move/runtime/src/memory.rs
@@ -35,25 +35,36 @@ impl MemoryRegion {
     /// given size. The bytes hold arbitrary values, so the region must be
     /// written before it is read.
     ///
-    /// # Safety
+    /// # Invariants
     ///
-    /// This is safe for the heap buffer and the GC to-space because every byte
-    /// that is ever read is written first:
-    /// - `heap_alloc` zeroes each object's region before returning its pointer,
-    ///   and all reads go through object pointers within `[buffer.start, bump_ptr)`.
-    /// - The GC copies fill to-space contiguously up to `free_ptr` and only ever
-    ///   scan `[to_space.start, free_ptr)`; the unbumped tail is never touched.
+    /// The caller must write every byte before it is read. The region carries
+    /// no guarantee about its initial contents; callers must not rely on any
+    /// (in particular, must not assume it is zeroed).
     ///
     /// OOM is handled by aborting via `handle_alloc_error`.
     pub fn new_uninit(size: usize) -> Self {
-        Self::new::<false>(size)
+        let region = Self::new::<false>(size);
+
+        // The allocator often hands back fresh, already-zeroed OS pages, so in
+        // practice uninitialized memory reads as zeros and code that wrongly
+        // relies on the old zeroing would keep passing. Poison the region in
+        // debug builds so the write-before-read contract is exercised in tests
+        // and CI. Gated on `not(miri)`: this write initializes the memory, which
+        // would otherwise hide genuine uninitialized reads from Miri.
+        #[cfg(all(debug_assertions, not(miri)))]
+        // SAFETY: `region.ptr` is a valid, `size`-byte allocation just returned
+        // by `Self::new` above.
+        unsafe {
+            std::ptr::write_bytes(region.ptr, 0xAA, size);
+        }
+        region
     }
 
     /// Shared body of [`Self::new_zeroed`] / [`Self::new_uninit`]. `ZEROED`
     /// selects `alloc_zeroed` vs `alloc`; both paths null-check and abort via
     /// `handle_alloc_error` on OOM.
     fn new<const ZEROED: bool>(size: usize) -> Self {
-        debug_assert!(size > 0);
+        assert!(size > 0);
         let layout = Layout::from_size_align(size, MAX_ALIGN).expect("invalid memory layout");
         // SAFETY: layout is valid (power-of-two alignment, non-zero size). Null
         // is checked below.


### PR DESCRIPTION
## Description

`MemoryRegion::new` always zeroed its allocation via `alloc_zeroed`. For the heap buffer that zeroing is redundant work: `heap_alloc` already zeroes each object's `[header|payload]` region before handing out its pointer, and no code path ever reads buffer bytes outside `[buffer.start, bump_ptr)`.

This PR splits the constructor into two explicit forms so each caller states its intent:

- `new_zeroed(size)` — the previous `alloc_zeroed` behavior. Used whenever a caller may read a slot before writing it.
- `new_uninit(size)` — uninitialized `alloc`. The bytes must be written before they are read.

The heap buffer (`Heap::new`) and the GC to-space (`gc_collect`) now use `new_uninit`. The interpreter stack keeps `new_zeroed`, since its frame-slot semantics can read a slot before writing it. That path is unchanged in behavior.

Why uninitialized is safe for the heap:
- Every object is zeroed before use — `heap_alloc` does `write_bytes(header_start, 0, aligned_size)` before writing the header and returning the object pointer. All reads go through object pointers within `[start, bump_ptr)`.
- The GC to-space tail is never read — `gc_copy_object` fills to-space contiguously up to `free_ptr` (no gaps), and the Phase-2 Cheney scan loops only while `scan_ptr < free_ptr`. The un-bumped tail is untouched, and after GC `bump_ptr = free_ptr`. `deep_copy` allocates via `heap_alloc` (zeroed) and copies from a live source.
- No whole-buffer read exists — the only buffer accesses are `fits_in_buffer` and `is_heap_ptr`, both pure `as usize` address math. `MemoryRegion` has no `Debug`/`Hash`/slice accessor and no snapshot/hash of the raw buffer anywhere.

## How Has This Been Tested?

- `cargo check -p mono-move-runtime` — clean; all call sites migrated, no `MemoryRegion::new(` references remain.
- `RUST_MIN_STACK=1073741824 cargo nextest run -p mono-move-runtime` — 441/441 pass, including the heap allocation, `gc_collect`, deep-copy, and reset tests that exercise alloc-then-read and full-survival GC.

Deferred: a scoped Miri run (`cargo +nightly miri test`) to machine-check that no uninitialized byte is ever read. Normal runs can't catch this since `alloc` often returns zeroed OS pages.

## Key Areas to Review

- The safety argument on `new_uninit` in `runtime/src/memory.rs` — correctness rests on "every byte read is written first" holding for the heap and GC to-space.
- That the interpreter stack correctly stays on `new_zeroed` (it reads slots before writing them, so it must not use the uninitialized path).

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Correctness depends on never reading unwritten heap/to-space bytes; a missed path would be UB in the VM heap/GC, though behavior is intended to match the prior zeroed-buffer model.
> 
> **Overview**
> **Skips redundant whole-buffer zeroing** for the mono-move VM heap and GC to-space by allocating those regions uninitialized, while keeping per-object zeroing in `heap_alloc`.
> 
> `MemoryRegion` is split into **`new_zeroed`** (previous `alloc_zeroed` behavior) and **`new_uninit`** (`alloc`). The **interpreter stack** stays on **`new_zeroed`** because frame slots can be read before they are written.
> 
> **`Heap::new`** and **`gc_collect`**’s to-space now call **`new_uninit`**, with comments documenting the safety argument: only `[buffer.start, bump_ptr)` / `[to_space.start, free_ptr)` are ever read, and those bytes are filled by **`heap_alloc`**’s memset or GC copies. The **`heap_alloc`** TODO is updated to note that skipping the per-object memset would read **uninitialized** backing memory (UB), not merely stale bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49fffcee6dea57f460dfe1e30ea22431492cec8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->