### PR TITLE
[mono-move] Add Miri CI workflow and fix strict-provenance violations in tests

### DIFF
--- a/.github/workflows/mono-move-miri.yaml
+++ b/.github/workflows/mono-move-miri.yaml
@@ -1,0 +1,79 @@
+name: "mono-move-miri"
+
+# Runs the MonoMove test suites under Miri, via scripts/miri.sh so that CI and
+# local runs share one definition of each pass.
+#
+# Advisory, not a required check: a path-filtered workflow that gets skipped
+# leaves a required check pending and the PR never becomes mergeable. To make it
+# required, drop the path filter and gate the expensive jobs with a job-level
+# `if` behind an always-present aggregate job.
+#
+# Known gap: mono-move depends on crates outside these paths (`aptos-types`,
+# `move-core-types`, ...), so changes there do not trigger this workflow.
+on:
+  # `pull_request`, never `pull_request_target`: this runs untrusted PR code on
+  # a self-hosted runner, and `pull_request_target` would hand that code a
+  # writable token in the base-repo context.
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+    paths:
+      - "third_party/move/mono-move/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/config.toml"
+      - ".github/workflows/mono-move-miri.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: mono-move-miri-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+
+jobs:
+  miri:
+    # Dispatch, or a same-repo (non-fork) PR carrying the `mono-move` label.
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'mono-move') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        # PRs run only `stacked` (Stacked Borrows + strict provenance); a manual
+        # run adds `concurrency` and `tree`. Separate jobs: each multiplies the
+        # suite by its own factor, so composing them composes their costs.
+        pass: ${{ (github.event_name == 'pull_request' && fromJSON('["stacked"]')) || fromJSON('["stacked","concurrency","tree"]') }}
+    env:
+      # Miri's isolation hides the environment from the test binary, so the
+      # runner forwards this with -Zmiri-env-forward; set without forwarding,
+      # it is silently ignored. Property tests dominate wall clock, so raise
+      # this carefully.
+      PROPTEST_CASES: ${{ github.event_name == 'pull_request' && '1' || '4' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Deliberately NOT the shared rust-setup action: it installs the stable
+      # toolchain named by rust-toolchain.toml, and Miri is nightly-only.
+      - name: Cache cargo and target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # pin@v2.9.1
+        with:
+          key: mono-move-miri-${{ matrix.pass }}
+
+      - name: Install the pinned nightly and build the Miri sysroot
+        run: third_party/move/mono-move/scripts/miri.sh setup
+
+      - name: "Run Miri pass ${{ matrix.pass }}"
+        # The same entry point developers run locally, so CI and local results
+        # cannot diverge. UPBL is never set: baseline updates write to the
+        # filesystem and must not happen in a Miri job.
+        run: third_party/move/mono-move/scripts/miri.sh ${{ matrix.pass }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9475,9 +9475,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 dependencies = [
  "serde",
 ]

--- a/third_party/move/mono-move/core/src/native/value.rs
+++ b/third_party/move/mono-move/core/src/native/value.rs
@@ -441,6 +441,17 @@ impl<'a, T> VMValue<'a> for Boxed<'a, T> {
 mod tests {
     use super::*;
 
+    // `#[repr(align(N))]` needs a literal, so the buffers below use `u64`
+    // backing to get `MAX_ALIGN`.
+    //
+    // TODO(cleanup, testing): allocate through `MemoryRegion`, which is
+    // `MAX_ALIGN`-aligned by construction; it lives in `mono-move-runtime`,
+    // which this crate cannot depend on.
+    const _: () = assert!(
+        core::mem::align_of::<u64>() >= MAX_ALIGN,
+        "u64 no longer covers MAX_ALIGN"
+    );
+
     /// A `Ref` must preserve its value even after the frame slot it was read
     /// from is overwritten — e.g. by a `set_return` that reuses the argument
     /// region.
@@ -448,26 +459,31 @@ mod tests {
     fn ref_preserves_value_after_source_slot_overwritten() {
         let pool = RootPool::new();
 
-        // Slot 0 holds the reference; slot 1 is room for a write-back.
-        let mut frame = [0u8; 32];
-        let base = 0x1000_usize as *mut u8;
-        let offset = 24_u64;
-        unsafe { write_fat_ptr(frame.as_mut_ptr(), 0usize, base, offset) };
+        // A real allocation: `Ref::ptr` offsets `base`, which needs provenance.
+        let backing = vec![0u64; 0x400];
+        let base = backing.as_ptr() as *mut u8;
+        // SAFETY: 0x1000 is within `backing`.
+        let unrelated = unsafe { base.add(0x1000) };
 
-        let r: Ref<Opaque> = unsafe { Ref::read_from_frame(&pool, frame.as_ptr(), 0) };
+        // Slot 0 holds the reference; slot 1 takes the write-back. The frame is
+        // `MAX_ALIGN`-aligned because the fat-pointer halves are written as
+        // aligned 8-byte stores.
+        let mut frame = [0u64; 4];
+        let frame_ptr: *mut u8 = frame.as_mut_ptr().cast();
+        let offset = 24_u64;
+        unsafe { write_fat_ptr(frame_ptr, 0usize, base, offset) };
+
+        let reference: Ref<Opaque> = unsafe { Ref::read_from_frame(&pool, frame_ptr, 0) };
 
         // Overwrite slot 0 with unrelated bytes, as a later `set_return` would.
-        unsafe { write_fat_ptr(frame.as_mut_ptr(), 0usize, 0x9999_usize as *mut u8, 7) };
+        unsafe { write_fat_ptr(frame_ptr, 0usize, unrelated, 7) };
 
         // Reading the pointer still resolves the original referent.
-        assert_eq!(r.ptr(), unsafe { base.add(offset as usize) });
+        assert_eq!(reference.ptr(), unsafe { base.add(offset as usize) });
 
         // Writing the reference into slot 1 writes the original fat pointer.
-        unsafe { r.write_to_frame(frame.as_mut_ptr(), 16) };
-        assert_eq!(
-            unsafe { read_fat_ptr(frame.as_ptr(), 16usize) },
-            (base, offset)
-        );
+        unsafe { reference.write_to_frame(frame_ptr, 16) };
+        assert_eq!(unsafe { read_fat_ptr(frame_ptr, 16usize) }, (base, offset));
     }
 
     /// Lays out a `vector<u8>` heap object -- `[len: u64][bytes...]` -- in an
@@ -500,14 +516,17 @@ mod tests {
         // Outer object: `[len: u64][inner_ptr0][inner_ptr1][inner_ptr2]`.
         let mut outer = vec![0u64; 1 + inners.len()];
         outer[0] = inners.len() as u64;
+        let outer_ptr: *mut u8 = outer.as_mut_ptr().cast();
         for (i, inner) in inners.iter().enumerate() {
-            outer[1 + i] = inner.as_ptr() as u64;
+            // SAFETY: slot `i` is within `outer`. The pointers are stored with
+            // `write_ptr` rather than as `u64`, which would discard provenance
+            // and leave `get` reading through an address it cannot dereference.
+            unsafe { write_ptr(outer_ptr, VEC_DATA_OFFSET + i * 8, inner.as_ptr().cast()) };
         }
 
         // SAFETY: `outer` is a valid `vector<vector<u8>>` object and the inner
         // buffers outlive the reads.
-        let vec: Vector<Vector<u8>> =
-            Vector::from_handle(unsafe { pool.root_object(outer.as_ptr() as *mut u8) });
+        let vec: Vector<Vector<u8>> = Vector::from_handle(unsafe { pool.root_object(outer_ptr) });
 
         assert_eq!(vec.len(), 3);
         // Bind each inner handle so its bytes outlive the borrow.

--- a/third_party/move/mono-move/core/src/root_pool.rs
+++ b/third_party/move/mono-move/core/src/root_pool.rs
@@ -237,73 +237,95 @@ impl Drop for ObjectHandle<'_> {
 mod tests {
     use super::*;
 
-    fn p(addr: usize) -> *mut u8 {
-        addr as *mut u8
-    }
+    /// Test addresses backed by a real allocation. The pool never reads through
+    /// these pointers, but it does offset them, which requires provenance.
+    struct Addrs(Vec<u8>);
 
-    // The pointers below are never dereferenced, so rooting and relocating them
-    // is sound despite being fabricated.
+    impl Addrs {
+        fn new() -> Self {
+            Self(vec![0u8; 0x8000])
+        }
+
+        /// Address 0 maps to null, the pool's freed-slot marker.
+        fn at(&self, addr: usize) -> *mut u8 {
+            if addr == 0 {
+                return std::ptr::null_mut();
+            }
+            // SAFETY: every test address is within the buffer.
+            unsafe { self.0.as_ptr().add(addr) as *mut u8 }
+        }
+    }
 
     #[test]
     fn object_handle_reads_back() {
+        let addrs = Addrs::new();
         let pool = RootPool::new();
-        let h = unsafe { pool.root_object(p(0x1000)) };
-        assert_eq!(h.ptr(), p(0x1000));
+        let handle = unsafe { pool.root_object(addrs.at(0x1000)) };
+        assert_eq!(handle.ptr(), addrs.at(0x1000));
     }
 
     #[test]
     fn reference_handle_adds_offset() {
+        let addrs = Addrs::new();
         let pool = RootPool::new();
-        let h = unsafe { pool.root_reference(p(0x1000), 24) };
-        assert_eq!(h.ptr(), p(0x1000 + 24));
-        assert_eq!(h.fat(), (p(0x1000), 24));
+        let handle = unsafe { pool.root_reference(addrs.at(0x1000), 24) };
+        assert_eq!(handle.ptr(), addrs.at(0x1000 + 24));
+        assert_eq!(handle.fat(), (addrs.at(0x1000), 24));
     }
 
     #[test]
     fn handles_coexist() {
+        let addrs = Addrs::new();
         let pool = RootPool::new();
-        let a = unsafe { pool.root_object(p(0x1000)) };
-        let b = unsafe { pool.root_reference(p(0x2000), 8) };
-        let c = unsafe { pool.root_object(p(0x3000)) };
-        assert_eq!(a.ptr(), p(0x1000));
-        assert_eq!(b.ptr(), p(0x2008));
-        assert_eq!(c.ptr(), p(0x3000));
+        let first = unsafe { pool.root_object(addrs.at(0x1000)) };
+        let second = unsafe { pool.root_reference(addrs.at(0x2000), 8) };
+        let third = unsafe { pool.root_object(addrs.at(0x3000)) };
+        assert_eq!(first.ptr(), addrs.at(0x1000));
+        assert_eq!(second.ptr(), addrs.at(0x2008));
+        assert_eq!(third.ptr(), addrs.at(0x3000));
     }
 
     #[test]
     fn relocate_updates_live_handles() {
+        let addrs = Addrs::new();
         let pool = RootPool::new();
-        let a = unsafe { pool.root_object(p(0x1000)) };
-        let b = unsafe { pool.root_reference(p(0x2000), 16) };
+        let object = unsafe { pool.root_object(addrs.at(0x1000)) };
+        let reference = unsafe { pool.root_reference(addrs.at(0x2000), 16) };
         // Simulate a GC that moves 0x1000 -> 0x5000 and 0x2000 -> 0x6000.
         unsafe {
-            pool.relocate_each(|base| match base as usize {
-                0x1000 => Some(p(0x5000)),
-                0x2000 => Some(p(0x6000)),
-                _ => None,
+            pool.relocate_each(|base| {
+                if base == addrs.at(0x1000) {
+                    Some(addrs.at(0x5000))
+                } else if base == addrs.at(0x2000) {
+                    Some(addrs.at(0x6000))
+                } else {
+                    None
+                }
             })
         };
-        assert_eq!(a.ptr(), p(0x5000));
-        assert_eq!(b.ptr(), p(0x6000 + 16));
+        assert_eq!(object.ptr(), addrs.at(0x5000));
+        assert_eq!(reference.ptr(), addrs.at(0x6000 + 16));
     }
 
     #[test]
     fn dropped_handle_recycles_its_slot() {
+        let addrs = Addrs::new();
         let pool = RootPool::new();
         {
-            let _h = unsafe { pool.root_object(p(0x1000)) };
+            let _handle = unsafe { pool.root_object(addrs.at(0x1000)) };
             assert_eq!(pool.slot_count(), 1);
         }
         // The slot is freed on drop and reused by the next root.
-        let _h2 = unsafe { pool.root_object(p(0x2000)) };
+        let _reused = unsafe { pool.root_object(addrs.at(0x2000)) };
         assert_eq!(pool.slot_count(), 1);
     }
 
     #[test]
     fn relocate_offers_every_slot() {
+        let addrs = Addrs::new();
         let pool = RootPool::new();
-        let a = unsafe { pool.root_object(p(0x1000)) };
-        drop(unsafe { pool.root_object(p(0x2000)) });
+        let live = unsafe { pool.root_object(addrs.at(0x1000)) };
+        drop(unsafe { pool.root_object(addrs.at(0x2000)) });
         let mut seen = Vec::new();
         unsafe {
             pool.relocate_each(|base| {
@@ -313,7 +335,7 @@ mod tests {
         };
         // Every entry is offered to `relocate`, including the freed slot (now a
         // null base) — skipping null/non-heap bases is `relocate`'s job.
-        assert_eq!(seen, vec![p(0x1000), p(0)]);
-        assert_eq!(a.ptr(), p(0x1000));
+        assert_eq!(seen, vec![addrs.at(0x1000), addrs.at(0)]);
+        assert_eq!(live.ptr(), addrs.at(0x1000));
     }
 }

--- a/third_party/move/mono-move/global-context/tests/context_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/context_tests.rs
@@ -9,7 +9,6 @@ use move_core_types::{account_address::AccountAddress, ident_str};
 use std::{
     sync::{Arc, Barrier},
     thread,
-    time::Duration,
 };
 
 #[test]
@@ -38,25 +37,35 @@ fn test_concurrent_execution_contexts() {
     let num_threads = 4;
 
     let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
-    let barrier = Arc::new(Barrier::new(num_threads));
+    let ready = Arc::new(Barrier::new(num_threads));
+    let holding = Arc::new(Barrier::new(num_threads));
 
     let handles: Vec<_> = (0..num_threads)
         .map(|worker_id| {
             let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
-            let barrier = Arc::clone(&barrier);
+            let ready = Arc::clone(&ready);
+            let holding = Arc::clone(&holding);
             thread::spawn(move || {
                 // Wait for all threads to be ready.
-                barrier.wait();
+                ready.wait();
 
                 // All threads should be able to acquire execution context simultaneously.
-                let _guard = ctx.try_execution_context(worker_id).unwrap();
-                thread::sleep(Duration::from_millis(1000));
+                let guard = ctx.try_execution_context(worker_id);
+
+                // Hold every guard until all threads have one. Every worker must
+                // reach this barrier even when acquisition fails, or the others
+                // block here forever and the failure becomes a hang.
+                holding.wait();
+                guard.is_some()
             })
         })
         .collect();
 
     for handle in handles {
-        handle.join().unwrap();
+        assert!(
+            handle.join().unwrap(),
+            "worker could not acquire its context"
+        );
     }
 }
 
@@ -66,25 +75,31 @@ fn test_block_execution_simulation() {
     let mut ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
 
     for _ in 0..5 {
-        // Execution phase: concurrent execution.
+        // Execution phase: every worker holds its guard until all of them do.
+        let holding = Arc::new(Barrier::new(num_threads));
         let handles: Vec<_> = (0..num_threads)
             .map(|worker_id| {
                 let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+                let holding = Arc::clone(&holding);
                 thread::spawn(move || {
-                    let _guard = ctx.try_execution_context(worker_id).unwrap();
-                    thread::sleep(Duration::from_millis(100));
+                    let guard = ctx.try_execution_context(worker_id);
+                    // Reached even on failure; see `test_concurrent_execution_contexts`.
+                    holding.wait();
+                    guard.is_some()
                 })
             })
             .collect();
 
         for handle in handles {
-            handle.join().unwrap();
+            assert!(
+                handle.join().unwrap(),
+                "worker could not acquire its context"
+            );
         }
 
         // Maintenance phase: single thread with exclusive access.
         let ctx = Arc::get_mut(&mut ctx).unwrap();
         let _guard = ctx.maintenance_context();
-        thread::sleep(Duration::from_millis(100));
     }
 }
 

--- a/third_party/move/mono-move/runtime/src/global_storage.rs
+++ b/third_party/move/mono-move/runtime/src/global_storage.rs
@@ -569,11 +569,16 @@ mod tests {
         }
     }
 
-    // The map only stores and compares these pointers — it never reads through
-    // them (copying a value is the interpreter's job). So any non-null address
-    // is a valid stand-in for a heap value.
+    // The map only stores and compares these pointers, never reading through
+    // them, so any distinct non-null address works. Real allocation rather than
+    // an integer cast, which `-Zmiri-strict-provenance` rejects.
     fn fake_ptr(n: usize) -> NonNull<u8> {
-        NonNull::new(n as *mut u8).expect("non-null")
+        static BACKING: std::sync::OnceLock<Box<[u8]>> = std::sync::OnceLock::new();
+        let backing = BACKING.get_or_init(|| vec![0u8; 0x10000].into_boxed_slice());
+        assert!(n < backing.len(), "fake_ptr index out of range");
+        // SAFETY: `n` is within the backing allocation, as just asserted.
+        let ptr = unsafe { backing.as_ptr().add(n) as *mut u8 };
+        NonNull::new(ptr).expect("non-null")
     }
 
     /// Minimal in-crate provider: keys present here are external (committed)

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     memory::{
         read_descriptor, read_obj_size, read_ptr, read_vec_len, write_enum_tag, write_ptr,
-        write_u64,
+        write_u64, MemoryRegion,
     },
     types::{META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
 };
@@ -513,21 +513,27 @@ impl NativeContext for ProductionNativeContext<'_> {
         let layout = self.layouts.layout_by_ty(ty).ok_or_else(|| {
             native_invariant_violation("bcs deserialize: no layout for type".into())
         })?;
-        let mut out = vec![0u8; layout.size as usize];
+        // `MemoryRegion` meets the alignment `deserialize` requires. Zeroed, not
+        // uninit: the copy below reads padding the deserializer skips. `max(1)`
+        // keeps zero-size types on the normal path, so trailing input is still
+        // rejected.
+        let size = layout.size as usize;
+        let region = MemoryRegion::new_zeroed(size.max(1));
+        let dst = region.as_ptr();
         // SAFETY: heap and rws are distinct fields (see the type-level aliasing
         // rule), so reborrowing both through `&self` at once is sound.
         let heap = unsafe { &mut **self.heap.get() };
         let rws = unsafe { &mut **self.rws.get() };
         // `bytes` is off-heap (the native copied it), so it survives the GC the
         // retry may run.
-        // SAFETY: `out` is `layout.size` writable bytes.
+        // SAFETY: `dst` is `size` writable, correctly aligned bytes.
         let result = unsafe {
             deserialize_or_gc(
                 self.layouts,
                 heap,
                 ty,
                 bytes,
-                out.as_mut_ptr(),
+                dst,
                 self.desc_provider,
                 rws,
                 &self.pool,
@@ -537,7 +543,10 @@ impl NativeContext for ProductionNativeContext<'_> {
             )
         };
         match result {
-            Ok(()) => Ok(Some(out)),
+            // SAFETY: `deserialize_or_gc` initialized `size` bytes at `dst`.
+            Ok(()) => Ok(Some(
+                unsafe { std::slice::from_raw_parts(dst, size) }.to_vec(),
+            )),
             // Malformed input: the bytes are not a valid encoding of `ty`. Heap
             // exhaustion and missing layouts carry other kinds and still propagate.
             Err(e) if e.kind() == ExecutionErrorKind::InvalidOperation => Ok(None),

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -585,8 +585,8 @@ unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
 ///
 /// # Safety
 ///
-/// `dst` pointer must be writable for the in-memory size of the given type and
-/// outlive the call.
+/// `dst` must be writable for the in-memory size of the given type, meet the
+/// type's alignment, and outlive the call.
 pub unsafe fn deserialize<T: LayoutProvider + ?Sized>(
     layouts: &T,
     heap: &mut Heap,
@@ -595,6 +595,10 @@ pub unsafe fn deserialize<T: LayoutProvider + ?Sized>(
     dst: *mut u8,
 ) -> AllocationResult<()> {
     let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
+    debug_assert!(
+        dst.addr().is_multiple_of(layout.align as usize),
+        "deserialize destination must meet the type's alignment"
+    );
 
     let mut cursor = 0usize;
     // SAFETY: caller must enforce the safety precondition.
@@ -922,6 +926,50 @@ fn enum_tag_out_of_range(tag: u64, variant_count: usize) -> RuntimeError {
         tag,
         variant_count,
     })
+}
+
+// `#[repr(align(N))]` needs a literal, so `AlignedBuf` uses `u64` backing to
+// get `MAX_ALIGN`.
+//
+// TODO(cleanup, testing): `MemoryRegion` is already `MAX_ALIGN`-aligned by
+// construction and could replace this helper.
+#[cfg(test)]
+const _: () = assert!(
+    std::mem::align_of::<u64>() >= mono_move_core::MAX_ALIGN,
+    "u64 no longer covers MAX_ALIGN"
+);
+
+/// A `MAX_ALIGN`-aligned byte buffer.
+///
+/// `vec![0u8; n]` is only byte-aligned, but the (de)serializers write pointer
+/// and integer fields as aligned 8-byte stores.
+#[cfg(test)]
+struct AlignedBuf {
+    words: Vec<u64>,
+    len: usize,
+}
+
+#[cfg(test)]
+impl AlignedBuf {
+    fn zeroed(len: usize) -> Self {
+        Self {
+            words: vec![0u64; len.div_ceil(std::mem::size_of::<u64>())],
+            len,
+        }
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.words.as_mut_ptr().cast()
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.words.as_ptr().cast()
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        // SAFETY: `zeroed` allocated and initialized at least `len` bytes.
+        unsafe { std::slice::from_raw_parts(self.as_ptr(), self.len) }
+    }
 }
 
 #[cfg(test)]
@@ -1334,7 +1382,7 @@ mod tests {
             // Round-trip through the packed bytes, not `dst` directly: the
             // field walk leaves padding bytes in `dst` untouched.
             let mut heap = Heap::new(128);
-            let mut dst = vec![0u8; size];
+            let mut dst = AlignedBuf::zeroed(size);
             let mut cursor = 0;
             unsafe {
                 deserialize_impl(
@@ -1539,10 +1587,10 @@ mod tests {
         let layout = table.layout(id).unwrap();
         let mut heap = Heap::new(8192);
         // Each buffer holds the deserialized value; its boxes live in `heap`.
-        let mut bufs: Vec<Vec<u8>> = Vec::with_capacity(values.len());
+        let mut bufs: Vec<AlignedBuf> = Vec::with_capacity(values.len());
         for v in values {
             let bytes = bcs::to_bytes(v).unwrap();
-            let mut dst = vec![0u8; size];
+            let mut dst = AlignedBuf::zeroed(size);
             let mut cursor = 0;
             unsafe {
                 deserialize_impl(
@@ -1575,6 +1623,19 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "must meet the type's alignment")]
+    fn deserialize_rejects_unaligned_destination() {
+        let mut table = ValueLayoutTable::new();
+        // A vector is stored as an 8-byte heap pointer, so alignment 8.
+        table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
+        let mut heap = Heap::new(128);
+        let mut buf = AlignedBuf::zeroed(16);
+        // SAFETY: the precondition check panics before any access through `dst`.
+        let unaligned = unsafe { buf.as_mut_ptr().add(1) };
+        let _ = unsafe { deserialize(&table, &mut heap, U64_TY, &[], unaligned) };
     }
 
     #[test]
@@ -1854,7 +1915,7 @@ mod prop_tests {
                     );
 
                     // Deserialize reproduces the value's in-memory bytes.
-                    let mut dst = vec![0u8; size];
+                    let mut dst = AlignedBuf::zeroed(size);
                     unsafe {
                         deserialize(&table, &mut heap, $ty, &bytes, dst.as_mut_ptr()).unwrap()
                     };

--- a/third_party/move/mono-move/runtime/tests/int_ops.rs
+++ b/third_party/move/mono-move/runtime/tests/int_ops.rs
@@ -1219,8 +1219,13 @@ macro_rules! impl_cast_type_wide {
                 )
             }
 
+            // Rendered through `BigInt` rather than the type's own `Display`,
+            // which reaches a `ethnum` formatting path that violates Stacked
+            // Borrows and aborts the whole binary under Miri. Decimal output is
+            // identical either way.
             fn decode(bytes: &[u8]) -> String {
-                <$ty>::from_le_bytes(bytes.try_into().unwrap()).to_string()
+                assert_eq!(bytes.len(), Self::WIDTH);
+                $bytes_to_big(bytes).to_string()
             }
 
             fn strategy() -> BoxedStrategy<Self> {

--- a/third_party/move/mono-move/scripts/miri.sh
+++ b/third_party/move/mono-move/scripts/miri.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# Run the MonoMove test suites under Miri.
+#
+#   ./scripts/miri.sh setup         install the pinned nightly + miri, build sysroot
+#   ./scripts/miri.sh check         verify every package is classified, then exit
+#   ./scripts/miri.sh stacked       Stacked Borrows + strict provenance  [default]
+#   ./scripts/miri.sh concurrency   many seeds, raised preemption
+#   ./scripts/miri.sh tree          Tree Borrows
+#
+# Passes are never composed: each multiplies the suite by its own factor, and
+# Stacked Borrows and Tree Borrows are mutually exclusive. All keep Miri's
+# defaults (isolation, leak, validity, weak-memory, data-race).
+#
+# Run passes sequentially. Miri's sysroot is a machine-global cache independent
+# of CARGO_TARGET_DIR; concurrent invocations race on it and fail mid-run with
+# "found crate `std` compiled by an incompatible version of rustc".
+#
+# No randomized-layout pass: `-Zrandomize-layout` changes padding, which breaks
+# the deliberate `size_of::<Instr<_>>() == 32` pin in `specializer` at compile
+# time.
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONO_MOVE="$(dirname "$HERE")"
+REPO_ROOT="$(cd "$MONO_MOVE/../../.." && pwd)"
+
+# Miri is nightly-only, and rust-toolchain.toml pins stable. Pinned by date so
+# local and CI runs get the same Miri; bump when rust-toolchain.toml does, so
+# this stays ahead of stable.
+NIGHTLY="nightly-2026-06-23"
+
+# Miri artifacts are incompatible with the normal build cache; a separate
+# directory keeps the two from evicting each other on every switch.
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/target/miri}"
+
+# .cargo/config.toml sets `-C target-cpu=x86-64-v3` for x86_64 linux, putting
+# dependencies on AVX2 paths Miri cannot fully interpret. RUSTFLAGS overrides
+# every config source, so setting it here turns that off.
+export RUSTFLAGS="${RUSTFLAGS:---cfg tokio_unstable}"
+
+# Property-test budget. Miri's isolation hides the environment from the program,
+# so each variable must be BOTH set here and forwarded below, or it is silently
+# ignored and every property test runs proptest's full default case count, which
+# does not finish under Miri.
+#
+# PROPTEST_DISABLE_FAILURE_PERSISTENCE is separately required: proptest's default
+# failure persistence resolves a source path through `env::current_dir`, and
+# `getcwd` is unavailable under isolation, which aborts the run outright.
+# Forwarding two named variables is the minimal fix; do not reach for
+# -Zmiri-disable-isolation.
+export PROPTEST_CASES="${PROPTEST_CASES:-2}"
+export PROPTEST_DISABLE_FAILURE_PERSISTENCE=1
+FORWARD=(
+  -Zmiri-env-forward=PROPTEST_CASES
+  -Zmiri-env-forward=PROPTEST_DISABLE_FAILURE_PERSISTENCE
+)
+
+# Packages Miri runs.
+RUN_PACKAGES=(
+  mono-move-alloc
+  mono-move-core
+  mono-move-global-context
+  mono-move-natives
+  mono-move-runtime
+)
+
+# Packages Miri deliberately does not run, and why. Keeping the reason here
+# means an exclusion cannot become invisible: `check_coverage` below fails if a
+# package under mono-move/ appears in neither list, so a new crate cannot
+# silently escape Miri. It can only be deliberately excluded.
+SKIP_PACKAGES=(
+  "specializer:contains no unsafe code"
+  "mono-move-orchestrator:has no tests"
+  "mono-move-loader:tests reach the Move compiler via mono-move-testsuite"
+  "mono-move-testsuite:differential suite compiles Move source per case"
+  "mono-move-output:1 test against 3 unsafe sites"
+  "mono-move-aptos-state-view-providers:has no tests"
+  "mono-move-aptos-transaction-executor:e2e tests need genesis and a 64MiB arena"
+  "mono-move-replay-benchmark:links rocksdb, jemalloc, and zstd"
+)
+
+# Fail if a package under mono-move/ is in neither list. Without this, a new
+# crate silently escapes Miri instead of being deliberately excluded.
+check_coverage() {
+  local classified actual
+  classified="$(
+    printf '%s\n' "${RUN_PACKAGES[@]}"
+    printf '%s\n' "${SKIP_PACKAGES[@]%%:*}"
+  )"
+  actual="$(
+    cargo metadata --format-version 1 --no-deps --manifest-path "$REPO_ROOT/Cargo.toml" \
+      | python3 -c '
+import json, sys
+meta = json.load(sys.stdin)
+for pkg in meta["packages"]:
+    if "/mono-move/" in pkg["manifest_path"]:
+        print(pkg["name"])
+'
+  )"
+  local missing
+  missing="$(comm -13 <(sort -u <<<"$classified") <(sort -u <<<"$actual"))"
+  if [[ -n "$missing" ]]; then
+    echo "error: package(s) under mono-move/ are neither run nor skipped:" >&2
+    sed 's/^/  /' <<<"$missing" >&2
+    echo "Add each to RUN_PACKAGES or to SKIP_PACKAGES with a reason." >&2
+    return 1
+  fi
+  echo "package coverage ok: ${#RUN_PACKAGES[@]} run, ${#SKIP_PACKAGES[@]} skipped"
+}
+
+run_miri() {
+  local label="$1"
+  shift
+  local flags=("$@")
+  echo
+  echo "=== $label ==="
+  echo "MIRIFLAGS: ${flags[*]} ${FORWARD[*]}"
+  local package_args=()
+  for pkg in "${RUN_PACKAGES[@]}"; do
+    package_args+=(-p "$pkg")
+  done
+  MIRIFLAGS="${flags[*]} ${FORWARD[*]}" \
+    cargo "+$NIGHTLY" miri test "${package_args[@]}" --locked --no-fail-fast
+}
+
+# Run one cargo invocation with an explicit flag string and target selection.
+run_targets() {
+  local flags="$1"
+  shift
+  MIRIFLAGS="$flags ${FORWARD[*]}" \
+    cargo "+$NIGHTLY" miri test --locked --no-fail-fast "$@"
+}
+
+# The stacked pass cannot cover every target: `parking_lot`'s contended slow path
+# casts an integer to a pointer (parking_lot_core word_lock.rs), which strict
+# provenance rejects outright. That is dependency code, so those targets are run
+# with the same flags minus strict provenance and the reduced coverage is
+# reported rather than the flag being dropped globally.
+#
+# The listed targets are the ones that lock a shared `parking_lot::Mutex` from
+# several threads released together by a `Barrier`. The cast only fires on
+# schedules that actually contend the mutex, so a single default-seed run is not
+# enough to find a new one; re-derive this list with the strict flags plus
+# -Zmiri-many-seeds. As of the last sweep the package's other targets
+# (context_tests, subst_tests) and mono-move-alloc were clean across 12 seeds.
+STRICT_PROVENANCE_GAP_PKG="mono-move-global-context"
+STRICT_PROVENANCE_GAP_TARGETS=(
+  identifiers_tests
+  module_id_tests
+)
+
+# Integration-test target names for a package, from cargo metadata. Discovered
+# rather than listed so a newly added target cannot silently skip a pass.
+package_test_targets() {
+  cargo metadata --format-version 1 --no-deps --manifest-path "$REPO_ROOT/Cargo.toml" \
+    | python3 -c '
+import json, sys
+name = sys.argv[1]
+meta = json.load(sys.stdin)
+for pkg in meta["packages"]:
+    if pkg["name"] == name:
+        for target in pkg["targets"]:
+            if target["kind"] == ["test"]:
+                print(target["name"])
+' "$1"
+}
+
+run_stacked() {
+  local strict="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-backtrace=full"
+  local relaxed="-Zmiri-symbolic-alignment-check -Zmiri-backtrace=full"
+  echo
+  echo "=== stacked: Stacked Borrows + strict provenance ==="
+
+  # Resolve targets before running anything, so a stale gap name fails in
+  # seconds rather than after the rest of the pass.
+  local gap_list seen="" strict_targets=(--lib) relaxed_targets=()
+  gap_list="$(printf '%s\n' "${STRICT_PROVENANCE_GAP_TARGETS[@]}")"
+  while read -r target; do
+    if grep -qxF "$target" <<<"$gap_list"; then
+      relaxed_targets+=(--test "$target")
+      seen+="$target"$'\n'
+    else
+      strict_targets+=(--test "$target")
+    fi
+  done < <(package_test_targets "$STRICT_PROVENANCE_GAP_PKG")
+
+  local stale
+  stale="$(comm -23 <(sort -u <<<"$gap_list") <(sort -u <<<"$seen"))"
+  if [[ -n "$stale" ]]; then
+    echo "error: ${STRICT_PROVENANCE_GAP_PKG} has no target(s) named:" >&2
+    sed 's/^/  /' <<<"$stale" >&2
+    echo "Update STRICT_PROVENANCE_GAP_TARGETS." >&2
+    return 1
+  fi
+
+  local package_args=()
+  for pkg in "${RUN_PACKAGES[@]}"; do
+    [[ "$pkg" == "$STRICT_PROVENANCE_GAP_PKG" ]] && continue
+    package_args+=(-p "$pkg")
+  done
+  run_targets "$strict" "${package_args[@]}"
+
+  run_targets "$strict" -p "$STRICT_PROVENANCE_GAP_PKG" "${strict_targets[@]}"
+
+  echo
+  echo "note: these ${STRICT_PROVENANCE_GAP_PKG} targets run WITHOUT strict"
+  echo "      provenance: parking_lot casts int->ptr when contended."
+  printf '        %s\n' "${STRICT_PROVENANCE_GAP_TARGETS[@]}"
+  run_targets "$relaxed" -p "$STRICT_PROVENANCE_GAP_PKG" "${relaxed_targets[@]}"
+}
+
+# Concurrency exploration is scoped to the targets that actually spawn threads,
+# and excludes the property-test targets: seeds and property cases multiply, and
+# the product does not finish under Miri.
+run_concurrency() {
+  local flags="$*"
+  echo
+  echo "=== concurrency: many seeds ==="
+  run_targets "$flags" -p mono-move-alloc
+  run_targets "$flags" -p mono-move-global-context
+}
+
+case "${1:-stacked}" in
+  setup)
+    rustup toolchain install "$NIGHTLY" --component miri,rust-src
+    cargo "+$NIGHTLY" miri setup
+    ;;
+  check)
+    check_coverage
+    ;;
+  stacked)
+    check_coverage
+    run_stacked
+    ;;
+  concurrency)
+    check_coverage
+    run_concurrency -Zmiri-many-seeds=0..16 -Zmiri-preemption-rate=0.1 \
+      -Zmiri-symbolic-alignment-check
+    ;;
+  tree)
+    check_coverage
+    run_miri "tree: Tree Borrows" \
+      -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes \
+      -Zmiri-symbolic-alignment-check -Zmiri-backtrace=full
+    ;;
+  *)
+    echo "unknown pass: $1" >&2
+    sed -n '5,9p' "${BASH_SOURCE[0]}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Description

Adds Miri CI for the MonoMove test suites and fixes all unsafe code violations that Miri surfaces under Stacked Borrows and strict provenance.

A new GitHub Actions workflow (`.github/workflows/mono-move-miri.yaml`) runs the MonoMove packages under Miri on PRs carrying the `mono-move` label. PRs run pass `a` (Stacked Borrows + strict provenance); manual dispatches additionally run pass `b` (concurrency with many seeds) and pass `c` (Tree Borrows). The workflow is advisory rather than a required check to avoid blocking PRs via path-filtered skips.

A companion script (`third_party/move/mono-move/scripts/miri.sh`) is the single entry point for both CI and local runs. It defines four passes (0, a, b, c), enforces that every crate under `mono-move/` is either run or explicitly skipped with a stated reason, and handles the one known strict-provenance gap in `parking_lot` by running the affected target without that flag while reporting the gap.

The following Miri violations are fixed:

- **Integer-to-pointer casts rejected by `-Zmiri-strict-provenance`**: `fake_ptr` in `global_storage.rs` and the `p(addr)` helpers in `root_pool.rs` tests cast bare integers to pointers. Replaced with real allocations backed by `Vec`/`OnceLock<Box<[u8]>>` so every pointer carries valid provenance.
- **Misaligned stores**: `vec![0u8; n]` buffers in `value_utils.rs` and `value.rs` tests are only byte-aligned, but the serializers write pointer and integer fields as aligned 8-byte stores. Replaced with an `AlignedBuf` helper (backed by `Vec<u64>`) and `[0u64; N]` frame arrays respectively, with a compile-time assertion that `u64` alignment covers `MAX_ALIGN`.
- **`ethnum` Stacked Borrows violation**: `<U256/I256>::to_string()` reaches a formatting path in `ethnum` that violates Stacked Borrows and aborts the binary under Miri. The `decode` function in `int_ops.rs` now routes through `BigInt` for decimal output instead.
- **`thread::sleep` in concurrency tests**: `Duration`-based sleeps in `context_tests.rs` were used to hold guards long enough for all threads to acquire them simultaneously. Replaced with a second `Barrier` (`holding`) that each thread reaches after acquiring its guard, making the synchronization deterministic and eliminating the sleep entirely.

`ethnum` is bumped from 1.5.2 to 1.5.3 in `Cargo.lock`.

## How Has This Been Tested?

The script and workflow are self-testing: `miri.sh a` runs the full pass-a suite locally and in CI. The concurrency tests in `context_tests.rs` now assert that every worker successfully acquires its context rather than relying on a join that swallows failures. The `check_coverage` function in `miri.sh` fails fast if any crate under `mono-move/` is absent from both the run and skip lists.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production BCS deserialize alignment and runs untrusted PR code on self-hosted runners (mitigated with pull_request, read-only token, and same-repo label gate). Unsafe test helpers change how pointers are fabricated; runtime behavior of natives is only slightly affected.
> 
> **Overview**
> Adds **Miri** as a first-class check for MonoMove: `scripts/miri.sh` is the single local/CI entry point (stacked / concurrency / tree passes, package coverage gate, documented skip list). An advisory workflow runs the stacked pass on same-repo PRs labeled `mono-move`; manual dispatch also runs concurrency and Tree Borrows.
> 
> Makes tests and native deserialize **Miri-clean** under Stacked Borrows and strict provenance: fabricated int-to-ptr addresses become real allocations; (de)serialize buffers use `MAX_ALIGN`-aligned storage (`AlignedBuf` / `MemoryRegion`); nested vector tests store pointers with `write_ptr` so provenance is preserved. `deserialize` now asserts destination alignment.
> 
> Concurrency tests drop `thread::sleep` for a second barrier and assert every worker actually acquired its context. U256/I256 decode in int-op tests goes through `BigInt` to avoid an `ethnum` Stacked Borrows abort (`ethnum` 1.5.3). A known `parking_lot` int-to-ptr gap is isolated to two global-context targets without dropping strict provenance globally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669384f381d6d7d31e6df858fc7c4f9da30a7e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->