### PR TITLE
[move prover] fix signed integer in prover

### DIFF
--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -4335,6 +4335,27 @@ impl SpecTranslator<'_> {
         }
     }
 
+    /// Whether this expression involves a signed integer anywhere, used to
+    /// decide whether a `num`-typed division needs the truncating helper.
+    /// Spec arithmetic widens to `num`, so a division over signed values can
+    /// reach the translator with its type erased — and only those disagree
+    /// with the body, which truncates toward zero. An all-unsigned expression
+    /// has no such disagreement, so it keeps the plain operator and its
+    /// encoding is untouched.
+    fn exp_involves_signed(&self, exp: &Exp) -> bool {
+        if self
+            .get_node_type(exp.node_id())
+            .skip_reference()
+            .is_signed_int()
+        {
+            return true;
+        }
+        match exp.as_ref() {
+            ExpData::Call(_, _, args) => args.iter().any(|a| self.exp_involves_signed(a)),
+            _ => false,
+        }
+    }
+
     /// Translates a binary arithmetic / relational op. `boogie_op` is the
     /// infix operator for the unsigned (Euclidean / boolean) case; `bv_op` is
     /// the bitwise function-name prefix (e.g. `Div`, `Lt`). `signed_helper`
@@ -4372,8 +4393,21 @@ impl SpecTranslator<'_> {
                 self.translate_op_operand(e, true, &conv_base)
             });
             emit!(self.writer, ")");
-        } else if let Some(helper) = signed_helper.filter(|_| ty0.skip_reference().is_signed_int())
-        {
+        } else if let Some(helper) = signed_helper.filter(|_| {
+            let ty = ty0.skip_reference();
+            // Spec arithmetic widens to `num`, so a division whose dividend
+            // is an expression rather than a variable or cast arrives here
+            // with its signed integer type erased, and falls back to Boogie's
+            // Euclidean `div` while the body truncates toward zero. Route it
+            // through the helper when signed values are involved anywhere in
+            // the operands. All-unsigned expressions are left alone: they have
+            // no disagreement to fix, and emitting the helper's conditional in
+            // place of a bare `div` would pessimize the unsigned arithmetic
+            // that dominates spec expressions.
+            ty.is_signed_int()
+                || (matches!(ty, Type::Primitive(PrimitiveType::Num))
+                    && args.iter().any(|a| self.exp_involves_signed(a)))
+        }) {
             emit!(self.writer, "{}(", helper);
             self.translate_seq(args.iter(), ", ", |e| {
                 self.translate_op_operand(e, false, "")

--- a/third_party/move/move-prover/tests/sources/functional/signed_div_compound_19877.move
+++ b/third_party/move/move-prover/tests/sources/functional/signed_div_compound_19877.move
@@ -1,0 +1,53 @@
+// Signed `/` and `%` must truncate toward zero on the SPEC side even when the
+// dividend is an arithmetic expression. Spec arithmetic widens to `num`, which
+// erases the signed integer type, so a dispatch keyed only on that type falls
+// back to Boogie's Euclidean `div` and disagrees with the truncating body.
+// The original #19877 regression covers plain variables and single casts, both
+// of which keep their type; these shapes do not.
+module 0x42::signed_div_compound_19877 {
+
+    // Product then divide, through casts: the `i64_math::mul_div` shape.
+    public fun mul_div(a: i64, b: u64, c: u64): i64 {
+        (((a as i128) * (b as i128) / (c as i128)) as i64)
+    }
+
+    spec mul_div {
+        aborts_if c == 0;
+        aborts_if (a as i128) * (b as i128) / (c as i128) > (MAX_I64 as i128);
+        aborts_if (a as i128) * (b as i128) / (c as i128) < (MIN_I64 as i128);
+        ensures (result as i128) == (a as i128) * (b as i128) / (c as i128);
+    }
+
+    // Compound dividend with no casts: the widening, not the cast, is what
+    // erases the type.
+    public fun div_compound(x: i64, y: i64, z: i64): i64 {
+        (x * y) / z
+    }
+
+    spec div_compound {
+        pragma aborts_if_is_partial;
+        ensures result == (x * y) / z;
+    }
+
+    // The same for `%`.
+    public fun mod_compound(x: i64, y: i64, z: i64): i64 {
+        (x * y) % z
+    }
+
+    spec mod_compound {
+        pragma aborts_if_is_partial;
+        ensures result == (x * y) % z;
+    }
+
+    // Unsigned compound division keeps the plain operator: truncation and
+    // Euclidean division agree on non-negative values, so this is only here to
+    // pin that the encoding is not disturbed.
+    public fun div_compound_unsigned(x: u64, y: u64, z: u64): u64 {
+        (x * y) / z
+    }
+
+    spec div_compound_unsigned {
+        pragma aborts_if_is_partial;
+        ensures result == (x * y) / z;
+    }
+}


### PR DESCRIPTION
## Description

Signed `/` and `%` in **specifications** fall back to Boogie's Euclidean `div` / `mod` whenever the dividend is an arithmetic expression rather than a variable or a cast. The function body truncates toward zero (Move/Rust semantics), so body and spec disagree by one whenever the dividend is negative and the division is not exact.

This is the residual of #19877. That issue was closed by #19886, which introduced `$signed_div` / `$signed_mod` and routed both the body and the spec side through them — but the spec-side dispatch keys on the static type of the dividend's AST node:

```rust
let ty0 = self.get_node_type(args[0].node_id());
} else if let Some(helper) = signed_helper.filter(|_| ty0.skip_reference().is_signed_int())
```

`is_signed_int()` matches only `Primitive(I8|I16|I32|I64|I128|I256)`. A variable or a cast carries such a type; an arithmetic expression does not, because spec arithmetic widens to `num` (confirmed by instrumenting the dispatch: the failing sites report `ty0 = Primitive(Num)`). The guard fails, and the translator emits a plain infix `div`.

The emitted Boogie, before this change:

```boogie
// ensures result == x / y                                  (i64 variables)   ✓
$IsEqual'i64'($t2, $signed_div($t0, $t1));

// ensures (result as i128) == (x as i128) / (y as i128)                      ✓
$IsEqual'i128'($t6, $signed_div($t0, $t1));

// ensures (result as i128) == (a as i128) * (b as i128) / (c as i128)        ✗
$IsEqual'i128'($t9, (($t0 * $t1) div $t2));
```

Casts are incidental — `result == (x * y) / z` over plain `i64` variables reproduces it too. What erases the type is the arithmetic, not the cast.

**Consequences.** Correct specs become unprovable, which is visible and merely annoying. The worse direction is `aborts_if`: the Euclidean quotient crosses `MIN_I64` exactly where the truncating one does not, so the prover insists a function aborts when it does not. Both appear in `decibel_dex::i64_math::mul_div`, whose symbolic postcondition and `< MIN_I64` abort clause each fail against a correct implementation.

## Approach

Extend the dispatch to `num`-typed division, but only when **signed values are involved anywhere in the operands**:

```rust
ty.is_signed_int()
    || (matches!(ty, Type::Primitive(PrimitiveType::Num))
        && args.iter().any(|a| self.exp_involves_signed(a)))
```

with `exp_involves_signed` walking the operand expression for any subexpression of signed integer type.

The narrower criterion is deliberate. Routing *every* `num` division through the helper is semantically fine — truncation and Euclidean division agree on non-negative values — but it replaces a bare `div` with the helper's conditional in all the unsigned arithmetic that dominates spec expressions. That measurably degrades the solver: it broke `closures/amm_example.move`, whose divisions are entirely unsigned (`reserve_out * amount_in / (reserve_in + amount_in)`), changing which invariant was reported as violated and leaving Boogie unable to produce an augmented trace. Restricting to signed involvement keeps every all-unsigned expression on exactly the encoding it has today, which also respects the "don't pessimize the unsigned hot path" constraint from #19886.

Note what is deliberately *not* changed: an all-unsigned `num` expression that can still go negative through spec subtraction (`a - b` with `a < b`, which does not underflow in spec arithmetic) keeps Euclidean semantics. It has no body to disagree with, so this PR leaves its behavior untouched rather than widening scope.

## How Has This Been Tested?

- **New regression** `signed_div_compound_19877.move`: the product-then-divide shape through casts, a compound dividend with no casts, the same for `%`, and an unsigned compound division pinning that the fast path is undisturbed. Verified to **fail without the fix** — the dispatch was reverted, rebuilt, and the test observed failing — then pass with it restored.
- **Why the original regression missed this**: `signed_div_mod_19877.move` exercises signed division only through plain variables and single casts, and pins the signed cases with concrete instances (`x == -7 && y == 3 ==> result == -2`) rather than a symbolic relation. Every shape in it takes the `$signed_div` path, so it passed before and passes now.
- **Non-vacuity**: an off-by-one postcondition (`result == (x * y) / z + 1`) over the same shapes must fail, and does.
- `cargo test -p move-prover --test testsuite` — **363 passed, 0 failed**.
- Framework prover batteries — 4 passed, 0 failed (318s); framework unit suites — 7 passed, 0 failed.
- `closures/amm_example.move`, which the broader first attempt broke, is green.
- Downstream: `decibel_dex::i64_math::mul_div` now verifies. The other four failures in that module are stale specs on its side (a widening change removed the overflow their `aborts_if` clauses assert) and are unaffected by this fix, which is the expected separation.

## Key Areas to Review

- The criterion in `translate_op`. It asks "are signed values involved?", not "can the dividend be negative?" — the latter was the first attempt and is what pessimized unsigned arithmetic. Worth confirming the narrower rule covers every shape where body and spec can disagree.
- `exp_involves_signed` is a syntactic walk over operands. It answers conservatively in one direction only: an unrecognized form yields `false`, so the risk is a missed signed case rather than a spurious conditional on unsigned code.
- The unchanged behavior for all-unsigned `num` divisions that can go negative via spec subtraction, described above — a deliberate scope decision rather than an oversight.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Move Prover

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit faae9738b822858937d5fa7e7d539924db4be571. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->