### PR TITLE
[mono-move] Enable stdlib on mono move

### DIFF
--- a/third_party/move/mono-move/testsuite/tests/unit_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/unit_tests.rs
@@ -38,7 +38,6 @@ fn move_stdlib_on_mono_move() {
 }
 
 #[test]
-#[ignore]
 fn aptos_stdlib_on_mono_move() {
     run_tests_for_pkg("aptos-stdlib", false);
 }


### PR DESCRIPTION
## Description

Runs the `aptos-stdlib` Move `#[test]` unit tests on mono-move in CI by
removing the `#[ignore]` on `aptos_stdlib_on_mono_move`.

The harness runs each package test on mono-move and scores it: a test
mono-move cannot yet run (missing native, unlowered construct) is recorded as
*unsupported* and does not fail the run; only a test that runs but produces the
wrong result fails. `aptos-stdlib` now has no wrong results, so it can be
enabled.

`move-stdlib` and `aptos-framework` stay ignored. `aptos-framework` is blocked
by one genuine divergence: `transaction_context::test_call_chain_id` expects
`chain_id_internal()` to abort with `ETRANSACTION_CONTEXT_NOT_AVAILABLE` when no
user transaction context is present, but mono-move does not yet model that case
(the `TODO(completeness)` in `natives/src/transaction_context.rs`) and returns
the seeded chain id instead.

## How Has This Been Tested?

Ran the enabled suite locally:

```
cargo nextest run -p mono-move-testsuite --test unit_tests -E 'test(aptos_stdlib_on_mono_move)'
```

Scoreboard: 216 passed, 0 failed, 81 unsupported (of 297 total). All 81
unsupported are unimplemented natives (ristretto255, crypto_algebra,
string_utils formatting), not wrong results.

## Type of Change

- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist

- [x] I have performed a self-review of my own code
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that enables an existing ignored test; no production VM or runtime behavior is modified.
> 
> **Overview**
> **aptos-stdlib** Move `#[test]` unit tests now run on mono-move in CI by removing `#[ignore]` from `aptos_stdlib_on_mono_move` in the mono-move testsuite.
> 
> The existing harness still treats tests mono-move cannot execute (missing natives, unlowered constructs) as *unsupported* rather than failures; only wrong results fail the run. **aptos-stdlib** is enabled because it has no failing wrong-result tests. **`move-stdlib`** and **`aptos-framework`** remain ignored (framework blocked by a known `transaction_context` divergence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fff71cb6c54aff49586c5b1fa398919c02ab9ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->