### PR TITLE
[mono-move] Fix constant_serialized_size descriptors

### DIFF
--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
@@ -242,7 +242,7 @@ fn runtime_error_to_status(err: &RuntimeError) -> VMStatus {
         | E::BCSRemainingInput { .. }
         | E::BCSInvalidBool { .. }
         | E::BCSSignerNotDeserializable => StatusCode::UNKNOWN_STATUS,
-        E::InvariantViolation(_) | E::ResourceProvider(_) => {
+        E::Unsupported(_) | E::InvariantViolation(_) | E::ResourceProvider(_) => {
             StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
         },
     };

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -105,6 +105,9 @@ pub enum RuntimeError {
 
     #[error("BCS deserialize: cannot deserialize a signer")]
     BCSSignerNotDeserializable,
+
+    #[error("unsupported: {0}")]
+    Unsupported(&'static str),
 }
 
 impl IntoExecutionError for RuntimeError {
@@ -140,6 +143,8 @@ impl IntoExecutionError for RuntimeError {
             | BCSRemainingInput { .. }
             | BCSInvalidBool { .. }
             | BCSSignerNotDeserializable => ExecutionErrorKind::InvalidOperation,
+
+            Unsupported(_) => ExecutionErrorKind::InvariantViolation,
 
             InvariantViolation(_) => ExecutionErrorKind::InvariantViolation,
             ResourceProvider(e) => e.kind(),

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -192,10 +192,8 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
             unsafe { serialize_impl(layouts, obj_ptr.add(ENUM_DATA_OFFSET), variant_layout, out)? };
             Ok(())
         },
-        LayoutKind::Function => {
-            // TODO(completeness): function values are not yet supported.
-            todo!("function values are not yet supported");
-        },
+        // TODO(completeness): function values are not yet supported.
+        LayoutKind::Function => Err(VMInternalError::new(function_values_unsupported())),
         LayoutKind::Ref => Err(VMInternalError::new(unreachable(
             "References cannot be serialized",
         ))),
@@ -355,10 +353,8 @@ unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
                 )
             }
         },
-        LayoutKind::Function => {
-            // TODO(completeness): function values are not yet supported.
-            todo!("function values are not yet supported");
-        },
+        // TODO(completeness): function values are not yet supported.
+        LayoutKind::Function => Err(VMInternalError::new(function_values_unsupported())),
         LayoutKind::Ref => Err(VMInternalError::new(unreachable(
             "Equality runs on pointee types only",
         ))),
@@ -558,10 +554,8 @@ unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
                 )
             }
         },
-        LayoutKind::Function => {
-            // TODO(completeness): function values are not yet supported.
-            todo!("function values are not yet supported");
-        },
+        // TODO(completeness): function values are not yet supported.
+        LayoutKind::Function => Err(VMInternalError::new(function_values_unsupported())),
         LayoutKind::Ref => Err(VMInternalError::new(unreachable(
             "Comparison runs on pointee types only",
         ))),
@@ -804,10 +798,8 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
             unsafe { write_ptr(dst, 0usize, obj_ptr) };
             Ok(())
         },
-        LayoutKind::Function => {
-            // TODO(completeness): function values are not yet supported.
-            todo!("function values are not yet supported");
-        },
+        // TODO(completeness): function values are not yet supported.
+        LayoutKind::Function => Err(function_values_unsupported().into()),
         LayoutKind::Ref => Err(unreachable("References cannot be deserialized").into()),
     }
 }
@@ -911,6 +903,13 @@ fn layout_not_found() -> RuntimeError {
 /// An invariant violation for an unreachable state.
 fn unreachable(message: &str) -> RuntimeError {
     RuntimeError::InvariantViolation(RuntimeInvariantViolation::Unreachable(message.to_string()))
+}
+
+/// Function values are a valid Move feature that the value walks do not support
+/// yet. Surfaced as an error (never a panic) so callers can classify it as an
+/// unsupported construct instead of aborting.
+fn function_values_unsupported() -> RuntimeError {
+    RuntimeError::Unsupported("function values are not yet supported")
 }
 
 /// Invariant violation when an enum tag does not name a variant, whether read

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -141,6 +141,26 @@ fn resource_types_for_native(
     Vec::new()
 }
 
+/// Returns type arguments for which the native function should know the layout.
+/// For example, `bcs::constant_serialized_size<T>` needs to know layout of `T`.
+//
+// TODO(completeness): Instead of hard-coding them here, figure out a way to allow natives to declare them.
+fn layout_type_args_for_native(
+    interner: &impl Interner,
+    module_id: InternedModuleId,
+    func_name: InternedIdentifier,
+    callee_ty_args: &[InternedType],
+) -> Vec<InternedType> {
+    let bcs = interner.module_id_of(&AccountAddress::ONE, ident_str!("bcs"));
+    if module_id == bcs
+        && func_name == interner.identifier_of(ident_str!("constant_serialized_size"))
+    {
+        return callee_ty_args.to_vec();
+    }
+
+    Vec::new()
+}
+
 /// Publishes a struct descriptor for the concrete `ty`, recording it in
 /// `descriptors`. A no-op when `ty` is not sized or its pointer offsets can't be
 /// derived (e.g. still generic).
@@ -1142,6 +1162,16 @@ fn try_discover_types_for_lowering_in_function_impl(
                 discover_type_metadata(ctx, interner, resource_ty, ty_args, visited, descriptors)?;
                 let resource_ty = interner.subst_type(resource_ty, ty_args)?;
                 publish_struct_descriptor_for(ctx, resource_ty, &mut descriptors.vec)?;
+            }
+
+            // Here we only need layout, so there is no need to publish the type descriptor.
+            for layout_ty in layout_type_args_for_native(
+                interner,
+                module_id,
+                func_name,
+                view_type_list(callee_ty_args),
+            ) {
+                discover_type_metadata(ctx, interner, layout_ty, ty_args, visited, descriptors)?;
             }
         }
 

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -369,6 +369,8 @@ fn classify_runtime_error(err: &RuntimeError) -> TestResult {
         | RuntimeError::AbortMessageTooLong { .. }
         | RuntimeError::StateKeyTypeTooDeep => TestResult::RuntimeFailure(err.to_string()),
 
+        RuntimeError::Unsupported(_) => TestResult::Unsupported(err.to_string()),
+
         // Genuine problems: infrastructure failure, or a VM bug.
         RuntimeError::InvariantViolation(_) | RuntimeError::ResourceProvider(_) => {
             TestResult::Error(err.to_string())

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/bcs.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/bcs.move
@@ -1,6 +1,14 @@
 // RUN: publish
+module 0x1::boxes {
+    struct Box<T> { value: T }
+
+    struct Pair<A, B> { first: A, second: B }
+}
+
 module 0x1::main {
     use std::bcs;
+    use std::option;
+    use 0x1::boxes;
 
     struct Pair has drop {
         a: u64,
@@ -74,6 +82,34 @@ module 0x1::main {
     public fun size_wrap(): u64 {
         bcs::serialized_size(&Wrap { v: b"hi" })
     }
+
+    public fun const_size_box_u64(): u64 {
+        option::destroy_some(bcs::constant_serialized_size<boxes::Box<u64>>())
+    }
+
+    public fun const_size_box_bool(): u64 {
+        option::destroy_some(bcs::constant_serialized_size<boxes::Box<bool>>())
+    }
+
+    public fun const_size_box_address(): u64 {
+        option::destroy_some(bcs::constant_serialized_size<boxes::Box<address>>())
+    }
+
+    public fun const_size_pair(): u64 {
+        option::destroy_some(bcs::constant_serialized_size<boxes::Pair<u64, bool>>())
+    }
+
+    public fun const_size_nested(): u64 {
+        option::destroy_some(bcs::constant_serialized_size<boxes::Box<boxes::Pair<u64, u128>>>())
+    }
+
+    public fun const_size_is_some_box_u64(): bool {
+        option::is_some(&bcs::constant_serialized_size<boxes::Box<u64>>())
+    }
+
+    public fun const_size_is_some_box_vec(): bool {
+        option::is_some(&bcs::constant_serialized_size<boxes::Box<vector<u8>>>())
+    }
 }
 
 // RUN: execute 0x1::main::bytes_u64
@@ -125,3 +161,24 @@ module 0x1::main {
 
 // RUN: execute 0x1::main::size_wrap
 // CHECK: results: 3
+
+// RUN: execute 0x1::main::const_size_box_u64
+// CHECK: results: 8
+
+// RUN: execute 0x1::main::const_size_box_bool
+// CHECK: results: 1
+
+// RUN: execute 0x1::main::const_size_box_address
+// CHECK: results: 32
+
+// RUN: execute 0x1::main::const_size_pair
+// CHECK: results: 9
+
+// RUN: execute 0x1::main::const_size_nested
+// CHECK: results: 24
+
+// RUN: execute 0x1::main::const_size_is_some_box_u64
+// CHECK: results: true
+
+// RUN: execute 0x1::main::const_size_is_some_box_vec
+// CHECK: results: false

--- a/third_party/move/mono-move/testsuite/tests/unit_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/unit_tests.rs
@@ -32,7 +32,6 @@ fn run_tests_for_pkg(pkg: &str, use_latest_language: bool) {
 }
 
 #[test]
-#[ignore]
 fn move_stdlib_on_mono_move() {
     run_tests_for_pkg("move-stdlib", false);
 }


### PR DESCRIPTION
## Description

Two related fixes in mono-move, plus differential coverage.

**`constant_serialized_size<T>()` had no published layout for `T`.**
The native takes no value argument, so `T` appears only as a phantom type
argument and is never materialized as a value. Layout discovery only
publishes layouts for types reachable from a function's value signature,
so `T`'s layout was never published and the native failed with
`invariant violation: type has no published layout` (seen as
`bcs_tests::encode_128` failing on move-stdlib).

The fix adds a layout-only discovery path, `layout_type_args_for_native`,
that publishes the layout of the native's type argument during lowering.
Unlike `resource_types_for_native`, it requires only a layout (not a
struct descriptor) and does not feed a call site's `required_descriptors`,
so no spurious descriptors are emitted. Scoped to `constant_serialized_size`;
`to_bytes`/`serialized_size` already discover `T` via their `&T` parameter.

**Function values panicked in the value walks.**
The four `todo!("function values are not yet supported")` arms in
`value_utils.rs` (serialize/deserialize/equals/compare) aborted the
process. They now return a typed `RuntimeError::Unsupported`, which the
unit-test harness classifies as an *unsupported* construct (a coverage
gap, not a wrong result) instead of crashing the run. In production this
maps to an invariant-violation kind so it still alerts.

With both fixes the move-stdlib unit tests pass on mono-move, so
`move_stdlib_on_mono_move` is un-`#[ignore]`d and runs by default.

## How Has This Been Tested?

- New differential test `natives/constant_serialized_size.move` exercises
  cross-module generic type arguments (`Box<T>`, `Pair<A, B>` defined in
  `0x1::boxes`, used from `0x1::main`): constant-size cases
  (`Box<u64>`=8, `Box<bool>`=1, `Box<address>`=32, `Pair<u64,bool>`=9,
  `Box<Pair<u64,u128>>`=24) and the non-constant `Box<vector<u8>>`
  returning `none`. Legacy MoveVM (v1) and mono-move (v2) agree on all.
- Full differential suite: 223 passed, 0 failed.
- `move_stdlib_on_mono_move`: 193 passed, 0 failed, 11 unsupported. The
  function-value case now shows as `unsupported: function values are not
  yet supported` in the reason histogram instead of panicking.

## Key Areas to Review

- `specializer/src/lower/context.rs` — `layout_type_args_for_native` and
  the discovery loop. It is hard-coded to `bcs::constant_serialized_size`
  (with a `TODO(completeness)` to let natives declare such requirements);
  confirm the layout-only path is the right seam and that no descriptor
  leaks to the call site.
- `runtime/src/error.rs` / `testsuite/src/unit_test.rs` — the new
  `Unsupported` variant's `ExecutionErrorKind` mapping (invariant
  violation in production) and its test classification (`Unsupported`).

## Type of Change
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM lowering and runtime error classification (including production invariant-violation mapping). Scope is limited to one native and previously panicking function-value walks.
> 
> **Overview**
> Fixes `bcs::constant_serialized_size<T>` failing when `T` is only a phantom type argument (no value to walk), and stops value walks from panicking on function values.
> 
> Lowering now has a layout-only discovery path (`layout_type_args_for_native`) that publishes `T`'s layout for `constant_serialized_size` without emitting a struct descriptor or call-site `required_descriptors`. Serialize/equals/compare/deserialize return `RuntimeError::Unsupported` instead of `todo!` for function values; tests treat that as a coverage gap, production still maps it to an invariant-violation status.
> 
> Un-ignores `move_stdlib_on_mono_move` and adds differential coverage for constant sizes of nested generic structs (and `none` for vectors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198f74f460ff9c29a4bab8faa783f4afcb8e0d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->