### PR TITLE
Improve consensus message deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,9 @@ name = "aptos-bcs-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs 0.1.4",
  "hex",
+ "serde",
 ]
 
 [[package]]
@@ -4978,6 +4980,7 @@ dependencies = [
  "ahash 0.8.12",
  "anyhow",
  "aptos-batch-encryption",
+ "aptos-bcs-utils",
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",

--- a/crates/aptos-bcs-utils/Cargo.toml
+++ b/crates/aptos-bcs-utils/Cargo.toml
@@ -15,3 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 hex = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+bcs = { workspace = true }

--- a/crates/aptos-bcs-utils/src/bounded_vec.rs
+++ b/crates/aptos-bcs-utils/src/bounded_vec.rs
@@ -1,0 +1,148 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use serde::{
+    de::{Error, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::{fmt, marker::PhantomData, ops::Deref};
+
+/// A vector that rejects an oversized sequence before deserializing its elements.
+///
+/// The serialized representation is identical to `Vec<T>`. In particular, BCS
+/// provides the declared sequence length through `SeqAccess::size_hint()`, which
+/// lets this type reject an oversized vector before any attacker-controlled
+/// element deserialization runs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedVec<T, const MAX_LEN: usize>(Vec<T>);
+
+impl<T, const MAX_LEN: usize> BoundedVec<T, MAX_LEN> {
+    pub fn new(inner: Vec<T>) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            inner.len() <= MAX_LEN,
+            "vector length {} exceeds maximum {}",
+            inner.len(),
+            MAX_LEN
+        );
+        Ok(Self(inner))
+    }
+
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T, const MAX_LEN: usize> Deref for BoundedVec<T, MAX_LEN> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Serialize, const MAX_LEN: usize> Serialize for BoundedVec<T, MAX_LEN> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>, const MAX_LEN: usize> Deserialize<'de> for BoundedVec<T, MAX_LEN> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BoundedVecVisitor<T, const MAX_LEN: usize>(PhantomData<T>);
+
+        impl<'de, T: Deserialize<'de>, const MAX_LEN: usize> Visitor<'de>
+            for BoundedVecVisitor<T, MAX_LEN>
+        {
+            type Value = BoundedVec<T, MAX_LEN>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a sequence with at most {} elements", MAX_LEN)
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                if let Some(len) = sequence.size_hint()
+                    && len > MAX_LEN
+                {
+                    return Err(A::Error::custom(format_args!(
+                        "sequence length {} exceeds maximum {}",
+                        len, MAX_LEN
+                    )));
+                }
+
+                let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0).min(MAX_LEN));
+                while let Some(value) = sequence.next_element()? {
+                    if values.len() == MAX_LEN {
+                        return Err(A::Error::custom(format_args!(
+                            "sequence length exceeds maximum {}",
+                            MAX_LEN
+                        )));
+                    }
+                    values.push(value);
+                }
+                Ok(BoundedVec(values))
+            }
+        }
+
+        deserializer.deserialize_seq(BoundedVecVisitor(PhantomData))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::de::Error;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static ELEMENT_DESERIALIZATIONS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug)]
+    struct CountingElement;
+
+    impl<'de> Deserialize<'de> for CountingElement {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            ELEMENT_DESERIALIZATIONS.fetch_add(1, Ordering::Relaxed);
+            u8::deserialize(deserializer)
+                .map(|_| Self)
+                .map_err(D::Error::custom)
+        }
+    }
+
+    #[test]
+    fn bcs_wire_format_matches_vec() {
+        let values = vec![1u64, 2, 3];
+        let bounded = BoundedVec::<_, 3>::new(values.clone()).unwrap();
+        assert_eq!(
+            bcs::to_bytes(&values).unwrap(),
+            bcs::to_bytes(&bounded).unwrap()
+        );
+    }
+
+    #[test]
+    fn accepts_sequence_at_limit() {
+        let bytes = bcs::to_bytes(&vec![1u64, 2, 3]).unwrap();
+        let decoded = bcs::from_bytes::<BoundedVec<u64, 3>>(&bytes).unwrap();
+        assert_eq!(&*decoded, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn rejects_oversized_bcs_sequence_before_elements() {
+        ELEMENT_DESERIALIZATIONS.store(0, Ordering::Relaxed);
+        let bytes = bcs::to_bytes(&vec![1u8, 2, 3]).unwrap();
+        let error = bcs::from_bytes::<BoundedVec<CountingElement, 2>>(&bytes).unwrap_err();
+
+        assert!(error.to_string().contains("exceeds maximum 2"));
+        assert_eq!(ELEMENT_DESERIALIZATIONS.load(Ordering::Relaxed), 0);
+    }
+}

--- a/crates/aptos-bcs-utils/src/lib.rs
+++ b/crates/aptos-bcs-utils/src/lib.rs
@@ -3,6 +3,10 @@
 
 use anyhow::bail;
 
+mod bounded_vec;
+
+pub use bounded_vec::BoundedVec;
+
 pub fn serialize_uleb128(buffer: &mut Vec<u8>, mut val: u64) -> anyhow::Result<()> {
     loop {
         let cur = val & 0x7F;

--- a/network/framework/src/counters.rs
+++ b/network/framework/src/counters.rs
@@ -388,6 +388,18 @@ pub static PENDING_NETWORK_NOTIFICATIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Messages shed when a peer already occupies its deserialization slot and its
+/// single pending slot. This prevents one peer from monopolizing decode workers
+/// or moving an unbounded raw-message backlog into the application stream.
+pub static NETWORK_DESERIALIZATION_BACKPRESSURE_DROPS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_network_deserialization_backpressure_drops",
+        "Number of inbound messages dropped by per-peer deserialization backpressure",
+        &["protocol_id"]
+    )
+    .unwrap()
+});
+
 /// Counter of pending requests in Network Provider
 pub static PENDING_NETWORK_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/network/framework/src/protocols/network/mod.rs
+++ b/network/framework/src/protocols/network/mod.rs
@@ -19,13 +19,30 @@ use aptos_types::{network_address::NetworkAddress, PeerId};
 use bytes::Bytes;
 use futures::{
     channel::oneshot,
-    stream::{FusedStream, Stream, StreamExt},
+    stream::{FusedStream, FuturesUnordered, Stream, StreamExt},
     task::{Context, Poll},
 };
 use futures_util::ready;
 use pin_project::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{cmp::min, fmt::Debug, future, marker::PhantomData, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    cmp::min,
+    collections::{HashMap, HashSet, VecDeque},
+    fmt::Debug,
+    future,
+    marker::PhantomData,
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
+
+/// Keep at most one message waiting behind each peer's active deserialization.
+/// The lower network queue remains the primary buffer; this slot exists so a
+/// short normal burst does not immediately shed the second message.
+const MAX_PENDING_DESERIALIZATIONS_PER_PEER: usize = 1;
+/// Bound how many immediately-ready lower-network messages a single stream poll
+/// handles before yielding back to the runtime.
+const MAX_INPUT_MESSAGES_PER_POLL: usize = 64;
 
 pub trait Message: DeserializeOwned + Serialize {}
 impl<T: DeserializeOwned + Serialize> Message for T {}
@@ -214,19 +231,17 @@ impl<TMessage: Message + Send + Sync + 'static> NewNetworkEvents for NetworkEven
         // Determine the number of parallel deserialization tasks to use
         let max_parallel_deserialization_tasks = max_parallel_deserialization_tasks.unwrap_or(1);
 
-        let data_event_stream = peer_mgr_notifs_rx.map(|notification| {
-            tokio::task::spawn_blocking(move || received_message_to_event(notification))
-        });
-
         let data_event_stream: Pin<
             Box<dyn Stream<Item = Event<TMessage>> + Send + Sync + 'static>,
         > = if allow_out_of_order_delivery {
-            Box::pin(
-                data_event_stream
-                    .buffer_unordered(max_parallel_deserialization_tasks)
-                    .filter_map(|res| future::ready(res.expect("JoinError from spawn blocking"))),
-            )
+            Box::pin(PeerFairDeserializationStream::new(
+                peer_mgr_notifs_rx,
+                max_parallel_deserialization_tasks,
+            ))
         } else {
+            let data_event_stream = peer_mgr_notifs_rx.map(|notification| {
+                tokio::task::spawn_blocking(move || received_message_to_event(notification))
+            });
             Box::pin(
                 data_event_stream
                     .buffered(max_parallel_deserialization_tasks)
@@ -238,6 +253,150 @@ impl<TMessage: Message + Send + Sync + 'static> NewNetworkEvents for NetworkEven
             event_stream: data_event_stream,
             done: false,
             _marker: PhantomData,
+        }
+    }
+}
+
+/// Schedules at most one blocking deserialization per peer while retaining the
+/// configured global parallelism across different peers. A peer that is already
+/// active gets one pending slot; further messages from that peer are shed so the
+/// scheduler can continue discovering and serving other peers.
+struct PeerFairDeserializationStream<TMessage> {
+    input: aptos_channel::Receiver<(PeerId, ProtocolId), ReceivedMessage>,
+    in_flight: FuturesUnordered<tokio::task::JoinHandle<(PeerNetworkId, Option<Event<TMessage>>)>>,
+    active_peers: HashSet<PeerNetworkId>,
+    pending_by_peer: HashMap<PeerNetworkId, VecDeque<ReceivedMessage>>,
+    ready_peers: VecDeque<PeerNetworkId>,
+    max_in_flight: usize,
+    input_done: bool,
+}
+
+impl<TMessage: Message + Send + 'static> PeerFairDeserializationStream<TMessage> {
+    fn new(
+        input: aptos_channel::Receiver<(PeerId, ProtocolId), ReceivedMessage>,
+        max_in_flight: usize,
+    ) -> Self {
+        Self {
+            input,
+            in_flight: FuturesUnordered::new(),
+            active_peers: HashSet::new(),
+            pending_by_peer: HashMap::new(),
+            ready_peers: VecDeque::new(),
+            max_in_flight: max_in_flight.max(1),
+            input_done: false,
+        }
+    }
+
+    fn start_deserialization(&mut self, message: ReceivedMessage) {
+        let peer = message.sender;
+        assert!(self.active_peers.insert(peer));
+        self.in_flight.push(tokio::task::spawn_blocking(move || {
+            (peer, received_message_to_event(message))
+        }));
+    }
+
+    fn enqueue(&mut self, message: ReceivedMessage) {
+        let peer = message.sender;
+        if !self.active_peers.contains(&peer) && self.in_flight.len() < self.max_in_flight {
+            self.start_deserialization(message);
+            return;
+        }
+
+        let peer_is_active = self.active_peers.contains(&peer);
+        let pending = self.pending_by_peer.entry(peer).or_default();
+        if pending.len() < MAX_PENDING_DESERIALIZATIONS_PER_PEER {
+            pending.push_back(message);
+            if !peer_is_active {
+                self.ready_peers.push_back(peer);
+            }
+        } else {
+            let protocol = message.protocol_id_as_str();
+            crate::counters::NETWORK_DESERIALIZATION_BACKPRESSURE_DROPS
+                .with_label_values(&[protocol])
+                .inc();
+        }
+    }
+
+    fn schedule_pending(&mut self) {
+        while self.in_flight.len() < self.max_in_flight {
+            let Some(peer) = self.ready_peers.pop_front() else {
+                break;
+            };
+            if self.active_peers.contains(&peer) {
+                continue;
+            }
+
+            let (message, remove_queue) = {
+                let Some(pending) = self.pending_by_peer.get_mut(&peer) else {
+                    continue;
+                };
+                let Some(message) = pending.pop_front() else {
+                    continue;
+                };
+                (message, pending.is_empty())
+            };
+            if remove_queue {
+                self.pending_by_peer.remove(&peer);
+            } else {
+                self.ready_peers.push_back(peer);
+            }
+            self.start_deserialization(message);
+        }
+    }
+
+    fn poll_completed(&mut self, context: &mut Context) -> Option<Event<TMessage>> {
+        loop {
+            let Poll::Ready(Some(result)) = self.in_flight.poll_next_unpin(context) else {
+                return None;
+            };
+            let (peer, event) = result.expect("JoinError from spawn blocking");
+            assert!(self.active_peers.remove(&peer));
+            if self.pending_by_peer.contains_key(&peer) {
+                self.ready_peers.push_back(peer);
+            }
+            self.schedule_pending();
+            if event.is_some() {
+                return event;
+            }
+        }
+    }
+}
+
+impl<TMessage: Message + Send + 'static> Stream for PeerFairDeserializationStream<TMessage> {
+    type Item = Event<TMessage>;
+
+    fn poll_next(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<Option<Self::Item>> {
+        self.schedule_pending();
+        if let Some(event) = self.poll_completed(context) {
+            return Poll::Ready(Some(event));
+        }
+
+        let mut messages_polled = 0;
+        while messages_polled < MAX_INPUT_MESSAGES_PER_POLL && !self.input_done {
+            match self.input.poll_next_unpin(context) {
+                Poll::Ready(Some(message)) => {
+                    messages_polled += 1;
+                    self.enqueue(message);
+                    self.schedule_pending();
+                },
+                Poll::Ready(None) => self.input_done = true,
+                Poll::Pending => break,
+            }
+        }
+
+        // Poll newly-created blocking tasks once so their completion wakers are
+        // registered before returning Pending.
+        if let Some(event) = self.poll_completed(context) {
+            return Poll::Ready(Some(event));
+        }
+
+        if self.input_done && self.in_flight.is_empty() && self.pending_by_peer.is_empty() {
+            Poll::Ready(None)
+        } else {
+            if messages_polled == MAX_INPUT_MESSAGES_PER_POLL {
+                context.waker().wake_by_ref();
+            }
+            Poll::Pending
         }
     }
 }
@@ -480,5 +639,106 @@ pub trait SerializedRequest {
     /// `ProtocolId`.  See: [`ProtocolId::from_bytes`]
     fn to_message<TMessage: DeserializeOwned>(&self) -> anyhow::Result<TMessage> {
         self.protocol_id().from_bytes(self.data())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::wire::messaging::v1::DirectSendMsg;
+    use aptos_channels::message_queues::QueueStyle;
+    use aptos_config::network_id::NetworkId;
+    use serde::{Deserialize, Deserializer};
+
+    #[derive(Debug, Eq, PartialEq, Serialize)]
+    struct DelayedMessage {
+        delay_ms: u64,
+        id: u8,
+    }
+
+    impl<'de> Deserialize<'de> for DelayedMessage {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            #[derive(Deserialize)]
+            struct WireMessage {
+                delay_ms: u64,
+                id: u8,
+            }
+
+            let message = WireMessage::deserialize(deserializer)?;
+            std::thread::sleep(Duration::from_millis(message.delay_ms));
+            Ok(Self {
+                delay_ms: message.delay_ms,
+                id: message.id,
+            })
+        }
+    }
+
+    fn received_message(peer: PeerId, message: DelayedMessage) -> ReceivedMessage {
+        let protocol = ProtocolId::ConsensusDirectSendBcs;
+        let raw_msg = protocol.to_bytes(&message).unwrap();
+        ReceivedMessage::new(
+            NetworkMessage::DirectSendMsg(DirectSendMsg {
+                protocol_id: protocol,
+                priority: 0,
+                raw_msg,
+            }),
+            PeerNetworkId::new(NetworkId::Validator, peer),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn busy_peer_cannot_fill_all_deserialization_slots() {
+        let protocol = ProtocolId::ConsensusDirectSendBcs;
+        let attacker = PeerId::random();
+        let honest_peer = PeerId::random();
+        let (sender, receiver) = aptos_channel::new(QueueStyle::FIFO, 10, None);
+        let mut events = NetworkEvents::<DelayedMessage>::new(receiver, Some(2), true);
+
+        sender
+            .push(
+                (attacker, protocol),
+                received_message(attacker, DelayedMessage {
+                    delay_ms: 250,
+                    id: 1,
+                }),
+            )
+            .unwrap();
+        sender
+            .push(
+                (attacker, protocol),
+                received_message(attacker, DelayedMessage {
+                    delay_ms: 250,
+                    id: 2,
+                }),
+            )
+            .unwrap();
+
+        // Poll once so both attacker messages enter the scheduler before the
+        // honest message arrives. Only one may start deserializing.
+        let next_event = events.next();
+        tokio::pin!(next_event);
+        tokio::select! {
+            event = &mut next_event => panic!("slow attacker unexpectedly completed: {event:?}"),
+            _ = tokio::time::sleep(Duration::from_millis(25)) => {},
+        }
+
+        sender
+            .push(
+                (honest_peer, protocol),
+                received_message(honest_peer, DelayedMessage { delay_ms: 0, id: 3 }),
+            )
+            .unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), &mut next_event)
+            .await
+            .expect("honest peer should use the other deserialization slot")
+            .expect("network event stream ended unexpectedly");
+        assert_eq!(
+            event,
+            Event::Message(honest_peer, DelayedMessage { delay_ms: 0, id: 3 },)
+        );
     }
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -29,6 +29,7 @@ fuzzing = [
 [dependencies]
 anyhow = { workspace = true }
 aptos-batch-encryption = { workspace = true }
+aptos-bcs-utils = { workspace = true }
 aptos-bitvec = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -362,7 +362,11 @@ impl ChunkyDKGSession {
 
         let eks: Vec<ChunkyEncryptPubKey> = target_validators
             .iter()
-            .map(|vi| (&vi.public_key).into())
+            .map(|vi| {
+                vi.public_key()
+                    .expect("on-chain validator consensus keys must be valid")
+                    .into()
+            })
             .collect();
 
         let profile = DKGRoundingProfile::new(

--- a/types/src/dkg/dummy_dkg/tests.rs
+++ b/types/src/dkg/dummy_dkg/tests.rs
@@ -26,7 +26,7 @@ impl DealerState {
     fn as_validator_consensus_info(&self) -> ValidatorConsensusInfo {
         ValidatorConsensusInfo {
             address: self.addr,
-            public_key: self.pk.clone(),
+            public_key: self.pk.clone().into(),
             voting_power: self.voting_power,
         }
     }
@@ -44,7 +44,7 @@ impl NewValidatorState {
     fn as_validator_consensus_info(&self) -> ValidatorConsensusInfo {
         ValidatorConsensusInfo {
             address: self.addr,
-            public_key: self.pk.clone(),
+            public_key: self.pk.clone().into(),
             voting_power: self.voting_power,
         }
     }

--- a/types/src/dkg/real_dkg/mod.rs
+++ b/types/src/dkg/real_dkg/mod.rs
@@ -119,7 +119,11 @@ pub fn build_dkg_pvss_config(
     let rounding_time = timer.elapsed();
     let validator_consensus_keys: Vec<bls12381::PublicKey> = next_validators
         .iter()
-        .map(|vi| vi.public_key.clone())
+        .map(|vi| {
+            vi.public_key()
+                .expect("on-chain validator consensus keys must be valid")
+                .clone()
+        })
         .collect();
 
     let consensus_keys: Vec<EncPK> = validator_consensus_keys

--- a/types/src/epoch_change.rs
+++ b/types/src/epoch_change.rs
@@ -108,10 +108,16 @@ impl EpochChangeProof {
             // While the original verification could've been via waypoints,
             // all the next epoch changes are verified using the (already
             // trusted) validator sets.
-            verifier_ref = ledger_info_with_sigs
+            let next_epoch_state = ledger_info_with_sigs
                 .ledger_info()
                 .next_epoch_state()
                 .ok_or_else(|| format_err!("LedgerInfo doesn't carry a ValidatorSet"))?;
+            // The ledger info has now been authenticated. Materialize its next
+            // validator set only after that cheap gate, preserving the trusted
+            // epoch-state invariant without decompressing attacker-selected
+            // keys during network deserialization.
+            next_epoch_state.verifier.validate_public_keys()?;
+            verifier_ref = next_epoch_state;
         }
 
         Ok(self.ledger_info_with_sigs.last().unwrap())

--- a/types/src/lazy_bls.rs
+++ b/types/src/lazy_bls.rs
@@ -1,7 +1,13 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Lazy wire type for BLS aggregate/multi-signatures.
+//! Lazy wire types for BLS public keys and aggregate/multi-signatures.
+//!
+//! `LazyBlsPublicKey` carries the same on-wire encoding as
+//! `aptos_crypto::bls12381::PublicKey` but leaves its compressed G1 point as
+//! bytes until an authenticated validator set is accepted. This keeps a forged
+//! `EpochChangeProof` from forcing one curve decompression per advertised
+//! validator during network deserialization.
 //!
 //! `LazyBlsSignature` carries the same on-wire encoding as
 //! `aptos_crypto::bls12381::Signature` but skips the expensive G2-point
@@ -43,6 +49,157 @@ use std::{fmt, sync::OnceLock};
 /// The serde data-model name used by `bls12381::Signature`'s `SerializeKey`
 /// derive. Must match so the on-wire encoding (and traced format) is identical.
 const SIGNATURE_NAME: &str = "Signature";
+
+/// The serde data-model name used by `bls12381::PublicKey`'s `SerializeKey`
+/// derive. Must match so the on-wire encoding (and traced format) is identical.
+const PUBLIC_KEY_NAME: &str = "PublicKey";
+
+/// Compressed-bytes form of a `bls12381::PublicKey`. Wire-identical to
+/// `bls12381::PublicKey`, but decoding does not decompress the G1 point.
+#[derive(Clone)]
+pub struct LazyBlsPublicKey {
+    /// The compressed 48-byte wire encoding. This is the canonical identity of
+    /// the key: the only field serialized, compared, or hashed.
+    bytes: [u8; bls12381::PublicKey::LENGTH],
+    /// Lazily-populated decompressed point. Locally constructed keys seed the
+    /// cache, while peer-supplied keys remain compressed until verification.
+    decompressed: OnceLock<Box<bls12381::PublicKey>>,
+}
+
+impl LazyBlsPublicKey {
+    /// Capture a known-valid key and retain its already-decompressed point.
+    pub fn from_public_key(public_key: &bls12381::PublicKey) -> Self {
+        let decompressed = OnceLock::new();
+        let _ = decompressed.set(Box::new(public_key.clone()));
+        Self {
+            bytes: public_key.to_bytes(),
+            decompressed,
+        }
+    }
+
+    /// Decompress and curve-check the key on first use, then cache it.
+    pub fn decompress(&self) -> Result<&bls12381::PublicKey, CryptoMaterialError> {
+        if self.decompressed.get().is_none() {
+            let public_key = bls12381::PublicKey::try_from(self.bytes.as_slice())?;
+            // Ignore a race where another thread cached the same deterministic
+            // value first.
+            let _ = self.decompressed.set(Box::new(public_key));
+        }
+        Ok(self
+            .decompressed
+            .get()
+            .expect("a valid BLS public key was cached above"))
+    }
+
+    /// Return the compressed wire bytes without decompressing the point.
+    pub fn to_bytes(&self) -> [u8; bls12381::PublicKey::LENGTH] {
+        self.bytes
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn from_raw_bytes_for_test(bytes: [u8; bls12381::PublicKey::LENGTH]) -> Self {
+        Self {
+            bytes,
+            decompressed: OnceLock::new(),
+        }
+    }
+}
+
+impl From<bls12381::PublicKey> for LazyBlsPublicKey {
+    fn from(public_key: bls12381::PublicKey) -> Self {
+        Self::from_public_key(&public_key)
+    }
+}
+
+impl PartialEq for LazyBlsPublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes == other.bytes
+    }
+}
+
+impl Eq for LazyBlsPublicKey {}
+
+impl std::hash::Hash for LazyBlsPublicKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.bytes.hash(state);
+    }
+}
+
+impl fmt::Debug for LazyBlsPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.bytes))
+    }
+}
+
+impl Serialize for LazyBlsPublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&format!("0x{}", hex::encode(self.bytes)))
+        } else {
+            serializer.serialize_newtype_struct(
+                PUBLIC_KEY_NAME,
+                serde_bytes::Bytes::new(self.bytes.as_slice()),
+            )
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for LazyBlsPublicKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        fn to_array<E: de::Error>(bytes: &[u8]) -> Result<[u8; bls12381::PublicKey::LENGTH], E> {
+            <[u8; bls12381::PublicKey::LENGTH]>::try_from(bytes).map_err(|_| {
+                E::custom(format!(
+                    "invalid BLS public key length: {} (expected {})",
+                    bytes.len(),
+                    bls12381::PublicKey::LENGTH
+                ))
+            })
+        }
+
+        if deserializer.is_human_readable() {
+            let encoded = <String>::deserialize(deserializer)?;
+            let stripped = encoded
+                .strip_prefix(bls12381::PublicKey::AIP_80_PREFIX)
+                .unwrap_or(&encoded);
+            let stripped = stripped.strip_prefix("0x").unwrap_or(stripped);
+            let bytes = hex::decode(stripped).map_err(de::Error::custom)?;
+            Ok(Self {
+                bytes: to_array(&bytes)?,
+                decompressed: OnceLock::new(),
+            })
+        } else {
+            #[derive(Deserialize)]
+            #[serde(rename = "PublicKey")]
+            struct Value<'a>(&'a [u8]);
+
+            let value = Value::deserialize(deserializer)?;
+            Ok(Self {
+                bytes: to_array(value.0)?,
+                decompressed: OnceLock::new(),
+            })
+        }
+    }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl proptest::arbitrary::Arbitrary for LazyBlsPublicKey {
+    type Parameters = ();
+    type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        use proptest::strategy::Strategy;
+
+        proptest::arbitrary::any::<bls12381::PublicKey>()
+            .prop_map(|key| Self::from_public_key(&key))
+            .boxed()
+    }
+}
 
 /// Compressed-bytes form of a `bls12381::Signature`. Wire-identical to
 /// `bls12381::Signature`, but decoding does not decompress the G2 point.
@@ -207,6 +364,53 @@ impl<'de> Deserialize<'de> for LazyBlsSignature {
 mod tests {
     use super::*;
     use aptos_crypto::{bls12381::PrivateKey, test_utils::TestAptosCrypto, SigningKey, Uniform};
+
+    fn sample_public_key() -> bls12381::PublicKey {
+        let mut rng = rand::thread_rng();
+        let sk = PrivateKey::generate(&mut rng);
+        bls12381::PublicKey::from(&sk)
+    }
+
+    #[test]
+    fn lazy_public_key_wire_compat_bcs_and_json() {
+        for _ in 0..16 {
+            let public_key = sample_public_key();
+            let lazy = LazyBlsPublicKey::from_public_key(&public_key);
+
+            let public_key_bcs = bcs::to_bytes(&public_key).unwrap();
+            let lazy_bcs = bcs::to_bytes(&lazy).unwrap();
+            assert_eq!(public_key_bcs, lazy_bcs);
+
+            let decoded: LazyBlsPublicKey = bcs::from_bytes(&public_key_bcs).unwrap();
+            assert_eq!(decoded, lazy);
+            assert_eq!(decoded.decompress().unwrap(), &public_key);
+
+            let public_key_json = serde_json::to_string(&public_key).unwrap();
+            let lazy_json = serde_json::to_string(&lazy).unwrap();
+            assert_eq!(public_key_json, lazy_json);
+            let decoded: LazyBlsPublicKey = serde_json::from_str(&public_key_json).unwrap();
+            assert_eq!(decoded.decompress().unwrap(), &public_key);
+        }
+    }
+
+    #[test]
+    fn invalid_public_key_is_rejected_only_when_materialized() {
+        let invalid = LazyBlsPublicKey::from_raw_bytes_for_test([0u8; bls12381::PublicKey::LENGTH]);
+        let bytes = bcs::to_bytes(&invalid).unwrap();
+
+        let decoded: LazyBlsPublicKey = bcs::from_bytes(&bytes).unwrap();
+        assert!(decoded.decompress().is_err());
+        assert!(bcs::from_bytes::<bls12381::PublicKey>(&bytes).is_err());
+    }
+
+    #[test]
+    fn uncached_public_key_footprint_is_small() {
+        let size = std::mem::size_of::<LazyBlsPublicKey>();
+        assert!(
+            size <= 64,
+            "LazyBlsPublicKey grew to {size} bytes; its decompressed cache must remain boxed",
+        );
+    }
 
     fn sample_signature() -> bls12381::Signature {
         let mut rng = rand::thread_rng();

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -5,7 +5,7 @@
 use crate::validator_signer::ValidatorSigner;
 use crate::{
     account_address::AccountAddress, aggregate_signature::AggregateSignature,
-    ledger_info::SignatureWithStatus, on_chain_config::ValidatorSet,
+    lazy_bls::LazyBlsPublicKey, ledger_info::SignatureWithStatus, on_chain_config::ValidatorSet,
 };
 use anyhow::{ensure, Result};
 use aptos_bcs_utils::BoundedVec;
@@ -60,6 +60,8 @@ pub enum VerifyError {
     InconsistentBlockInfo,
     #[error("Failed to aggregate public keys")]
     FailedToAggregatePubKey,
+    #[error("Invalid validator public key")]
+    InvalidPublicKey,
     #[error("Failed to aggregate signatures")]
     FailedToAggregateSignature,
     #[error("Failed to verify multi-signature")]
@@ -75,7 +77,7 @@ pub enum VerifyError {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct ValidatorConsensusInfo {
     pub address: AccountAddress,
-    pub public_key: PublicKey,
+    pub public_key: LazyBlsPublicKey,
     pub voting_power: u64,
 }
 
@@ -83,13 +85,13 @@ impl ValidatorConsensusInfo {
     pub fn new(address: AccountAddress, public_key: PublicKey, voting_power: u64) -> Self {
         ValidatorConsensusInfo {
             address,
-            public_key,
+            public_key: public_key.into(),
             voting_power,
         }
     }
 
-    pub fn public_key(&self) -> &PublicKey {
-        &self.public_key
+    pub fn public_key(&self) -> std::result::Result<&PublicKey, aptos_crypto::CryptoMaterialError> {
+        self.public_key.decompress()
     }
 }
 
@@ -262,8 +264,10 @@ impl ValidatorVerifier {
         message: &T,
         signature: &bls12381::Signature,
     ) -> std::result::Result<(), VerifyError> {
-        match self.get_public_key(&author) {
-            Some(public_key) => public_key
+        match self.get_validator_info(&author) {
+            Some(validator) => validator
+                .public_key()
+                .map_err(|_| VerifyError::InvalidPublicKey)?
                 .verify_struct_signature(message, signature)
                 .map_err(|_| VerifyError::InvalidMultiSignature),
             None => Err(VerifyError::UnknownAuthor),
@@ -276,7 +280,7 @@ impl ValidatorVerifier {
         message: &T,
         signature_with_status: &SignatureWithStatus,
     ) -> std::result::Result<(), VerifyError> {
-        if self.get_public_key(&author).is_none() {
+        if self.get_validator_info(&author).is_none() {
             return Err(VerifyError::UnknownAuthor);
         }
         if (!self.optimistic_sig_verification || self.pessimistic_verify_set.contains(&author))
@@ -365,7 +369,11 @@ impl ValidatorVerifier {
                 .get(index)
                 .ok_or(VerifyError::UnknownAuthor)?;
             authors.push(validator.address);
-            pub_keys.push(validator.public_key());
+            pub_keys.push(
+                validator
+                    .public_key()
+                    .map_err(|_| VerifyError::InvalidPublicKey)?,
+            );
         }
         // Verify the quorum voting power of the authors
         self.check_voting_power(authors.iter(), true)?;
@@ -409,7 +417,11 @@ impl ValidatorVerifier {
                 .get(index)
                 .ok_or(VerifyError::UnknownAuthor)?;
             authors.push(validator.address);
-            pub_keys.push(validator.public_key());
+            pub_keys.push(
+                validator
+                    .public_key()
+                    .map_err(|_| VerifyError::InvalidPublicKey)?,
+            );
         }
         // Verify the quorum voting power of the authors
         self.check_voting_power(authors.iter(), true)?;
@@ -504,9 +516,27 @@ impl ValidatorVerifier {
 
     /// Returns the public key for this address.
     pub fn get_public_key(&self, author: &AccountAddress) -> Option<PublicKey> {
+        self.get_validator_info(author)
+            .and_then(|validator| validator.public_key().ok().cloned())
+    }
+
+    /// Materialize every validator public key after the validator set has been
+    /// authenticated. This preserves the old invariant that a trusted
+    /// `ValidatorVerifier` contains only curve-valid public keys without doing
+    /// attacker-amplifiable G1 decompression during wire decoding.
+    pub fn validate_public_keys(&self) -> std::result::Result<(), VerifyError> {
+        self.validator_infos.iter().try_for_each(|validator| {
+            validator
+                .public_key()
+                .map(|_| ())
+                .map_err(|_| VerifyError::InvalidPublicKey)
+        })
+    }
+
+    fn get_validator_info(&self, author: &AccountAddress) -> Option<&ValidatorConsensusInfo> {
         self.address_to_validator_index
             .get(author)
-            .map(|index| self.validator_infos[*index].public_key().clone())
+            .map(|index| &self.validator_infos[*index])
     }
 
     /// Returns the voting power for this address.
@@ -807,6 +837,26 @@ mod tests {
                 .contains("sequence length 65537 exceeds maximum 65536"),
             "unexpected error: {}",
             error
+        );
+    }
+
+    #[test]
+    fn test_validator_set_deserialization_defers_public_key_materialization() {
+        let verifier = ValidatorVerifier::new(vec![ValidatorConsensusInfo {
+            address: AccountAddress::ONE,
+            public_key: LazyBlsPublicKey::from_raw_bytes_for_test(
+                [0u8; bls12381::PublicKey::LENGTH],
+            ),
+            voting_power: 1,
+        }]);
+        let bytes = bcs::to_bytes(&verifier).unwrap();
+
+        let decoded: ValidatorVerifier =
+            bcs::from_bytes(&bytes).expect("wire decoding must not decompress G1 points");
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(
+            decoded.validate_public_keys(),
+            Err(VerifyError::InvalidPublicKey)
         );
     }
 

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -8,6 +8,7 @@ use crate::{
     ledger_info::SignatureWithStatus, on_chain_config::ValidatorSet,
 };
 use anyhow::{ensure, Result};
+use aptos_bcs_utils::BoundedVec;
 use aptos_bitvec::BitVec;
 use aptos_crypto::{
     bls12381,
@@ -27,6 +28,9 @@ use std::{
     fmt,
 };
 use thiserror::Error;
+
+/// The on-chain validator set cannot exceed the `u16` index space used by `BitVec`.
+pub const MAX_VALIDATOR_SET_SIZE: usize = (u16::MAX as usize) + 1;
 
 /// Errors possible during signature verification.
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -169,13 +173,13 @@ impl<'de> Deserialize<'de> for ValidatorVerifier {
         #[derive(Deserialize)]
         #[serde(rename = "ValidatorVerifier")]
         struct RawValidatorVerifier {
-            validator_infos: Vec<ValidatorConsensusInfo>,
+            validator_infos: BoundedVec<ValidatorConsensusInfo, MAX_VALIDATOR_SET_SIZE>,
         }
 
         let RawValidatorVerifier { validator_infos } =
             RawValidatorVerifier::deserialize(deserializer)?;
 
-        Ok(ValidatorVerifier::new(validator_infos))
+        Ok(ValidatorVerifier::new(validator_infos.into_inner()))
     }
 }
 
@@ -786,6 +790,23 @@ mod tests {
         assert_eq!(
             validator.verify(validator_signer.author(), &dummy_struct, &unknown_signature),
             Err(VerifyError::InvalidMultiSignature)
+        );
+    }
+
+    #[test]
+    fn test_rejects_oversized_validator_set_before_elements() {
+        // ValidatorVerifier's only serialized field is validator_infos. This is the
+        // canonical ULEB128 encoding of a vector length of 65,537, with no elements.
+        // A length-first rejection returns the bound error instead of reaching EOF
+        // while attempting to deserialize the first public key.
+        let bytes = [0x81, 0x80, 0x04];
+        let error = bcs::from_bytes::<ValidatorVerifier>(&bytes).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("sequence length 65537 exceeds maximum 65536"),
+            "unexpected error: {}",
+            error
         );
     }
 


### PR DESCRIPTION
## Changes

- `9c15fffc9b` — Bound validator set deserialization.
- `6057286fe5` — Defer validator public key decompression.
- `2f772ddb5f` — Isolate deserialization work per peer.