### PR TITLE
[trading] Add per-market fee override support

### DIFF
--- a/aptos-move/framework/aptos-experimental/sources/trading/market/market_types.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/market/market_types.move
@@ -572,7 +572,11 @@ module aptos_experimental::market_types {
             pre_cancellation_window_secs: u64,
             /// Enable dead man's switch functionality
             enable_dead_mans_switch: bool,
-            min_keep_alive_time_secs: u64
+            min_keep_alive_time_secs: u64,
+            /// Optional maker fee in basis points (10000 = 100%). None means use default fee.
+            maker_fee_bps: Option<u64>,
+            /// Optional taker fee in basis points (10000 = 100%). None means use default fee.
+            taker_fee_bps: Option<u64>
         }
     }
 
@@ -684,15 +688,39 @@ module aptos_experimental::market_types {
         allow_events_emission: bool,
         pre_cancellation_window_secs: u64,
         enable_dead_mans_switch: bool,
-        min_keep_alive_time_secs: u64
+        min_keep_alive_time_secs: u64,
+        maker_fee_bps: Option<u64>,
+        taker_fee_bps: Option<u64>
     ): MarketConfig {
         MarketConfig::V1 {
             allow_self_trade: allow_self_matching,
             allow_events_emission,
             pre_cancellation_window_secs,
             enable_dead_mans_switch,
-            min_keep_alive_time_secs
+            min_keep_alive_time_secs,
+            maker_fee_bps,
+            taker_fee_bps
         }
+    }
+
+    /// Convenience function to create a market config with zero fees.
+    /// Useful for stablecoin-to-stablecoin markets or other low-fee markets.
+    public fun new_market_config_with_zero_fees(
+        allow_self_matching: bool,
+        allow_events_emission: bool,
+        pre_cancellation_window_secs: u64,
+        enable_dead_mans_switch: bool,
+        min_keep_alive_time_secs: u64
+    ): MarketConfig {
+        new_market_config(
+            allow_self_matching,
+            allow_events_emission,
+            pre_cancellation_window_secs,
+            enable_dead_mans_switch,
+            min_keep_alive_time_secs,
+            option::some(0), // maker_fee_bps = 0
+            option::some(0) // taker_fee_bps = 0
+        )
     }
 
     public fun new_market<M: store + copy + drop>(
@@ -751,6 +779,26 @@ module aptos_experimental::market_types {
             market,
             min_keep_alive_time_secs
         );
+    }
+
+    public fun set_maker_fee_bps<M: store + copy + drop>(
+        self: &mut Market<M>, maker_fee_bps: Option<u64>
+    ) {
+        self.config.maker_fee_bps = maker_fee_bps;
+    }
+
+    public fun set_taker_fee_bps<M: store + copy + drop>(
+        self: &mut Market<M>, taker_fee_bps: Option<u64>
+    ) {
+        self.config.taker_fee_bps = taker_fee_bps;
+    }
+
+    public fun get_maker_fee_bps<M: store + copy + drop>(self: &Market<M>): Option<u64> {
+        self.config.maker_fee_bps
+    }
+
+    public fun get_taker_fee_bps<M: store + copy + drop>(self: &Market<M>): Option<u64> {
+        self.config.taker_fee_bps
     }
 
     public fun get_order_book<M: store + copy + drop>(self: &Market<M>): &OrderBook<M> {
@@ -1111,7 +1159,9 @@ module aptos_experimental::market_types {
             allow_events_emission: _,
             pre_cancellation_window_secs: _,
             enable_dead_mans_switch: _,
-            min_keep_alive_time_secs: _
+            min_keep_alive_time_secs: _,
+            maker_fee_bps: _,
+            taker_fee_bps: _
         } = config;
         destroy_tracker(pre_cancellation_tracker.remove(PRE_CANCELLATION_TRACKER_KEY));
         dead_mans_switch_tracker::destroy_tracker(

--- a/aptos-move/framework/aptos-experimental/sources/trading/tests/market/dead_mans_switch_operations_test.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/tests/market/dead_mans_switch_operations_test.move
@@ -28,7 +28,9 @@ module aptos_experimental::dead_mans_switch_operations_test {
                     true, // allow_events_emission
                     1, // pre_cancellation_window_secs
                     true, // enable_dead_mans_switch
-                    MIN_KEEP_ALIVE_TIME_SECS
+                    MIN_KEEP_ALIVE_TIME_SECS,
+                    option::none(), // maker_fee_bps
+                    option::none() // taker_fee_bps
                 )
             );
         clearinghouse_test::initialize(admin);
@@ -186,7 +188,7 @@ module aptos_experimental::dead_mans_switch_operations_test {
             new_market(
                 &admin,
                 &mut market_signer,
-                new_market_config(false, true, 1, false, 0) // DMS disabled
+                new_market_config(false, true, 1, false, 0, option::none(), option::none()) // DMS disabled
             );
         clearinghouse_test::initialize(&admin);
 
@@ -608,7 +610,7 @@ module aptos_experimental::dead_mans_switch_operations_test {
             new_market(
                 &admin,
                 &mut market_signer,
-                new_market_config(false, true, 1, false, 0) // DMS disabled
+                new_market_config(false, true, 1, false, 0, option::none(), option::none()) // DMS disabled
             );
         clearinghouse_test::initialize(&admin);
 

--- a/aptos-move/framework/aptos-experimental/sources/trading/tests/market/market_tests_common.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/tests/market/market_tests_common.move
@@ -52,7 +52,9 @@ module aptos_experimental::market_tests_common {
                     true,
                     PRE_CANCEL_WINDOW_SECS,
                     false,
-                    0
+                    0,
+                    option::none(),
+                    option::none()
                 )
             );
         clearinghouse_test::initialize(admin);

--- a/aptos-move/framework/aptos-experimental/sources/trading/tests/market/pre_cancellation_tests.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/tests/market/pre_cancellation_tests.move
@@ -35,7 +35,7 @@ module aptos_experimental::pre_cancellation_tests {
             new_market(
                 admin,
                 market_signer,
-                new_market_config(false, true, PRE_CANCEL_WINDOW_SECS, false, 0)
+                new_market_config(false, true, PRE_CANCEL_WINDOW_SECS, false, 0, option::none(), option::none())
             );
         clearinghouse_test::initialize(admin);
         let event_store = event_utils::new_event_store();
@@ -113,7 +113,7 @@ module aptos_experimental::pre_cancellation_tests {
             new_market(
                 admin,
                 market_signer,
-                new_market_config(false, true, PRE_CANCEL_WINDOW_SECS, false, 0)
+                new_market_config(false, true, PRE_CANCEL_WINDOW_SECS, false, 0, option::none(), option::none())
             );
         clearinghouse_test::initialize(admin);
         let event_store = event_utils::new_event_store();
@@ -175,7 +175,7 @@ module aptos_experimental::pre_cancellation_tests {
             new_market(
                 admin,
                 market_signer,
-                new_market_config(false, true, PRE_CANCEL_WINDOW_SECS, false, 0)
+                new_market_config(false, true, PRE_CANCEL_WINDOW_SECS, false, 0, option::none(), option::none())
             );
         clearinghouse_test::initialize(admin);
         let event_store = event_utils::new_event_store();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

This PR adds support for per-market fee overrides in the spot trading market system, allowing different markets to have different fee structures.

## Motivation

Currently, all markets use the same fee structure. This PR enables:
- **Zero-fee markets** for stablecoin pairs (USDC/USDT) to compete with AMMs
- **Low-fee markets** for wrapped asset pairs (stAPT/APT, xBTC/NearBTC)
- **Custom fee tiers** per trading pair for flexible pricing strategies

This addresses the need for flexible fee structures as discussed in the Decibel rollout planning.

## Changes

### Core Changes
- Added `maker_fee_bps: Option<u64>` to `MarketConfig` - fee in basis points (10000 = 100%)
- Added `taker_fee_bps: Option<u64>` to `MarketConfig`
- Added getter functions: `get_maker_fee_bps()` and `get_taker_fee_bps()`
- Added setter functions: `set_maker_fee_bps()` and `set_taker_fee_bps()`

### Convenience Functions
- Added `new_market_config_with_zero_fees()` helper for easily creating zero-fee markets

### Test Updates
- Updated all test code to pass the new fee parameters (using `option::none()` for default behavior)
- Modified tests in: `pre_cancellation_tests`, `market_tests_common`, `dead_mans_switch_operations_test`

## Usage Example

```move
// Create a zero-fee market for USDC/USDT
let config = new_market_config_with_zero_fees(
    false,  // allow_self_matching
    true,   // allow_events_emission
    1,      // pre_cancellation_window_secs
    false,  // enable_dead_mans_switch
    0       // min_keep_alive_time_secs
);

// Or create a market with custom fees (5 bps maker, 10 bps taker)
let config = new_market_config(
    false,
    true,
    1,
    false,
    0,
    option::some(5),   // 0.05% maker fee
    option::some(10)   // 0.10% taker fee
);

// Get fee configuration from market
let maker_fee = market.get_maker_fee_bps();  // Returns Option<u64>
let taker_fee = market.get_taker_fee_bps();  // Returns Option<u64>
```

## Implementation Notes

- Fee fields are `Option<u64>` where `None` means "use default fee" and `Some(value)` specifies the fee override in basis points
- The actual fee collection is handled by the clearinghouse implementation, which can query these values during trade settlement
- Existing markets without fee overrides will return `option::none()`, maintaining backward compatibility

## Testing

- ✅ Code compiles successfully (`cargo build -p aptos-cached-packages`)
- ✅ All test files updated to accommodate new API
- Framework cached packages rebuilt

## Related

- Addresses request from #spot_e2e_rollout Slack discussion
- Enables competitive stablecoin swap markets on Decibel
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C0BKN5G2ZQS/p1787242592559239?thread_ts=1787242592.559239&cid=C0BKN5G2ZQS)

<div><a href="https://cursor.com/agents/bc-61f0fb03-63c4-589b-8505-3dab09243410?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61f0fb03-63c4-589b-8505-3dab09243410&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

