### PR TITLE
[crypto] Route batch-encryption pairings and MSMs through blst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "bcs 0.1.4",
+ "blst",
  "criterion",
  "ed25519-dalek 2.1.1",
  "generic-array",

--- a/crates/aptos-batch-encryption/Cargo.toml
+++ b/crates/aptos-batch-encryption/Cargo.toml
@@ -33,6 +33,7 @@ ark-poly = { workspace = true }
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 bcs = { workspace = true }
+blst = { workspace = true }
 # TODO: Fix compiler errors so we can use `workspace = true` here
 ed25519-dalek = { version = "2.1.1", features = ["serde"] }
 generic-array = { workspace = true }

--- a/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
+++ b/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
@@ -6,7 +6,6 @@ use crate::{
     shared::blst_ops::{self, BlstG1, G1MsmBases},
 };
 use aptos_crypto::arkworks::serialization::{ark_de_uncompressed_no_validate, ark_se_uncompressed};
-use ark_ec::CurveGroup as _;
 use ark_ff::{FftField, Zero as _};
 use ark_poly::{domain::DomainCoeff, EvaluationDomain, Radix2EvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -20,6 +19,27 @@ use serde::{
     Deserialize, Serialize,
 };
 use std::{fmt, marker::PhantomData};
+
+/// The representation in which a circulant evaluation's group arithmetic -- the
+/// Hadamard product and the inverse FFT -- is actually carried out.
+///
+/// A [`PreparedInput`] always stores its points as `T`, since that is the form
+/// that gets serialized. The arithmetic on top of it, though, need not happen in
+/// `T`: any representation we can batch-convert into will do, and some are much
+/// faster. The blanket impl below is the identity -- stay in `T`, use arkworks
+/// throughout -- while [`BlstG1`] converts into blst points, so that the same
+/// evaluation code drives blst's curve arithmetic instead.
+pub trait EvalRepr<F: FftField, T>: DomainCoeff<F> {
+    /// Batch-convert the prepared (already FFT'd) input points into this
+    /// representation.
+    fn from_prepared(prepared: &[T]) -> Vec<Self>;
+}
+
+impl<F: FftField, T: DomainCoeff<F>> EvalRepr<F, T> for T {
+    fn from_prepared(prepared: &[T]) -> Vec<T> {
+        prepared.to_vec()
+    }
+}
 
 /// To efficiently evaluate a Circulant matrix of size `n x n` over an input,
 /// a FFT-friendly subset of a field of size `n` is required. This struct
@@ -121,11 +141,18 @@ impl<F: FftField> CirculantDomain<F> {
 
     /// Evaluate a circulant matrix given by the vector `circulant`, on a prepared input
     /// `prepared_input`.
-    pub fn eval_prepared<T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize>(
+    ///
+    /// The output representation `U` selects which library performs the group
+    /// arithmetic; see [`EvalRepr`]. It defaults to `T` by inference, which is
+    /// the all-arkworks path.
+    pub fn eval_prepared<
+        T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize,
+        U: EvalRepr<F, T>,
+    >(
         &self,
         circulant: &[F],
         prepared_input: &PreparedInput<F, T>,
-    ) -> Vec<T> {
+    ) -> Vec<U> {
         assert_eq!(circulant.len(), prepared_input.y.len());
         assert_eq!(circulant.len(), self.dimension());
 
@@ -133,10 +160,10 @@ impl<F: FftField> CirculantDomain<F> {
 
         // Hadamard product of y and v
         // Would like to write
-        // let u : Vec<T> = zip(y, v).map(|(yi, vi)| yi * vi).collect();
+        // let u : Vec<U> = zip(y, v).map(|(yi, vi)| yi * vi).collect();
         // but looks like DomainCoeff only is required to implement MulAssign<F> and not Mul<F>...
         // so have to do something uglier:
-        let mut u: Vec<T> = prepared_input.y.clone();
+        let mut u: Vec<U> = U::from_prepared(&prepared_input.y);
         u.par_iter_mut().zip(v.par_iter()).for_each(|(u, v)| {
             *u *= *v;
         });
@@ -259,11 +286,17 @@ impl<F: FftField + Sized> ToeplitzDomain<F> {
 
     /// Evaluate a Toeplitz matrix given by the vector `toeplitz`, on a prepared input
     /// `prepared_input`.
-    pub fn eval_prepared<T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize>(
+    ///
+    /// As in [`CirculantDomain::eval_prepared`], `U` selects the representation
+    /// the group arithmetic runs in.
+    pub fn eval_prepared<
+        T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize,
+        U: EvalRepr<F, T>,
+    >(
         &self,
         toeplitz: &[F],
         prepared_input: &PreparedInput<F, T>,
-    ) -> Vec<T> {
+    ) -> Vec<U> {
         assert_eq!(toeplitz.len() + 1, self.circulant_domain.dimension());
         assert_eq!(prepared_input.y.len(), self.circulant_domain.dimension());
 
@@ -344,16 +377,10 @@ impl<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize>
 impl FKDomain<Fr, G1Projective> {
     /// Compute the `H_j(tau)` commitments for the polynomial `f`.
     ///
-    /// This is a Toeplitz-matrix evaluation on the prepared (already FFT'd) tau
-    /// powers: an FFT of the circulant form of the matrix, a Hadamard product
-    /// against the prepared input, and a group inverse FFT. It is the same
-    /// computation as [`ToeplitzDomain::eval_prepared`], inlined here so that
-    /// the two group-arithmetic steps -- the Hadamard product's scalar
-    /// multiplications and the inverse FFT's butterflies -- can run over blst
-    /// points instead of arkworks ones.
-    ///
-    /// Returns blst-native points, so that callers doing an MSM next can feed
-    /// them straight in without a round trip through arkworks.
+    /// Returns blst-native points -- the [`BlstG1`] return type is what selects
+    /// blst for the underlying Toeplitz evaluation's group arithmetic -- so that
+    /// callers doing an MSM next can feed them straight in without a round trip
+    /// through arkworks.
     pub(crate) fn compute_h_term_commitments(&self, f: &[Fr], round: usize) -> Vec<BlstG1> {
         let mut f = Vec::from(f);
         f.extend(std::iter::repeat_n(
@@ -364,29 +391,12 @@ impl FKDomain<Fr, G1Projective> {
         // dimension.
         debug_assert_eq!(self.toeplitz_domain.dimension(), f.len() - 1);
 
-        // The Toeplitz matrix is only evaluated on the powers up to max_poly_degree - 1,
-        // since the H_j(X) polynomials have degree at most that.
-        let prepared_input = &self.prepared_toeplitz_inputs[round];
-        let circulant_domain = &self.toeplitz_domain.circulant_domain;
-        let circulant = self
-            .toeplitz_domain
-            .toeplitz_to_circulant(&self.toeplitz_for_poly(&f));
-
-        assert_eq!(circulant.len(), prepared_input.y.len());
-        assert_eq!(circulant.len(), circulant_domain.dimension());
-
-        let v = circulant_domain.fft_domain.fft(&circulant);
-
-        // One batch inversion to move the prepared tau powers into blst representation.
-        let y_affine = G1Projective::normalize_batch(&prepared_input.y);
-        let mut u: Vec<BlstG1> = y_affine.iter().map(BlstG1::from_ark).collect();
-
-        u.par_iter_mut().zip(v.par_iter()).for_each(|(u, v)| {
-            *u *= *v;
-        });
-
-        let h = circulant_domain.fft_domain.ifft(&u);
-        Vec::from(&h[..self.toeplitz_domain.dimension()])
+        self.toeplitz_domain.eval_prepared(
+            &self.toeplitz_for_poly(&f),
+            // The Toeplitz matrix is only evaluated on the powers up to max_poly_degree - 1,
+            // since the H_j(X) polynomials have degree at most that
+            &self.prepared_toeplitz_inputs[round],
+        )
     }
 
     /// Compute the evaluation proofs for a KZG commitment of a polynomial `f`, committed to under
@@ -424,12 +434,7 @@ impl FKDomain<Fr, G1Projective> {
 
         // All `x_coords.len()` MSMs share the same bases, so the blst Pippenger
         // table is built once and reused across them.
-        let bases = G1MsmBases::from_blst(
-            &h_term_commitments
-                .iter()
-                .map(|p| p.0)
-                .collect::<Vec<blst::blst_p1>>(),
-        );
+        let bases = G1MsmBases::from_blst(&h_term_commitments);
         blst_ops::multi_point_eval_naive_with_bases(&bases, x_coords)
     }
 }
@@ -636,9 +641,10 @@ mod tests {
             let fk_domain =
                 FKDomain::new(poly_degree, poly_degree, tau_powers_g1_projective).unwrap();
 
-            // Reference: the same Toeplitz evaluation done entirely in arkworks.
-            // `poly.coeffs` already has degree equal to the Toeplitz dimension,
-            // so no zero-padding is needed here.
+            // Reference: the same evaluation, but with `G1Projective` as the
+            // representation, so the arithmetic runs in arkworks. `poly.coeffs`
+            // already has degree equal to the Toeplitz dimension, so no
+            // zero-padding is needed here.
             let expected: Vec<G1Projective> = fk_domain.toeplitz_domain.eval_prepared(
                 &fk_domain.toeplitz_for_poly(&poly.coeffs),
                 &fk_domain.prepared_toeplitz_inputs[0],

--- a/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
+++ b/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
@@ -377,11 +377,16 @@ impl<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize>
 impl FKDomain<Fr, G1Projective> {
     /// Compute the `H_j(tau)` commitments for the polynomial `f`.
     ///
-    /// Returns blst-native points -- the [`BlstG1`] return type is what selects
-    /// blst for the underlying Toeplitz evaluation's group arithmetic -- so that
-    /// callers doing an MSM next can feed them straight in without a round trip
-    /// through arkworks.
-    pub(crate) fn compute_h_term_commitments(&self, f: &[Fr], round: usize) -> Vec<BlstG1> {
+    /// The output representation `U` selects which library does the underlying
+    /// Toeplitz evaluation's group arithmetic; see [`EvalRepr`]. Callers pick
+    /// whichever form they consume next, so that neither of them pays for a
+    /// round trip: [`BlstG1`] for the blst MSM and group FFT paths,
+    /// `G1Projective` for the arkworks multi-point evaluation.
+    pub(crate) fn compute_h_term_commitments<U: EvalRepr<Fr, G1Projective>>(
+        &self,
+        f: &[Fr],
+        round: usize,
+    ) -> Vec<U> {
         let mut f = Vec::from(f);
         f.extend(std::iter::repeat_n(
             Fr::zero(),
@@ -402,7 +407,9 @@ impl FKDomain<Fr, G1Projective> {
     /// Compute the evaluation proofs for a KZG commitment of a polynomial `f`, committed to under
     /// `tau_powers`, on the FFT domain encapsulated by this [`FKDomain`].
     pub fn eval_proofs_at_roots_of_unity(&self, f: &[Fr], round: usize) -> Vec<G1Projective> {
-        let h_term_commitments = self.compute_h_term_commitments(f, round);
+        // The group FFT is blst point addition, so stay in blst for it and
+        // convert only the results.
+        let h_term_commitments: Vec<BlstG1> = self.compute_h_term_commitments(f, round);
         self.fft_domain
             .fft(&h_term_commitments)
             .iter()
@@ -416,11 +423,9 @@ impl FKDomain<Fr, G1Projective> {
         x_coords: &[Fr],
         round: usize,
     ) -> Vec<G1Projective> {
-        let h_term_commitments: Vec<G1Projective> = self
-            .compute_h_term_commitments(f, round)
-            .iter()
-            .map(BlstG1::to_ark)
-            .collect();
+        // `multi_point_eval` is arkworks throughout, so ask for arkworks points
+        // rather than converting a blst result back.
+        let h_term_commitments: Vec<G1Projective> = self.compute_h_term_commitments(f, round);
         multi_point_eval(&h_term_commitments, x_coords)
     }
 
@@ -430,7 +435,7 @@ impl FKDomain<Fr, G1Projective> {
         x_coords: &[Fr],
         round: usize,
     ) -> Vec<G1Projective> {
-        let h_term_commitments = self.compute_h_term_commitments(f, round);
+        let h_term_commitments: Vec<BlstG1> = self.compute_h_term_commitments(f, round);
 
         // All `x_coords.len()` MSMs share the same bases, so the blst Pippenger
         // table is built once and reused across them.
@@ -570,7 +575,10 @@ impl<'de, F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeseria
 #[cfg(test)]
 mod tests {
     use super::FKDomain;
-    use crate::group::{Fr, G1Affine, G1Projective, G2Affine, G2Projective, PairingSetting};
+    use crate::{
+        group::{Fr, G1Affine, G1Projective, G2Affine, G2Projective, PairingSetting},
+        shared::blst_ops::BlstG1,
+    };
     use ark_ec::{pairing::Pairing, AffineRepr as _, PrimeGroup, ScalarMul as _, VariableBaseMSM};
     use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Polynomial};
     use ark_std::{rand::thread_rng, One, UniformRand};
@@ -649,7 +657,7 @@ mod tests {
                 &fk_domain.toeplitz_for_poly(&poly.coeffs),
                 &fk_domain.prepared_toeplitz_inputs[0],
             );
-            let actual = fk_domain.compute_h_term_commitments(&poly.coeffs, 0);
+            let actual: Vec<BlstG1> = fk_domain.compute_h_term_commitments(&poly.coeffs, 0);
 
             assert_eq!(expected.len(), actual.len());
             for (e, a) in expected.iter().zip(&actual) {

--- a/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
+++ b/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
@@ -343,7 +343,7 @@ impl<
         toeplitz
     }
 
-    fn compute_h_term_commitments(&self, f: &[F], round: usize) -> Vec<T> {
+    pub(crate) fn compute_h_term_commitments(&self, f: &[F], round: usize) -> Vec<T> {
         let mut f = Vec::from(f);
         f.extend(std::iter::repeat_n(
             F::zero(),
@@ -388,6 +388,55 @@ impl<
                 .collect::<Vec<T::MulBase>>(),
             x_coords,
         )
+    }
+}
+
+impl FKDomain<crate::group::Fr, crate::group::G1Projective> {
+    /// Same as [`Self::compute_h_term_commitments`], but with all G1 point
+    /// operations (the Hadamard-product scalar multiplications and the group
+    /// iFFT butterflies) routed through blst via [`crate::shared::blst_ops::BlstG1`].
+    /// Returns blst-native points so callers can feed them straight into a
+    /// blst MSM without round-tripping through arkworks.
+    pub(crate) fn compute_h_term_commitments_blst(
+        &self,
+        f: &[crate::group::Fr],
+        round: usize,
+    ) -> Vec<crate::shared::blst_ops::BlstG1> {
+        use crate::{
+            group::{Fr, G1Projective},
+            shared::blst_ops::BlstG1,
+        };
+        use ark_ec::CurveGroup as _;
+        use ark_ff::Zero as _;
+
+        let mut f = Vec::from(f);
+        f.extend(std::iter::repeat_n(
+            Fr::zero(),
+            self.toeplitz_domain.dimension() + 1 - f.len(),
+        ));
+        debug_assert_eq!(self.toeplitz_domain.dimension(), f.len() - 1);
+
+        let toeplitz = self.toeplitz_for_poly(&f);
+        let circulant = self.toeplitz_domain.toeplitz_to_circulant(&toeplitz);
+        let prepared_input = &self.prepared_toeplitz_inputs[round];
+        let circulant_domain = &self.toeplitz_domain.circulant_domain;
+
+        assert_eq!(circulant.len(), prepared_input.y.len());
+        assert_eq!(circulant.len(), circulant_domain.dimension());
+
+        let v = circulant_domain.fft_domain.fft(&circulant);
+
+        // One batch inversion to move the prepared (already-FFT'd) tau powers
+        // into blst representation.
+        let y_affine = G1Projective::normalize_batch(&prepared_input.y);
+        let mut u: Vec<BlstG1> = y_affine.iter().map(BlstG1::from_ark).collect();
+
+        u.par_iter_mut().zip(v.par_iter()).for_each(|(u, v)| {
+            *u *= *v;
+        });
+
+        let h = circulant_domain.fft_domain.ifft(&u);
+        Vec::from(&h[..self.toeplitz_domain.dimension()])
     }
 }
 
@@ -562,6 +611,44 @@ mod tests {
             let fk_domain2: FKDomain<Fr, G1Projective> = serde_json::from_str(&json).unwrap();
 
             assert_eq!(fk_domain, fk_domain2);
+        }
+    }
+
+    #[test]
+    fn compute_h_term_commitments_blst_matches_generic() {
+        for poly_degree_exp in 1..5 {
+            let poly_degree = 2usize.pow(poly_degree_exp);
+            let mut rng = thread_rng();
+
+            let tau = Fr::rand(&mut rng);
+
+            let mut tau_powers_fr = vec![Fr::one()];
+            let mut cur = tau;
+            for _ in 0..poly_degree {
+                tau_powers_fr.push(cur);
+                cur *= &tau;
+            }
+
+            let poly: DensePolynomial<Fr> = DensePolynomial::from_coefficients_vec(
+                (0..(poly_degree + 1)).map(|_| Fr::rand(&mut rng)).collect(),
+            );
+
+            let tau_powers_g1 = G1Projective::from(G1Affine::generator()).batch_mul(&tau_powers_fr);
+            let tau_powers_g1_projective: Vec<Vec<G1Projective>> = vec![tau_powers_g1
+                .iter()
+                .map(|g| G1Projective::from(*g))
+                .collect()];
+
+            let fk_domain =
+                FKDomain::new(poly_degree, poly_degree, tau_powers_g1_projective).unwrap();
+
+            let expected = fk_domain.compute_h_term_commitments(&poly.coeffs, 0);
+            let actual = fk_domain.compute_h_term_commitments_blst(&poly.coeffs, 0);
+
+            assert_eq!(expected.len(), actual.len());
+            for (e, a) in expected.iter().zip(&actual) {
+                assert_eq!(*e, a.to_ark());
+            }
         }
     }
 

--- a/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
+++ b/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
@@ -1,10 +1,13 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use super::multi_point_eval::multi_point_eval;
-use crate::shared::algebra::multi_point_eval::multi_point_eval_naive;
+use crate::{
+    group::{Fr, G1Projective},
+    shared::blst_ops::{self, BlstG1, G1MsmBases},
+};
 use aptos_crypto::arkworks::serialization::{ark_de_uncompressed_no_validate, ark_se_uncompressed};
-use ark_ec::VariableBaseMSM;
-use ark_ff::FftField;
+use ark_ec::CurveGroup as _;
+use ark_ff::{FftField, Zero as _};
 use ark_poly::{domain::DomainCoeff, EvaluationDomain, Radix2EvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use rayon::iter::{
@@ -16,7 +19,7 @@ use serde::{
     ser::SerializeStruct as _,
     Deserialize, Serialize,
 };
-use std::{fmt, marker::PhantomData, ops::Mul};
+use std::{fmt, marker::PhantomData};
 
 /// To efficiently evaluate a Circulant matrix of size `n x n` over an input,
 /// a FFT-friendly subset of a field of size `n` is required. This struct
@@ -282,15 +285,7 @@ pub struct FKDomain<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + Canoni
     pub prepared_toeplitz_inputs: Vec<PreparedInput<F, T>>,
 }
 
-impl<
-        F: FftField,
-        T: DomainCoeff<F>
-            + Mul<F, Output = T>
-            + VariableBaseMSM<ScalarField = F>
-            + CanonicalSerialize
-            + CanonicalDeserialize,
-    > FKDomain<F, T>
-{
+impl<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize> FKDomain<F, T> {
     pub fn new(
         max_poly_degree: usize,
         eval_domain_size: usize,
@@ -342,92 +337,47 @@ impl<
 
         toeplitz
     }
+}
 
-    pub(crate) fn compute_h_term_commitments(&self, f: &[F], round: usize) -> Vec<T> {
+/// The FK evaluation-proof routines are specialized to BLS12-381, because their
+/// G1 arithmetic runs through blst rather than arkworks.
+impl FKDomain<Fr, G1Projective> {
+    /// Compute the `H_j(tau)` commitments for the polynomial `f`.
+    ///
+    /// This is a Toeplitz-matrix evaluation on the prepared (already FFT'd) tau
+    /// powers: an FFT of the circulant form of the matrix, a Hadamard product
+    /// against the prepared input, and a group inverse FFT. It is the same
+    /// computation as [`ToeplitzDomain::eval_prepared`], inlined here so that
+    /// the two group-arithmetic steps -- the Hadamard product's scalar
+    /// multiplications and the inverse FFT's butterflies -- can run over blst
+    /// points instead of arkworks ones.
+    ///
+    /// Returns blst-native points, so that callers doing an MSM next can feed
+    /// them straight in without a round trip through arkworks.
+    pub(crate) fn compute_h_term_commitments(&self, f: &[Fr], round: usize) -> Vec<BlstG1> {
         let mut f = Vec::from(f);
         f.extend(std::iter::repeat_n(
-            F::zero(),
+            Fr::zero(),
             self.toeplitz_domain.dimension() + 1 - f.len(),
         ));
         // f.len() = (degree of f) + 1. Degree of f should be equal to the toeplitz domain
         // dimension.
         debug_assert_eq!(self.toeplitz_domain.dimension(), f.len() - 1);
 
-        self.toeplitz_domain.eval_prepared(
-            &self.toeplitz_for_poly(&f),
-            // The Toeplitz matrix is only evaluated on the powers up to max_poly_degree - 1,
-            // since the H_j(X) polynomials have degree at most that
-            &self.prepared_toeplitz_inputs[round],
-        )
-    }
-
-    /// Compute the evaluation proofs for a KZG commitment of a polynomial `f`, committed to under
-    /// `tau_powers`, on the FFT domain encapsulated by this [`FKDomain`].
-    pub fn eval_proofs_at_roots_of_unity(&self, f: &[F], round: usize) -> Vec<T> {
-        let h_term_commitments = self.compute_h_term_commitments(f, round);
-        self.fft_domain.fft(&h_term_commitments)
-    }
-
-    pub fn eval_proofs_at_x_coords(&self, f: &[F], x_coords: &[F], round: usize) -> Vec<T> {
-        let h_term_commitments = self.compute_h_term_commitments(f, round);
-        multi_point_eval(&h_term_commitments, x_coords)
-    }
-
-    pub fn eval_proofs_at_x_coords_naive_multi_point_eval(
-        &self,
-        f: &[F],
-        x_coords: &[F],
-        round: usize,
-    ) -> Vec<T> {
-        let h_term_commitments = self.compute_h_term_commitments(f, round);
-
-        multi_point_eval_naive(
-            &h_term_commitments
-                .into_iter()
-                .map(T::MulBase::from)
-                .collect::<Vec<T::MulBase>>(),
-            x_coords,
-        )
-    }
-}
-
-impl FKDomain<crate::group::Fr, crate::group::G1Projective> {
-    /// Same as [`Self::compute_h_term_commitments`], but with all G1 point
-    /// operations (the Hadamard-product scalar multiplications and the group
-    /// iFFT butterflies) routed through blst via [`crate::shared::blst_ops::BlstG1`].
-    /// Returns blst-native points so callers can feed them straight into a
-    /// blst MSM without round-tripping through arkworks.
-    pub(crate) fn compute_h_term_commitments_blst(
-        &self,
-        f: &[crate::group::Fr],
-        round: usize,
-    ) -> Vec<crate::shared::blst_ops::BlstG1> {
-        use crate::{
-            group::{Fr, G1Projective},
-            shared::blst_ops::BlstG1,
-        };
-        use ark_ec::CurveGroup as _;
-        use ark_ff::Zero as _;
-
-        let mut f = Vec::from(f);
-        f.extend(std::iter::repeat_n(
-            Fr::zero(),
-            self.toeplitz_domain.dimension() + 1 - f.len(),
-        ));
-        debug_assert_eq!(self.toeplitz_domain.dimension(), f.len() - 1);
-
-        let toeplitz = self.toeplitz_for_poly(&f);
-        let circulant = self.toeplitz_domain.toeplitz_to_circulant(&toeplitz);
+        // The Toeplitz matrix is only evaluated on the powers up to max_poly_degree - 1,
+        // since the H_j(X) polynomials have degree at most that.
         let prepared_input = &self.prepared_toeplitz_inputs[round];
         let circulant_domain = &self.toeplitz_domain.circulant_domain;
+        let circulant = self
+            .toeplitz_domain
+            .toeplitz_to_circulant(&self.toeplitz_for_poly(&f));
 
         assert_eq!(circulant.len(), prepared_input.y.len());
         assert_eq!(circulant.len(), circulant_domain.dimension());
 
         let v = circulant_domain.fft_domain.fft(&circulant);
 
-        // One batch inversion to move the prepared (already-FFT'd) tau powers
-        // into blst representation.
+        // One batch inversion to move the prepared tau powers into blst representation.
         let y_affine = G1Projective::normalize_batch(&prepared_input.y);
         let mut u: Vec<BlstG1> = y_affine.iter().map(BlstG1::from_ark).collect();
 
@@ -437,6 +387,50 @@ impl FKDomain<crate::group::Fr, crate::group::G1Projective> {
 
         let h = circulant_domain.fft_domain.ifft(&u);
         Vec::from(&h[..self.toeplitz_domain.dimension()])
+    }
+
+    /// Compute the evaluation proofs for a KZG commitment of a polynomial `f`, committed to under
+    /// `tau_powers`, on the FFT domain encapsulated by this [`FKDomain`].
+    pub fn eval_proofs_at_roots_of_unity(&self, f: &[Fr], round: usize) -> Vec<G1Projective> {
+        let h_term_commitments = self.compute_h_term_commitments(f, round);
+        self.fft_domain
+            .fft(&h_term_commitments)
+            .iter()
+            .map(BlstG1::to_ark)
+            .collect()
+    }
+
+    pub fn eval_proofs_at_x_coords(
+        &self,
+        f: &[Fr],
+        x_coords: &[Fr],
+        round: usize,
+    ) -> Vec<G1Projective> {
+        let h_term_commitments: Vec<G1Projective> = self
+            .compute_h_term_commitments(f, round)
+            .iter()
+            .map(BlstG1::to_ark)
+            .collect();
+        multi_point_eval(&h_term_commitments, x_coords)
+    }
+
+    pub fn eval_proofs_at_x_coords_naive_multi_point_eval(
+        &self,
+        f: &[Fr],
+        x_coords: &[Fr],
+        round: usize,
+    ) -> Vec<G1Projective> {
+        let h_term_commitments = self.compute_h_term_commitments(f, round);
+
+        // All `x_coords.len()` MSMs share the same bases, so the blst Pippenger
+        // table is built once and reused across them.
+        let bases = G1MsmBases::from_blst(
+            &h_term_commitments
+                .iter()
+                .map(|p| p.0)
+                .collect::<Vec<blst::blst_p1>>(),
+        );
+        blst_ops::multi_point_eval_naive_with_bases(&bases, x_coords)
     }
 }
 
@@ -615,7 +609,7 @@ mod tests {
     }
 
     #[test]
-    fn compute_h_term_commitments_blst_matches_generic() {
+    fn compute_h_term_commitments_matches_arkworks() {
         for poly_degree_exp in 1..5 {
             let poly_degree = 2usize.pow(poly_degree_exp);
             let mut rng = thread_rng();
@@ -642,8 +636,14 @@ mod tests {
             let fk_domain =
                 FKDomain::new(poly_degree, poly_degree, tau_powers_g1_projective).unwrap();
 
-            let expected = fk_domain.compute_h_term_commitments(&poly.coeffs, 0);
-            let actual = fk_domain.compute_h_term_commitments_blst(&poly.coeffs, 0);
+            // Reference: the same Toeplitz evaluation done entirely in arkworks.
+            // `poly.coeffs` already has degree equal to the Toeplitz dimension,
+            // so no zero-padding is needed here.
+            let expected: Vec<G1Projective> = fk_domain.toeplitz_domain.eval_prepared(
+                &fk_domain.toeplitz_for_poly(&poly.coeffs),
+                &fk_domain.prepared_toeplitz_inputs[0],
+            );
+            let actual = fk_domain.compute_h_term_commitments(&poly.coeffs, 0);
 
             assert_eq!(expected.len(), actual.len());
             for (e, a) in expected.iter().zip(&actual) {

--- a/crates/aptos-batch-encryption/src/shared/algebra/multi_point_eval.rs
+++ b/crates/aptos-batch-encryption/src/shared/algebra/multi_point_eval.rs
@@ -121,6 +121,18 @@ pub fn multi_point_eval<F: FftField, T: DomainCoeff<F> + Mul<F, Output = T>>(
     recurse(f, &mult_tree, mult_tree.len() - 1, 0)
 }
 
+/// `[1, x, x^2, ..., x^(n-1)]`, i.e. the scalars that evaluate a degree-`n-1`
+/// polynomial at `x` when paired with its coefficients in an MSM.
+pub fn powers_of<F: FftField>(x: &F, n: usize) -> Vec<F> {
+    let mut result = Vec::with_capacity(n);
+    let mut x_power = F::one();
+    for _ in 0..n {
+        result.push(x_power);
+        x_power *= x;
+    }
+    result
+}
+
 pub fn multi_point_eval_naive<
     F: FftField,
     T: DomainCoeff<F> + Mul<F, Output = T> + VariableBaseMSM<ScalarField = F>,
@@ -132,15 +144,7 @@ pub fn multi_point_eval_naive<
     // number of x coords
     let powers = x_coords
         .into_par_iter()
-        .map(|x| {
-            let mut result = Vec::new();
-            let mut x_power = F::one();
-            for _i in 0..f.len() {
-                result.push(x_power);
-                x_power *= x;
-            }
-            result
-        })
+        .map(|x| powers_of(x, f.len()))
         .collect::<Vec<Vec<F>>>();
 
     powers

--- a/crates/aptos-batch-encryption/src/shared/blst_ops.rs
+++ b/crates/aptos-batch-encryption/src/shared/blst_ops.rs
@@ -10,9 +10,12 @@
 //! BLS12-381 only; if `crate::group` is switched to another curve this module
 //! must be disabled.
 
-use crate::group::{Fr, G1Affine, G1Projective, PairingOutput};
+use crate::{
+    group::{Fr, G1Affine, G1Projective, PairingOutput},
+    shared::algebra::{fk_algorithm::EvalRepr, multi_point_eval::powers_of},
+};
 use ark_bls12_381::{Fq, Fq12, Fq2, Fq6, G2Affine};
-use ark_ec::AffineRepr;
+use ark_ec::{AffineRepr, CurveGroup as _};
 use ark_ff::{BigInteger, PrimeField, Zero};
 use blst::{
     blst_bendian_from_fp, blst_final_exp, blst_fp, blst_fp12, blst_fp12_mul, blst_fp_from_bendian,
@@ -89,17 +92,7 @@ fn blst_fp12_to_ark(f: &blst_fp12) -> Fq12 {
 
 /// Equivalent to `PairingSetting::pairing(p, q)`, computed with blst.
 pub fn pairing(p: &G1Affine, q: &G2Affine) -> PairingOutput {
-    if p.is_zero() || q.is_zero() {
-        return PairingOutput::zero();
-    }
-    let p = g1_to_blst_affine(p);
-    let q = g2_to_blst_affine(q);
-    let mut acc = blst_fp12::default();
-    unsafe {
-        blst_miller_loop(&mut acc, &q, &p);
-        blst_final_exp(&mut acc, &acc);
-    }
-    ark_ec::pairing::PairingOutput(blst_fp12_to_ark(&acc))
+    multi_pairing(std::slice::from_ref(p), std::slice::from_ref(q))
 }
 
 /// Equivalent to `PairingSetting::multi_pairing(ps, qs)`, computed with blst.
@@ -136,6 +129,7 @@ pub fn multi_pairing(ps: &[G1Affine], qs: &[G2Affine]) -> PairingOutput {
 /// generic (parallel) FFT routines run over blst point arithmetic instead of
 /// arkworks' own. The all-zero `blst_p1` is the point at infinity.
 #[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
 pub struct BlstG1(pub blst_p1);
 
 impl BlstG1 {
@@ -148,6 +142,20 @@ impl BlstG1 {
 
     pub fn to_ark(&self) -> G1Projective {
         blst_p1_to_ark(&self.0)
+    }
+}
+
+/// Lets the Toeplitz/circulant evaluation in [`crate::shared::algebra::fk_algorithm`]
+/// run its Hadamard product and group inverse FFT over blst points: the prepared
+/// tau powers are converted in one batch up front, and everything downstream is
+/// blst arithmetic.
+impl EvalRepr<Fr, G1Projective> for BlstG1 {
+    fn from_prepared(prepared: &[G1Projective]) -> Vec<Self> {
+        // A single batch inversion for the whole conversion.
+        G1Projective::normalize_batch(prepared)
+            .iter()
+            .map(Self::from_ark)
+            .collect()
     }
 }
 
@@ -235,22 +243,15 @@ pub struct G1MsmBases {
 
 impl G1MsmBases {
     pub fn new(bases: &[G1Affine]) -> Self {
-        let points: Vec<blst_p1> = bases
-            .iter()
-            .map(|b| {
-                let aff = g1_to_blst_affine(b);
-                let mut p = blst_p1::default();
-                unsafe { blst_p1_from_affine(&mut p, &aff) };
-                p
-            })
-            .collect();
-        Self::from_blst(&points)
+        Self::from_blst(&bases.iter().map(BlstG1::from_ark).collect::<Vec<BlstG1>>())
     }
 
-    pub fn from_blst(points: &[blst_p1]) -> Self {
+    pub fn from_blst(points: &[BlstG1]) -> Self {
         let n = points.len();
         let mut affine = vec![blst_p1_affine::default(); n];
-        let point_ptrs = [points.as_ptr(), std::ptr::null()];
+        // `BlstG1` is a transparent newtype, so this slice is layout-compatible
+        // with the `blst_p1[]` that blst expects.
+        let point_ptrs = [points.as_ptr().cast::<blst_p1>(), std::ptr::null()];
         unsafe { blst::blst_p1s_to_affine(affine.as_mut_ptr(), point_ptrs.as_ptr(), n) };
 
         let table_len = unsafe { blst::blst_p1s_mult_wbits_precompute_sizeof(MSM_WBITS, n) }
@@ -318,18 +319,9 @@ pub fn multi_point_eval_naive(f: &[G1Affine], x_coords: &[Fr]) -> Vec<G1Projecti
 /// Same as [`multi_point_eval_naive`], but starting from an already-built
 /// Pippenger table (e.g. from blst-native points, skipping ark conversions).
 pub fn multi_point_eval_naive_with_bases(bases: &G1MsmBases, x_coords: &[Fr]) -> Vec<G1Projective> {
-    let f_len = bases.len;
     x_coords
         .par_iter()
-        .map(|x| {
-            let mut powers = Vec::with_capacity(f_len);
-            let mut xp = Fr::from(1u64);
-            for _ in 0..f_len {
-                powers.push(xp);
-                xp *= x;
-            }
-            bases.msm(&powers)
-        })
+        .map(|x| bases.msm(&powers_of(x, bases.len)))
         .collect()
 }
 

--- a/crates/aptos-batch-encryption/src/shared/blst_ops.rs
+++ b/crates/aptos-batch-encryption/src/shared/blst_ops.rs
@@ -18,10 +18,10 @@ use ark_bls12_381::{Fq, Fq12, Fq2, Fq6, G2Affine};
 use ark_ec::{AffineRepr, CurveGroup as _};
 use ark_ff::{BigInteger, PrimeField, Zero};
 use blst::{
-    blst_bendian_from_fp, blst_final_exp, blst_fp, blst_fp12, blst_fp12_mul, blst_fp_from_bendian,
-    blst_miller_loop, blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_cneg,
-    blst_p1_from_affine, blst_p1_is_equal, blst_p1_is_inf, blst_p1_mult, blst_p1_serialize,
-    blst_p2_affine,
+    blst_bendian_from_fp, blst_final_exp, blst_fp, blst_fp12, blst_fp12_mul, blst_fp6,
+    blst_fp_from_bendian, blst_miller_loop, blst_miller_loop_lines, blst_p1, blst_p1_add_or_double,
+    blst_p1_affine, blst_p1_cneg, blst_p1_from_affine, blst_p1_is_equal, blst_p1_is_inf,
+    blst_p1_mult, blst_p1_serialize, blst_p2_affine, blst_precompute_lines,
 };
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator as _};
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
@@ -122,6 +122,56 @@ pub fn multi_pairing(ps: &[G1Affine], qs: &[G2Affine]) -> PairingOutput {
             unsafe { blst_final_exp(&mut acc, &acc) };
             ark_ec::pairing::PairingOutput(blst_fp12_to_ark(&acc))
         },
+    }
+}
+
+/// The number of Miller-loop line coefficients blst precomputes for a G2 point.
+/// Fixed by `blst.h`'s `blst_precompute_lines(blst_fp6 Qlines[68], ...)`: the
+/// BLS12-381 Miller loop runs 63 doublings and 5 additions over the bits of `x`.
+const N_LINES: usize = 68;
+
+/// blst's precomputed Miller-loop line coefficients for a fixed G2 point -- the
+/// analogue of arkworks' `G2Prepared`, and usable the same way: build it once
+/// while the G2 point is known, then pair against many G1 points without
+/// redoing the G2-side work.
+///
+/// Note that this is *not* interchangeable with `G2Prepared` despite holding
+/// the same count and shape of coefficients (68 triples of Fq2). blst derives
+/// its lines in Jacobian coordinates and arkworks in homogeneous projective, so
+/// corresponding entries differ by per-step projective scalars; the Miller loop
+/// only tolerates those because their product dies in the final exponentiation.
+#[derive(Clone)]
+pub struct G2Lines {
+    lines: Box<[blst_fp6; N_LINES]>,
+    infinity: bool,
+}
+
+impl G2Lines {
+    pub fn new(q: &G2Affine) -> Self {
+        let mut lines = Box::new([blst_fp6::default(); N_LINES]);
+        if !q.is_zero() {
+            let q = g2_to_blst_affine(q);
+            unsafe { blst_precompute_lines(lines.as_mut_ptr(), &q) };
+        }
+        Self {
+            lines,
+            infinity: q.is_zero(),
+        }
+    }
+
+    /// Equivalent to `pairing(p, q)` for the `q` these lines were built from,
+    /// but skipping the G2-side line computation.
+    pub fn pairing(&self, p: &G1Affine) -> PairingOutput {
+        if self.infinity || p.is_zero() {
+            return PairingOutput::zero();
+        }
+        let p = g1_to_blst_affine(p);
+        let mut ml = blst_fp12::default();
+        unsafe {
+            blst_miller_loop_lines(&mut ml, self.lines.as_ptr(), &p);
+            blst_final_exp(&mut ml, &ml);
+        }
+        ark_ec::pairing::PairingOutput(blst_fp12_to_ark(&ml))
     }
 }
 
@@ -344,6 +394,154 @@ mod tests {
             pairing(&G1Affine::zero(), &G2Affine::rand(&mut rng)),
             PairingSetting::pairing(G1Affine::zero(), G2Affine::rand(&mut rng))
         );
+    }
+
+    #[test]
+    fn test_g2_lines_pairing_matches_ark() {
+        let mut rng = thread_rng();
+        for _ in 0..3 {
+            let p = G1Affine::rand(&mut rng);
+            let q = G2Affine::rand(&mut rng);
+            assert_eq!(G2Lines::new(&q).pairing(&p), PairingSetting::pairing(p, q));
+        }
+        // Either argument at infinity gives the identity in Gt.
+        let q = G2Affine::rand(&mut rng);
+        assert!(G2Lines::new(&q).pairing(&G1Affine::zero()).is_zero());
+        assert!(G2Lines::new(&G2Affine::zero())
+            .pairing(&G1Affine::rand(&mut rng))
+            .is_zero());
+    }
+
+    /// Are arkworks' `G2Prepared` line coefficients and blst's precomputed lines
+    /// the same bytes? If they were, an existing `G2Prepared` could be handed
+    /// straight to `blst_miller_loop_lines` and the two libraries' prepared
+    /// forms would be interchangeable.
+    ///
+    /// They are not -- blst works in Jacobian coordinates and arkworks in
+    /// homogeneous projective -- but that is a structural argument, so check it
+    /// rather than assert it. Run with:
+    ///   cargo test -p aptos-batch-encryption --release -- perf_probe --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn perf_probe_lines_layout() {
+        use crate::group::G2Prepared;
+
+        let mut rng = thread_rng();
+        let q = G2Affine::rand(&mut rng);
+
+        let ark = G2Prepared::from(q);
+        let blst = G2Lines::new(&q);
+
+        println!("ark ell_coeffs: {}", ark.ell_coeffs.len());
+        println!("blst lines:     {}", N_LINES);
+
+        let mut matching = 0usize;
+        for (i, (c0, c1, c2)) in ark.ell_coeffs.iter().enumerate() {
+            // Both sides store Fq as 6 little-endian u64 limbs in Montgomery
+            // form with the same R and modulus, so the limbs are directly
+            // comparable.
+            let ark_limbs: Vec<[u64; 6]> = [c0, c1, c2]
+                .iter()
+                .flat_map(|c| [c.c0.0 .0, c.c1.0 .0])
+                .collect();
+            let blst_limbs: Vec<[u64; 6]> = (0..3)
+                .flat_map(|j| {
+                    let fp2 = blst.lines[i].fp2[j];
+                    [fp2.fp[0].l, fp2.fp[1].l]
+                })
+                .collect();
+            if ark_limbs == blst_limbs {
+                matching += 1;
+            }
+        }
+        println!("entries matching byte-for-byte: {}/{}", matching, N_LINES);
+
+        // Whatever the layout, the two must agree on the pairing itself.
+        let p = G1Affine::rand(&mut rng);
+        assert_eq!(blst.pairing(&p), PairingSetting::pairing(p, q));
+    }
+
+    /// How much of a pairing is the G2-side line precompute? That is the work
+    /// `prepare()` could absorb so that `decrypt()` does not have to.
+    ///
+    /// Timed for both libraries, because the split is what the two designs
+    /// differ on: baseline stored an arkworks `G2Prepared`, so its precompute
+    /// already sat in `prepare()`, while the blst port pairs from a `G2Affine`
+    /// and pays for the lines inside `decrypt()`.
+    #[test]
+    #[ignore]
+    fn perf_probe_lines_timing() {
+        use crate::group::G2Prepared;
+        use std::time::Instant;
+
+        let mut rng = thread_rng();
+        let p = G1Affine::rand(&mut rng);
+        let q = G2Affine::rand(&mut rng);
+        let lines = G2Lines::new(&q);
+        let prepared = G2Prepared::from(q);
+
+        // Warm up, and confirm every route agrees before timing them.
+        let expected = PairingSetting::pairing(p, q);
+        assert_eq!(pairing(&p, &q), expected);
+        assert_eq!(lines.pairing(&p), expected);
+
+        const N: u32 = 200;
+        let time = |label: &str, f: &dyn Fn()| {
+            let start = Instant::now();
+            for _ in 0..N {
+                f();
+            }
+            let ns = start.elapsed().as_nanos() as f64 / f64::from(N);
+            println!("  {label:<30} {:>9.1} µs", ns / 1000.0);
+            ns
+        };
+
+        // The decrypt half, spelled out: arkworks' `pairing()` prepares
+        // internally, so the prepared path has to go through `multi_miller_loop`
+        // and `final_exponentiation` by hand.
+        let ark_from_prepared = || {
+            let ml = PairingSetting::multi_miller_loop([p], [prepared.clone()]);
+            PairingSetting::final_exponentiation(ml).unwrap()
+        };
+        assert_eq!(ark_from_prepared(), expected);
+
+        println!("\narkworks");
+        let ark_full = time("full pairing", &|| {
+            let _ = std::hint::black_box(PairingSetting::pairing(p, q));
+        });
+        let ark_prep = time("G2Prepared::from  (prepare)", &|| {
+            std::hint::black_box(G2Prepared::from(q));
+        });
+        let ark_rest = time("miller_loop + final_exp (decrypt)", &|| {
+            let _ = std::hint::black_box(ark_from_prepared());
+        });
+
+        println!("\nblst");
+        let blst_full = time("full pairing", &|| {
+            let _ = std::hint::black_box(pairing(&p, &q));
+        });
+        let blst_prep = time("precompute_lines  (prepare)", &|| {
+            std::hint::black_box(G2Lines::new(&q));
+        });
+        let blst_rest = time("miller_loop_lines + final_exp (decrypt)", &|| {
+            let _ = std::hint::black_box(lines.pairing(&p));
+        });
+
+        println!(
+            "\n{:<10} {:>10} {:>10} {:>10} {:>10}",
+            "", "full", "prepare", "decrypt", "prep %"
+        );
+        let row = |label: &str, full: f64, prep: f64, rest: f64| {
+            println!(
+                "{label:<10} {:>9.1} {:>9.1} {:>9.1} {:>9.1}%",
+                full / 1000.0,
+                prep / 1000.0,
+                rest / 1000.0,
+                100.0 * prep / full
+            );
+        };
+        row("arkworks", ark_full, ark_prep, ark_rest);
+        row("blst", blst_full, blst_prep, blst_rest);
     }
 
     #[test]

--- a/crates/aptos-batch-encryption/src/shared/blst_ops.rs
+++ b/crates/aptos-batch-encryption/src/shared/blst_ops.rs
@@ -1,0 +1,390 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Routes pairings and G1 MSMs through the blst library (hand-tuned ADX
+//! assembly), which is substantially faster than arkworks' pure-Rust
+//! arithmetic. Conversions go through canonical big-endian coordinate bytes,
+//! so results are bit-identical to the arkworks equivalents (the two
+//! libraries use the same Fq12 tower construction).
+//!
+//! BLS12-381 only; if `crate::group` is switched to another curve this module
+//! must be disabled.
+
+use crate::group::{Fr, G1Affine, G1Projective, PairingOutput};
+use ark_bls12_381::{Fq, Fq12, Fq2, Fq6, G2Affine};
+use ark_ec::AffineRepr;
+use ark_ff::{BigInteger, PrimeField, Zero};
+use blst::{
+    blst_bendian_from_fp, blst_final_exp, blst_fp, blst_fp12, blst_fp12_mul, blst_fp_from_bendian,
+    blst_miller_loop, blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_cneg,
+    blst_p1_from_affine, blst_p1_is_equal, blst_p1_is_inf, blst_p1_mult, blst_p1_serialize,
+    blst_p2_affine,
+};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator as _};
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+
+fn fq_to_blst_fp(x: &Fq) -> blst_fp {
+    let bytes = x.into_bigint().to_bytes_be();
+    let mut fp = blst_fp::default();
+    unsafe { blst_fp_from_bendian(&mut fp, bytes.as_ptr()) };
+    fp
+}
+
+fn blst_fp_to_fq(fp: &blst_fp) -> Fq {
+    let mut bytes = [0u8; 48];
+    unsafe { blst_bendian_from_fp(bytes.as_mut_ptr(), fp) };
+    Fq::from_be_bytes_mod_order(&bytes)
+}
+
+fn g1_to_blst_affine(p: &G1Affine) -> blst_p1_affine {
+    match p.xy() {
+        Some((x, y)) => blst_p1_affine {
+            x: fq_to_blst_fp(&x),
+            y: fq_to_blst_fp(&y),
+        },
+        // blst represents the point at infinity as the all-zero affine point.
+        None => blst_p1_affine::default(),
+    }
+}
+
+fn g2_to_blst_affine(q: &G2Affine) -> blst_p2_affine {
+    match q.xy() {
+        Some((x, y)) => blst_p2_affine {
+            x: blst::blst_fp2 {
+                fp: [fq_to_blst_fp(&x.c0), fq_to_blst_fp(&x.c1)],
+            },
+            y: blst::blst_fp2 {
+                fp: [fq_to_blst_fp(&y.c0), fq_to_blst_fp(&y.c1)],
+            },
+        },
+        None => blst_p2_affine::default(),
+    }
+}
+
+fn blst_p1_to_ark(p: &blst_p1) -> G1Projective {
+    let mut bytes = [0u8; 96];
+    unsafe { blst_p1_serialize(bytes.as_mut_ptr(), p) };
+    if bytes[0] & 0x40 != 0 {
+        return G1Projective::zero();
+    }
+    // Serialized form is big-endian x || y; the top three bits of byte 0 are
+    // flag bits (all zero here since the point is uncompressed and finite).
+    let x = Fq::from_be_bytes_mod_order(&bytes[..48]);
+    let y = Fq::from_be_bytes_mod_order(&bytes[48..]);
+    G1Affine::new_unchecked(x, y).into()
+}
+
+fn blst_fp12_to_ark(f: &blst_fp12) -> Fq12 {
+    let fq6 = |i: usize| {
+        let fq2 = |j: usize| {
+            Fq2::new(
+                blst_fp_to_fq(&f.fp6[i].fp2[j].fp[0]),
+                blst_fp_to_fq(&f.fp6[i].fp2[j].fp[1]),
+            )
+        };
+        Fq6::new(fq2(0), fq2(1), fq2(2))
+    };
+    Fq12::new(fq6(0), fq6(1))
+}
+
+/// Equivalent to `PairingSetting::pairing(p, q)`, computed with blst.
+pub fn pairing(p: &G1Affine, q: &G2Affine) -> PairingOutput {
+    if p.is_zero() || q.is_zero() {
+        return PairingOutput::zero();
+    }
+    let p = g1_to_blst_affine(p);
+    let q = g2_to_blst_affine(q);
+    let mut acc = blst_fp12::default();
+    unsafe {
+        blst_miller_loop(&mut acc, &q, &p);
+        blst_final_exp(&mut acc, &acc);
+    }
+    ark_ec::pairing::PairingOutput(blst_fp12_to_ark(&acc))
+}
+
+/// Equivalent to `PairingSetting::multi_pairing(ps, qs)`, computed with blst.
+pub fn multi_pairing(ps: &[G1Affine], qs: &[G2Affine]) -> PairingOutput {
+    assert_eq!(ps.len(), qs.len());
+    let mut acc: Option<blst_fp12> = None;
+    for (p, q) in ps.iter().zip(qs) {
+        if p.is_zero() || q.is_zero() {
+            continue;
+        }
+        let p = g1_to_blst_affine(p);
+        let q = g2_to_blst_affine(q);
+        let mut ml = blst_fp12::default();
+        unsafe { blst_miller_loop(&mut ml, &q, &p) };
+        acc = Some(match acc {
+            None => ml,
+            Some(prev) => {
+                let mut out = blst_fp12::default();
+                unsafe { blst_fp12_mul(&mut out, &prev, &ml) };
+                out
+            },
+        });
+    }
+    match acc {
+        None => PairingOutput::zero(),
+        Some(mut acc) => {
+            unsafe { blst_final_exp(&mut acc, &acc) };
+            ark_ec::pairing::PairingOutput(blst_fp12_to_ark(&acc))
+        },
+    }
+}
+
+/// A blst-backed G1 point that implements `DomainCoeff<Fr>`, so arkworks'
+/// generic (parallel) FFT routines run over blst point arithmetic instead of
+/// arkworks' own. The all-zero `blst_p1` is the point at infinity.
+#[derive(Clone, Copy, Debug)]
+pub struct BlstG1(pub blst_p1);
+
+impl BlstG1 {
+    pub fn from_ark(p: &G1Affine) -> Self {
+        let aff = g1_to_blst_affine(p);
+        let mut out = blst_p1::default();
+        unsafe { blst_p1_from_affine(&mut out, &aff) };
+        Self(out)
+    }
+
+    pub fn to_ark(&self) -> G1Projective {
+        blst_p1_to_ark(&self.0)
+    }
+}
+
+impl PartialEq for BlstG1 {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { blst_p1_is_equal(&self.0, &other.0) }
+    }
+}
+
+impl Eq for BlstG1 {}
+
+impl AddAssign for BlstG1 {
+    fn add_assign(&mut self, rhs: Self) {
+        unsafe { blst_p1_add_or_double(&mut self.0, &self.0, &rhs.0) };
+    }
+}
+
+impl Add for BlstG1 {
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self {
+        self += rhs;
+        self
+    }
+}
+
+impl SubAssign for BlstG1 {
+    fn sub_assign(&mut self, rhs: Self) {
+        let mut neg = rhs.0;
+        unsafe {
+            blst_p1_cneg(&mut neg, true);
+            blst_p1_add_or_double(&mut self.0, &self.0, &neg);
+        }
+    }
+}
+
+impl Sub for BlstG1 {
+    type Output = Self;
+
+    fn sub(mut self, rhs: Self) -> Self {
+        self -= rhs;
+        self
+    }
+}
+
+impl MulAssign<Fr> for BlstG1 {
+    fn mul_assign(&mut self, rhs: Fr) {
+        let bytes = rhs.into_bigint().to_bytes_le();
+        unsafe { blst_p1_mult(&mut self.0, &self.0, bytes.as_ptr(), 255) };
+    }
+}
+
+impl Mul<Fr> for BlstG1 {
+    type Output = Self;
+
+    fn mul(mut self, rhs: Fr) -> Self {
+        self *= rhs;
+        self
+    }
+}
+
+impl Zero for BlstG1 {
+    fn zero() -> Self {
+        // z = 0 is blst's representation of the point at infinity.
+        Self(blst_p1::default())
+    }
+
+    fn is_zero(&self) -> bool {
+        unsafe { blst_p1_is_inf(&self.0) }
+    }
+}
+
+/// Window size for `blst_p1s_mult_wbits`. Table memory is
+/// `npoints * 2^(WBITS-1) * 96` bytes, i.e. ~1.5 MiB at 128 points.
+const MSM_WBITS: usize = 8;
+
+/// A precomputed blst window table for repeated single-threaded MSMs over the
+/// same G1 bases. `msm` is deliberately single-threaded (unlike blst's
+/// `p1_affines::mult`, which spins up its own thread pool per call) so that
+/// callers can parallelize over many MSMs with rayon without oversubscribing.
+pub struct G1MsmBases {
+    table: Vec<blst_p1_affine>,
+    len: usize,
+}
+
+impl G1MsmBases {
+    pub fn new(bases: &[G1Affine]) -> Self {
+        let points: Vec<blst_p1> = bases
+            .iter()
+            .map(|b| {
+                let aff = g1_to_blst_affine(b);
+                let mut p = blst_p1::default();
+                unsafe { blst_p1_from_affine(&mut p, &aff) };
+                p
+            })
+            .collect();
+        Self::from_blst(&points)
+    }
+
+    pub fn from_blst(points: &[blst_p1]) -> Self {
+        let n = points.len();
+        let mut affine = vec![blst_p1_affine::default(); n];
+        let point_ptrs = [points.as_ptr(), std::ptr::null()];
+        unsafe { blst::blst_p1s_to_affine(affine.as_mut_ptr(), point_ptrs.as_ptr(), n) };
+
+        let table_len = unsafe { blst::blst_p1s_mult_wbits_precompute_sizeof(MSM_WBITS, n) }
+            / std::mem::size_of::<blst_p1_affine>();
+        let mut table = vec![blst_p1_affine::default(); table_len];
+        // The table is one contiguous block of `table_len / n` entries per
+        // point, so the precompute parallelizes cleanly across points.
+        let row_len = table_len / n;
+        use rayon::{iter::IndexedParallelIterator as _, slice::ParallelSliceMut as _};
+        table
+            .par_chunks_mut(row_len)
+            .zip(affine.par_iter())
+            .for_each(|(row, point)| {
+                let ptrs = [point as *const blst_p1_affine, std::ptr::null()];
+                unsafe {
+                    blst::blst_p1s_mult_wbits_precompute(
+                        row.as_mut_ptr(),
+                        MSM_WBITS,
+                        ptrs.as_ptr(),
+                        1,
+                    )
+                };
+            });
+
+        Self { table, len: n }
+    }
+
+    /// Equivalent to `G1Projective::msm(bases, scalars)`, computed with blst
+    /// on the calling thread only.
+    pub fn msm(&self, scalars: &[Fr]) -> G1Projective {
+        assert_eq!(scalars.len(), self.len);
+        let mut scalar_bytes = Vec::with_capacity(32 * scalars.len());
+        for s in scalars {
+            scalar_bytes.extend_from_slice(&s.into_bigint().to_bytes_le());
+        }
+        let scalar_ptrs = [scalar_bytes.as_ptr(), std::ptr::null()];
+
+        let scratch_len = unsafe { blst::blst_p1s_mult_wbits_scratch_sizeof(self.len) }
+            / std::mem::size_of::<u64>();
+        let mut scratch = vec![0u64; scratch_len];
+
+        let mut ret = blst_p1::default();
+        unsafe {
+            blst::blst_p1s_mult_wbits(
+                &mut ret,
+                self.table.as_ptr(),
+                MSM_WBITS,
+                self.len,
+                scalar_ptrs.as_ptr(),
+                255,
+                scratch.as_mut_ptr(),
+            )
+        };
+        blst_p1_to_ark(&ret)
+    }
+}
+
+/// Naive multi-point evaluation of the G1-polynomial `f` at each of
+/// `x_coords`, i.e. one size-`f.len()` MSM per coordinate, all sharing one
+/// blst Pippenger table.
+pub fn multi_point_eval_naive(f: &[G1Affine], x_coords: &[Fr]) -> Vec<G1Projective> {
+    multi_point_eval_naive_with_bases(&G1MsmBases::new(f), x_coords)
+}
+
+/// Same as [`multi_point_eval_naive`], but starting from an already-built
+/// Pippenger table (e.g. from blst-native points, skipping ark conversions).
+pub fn multi_point_eval_naive_with_bases(bases: &G1MsmBases, x_coords: &[Fr]) -> Vec<G1Projective> {
+    let f_len = bases.len;
+    x_coords
+        .par_iter()
+        .map(|x| {
+            let mut powers = Vec::with_capacity(f_len);
+            let mut xp = Fr::from(1u64);
+            for _ in 0..f_len {
+                powers.push(xp);
+                xp *= x;
+            }
+            bases.msm(&powers)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group::PairingSetting;
+    use ark_ec::{pairing::Pairing as _, CurveGroup, VariableBaseMSM};
+    use ark_std::{rand::thread_rng, UniformRand};
+
+    #[test]
+    fn test_pairing_matches_ark() {
+        let mut rng = thread_rng();
+        for _ in 0..3 {
+            let p = G1Affine::rand(&mut rng);
+            let q = G2Affine::rand(&mut rng);
+            assert_eq!(pairing(&p, &q), PairingSetting::pairing(p, q));
+        }
+        assert_eq!(
+            pairing(&G1Affine::zero(), &G2Affine::rand(&mut rng)),
+            PairingSetting::pairing(G1Affine::zero(), G2Affine::rand(&mut rng))
+        );
+    }
+
+    #[test]
+    fn test_multi_pairing_matches_ark() {
+        let mut rng = thread_rng();
+        let ps: Vec<G1Affine> = (0..3).map(|_| G1Affine::rand(&mut rng)).collect();
+        let qs: Vec<G2Affine> = (0..3).map(|_| G2Affine::rand(&mut rng)).collect();
+        assert_eq!(
+            multi_pairing(&ps, &qs),
+            PairingSetting::multi_pairing(ps.clone(), qs.clone())
+        );
+    }
+
+    #[test]
+    fn test_msm_matches_ark() {
+        let mut rng = thread_rng();
+        let bases: Vec<G1Affine> = (0..64).map(|_| G1Affine::rand(&mut rng)).collect();
+        let scalars: Vec<Fr> = (0..64).map(|_| Fr::rand(&mut rng)).collect();
+        let expected = G1Projective::msm(&bases, &scalars).unwrap();
+        let actual = G1MsmBases::new(&bases).msm(&scalars);
+        assert_eq!(actual.into_affine(), expected.into_affine());
+    }
+
+    #[test]
+    fn test_multi_point_eval_naive_matches_ark() {
+        let mut rng = thread_rng();
+        let f: Vec<G1Affine> = (0..16).map(|_| G1Affine::rand(&mut rng)).collect();
+        let xs: Vec<Fr> = (0..16).map(|_| Fr::rand(&mut rng)).collect();
+        let expected: Vec<G1Projective> =
+            crate::shared::algebra::multi_point_eval::multi_point_eval_naive(&f, &xs);
+        let actual = multi_point_eval_naive(&f, &xs);
+        for (a, e) in actual.iter().zip(&expected) {
+            assert_eq!(a.into_affine(), e.into_affine());
+        }
+    }
+}

--- a/crates/aptos-batch-encryption/src/shared/blst_ops.rs
+++ b/crates/aptos-batch-encryption/src/shared/blst_ops.rs
@@ -3,9 +3,9 @@
 
 //! Routes pairings and G1 MSMs through the blst library (hand-tuned ADX
 //! assembly), which is substantially faster than arkworks' pure-Rust
-//! arithmetic. Conversions go through canonical big-endian coordinate bytes,
-//! so results are bit-identical to the arkworks equivalents (the two
-//! libraries use the same Fq12 tower construction).
+//! arithmetic. Both libraries represent Fq identically (Montgomery form, six
+//! little-endian limbs) and build the same Fq12 tower, so conversions are limb
+//! moves and results are bit-identical to the arkworks equivalents.
 //!
 //! BLS12-381 only; if `crate::group` is switched to another curve this module
 //! must be disabled.
@@ -16,27 +16,32 @@ use crate::{
 };
 use ark_bls12_381::{Fq, Fq12, Fq2, Fq6, G2Affine};
 use ark_ec::{AffineRepr, CurveGroup as _};
-use ark_ff::{BigInteger, PrimeField, Zero};
+use ark_ff::{BigInt, BigInteger, PrimeField, Zero};
 use blst::{
-    blst_bendian_from_fp, blst_final_exp, blst_fp, blst_fp12, blst_fp12_mul, blst_fp6,
-    blst_fp_from_bendian, blst_miller_loop, blst_miller_loop_lines, blst_p1, blst_p1_add_or_double,
-    blst_p1_affine, blst_p1_cneg, blst_p1_from_affine, blst_p1_is_equal, blst_p1_is_inf,
-    blst_p1_mult, blst_p1_serialize, blst_p2_affine, blst_precompute_lines,
+    blst_final_exp, blst_fp, blst_fp12, blst_fp12_mul, blst_fp6, blst_miller_loop,
+    blst_miller_loop_lines, blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_cneg,
+    blst_p1_from_affine, blst_p1_is_equal, blst_p1_is_inf, blst_p1_mult, blst_p1_serialize,
+    blst_p2_affine, blst_precompute_lines,
 };
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator as _};
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
+// Both libraries hold an Fq as six little-endian 64-bit limbs in Montgomery
+// form against the same modulus and the same R = 2^384, so the two
+// representations are bit-identical and converting is a move, not arithmetic.
+//
+// The obvious spelling -- serialize to big-endian bytes and call
+// `blst_fp_from_bendian` / `blst_bendian_from_fp` -- costs a byte swap plus a
+// full Montgomery round trip in each direction, on 24 limbs per Fq12, on every
+// pairing. `test_fq_conversion_matches_bendian` pins the equivalence.
 fn fq_to_blst_fp(x: &Fq) -> blst_fp {
-    let bytes = x.into_bigint().to_bytes_be();
-    let mut fp = blst_fp::default();
-    unsafe { blst_fp_from_bendian(&mut fp, bytes.as_ptr()) };
-    fp
+    blst_fp { l: x.0 .0 }
 }
 
 fn blst_fp_to_fq(fp: &blst_fp) -> Fq {
-    let mut bytes = [0u8; 48];
-    unsafe { blst_bendian_from_fp(bytes.as_mut_ptr(), fp) };
-    Fq::from_be_bytes_mod_order(&bytes)
+    // Already Montgomery-form and reduced, which is exactly `new_unchecked`'s
+    // contract; `Fp::new` would multiply by R^2 and give a different element.
+    Fq::new_unchecked(BigInt(fp.l))
 }
 
 fn g1_to_blst_affine(p: &G1Affine) -> blst_p1_affine {
@@ -381,6 +386,38 @@ mod tests {
     use crate::group::PairingSetting;
     use ark_ec::{pairing::Pairing as _, CurveGroup, VariableBaseMSM};
     use ark_std::{rand::thread_rng, UniformRand};
+
+    /// The limb-move conversions must agree with the big-endian-bytes spelling
+    /// they replaced. If a future arkworks or blst release changes either
+    /// internal representation, this is what catches it.
+    #[test]
+    fn test_fq_conversion_matches_bendian() {
+        use ark_ff::{BigInteger as _, PrimeField as _};
+
+        let via_bendian_to_blst = |x: &Fq| {
+            let bytes = x.into_bigint().to_bytes_be();
+            let mut fp = blst_fp::default();
+            unsafe { blst::blst_fp_from_bendian(&mut fp, bytes.as_ptr()) };
+            fp
+        };
+        let via_bendian_to_ark = |fp: &blst_fp| {
+            let mut bytes = [0u8; 48];
+            unsafe { blst::blst_bendian_from_fp(bytes.as_mut_ptr(), fp) };
+            Fq::from_be_bytes_mod_order(&bytes)
+        };
+
+        let mut rng = thread_rng();
+        // Include the edge cases a random sample will never produce.
+        let mut xs = vec![Fq::zero(), Fq::from(1u64), -Fq::from(1u64)];
+        xs.extend((0..64).map(|_| Fq::rand(&mut rng)));
+
+        for x in xs {
+            let fp = fq_to_blst_fp(&x);
+            assert_eq!(fp.l, via_bendian_to_blst(&x).l, "ark -> blst for {x}");
+            assert_eq!(blst_fp_to_fq(&fp), via_bendian_to_ark(&fp), "blst -> ark");
+            assert_eq!(blst_fp_to_fq(&fp), x, "round trip");
+        }
+    }
 
     #[test]
     fn test_pairing_matches_ark() {

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
@@ -7,7 +7,7 @@ use super::super::{
 };
 use crate::{
     errors::MissingEvalProofError,
-    group::{Fr, G1Affine, G2Affine, G2Prepared, PairingOutput, PairingSetting},
+    group::{Fr, G1Affine, G2Affine, PairingOutput, PairingSetting},
     shared::{digest::EvalProof, encryption_key::EncryptionKey, ids::Id},
     traits::Plaintext,
 };
@@ -54,7 +54,7 @@ pub struct PreparedBIBECiphertext {
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
     pub(crate) pairing_output: PairingOutput,
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
-    pub(crate) ct_g2: G2Prepared,
+    pub(crate) ct_g2: G2Affine,
     pub(crate) padded_key: OneTimePaddedKey,
     pub(crate) symmetric_ciphertext: SymmetricCiphertext,
 }
@@ -100,15 +100,16 @@ impl InnerCiphertext for BIBECiphertext {
         digest: &Digest,
         eval_proof: &EvalProof,
     ) -> PreparedBIBECiphertext {
-        let pairing_output = PairingSetting::multi_pairing([digest.as_g1(), **eval_proof], [
-            self.ct_g2[0],
-            self.ct_g2[1],
-        ]);
+        let pairing_output =
+            crate::shared::blst_ops::multi_pairing(&[digest.as_g1(), **eval_proof], &[
+                self.ct_g2[0],
+                self.ct_g2[1],
+            ]);
 
         PreparedBIBECiphertext {
             id: self.id,
             pairing_output,
-            ct_g2: self.ct_g2[2].into(),
+            ct_g2: self.ct_g2[2],
             padded_key: self.padded_key.clone(),
             symmetric_ciphertext: self.symmetric_ciphertext.clone(),
         }
@@ -163,7 +164,7 @@ impl BIBECTEncrypt for EncryptionKey {
 
 impl<P: Plaintext> BIBECTDecrypt<P> for BIBEDecryptionKey {
     fn bibe_decrypt(&self, ct: &PreparedBIBECiphertext) -> Result<P> {
-        let otp_source_1 = PairingSetting::pairing(self.signature_g1, ct.ct_g2.clone());
+        let otp_source_1 = crate::shared::blst_ops::pairing(&self.signature_g1, &ct.ct_g2);
         let otp_source_gt = otp_source_1 + ct.pairing_output;
 
         let mut otp_source_bytes = Vec::new();

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
@@ -48,13 +48,67 @@ pub struct BIBECiphertext {
     symmetric_ciphertext: SymmetricCiphertext,
 }
 
+/// The G2 ciphertext component `decrypt()` pairs against, carried together with
+/// its blst Miller-loop lines.
+///
+/// `prepare()` runs before the threshold key exists and `decrypt()` runs once
+/// everyone is waiting, so the G2-side line computation belongs on this side of
+/// the split. Only the affine point goes on the wire -- the lines are rebuilt on
+/// deserialization -- so the format is unchanged and the precompute lands in
+/// whoever decodes the ciphertext rather than in `decrypt()`.
+#[derive(Clone)]
+pub struct PreparedG2 {
+    point: G2Affine,
+    lines: blst_ops::G2Lines,
+}
+
+impl PreparedG2 {
+    pub(crate) fn new(point: G2Affine) -> Self {
+        Self {
+            lines: blst_ops::G2Lines::new(&point),
+            point,
+        }
+    }
+
+    /// Equivalent to `blst_ops::pairing(p, self.point)`, minus the G2-side work.
+    pub(crate) fn pairing(&self, p: &G1Affine) -> PairingOutput {
+        self.lines.pairing(p)
+    }
+}
+
+// The lines are a pure function of the point, so identity and display follow it.
+impl PartialEq for PreparedG2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.point == other.point
+    }
+}
+
+impl Eq for PreparedG2 {}
+
+impl std::fmt::Debug for PreparedG2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.point.fmt(f)
+    }
+}
+
+impl Serialize for PreparedG2 {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
+        ark_se(&self.point, s)
+    }
+}
+
+impl<'de> Deserialize<'de> for PreparedG2 {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        Ok(Self::new(ark_de(d)?))
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct PreparedBIBECiphertext {
     pub id: Id,
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
     pub(crate) pairing_output: PairingOutput,
-    #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
-    pub(crate) ct_g2: G2Affine,
+    pub(crate) ct_g2: PreparedG2,
     pub(crate) padded_key: OneTimePaddedKey,
     pub(crate) symmetric_ciphertext: SymmetricCiphertext,
 }
@@ -108,7 +162,7 @@ impl InnerCiphertext for BIBECiphertext {
         PreparedBIBECiphertext {
             id: self.id,
             pairing_output,
-            ct_g2: self.ct_g2[2],
+            ct_g2: PreparedG2::new(self.ct_g2[2]),
             padded_key: self.padded_key.clone(),
             symmetric_ciphertext: self.symmetric_ciphertext.clone(),
         }
@@ -163,7 +217,7 @@ impl BIBECTEncrypt for EncryptionKey {
 
 impl<P: Plaintext> BIBECTDecrypt<P> for BIBEDecryptionKey {
     fn bibe_decrypt(&self, ct: &PreparedBIBECiphertext) -> Result<P> {
-        let otp_source_1 = blst_ops::pairing(&self.signature_g1, &ct.ct_g2);
+        let otp_source_1 = ct.ct_g2.pairing(&self.signature_g1);
         let otp_source_gt = otp_source_1 + ct.pairing_output;
 
         let mut otp_source_bytes = Vec::new();

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
@@ -8,7 +8,7 @@ use super::super::{
 use crate::{
     errors::MissingEvalProofError,
     group::{Fr, G1Affine, G2Affine, PairingOutput, PairingSetting},
-    shared::{digest::EvalProof, encryption_key::EncryptionKey, ids::Id},
+    shared::{blst_ops, digest::EvalProof, encryption_key::EncryptionKey, ids::Id},
     traits::Plaintext,
 };
 use anyhow::Result;
@@ -100,11 +100,10 @@ impl InnerCiphertext for BIBECiphertext {
         digest: &Digest,
         eval_proof: &EvalProof,
     ) -> PreparedBIBECiphertext {
-        let pairing_output =
-            crate::shared::blst_ops::multi_pairing(&[digest.as_g1(), **eval_proof], &[
-                self.ct_g2[0],
-                self.ct_g2[1],
-            ]);
+        let pairing_output = blst_ops::multi_pairing(&[digest.as_g1(), **eval_proof], &[
+            self.ct_g2[0],
+            self.ct_g2[1],
+        ]);
 
         PreparedBIBECiphertext {
             id: self.id,
@@ -164,7 +163,7 @@ impl BIBECTEncrypt for EncryptionKey {
 
 impl<P: Plaintext> BIBECTDecrypt<P> for BIBEDecryptionKey {
     fn bibe_decrypt(&self, ct: &PreparedBIBECiphertext) -> Result<P> {
-        let otp_source_1 = crate::shared::blst_ops::pairing(&self.signature_g1, &ct.ct_g2);
+        let otp_source_1 = blst_ops::pairing(&self.signature_g1, &ct.ct_g2);
         let otp_source_gt = otp_source_1 + ct.pairing_output;
 
         let mut otp_source_bytes = Vec::new();

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
@@ -58,12 +58,12 @@ impl InnerCiphertext for BIBESuccinctCiphertext {
         _digest: &Digest,
         eval_proof: &EvalProof,
     ) -> PreparedBIBECiphertext {
-        let pairing_output = PairingSetting::pairing(**eval_proof, self.ct_g2[1]);
+        let pairing_output = crate::shared::blst_ops::pairing(eval_proof, &self.ct_g2[1]);
 
         PreparedBIBECiphertext {
             id: self.id,
             pairing_output,
-            ct_g2: self.ct_g2[0].into(),
+            ct_g2: self.ct_g2[0],
             padded_key: self.padded_key.clone(),
             symmetric_ciphertext: self.symmetric_ciphertext.clone(),
         }

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
@@ -11,6 +11,7 @@ use crate::{
     errors::MissingEvalProofError,
     group::{Fr, G1Affine, G2Affine, PairingOutput, PairingSetting},
     shared::{
+        blst_ops,
         ciphertext::bibe::{BIBECTEncrypt, InnerCiphertext},
         digest::{Digest, EvalProof},
         encryption_key::AugmentedEncryptionKey,
@@ -58,7 +59,7 @@ impl InnerCiphertext for BIBESuccinctCiphertext {
         _digest: &Digest,
         eval_proof: &EvalProof,
     ) -> PreparedBIBECiphertext {
-        let pairing_output = crate::shared::blst_ops::pairing(eval_proof, &self.ct_g2[1]);
+        let pairing_output = blst_ops::pairing(eval_proof, &self.ct_g2[1]);
 
         PreparedBIBECiphertext {
             id: self.id,

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
@@ -12,7 +12,7 @@ use crate::{
     group::{Fr, G1Affine, G2Affine, PairingOutput, PairingSetting},
     shared::{
         blst_ops,
-        ciphertext::bibe::{BIBECTEncrypt, InnerCiphertext},
+        ciphertext::bibe::{BIBECTEncrypt, InnerCiphertext, PreparedG2},
         digest::{Digest, EvalProof},
         encryption_key::AugmentedEncryptionKey,
         ids::Id,
@@ -64,7 +64,7 @@ impl InnerCiphertext for BIBESuccinctCiphertext {
         PreparedBIBECiphertext {
             id: self.id,
             pairing_output,
-            ct_g2: self.ct_g2[0],
+            ct_g2: PreparedG2::new(self.ct_g2[0]),
             padded_key: self.padded_key.clone(),
             symmetric_ciphertext: self.symmetric_ciphertext.clone(),
         }

--- a/crates/aptos-batch-encryption/src/shared/ids.rs
+++ b/crates/aptos-batch-encryption/src/shared/ids.rs
@@ -143,17 +143,16 @@ impl IdSet<ComputedCoeffs> {
         setup: &crate::shared::digest::DigestKey,
         round: usize,
     ) -> HashMap<Id, G1Affine> {
-        let h_term_commitments = setup
+        let pfs: Vec<G1Affine> = setup
             .fk_domain
-            .compute_h_term_commitments_blst(&self.poly_coeffs(), round);
-        let bases = crate::shared::blst_ops::G1MsmBases::from_blst(
-            &h_term_commitments.iter().map(|p| p.0).collect::<Vec<_>>(),
-        );
-        let pfs: Vec<G1Affine> =
-            crate::shared::blst_ops::multi_point_eval_naive_with_bases(&bases, &self.poly_roots)
-                .iter()
-                .map(|g| G1Affine::from(*g))
-                .collect();
+            .eval_proofs_at_x_coords_naive_multi_point_eval(
+                &self.poly_coeffs(),
+                &self.poly_roots,
+                round,
+            )
+            .iter()
+            .map(|g| G1Affine::from(*g))
+            .collect();
 
         HashMap::from_iter(
             self.as_vec()

--- a/crates/aptos-batch-encryption/src/shared/ids.rs
+++ b/crates/aptos-batch-encryption/src/shared/ids.rs
@@ -143,16 +143,17 @@ impl IdSet<ComputedCoeffs> {
         setup: &crate::shared::digest::DigestKey,
         round: usize,
     ) -> HashMap<Id, G1Affine> {
-        let pfs: Vec<G1Affine> = setup
+        let h_term_commitments = setup
             .fk_domain
-            .eval_proofs_at_x_coords_naive_multi_point_eval(
-                &self.poly_coeffs(),
-                &self.poly_roots,
-                round,
-            )
-            .iter()
-            .map(|g| G1Affine::from(*g))
-            .collect();
+            .compute_h_term_commitments_blst(&self.poly_coeffs(), round);
+        let bases = crate::shared::blst_ops::G1MsmBases::from_blst(
+            &h_term_commitments.iter().map(|p| p.0).collect::<Vec<_>>(),
+        );
+        let pfs: Vec<G1Affine> =
+            crate::shared::blst_ops::multi_point_eval_naive_with_bases(&bases, &self.poly_roots)
+                .iter()
+                .map(|g| G1Affine::from(*g))
+                .collect();
 
         HashMap::from_iter(
             self.as_vec()

--- a/crates/aptos-batch-encryption/src/shared/mod.rs
+++ b/crates/aptos-batch-encryption/src/shared/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 pub mod algebra;
+pub mod blst_ops;
 pub mod ciphertext;
 pub mod digest;
 pub mod digest_key_file;


### PR DESCRIPTION
Routes the BLS12-381 pairings and G1 MSMs in `aptos-batch-encryption` through
the `blst` C library instead of arkworks, and moves the decrypt-side pairing
precompute into `prepare`.

Draft: the numbers below are from a single GCP VM and the build-flag caveat at
the bottom needs a decision before this is ready for review.

## Results

`decrypt` is the phase that runs after the threshold key is reconstructed, with
everyone waiting on it. Batch size 2048, 16 cores:

| build | arkworks (main) | this PR | speedup |
|---|---|---|---|
| `x86-64-v3` (workspace default) | 162.3 ms | 114.4 ms | **1.42x** |
| `target-cpu=native` | 155.6 ms | 93.1 ms | **1.68x** |

`prepare` runs before the key exists, off the critical path, and is also faster
than baseline despite absorbing the precompute (199.3 -> 150.6 ms at B=2048).
`eval_proofs_compute_all` is 1.6-2.1x depending on batch size.

## What is in here

- **blst-backed group ops** (`shared/blst_ops.rs`): pairings, multi-pairings,
  and a `BlstG1` point that implements `DomainCoeff<Fr>` so arkworks' generic
  parallel FFTs run over blst arithmetic. Outputs are bit-identical to the
  arkworks equivalents and the tests assert it.
- **FK eval-proof pipeline** routed through blst, with the h-term computation
  parameterized by output representation so each caller gets the form it
  consumes rather than converting back and forth.
- **`G2Lines`**, the blst analogue of arkworks' `G2Prepared`.
  `PreparedBIBECiphertext` now carries one, so the Miller-loop line computation
  happens in `prepare` instead of `decrypt`. Worth 1.16-1.18x on `decrypt`
  across batch sizes and both build configs. Only the affine point is
  serialized and the lines are rebuilt on deserialization, so **the wire format
  is unchanged**.
- **Limb-move Fq conversions.** ark and blst use the same Montgomery
  representation, so converting is a move rather than a byte-swap plus
  Montgomery round trip. Not a measurable speedup -- included because it
  removes work that was never needed, not because it fixed anything.

## Build-flag caveat, needs a decision

The workspace sets `-C target-cpu=x86-64-v3`. On this crate that is **~20%
slower than either generic x86-64 or `target-cpu=native`** for the blst path
(`decrypt` at B=128: 8.55 ms v3, 6.91 ms generic, 6.99 ms native). `x86-64-v3`
has BMI2 (`mulx`) but not ADX (`adcx`/`adox`), which is a plausible mechanism,
but the arkworks baseline barely moves under the same flag change (-3%), so
that explanation is **not confirmed** and the real cause is still open.

Two consequences worth deciding on separately from this PR:
- `experiments/REPORT.md` measures under `native`, not the production flags, so
  its headline speedups are the optimistic end of the range.
- `x86-64-v3` is a workspace-wide flag. If this reproduces outside this crate it
  is worth a broader look.

## Testing

`cargo test -p aptos-batch-encryption` (49 tests) passes. Correctness is pinned
by equivalence tests against arkworks for the pairings, the prepared-lines
pairing, the h-term commitments, and the Fq conversions, plus the existing smoke
tests.
