### PR TITLE
[move prover][trvial] fix cmp

### DIFF
--- a/third_party/move/move-prover/boogie-backend/src/lib.rs
+++ b/third_party/move/move-prover/boogie-backend/src/lib.rs
@@ -538,7 +538,7 @@ pub fn add_prelude(
     cmp_struct_types.sort();
     cmp_struct_types.dedup();
     context.insert("cmp_int_instances", &cmp_int_types);
-    env.cmp_types.borrow_mut().extend(cmp_struct_types);
+    *env.cmp_types.borrow_mut() = cmp_struct_types.into_iter().collect();
 
     let filter_cmp_instances_with_name_prefix = |name_prefix: &str| {
         cmp_instances


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

With latest change to generate Boogie program per verification root, this one line change is needed to avoid duplicated generation of cmp procedures/functions.





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to how the prelude populates a shared type set; no auth, data, or runtime behavior changes.
> 
> **Overview**
> When Boogie is generated **per verification root**, `add_prelude` runs more than once on the same `GlobalEnv`. The prelude used to **append** struct types into `env.cmp_types` on each run, so the set grew with duplicates across roots.
> 
> This change **reassigns** `cmp_types` to the struct types computed for that prelude pass (after sort/dedup), instead of `extend`. Downstream struct translation still reads `cmp_types` to emit compare functions, so each root no longer accumulates extra entries and **cmp Boogie procedures/functions are not generated twice**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a800e887baa064de0151ee0420ca02ea3ff42a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->