### PR TITLE
[ci] Publish framework usage reports privately

### DIFF
--- a/.github/workflows/framework-usage-mainnet.yaml
+++ b/.github/workflows/framework-usage-mainnet.yaml
@@ -23,11 +23,6 @@ on:
         required: false
         type: string
         description: 'End time, for example "now" or "2026-08-08" (UTC).'
-      RESULTS_BUCKET:
-        required: false
-        type: string
-        description: GCS bucket for worker shards; required for ranges over 10,000 transactions.
-        default: aptos-framework-usage-reports
       DRY_RUN:
         required: false
         type: boolean
@@ -45,7 +40,15 @@ concurrency:
 jobs:
   collect:
     uses: ./.github/workflows/workflow-run-replay-verify-on-archive.yaml
-    secrets: inherit
+    secrets:
+      APTOS_BOT_PAT: ${{ secrets.APTOS_BOT_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      ENV_ECR_AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
+      GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
     with:
       NETWORK: mainnet
       IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
@@ -54,7 +57,4 @@ jobs:
       START_TIME: ${{ inputs.START_TIME }}
       END_TIME: ${{ inputs.END_TIME }}
       FRAMEWORK_USAGE: true
-      RESULTS_BUCKET: ${{ inputs.RESULTS_BUCKET }}
-      REPORT_REPOSITORY: aptos-labs/aptos-core-private
-      REPORT_BRANCH: gh-pages
       DRY_RUN: ${{ inputs.DRY_RUN || false }}

--- a/.github/workflows/framework-usage-mainnet.yaml
+++ b/.github/workflows/framework-usage-mainnet.yaml
@@ -28,11 +28,6 @@ on:
         type: string
         description: GCS bucket for worker shards; required for ranges over 10,000 transactions.
         default: aptos-framework-usage-reports
-      REPORT_BUCKET:
-        required: false
-        type: string
-        description: Public GCS bucket for the rendered HTML report.
-        default: aptos-framework-usage-reports
       DRY_RUN:
         required: false
         type: boolean
@@ -60,5 +55,6 @@ jobs:
       END_TIME: ${{ inputs.END_TIME }}
       FRAMEWORK_USAGE: true
       RESULTS_BUCKET: ${{ inputs.RESULTS_BUCKET }}
-      REPORT_BUCKET: ${{ inputs.REPORT_BUCKET }}
+      REPORT_REPOSITORY: aptos-labs/aptos-core-private
+      REPORT_BRANCH: gh-pages
       DRY_RUN: ${{ inputs.DRY_RUN || false }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -35,6 +35,21 @@ on:
         type: boolean
         description: If true, the workflow will not build and push images.
         default: false
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_DOCKER_ARTIFACT_REPO:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      ENV_ECR_AWS_ACCOUNT_NUM:
+        required: false
+      GCP_SERVICE_ACCOUNT_EMAIL:
+        required: false
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: false
+      GIT_CREDENTIALS:
+        required: false
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -247,17 +247,33 @@ jobs:
           poetry run python main.py "${ARGS[@]}"
         timeout-minutes: 420 # 7 hours
 
-      - name: Upload framework usage report
+      - name: Verify private framework usage Pages site
         if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
-        with:
-          name: framework-usage-${{ inputs.NETWORK }}-${{ github.run_id }}
-          path: framework-usage-results/
-          if-no-files-found: error
+        env:
+          GH_TOKEN: ${{ secrets.APTOS_BOT_PAT }}
+          REPORT_REPOSITORY: ${{ inputs.REPORT_REPOSITORY }}
+          REPORT_BRANCH: ${{ inputs.REPORT_BRANCH }}
+        run: |
+          REPOSITORY_PRIVATE="$(gh api "repos/${REPORT_REPOSITORY}" --jq '.private')"
+          PAGES_PUBLIC="$(gh api "repos/${REPORT_REPOSITORY}/pages" --jq '.public')"
+          PAGES_BRANCH="$(gh api "repos/${REPORT_REPOSITORY}/pages" --jq '.source.branch')"
+
+          if [ "$REPOSITORY_PRIVATE" != "true" ]; then
+            echo "::error::Refusing to publish framework usage data to a public repository."
+            exit 1
+          fi
+          if [ "$PAGES_PUBLIC" != "false" ]; then
+            echo "::error::Refusing to publish framework usage data to a public Pages site."
+            exit 1
+          fi
+          if [ "$PAGES_BRANCH" != "$REPORT_BRANCH" ]; then
+            echo "::error::Pages publishes from '${PAGES_BRANCH}', not the configured '${REPORT_BRANCH}' branch."
+            exit 1
+          fi
 
       - name: Checkout private framework usage Pages site
         if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pin@v4.4.0
         with:
           repository: ${{ inputs.REPORT_REPOSITORY }}
           ref: ${{ inputs.REPORT_BRANCH }}

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -299,12 +299,16 @@ jobs:
           REPORT_HTML="framework-usage-results/framework-usage.html"
           REPORT_PREFIX="framework-usage/${NETWORK}/runs/${GITHUB_RUN_ID}/attempt-${GITHUB_RUN_ATTEMPT}"
           REPORT_DIRECTORY="framework-usage-pages/${REPORT_PREFIX}"
+          LATEST_REPORT_PREFIX="framework-usage/${NETWORK}"
+          LATEST_REPORT_DIRECTORY="framework-usage-pages/${LATEST_REPORT_PREFIX}"
           install -D -m 0644 "$REPORT_HTML" "${REPORT_DIRECTORY}/index.html"
           install -D -m 0644 "$REPORT_JSON" "${REPORT_DIRECTORY}/framework-usage.json"
+          install -D -m 0644 "$REPORT_HTML" "${LATEST_REPORT_DIRECTORY}/index.html"
+          install -D -m 0644 "$REPORT_JSON" "${LATEST_REPORT_DIRECTORY}/framework-usage.json"
 
           git -C framework-usage-pages config user.name "aptos-bot[bot]"
           git -C framework-usage-pages config user.email "aptos-bot[bot]@users.noreply.github.com"
-          git -C framework-usage-pages add -- "$REPORT_PREFIX"
+          git -C framework-usage-pages add -- "$REPORT_PREFIX" "${LATEST_REPORT_PREFIX}/index.html" "${LATEST_REPORT_PREFIX}/framework-usage.json"
           git -C framework-usage-pages commit -m "Publish framework usage report ${GITHUB_RUN_ID}"
           for attempt in 1 2 3; do
             if git -C framework-usage-pages pull --rebase origin "$REPORT_BRANCH" && git -C framework-usage-pages push origin "HEAD:${REPORT_BRANCH}"; then
@@ -320,6 +324,8 @@ jobs:
           PAGES_URL="$(gh api "repos/${REPORT_REPOSITORY}/pages" --jq '.html_url')"
           HTML_REPORT_URL="${PAGES_URL%/}/${REPORT_PREFIX}/index.html"
           JSON_REPORT_URL="${PAGES_URL%/}/${REPORT_PREFIX}/framework-usage.json"
+          LATEST_HTML_REPORT_URL="${PAGES_URL%/}/${LATEST_REPORT_PREFIX}/index.html"
+          LATEST_JSON_REPORT_URL="${PAGES_URL%/}/${LATEST_REPORT_PREFIX}/framework-usage.json"
 
           START_VERSION="$(jq -r '.start_version' "$REPORT_JSON")"
           END_VERSION="$(jq -r '.end_version' "$REPORT_JSON")"
@@ -336,6 +342,8 @@ jobs:
             echo
             echo "- [Open interactive HTML report](${HTML_REPORT_URL})"
             echo "- [Open merged JSON report](${JSON_REPORT_URL})"
+            echo "- [Open latest ${NETWORK} HTML report](${LATEST_HTML_REPORT_URL})"
+            echo "- [Open latest ${NETWORK} JSON report](${LATEST_JSON_REPORT_URL})"
             echo
             echo "| Property | Value |"
             echo "| --- | --- |"

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -38,20 +38,23 @@ on:
         type: boolean
         description: Collect framework function usage instead of only replay-verifying.
         default: false
-      RESULTS_BUCKET:
+    secrets:
+      APTOS_BOT_PAT:
         required: false
-        type: string
-        description: GCS bucket used for framework usage shards.
-      REPORT_REPOSITORY:
+      AWS_ACCESS_KEY_ID:
         required: false
-        type: string
-        description: Private GitHub repository whose Pages site publishes framework usage reports.
-        default: aptos-labs/aptos-core-private
-      REPORT_BRANCH:
+      AWS_DOCKER_ARTIFACT_REPO:
         required: false
-        type: string
-        description: GitHub Pages branch in REPORT_REPOSITORY.
-        default: gh-pages
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      ENV_ECR_AWS_ACCOUNT_NUM:
+        required: false
+      GCP_SERVICE_ACCOUNT_EMAIL:
+        required: false
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: false
+      GIT_CREDENTIALS:
+        required: false
 
   workflow_dispatch:
     inputs:
@@ -89,20 +92,6 @@ on:
         type: boolean
         description: Collect framework function usage instead of only replay-verifying.
         default: false
-      RESULTS_BUCKET:
-        required: false
-        type: string
-        description: GCS bucket used for framework usage shards.
-      REPORT_REPOSITORY:
-        required: false
-        type: string
-        description: Private GitHub repository whose Pages site publishes framework usage reports.
-        default: aptos-labs/aptos-core-private
-      REPORT_BRANCH:
-        required: false
-        type: string
-        description: GitHub Pages branch in REPORT_REPOSITORY.
-        default: gh-pages
 permissions:
   contents: read
 
@@ -117,7 +106,6 @@ jobs:
           END_VERSION: ${{ inputs.END_VERSION }}
           END_TIME: ${{ inputs.END_TIME }}
           FRAMEWORK_USAGE: ${{ inputs.FRAMEWORK_USAGE }}
-          RESULTS_BUCKET: ${{ inputs.RESULTS_BUCKET }}
         run: |
           if [ -n "$START_VERSION" ] && [ -n "$START_TIME" ]; then
             echo "::error::START_VERSION and START_TIME are mutually exclusive. Please specify only one."
@@ -143,8 +131,15 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    secrets: inherit
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      ENV_ECR_AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
+      GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+    uses: ./.github/workflows/workflow-run-docker-rust-build.yaml
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
@@ -155,6 +150,10 @@ jobs:
     runs-on: 4cpu-gh-ubuntu24-x64
     timeout-minutes: 420 # 7 hours
     needs: build-images
+    env:
+      FRAMEWORK_USAGE_BUCKET: aptos-framework-usage-reports
+      REPORT_BRANCH: gh-pages
+      REPORT_REPOSITORY: aptos-labs/aptos-core-private
     permissions:
       contents: read
       id-token: write
@@ -203,6 +202,20 @@ jobs:
         shell: bash
         run: gcloud config set project aptos-devinfra-0
 
+      - name: Verify private framework usage shard bucket
+        if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
+        run: |
+          PUBLIC_ACCESS_PREVENTION="$(gcloud storage buckets describe "gs://${FRAMEWORK_USAGE_BUCKET}" --format='value(public_access_prevention)')"
+          UNIFORM_BUCKET_ACCESS="$(gcloud storage buckets describe "gs://${FRAMEWORK_USAGE_BUCKET}" --format='value(uniform_bucket_level_access)')"
+          if [ "$PUBLIC_ACCESS_PREVENTION" != "enforced" ]; then
+            echo "::error::Framework usage shard bucket must enforce public access prevention."
+            exit 1
+          fi
+          if [ "$UNIFORM_BUCKET_ACCESS" != "true" ]; then
+            echo "::error::Framework usage shard bucket must use uniform bucket-level access."
+            exit 1
+          fi
+
       - uses: ./.github/actions/python-setup
         with:
           pyproject_directory: testsuite/replay-verify
@@ -218,7 +231,6 @@ jobs:
           END_TIME: ${{ inputs.END_TIME }}
           IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
           FRAMEWORK_USAGE: ${{ inputs.FRAMEWORK_USAGE }}
-          RESULTS_BUCKET: ${{ inputs.RESULTS_BUCKET }}
         run: |
           cd testsuite/replay-verify
           ARGS=(--network "$NETWORK")
@@ -239,9 +251,7 @@ jobs:
           fi
           if [ "$FRAMEWORK_USAGE" = "true" ]; then
             ARGS+=(--framework-usage-output-dir ../../framework-usage-results)
-            if [ -n "$RESULTS_BUCKET" ]; then
-              ARGS+=(--framework-usage-bucket "$RESULTS_BUCKET")
-            fi
+            ARGS+=(--framework-usage-bucket "$FRAMEWORK_USAGE_BUCKET")
           fi
           ARGS+=(--image_profile performance)
           poetry run python main.py "${ARGS[@]}"
@@ -251,8 +261,6 @@ jobs:
         if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
         env:
           GH_TOKEN: ${{ secrets.APTOS_BOT_PAT }}
-          REPORT_REPOSITORY: ${{ inputs.REPORT_REPOSITORY }}
-          REPORT_BRANCH: ${{ inputs.REPORT_BRANCH }}
         run: |
           REPOSITORY_PRIVATE="$(gh api "repos/${REPORT_REPOSITORY}" --jq '.private')"
           PAGES_PUBLIC="$(gh api "repos/${REPORT_REPOSITORY}/pages" --jq '.public')"
@@ -275,8 +283,8 @@ jobs:
         if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pin@v4.4.0
         with:
-          repository: ${{ inputs.REPORT_REPOSITORY }}
-          ref: ${{ inputs.REPORT_BRANCH }}
+          repository: aptos-labs/aptos-core-private
+          ref: gh-pages
           path: framework-usage-pages
           token: ${{ secrets.APTOS_BOT_PAT }}
           fetch-depth: 1
@@ -285,8 +293,6 @@ jobs:
         if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
         env:
           NETWORK: ${{ inputs.NETWORK }}
-          REPORT_REPOSITORY: ${{ inputs.REPORT_REPOSITORY }}
-          REPORT_BRANCH: ${{ inputs.REPORT_BRANCH }}
           GH_TOKEN: ${{ secrets.APTOS_BOT_PAT }}
         run: |
           REPORT_JSON="framework-usage-results/framework-usage.json"

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -42,10 +42,16 @@ on:
         required: false
         type: string
         description: GCS bucket used for framework usage shards.
-      REPORT_BUCKET:
+      REPORT_REPOSITORY:
         required: false
         type: string
-        description: Public GCS bucket used to publish the rendered HTML report.
+        description: Private GitHub repository whose Pages site publishes framework usage reports.
+        default: aptos-labs/aptos-core-private
+      REPORT_BRANCH:
+        required: false
+        type: string
+        description: GitHub Pages branch in REPORT_REPOSITORY.
+        default: gh-pages
 
   workflow_dispatch:
     inputs:
@@ -87,10 +93,16 @@ on:
         required: false
         type: string
         description: GCS bucket used for framework usage shards.
-      REPORT_BUCKET:
+      REPORT_REPOSITORY:
         required: false
         type: string
-        description: Public GCS bucket used to publish the rendered HTML report.
+        description: Private GitHub repository whose Pages site publishes framework usage reports.
+        default: aptos-labs/aptos-core-private
+      REPORT_BRANCH:
+        required: false
+        type: string
+        description: GitHub Pages branch in REPORT_REPOSITORY.
+        default: gh-pages
 permissions:
   contents: read
 
@@ -243,28 +255,49 @@ jobs:
           path: framework-usage-results/
           if-no-files-found: error
 
+      - name: Checkout private framework usage Pages site
+        if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.REPORT_REPOSITORY }}
+          ref: ${{ inputs.REPORT_BRANCH }}
+          path: framework-usage-pages
+          token: ${{ secrets.APTOS_BOT_PAT }}
+          fetch-depth: 1
+
       - name: Publish framework usage reports
-        if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE && inputs.REPORT_BUCKET != '' }}
+        if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
         env:
           NETWORK: ${{ inputs.NETWORK }}
-          REPORT_BUCKET: ${{ inputs.REPORT_BUCKET }}
+          REPORT_REPOSITORY: ${{ inputs.REPORT_REPOSITORY }}
+          REPORT_BRANCH: ${{ inputs.REPORT_BRANCH }}
+          GH_TOKEN: ${{ secrets.APTOS_BOT_PAT }}
         run: |
           REPORT_JSON="framework-usage-results/framework-usage.json"
           REPORT_HTML="framework-usage-results/framework-usage.html"
           REPORT_PREFIX="framework-usage/${NETWORK}/runs/${GITHUB_RUN_ID}/attempt-${GITHUB_RUN_ATTEMPT}"
-          HTML_OBJECT_PATH="${REPORT_PREFIX}/index.html"
-          JSON_OBJECT_PATH="${REPORT_PREFIX}/framework-usage.json"
-          HTML_REPORT_URL="https://storage.googleapis.com/${REPORT_BUCKET}/${HTML_OBJECT_PATH}"
-          JSON_REPORT_URL="https://storage.googleapis.com/${REPORT_BUCKET}/${JSON_OBJECT_PATH}"
+          REPORT_DIRECTORY="framework-usage-pages/${REPORT_PREFIX}"
+          install -D -m 0644 "$REPORT_HTML" "${REPORT_DIRECTORY}/index.html"
+          install -D -m 0644 "$REPORT_JSON" "${REPORT_DIRECTORY}/framework-usage.json"
 
-          gcloud storage cp "$REPORT_HTML" "gs://${REPORT_BUCKET}/${HTML_OBJECT_PATH}" \
-            --content-type="text/html; charset=utf-8" \
-            --content-disposition=inline \
-            --cache-control="public,max-age=31536000,immutable"
-          gcloud storage cp "$REPORT_JSON" "gs://${REPORT_BUCKET}/${JSON_OBJECT_PATH}" \
-            --content-type="application/json" \
-            --content-disposition=inline \
-            --cache-control="public,max-age=31536000,immutable"
+          git -C framework-usage-pages config user.name "aptos-bot[bot]"
+          git -C framework-usage-pages config user.email "aptos-bot[bot]@users.noreply.github.com"
+          git -C framework-usage-pages add -- "$REPORT_PREFIX"
+          git -C framework-usage-pages commit -m "Publish framework usage report ${GITHUB_RUN_ID}"
+          for attempt in 1 2 3; do
+            if git -C framework-usage-pages pull --rebase origin "$REPORT_BRANCH" && git -C framework-usage-pages push origin "HEAD:${REPORT_BRANCH}"; then
+              break
+            fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::Failed to publish the framework usage report after ${attempt} attempts."
+              exit 1
+            fi
+            sleep "$attempt"
+          done
+
+          PAGES_URL="$(gh api "repos/${REPORT_REPOSITORY}/pages" --jq '.html_url')"
+          HTML_REPORT_URL="${PAGES_URL%/}/${REPORT_PREFIX}/index.html"
+          JSON_REPORT_URL="${PAGES_URL%/}/${REPORT_PREFIX}/framework-usage.json"
 
           START_VERSION="$(jq -r '.start_version' "$REPORT_JSON")"
           END_VERSION="$(jq -r '.end_version' "$REPORT_JSON")"

--- a/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
+++ b/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
@@ -453,6 +453,9 @@ job summary links directly to both reports and shows its resolved UTC time
 range, ledger-version range, and processed transaction count. Access to the
 rendered report follows the private repository's GitHub access controls. The
 repository and branch are fixed in the workflow rather than dispatch inputs.
+Each publication also updates stable `framework-usage/<network>/index.html` and
+`framework-usage/<network>/framework-usage.json` URLs. The merged JSON records
+its UTC generation timestamp, which the HTML displays in its header.
 
 The result bucket should have a lifecycle policy. CI cleanup always removes
 pods and temporary PVCs, and final reports remain available through the private

--- a/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
+++ b/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
@@ -13,8 +13,8 @@ The implementation reuses archive replay and output verification, but it does
 not reuse the existing Move bytecode coverage file format. Instead, the VM
 exposes a low-overhead function-call observer. Replay workers aggregate
 observations into deterministic JSON range shards, and a manually triggered
-GitHub Actions workflow merges those shards into a machine-readable JSON report
-and a zero-inclusive CSV inventory.
+GitHub Actions workflow merges those shards into a canonical machine-readable
+JSON report and a self-contained HTML view.
 
 The first implementation requires sequential execution inside each replayed
 transaction block. Replay ranges can still run concurrently, as they do today.
@@ -406,7 +406,6 @@ Inputs mirror replay verify:
 - `IMAGE_TAG`
 - `START_VERSION` and `END_VERSION`
 - `START_TIME` and `END_TIME`
-- `RESULTS_BUCKET`
 - `DRY_RUN`
 
 Version and time inputs remain mutually exclusive. UTC times are resolved to
@@ -414,13 +413,13 @@ versions before tasks are created, and the resolved range is included in the
 manifest.
 
 The replay scheduler is extended with a framework-usage worker mode while
-retaining the same archive snapshot provisioning and cleanup behavior. For
-ranges of up to 10,000 transactions, completed workers delimit their report in
-the existing Kubernetes pod logs and the scheduler extracts and validates it.
-Larger runs require `RESULTS_BUCKET`; workers then write result shards to a
-run-specific object-storage prefix. Object names use the requested range and
-workflow run identity. The worker must successfully upload the shard before
-its Kubernetes job is considered successful.
+retaining the same archive snapshot provisioning and cleanup behavior. The CI
+workflow writes result shards to a run-specific prefix in the fixed
+`aptos-framework-usage-reports` bucket. Before scheduling workers, it requires
+that the bucket enforce public access prevention and uniform bucket-level
+access. Object names use the requested range and workflow run identity. The
+worker must successfully upload the shard before its Kubernetes job is
+considered successful.
 
 After every task succeeds, the GitHub runner downloads and merges the shards.
 The merge step rejects:
@@ -431,34 +430,31 @@ The merge step rejects:
 - unexplained gaps
 - failed replay verification
 
-The final GitHub Actions artifact contains:
+The final private report contains:
 
 - `framework-usage.html`: self-contained interactive deprecation evidence view
-- `framework-usage-summary.csv`: one row per framework function, including zero
-  counts
-- `framework-usage-callers.csv`: immediate and root contract caller breakdown
 - `framework-usage.json`: complete per-function and immediate/root caller
-  aggregates plus run metadata
+  aggregates plus run metadata; this is the canonical machine-readable report
 
 The workflow publishes both the self-contained HTML and merged JSON under a
 path unique to the workflow run and retry attempt on the private GitHub Pages
 site in `aptos-labs/aptos-core-private`, using its `gh-pages` branch. The Actions
 job summary links directly to both reports and shows its resolved UTC time
 range, ledger-version range, and processed transaction count. Access to the
-rendered report follows the private repository's GitHub access controls; CSV
-files remain available through the Actions artifact.
+rendered report follows the private repository's GitHub access controls. The
+repository and branch are fixed in the workflow rather than dispatch inputs.
 
-When a result bucket is used, it should have a lifecycle policy. CI cleanup
-always removes pods and temporary PVCs, while completed workflow artifacts
-remain available for the configured retention period.
+The result bucket should have a lifecycle policy. CI cleanup always removes
+pods and temporary PVCs, and final reports remain available through the private
+Pages site.
 
 ## Report Interpretation
 
-The CSV provides exact total invocation and distinct-transaction counts for
-each current bundled function, including zero rows. The JSON additionally
-separates successful and aborted outcomes and retains immediate and root caller
-paths. A zero-count function is a deprecation candidate, not an automatic
-removal candidate. A review must additionally consider:
+The JSON provides exact invocation and distinct-transaction counts, separates
+successful and aborted outcomes, and retains immediate and root caller paths.
+The HTML derives its deprecation view from that canonical data. A zero-count
+function is a deprecation candidate, not an automatic removal candidate. A
+review must additionally consider:
 
 - static references from published bytecode
 - public API and bytecode compatibility rules

--- a/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
+++ b/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
@@ -407,7 +407,6 @@ Inputs mirror replay verify:
 - `START_VERSION` and `END_VERSION`
 - `START_TIME` and `END_TIME`
 - `RESULTS_BUCKET`
-- `REPORT_BUCKET`
 - `DRY_RUN`
 
 Version and time inputs remain mutually exclusive. UTC times are resolved to
@@ -441,12 +440,13 @@ The final GitHub Actions artifact contains:
 - `framework-usage.json`: complete per-function and immediate/root caller
   aggregates plus run metadata
 
-When `REPORT_BUCKET` is set, the workflow also publishes the self-contained
-HTML under a path unique to the workflow run and retry attempt. The Actions job
-summary links directly to that rendered report and shows its resolved UTC time
-range, ledger-version range, and processed transaction count. The bucket grants
-CI object-creation access and public object-read access; raw JSON and CSV files
-remain available only through the Actions artifact.
+The workflow publishes both the self-contained HTML and merged JSON under a
+path unique to the workflow run and retry attempt on the private GitHub Pages
+site in `aptos-labs/aptos-core-private`, using its `gh-pages` branch. The Actions
+job summary links directly to both reports and shows its resolved UTC time
+range, ledger-version range, and processed transaction count. Access to the
+rendered report follows the private repository's GitHub access controls; CSV
+files remain available through the Actions artifact.
 
 When a result bucket is used, it should have a lifecycle policy. CI cleanup
 always removes pods and temporary PVCs, while completed workflow artifacts

--- a/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
+++ b/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
@@ -310,6 +310,14 @@ first_version: u64
 last_version: u64
 ```
 
+Per-function totals are complete. Caller identities are transaction-controlled,
+so detailed immediate-call paths use a global row limit. Root entry attribution
+is collected separately with a row limit per callee; this prevents high-cardinality
+traffic to one popular function from hiding which entry function reached an
+otherwise rare framework function. Reports expose both limits and all dropped
+counts. The HTML distinguishes an unobserved function from an observed function
+whose detailed attribution was truncated.
+
 Type arguments are not part of the key. They would create high cardinality and
 are not needed to decide whether a generic function is used.
 
@@ -321,7 +329,8 @@ Each shard contains:
 - ledger timestamps for the first and last version in the range
 - the target module list and complete function inventory
 - processed ledger transaction and user-transaction usage record counts
-- exact per-function and per-call-path aggregates
+- exact per-function aggregates, bounded per-function root-entry attribution,
+  and bounded immediate-call-path aggregates
 
 Each shard is named deterministically by its exact range. Retrying a range
 overwrites its previous object, preventing retry double-counting.
@@ -433,8 +442,9 @@ The merge step rejects:
 The final private report contains:
 
 - `framework-usage.html`: self-contained interactive deprecation evidence view
-- `framework-usage.json`: complete per-function and immediate/root caller
-  aggregates plus run metadata; this is the canonical machine-readable report
+- `framework-usage.json`: complete per-function totals, bounded root-entry and
+  immediate-caller aggregates, truncation metadata, and run metadata; this is
+  the canonical machine-readable report
 
 The workflow publishes both the self-contained HTML and merged JSON under a
 path unique to the workflow run and retry attempt on the private GitHub Pages

--- a/storage/db-tool/src/framework_usage.rs
+++ b/storage/db-tool/src/framework_usage.rs
@@ -20,12 +20,17 @@ use std::{
 };
 use tempfile::NamedTempFile;
 
-const SCHEMA_VERSION: u64 = 4;
+const SCHEMA_VERSION: u64 = 5;
 
 // Caller and root-function identities originate in replayed transactions. Keep the detailed
 // call-path map bounded so a stream of uniquely addressed wrapper modules cannot exhaust a
 // replay worker. Per-function totals are collected independently and remain complete.
 const MAX_USAGE_DETAIL_ROWS: usize = 100_000;
+
+// Preserve the originating transaction entry function independently for every framework
+// function. A per-callee limit prevents a popular function with many distinct wrappers from
+// consuming the attribution budget needed by rare functions.
+const MAX_ROOT_FUNCTION_ROWS_PER_FUNCTION: usize = 32;
 
 // Root entry functions are also transaction-controlled identities. Keep a separate, smaller
 // budget for the active-caller summary so it cannot reintroduce the unbounded growth avoided
@@ -99,6 +104,12 @@ struct FunctionUsageKey {
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+struct RootFunctionUsageKey {
+    root_function: Option<FunctionId>,
+    outcome: TransactionOutcome,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 struct ActiveEntryFunctionCallerKey {
     address: AccountAddress,
     entry_function: FunctionId,
@@ -154,12 +165,17 @@ struct FrameworkUsageReport {
     usage_detail_truncated: bool,
     dropped_usage_invocation_count: u64,
     dropped_usage_transaction_count: u64,
+    root_function_row_limit_per_function: usize,
+    root_function_usage_truncated: bool,
+    dropped_root_function_usage_invocation_count: u64,
+    dropped_root_function_usage_transaction_count: u64,
     active_entry_function_caller_row_limit: usize,
     active_entry_function_callers_truncated: bool,
     dropped_active_entry_function_framework_invocation_count: u64,
     dropped_active_entry_function_transaction_count: u64,
     functions: Vec<FunctionInventoryRow>,
     function_usage: Vec<FunctionUsageRow>,
+    root_function_usage: Vec<RootFunctionUsageRow>,
     usage: Vec<UsageRow>,
     active_entry_function_callers: Vec<ActiveEntryFunctionCallerRow>,
 }
@@ -168,6 +184,15 @@ struct FrameworkUsageReport {
 struct FunctionUsageRow {
     #[serde(flatten)]
     key: FunctionUsageKey,
+    #[serde(flatten)]
+    counts: UsageCounts,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct RootFunctionUsageRow {
+    callee: FunctionId,
+    #[serde(flatten)]
+    key: RootFunctionUsageKey,
     #[serde(flatten)]
     counts: UsageCounts,
 }
@@ -184,12 +209,15 @@ struct ActiveEntryFunctionCallerRow {
 struct CollectorState {
     pending: HashMap<HashValue, TransactionFunctionUsage>,
     function_usage: BTreeMap<FunctionUsageKey, UsageCounts>,
+    root_function_usage: BTreeMap<FunctionId, BTreeMap<RootFunctionUsageKey, UsageCounts>>,
     usage: BTreeMap<UsageKey, UsageCounts>,
     active_entry_function_callers:
         BTreeMap<ActiveEntryFunctionCallerKey, ActiveEntryFunctionCallerCounts>,
     transaction_usage_records: u64,
     dropped_usage_invocation_count: u64,
     dropped_usage_transaction_count: u64,
+    dropped_root_function_usage_invocation_count: u64,
+    dropped_root_function_usage_transaction_count: u64,
     dropped_active_entry_function_framework_invocation_count: u64,
     dropped_active_entry_function_transaction_count: u64,
     ledger_timestamps: Option<(u64, u64)>,
@@ -201,6 +229,7 @@ pub(crate) struct FrameworkUsageCollector {
     target_modules: BTreeSet<ModuleId>,
     inventory: Vec<FunctionInventoryRow>,
     usage_detail_row_limit: usize,
+    root_function_row_limit_per_function: usize,
     active_entry_function_caller_row_limit: usize,
     state: Mutex<CollectorState>,
 }
@@ -246,6 +275,7 @@ impl FrameworkUsageCollector {
             target_modules,
             inventory,
             usage_detail_row_limit,
+            root_function_row_limit_per_function: MAX_ROOT_FUNCTION_ROWS_PER_FUNCTION,
             active_entry_function_caller_row_limit: MAX_ACTIVE_ENTRY_FUNCTION_CALLER_ROWS,
             state: Mutex::new(CollectorState::default()),
         }
@@ -316,7 +346,10 @@ impl FrameworkUsageCollector {
         }
         let mut per_transaction = BTreeMap::<UsageKey, u64>::new();
         let mut per_function = BTreeMap::<FunctionUsageKey, u64>::new();
+        let mut per_root_function =
+            BTreeMap::<FunctionId, BTreeMap<RootFunctionUsageKey, u64>>::new();
         let mut usage_detail_truncated = false;
+        let mut root_function_usage_truncated = false;
         for call in transaction.calls {
             let function_key = FunctionUsageKey {
                 callee: call.callee.clone(),
@@ -326,6 +359,29 @@ impl FrameworkUsageCollector {
             *function_count = function_count
                 .checked_add(1)
                 .context("per-transaction function invocation count overflow")?;
+
+            let root_key = RootFunctionUsageKey {
+                root_function: root_function.clone(),
+                outcome: outcome.clone(),
+            };
+            let retained_roots = state.root_function_usage.get(&call.callee);
+            let pending_roots = per_root_function.entry(call.callee.clone()).or_default();
+            if retained_roots.is_some_and(|roots| roots.contains_key(&root_key))
+                || pending_roots.contains_key(&root_key)
+                || retained_roots.map_or(0, BTreeMap::len) + pending_roots.len()
+                    < self.root_function_row_limit_per_function
+            {
+                let count = pending_roots.entry(root_key).or_default();
+                *count = count
+                    .checked_add(1)
+                    .context("per-transaction root function invocation count overflow")?;
+            } else {
+                state.dropped_root_function_usage_invocation_count = state
+                    .dropped_root_function_usage_invocation_count
+                    .checked_add(1)
+                    .context("dropped root function usage invocation count overflow")?;
+                root_function_usage_truncated = true;
+            }
 
             let key = UsageKey {
                 callee: call.callee,
@@ -358,8 +414,15 @@ impl FrameworkUsageCollector {
                 .checked_add(1)
                 .context("dropped usage transaction count overflow")?;
         }
+        if root_function_usage_truncated {
+            state.dropped_root_function_usage_transaction_count = state
+                .dropped_root_function_usage_transaction_count
+                .checked_add(1)
+                .context("dropped root function usage transaction count overflow")?;
+        }
 
         merge_usage_counts(&mut state.function_usage, per_function, version)?;
+        merge_nested_usage_counts(&mut state.root_function_usage, per_root_function, version)?;
         merge_usage_counts(&mut state.usage, per_transaction, version)?;
         Ok(())
     }
@@ -411,6 +474,12 @@ impl FrameworkUsageCollector {
             usage_detail_truncated: state.dropped_usage_invocation_count > 0,
             dropped_usage_invocation_count: state.dropped_usage_invocation_count,
             dropped_usage_transaction_count: state.dropped_usage_transaction_count,
+            root_function_row_limit_per_function: self.root_function_row_limit_per_function,
+            root_function_usage_truncated: state.dropped_root_function_usage_invocation_count > 0,
+            dropped_root_function_usage_invocation_count: state
+                .dropped_root_function_usage_invocation_count,
+            dropped_root_function_usage_transaction_count: state
+                .dropped_root_function_usage_transaction_count,
             active_entry_function_caller_row_limit: self.active_entry_function_caller_row_limit,
             active_entry_function_callers_truncated: state
                 .dropped_active_entry_function_transaction_count
@@ -426,6 +495,17 @@ impl FrameworkUsageCollector {
                 .map(|(key, counts)| FunctionUsageRow {
                     key: key.clone(),
                     counts: counts.clone(),
+                })
+                .collect(),
+            root_function_usage: state
+                .root_function_usage
+                .iter()
+                .flat_map(|(callee, roots)| {
+                    roots.iter().map(|(key, counts)| RootFunctionUsageRow {
+                        callee: callee.clone(),
+                        key: key.clone(),
+                        counts: counts.clone(),
+                    })
                 })
                 .collect(),
             usage: state
@@ -507,6 +587,17 @@ fn merge_usage_counts<K: Ord>(
             .context("transaction count overflow")?;
         counts.first_version = counts.first_version.min(version);
         counts.last_version = counts.last_version.max(version);
+    }
+    Ok(())
+}
+
+fn merge_nested_usage_counts<OuterKey: Ord, InnerKey: Ord>(
+    aggregate: &mut BTreeMap<OuterKey, BTreeMap<InnerKey, UsageCounts>>,
+    transaction: BTreeMap<OuterKey, BTreeMap<InnerKey, u64>>,
+    version: Version,
+) -> Result<()> {
+    for (outer_key, counts) in transaction {
+        merge_usage_counts(aggregate.entry(outer_key).or_default(), counts, version)?;
     }
     Ok(())
 }
@@ -602,6 +693,16 @@ mod tests {
         let call_path_counts = state.usage.values().next().unwrap();
         assert_eq!(call_path_counts.invocation_count, 2);
         assert_eq!(call_path_counts.transaction_count, 1);
+        let root_function_counts = state
+            .root_function_usage
+            .values()
+            .next()
+            .unwrap()
+            .values()
+            .next()
+            .unwrap();
+        assert_eq!(root_function_counts.invocation_count, 2);
+        assert_eq!(root_function_counts.transaction_count, 1);
         let active_entry_function_counts =
             state.active_entry_function_callers.values().next().unwrap();
         assert_eq!(active_entry_function_counts.framework_invocation_count, 2);
@@ -623,6 +724,16 @@ mod tests {
         assert_eq!(report["usage_detail_truncated"], false);
         assert_eq!(report["dropped_usage_invocation_count"], 0);
         assert_eq!(report["dropped_usage_transaction_count"], 0);
+        assert_eq!(
+            report["root_function_row_limit_per_function"],
+            MAX_ROOT_FUNCTION_ROWS_PER_FUNCTION
+        );
+        assert_eq!(report["root_function_usage_truncated"], false);
+        assert_eq!(
+            report["root_function_usage"][0]["root_function"]["function_name"],
+            "entry"
+        );
+        assert_eq!(report["root_function_usage"][0]["invocation_count"], 2);
         assert_eq!(
             report["active_entry_function_caller_row_limit"],
             MAX_ACTIVE_ENTRY_FUNCTION_CALLER_ROWS
@@ -690,6 +801,63 @@ mod tests {
         assert_eq!(call_path_counts.transaction_count, 2);
         assert_eq!(state.dropped_usage_invocation_count, 1);
         assert_eq!(state.dropped_usage_transaction_count, 1);
+        let root_function_counts = state
+            .root_function_usage
+            .values()
+            .next()
+            .unwrap()
+            .values()
+            .next()
+            .unwrap();
+        assert_eq!(root_function_counts.invocation_count, 3);
+        assert_eq!(root_function_counts.transaction_count, 3);
+        assert_eq!(state.dropped_root_function_usage_invocation_count, 0);
+    }
+
+    #[test]
+    fn applies_root_function_limit_independently_per_callee() {
+        let mut collector = FrameworkUsageCollector::new(10, 20);
+        collector.root_function_row_limit_per_function = 1;
+        let module_id = collector.target_modules.iter().next().unwrap().clone();
+        let first_callee = FunctionId {
+            module_id: Some(module_id.clone()),
+            function_name: "first_target".to_owned(),
+        };
+        let second_callee = FunctionId {
+            module_id: Some(module_id.clone()),
+            function_name: "second_target".to_owned(),
+        };
+        let record = |transaction_hash, version, callee: FunctionId, root_name: &str| {
+            collector.record_transaction(TransactionFunctionUsage {
+                transaction_hash,
+                sender: AccountAddress::ONE,
+                multisig_address: None,
+                root_function: Some(FunctionId {
+                    module_id: Some(module_id.clone()),
+                    function_name: root_name.to_owned(),
+                }),
+                status: TransactionStatus::Keep(ExecutionStatus::Success),
+                calls: vec![aptos_vm::function_usage::FunctionCall {
+                    caller: None,
+                    callee,
+                    kind: UsageCallKind::Call,
+                }],
+            });
+            collector.assign_version(transaction_hash, version).unwrap();
+        };
+
+        record(HashValue::zero(), 10, first_callee.clone(), "first_root");
+        record(HashValue::from_u64(1), 11, first_callee, "dropped_root");
+        record(HashValue::from_u64(2), 12, second_callee, "second_root");
+
+        let state = collector.lock_state();
+        assert_eq!(state.root_function_usage.len(), 2);
+        assert!(state
+            .root_function_usage
+            .values()
+            .all(|roots| roots.len() == 1));
+        assert_eq!(state.dropped_root_function_usage_invocation_count, 1);
+        assert_eq!(state.dropped_root_function_usage_transaction_count, 1);
     }
 
     #[test]

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -57,11 +57,15 @@ code { font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
 .meta { color:var(--muted); font-size:12px; }
 button.link { border:0; background:none; color:var(--accent); padding:0; cursor:pointer; font:inherit; text-decoration:underline; }
 #details[hidden] { display:none; }
+#details { position:fixed; z-index:20; width:min(920px,calc(100vw - 32px)); max-height:min(70vh,680px); overflow:auto; margin:0; padding:16px; border-color:#aebbc6; box-shadow:0 12px 35px #14202b33; }
+.detail-header { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; margin-bottom:12px; }
+.detail-header h2 { margin:0; overflow-wrap:anywhere; }
+.detail-close { flex:0 0 auto; width:28px; height:28px; border:1px solid #bdc7d0; border-radius:6px; background:white; color:var(--muted); cursor:pointer; font:18px/1 ui-sans-serif,system-ui,sans-serif; }
 .detail-grid { display:grid; grid-template-columns:repeat(4,minmax(120px,1fr)); gap:8px 18px; margin-bottom:12px; }
 .detail-grid .value { display:block; font-weight:650; overflow-wrap:anywhere; }
 .paths { max-height:330px; overflow:auto; }
 .empty { padding:25px; text-align:center; color:var(--muted); }
-@media (max-width:900px) { main{padding:15px}.cards{grid-template-columns:repeat(2,1fr)}.controls{grid-template-columns:1fr 1fr}.detail-grid{grid-template-columns:1fr 1fr} }
+@media (max-width:900px) { main{padding:15px}.cards{grid-template-columns:repeat(2,1fr)}.controls{grid-template-columns:1fr 1fr}.detail-grid{grid-template-columns:1fr 1fr}#details{width:calc(100vw - 20px);max-height:calc(100vh - 20px)} }
 </style>
 </head>
 <body>
@@ -80,8 +84,8 @@ button.link { border:0; background:none; color:var(--accent); padding:0; cursor:
     </div>
     <div class="legend"><span><i class="dot" style="background:#c64a4a"></i>unobserved external</span><span><i class="dot" style="background:#d29a20"></i>rare external</span><span><i class="dot" style="background:#8c6bb1"></i>unobserved internal</span><span><i class="dot" style="background:#3a9665"></i>active</span></div>
   </section>
-  <section class="panel" id="details" hidden>
-    <h2 id="detail-title"></h2>
+  <section class="panel" id="details" role="dialog" aria-labelledby="detail-title" hidden>
+    <div class="detail-header"><h2 id="detail-title"></h2><button class="detail-close" id="detail-close" type="button" aria-label="Close function details">×</button></div>
     <div class="detail-grid" id="detail-summary"></div>
     <h2>Observed call paths</h2>
     <div class="paths table-wrap" id="detail-paths"></div>
@@ -221,6 +225,7 @@ function renderActiveEntryFunctionCallers() {
 }
 
 function renderFunctions() {
+  closeDetails();
   const threshold = Math.max(1, Number(document.getElementById("threshold").value) || 10);
   const query = document.getElementById("search").value.trim().toLowerCase();
   const classFilter = document.getElementById("class-filter").value;
@@ -291,11 +296,35 @@ function renderFunctions() {
     if (collapsedModules.has(moduleId)) collapsedModules.delete(moduleId); else collapsedModules.add(moduleId);
     renderFunctions();
   });
-  for (const button of document.querySelectorAll("button[data-function]")) button.addEventListener("click", () => renderDetails(functions.get(button.dataset.function)));
+  for (const button of document.querySelectorAll("button[data-function]")) button.addEventListener("click", () => renderDetails(functions.get(button.dataset.function), button));
 }
 
-function renderDetails(f) {
+let detailAnchor = null;
+function closeDetails() {
+  document.getElementById("details").hidden=true;
+  detailAnchor=null;
+}
+
+function positionDetails(anchor) {
   const details=document.getElementById("details");
+  if (details.hidden || !anchor?.isConnected) return closeDetails();
+  const margin=10, gap=8, anchorRect=anchor.getBoundingClientRect();
+  details.style.visibility="hidden";
+  details.style.left=`${margin}px`;
+  details.style.top=`${margin}px`;
+  const detailRect=details.getBoundingClientRect();
+  const left=Math.min(Math.max(margin,anchorRect.left),window.innerWidth-detailRect.width-margin);
+  const below=anchorRect.bottom+gap;
+  const above=anchorRect.top-detailRect.height-gap;
+  const top=below+detailRect.height<=window.innerHeight-margin ? below : Math.max(margin,above);
+  details.style.left=`${left}px`;
+  details.style.top=`${top}px`;
+  details.style.visibility="visible";
+}
+
+function renderDetails(f, anchor) {
+  const details=document.getElementById("details");
+  detailAnchor=anchor;
   details.hidden=false;
   document.getElementById("detail-title").innerHTML=`<code title="${esc(f.id)}">${esc(f.displayId)}</code>`;
   const summary=[
@@ -307,8 +336,19 @@ function renderDetails(f) {
   document.getElementById("detail-summary").innerHTML=summary.map(([label,value])=>`<div><span class="meta">${esc(label)}</span><span class="value">${esc(value)}</span></div>`).join("");
   const paths=[...f.paths].sort((a,b)=>b.invocation_count-a.invocation_count);
   document.getElementById("detail-paths").innerHTML=paths.length?`<table><thead><tr><th>Immediate caller</th><th>Root payload</th><th>Kind</th><th>Outcome</th><th class="number">Transactions</th><th class="number">Invocations</th><th>Versions</th></tr></thead><tbody>${paths.map(p=>`<tr><td><code>${esc(functionName(p.caller))}</code></td><td><code>${esc(functionName(p.root_function))}</code></td><td>${esc(p.call_kind)}</td><td>${esc(p.outcome)}</td><td class="number">${nf.format(p.transaction_count)}</td><td class="number">${nf.format(p.invocation_count)}</td><td>${nf.format(p.first_version)}–${nf.format(p.last_version)}</td></tr>`).join("")}</tbody></table>`:`<div class="empty">No calls to this function were observed in the replay range.</div>`;
-  details.scrollIntoView({behavior:"smooth",block:"start"});
+  positionDetails(anchor);
 }
+
+document.getElementById("detail-close").addEventListener("click",closeDetails);
+document.addEventListener("keydown",event=>{if(event.key==="Escape")closeDetails();});
+document.addEventListener("pointerdown",event=>{
+  const details=document.getElementById("details");
+  if (!details.hidden && !details.contains(event.target) && !event.target.closest("button[data-function]")) closeDetails();
+});
+document.addEventListener("scroll",event=>{
+  if (!document.getElementById("details").contains(event.target)) positionDetails(detailAnchor);
+},true);
+window.addEventListener("resize",()=>positionDetails(detailAnchor));
 
 for (const id of ["search","class-filter","visibility","threshold"]) document.getElementById(id).addEventListener(id==="search"||id==="threshold"?"input":"change",renderFunctions);
 document.getElementById("toggle-entrypoint-callers").addEventListener("click", () => {

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -257,18 +257,25 @@ function renderFunctions() {
     if (!grouped.has(moduleId)) grouped.set(moduleId, []);
     grouped.get(moduleId).push(f);
   }
-  const moduleEvidence = module => ({
-    unobservedFunctions: module.functions.filter(f => f.invocations === 0).length,
-    invocationCount: module.functions.reduce((total, f) => total + f.invocations, 0)
-  });
+  const moduleEvidence = module => {
+    const unobservedFunctions=module.functions.filter(f => f.invocations === 0).length;
+    const invocationCount=module.functions.reduce((total, f) => total + f.invocations, 0);
+    const rarelyObserved=invocationCount > 0 && module.functions.every(f => f.invocations === 0 || f.transactions <= threshold);
+    return {
+      rank:invocationCount === 0 ? 0 : rarelyObserved ? 1 : 2,
+      unobservedFunctions,
+      invocationCount,
+      rarelyObserved
+    };
+  };
   const groups = [...grouped].sort(([left], [right]) => {
     const leftModule = modules.get(left), rightModule = modules.get(right);
     const leftEvidence = moduleEvidence(leftModule), rightEvidence = moduleEvidence(rightModule);
-    // First surface whole modules with no calls, then the least-called modules.
-    // More unobserved functions only breaks ties between equally called modules.
-    return Number(rightEvidence.invocationCount === 0) - Number(leftEvidence.invocationCount === 0)
-      || leftEvidence.invocationCount - rightEvidence.invocationCount
+    // Keep unobserved, rare-only, and regularly observed modules in distinct tiers.
+    // Within a tier, surface the broadest deprecation candidates and least-used code first.
+    return leftEvidence.rank - rightEvidence.rank
       || rightEvidence.unobservedFunctions - leftEvidence.unobservedFunctions
+      || leftEvidence.invocationCount - rightEvidence.invocationCount
       || leftModule.displayId.localeCompare(rightModule.displayId);
   });
   visibleModuleIds = groups.map(([moduleId]) => moduleId);
@@ -293,7 +300,7 @@ function renderFunctions() {
     if (!module.functions.some(external)) statuses.push(`<span class="badge unused-internal">No externally callable functions</span>`);
     if (observed === 0) {
       statuses.push(`<span class="badge unused-external">Entire module unobserved</span>`);
-    } else if (module.functions.every(f => f.invocations === 0 || f.transactions <= threshold)) {
+    } else if (moduleEvidence(module).rarelyObserved) {
       statuses.push(`<span class="badge rare-external">Rarely observed</span>`);
     }
     const moduleStatus = statuses.join("");

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -46,6 +46,7 @@ code { font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
 .module-summary { margin-left:auto; color:var(--muted); font-size:12px; font-weight:400; }
 .table-heading { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:12px; }
 .table-heading h2 { margin:0; }
+.table-heading .meta { margin:3px 0 0; }
 .module-control { border:1px solid #bdc7d0; border-radius:6px; padding:6px 9px; background:white; color:var(--ink); cursor:pointer; font:inherit; font-size:12px; }
 .module-control:disabled { cursor:default; opacity:.55; }
 .badge { display:inline-block; border-radius:999px; padding:2px 7px; font-size:11px; font-weight:650; white-space:nowrap; }
@@ -86,8 +87,7 @@ button.link { border:0; background:none; color:var(--accent); padding:0; cursor:
     <div class="paths table-wrap" id="detail-paths"></div>
   </section>
   <section class="panel">
-    <h2>Active entry-function callers</h2>
-    <p class="meta">Observed entry functions that invoked framework code, grouped by their module address.</p>
+    <div class="table-heading"><div><h2>Active entry-function callers</h2><p class="meta">Observed entry functions that invoked framework code, grouped by their module address.</p></div><button class="module-control" id="toggle-entrypoint-callers" type="button">Expand all entrypoints</button></div>
     <div class="table-wrap"><table><thead><tr><th>Module address</th><th class="function-column">Entry function</th><th>Outcome</th><th class="number">Transactions</th><th class="number">Framework invocations</th><th>Observed versions</th></tr></thead><tbody id="active-entry-function-callers"></tbody></table></div>
   </section>
   <section class="panel">
@@ -144,8 +144,12 @@ for (const f of all) {
   if (!modules.has(id)) modules.set(id, {id, displayId:moduleName(f.module_id), functions:[]});
   modules.get(id).functions.push(f);
 }
-const collapsedModules = new Set();
+// Every expandable group starts collapsed: the report's first view should surface the
+// least-observed modules and their aggregate evidence without overwhelming the reader.
+const collapsedModules = new Set(modules.keys());
+const expandedEntrypointAddresses = new Set();
 let visibleModuleIds = [];
+let visibleEntrypointAddresses = [];
 
 function evidence(f, threshold) {
   if (f.invocations === 0 && external(f)) return {rank:0, cls:"unused-external", text:"Unobserved external"};
@@ -190,15 +194,29 @@ function renderActiveEntryFunctionCallers() {
     if (!groups.has(caller.address)) groups.set(caller.address, []);
     groups.get(caller.address).push(caller);
   }
-  const rows = [...groups].sort(([left], [right]) => left.localeCompare(right)).map(([address, callers]) => {
+  const sections = [...groups].map(([address, callers]) => ({
+    address,
+    callers,
+    invocationCount: callers.reduce((total, caller) => total + caller.framework_invocation_count, 0)
+  })).sort((left, right) => right.invocationCount - left.invocationCount || left.address.localeCompare(right.address));
+  visibleEntrypointAddresses = sections.map(section => section.address);
+  const toggle = document.getElementById("toggle-entrypoint-callers");
+  const allExpanded = visibleEntrypointAddresses.length > 0 && visibleEntrypointAddresses.every(address => expandedEntrypointAddresses.has(address));
+  toggle.textContent = allExpanded ? "Collapse all entrypoints" : "Expand all entrypoints";
+  toggle.disabled = visibleEntrypointAddresses.length === 0;
+  const rows = sections.map(({address, callers, invocationCount}) => {
     callers.sort((left, right) => right.transaction_count - left.transaction_count || right.framework_invocation_count - left.framework_invocation_count || functionName(left.entry_function).localeCompare(functionName(right.entry_function)));
-    const transactionCount = callers.reduce((total, caller) => total + caller.transaction_count, 0);
-    const invocationCount = callers.reduce((total, caller) => total + caller.framework_invocation_count, 0);
-    const header = `<tr class="module-row"><td colspan="6"><code title="${esc(address)}">${esc(shortAddress(address))}</code><span class="module-summary">${nf.format(callers.length)} active entry function${callers.length === 1 ? "" : "s"} · ${nf.format(transactionCount)} transaction${transactionCount === 1 ? "" : "s"} · ${nf.format(invocationCount)} framework invocations</span></td></tr>`;
+    const expanded = expandedEntrypointAddresses.has(address);
+    const header = `<tr class="module-row"><td colspan="6"><button class="module-toggle" data-entrypoint-address="${esc(address)}" aria-expanded="${expanded}"><span class="module-chevron">${expanded?"▾":"▸"}</span><code title="${esc(address)}">${esc(shortAddress(address))}</code><span class="module-summary">${nf.format(invocationCount)} framework call${invocationCount === 1 ? "" : "s"}</span></button></td></tr>`;
     const callerRows = callers.map(caller => `<tr><td></td><td class="function-column"><code title="${esc(functionName(caller.entry_function))}">${esc(functionName(caller.entry_function))}</code></td><td>${esc(caller.outcome)}</td><td class="number">${nf.format(caller.transaction_count)}</td><td class="number">${nf.format(caller.framework_invocation_count)}</td><td>${nf.format(caller.first_version)}–${nf.format(caller.last_version)}</td></tr>`).join("");
-    return header + callerRows;
+    return header + (expanded ? callerRows : "");
   });
   document.getElementById("active-entry-function-callers").innerHTML = rows.length ? rows.join("") : `<tr><td colspan="6" class="empty">No module entry functions invoked framework code in this replay range.</td></tr>`;
+  for (const button of document.querySelectorAll("button[data-entrypoint-address]")) button.addEventListener("click", () => {
+    const address = button.dataset.entrypointAddress;
+    if (expandedEntrypointAddresses.has(address)) expandedEntrypointAddresses.delete(address); else expandedEntrypointAddresses.add(address);
+    renderActiveEntryFunctionCallers();
+  });
 }
 
 function renderFunctions() {
@@ -224,7 +242,21 @@ function renderFunctions() {
     if (!grouped.has(moduleId)) grouped.set(moduleId, []);
     grouped.get(moduleId).push(f);
   }
-  const groups = [...grouped].sort(([left], [right]) => modules.get(left).displayId.localeCompare(modules.get(right).displayId));
+  const moduleEvidence = module => ({
+    // Modules without any public, friend, or entry function cannot be invoked directly
+    // by an external contract. Keep those least directly observable modules first.
+    unobservable: !module.functions.some(external),
+    unobservedFunctions: module.functions.filter(f => f.invocations === 0).length,
+    observedInvocations: module.functions.reduce((total, f) => total + f.invocations, 0)
+  });
+  const groups = [...grouped].sort(([left], [right]) => {
+    const leftModule = modules.get(left), rightModule = modules.get(right);
+    const leftEvidence = moduleEvidence(leftModule), rightEvidence = moduleEvidence(rightModule);
+    return Number(rightEvidence.unobservable) - Number(leftEvidence.unobservable)
+      || rightEvidence.unobservedFunctions - leftEvidence.unobservedFunctions
+      || leftEvidence.observedInvocations - rightEvidence.observedInvocations
+      || leftModule.displayId.localeCompare(rightModule.displayId);
+  });
   visibleModuleIds = groups.map(([moduleId]) => moduleId);
   const toggle = document.getElementById("toggle-modules");
   const allCollapsed = visibleModuleIds.length > 0 && visibleModuleIds.every(moduleId => collapsedModules.has(moduleId));
@@ -243,7 +275,9 @@ function renderFunctions() {
     const invocations = module.functions.reduce((total, f) => total + f.invocations, 0);
     const collapsed = collapsedModules.has(moduleId);
     const summary = `${nf.format(observed)} of ${nf.format(module.functions.length)} functions observed · ${nf.format(candidates)} candidates · ${nf.format(invocations)} invocations`;
-    const moduleStatus = observed === 0 ? `<span class="badge unused-external">Entire module unobserved</span>` : "";
+    const moduleStatus = !module.functions.some(external)
+      ? `<span class="badge unused-internal">No externally callable functions</span>`
+      : observed === 0 ? `<span class="badge unused-external">Entire module unobserved</span>` : "";
     const header = `<tr class="module-row"><td colspan="8"><button class="module-toggle" data-module="${esc(moduleId)}" aria-expanded="${!collapsed}"><span class="module-chevron">${collapsed?"▸":"▾"}</span><code title="${esc(module.id)}">${esc(module.displayId)}</code>${moduleStatus}<span class="module-summary">${esc(summary)}</span></button></td></tr>`;
     return header + (collapsed ? "" : visibleFunctions.map(functionRow).join(""));
   }).join("") : `<tr><td colspan="8" class="empty">No functions match these filters.</td></tr>`;
@@ -272,6 +306,13 @@ function renderDetails(f) {
 }
 
 for (const id of ["search","class-filter","visibility","threshold"]) document.getElementById(id).addEventListener(id==="search"||id==="threshold"?"input":"change",renderFunctions);
+document.getElementById("toggle-entrypoint-callers").addEventListener("click", () => {
+  const expand = visibleEntrypointAddresses.length > 0 && visibleEntrypointAddresses.every(address => expandedEntrypointAddresses.has(address));
+  for (const address of visibleEntrypointAddresses) {
+    if (expand) expandedEntrypointAddresses.delete(address); else expandedEntrypointAddresses.add(address);
+  }
+  renderActiveEntryFunctionCallers();
+});
 document.getElementById("toggle-modules").addEventListener("click", () => {
   const expand = visibleModuleIds.length > 0 && visibleModuleIds.every(moduleId => collapsedModules.has(moduleId));
   for (const moduleId of visibleModuleIds) {

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -275,9 +275,14 @@ function renderFunctions() {
     const invocations = module.functions.reduce((total, f) => total + f.invocations, 0);
     const collapsed = collapsedModules.has(moduleId);
     const summary = `${nf.format(observed)} of ${nf.format(module.functions.length)} functions observed · ${nf.format(candidates)} candidates · ${nf.format(invocations)} invocations`;
-    const moduleStatus = !module.functions.some(external)
-      ? `<span class="badge unused-internal">No externally callable functions</span>`
-      : observed === 0 ? `<span class="badge unused-external">Entire module unobserved</span>` : "";
+    const statuses = [];
+    if (!module.functions.some(external)) statuses.push(`<span class="badge unused-internal">No externally callable functions</span>`);
+    if (observed === 0) {
+      statuses.push(`<span class="badge unused-external">Entire module unobserved</span>`);
+    } else if (module.functions.every(f => f.invocations === 0 || f.transactions <= threshold)) {
+      statuses.push(`<span class="badge rare-external">Rarely observed</span>`);
+    }
+    const moduleStatus = statuses.join("");
     const header = `<tr class="module-row"><td colspan="8"><button class="module-toggle" data-module="${esc(moduleId)}" aria-expanded="${!collapsed}"><span class="module-chevron">${collapsed?"▸":"▾"}</span><code title="${esc(module.id)}">${esc(module.displayId)}</code>${moduleStatus}<span class="module-summary">${esc(summary)}</span></button></td></tr>`;
     return header + (collapsed ? "" : visibleFunctions.map(functionRow).join(""));
   }).join("") : `<tr><td colspan="8" class="empty">No functions match these filters.</td></tr>`;

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -243,18 +243,17 @@ function renderFunctions() {
     grouped.get(moduleId).push(f);
   }
   const moduleEvidence = module => ({
-    // Modules without any public, friend, or entry function cannot be invoked directly
-    // by an external contract. Keep those least directly observable modules first.
-    unobservable: !module.functions.some(external),
     unobservedFunctions: module.functions.filter(f => f.invocations === 0).length,
-    observedInvocations: module.functions.reduce((total, f) => total + f.invocations, 0)
+    invocationCount: module.functions.reduce((total, f) => total + f.invocations, 0)
   });
   const groups = [...grouped].sort(([left], [right]) => {
     const leftModule = modules.get(left), rightModule = modules.get(right);
     const leftEvidence = moduleEvidence(leftModule), rightEvidence = moduleEvidence(rightModule);
-    return Number(rightEvidence.unobservable) - Number(leftEvidence.unobservable)
+    // First surface whole modules with no calls, then the least-called modules.
+    // More unobserved functions only breaks ties between equally called modules.
+    return Number(rightEvidence.invocationCount === 0) - Number(leftEvidence.invocationCount === 0)
+      || leftEvidence.invocationCount - rightEvidence.invocationCount
       || rightEvidence.unobservedFunctions - leftEvidence.unobservedFunctions
-      || leftEvidence.observedInvocations - rightEvidence.observedInvocations
       || leftModule.displayId.localeCompare(rightModule.displayId);
   });
   visibleModuleIds = groups.map(([moduleId]) => moduleId);

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -182,7 +182,8 @@ function renderCards() {
     ["All unobserved", nf.format(unused), ""]
   ];
   document.getElementById("cards").innerHTML = values.map(([label,value,cls]) => `<div class="card"><span class="label">${esc(label)}</span><span class="value ${cls}">${esc(value)}</span></div>`).join("");
-  document.getElementById("subtitle").textContent = `Replay ${nf.format(report.start_version)}–${nf.format(report.end_version)} · schema ${report.schema_version} · build ${report.git_sha || "unknown"}`;
+  const recordedAt = report.report_generated_at_utc ? new Date(report.report_generated_at_utc).toISOString() : "recording date unavailable";
+  document.getElementById("subtitle").textContent = `Recorded ${recordedAt} · Replay ${nf.format(report.start_version)}–${nf.format(report.end_version)} · schema ${report.schema_version} · build ${report.git_sha || "unknown"}`;
   const truncationNotices = [];
   if (report.usage_detail_truncated) {
     const rowLimit = report.merged_usage_detail_row_limit ?? report.usage_detail_row_limit;

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -87,7 +87,9 @@ button.link { border:0; background:none; color:var(--accent); padding:0; cursor:
   <section class="panel" id="details" role="dialog" aria-labelledby="detail-title" hidden>
     <div class="detail-header"><h2 id="detail-title"></h2><button class="detail-close" id="detail-close" type="button" aria-label="Close function details">×</button></div>
     <div class="detail-grid" id="detail-summary"></div>
-    <h2>Observed call paths</h2>
+    <h2>Calling entry functions</h2>
+    <div class="paths table-wrap" id="detail-roots"></div>
+    <h2>Immediate call paths</h2>
     <div class="paths table-wrap" id="detail-paths"></div>
   </section>
   <section class="panel">
@@ -125,7 +127,7 @@ const functions = new Map();
 for (const f of report.functions) {
   const id = `${rawModuleName(f.module_id)}::${f.function_name}`;
   const displayId = `${moduleName(f.module_id)}::${f.function_name}`;
-  functions.set(id, {...f, id, displayId, invocations:0, transactions:0, successful:0, first:null, last:null, paths:[], callers:new Set()});
+  functions.set(id, {...f, id, displayId, invocations:0, transactions:0, successful:0, first:null, last:null, roots:[], paths:[], callers:new Set()});
 }
 for (const u of report.function_usage) {
   const f = functions.get(keyOf(u.callee));
@@ -135,6 +137,10 @@ for (const u of report.function_usage) {
   if (u.outcome === "success") f.successful += u.invocation_count;
   f.first = f.first === null ? u.first_version : Math.min(f.first, u.first_version);
   f.last = f.last === null ? u.last_version : Math.max(f.last, u.last_version);
+}
+for (const r of report.root_function_usage ?? []) {
+  const f = functions.get(keyOf(r.callee));
+  if (f) f.roots.push(r);
 }
 for (const p of report.usage) {
   const f = functions.get(keyOf(p.callee));
@@ -181,6 +187,9 @@ function renderCards() {
   if (report.usage_detail_truncated) {
     const rowLimit = report.merged_usage_detail_row_limit ?? report.usage_detail_row_limit;
     truncationNotices.push(`Call-path detail is partial: it is capped at ${nf.format(rowLimit)} rows; ${nf.format(report.dropped_usage_invocation_count)} invocation${report.dropped_usage_invocation_count === 1 ? " was" : "s were"} omitted across ${nf.format(report.dropped_usage_transaction_count)} transaction${report.dropped_usage_transaction_count === 1 ? "" : "s"}. Per-function totals remain complete.`);
+  }
+  if (report.root_function_usage_truncated) {
+    truncationNotices.push(`Calling-entry attribution is partial for functions with more than ${nf.format(report.root_function_row_limit_per_function)} distinct entry/outcome combinations; ${nf.format(report.dropped_root_function_usage_invocation_count)} invocation${report.dropped_root_function_usage_invocation_count === 1 ? " was" : "s were"} omitted across ${nf.format(report.dropped_root_function_usage_transaction_count)} transaction${report.dropped_root_function_usage_transaction_count === 1 ? "" : "s"}.`);
   }
   if (report.active_entry_function_callers_truncated) {
     const rowLimit = report.merged_active_entry_function_caller_row_limit ?? report.active_entry_function_caller_row_limit;
@@ -331,11 +340,23 @@ function renderDetails(f, anchor) {
     ["Visibility",`${f.visibility}${f.is_entry?" · entry":""}${f.is_native?" · native":""}`],
     ["Transactions",nf.format(f.transactions)],
     ["Invocations",nf.format(f.invocations)],
-    ["Immediate caller addresses",nf.format(f.callers.size)]
+    ["Retained calling entries",nf.format(new Set(f.roots.map(r=>rawFunctionName(r.root_function))).size)],
+    ["Retained immediate caller addresses",nf.format(f.callers.size)]
   ];
   document.getElementById("detail-summary").innerHTML=summary.map(([label,value])=>`<div><span class="meta">${esc(label)}</span><span class="value">${esc(value)}</span></div>`).join("");
+  const roots=[...f.roots].sort((a,b)=>b.invocation_count-a.invocation_count || functionName(a.root_function).localeCompare(functionName(b.root_function)));
+  let missingRoots;
+  if (f.invocations === 0) {
+    missingRoots="No calls to this function were observed in the replay range.";
+  } else if ((report.schema_version ?? 0) < 5) {
+    missingRoots="Calling-entry attribution was not retained by this report version. Run the updated workflow to collect it.";
+  } else {
+    missingRoots="Calling-entry attribution was not retained for this function because its per-function limit was reached.";
+  }
+  document.getElementById("detail-roots").innerHTML=roots.length?`<table><thead><tr><th>Entry function</th><th>Outcome</th><th class="number">Transactions</th><th class="number">Invocations</th><th>Versions</th></tr></thead><tbody>${roots.map(r=>`<tr><td><code title="${esc(rawFunctionName(r.root_function))}">${esc(r.root_function ? functionName(r.root_function) : "<unknown entry>")}</code></td><td>${esc(r.outcome)}</td><td class="number">${nf.format(r.transaction_count)}</td><td class="number">${nf.format(r.invocation_count)}</td><td>${nf.format(r.first_version)}–${nf.format(r.last_version)}</td></tr>`).join("")}</tbody></table>`:`<div class="empty">${esc(missingRoots)}</div>`;
   const paths=[...f.paths].sort((a,b)=>b.invocation_count-a.invocation_count);
-  document.getElementById("detail-paths").innerHTML=paths.length?`<table><thead><tr><th>Immediate caller</th><th>Root payload</th><th>Kind</th><th>Outcome</th><th class="number">Transactions</th><th class="number">Invocations</th><th>Versions</th></tr></thead><tbody>${paths.map(p=>`<tr><td><code>${esc(functionName(p.caller))}</code></td><td><code>${esc(functionName(p.root_function))}</code></td><td>${esc(p.call_kind)}</td><td>${esc(p.outcome)}</td><td class="number">${nf.format(p.transaction_count)}</td><td class="number">${nf.format(p.invocation_count)}</td><td>${nf.format(p.first_version)}–${nf.format(p.last_version)}</td></tr>`).join("")}</tbody></table>`:`<div class="empty">No calls to this function were observed in the replay range.</div>`;
+  const missingPaths=f.invocations === 0 ? "No calls to this function were observed in the replay range." : report.usage_detail_truncated ? "Immediate call-path detail was not retained for this function because the report reached its global detail limit." : "Immediate call-path detail is unavailable for this observed function.";
+  document.getElementById("detail-paths").innerHTML=paths.length?`<table><thead><tr><th>Immediate caller</th><th>Root payload</th><th>Kind</th><th>Outcome</th><th class="number">Transactions</th><th class="number">Invocations</th><th>Versions</th></tr></thead><tbody>${paths.map(p=>`<tr><td><code>${esc(functionName(p.caller))}</code></td><td><code>${esc(functionName(p.root_function))}</code></td><td>${esc(p.call_kind)}</td><td>${esc(p.outcome)}</td><td class="number">${nf.format(p.transaction_count)}</td><td class="number">${nf.format(p.invocation_count)}</td><td>${nf.format(p.first_version)}–${nf.format(p.last_version)}</td></tr>`).join("")}</tbody></table>`:`<div class="empty">${esc(missingPaths)}</div>`;
   positionDetails(anchor);
 }
 

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -207,7 +207,7 @@ function renderActiveEntryFunctionCallers() {
   const rows = sections.map(({address, callers, invocationCount}) => {
     callers.sort((left, right) => right.transaction_count - left.transaction_count || right.framework_invocation_count - left.framework_invocation_count || functionName(left.entry_function).localeCompare(functionName(right.entry_function)));
     const expanded = expandedEntrypointAddresses.has(address);
-    const header = `<tr class="module-row"><td colspan="6"><button class="module-toggle" data-entrypoint-address="${esc(address)}" aria-expanded="${expanded}"><span class="module-chevron">${expanded?"▾":"▸"}</span><code title="${esc(address)}">${esc(shortAddress(address))}</code><span class="module-summary">${nf.format(invocationCount)} framework call${invocationCount === 1 ? "" : "s"}</span></button></td></tr>`;
+    const header = `<tr class="module-row"><td colspan="6"><button class="module-toggle" data-entrypoint-address="${esc(address)}" aria-expanded="${expanded}"><span class="module-chevron">${expanded?"▾":"▸"}</span><code>${esc(address)}</code><span class="module-summary">${nf.format(invocationCount)} framework call${invocationCount === 1 ? "" : "s"}</span></button></td></tr>`;
     const callerRows = callers.map(caller => `<tr><td></td><td class="function-column"><code title="${esc(functionName(caller.entry_function))}">${esc(functionName(caller.entry_function))}</code></td><td>${esc(caller.outcome)}</td><td class="number">${nf.format(caller.transaction_count)}</td><td class="number">${nf.format(caller.framework_invocation_count)}</td><td>${nf.format(caller.first_version)}–${nf.format(caller.last_version)}</td></tr>`).join("");
     return header + (expanded ? callerRows : "");
   });

--- a/storage/db-tool/src/framework_usage_template.rs
+++ b/storage/db-tool/src/framework_usage_template.rs
@@ -113,6 +113,7 @@ const rawModuleName = m => m ? `${m.address}::${m.name}` : "<script>";
 const rawFunctionName = f => f ? `${rawModuleName(f.module_id)}::${f.function_name}` : "<entrypoint>";
 const moduleName = m => m ? `${shortAddress(m.address)}::${m.name}` : "<script>";
 const functionName = f => f ? `${moduleName(f.module_id)}::${f.function_name}` : "<entrypoint>";
+const entrypointFunctionName = f => f?.module_id ? `${f.module_id.name}::${f.function_name}` : "<entrypoint>";
 const keyOf = f => rawFunctionName(f);
 const external = f => f.visibility !== "private" || f.is_entry;
 
@@ -205,10 +206,10 @@ function renderActiveEntryFunctionCallers() {
   toggle.textContent = allExpanded ? "Collapse all entrypoints" : "Expand all entrypoints";
   toggle.disabled = visibleEntrypointAddresses.length === 0;
   const rows = sections.map(({address, callers, invocationCount}) => {
-    callers.sort((left, right) => right.transaction_count - left.transaction_count || right.framework_invocation_count - left.framework_invocation_count || functionName(left.entry_function).localeCompare(functionName(right.entry_function)));
+    callers.sort((left, right) => right.transaction_count - left.transaction_count || right.framework_invocation_count - left.framework_invocation_count || entrypointFunctionName(left.entry_function).localeCompare(entrypointFunctionName(right.entry_function)));
     const expanded = expandedEntrypointAddresses.has(address);
     const header = `<tr class="module-row"><td colspan="6"><button class="module-toggle" data-entrypoint-address="${esc(address)}" aria-expanded="${expanded}"><span class="module-chevron">${expanded?"▾":"▸"}</span><code>${esc(address)}</code><span class="module-summary">${nf.format(invocationCount)} framework call${invocationCount === 1 ? "" : "s"}</span></button></td></tr>`;
-    const callerRows = callers.map(caller => `<tr><td></td><td class="function-column"><code title="${esc(functionName(caller.entry_function))}">${esc(functionName(caller.entry_function))}</code></td><td>${esc(caller.outcome)}</td><td class="number">${nf.format(caller.transaction_count)}</td><td class="number">${nf.format(caller.framework_invocation_count)}</td><td>${nf.format(caller.first_version)}–${nf.format(caller.last_version)}</td></tr>`).join("");
+    const callerRows = callers.map(caller => `<tr><td></td><td class="function-column"><code title="${esc(functionName(caller.entry_function))}">${esc(entrypointFunctionName(caller.entry_function))}</code></td><td>${esc(caller.outcome)}</td><td class="number">${nf.format(caller.transaction_count)}</td><td class="number">${nf.format(caller.framework_invocation_count)}</td><td>${nf.format(caller.first_version)}–${nf.format(caller.last_version)}</td></tr>`).join("");
     return header + (expanded ? callerRows : "");
   });
   document.getElementById("active-entry-function-callers").innerHTML = rows.length ? rows.join("") : `<tr><td colspan="6" class="empty">No module entry functions invoked framework code in this replay range.</td></tr>`;

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -1,6 +1,5 @@
 import argparse
 from collections import Counter
-import csv
 from dataclasses import dataclass
 import datetime
 import dateparser
@@ -1442,7 +1441,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--framework-usage-output-dir",
         required=False,
-        help="Local directory for merged framework usage artifacts",
+        help="Local directory for merged framework usage reports",
     )
     parser.add_argument("--cleanup", required=False, action="store_true", default=False)
     args = parser.parse_args()
@@ -1566,12 +1565,6 @@ def read_framework_usage_html_template() -> str:
             "framework usage HTML template has an invalid Rust delimiter"
         )
     return template
-
-
-def format_module_id(module_id: Optional[dict]) -> str:
-    if module_id is None:
-        return ""
-    return f"{module_id['address']}::{module_id['name']}"
 
 
 def merge_framework_usage_reports(
@@ -1770,95 +1763,7 @@ def merge_framework_usage_reports(
     with open(html_path, "w") as output:
         output.write(html.replace(marker, embedded_json))
 
-    totals: dict[str, dict] = {}
-    for row in merged["function_usage"]:
-        encoded_callee = json.dumps(row["callee"], sort_keys=True)
-        if encoded_callee not in totals:
-            totals[encoded_callee] = {
-                "invocation_count": 0,
-                "transaction_count": 0,
-                "first_version": row["first_version"],
-                "last_version": row["last_version"],
-            }
-        total = totals[encoded_callee]
-        total["invocation_count"] += row["invocation_count"]
-        total["transaction_count"] += row["transaction_count"]
-        total["first_version"] = min(total["first_version"], row["first_version"])
-        total["last_version"] = max(total["last_version"], row["last_version"])
-
-    summary_path = os.path.join(output_dir, "framework-usage-summary.csv")
-    columns = [
-        "module_id",
-        "function_name",
-        "visibility",
-        "is_entry",
-        "is_native",
-        "type_parameter_count",
-        "invocation_count",
-        "transaction_count",
-        "first_version",
-        "last_version",
-    ]
-    with open(summary_path, "w", newline="") as output:
-        writer = csv.DictWriter(output, fieldnames=columns)
-        writer.writeheader()
-        for function in merged["functions"]:
-            function_id = {
-                "module_id": function["module_id"],
-                "function_name": function["function_name"],
-            }
-            total = totals.get(json.dumps(function_id, sort_keys=True), {})
-            writer.writerow(
-                {
-                    **function,
-                    "module_id": format_module_id(function["module_id"]),
-                    "invocation_count": total.get("invocation_count", 0),
-                    "transaction_count": total.get("transaction_count", 0),
-                    "first_version": total.get("first_version", ""),
-                    "last_version": total.get("last_version", ""),
-                }
-            )
-
-    callers_path = os.path.join(output_dir, "framework-usage-callers.csv")
-    caller_columns = [
-        "callee_module_id",
-        "callee_function",
-        "caller_module_id",
-        "caller_function",
-        "root_module_id",
-        "root_function",
-        "call_kind",
-        "outcome",
-        "invocation_count",
-        "transaction_count",
-        "first_version",
-        "last_version",
-    ]
-    with open(callers_path, "w", newline="") as output:
-        writer = csv.DictWriter(output, fieldnames=caller_columns)
-        writer.writeheader()
-        for row in merged["usage"]:
-            caller = row.get("caller") or {}
-            root = row.get("root_function") or {}
-            writer.writerow(
-                {
-                    "callee_module_id": format_module_id(
-                        row["callee"].get("module_id")
-                    ),
-                    "callee_function": row["callee"]["function_name"],
-                    "caller_module_id": format_module_id(caller.get("module_id")),
-                    "caller_function": caller.get("function_name", ""),
-                    "root_module_id": format_module_id(root.get("module_id")),
-                    "root_function": root.get("function_name", ""),
-                    "call_kind": row["call_kind"],
-                    "outcome": row["outcome"],
-                    "invocation_count": row["invocation_count"],
-                    "transaction_count": row["transaction_count"],
-                    "first_version": row["first_version"],
-                    "last_version": row["last_version"],
-                }
-            )
-    logger.info(f"Wrote merged framework usage artifacts to {output_dir}")
+    logger.info(f"Wrote merged framework usage reports to {output_dir}")
 
 
 if __name__ == "__main__":

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -1534,6 +1534,55 @@ def merge_usage_rows(
     return dropped_invocation_count, dropped_transaction_count
 
 
+def merge_usage_rows_per_group(
+    aggregate_rows: dict[str, dict],
+    rows: list[dict],
+    group_field: str,
+    max_rows_per_group: int,
+) -> tuple[int, int]:
+    rows_per_group = Counter(
+        json.dumps(row[group_field], sort_keys=True, separators=(",", ":"))
+        for row in aggregate_rows.values()
+    )
+    count_fields = {
+        "invocation_count",
+        "transaction_count",
+        "first_version",
+        "last_version",
+    }
+    dropped_invocation_count = 0
+    dropped_transaction_count = 0
+    for row in rows:
+        key = {name: value for name, value in row.items() if name not in count_fields}
+        encoded_key = json.dumps(key, sort_keys=True, separators=(",", ":"))
+        if encoded_key not in aggregate_rows:
+            encoded_group = json.dumps(
+                row[group_field], sort_keys=True, separators=(",", ":")
+            )
+            if rows_per_group[encoded_group] >= max_rows_per_group:
+                dropped_invocation_count += row["invocation_count"]
+                dropped_transaction_count += row["transaction_count"]
+                continue
+            rows_per_group[encoded_group] += 1
+            aggregate_rows[encoded_key] = {
+                **key,
+                "invocation_count": 0,
+                "transaction_count": 0,
+                "first_version": row["first_version"],
+                "last_version": row["last_version"],
+            }
+        aggregate = aggregate_rows[encoded_key]
+        aggregate["invocation_count"] += row["invocation_count"]
+        aggregate["transaction_count"] += row["transaction_count"]
+        aggregate["first_version"] = min(
+            aggregate["first_version"], row["first_version"]
+        )
+        aggregate["last_version"] = max(
+            aggregate["last_version"], row["last_version"]
+        )
+    return dropped_invocation_count, dropped_transaction_count
+
+
 def shard_start_version(source: str) -> int:
     file_name = os.path.basename(source)
     try:
@@ -1612,10 +1661,14 @@ def merge_framework_usage_reports(
     usage_detail_truncated = False
     dropped_usage_invocation_count = 0
     dropped_usage_transaction_count = 0
+    root_function_usage_truncated = False
+    dropped_root_function_usage_invocation_count = 0
+    dropped_root_function_usage_transaction_count = 0
     active_entry_function_callers_truncated = False
     dropped_active_entry_function_framework_invocation_count = 0
     dropped_active_entry_function_transaction_count = 0
     function_usage: dict[str, dict] = {}
+    root_function_usage: dict[str, dict] = {}
     usage: dict[str, dict] = {}
     active_entry_function_callers: dict[str, dict] = {}
     for shard_source in sources:
@@ -1635,6 +1688,7 @@ def merge_framework_usage_reports(
                 "target_modules",
                 "functions",
                 "usage_detail_row_limit",
+                "root_function_row_limit_per_function",
                 "active_entry_function_caller_row_limit",
             ):
                 if report[field] != reference[field]:
@@ -1663,6 +1717,13 @@ def merge_framework_usage_reports(
         usage_detail_truncated |= report["usage_detail_truncated"]
         dropped_usage_invocation_count += report["dropped_usage_invocation_count"]
         dropped_usage_transaction_count += report["dropped_usage_transaction_count"]
+        root_function_usage_truncated |= report["root_function_usage_truncated"]
+        dropped_root_function_usage_invocation_count += report[
+            "dropped_root_function_usage_invocation_count"
+        ]
+        dropped_root_function_usage_transaction_count += report[
+            "dropped_root_function_usage_transaction_count"
+        ]
         active_entry_function_callers_truncated |= report[
             "active_entry_function_callers_truncated"
         ]
@@ -1673,6 +1734,15 @@ def merge_framework_usage_reports(
             "dropped_active_entry_function_transaction_count"
         ]
         merge_usage_rows(function_usage, report["function_usage"])
+        dropped_invocations, dropped_transactions = merge_usage_rows_per_group(
+            root_function_usage,
+            report["root_function_usage"],
+            group_field="callee",
+            max_rows_per_group=reference["root_function_row_limit_per_function"],
+        )
+        dropped_root_function_usage_invocation_count += dropped_invocations
+        dropped_root_function_usage_transaction_count += dropped_transactions
+        root_function_usage_truncated |= dropped_invocations > 0
         dropped_invocations, dropped_transactions = merge_usage_rows(
             usage,
             report["usage"],
@@ -1714,6 +1784,16 @@ def merge_framework_usage_reports(
         "usage_detail_truncated": usage_detail_truncated,
         "dropped_usage_invocation_count": dropped_usage_invocation_count,
         "dropped_usage_transaction_count": dropped_usage_transaction_count,
+        "root_function_row_limit_per_function": reference[
+            "root_function_row_limit_per_function"
+        ],
+        "root_function_usage_truncated": root_function_usage_truncated,
+        "dropped_root_function_usage_invocation_count": (
+            dropped_root_function_usage_invocation_count
+        ),
+        "dropped_root_function_usage_transaction_count": (
+            dropped_root_function_usage_transaction_count
+        ),
         "active_entry_function_caller_row_limit": reference[
             "active_entry_function_caller_row_limit"
         ],
@@ -1733,6 +1813,9 @@ def merge_framework_usage_reports(
         "gcs_prefix": f"gs://{bucket_name}/{prefix}/" if bucket_name else None,
         "functions": reference["functions"],
         "function_usage": [function_usage[key] for key in sorted(function_usage)],
+        "root_function_usage": [
+            root_function_usage[key] for key in sorted(root_function_usage)
+        ],
         "usage": [usage[key] for key in sorted(usage)],
         "active_entry_function_callers": [
             active_entry_function_callers[key]

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -1768,8 +1768,14 @@ def merge_framework_usage_reports(
     assert reference is not None
     assert start_timestamp_usecs is not None
     assert end_timestamp_usecs is not None
+    report_generated_at_utc = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
     merged = {
         "schema_version": reference["schema_version"],
+        "report_generated_at_utc": report_generated_at_utc,
         "network": network,
         "start_version": expected_start,
         "end_version": expected_end,


### PR DESCRIPTION
## Summary

- Add a manually triggered mainnet framework-usage workflow built on archive replay, publishing canonical JSON and self-contained HTML to private GitHub Pages.
- Collect complete per-function totals, bounded immediate call paths, active entrypoint callers, and schema-v5 per-function root-entry attribution so unrelated high-cardinality traffic cannot hide rare usage.
- Focus the HTML on deprecation review: group functions by module, sort least-observed modules/functions first, label unobserved and rarely observed modules, and collapse all groups by default.
- Add collapsible entrypoint groups, compact address display, and a function-details popover separating retained calling entries from immediate call paths.

## Validation

- cargo check -p aptos-db-tool
- cargo test -p aptos-db-tool --lib
- cargo +nightly fmt --all -- --check
- Python merge and JavaScript syntax checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now pushes usage data to a private repo via PAT and enforces bucket/Pages privacy; misconfiguration could block publishes or expose data if checks fail open. Schema v5 changes report shape and publishing path, affecting consumers of old buckets/CSVs.
> 
> **Overview**
> Moves framework usage reporting off configurable public GCS buckets and onto **private GitHub Pages** in `aptos-labs/aptos-core-private` (`gh-pages`), with pre-flight checks on the fixed shard bucket and Pages site privacy. Workflow inputs **`RESULTS_BUCKET` / `REPORT_BUCKET` are removed**; reusable workflows now pass secrets explicitly and build images from the local docker workflow.
> 
> **Schema v5** adds **per-callee root-entry attribution** (32 rows per function) so popular callees cannot crowd out rare functions in caller detail; merge and HTML surface truncation metadata. Merged output is **JSON + self-contained HTML only** (CSV artifacts dropped), with **`report_generated_at_utc`** and stable per-network “latest” links.
> 
> The HTML report is reworked for deprecation review: modules and entrypoint callers **collapse by default** and sort toward unobserved/rare usage; function details use a **fixed popover** separating **calling entry functions** from **immediate call paths**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c235e3f0ba2265e7290e66e4a514934b93bc2602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

