### PR TITLE
[Consensus] Route single-entry epoch proofs through commit path

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1797,7 +1797,34 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                     "Proof from epoch {}", msg_epoch,
                 );
                 if msg_epoch == self.epoch() {
-                    monitor!("process_epoch_proof", self.initiate_new_epoch(*proof).await)?;
+                    // A single-entry proof from a peer is also a commit certificate for this
+                    // epoch's reconfiguration block. Let the round manager process that certificate
+                    // through the normal local commit path. Persistence will send the proof back to
+                    // us from self, and only then do we initiate the epoch transition.
+                    let forward_to_round_manager = peer_id != self.author
+                        && proof.ledger_info_with_sigs.len() == 1
+                        && !self.recovery_mode;
+                    if forward_to_round_manager {
+                        proof
+                            .verify(self.epoch_state())
+                            .context("[EpochManager] Invalid EpochChangeProof")?;
+                        let ledger_info = proof.ledger_info_with_sigs[0].clone();
+                        let event = VerifiedEvent::CommitCert(Box::new(ledger_info));
+                        let key = (peer_id, discriminant(&event));
+                        let forwarded = self
+                            .round_manager_tx
+                            .as_mut()
+                            .is_some_and(|sender| sender.push(key, (peer_id, event)).is_ok());
+                        if !forwarded {
+                            warn!(
+                                remote_peer = peer_id,
+                                "Failed to forward epoch change commit certificate to round manager; falling back to state sync",
+                            );
+                            monitor!("process_epoch_proof", self.initiate_new_epoch(*proof).await)?;
+                        }
+                    } else {
+                        monitor!("process_epoch_proof", self.initiate_new_epoch(*proof).await)?;
+                    }
                 } else {
                     info!(
                         remote_peer = peer_id,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -528,6 +528,11 @@ impl NetworkSender {
         self.send(msg, vec![self.author]).await
     }
 
+    pub async fn send_epoch_change_from_ledger_info(&self, ledger_info: LedgerInfoWithSignatures) {
+        self.send_epoch_change(EpochChangeProof::new(vec![ledger_info], false))
+            .await;
+    }
+
     /// Sends the ledger info to self buffer manager
     pub async fn send_commit_proof(&self, ledger_info: LedgerInfoWithSignatures) {
         fail_point!("consensus::send::commit_decision", |_| ());

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -688,6 +688,7 @@ mod tests {
             test_utils::placeholder_sync_info(),
         );
         let previous_qc = certificate_for_genesis();
+        let epoch_change_ledger_info = previous_qc.ledger_info().clone();
         let proposal = ProposalMsg::new(
             Block::new_proposal(
                 Payload::empty(false),
@@ -728,6 +729,17 @@ mod tests {
                     ConsensusMsg::ProposalMsg(p) => assert_eq!(*p, proposal),
                     _ => panic!("unexpected messages"),
                 }
+            }
+            nodes[0]
+                .send_epoch_change_from_ledger_info(epoch_change_ledger_info.clone())
+                .await;
+            let (peer, msg) = receivers[0].consensus_messages.next().await.unwrap();
+            assert_eq!(peer, peers[0]);
+            match msg {
+                ConsensusMsg::EpochChangeProof(proof) => {
+                    assert_eq!(proof.ledger_info_with_sigs, vec![epoch_change_ledger_info])
+                },
+                _ => panic!("unexpected message"),
             }
         });
     }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -64,6 +64,7 @@ use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::{
     block_info::BlockInfo,
     epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
     on_chain_config::{
         OnChainChunkyDKGConfig, OnChainConsensusConfig, OnChainJWKConsensusConfig,
         OnChainRandomnessConfig, ValidatorTxnConfig,
@@ -401,6 +402,7 @@ pub enum VerifiedEvent {
     RoundTimeoutMsg(Box<RoundTimeoutMsg>),
     OrderVoteMsg(Box<OrderVoteMsg>),
     UnverifiedSyncInfo(Box<SyncInfo>),
+    CommitCert(Box<LedgerInfoWithSignatures>),
     BatchMsg(Box<BatchMsg<BatchInfoExt>>),
     SignedBatchInfo(Box<SignedBatchInfoMsg<BatchInfoExt>>),
     ProofOfStoreMsg(Box<ProofOfStoreMsg<BatchInfoExt>>),
@@ -1027,6 +1029,28 @@ impl RoundManager {
         } else {
             Ok(())
         }
+    }
+
+    /// Process a commit certificate using the same state-sync threshold as SyncInfo. If the node
+    /// is too far behind, send the certificate through the local epoch-change path to shut down the
+    /// current processor and sync to the epoch-ending ledger info. Otherwise, send it to the buffer
+    /// manager, which retains it until the corresponding block is locally ordered and executed.
+    async fn process_commit_cert(
+        &mut self,
+        ledger_info: LedgerInfoWithSignatures,
+    ) -> anyhow::Result<()> {
+        if self
+            .block_store
+            .need_sync_for_ledger_info(&ledger_info)
+            .is_some()
+        {
+            self.network
+                .send_epoch_change_from_ledger_info(ledger_info)
+                .await;
+        } else {
+            self.network.send_commit_proof(ledger_info).await;
+        }
+        Ok(())
     }
 
     /// The function makes sure that it ensures the message_round equal to what we have locally,
@@ -2322,6 +2346,10 @@ impl RoundManager {
                                 self.process_sync_info_msg(*sync_info, peer_id).await
                             )
                         }
+                        VerifiedEvent::CommitCert(ledger_info) => monitor!(
+                            "process_commit_cert",
+                            self.process_commit_cert(*ledger_info).await
+                        ),
                         VerifiedEvent::LocalTimeout(round) => monitor!(
                             "process_local_timeout",
                             self.process_local_timeout(round).await


### PR DESCRIPTION
## Summary

- treat a peer-originated, single-entry epoch change proof for the current epoch as a commit certificate
- verify and unwrap the proof in EpochManager, forwarding only LedgerInfoWithSignatures to RoundManager
- forward the certificate through the normal local commit-proof path when its block is already ordered, allowing persistence to emit the local epoch change proof
- preserve the existing direct epoch-transition path for local proofs, multi-entry proofs, recovery mode, and RoundManager channel failures

## Test plan

- cargo check -p aptos-consensus
- cargo test -p aptos-consensus test_can_forward_commit_proof --lib
- cargo test -p aptos-consensus (424 passed, 2 unrelated quorum-store flakes; both passed when rerun individually)
- cargo xclippy
- cargo +nightly fmt --check
- cargo-sort --grouped --workspace --check .
- cargo machete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes epoch-boundary and commit routing in core consensus; mis-handling could delay or incorrectly trigger epoch transitions or state sync.
> 
> **Overview**
> **Peer single-entry epoch change proofs** for the current epoch are no longer handled as an immediate epoch transition in `EpochManager`. When the proof comes from another validator, has one `LedgerInfoWithSignatures`, and the node is not in recovery mode, it is verified and forwarded to `RoundManager` as a **`CommitCert`** so the reconfiguration block follows the normal local commit pipeline.
> 
> `RoundManager` adds **`process_commit_cert`**: if the node is too far behind (`need_sync_for_ledger_info`), it wraps the ledger info in an epoch-change message to self via **`send_epoch_change_from_ledger_info`**; otherwise it sends **`send_commit_proof`** to the buffer manager until the block is ordered and executed. Persistence can then emit the local epoch proof, which still triggers **`initiate_new_epoch`** as before.
> 
> **Unchanged fallbacks:** local proofs, multi-entry proofs, recovery mode, and failed RoundManager forwarding still call **`initiate_new_epoch`** directly. A network test asserts **`send_epoch_change_from_ledger_info`** delivers the expected self `EpochChangeProof`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636b218ed51ea99aafe5fb44b73a3a9488882ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->