### PR TITLE
[vm] Meter BCS value nodes on deserialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,7 +3389,6 @@ dependencies = [
 name = "aptos-move-stdlib"
 version = "0.1.1"
 dependencies = [
- "aptos-gas-algebra",
  "aptos-gas-schedule",
  "aptos-native-interface",
  "aptos-types",
@@ -4565,6 +4564,7 @@ dependencies = [
 name = "aptos-table-natives"
 version = "0.1.0"
 dependencies = [
+ "aptos-gas-algebra",
  "aptos-gas-schedule",
  "aptos-native-interface",
  "aptos-types",

--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -5,7 +5,9 @@ use crate::{
     traits::{AptosGasMeter, GasAlgebra},
     CacheValueSizes,
 };
-use aptos_gas_algebra::{AbstractValueSize, Fee, FeePerGasUnit, NumTypeNodes};
+use aptos_gas_algebra::{
+    AbstractValueSize, Fee, FeePerGasUnit, InternalGasPerAbstractValueUnit, NumTypeNodes,
+};
 use aptos_gas_schedule::{
     gas_feature_versions::*,
     gas_params::{instr::*, txn::*},
@@ -29,19 +31,33 @@ use move_vm_types::{
     views::{TypeView, ValueView},
 };
 
+// Charges for traversing the value graph produced when a resource is loaded and
+// deserialized by the interpreter. Mirrors the serialize-side `bcs` traversal
+// pricing (3x `cmp::compare`'s base and per-abstract-value-unit costs).
+// TODO: add these to 1.50 schedule.
+const LOAD_RESOURCE_PER_VALUE_TRAVERSAL_BASE: InternalGas = InternalGas::new(11010);
+const LOAD_RESOURCE_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT: InternalGasPerAbstractValueUnit =
+    InternalGasPerAbstractValueUnit::new(420);
+
 /// The official gas meter used inside the Aptos VM.
 /// It maintains an internal gas counter, measured in internal gas units, and carries an environment
 /// consisting all the gas parameters, which it can lookup when performing gas calculations.
 pub struct StandardGasMeter<A> {
     algebra: A,
+    /// Whether to charge execution gas for the value graph produced on a
+    /// resource load.
+    meter_value_nodes_on_deserialize: bool,
 }
 
 impl<A> StandardGasMeter<A>
 where
     A: GasAlgebra,
 {
-    pub fn new(algebra: A) -> Self {
-        Self { algebra }
+    pub fn new(algebra: A, meter_value_nodes_on_deserialize: bool) -> Self {
+        Self {
+            algebra,
+            meter_value_nodes_on_deserialize,
+        }
     }
 
     pub fn feature_version(&self) -> u64 {
@@ -235,6 +251,26 @@ where
         if self.feature_version() <= 8 && val.is_none() && bytes_loaded != 0.into() {
             return Err(PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message("in legacy versions, number of bytes loaded must be zero when the resource does not exist ".to_string()));
         }
+
+        // The interpreter only calls this on a cache miss, i.e., a real load
+        // and deserialize, so each loaded value is charged exactly once. The
+        // IO charge below reflects only the stored blob length, but a value
+        // can amplify into a graph orders of magnitude larger; charge the
+        // execution gas proportional to that graph.
+        if self.meter_value_nodes_on_deserialize
+            && let Some(val) = &val
+        {
+            let size = self
+                .vm_gas_params()
+                .misc
+                .abs_val
+                .abstract_value_size(val, self.feature_version())?;
+            self.algebra.charge_execution(
+                LOAD_RESOURCE_PER_VALUE_TRAVERSAL_BASE
+                    + LOAD_RESOURCE_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT * size,
+            )?;
+        }
+
         let cost = self
             .io_pricing()
             .calculate_read_gas(val.is_some(), bytes_loaded);

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
@@ -963,6 +963,18 @@ impl AbstractValueSizeGasParameters {
 
         Ok(abs_size.checked_sub(stack_size).unwrap_or_else(|| 0.into()))
     }
+
+    pub fn abstract_heap_and_value_size(
+        &self,
+        val: impl ValueView,
+        feature_version: u64,
+    ) -> PartialVMResult<(AbstractValueSize, AbstractValueSize)> {
+        let stack_size = self.abstract_stack_size(&val, feature_version)?;
+        let abs_size = self.abstract_value_size(val, feature_version)?;
+
+        let heap_size = abs_size.checked_sub(stack_size).unwrap_or_else(|| 0.into());
+        Ok((heap_size, abs_size))
+    }
 }
 
 /// Miscellaneous gas parameters.

--- a/aptos-move/aptos-native-interface/src/context.rs
+++ b/aptos-move/aptos-native-interface/src/context.rs
@@ -3,27 +3,59 @@
 
 use crate::errors::{LimitExceededError, SafeNativeError, SafeNativeResult};
 use aptos_gas_algebra::{
-    AbstractValueSize, DynamicExpression, GasExpression, GasQuantity, InternalGasUnit,
+    AbstractValueSize, DynamicExpression, GasExpression, GasQuantity,
+    InternalGasPerAbstractValueUnit, InternalGasUnit,
 };
 use aptos_gas_schedule::{
     gas_feature_versions::RELEASE_V1_32, AbstractValueSizeGasParameters, MiscGasParameters,
     NativeGasParameters,
 };
 use aptos_types::on_chain_config::{Features, TimedFeatureFlag, TimedFeatures};
-use move_binary_format::errors::{Location, PartialVMResult, VMResult};
+use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
-    gas_algebra::InternalGas, identifier::Identifier, language_storage::ModuleId,
+    account_address::AccountAddress,
+    gas_algebra::{InternalGas, NumBytes},
+    identifier::Identifier,
+    language_storage::ModuleId,
 };
 use move_vm_runtime::{
     native_extensions::NativeContextExtensions,
     native_functions::{LoaderContext, NativeContext},
     Function,
 };
-use move_vm_types::values::Value;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    values::{GlobalValue, Value},
+};
 use std::{
     ops::{Deref, DerefMut},
     sync::Arc,
 };
+
+/// Computes the abstract heap and value sizes of a just-loaded resource, but only when
+/// value-node metering is enabled and the resource was actually present. Kept as a macro
+/// so the immutable field borrows of context stay disjoint from the mutable borrow behind
+/// other data.
+macro_rules! compute_abs_heap_and_value_size {
+    ($self:expr, $gv:expr, $num_bytes:expr) => {{
+        let calculate_abs_size = $self
+            .timed_features
+            .is_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize);
+        if calculate_abs_size && $num_bytes.is_some() {
+            $gv.view()
+                .map(|val| {
+                    let (heap_size, val_size) = $self
+                        .misc_gas_params
+                        .abs_val
+                        .abstract_heap_and_value_size(&val, $self.gas_feature_version)?;
+                    Ok::<_, PartialVMError>((u64::from(heap_size), val_size))
+                })
+                .transpose()?
+        } else {
+            None
+        }
+    }};
+}
 
 /// A proxy between the VM and the native functions, allowing the latter to query VM configurations
 /// or access certain VM functionalities.
@@ -100,6 +132,53 @@ impl<'b, 'c> SafeNativeContext<'_, 'b, 'c, '_> {
                 Ok(())
             }
         }
+    }
+
+    /// Loads resource from global storage for immutable borrow.
+    /// Returns the value, the number of bytes loaded, and the heap
+    /// size and the value size of the loaded data.
+    pub fn load_resource_with_abs_sizes(
+        &mut self,
+        address: AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(
+        &GlobalValue,
+        Option<NumBytes>,
+        Option<(u64, AbstractValueSize)>,
+    )> {
+        let (gv, num_bytes) = self.inner.load_resource(address, ty)?;
+        let amount = compute_abs_heap_and_value_size!(self, gv, num_bytes);
+        Ok((gv, num_bytes, amount))
+    }
+
+    /// Loads resource from global storage for mutable borrow.
+    /// Returns the value, the number of bytes loaded and the heap
+    /// size and the value size of the loaded data.
+    pub fn load_resource_mut_with_abs_sizes(
+        &mut self,
+        address: AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(
+        &mut GlobalValue,
+        Option<NumBytes>,
+        Option<(u64, AbstractValueSize)>,
+    )> {
+        let (gv, num_bytes) = self.inner.load_resource_mut(address, ty)?;
+        let amount = compute_abs_heap_and_value_size!(self, gv, num_bytes);
+        Ok((gv, num_bytes, amount))
+    }
+
+    /// Charges gas proportional to the number of value nodes.
+    pub fn charge_value_traversal(&mut self, val_size: AbstractValueSize) -> SafeNativeResult<()> {
+        // Set to 3x `cmp::compare`'s base and per-abstract-value-unit costs
+        // (3670 and 140).
+        // TODO: add these to 1.50 schedule.
+        const PER_VALUE_TRAVERSAL_BASE: InternalGas = InternalGas::new(11010);
+        const PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT: InternalGasPerAbstractValueUnit =
+            InternalGasPerAbstractValueUnit::new(420);
+
+        self.charge(PER_VALUE_TRAVERSAL_BASE + PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT * val_size)?;
+        Ok(())
     }
 
     /// Returns true if native functions have access to gas meter and cah charge gas. Otherwise,

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2473,6 +2473,8 @@ impl AptosVM {
                     txn_limits_request,
                     meter_balance,
                     &NoopBlockSynchronizationKillSwitch {},
+                    self.timed_features()
+                        .is_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize),
                 ))
             },
             auxiliary_info,
@@ -2493,7 +2495,23 @@ impl AptosVM {
             code_storage,
             txn,
             log_context,
-            make_prod_gas_meter,
+            |gas_feature_version,
+             vm_gas_params,
+             storage_gas_params,
+             txn_limits_request,
+             meter_balance,
+             block_synchronization_kill_switch| {
+                make_prod_gas_meter(
+                    gas_feature_version,
+                    vm_gas_params,
+                    storage_gas_params,
+                    txn_limits_request,
+                    meter_balance,
+                    block_synchronization_kill_switch,
+                    self.timed_features()
+                        .is_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize),
+                )
+            },
             auxiliary_info,
         ) {
             Ok((vm_status, vm_output, _gas_meter)) => (vm_status, vm_output),
@@ -2926,7 +2944,10 @@ impl AptosVM {
             type_args,
             arguments,
             max_gas_amount,
-            |gas_feature_version, vm_gas_params, storage_gas_params| {
+            |gas_feature_version,
+             vm_gas_params,
+             storage_gas_params,
+             meter_value_nodes_on_deserialize| {
                 make_prod_gas_meter(
                     gas_feature_version,
                     vm_gas_params,
@@ -2934,6 +2955,7 @@ impl AptosVM {
                     None,
                     max_gas_amount.into(),
                     &NoopBlockSynchronizationKillSwitch {},
+                    meter_value_nodes_on_deserialize,
                 )
             },
         );
@@ -2972,7 +2994,10 @@ impl AptosVM {
             type_args,
             arguments,
             max_gas_amount,
-            |gas_feature_version, vm_gas_params, storage_gas_params| {
+            |gas_feature_version,
+             vm_gas_params,
+             storage_gas_params,
+             meter_value_nodes_on_deserialize| {
                 let gas_meter = make_prod_gas_meter_impl::<_, M>(
                     gas_feature_version,
                     vm_gas_params,
@@ -2980,6 +3005,7 @@ impl AptosVM {
                     None,
                     max_gas_amount.into(),
                     &NoopBlockSynchronizationKillSwitch {},
+                    meter_value_nodes_on_deserialize,
                 );
                 modify_gas_meter(gas_meter)
             },
@@ -2999,7 +3025,7 @@ impl AptosVM {
         type_args: Vec<TypeTag>,
         arguments: Vec<Vec<u8>>,
         max_gas_amount: u64,
-        make_gas_meter: impl FnOnce(u64, VMGasParameters, StorageGasParameters) -> G,
+        make_gas_meter: impl FnOnce(u64, VMGasParameters, StorageGasParameters, bool) -> G,
     ) -> (ViewFunctionOutput, Option<G>) {
         let env = AptosEnvironment::new(state_view);
         let vm = AptosVM::new(&env);
@@ -3033,8 +3059,13 @@ impl AptosVM {
             },
         };
 
-        let mut gas_meter =
-            make_gas_meter(vm.gas_feature_version(), vm_gas_params, storage_gas_params);
+        let mut gas_meter = make_gas_meter(
+            vm.gas_feature_version(),
+            vm_gas_params,
+            storage_gas_params,
+            vm.timed_features()
+                .is_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize),
+        );
 
         let resolver = state_view.as_move_resolver();
         let module_storage = state_view.as_aptos_code_storage(&env);
@@ -3615,6 +3646,8 @@ impl VMValidator for AptosVM {
             txn_data.txn_limits.as_ref(),
             initial_balance,
             &NoopBlockSynchronizationKillSwitch {},
+            self.timed_features()
+                .is_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize),
         );
         let storage = TraversalStorage::new();
 

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -40,6 +40,7 @@ pub fn make_prod_gas_meter<'a, T: BlockSynchronizationKillSwitch>(
     txn_limits_request: Option<&TxnLimitsRequest>,
     meter_balance: Gas,
     block_synchronization_kill_switch: &'a T,
+    meter_value_nodes_on_deserialize: bool,
 ) -> ProdGasMeter<'a, T> {
     make_prod_gas_meter_impl::<T, StandardMemoryAlgebra>(
         gas_feature_version,
@@ -48,6 +49,7 @@ pub fn make_prod_gas_meter<'a, T: BlockSynchronizationKillSwitch>(
         txn_limits_request,
         meter_balance,
         block_synchronization_kill_switch,
+        meter_value_nodes_on_deserialize,
     )
 }
 
@@ -58,15 +60,19 @@ pub fn make_prod_gas_meter_impl<'a, T: BlockSynchronizationKillSwitch, M: Memory
     txn_limits_request: Option<&TxnLimitsRequest>,
     meter_balance: Gas,
     block_synchronization_kill_switch: &'a T,
+    meter_value_nodes_on_deserialize: bool,
 ) -> MemoryTrackedGasMeterImpl<StandardGasMeter<StandardGasAlgebra<'a, T>>, M> {
-    MemoryTrackedGasMeterImpl::new(StandardGasMeter::new(StandardGasAlgebra::new(
-        gas_feature_version,
-        vm_gas_params,
-        storage_gas_params,
-        txn_limits_request,
-        meter_balance,
-        block_synchronization_kill_switch,
-    )))
+    MemoryTrackedGasMeterImpl::new(StandardGasMeter::new(
+        StandardGasAlgebra::new(
+            gas_feature_version,
+            vm_gas_params,
+            storage_gas_params,
+            txn_limits_request,
+            meter_balance,
+            block_synchronization_kill_switch,
+        ),
+        meter_value_nodes_on_deserialize,
+    ))
 }
 
 pub(crate) fn check_gas(

--- a/aptos-move/aptos-vm/src/testing.rs
+++ b/aptos-move/aptos-vm/src/testing.rs
@@ -103,6 +103,9 @@ impl AptosVM {
             None,
             gas_meter_balance.into(),
             &NoopBlockSynchronizationKillSwitch {},
+            self.timed_features().is_enabled(
+                aptos_types::on_chain_config::TimedFeatureFlag::MeterValueNodesOnDeserialize,
+            ),
         );
 
         let change_set_configs = &self

--- a/aptos-move/e2e-move-tests/src/tests/bcs.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bcs.rs
@@ -7,6 +7,7 @@ use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
 use aptos_package_builder::PackageBuilder;
 use aptos_types::{
     move_utils::MemberId,
+    on_chain_config::TimedFeatureFlag,
     transaction::{ExecutionStatus, TransactionStatus},
 };
 use claims::assert_ok;
@@ -14,10 +15,7 @@ use move_core_types::{
     account_address::AccountAddress,
     ident_str,
     language_storage::ModuleId,
-    vm_status::{
-        sub_status::NFE_BCS_SERIALIZATION_FAILURE, AbortLocation,
-        StatusCode::EXECUTION_LIMIT_REACHED,
-    },
+    vm_status::{sub_status::NFE_BCS_SERIALIZATION_FAILURE, AbortLocation, StatusCode},
 };
 use std::str::FromStr;
 
@@ -190,7 +188,7 @@ fn test_bcs_to_bytes_value_size_metering() {
     publish_deep_wrapper(&mut h, &acc, 120, 100, 30);
 
     let gas_off = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
-    h.new_epoch();
+    h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, true);
     let gas_on = h.evaluate_entry_function_gas(&acc, run_id(), vec![], vec![]);
 
     println!("bcs::to_bytes gas  off={gas_off}  on={gas_on}");
@@ -209,13 +207,257 @@ fn test_bcs_to_bytes_execution_limit() {
     assert_success!(h.run_entry_function(&acc, run_id(), vec![], vec![]));
 
     // Enable timed feature flag.
-    h.new_epoch();
+    h.set_timed_feature(TimedFeatureFlag::MeterBcsByValueSize, true);
 
     let status = h.run_entry_function(&acc, run_id(), vec![], vec![]);
     assert!(matches!(
         status,
         TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(
-            EXECUTION_LIMIT_REACHED
+            StatusCode::EXECUTION_LIMIT_REACHED
         )))
     ));
+}
+
+// A `vector<D1>` of `n` depth-120 single-field values holds `1 + 121 * n` value
+// nodes, so a few hundred input bytes expand into thousands of value nodes.
+const SMALL_ELEMS: u64 = 60;
+const LARGE_ELEMS: u64 = 100;
+
+/// Generates a module for exercising deserialize-side value-node metering. `D1{f: D2}
+/// ... D{depth}{f: u8}` is a single-field wrapper chain (all `copy`+`store`+`drop`),
+/// so a `vector<D1>` of `n` elements is only ~`n` input bytes but ~`(depth + 1) * n`
+/// value nodes. The entries let a test store a value with the flag off, then load it
+/// with `borrow_global`, unpack it with `from_bytes` (via `copyable_any`), or read it
+/// back through the table natives (`init_table`/`load_table`) once the flag is on —
+/// deserialization is never capped, so it is charged, not rejected.
+fn deep_deser_source(depth: usize) -> String {
+    let mut src = String::from(
+        "module 0xcafe::test {\n    use std::vector;\n    use aptos_std::copyable_any;\n    use aptos_std::table::{Self, Table};\n\n",
+    );
+    for k in 1..depth {
+        src.push_str(&format!(
+            "    struct D{} has drop, store, copy {{ f: D{} }}\n",
+            k,
+            k + 1
+        ));
+    }
+    src.push_str(&format!(
+        "    struct D{} has drop, store, copy {{ f: u8 }}\n\n",
+        depth
+    ));
+    src.push_str("    struct Big has key { v: vector<D1> }\n");
+    src.push_str("    struct Holder has key { a: copyable_any::Any }\n");
+    src.push_str("    struct BigTable has key { t: Table<u64, vector<D1>> }\n\n");
+
+    // Nested single-field constructor: D1{f:D2{f: ... D{depth}{f:0u8} ...}}.
+    let mut ctor = String::from("0u8");
+    for k in (1..=depth).rev() {
+        ctor = format!("D{}{{f:{}}}", k, ctor);
+    }
+
+    src.push_str("    fun build(n: u64): vector<D1> {\n");
+    src.push_str("        let v = vector::empty<D1>();\n");
+    src.push_str("        let i: u64 = 0;\n");
+    src.push_str(&format!(
+        "        while (i < n) {{ vector::push_back(&mut v, {ctor}); i = i + 1; }};\n"
+    ));
+    src.push_str("        v\n    }\n\n");
+
+    src.push_str("    public entry fun init_big(s: &signer, n: u64) {\n");
+    src.push_str("        move_to(s, Big { v: build(n) });\n    }\n\n");
+
+    src.push_str("    public entry fun load_big(addr: address) acquires Big {\n");
+    src.push_str("        let b = borrow_global<Big>(addr);\n");
+    src.push_str("        let _len = vector::length(&b.v);\n    }\n\n");
+
+    src.push_str("    public entry fun init_holder(s: &signer, n: u64) {\n");
+    src.push_str("        move_to(s, Holder { a: copyable_any::pack(build(n)) });\n    }\n\n");
+
+    src.push_str("    public entry fun unpack_holder(addr: address) acquires Holder {\n");
+    src.push_str("        let Holder { a } = move_from<Holder>(addr);\n");
+    src.push_str("        let _v = copyable_any::unpack<vector<D1>>(a);\n    }\n\n");
+
+    src.push_str("    public entry fun init_table(s: &signer, n: u64, m: u64) {\n");
+    src.push_str("        let t = table::new<u64, vector<D1>>();\n");
+    src.push_str("        let k: u64 = 0;\n");
+    src.push_str("        while (k < m) { table::add(&mut t, k, build(n)); k = k + 1; };\n");
+    src.push_str("        move_to(s, BigTable { t });\n    }\n\n");
+
+    src.push_str("    public entry fun load_table(addr: address, m: u64) acquires BigTable {\n");
+    src.push_str("        let b = borrow_global<BigTable>(addr);\n");
+    src.push_str("        let k: u64 = 0;\n");
+    src.push_str("        while (k < m) { let _len = vector::length(table::borrow(&b.t, k)); k = k + 1; };\n");
+    src.push_str("    }\n\n");
+
+    src.push_str("    public entry fun roundtrip(n: u64, iters: u64) {\n");
+    src.push_str("        let a = copyable_any::pack(build(n));\n");
+    src.push_str("        let i: u64 = 0;\n");
+    src.push_str("        while (i < iters) {\n");
+    src.push_str("            let _v = copyable_any::unpack<vector<D1>>(copy a);\n");
+    src.push_str("            i = i + 1;\n        };\n    }\n}");
+    src
+}
+
+fn publish_deep_deser(h: &mut MoveHarness, acc: &Account) {
+    let mut builder = PackageBuilder::new("P");
+    builder.add_source("test", &deep_deser_source(120));
+    builder.add_local_dep(
+        "AptosStdlib",
+        &common::framework_dir_path("aptos-stdlib").to_string_lossy(),
+    );
+    builder.add_local_dep(
+        "MoveStdlib",
+        &common::framework_dir_path("move-stdlib").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+    assert_success!(h.publish_package_with_options(
+        acc,
+        path.path(),
+        BuildOptions::move_2().set_latest_language(),
+    ));
+}
+
+fn entry(name: &str) -> MemberId {
+    MemberId::from_str(&format!("0xcafe::test::{name}")).unwrap()
+}
+
+/// Deserializing a value via `from_bytes` (reached through `copyable_any::unpack`)
+/// must cost execution gas proportional to the produced node count once the flag is
+/// on. Loops `unpack` so the traversal charge dominates the transaction.
+#[test]
+fn test_from_bytes_value_node_metering() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    publish_deep_deser(&mut h, &acc);
+
+    let args = vec![
+        bcs::to_bytes(&SMALL_ELEMS).unwrap(),
+        bcs::to_bytes(&30u64).unwrap(),
+    ];
+    let gas_off = h.evaluate_entry_function_gas(&acc, entry("roundtrip"), vec![], args.clone());
+    // Enabling the flag activates the per-node deserialize charge. The baseline is
+    // measured at genesis (flag off); a single `set_timed_feature` flips it on.
+    h.set_timed_feature(TimedFeatureFlag::MeterValueNodesOnDeserialize, true);
+    let gas_on = h.evaluate_entry_function_gas(&acc, entry("roundtrip"), vec![], args);
+
+    println!("from_bytes gas  off={gas_off}  on={gas_on}");
+    assert!(
+        gas_on > gas_off * 20,
+        "deserialize node metering should dominate: on={gas_on} off={gas_off}"
+    );
+}
+
+/// Deserialization has no node-count limit: a large value unpacks via
+/// `copyable_any::unpack` (`from_bytes`) once the flag is on and is only charged for
+/// the traversal, never rejected. Gas, not a hard cap, bounds deserialization.
+#[test]
+fn test_from_bytes_large_value_unpacks() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    publish_deep_deser(&mut h, &acc);
+
+    let n = vec![bcs::to_bytes(&LARGE_ELEMS).unwrap()];
+    assert_success!(h.run_entry_function(&acc, entry("init_holder"), vec![], n));
+
+    h.set_timed_feature(TimedFeatureFlag::MeterValueNodesOnDeserialize, true);
+    let addr = vec![bcs::to_bytes(acc.address()).unwrap()];
+    assert_success!(h.run_entry_function(&acc, entry("unpack_holder"), vec![], addr));
+}
+
+/// Loading a present resource with `borrow_global` must cost execution gas
+/// proportional to its node count once the flag is on. `MeterBcsByValueSize` does
+/// not touch the load path, so the genesis-vs-on delta isolates this charge.
+#[test]
+fn test_load_resource_value_node_metering() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    publish_deep_deser(&mut h, &acc);
+
+    let n = vec![bcs::to_bytes(&SMALL_ELEMS).unwrap()];
+    assert_success!(h.run_entry_function(&acc, entry("init_big"), vec![], n));
+
+    let addr = vec![bcs::to_bytes(acc.address()).unwrap()];
+    let gas_off = h.evaluate_entry_function_gas(&acc, entry("load_big"), vec![], addr.clone());
+    h.set_timed_feature(TimedFeatureFlag::MeterValueNodesOnDeserialize, true);
+    let gas_on = h.evaluate_entry_function_gas(&acc, entry("load_big"), vec![], addr);
+
+    println!("load_resource gas  off={gas_off}  on={gas_on}");
+    assert!(
+        gas_on > gas_off * 3,
+        "resource-load node metering should raise gas: on={gas_on} off={gas_off}"
+    );
+}
+
+/// The same for the bytecode load path: a large stored resource loads with
+/// `borrow_global` once the flag is on, bounded by the per-node gas charge rather than
+/// any node-count cap.
+#[test]
+fn test_load_resource_large_value_loads() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    publish_deep_deser(&mut h, &acc);
+
+    let n = vec![bcs::to_bytes(&LARGE_ELEMS).unwrap()];
+    assert_success!(h.run_entry_function(&acc, entry("init_big"), vec![], n));
+
+    h.set_timed_feature(TimedFeatureFlag::MeterValueNodesOnDeserialize, true);
+    let addr = vec![bcs::to_bytes(acc.address()).unwrap()];
+    assert_success!(h.run_entry_function(&acc, entry("load_big"), vec![], addr));
+}
+
+/// The table natives deserialize a value from storage on `table::borrow`, so loading it
+/// must cost execution gas proportional to its node count once the flag is on. Each
+/// distinct key is deserialized once per transaction, so borrowing `M` keys forces `M`
+/// independent deserializations; the genesis-vs-on delta isolates the per-node charge
+/// added to the table natives.
+#[test]
+fn test_table_load_value_node_metering() {
+    const M: u64 = 10;
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    publish_deep_deser(&mut h, &acc);
+
+    let init_args = vec![
+        bcs::to_bytes(&SMALL_ELEMS).unwrap(),
+        bcs::to_bytes(&M).unwrap(),
+    ];
+    assert_success!(h.run_entry_function(&acc, entry("init_table"), vec![], init_args));
+
+    let load_args = vec![
+        bcs::to_bytes(acc.address()).unwrap(),
+        bcs::to_bytes(&M).unwrap(),
+    ];
+    let gas_off =
+        h.evaluate_entry_function_gas(&acc, entry("load_table"), vec![], load_args.clone());
+    h.set_timed_feature(TimedFeatureFlag::MeterValueNodesOnDeserialize, true);
+    let gas_on = h.evaluate_entry_function_gas(&acc, entry("load_table"), vec![], load_args);
+
+    println!("table load gas  off={gas_off}  on={gas_on}");
+    assert!(
+        gas_on > gas_off * 3,
+        "table deserialize node metering should raise gas: on={gas_on} off={gas_off}"
+    );
+}
+
+/// Table loads have no node-count limit either: a large value deserializes through
+/// `table::borrow` once the flag is on and is only charged for the traversal, never
+/// rejected.
+#[test]
+fn test_table_load_large_value_loads() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    publish_deep_deser(&mut h, &acc);
+
+    let init_args = vec![
+        bcs::to_bytes(&LARGE_ELEMS).unwrap(),
+        bcs::to_bytes(&1u64).unwrap(),
+    ];
+    assert_success!(h.run_entry_function(&acc, entry("init_table"), vec![], init_args));
+
+    h.set_timed_feature(TimedFeatureFlag::MeterValueNodesOnDeserialize, true);
+    let load_args = vec![
+        bcs::to_bytes(acc.address()).unwrap(),
+        bcs::to_bytes(&1u64).unwrap(),
+    ];
+    assert_success!(h.run_entry_function(&acc, entry("load_table"), vec![], load_args));
 }

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -1420,6 +1420,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
                         None,
                         1_000_000_000_000_000.into(),
                         &NoopBlockSynchronizationKillSwitch {},
+                        true,
                     )),
                     None,
                 ),
@@ -1531,17 +1532,20 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
                 &fun_name,
                 type_params,
                 args,
-                &mut StandardGasMeter::new(CalibrationAlgebra {
-                    base: StandardGasAlgebra::new(
-                        env.gas_feature_version(),
-                        env.gas_params().as_ref().unwrap().vm.clone(),
-                        env.storage_gas_params().as_ref().unwrap().clone(),
-                        None,
-                        10_000_000_000_000,
-                        &NoopBlockSynchronizationKillSwitch {},
-                    ),
-                    shared_buffer: Arc::clone(&a1),
-                }),
+                &mut StandardGasMeter::new(
+                    CalibrationAlgebra {
+                        base: StandardGasAlgebra::new(
+                            env.gas_feature_version(),
+                            env.gas_params().as_ref().unwrap().vm.clone(),
+                            env.storage_gas_params().as_ref().unwrap().clone(),
+                            None,
+                            10_000_000_000_000,
+                            &NoopBlockSynchronizationKillSwitch {},
+                        ),
+                        shared_buffer: Arc::clone(&a1),
+                    },
+                    true,
+                ),
                 &mut traversal_context,
                 &module_storage,
             );

--- a/aptos-move/framework/move-stdlib/Cargo.toml
+++ b/aptos-move/framework/move-stdlib/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-aptos-gas-algebra = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-native-interface = { workspace = true }
 aptos-types = { workspace = true }

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -5,7 +5,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_gas_algebra::{InternalGas, InternalGasPerAbstractValueUnit};
 use aptos_gas_schedule::gas_params::natives::move_stdlib::*;
 use aptos_native_interface::{
     safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
@@ -26,13 +25,6 @@ use move_vm_types::{
 };
 use smallvec::{smallvec, SmallVec};
 use std::collections::VecDeque;
-
-// Set to 3x `cmp::compare`'s base and per-abstract-value-unit costs
-// (3670 and 140).
-// TODO: add these to 1.50 schedule.
-const BCS_PER_VALUE_TRAVERSAL_BASE: InternalGas = InternalGas::new(11010);
-const BCS_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT: InternalGasPerAbstractValueUnit =
-    InternalGasPerAbstractValueUnit::new(420);
 
 pub fn create_option_u64(enum_option_enabled: bool, value: Option<u64>) -> Value {
     if enum_option_enabled {
@@ -74,9 +66,7 @@ fn native_to_bytes(
     // serialization traversal and drop).
     if context.timed_feature_enabled(TimedFeatureFlag::MeterBcsByValueSize) {
         let size = context.abs_val_size_dereferenced(&reference_value)?;
-        context.charge(
-            BCS_PER_VALUE_TRAVERSAL_BASE + BCS_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT * size,
-        )?;
+        context.charge_value_traversal(size)?;
     }
 
     let layout = if context.get_feature_flags().is_lazy_loading_enabled() {
@@ -157,9 +147,7 @@ fn native_serialized_size(
     // serialization traversal and drop).
     if context.timed_feature_enabled(TimedFeatureFlag::MeterBcsByValueSize) {
         let size = context.abs_val_size_dereferenced(&reference_value)?;
-        context.charge(
-            BCS_PER_VALUE_TRAVERSAL_BASE + BCS_PER_VALUE_TRAVERSAL_PER_ABS_VAL_UNIT * size,
-        )?;
+        context.charge_value_traversal(size)?;
     }
 
     let reference = reference_value

--- a/aptos-move/framework/natives/src/object.rs
+++ b/aptos-move/framework/natives/src/object.rs
@@ -84,7 +84,7 @@ fn native_exists_at(
     safely_assert_eq!(ty_args.len(), 1);
     safely_assert_eq!(args.len(), 1);
 
-    let type_ = &ty_args[0];
+    let ty = &ty_args[0];
     let address = safely_pop_arg!(args, AccountAddress);
 
     context.charge(OBJECT_EXISTS_AT_BASE)?;
@@ -92,24 +92,32 @@ fn native_exists_at(
     // Only structs can be resources in global storage. A non-struct type (e.g., a function type
     // that declared the `key` ability) would reach the data cache and trip a VM invariant
     // violation, so reject it here with a deterministic, kept abort instead.
-    if context.gas_feature_version() >= RELEASE_V1_50 && !type_.is_struct_or_enum() {
+    if context.gas_feature_version() >= RELEASE_V1_50 && !ty.is_struct_or_enum() {
         return Err(SafeNativeError::abort_with_message(
             ENOT_A_RESOURCE_TYPE,
             "Object type argument must be a resource (struct) type",
         ));
     }
 
-    let (exists, num_bytes) = context.exists_at(address, type_).map_err(|err| {
-        PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(format!(
-            "Failed to read resource: {:?} at {}. With error: {}",
-            type_, address, err
-        ))
-    })?;
+    let (gv, num_bytes, amount) =
+        context
+            .load_resource_with_abs_sizes(address, ty)
+            .map_err(|err| {
+                PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(format!(
+                    "Failed to read resource: {:?} at {}. With error: {}",
+                    ty, address, err
+                ))
+            })?;
+    let exists = gv.exists();
 
     if let Some(num_bytes) = num_bytes {
         context.charge(
             OBJECT_EXISTS_AT_PER_ITEM_LOADED + OBJECT_EXISTS_AT_PER_BYTE_LOADED * num_bytes,
         )?;
+    }
+    if let Some((heap_size, val_size)) = amount {
+        context.use_heap_memory(heap_size)?;
+        context.charge_value_traversal(val_size)?;
     }
 
     Ok(smallvec![Value::bool(exists)])

--- a/aptos-move/framework/natives/src/storage_slot.rs
+++ b/aptos-move/framework/natives/src/storage_slot.rs
@@ -11,11 +11,11 @@ use aptos_native_interface::{
     safely_assert_eq, safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext,
     SafeNativeError, SafeNativeResult,
 };
-use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
+use move_core_types::account_address::AccountAddress;
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{
     loaded_data::runtime_types::Type,
-    values::{Reference, StructRef, Value},
+    values::{GlobalValue, Reference, StructRef, Value},
 };
 use smallvec::{smallvec, SmallVec};
 use std::collections::VecDeque;
@@ -55,23 +55,17 @@ fn native_borrow_storage_slot_resource(
     let storage_slot_resource_ty = &ty_args[1];
 
     // Borrow the resource from global storage
-    let (ref_val, num_bytes) = context
-        .borrow_resource(addr, storage_slot_resource_ty)
-        .map_err(|err| {
-            // Check if resource doesn't exist
-            if err.major_status() == StatusCode::MISSING_DATA {
-                SafeNativeError::abort_with_message(
-                    ESTORAGE_SLOT_NOT_FOUND,
-                    format!("StorageSlotResource at address {} not found", addr),
-                )
-            } else {
-                err.into()
-            }
-        })?;
+    let (gv, num_bytes, amount) =
+        context.load_resource_with_abs_sizes(addr, storage_slot_resource_ty)?;
+    let ref_val = borrow_gv(gv, addr)?;
 
     // Charge for loaded bytes
     if let Some(num_bytes) = num_bytes {
         context.charge(STORAGE_SLOT_BORROW_PER_BYTE_LOADED * num_bytes)?;
+    }
+    if let Some((heap_size, val_size)) = amount {
+        context.use_heap_memory(heap_size)?;
+        context.charge_value_traversal(val_size)?;
     }
 
     Ok(smallvec![ref_val])
@@ -109,26 +103,31 @@ fn native_borrow_storage_slot_resource_mut(
     let storage_slot_resource_ty = &ty_args[1];
 
     // Borrow the resource mutably from global storage
-    let (ref_val, num_bytes) = context
-        .borrow_resource_mut(addr, storage_slot_resource_ty)
-        .map_err(|err| {
-            // Check if resource doesn't exist
-            if err.major_status() == StatusCode::MISSING_DATA {
-                SafeNativeError::abort_with_message(
-                    ESTORAGE_SLOT_NOT_FOUND,
-                    format!("StorageSlotResource at address {} not found", addr),
-                )
-            } else {
-                err.into()
-            }
-        })?;
+    let (gv, num_bytes, amount) =
+        context.load_resource_mut_with_abs_sizes(addr, storage_slot_resource_ty)?;
+    let ref_val = borrow_gv(gv, addr)?;
 
     // Charge for loaded bytes
     if let Some(num_bytes) = num_bytes {
         context.charge(STORAGE_SLOT_BORROW_MUT_PER_BYTE_LOADED * num_bytes)?;
     }
+    if let Some((heap_size, val_size)) = amount {
+        context.use_heap_memory(heap_size)?;
+        context.charge_value_traversal(val_size)?;
+    }
 
     Ok(smallvec![ref_val])
+}
+
+fn borrow_gv(gv: &GlobalValue, addr: AccountAddress) -> SafeNativeResult<Value> {
+    if gv.exists() {
+        Ok(gv.borrow_global()?)
+    } else {
+        Err(SafeNativeError::abort_with_message(
+            ESTORAGE_SLOT_NOT_FOUND,
+            format!("StorageSlotResource at address {} not found", addr),
+        ))
+    }
 }
 
 /***************************************************************************************************

--- a/aptos-move/framework/natives/src/util.rs
+++ b/aptos-move/framework/natives/src/util.rs
@@ -6,6 +6,7 @@ use aptos_native_interface::{
     safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
     SafeNativeResult,
 };
+use aptos_types::on_chain_config::TimedFeatureFlag;
 use move_core_types::gas_algebra::NumBytes;
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{
@@ -53,6 +54,11 @@ fn native_from_bytes(
         Some(val) => val,
         None => return Err(SafeNativeError::abort(EFROM_BYTES)),
     };
+
+    if context.timed_feature_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize) {
+        let size = context.abs_val_size(&val)?;
+        context.charge_value_traversal(size)?;
+    }
 
     Ok(smallvec![val])
 }

--- a/aptos-move/framework/table-natives/Cargo.toml
+++ b/aptos-move/framework/table-natives/Cargo.toml
@@ -12,6 +12,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-gas-algebra = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-native-interface = { workspace = true }
 aptos-types = { workspace = true }

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -10,7 +10,8 @@
 //! See [`Table.move`](../sources/Table.move) for language use.
 //! See [`README.md`](../README.md) for integration into an adapter.
 
-use aptos_gas_schedule::gas_params::natives::table::*;
+use aptos_gas_algebra::AbstractValueSize;
+use aptos_gas_schedule::{gas_params::natives::table::*, AbstractValueSizeGasParameters};
 use aptos_native_interface::{
     safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
     SafeNativeResult,
@@ -41,7 +42,6 @@ use std::{
     mem::drop,
 };
 use triomphe::Arc as TriompheArc;
-
 // ===========================================================================================
 // Public Data Structures and Constants
 
@@ -322,10 +322,46 @@ pub fn table_natives(
     })
 }
 
+/// Computes the heap memory usage and, when value-node traversal metering is enabled,
+/// the abstract value size of a just-loaded table entry. Returns `None` when memory
+/// double counting is fixed and nothing was loaded (the value is already accounted for
+/// elsewhere). The value size is only `Some` when `charge_value_traversal` is set.
+fn compute_mem_usage(
+    gv: &GlobalValue,
+    abs_val_gas_params: &AbstractValueSizeGasParameters,
+    gas_feature_version: u64,
+    fix_memory_double_counting: bool,
+    loaded: Option<Option<NumBytes>>,
+    charge_value_traversal: bool,
+) -> PartialVMResult<Option<(u64, Option<AbstractValueSize>)>> {
+    if !fix_memory_double_counting || loaded.is_some() {
+        gv.view()
+            .map(|val| {
+                let (heap_size, val_size) =
+                    abs_val_gas_params.abstract_heap_and_value_size(&val, gas_feature_version)?;
+                Ok::<_, PartialVMError>((
+                    u64::from(heap_size),
+                    charge_value_traversal.then_some(val_size),
+                ))
+            })
+            .transpose()
+    } else {
+        Ok(None)
+    }
+}
+
 fn charge_load_cost(
     context: &mut SafeNativeContext,
     loaded: Option<Option<NumBytes>>,
+    mem_usage: Option<(u64, Option<AbstractValueSize>)>,
 ) -> SafeNativeResult<()> {
+    if let Some((amount, val_size)) = mem_usage {
+        context.use_heap_memory(amount)?;
+        if let Some(val_size) = val_size {
+            context.charge_value_traversal(val_size)?;
+        }
+    }
+
     context.charge(COMMON_LOAD_BASE_LEGACY)?;
 
     match loaded {
@@ -397,6 +433,8 @@ fn native_add_box(
     let closure_serialization_disabled = context
         .get_feature_flags()
         .is_closure_bcs_serialization_disabled();
+    let charge_value_traversal =
+        context.timed_feature_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize);
 
     let (extensions, mut loader_context, abs_val_gas_params, gas_feature_version) =
         context.extensions_with_loader_context_and_gas_params();
@@ -421,17 +459,14 @@ fn native_add_box(
 
     let (gv, loaded) =
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
-    let mem_usage = if !fix_memory_double_counting || loaded.is_some() {
-        gv.view()
-            .map(|val| {
-                abs_val_gas_params
-                    .abstract_heap_size(&val, gas_feature_version)
-                    .map(u64::from)
-            })
-            .transpose()?
-    } else {
-        None
-    };
+    let mem_usage = compute_mem_usage(
+        gv,
+        abs_val_gas_params,
+        gas_feature_version,
+        fix_memory_double_counting,
+        loaded,
+        charge_value_traversal,
+    )?;
 
     let res = match gv.move_to(val) {
         Ok(_) => Ok(smallvec![]),
@@ -442,10 +477,7 @@ fn native_add_box(
 
     // TODO(Gas): Figure out a way to charge this earlier.
     context.charge(key_cost)?;
-    if let Some(amount) = mem_usage {
-        context.use_heap_memory(amount)?;
-    }
-    charge_load_cost(context, loaded)?;
+    charge_load_cost(context, loaded, mem_usage)?;
 
     res
 }
@@ -464,6 +496,8 @@ fn native_borrow_box(
     let closure_serialization_disabled = context
         .get_feature_flags()
         .is_closure_bcs_serialization_disabled();
+    let charge_value_traversal =
+        context.timed_feature_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize);
 
     let (extensions, mut loader_context, abs_val_gas_params, gas_feature_version) =
         context.extensions_with_loader_context_and_gas_params();
@@ -487,17 +521,14 @@ fn native_borrow_box(
 
     let (gv, loaded) =
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
-    let mem_usage = if !fix_memory_double_counting || loaded.is_some() {
-        gv.view()
-            .map(|val| {
-                abs_val_gas_params
-                    .abstract_heap_size(&val, gas_feature_version)
-                    .map(u64::from)
-            })
-            .transpose()?
-    } else {
-        None
-    };
+    let mem_usage = compute_mem_usage(
+        gv,
+        abs_val_gas_params,
+        gas_feature_version,
+        fix_memory_double_counting,
+        loaded,
+        charge_value_traversal,
+    )?;
 
     let res = match gv.borrow_global() {
         Ok(ref_val) => Ok(smallvec![ref_val]),
@@ -508,10 +539,7 @@ fn native_borrow_box(
 
     // TODO(Gas): Figure out a way to charge this earlier.
     context.charge(key_cost)?;
-    if let Some(amount) = mem_usage {
-        context.use_heap_memory(amount)?;
-    }
-    charge_load_cost(context, loaded)?;
+    charge_load_cost(context, loaded, mem_usage)?;
 
     res
 }
@@ -530,6 +558,8 @@ fn native_contains_box(
     let closure_serialization_disabled = context
         .get_feature_flags()
         .is_closure_bcs_serialization_disabled();
+    let charge_value_traversal =
+        context.timed_feature_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize);
 
     let (extensions, mut loader_context, abs_val_gas_params, gas_feature_version) =
         context.extensions_with_loader_context_and_gas_params();
@@ -553,27 +583,21 @@ fn native_contains_box(
 
     let (gv, loaded) =
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
-    let mem_usage = if !fix_memory_double_counting || loaded.is_some() {
-        gv.view()
-            .map(|val| {
-                abs_val_gas_params
-                    .abstract_heap_size(&val, gas_feature_version)
-                    .map(u64::from)
-            })
-            .transpose()?
-    } else {
-        None
-    };
+    let mem_usage = compute_mem_usage(
+        gv,
+        abs_val_gas_params,
+        gas_feature_version,
+        fix_memory_double_counting,
+        loaded,
+        charge_value_traversal,
+    )?;
     let exists = Value::bool(gv.exists());
 
     drop(table_data);
 
     // TODO(Gas): Figure out a way to charge this earlier.
     context.charge(key_cost)?;
-    if let Some(amount) = mem_usage {
-        context.use_heap_memory(amount)?;
-    }
-    charge_load_cost(context, loaded)?;
+    charge_load_cost(context, loaded, mem_usage)?;
 
     Ok(smallvec![exists])
 }
@@ -592,6 +616,8 @@ fn native_remove_box(
     let closure_serialization_disabled = context
         .get_feature_flags()
         .is_closure_bcs_serialization_disabled();
+    let charge_value_traversal =
+        context.timed_feature_enabled(TimedFeatureFlag::MeterValueNodesOnDeserialize);
 
     let (extensions, mut loader_context, abs_val_gas_params, gas_feature_version) =
         context.extensions_with_loader_context_and_gas_params();
@@ -615,17 +641,14 @@ fn native_remove_box(
 
     let (gv, loaded) =
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
-    let mem_usage = if !fix_memory_double_counting || loaded.is_some() {
-        gv.view()
-            .map(|val| {
-                abs_val_gas_params
-                    .abstract_heap_size(&val, gas_feature_version)
-                    .map(u64::from)
-            })
-            .transpose()?
-    } else {
-        None
-    };
+    let mem_usage = compute_mem_usage(
+        gv,
+        abs_val_gas_params,
+        gas_feature_version,
+        fix_memory_double_counting,
+        loaded,
+        charge_value_traversal,
+    )?;
 
     let res = match gv.move_from() {
         Ok(val) => Ok(smallvec![val]),
@@ -636,10 +659,7 @@ fn native_remove_box(
 
     // TODO(Gas): Figure out a way to charge this earlier.
     context.charge(key_cost)?;
-    if let Some(amount) = mem_usage {
-        context.use_heap_memory(amount)?;
-    }
-    charge_load_cost(context, loaded)?;
+    charge_load_cost(context, loaded, mem_usage)?;
 
     res
 }

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -36,35 +36,25 @@ use triomphe::Arc as TriompheArc;
 /// A hack to be able to use [MoveVmDataCache] in native context where there is no access to
 /// static gas meter.
 pub trait NativeContextMoveVmDataCache {
-    /// Used by native context only! Returns true if resource exists in global storage, and false
-    /// otherwise. Also, returns the number of bytes loaded (if any, otherwise [None]).
-    fn native_check_resource_exists(
+    /// Loads resource from global storage for immutable borrow.
+    /// Returns the global value and the number of bytes loaded (if any).
+    fn native_load_resource(
         &mut self,
         gas_meter: &mut dyn DependencyGasMeter,
         traversal_context: &mut TraversalContext,
         addr: &AccountAddress,
         ty: &Type,
-    ) -> PartialVMResult<(bool, Option<NumBytes>)>;
+    ) -> PartialVMResult<(&GlobalValue, Option<NumBytes>)>;
 
-    /// Loads resource from global storage and borrows an immutable reference to it.
-    /// Returns the borrowed value and the number of bytes loaded (if any).
-    fn native_borrow_resource(
+    /// Loads resource from global storage for mutable borrow.
+    /// Returns the global value and the number of bytes loaded (if any).
+    fn native_load_resource_mut(
         &mut self,
         gas_meter: &mut dyn DependencyGasMeter,
         traversal_context: &mut TraversalContext,
         addr: &AccountAddress,
         ty: &Type,
-    ) -> PartialVMResult<(Value, Option<NumBytes>)>;
-
-    /// Loads resource from global storage and borrows a mutable reference to it.
-    /// Returns the borrowed value and the number of bytes loaded (if any).
-    fn native_borrow_resource_mut(
-        &mut self,
-        gas_meter: &mut dyn DependencyGasMeter,
-        traversal_context: &mut TraversalContext,
-        addr: &AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(Value, Option<NumBytes>)>;
+    ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)>;
 }
 
 /// Provides access to global storage for Move VM.
@@ -108,44 +98,26 @@ impl<'a, LoaderImpl> NativeContextMoveVmDataCache for MoveVmDataCacheAdapter<'a,
 where
     LoaderImpl: Loader,
 {
-    fn native_check_resource_exists(
+    fn native_load_resource(
         &mut self,
         gas_meter: &mut dyn DependencyGasMeter,
         traversal_context: &mut TraversalContext,
         addr: &AccountAddress,
         ty: &Type,
-    ) -> PartialVMResult<(bool, Option<NumBytes>)> {
+    ) -> PartialVMResult<(&GlobalValue, Option<NumBytes>)> {
         let mut gas_meter = DependencyGasMeterWrapper::new(gas_meter);
-        let (gv, bytes_loaded) = self.load_resource(&mut gas_meter, traversal_context, addr, ty)?;
-        let exists = gv.exists();
-        Ok((exists, bytes_loaded))
+        self.load_resource(&mut gas_meter, traversal_context, addr, ty)
     }
 
-    fn native_borrow_resource(
+    fn native_load_resource_mut(
         &mut self,
         gas_meter: &mut dyn DependencyGasMeter,
         traversal_context: &mut TraversalContext,
         addr: &AccountAddress,
         ty: &Type,
-    ) -> PartialVMResult<(Value, Option<NumBytes>)> {
+    ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)> {
         let mut gas_meter = DependencyGasMeterWrapper::new(gas_meter);
-        let (gv, bytes_loaded) = self.load_resource(&mut gas_meter, traversal_context, addr, ty)?;
-        let ref_val = gv.borrow_global()?;
-        Ok((ref_val, bytes_loaded))
-    }
-
-    fn native_borrow_resource_mut(
-        &mut self,
-        gas_meter: &mut dyn DependencyGasMeter,
-        traversal_context: &mut TraversalContext,
-        addr: &AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(Value, Option<NumBytes>)> {
-        let mut gas_meter = DependencyGasMeterWrapper::new(gas_meter);
-        let (gv, bytes_loaded) =
-            self.load_resource_mut(&mut gas_meter, traversal_context, addr, ty)?;
-        let ref_val = gv.borrow_global()?;
-        Ok((ref_val, bytes_loaded))
+        self.load_resource_mut(&mut gas_meter, traversal_context, addr, ty)
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -39,7 +39,7 @@ use move_vm_types::{
     gas::{ambassador_impl_DependencyGasMeter, DependencyGasMeter, DependencyKind, NativeGasMeter},
     loaded_data::runtime_types::{Type, TypeParamMap},
     natives::function::NativeResult,
-    values::{AbstractFunction, Value},
+    values::{AbstractFunction, GlobalValue, Value},
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -150,38 +150,25 @@ impl<'b, 'c> NativeContext<'_, 'b, 'c> {
             .debug_print_stack_trace(buf, self.module_storage.runtime_environment())
     }
 
-    pub fn exists_at(
+    /// Loads resource from global storage for immutable borrow.
+    /// Returns the value and the number of bytes loaded.
+    pub fn load_resource(
         &mut self,
         address: AccountAddress,
         ty: &Type,
-    ) -> PartialVMResult<(bool, Option<NumBytes>)> {
-        self.data_cache.native_check_resource_exists(
-            self.gas_meter,
-            self.traversal_context,
-            &address,
-            ty,
-        )
-    }
-
-    /// Borrows an immutable reference to a resource in global storage.
-    /// Returns the reference value and the number of bytes loaded.
-    pub fn borrow_resource(
-        &mut self,
-        address: AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(Value, Option<NumBytes>)> {
+    ) -> PartialVMResult<(&GlobalValue, Option<NumBytes>)> {
         self.data_cache
-            .native_borrow_resource(self.gas_meter, self.traversal_context, &address, ty)
+            .native_load_resource(self.gas_meter, self.traversal_context, &address, ty)
     }
 
-    /// Borrows a mutable reference to a resource in global storage.
-    /// Returns the reference value and the number of bytes loaded.
-    pub fn borrow_resource_mut(
+    /// Loads resource from global storage for mutable borrow.
+    /// Returns the value and the number of bytes loaded.
+    pub fn load_resource_mut(
         &mut self,
         address: AccountAddress,
         ty: &Type,
-    ) -> PartialVMResult<(Value, Option<NumBytes>)> {
-        self.data_cache.native_borrow_resource_mut(
+    ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)> {
+        self.data_cache.native_load_resource_mut(
             self.gas_meter,
             self.traversal_context,
             &address,

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::chain_id::{ChainId, NamedChain};
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Timelike, Utc};
 use chrono_tz::America::Los_Angeles;
 use serde::Serialize;
 use strum::{EnumCount, IntoEnumIterator};
@@ -63,6 +63,10 @@ pub enum TimedFeatureFlag {
     /// Charge `bcs::to_bytes` and `bcs::serialized_size` per input value node
     /// instead of only per output byte.
     MeterBcsByValueSize,
+
+    /// Charge execution gas for value deserialization proportional to the
+    /// produced value size.
+    MeterValueNodesOnDeserialize,
 }
 
 /// Representation of features that are gated by the block timestamps.
@@ -112,7 +116,8 @@ impl TimedFeatureOverride {
                 | ConstantSerializedSizeLocalCache
                 | RejectV5ModulePublishing
                 | RevalidateResolvedClosures
-                | MeterBcsByValueSize,
+                | MeterBcsByValueSize
+                | MeterValueNodesOnDeserialize,
             ) => None,
         }
     }
@@ -151,7 +156,7 @@ impl TimedFeatureFlag {
 
             // Note: Activation time set to 1 hour after the beginning of time
             //       so we can test the old and new behaviors in tests.
-            (FixMemoryUsageTracking, TESTING) => Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap(),
+            (FixMemoryUsageTracking, TESTING) => BEGINNING_OF_TIME.with_hour(1).unwrap(),
             (FixMemoryUsageTracking, TESTNET) => Los_Angeles
                 .with_ymd_and_hms(2025, 3, 7, 12, 0, 0)
                 .unwrap()
@@ -174,7 +179,7 @@ impl TimedFeatureFlag {
                 .unwrap()
                 .with_timezone(&Utc),
             // For testing, time set to 1 hour after the beginning of time to test the old and new behaviors in tests.
-            (_DisabledCaptureOption, TESTING) => Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap(),
+            (_DisabledCaptureOption, TESTING) => BEGINNING_OF_TIME.with_hour(1).unwrap(),
             // For mainnet, always enable this feature.
             (_DisabledCaptureOption, MAINNET) => BEGINNING_OF_TIME,
 
@@ -199,7 +204,7 @@ impl TimedFeatureFlag {
 
             // For testing, time set to 1 hour after the beginning of time to test the old and new behaviors in tests.
             (FixCryptoAlgebraNativesResultHandling, TESTING) => {
-                Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap()
+                BEGINNING_OF_TIME.with_hour(1).unwrap()
             },
             (FixCryptoAlgebraNativesResultHandling, TESTNET) => Los_Angeles
                 .with_ymd_and_hms(2026, 2, 2, 22, 0, 0)
@@ -270,13 +275,29 @@ impl TimedFeatureFlag {
                 .unwrap()
                 .with_timezone(&Utc),
 
-            (MeterBcsByValueSize, TESTING) => Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap(),
+            (MeterBcsByValueSize, TESTING) => BEGINNING_OF_TIME.with_hour(1).unwrap(),
             (MeterBcsByValueSize, TESTNET) => Los_Angeles
                 .with_ymd_and_hms(2026, 8, 4, 14, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
             (MeterBcsByValueSize, MAINNET) => Los_Angeles
                 .with_ymd_and_hms(2026, 8, 6, 14, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // Note: Set to a future date so forge's framework-upgrade compat test runs
+            // with this feature off, matching the pre-feature old image and avoiding a
+            // fork (see UseFullTransactionSizeForGasCheck).
+            (MeterValueNodesOnDeserialize, TESTING) => Los_Angeles
+                .with_ymd_and_hms(2026, 8, 26, 14, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (MeterValueNodesOnDeserialize, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 8, 19, 14, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (MeterValueNodesOnDeserialize, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 8, 21, 14, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Gas behavior changes when the timed feature activates, affecting transaction cost and out-of-gas outcomes on deserialize-heavy workloads; VM/native API refactors touch multiple load paths but are feature-gated.
> 
> **Overview**
> Adds **`TimedFeatureFlag::MeterValueNodesOnDeserialize`** so execution gas scales with the **abstract value size** of deserialized data, not just blob I/O bytes. Pricing mirrors serialize-side BCS traversal (3× `cmp::compare` base + per abstract-value-unit); constants are hardcoded pending a 1.50 gas schedule entry.
> 
> **Interpreter path:** `StandardGasMeter` takes a flag from timed features and, on resource load cache misses, charges traversal gas in `charge_load_resource` in addition to existing read I/O gas.
> 
> **Native paths:** Centralizes traversal charging in `SafeNativeContext::charge_value_traversal`. Applies on `from_bytes`, refactors BCS natives to use it, and extends resource/table loads via `load_resource_with_abs_sizes` / `load_resource_mut_with_abs_sizes` (heap memory + traversal). Table natives share `compute_mem_usage` + updated `charge_load_cost`. Move VM native APIs now return `GlobalValue` from `load_resource` / `load_resource_mut` instead of pre-borrowed `Value`.
> 
> **Tests:** E2E coverage for `borrow_global`, `copyable_any::unpack`, and `table::borrow`; BCS tests use `set_timed_feature` instead of epoch rollover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9235489ebeb4e39a189a41b6d1d71d4f6ac57e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->