### PR TITLE
[mono-move] Tie `SessionEffects` to the guard lifetime and remove `ExecutionGuard` from materialization API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13107,6 +13107,7 @@ dependencies = [
  "mono-move-global-context",
  "mono-move-loader",
  "mono-move-natives",
+ "mono-move-output",
  "mono-move-runtime",
  "move-asm",
  "move-binary-format",

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -71,7 +71,11 @@ impl<'a> AptosTransactionExecutor<'a> {
     //
     // TODO(completeness): genesis, state-checkpoint, validator, and
     // block-epilogue transactions; some may stay the block coordinator's job.
-    pub fn execute_transaction(&self, txn: &Transaction, aux_info: &AuxiliaryInfo) -> TxnOutcome {
+    pub fn execute_transaction(
+        &self,
+        txn: &Transaction,
+        aux_info: &AuxiliaryInfo,
+    ) -> TxnOutcome<'a> {
         match txn {
             Transaction::UserTransaction(txn) => self.execute_user_transaction(txn, aux_info),
             Transaction::BlockMetadata(block_metadata) => {

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/txn_output.rs
@@ -13,7 +13,6 @@ use bytes::Bytes;
 use mono_move_core::{
     nominal_tag, storage::resource_provider::InMemoryStorageKey, types::InternedType,
 };
-use mono_move_global_context::ExecutionGuard;
 use mono_move_output::to_contract_events;
 use mono_move_runtime::{serialize, SessionEffects, WriteClass};
 use move_core_types::{language_storage::StructTag, vm_status::StatusCode};
@@ -27,17 +26,19 @@ use std::{
 
 /// Creates the output of an executed transaction from its effects.
 pub(crate) fn executed_output(
-    effects: &SessionEffects,
-    guard: &ExecutionGuard,
+    effects: &SessionEffects<'_>,
     provider: &dyn AptosDataProvider,
     gas_used: u64,
     status: TransactionStatus,
     auxiliary_data: TransactionAuxiliaryData,
 ) -> Result<TransactionOutput, MaterializationError> {
-    let write_set = drain_write_set(effects, guard, provider).map_err(MaterializationError::new)?;
-    // SAFETY: the effects' frozen heap (which event payloads point into) is
-    // live for the duration of output assembly.
-    let events = unsafe { to_contract_events(&effects.extensions, guard) }
+    if !effects.originates_from_provider(provider) {
+        return Err(MaterializationError::new(vec![
+            "materialization provider differs from execution provider".to_string(),
+        ]));
+    }
+    let write_set = drain_write_set(effects, provider).map_err(MaterializationError::new)?;
+    let events = to_contract_events(effects)
         .map_err(|e| MaterializationError::new(vec![format!("event finalization failed: {e}")]))?;
     Ok(TransactionOutput::new(
         write_set,
@@ -78,19 +79,20 @@ type MemberOp = Option<Bytes>;
 //
 // TODO(metering): writes are not charged IO gas or storage fees.
 fn drain_write_set(
-    effects: &SessionEffects,
-    guard: &ExecutionGuard<'_>,
+    effects: &SessionEffects<'_>,
     provider: &dyn AptosDataProvider,
 ) -> Result<WriteSet, Vec<String>> {
+    let layouts = effects.layout_provider();
     let mut writes: Vec<(StateKey, WriteOp)> = vec![];
     let mut group_ops: HashMap<StateKey, HashMap<InternedType, MemberOp>> = HashMap::new();
     let mut failures: Vec<String> = vec![];
 
     // SAFETY: written pointers refer to live values in the effects' frozen
-    // heap, and no GC runs during the drain.
+    // heap, the retained layout provider originates from the same execution,
+    // and no GC runs during the drain.
     let written_bytes = |ptr: NonNull<u8>, ty: InternedType| -> Result<Bytes, String> {
         // SAFETY: forwarded from this function's contract.
-        let blob = unsafe { serialize(guard, ptr.as_ptr(), ty) }
+        let blob = unsafe { serialize(layouts, ptr.as_ptr(), ty) }
             .map_err(|e| format!("failed to serialize written value: {e}"))?;
         Ok(Bytes::from(blob))
     };
@@ -137,7 +139,7 @@ fn drain_write_set(
     // TODO(correctness): consider sorting the keys first to ensure determinism. This
     // cannot currently be done because keys contain `InternedType`, which is
     // basically a pointer and does not implement `Ord`.
-    for (key, class, group) in effects.read_write_set.writes_unordered() {
+    for (key, class, group) in effects.read_write_set().writes_unordered() {
         // TODO(perf): currently we collect all errors and sort them to ensure determinism.
         // We should however revisit the design later and see if we want to switch to an alternative approach.
         //   - What if you want to fail fast on error?

--- a/third_party/move/mono-move/aptos-transaction-executor/src/outcome.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/outcome.rs
@@ -11,12 +11,11 @@ use aptos_types::{
     on_chain_config::Features,
     transaction::{TransactionAuxiliaryData, TransactionOutput, TransactionStatus},
 };
-use mono_move_global_context::ExecutionGuard;
 use mono_move_runtime::SessionEffects;
 
 /// The outcome of one transaction, not yet materialized into a write set.
 /// Intended to be consumed by the block coordinator for efficient handling.
-pub enum TxnOutcome {
+pub enum TxnOutcome<'guard> {
     /// Rejected without side effects.
     Discarded(DiscardReason),
     /// A system transaction failed unexpectedly: there is no per-transaction
@@ -27,11 +26,11 @@ pub enum TxnOutcome {
     Executed {
         status: ExecutionStatus,
         fee_statement: FeeStatement,
-        effects: SessionEffects,
+        effects: SessionEffects<'guard>,
     },
 }
 
-impl TxnOutcome {
+impl TxnOutcome<'_> {
     pub fn is_discarded(&self) -> bool {
         matches!(self, TxnOutcome::Discarded(_))
     }
@@ -41,12 +40,14 @@ impl TxnOutcome {
     /// events. Fails only if the effects cannot be converted to storage
     /// formats, e.g. BCS serialized, which is abnormal — unlike a discard,
     /// which is a normal outcome carried in the output's status.
+    /// `provider` must be the exact provider instance used for execution so its
+    /// pointer-keyed caches and resource-group pre-state match the effects;
+    /// materialization rejects a different provider.
     //
     // TODO(perf): this is only intended for compatibility and testing, and
     // the block coordinator should eventually handle the effects directly.
     pub fn materialize(
         self,
-        guard: &ExecutionGuard,
         provider: &dyn AptosDataProvider,
         features: &Features,
         auxiliary_data: TransactionAuxiliaryData,
@@ -75,7 +76,6 @@ impl TxnOutcome {
                 let txn_status = TransactionStatus::from_vm_status(vm_status, features, true);
                 materialize::executed_output(
                     &effects,
-                    guard,
                     provider,
                     fee_statement.gas_used(),
                     txn_status,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/block_metadata.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/block_metadata.rs
@@ -25,14 +25,14 @@ const BLOCK_PROLOGUE_EXT: &IdentStr = ident_str!("block_prologue_ext");
 const BLOCK_PROLOGUE_EXT_V2: &IdentStr = ident_str!("block_prologue_ext_v2");
 const BLOCK_PROLOGUE_EXT_V3: &IdentStr = ident_str!("block_prologue_ext_v3");
 
-impl AptosTransactionExecutor<'_> {
+impl<'guard> AptosTransactionExecutor<'guard> {
     /// Executes a block-metadata (system) transaction. The auxiliary info is
     /// unused: system sessions carry no user transaction context.
     pub fn execute_block_metadata_transaction(
         &self,
         block_metadata: &BlockMetadata,
         _aux_info: &AuxiliaryInfo,
-    ) -> TxnOutcome {
+    ) -> TxnOutcome<'guard> {
         let txn_data = SystemTxnMetadata::for_block_metadata(block_metadata);
         let mut interp = self.system_session(&txn_data);
         match run_block_prologue(&mut interp, self.guard, block_metadata) {
@@ -51,7 +51,7 @@ impl AptosTransactionExecutor<'_> {
         &self,
         block_metadata_ext: &BlockMetadataExt,
         aux_info: &AuxiliaryInfo,
-    ) -> TxnOutcome {
+    ) -> TxnOutcome<'guard> {
         if let BlockMetadataExt::V0(block_metadata) = block_metadata_ext {
             return self.execute_block_metadata_transaction(block_metadata, aux_info);
         }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/common.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/common.rs
@@ -74,7 +74,7 @@ impl<'a> AptosTransactionExecutor<'a> {
 }
 
 /// The outcome of a completed system transaction: fee-free and successful.
-pub(super) fn system_txn_outcome(interp: InterpreterContext<'_>) -> TxnOutcome {
+pub(super) fn system_txn_outcome<'guard>(interp: InterpreterContext<'guard>) -> TxnOutcome<'guard> {
     TxnOutcome::Executed {
         status: ExecutionStatus::Success,
         fee_statement: FeeStatement::zero(),

--- a/third_party/move/mono-move/aptos-transaction-executor/src/user_txn/execute.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/user_txn/execute.rs
@@ -28,7 +28,7 @@ use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
 use mono_move_natives::TransactionContextExtension;
 use mono_move_runtime::{InterpreterContext, RuntimeStatus};
 
-impl AptosTransactionExecutor<'_> {
+impl<'guard> AptosTransactionExecutor<'guard> {
     /// Executes one user transaction, returning its side effects unmaterialized (see [`TxnOutcome`]).
     /// `aux_info` carries the transaction's index in its block, which seeds
     /// `monotonically_increasing_number`.
@@ -38,7 +38,7 @@ impl AptosTransactionExecutor<'_> {
         &self,
         txn: &SignedTransaction,
         aux_info: &AuxiliaryInfo,
-    ) -> TxnOutcome {
+    ) -> TxnOutcome<'guard> {
         match self.execute_user_transaction_impl(txn, aux_info) {
             Ok(outcome) => outcome,
             Err(reason) => TxnOutcome::Discarded(reason),
@@ -50,7 +50,7 @@ impl AptosTransactionExecutor<'_> {
         &self,
         txn: &SignedTransaction,
         aux_info: &AuxiliaryInfo,
-    ) -> Result<TxnOutcome, DiscardReason> {
+    ) -> Result<TxnOutcome<'guard>, DiscardReason> {
         let guard = self.guard;
 
         // ======================== Pre-execution checks ========================

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -78,7 +78,7 @@ fn first_txn_aux_info() -> AuxiliaryInfo {
 /// materializes the outcome.
 fn execute_v2_with<S: StateView>(
     state: &S,
-    run: impl FnOnce(&AptosTransactionExecutor) -> TxnOutcome,
+    run: impl for<'guard> FnOnce(&AptosTransactionExecutor<'guard>) -> TxnOutcome<'guard>,
 ) -> TransactionOutput {
     let global_ctx = GlobalContext::with_num_execution_workers(1);
     let guard = global_ctx
@@ -99,7 +99,6 @@ fn execute_v2_with<S: StateView>(
     );
     run(&executor)
         .materialize(
-            &guard,
             &data_provider,
             env.features(),
             TransactionAuxiliaryData::default(),

--- a/third_party/move/mono-move/core/src/native/extension.rs
+++ b/third_party/move/mono-move/core/src/native/extension.rs
@@ -5,7 +5,7 @@ use crate::{native::native_invariant_violation, VMResult};
 use fxhash::FxHashMap;
 use std::{
     any::{Any, TypeId},
-    cell::{RefCell, RefMut},
+    cell::{Ref, RefCell, RefMut},
 };
 
 /// An extensible state defined by a native function. Persisted throughout
@@ -68,9 +68,39 @@ impl NativeExtensions {
         );
     }
 
+    /// Gets immutable access to the extension of type `T`.
+    ///
+    /// Errors if `T` is not installed, or if it is mutably borrowed.
+    /// The returned borrow must be released before an operation that can
+    /// trigger GC, checkpointing, or rollback, because each requires mutable
+    /// access to every extension.
+    pub fn get<T: NativeExtension>(&self) -> VMResult<Ref<'_, T>> {
+        let cell = self.map.get(&TypeId::of::<T>()).ok_or_else(|| {
+            native_invariant_violation(format!(
+                "native extension {} not installed for this transaction",
+                std::any::type_name::<T>(),
+            ))
+        })?;
+        let guard = cell.try_borrow().map_err(|_| {
+            native_invariant_violation(format!(
+                "native extension {} is already mutably borrowed",
+                std::any::type_name::<T>(),
+            ))
+        })?;
+        Ok(Ref::map(guard, |ext| {
+            // Upcast `dyn NativeExtension` to `dyn Any`, then downcast to `T`.
+            let ext: &dyn Any = &**ext;
+            ext.downcast_ref::<T>()
+                .expect("TypeId key matches the stored extension type")
+        }))
+    }
+
     /// Gets a mutable access to the extension of type `T`.
     ///
     /// Errors if `T` is not installed, or if it is already borrowed.
+    /// The returned borrow must be released before an operation that can
+    /// trigger GC, checkpointing, or rollback, because each requires mutable
+    /// access to every extension.
     pub fn get_mut<T: NativeExtension>(&self) -> VMResult<RefMut<'_, T>> {
         let cell = self.map.get(&TypeId::of::<T>()).ok_or_else(|| {
             native_invariant_violation(format!(

--- a/third_party/move/mono-move/output/src/events.rs
+++ b/third_party/move/mono-move/output/src/events.rs
@@ -5,29 +5,39 @@
 
 use crate::error::OutputError;
 use aptos_types::{contract_event::ContractEvent, event::EventKey};
-use mono_move_core::{
-    native::NativeExtensions, type_tag_of, value_layout::LayoutProvider, VMInternalError, VMResult,
-};
+use mono_move_core::{type_tag_of, value_layout::LayoutProvider, VMInternalError, VMResult};
 use mono_move_natives::{EventKind, EventStore};
-use mono_move_runtime::serialize;
+use mono_move_runtime::{serialize, SessionEffects};
 
 /// Materializes the emitted events into [`ContractEvent`]s, in emission order.
-/// `layouts` BCS-serializes each event's value.
+/// The effects retain every backing allocation reachable from the event values
+/// and the originating layout provider needed to BCS-serialize them.
+pub fn to_contract_events(effects: &SessionEffects<'_>) -> VMResult<Vec<ContractEvent>> {
+    let store = effects.extension::<EventStore>()?;
+    let layouts = effects.layout_provider();
+
+    // SAFETY: the effects retain their frozen local heap, originating resource
+    // provider, and matching layout provider; no GC can run after execution.
+    unsafe { to_contract_events_from_store(&store, layouts) }
+}
+
+/// Materializes an [`EventStore`] into [`ContractEvent`]s, in emission order.
 ///
 /// # Safety
 ///
-/// The heap the event values point into must be live.
-pub unsafe fn to_contract_events(
-    extensions: &NativeExtensions,
-    layouts: &impl LayoutProvider,
+/// Every allocation reachable through an entry's `msg_data` must remain live,
+/// `layouts` must describe the entry's interned type, and no GC may run during
+/// serialization.
+pub unsafe fn to_contract_events_from_store<L: LayoutProvider + ?Sized>(
+    store: &EventStore,
+    layouts: &L,
 ) -> VMResult<Vec<ContractEvent>> {
-    let store = extensions.get_mut::<EventStore>()?;
     store
         .entries()
         .iter()
         .map(|entry| {
             let type_tag = type_tag_of(entry.msg_ty).ok_or(OutputError::InvalidEventType)?;
-            // SAFETY: forwarded from this function's contract — the heap is live.
+            // SAFETY: forwarded from this function's contract.
             let data = unsafe { serialize(layouts, entry.msg_data.as_ptr(), entry.msg_ty) }?;
             let event = match &entry.kind {
                 EventKind::V2 => ContractEvent::new_v2(type_tag, data),

--- a/third_party/move/mono-move/output/src/lib.rs
+++ b/third_party/move/mono-move/output/src/lib.rs
@@ -10,4 +10,4 @@ pub mod error;
 pub mod events;
 
 pub use error::OutputError;
-pub use events::to_contract_events;
+pub use events::{to_contract_events, to_contract_events_from_store};

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -52,7 +52,6 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
         executor
             .execute_transaction(&txn, &aux_info)
             .materialize(
-                &guard,
                 &data_provider,
                 env.features(),
                 TransactionAuxiliaryData::default(),

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -18,13 +18,13 @@ bcs = { workspace = true }
 hashbrown = { workspace = true }
 mono-move-alloc = { workspace = true }
 mono-move-core = { workspace = true }
+mono-move-global-context = { workspace = true }
 mono-move-loader = { workspace = true }
 move-core-types = { workspace = true }
 rand = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-mono-move-global-context = { workspace = true }
 num-bigint = { workspace = true }
 paste = { workspace = true }
 proptest = { workspace = true }

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -30,26 +30,34 @@ use crate::{
 use mono_move_core::{
     captured_values_size,
     interner::{module_id_of, InternedIdentifier, InternedModuleId},
-    native::{NativeABI, NativeExtensions, NativeIdx, NativeStatus, ObjectHandle, RootPool},
+    native::{
+        NativeABI, NativeExtension, NativeExtensions, NativeIdx, NativeStatus, ObjectHandle,
+        RootPool,
+    },
     next_captured_value_offset,
     storage::resource_provider::InMemoryStorageKey,
     types::{view_type, view_type_list, InternedType, InternedTypeList, Type},
     CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, ConstantPoolIndex, DescriptorId,
     FrameOffset, Function, FunctionPtr, FunctionRef, GasMeter, IntBinaryOp, IntCastOp, IntNegateOp,
-    IntOperand, IntShiftOp, IntTy, MicroOp, PackClosureOp, ResourceProvider, ShiftOperand,
-    VMInternalError, VMResult, VecPackOp, VecUnpackOp, CAPTURED_DATA_TAG_MATERIALIZED,
-    CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET, CAPTURED_DATA_VALUES_SIZE_OFFSET,
-    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID, CLOSURE_FUNC_REF_OFFSET,
-    CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
-    FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
+    IntOperand, IntShiftOp, IntTy, LayoutProvider, MicroOp, PackClosureOp, ResourceProvider,
+    ShiftOperand, VMInternalError, VMResult, VecPackOp, VecUnpackOp,
+    CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET,
+    CAPTURED_DATA_VALUES_SIZE_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID,
+    CLOSURE_FUNC_REF_OFFSET, CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET,
+    FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN,
+    OBJECT_HEADER_SIZE,
 };
+use mono_move_global_context::ExecutionGuard;
 use mono_move_loader::{Loader, ModuleReadSet};
 use move_core_types::{
     int256::{I256, U256},
     vm_status::AbortLocation,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::ptr::{null, NonNull};
+use std::{
+    cell::Ref,
+    ptr::{null, NonNull},
+};
 
 /// Resolves the resource-group container a resource type belongs to from the
 /// read-set-pinned defining module, or [`None`] for an own storage slot.
@@ -138,17 +146,54 @@ fn root_frame_base(stack: &MemoryRegion) -> *mut u8 {
 
 /// What a finished transaction leaves behind: the frozen heap, the
 /// global-storage read-write set, and the native extensions (event store and
-/// friends). Read-write-set and extension entries point into `heap`, so the
-/// parts are only valid together; external read pointers remain owned by the
-/// resource provider.
+/// friends).
 ///
-// TODO(correctness): the effects hold interned types but carry no lifetime, so
-// they can outlive the guard and dereference freed arenas after a maintenance
-// reset. Tie them to the guard lifetime (`SessionEffects<'guard>`).
-pub struct SessionEffects {
-    pub heap: Heap,
-    pub read_write_set: ResourceReadWriteSet,
-    pub extensions: NativeExtensions,
+/// Read-write-set and extension entries point into the frozen heap, so the
+/// parts are only valid together. Read-write-set keys and some extension
+/// entries, notably emitted events, contain interned types backed by the global
+/// arena. Retaining the originating execution guard prevents arena-resetting
+/// maintenance while the effects exist and supplies the matching layout table
+/// during materialization. Retaining the exact resource provider used during
+/// execution keeps its external read allocations alive and lets materializers
+/// reject another provider whose pointer-keyed caches or state snapshot do not
+/// match these effects.
+pub struct SessionEffects<'guard> {
+    read_write_set: ResourceReadWriteSet,
+    extensions: NativeExtensions,
+    /// The guard whose layout table describes the effects' interned types.
+    guard: &'guard ExecutionGuard<'guard>,
+    /// The exact provider that supplied external reads during execution.
+    resource_provider: &'guard dyn ResourceProvider,
+    /// Owns the allocations referenced by the read-write set and extensions.
+    /// Not read directly: those hold raw pointers into it, so it only needs to
+    /// outlive them. Declared last because fields drop in declaration order.
+    _heap: Heap,
+}
+
+impl<'guard> SessionEffects<'guard> {
+    /// The transaction's global-storage read-write set.
+    pub fn read_write_set(&self) -> &ResourceReadWriteSet {
+        &self.read_write_set
+    }
+
+    /// Immutable access to one of the transaction's native extensions.
+    pub fn extension<T: NativeExtension>(&self) -> VMResult<Ref<'_, T>> {
+        self.extensions.get::<T>()
+    }
+
+    /// The originating layout provider for the effects' interned types.
+    #[inline]
+    pub fn layout_provider(&self) -> &impl LayoutProvider {
+        self.guard
+    }
+
+    /// Whether `provider` is the exact provider instance used during execution.
+    ///
+    /// Identity matters because storage keys and provider caches can contain
+    /// pointer-identified interned types.
+    pub fn originates_from_provider(&self, provider: &dyn ResourceProvider) -> bool {
+        std::ptr::addr_eq(self.resource_provider, provider)
+    }
 }
 
 /// Materializes the [`AbortLocation`] naming the module that raised an abort.
@@ -422,12 +467,17 @@ impl<'guard> InterpreterContext<'guard> {
     /// Consumes the context, returning the transaction's side effects for
     /// publication. No execution can follow, so the heap is frozen and every
     /// heap pointer inside the read-write set and extensions stays valid for
-    /// as long as the returned effects live.
-    pub fn finish(self) -> SessionEffects {
+    /// as long as the returned effects live. Retaining the originating guard
+    /// also prevents the global arena that owns their interned types from being
+    /// reset and supplies the matching layout table during materialization.
+    pub fn finish(self) -> SessionEffects<'guard> {
+        let guard = self.loader.guard();
         SessionEffects {
-            heap: self.heap,
             read_write_set: self.read_write_set,
             extensions: self.extensions,
+            guard,
+            resource_provider: self.resource_provider,
+            _heap: self.heap,
         }
     }
 

--- a/third_party/move/mono-move/testsuite/Cargo.toml
+++ b/third_party/move/mono-move/testsuite/Cargo.toml
@@ -29,6 +29,7 @@ mono-move-core = { workspace = true }
 mono-move-global-context = { workspace = true }
 mono-move-loader = { workspace = true }
 mono-move-natives = { workspace = true, features = ["testing"] }
+mono-move-output = { workspace = true }
 mono-move-runtime = { workspace = true }
 move-asm = { workspace = true }
 move-binary-format = { workspace = true }

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -24,7 +24,6 @@ use aptos_framework_natives::{
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
 use aptos_types::{
     contract_event::ContractEvent,
-    event::EventKey,
     on_chain_config::{Features, TimedFeaturesBuilder},
     state_store::{
         errors::StateViewError, state_key::StateKey, state_storage_usage::StateStorageUsage,
@@ -33,10 +32,10 @@ use aptos_types::{
 };
 use aptos_vm::natives::aptos_natives;
 use aptos_vm_types::resolver::StateStorageView;
-use mono_move_core::{native::NativeExtensions, types::type_to_string};
+use mono_move_core::native::NativeExtensions;
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
-use mono_move_natives::{EventKind, EventStore};
-use mono_move_runtime::serialize;
+use mono_move_natives::EventStore;
+use mono_move_output::to_contract_events_from_store;
 use move_binary_format::{errors::Location, CompiledModule};
 use move_core_types::{
     account_address::AccountAddress,
@@ -130,9 +129,14 @@ fn render_execution_output(vals: &[String], events: &[String]) -> String {
 /// Renders the events emitted into the legacy VM's [`NativeEventContext`], in
 /// emission order, for cross-VM comparison.
 pub fn finalize_events_v1(extensions: &NativeContextExtensions) -> Vec<String> {
-    extensions
-        .get::<NativeEventContext>()
-        .events_iter()
+    render_contract_events(extensions.get::<NativeEventContext>().events_iter())
+}
+
+/// Renders materialized events into the normalized form used for cross-VM
+/// comparison.
+fn render_contract_events<'a>(events: impl IntoIterator<Item = &'a ContractEvent>) -> Vec<String> {
+    events
+        .into_iter()
         .map(|event| {
             let type_str = event.type_tag().to_canonical_string();
             match event {
@@ -154,40 +158,20 @@ pub fn finalize_events_v1(extensions: &NativeContextExtensions) -> Vec<String> {
 ///
 /// # Safety
 ///
-/// The VM heap must be live: each entry's `msg_data` embeds heap pointers that
-/// [`serialize`] dereferences.
+/// Every allocation reachable through the event data must remain live, and
+/// `layouts` must be the matching execution guard. No GC may run during
+/// serialization.
 pub unsafe fn finalize_events_v2(
     extensions: &NativeExtensions,
     layouts: &ExecutionGuard<'_>,
 ) -> Vec<String> {
     let store = extensions
-        .get_mut::<EventStore>()
+        .get::<EventStore>()
         .expect("event store installed");
-    store
-        .entries()
-        .iter()
-        .map(|entry| {
-            let type_str = type_to_string(entry.msg_ty);
-            // SAFETY: forwarded from this function's contract — the heap is live.
-            let blob = unsafe { serialize(layouts, entry.msg_data.as_ptr(), entry.msg_ty) }
-                .expect("event value serializes");
-            match &entry.kind {
-                EventKind::V2 => render_event(None, None, &type_str, &blob),
-                EventKind::V1 {
-                    guid,
-                    sequence_number,
-                } => {
-                    let key: EventKey = bcs::from_bytes(guid).expect("guid decodes to EventKey");
-                    render_event(
-                        Some(key.get_creator_address()),
-                        Some(*sequence_number),
-                        &type_str,
-                        &blob,
-                    )
-                },
-            }
-        })
-        .collect()
+    // SAFETY: forwarded from this function's contract.
+    let events = unsafe { to_contract_events_from_store(&store, layouts) }
+        .expect("events materialize into ContractEvents");
+    render_contract_events(&events)
 }
 
 /// Run all steps in a differential test, checking both VMs produce matching


### PR DESCRIPTION
## Description

`SessionEffects` now carries a `'guard` lifetime, binding it to the `ExecutionGuard` that was active during execution. This resolves a correctness gap where effects could outlive their guard and dereference freed arenas after a maintenance reset.

The guard reference is stored directly inside `SessionEffects`, which means:
- The global arena backing interned types cannot be reset while effects are live.
- The matching layout table is available directly from the effects for materialization, eliminating the need for callers to pass a separate `&ExecutionGuard` to `materialize()`.
- The exact `ResourceProvider` instance used during execution is retained and checked at materialization time, so a mismatched provider (with incompatible pointer-keyed caches or state snapshot) is rejected with an explicit error rather than silently producing wrong output.

`TxnOutcome` is parameterized with the same `'guard` lifetime so the effects it carries propagate the constraint through the executor's public API. `execute_transaction`, `execute_user_transaction`, `execute_block_metadata_transaction`, and related helpers all now return `TxnOutcome<'guard>`.

The `executed_output` and `materialize` functions no longer accept an `&ExecutionGuard` argument; the guard is obtained from the effects themselves. Call sites in the e2e tests, replay benchmark, and testsuite runner are updated accordingly.

`NativeExtensions` gains an immutable `get<T>()` accessor (alongside the existing `get_mut<T>()`), returning a `Ref<'_, T>`. The event-finalization path in the testsuite runner is updated to use this, and `to_contract_events` is refactored into a safe public wrapper over `SessionEffects` and an unsafe `to_contract_events_from_store` for callers that hold a raw `EventStore` reference.

## How Has This Been Tested?

Existing e2e tests and the testsuite differential runner exercise the updated materialization path, including the provider-identity check and the lifetime-constrained effects. The testsuite runner's `finalize_events_v2` is updated to go through `to_contract_events_from_store` and `render_contract_events`, keeping cross-VM event comparison intact.

## Key Areas to Review

- **`SessionEffects<'guard>` struct layout**: The `_heap` field is declared last so the read-write set and extensions (which point into the heap) are dropped before the heap itself. This ordering is load-bearing.
- **Provider identity check in `executed_output`**: `originates_from_provider` uses `std::ptr::addr_eq` on fat pointers. Reviewers should confirm this is the right comparison for `dyn ResourceProvider` trait objects in all expected call patterns.
- **`NativeExtensions::get<T>()`**: The immutable borrow path mirrors `get_mut` but returns a `Ref`. The `Ref::map` call upcasts through `dyn Any` before downcasting to `T`; the `expect` is justified by the TypeId key invariant.
- **Removal of `unsafe` from `to_contract_events`**: Safety is now encapsulated inside `SessionEffects`; the public wrapper is safe. The lower-level `to_contract_events_from_store` remains `unsafe` and its contract is documented.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction output materialization and lifetime contracts for execution effects; incorrect provider identity or drop order could cause wrong writes/events or use-after-free, but the new checks and typing are aimed at preventing silent corruption.
> 
> **Overview**
> **`SessionEffects<'guard>`** now pins the active **`ExecutionGuard`** and the exact **`ResourceProvider`** used at execution, with accessors for the read-write set, layout provider, and extensions. That blocks arena reset while effects are live and lets materialization pull layouts from the effects instead of a separate guard argument.
> 
> **`TxnOutcome<'guard>`** and executor entry points propagate the same lifetime. **`materialize`** / **`executed_output`** drop the **`ExecutionGuard`** parameter; they use **`effects.layout_provider()`** and **`originates_from_provider`** (pointer identity) so a mismatched provider fails explicitly.
> 
> **`NativeExtensions::get<T>()`** adds immutable borrows for read-only paths (e.g. events). **`to_contract_events`** is a safe wrapper over **`SessionEffects`**; **`to_contract_events_from_store`** remains **`unsafe`** for raw store + layouts. E2E, replay benchmark, and testsuite call sites are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1cef55037f15e4a8d73fabd76c3656cbd95a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->