### PR TITLE
[ci] Remove framework usage shard bucket

### DIFF
--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -151,7 +151,6 @@ jobs:
     timeout-minutes: 420 # 7 hours
     needs: build-images
     env:
-      FRAMEWORK_USAGE_BUCKET: aptos-framework-usage-reports
       REPORT_BRANCH: gh-pages
       REPORT_REPOSITORY: aptos-labs/aptos-core-private
     permissions:
@@ -202,21 +201,8 @@ jobs:
         shell: bash
         run: gcloud config set project aptos-devinfra-0
 
-      - name: Verify private framework usage shard bucket
-        if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
-        run: |
-          PUBLIC_ACCESS_PREVENTION="$(gcloud storage buckets describe "gs://${FRAMEWORK_USAGE_BUCKET}" --format='value(public_access_prevention)')"
-          UNIFORM_BUCKET_ACCESS="$(gcloud storage buckets describe "gs://${FRAMEWORK_USAGE_BUCKET}" --format='value(uniform_bucket_level_access)')"
-          if [ "$PUBLIC_ACCESS_PREVENTION" != "enforced" ]; then
-            echo "::error::Framework usage shard bucket must enforce public access prevention."
-            exit 1
-          fi
-          if [ "$UNIFORM_BUCKET_ACCESS" != "true" ]; then
-            echo "::error::Framework usage shard bucket must use uniform bucket-level access."
-            exit 1
-          fi
-
       - uses: ./.github/actions/python-setup
+        id: replay-verify-python
         with:
           pyproject_directory: testsuite/replay-verify
 
@@ -251,7 +237,6 @@ jobs:
           fi
           if [ "$FRAMEWORK_USAGE" = "true" ]; then
             ARGS+=(--framework-usage-output-dir ../../framework-usage-results)
-            ARGS+=(--framework-usage-bucket "$FRAMEWORK_USAGE_BUCKET")
           fi
           ARGS+=(--image_profile performance)
           poetry run python main.py "${ARGS[@]}"
@@ -362,7 +347,7 @@ jobs:
           GOOGLE_CLOUD_PROJECT: aptos-devinfra-0
           NETWORK: ${{ inputs.NETWORK }}
           IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
-        if: ${{ always() && inputs.DRY_RUN == false }}
+        if: ${{ always() && inputs.DRY_RUN == false && steps.replay-verify-python.outcome == 'success' }}
         run: |
           cd testsuite/replay-verify
           ARGS=(--network "$NETWORK" --cleanup)

--- a/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
+++ b/aptos-move/framework/FRAMEWORK-USAGE-COVERAGE-DESIGN.md
@@ -422,15 +422,14 @@ versions before tasks are created, and the resolved range is included in the
 manifest.
 
 The replay scheduler is extended with a framework-usage worker mode while
-retaining the same archive snapshot provisioning and cleanup behavior. The CI
-workflow writes result shards to a run-specific prefix in the fixed
-`aptos-framework-usage-reports` bucket. Before scheduling workers, it requires
-that the bucket enforce public access prevention and uniform bucket-level
-access. Object names use the requested range and workflow run identity. The
-worker must successfully upload the shard before its Kubernetes job is
-considered successful.
+retaining the same archive snapshot provisioning and cleanup behavior.
+Completed workers delimit their bounded result shard in their Kubernetes pod
+logs; the GitHub runner extracts and validates each shard before merging. No
+GCS bucket is used for framework-usage results. To keep log retrieval bounded,
+each collection run is limited to 10,000 transactions; larger ranges must be
+split across runs.
 
-After every task succeeds, the GitHub runner downloads and merges the shards.
+After every task succeeds, the GitHub runner extracts and merges the shards.
 The merge step rejects:
 
 - incompatible schema versions
@@ -457,9 +456,8 @@ Each publication also updates stable `framework-usage/<network>/index.html` and
 `framework-usage/<network>/framework-usage.json` URLs. The merged JSON records
 its UTC generation timestamp, which the HTML displays in its header.
 
-The result bucket should have a lifecycle policy. CI cleanup always removes
-pods and temporary PVCs, and final reports remain available through the private
-Pages site.
+CI cleanup always removes pods and temporary PVCs, and final reports remain
+available through the private Pages site.
 
 ## Report Interpretation
 


### PR DESCRIPTION
Removes the deleted framework-usage GCS bucket from the archive replay workflow.

- use existing bounded pod-log shard transport
- skip cleanup when Poetry setup did not complete
- align the framework usage design document

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation changes only; framework usage still publishes to private GitHub Pages with unchanged access checks.
> 
> **Overview**
> **Framework usage collection no longer depends on the `aptos-framework-usage-reports` GCS bucket** in the archive replay reusable workflow. The job drops the bucket env var, the pre-schedule bucket hardening check, and the `--framework-usage-bucket` flag; workers still write local output under `--framework-usage-output-dir`, consistent with **bounded shards carried in Kubernetes pod logs** (documented in `FRAMEWORK-USAGE-COVERAGE-DESIGN.md`, including a **10,000-transaction cap per run**).
> 
> **Post-run Kubernetes cleanup** now runs only when Poetry setup for replay-verify succeeded (`steps.replay-verify-python.outcome == 'success'`), so failed dependency setup does not trigger a cleanup pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f4822020de493ef28f637b0fa4c627bd007f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->