### PR TITLE
[vm] Harden reference aliasing

### DIFF
--- a/third_party/move/move-vm/types/src/values/value_tests.rs
+++ b/third_party/move/move-vm/types/src/values/value_tests.rs
@@ -232,6 +232,30 @@ fn test_mem_swap() -> PartialVMResult<()> {
         }
     }
 
+    // Swapping a container reference with itself must return an error, not panic.
+    // Index 4 is a specialized vector, index 8 is a generic container.
+    for i in [4, 8] {
+        assert_err!(get_local(&locals, i).swap_values(get_local(&locals, i)));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_move_range_aliasing() -> PartialVMResult<()> {
+    use crate::loaded_data::runtime_types::Type;
+
+    let mut locals = Locals::new(1);
+    locals.store_loc(0, Value::vector_u64(vec![1, 2, 3]))?;
+
+    let get_ref = |ls: &Locals| ls.borrow_loc(0).unwrap().value_as::<VectorRef>().unwrap();
+
+    // Moving a range between a vector reference and itself must return an error,
+    // not panic.
+    let from = get_ref(&locals);
+    let to = get_ref(&locals);
+    assert_err!(VectorRef::move_range(&from, 0, 1, &to, 0, &Type::U64));
+
     Ok(())
 }
 

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -2051,26 +2051,44 @@ impl Container {
     fn swap_contents(&self, other: &Self) -> PartialVMResult<()> {
         use Container::*;
 
+        // The two references must point to different containers. If they
+        // alias, borrowing both mutably would panic, so return an invariant
+        // violation instead. In general, bytecode verifier should never allow
+        // this to happen.
+        macro_rules! swap {
+            ($l:ident, $r:ident) => {{
+                let (mut lref, mut rref) = match ($l.try_borrow_mut(), $r.try_borrow_mut()) {
+                    (Ok(lref), Ok(rref)) => (lref, rref),
+                    _ => {
+                        return Err(PartialVMError::new_invariant_violation(
+                            "cannot swap aliasing container references",
+                        ));
+                    },
+                };
+                mem::swap(&mut *lref, &mut *rref);
+            }};
+        }
+
         match (self, other) {
-            (Vec(l), Vec(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (Struct(l), Struct(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
+            (Vec(l), Vec(r)) => swap!(l, r),
+            (Struct(l), Struct(r)) => swap!(l, r),
 
-            (VecBool(l), VecBool(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecAddress(l), VecAddress(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
+            (VecBool(l), VecBool(r)) => swap!(l, r),
+            (VecAddress(l), VecAddress(r)) => swap!(l, r),
 
-            (VecU8(l), VecU8(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU16(l), VecU16(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU32(l), VecU32(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU64(l), VecU64(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU128(l), VecU128(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU256(l), VecU256(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
+            (VecU8(l), VecU8(r)) => swap!(l, r),
+            (VecU16(l), VecU16(r)) => swap!(l, r),
+            (VecU32(l), VecU32(r)) => swap!(l, r),
+            (VecU64(l), VecU64(r)) => swap!(l, r),
+            (VecU128(l), VecU128(r)) => swap!(l, r),
+            (VecU256(l), VecU256(r)) => swap!(l, r),
 
-            (VecI8(l), VecI8(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecI16(l), VecI16(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecI32(l), VecI32(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecI64(l), VecI64(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecI128(l), VecI128(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecI256(l), VecI256(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
+            (VecI8(l), VecI8(r)) => swap!(l, r),
+            (VecI16(l), VecI16(r)) => swap!(l, r),
+            (VecI32(l), VecI32(r)) => swap!(l, r),
+            (VecI64(l), VecI64(r)) => swap!(l, r),
+            (VecI128(l), VecI128(r)) => swap!(l, r),
+            (VecI256(l), VecI256(r)) => swap!(l, r),
 
             (
                 Locals(_) | Vec(_) | Struct(_) | VecBool(_) | VecAddress(_) | VecU8(_) | VecU16(_)
@@ -4131,8 +4149,20 @@ impl VectorRef {
 
         macro_rules! move_range {
             ($from:expr, $to:expr) => {{
-                let mut from_v = $from.borrow_mut();
-                let mut to_v = $to.borrow_mut();
+                // `from` and `to` must be distinct vectors. If they alias,
+                // borrowing both mutably would panic, so return an invariant
+                // violation instead.
+                let (mut from_v, mut to_v) = match ($from.try_borrow_mut(), $to.try_borrow_mut()) {
+                    (Ok(from_v), Ok(to_v)) => (from_v, to_v),
+                    _ => {
+                        return Err(PartialVMError::new(
+                            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                        )
+                        .with_message(
+                            "cannot move range between aliasing vector references".to_string(),
+                        ));
+                    },
+                };
 
                 if removal_position.checked_add(length).map_or(true, |end| end > from_v.len())
                         || insert_position > to_v.len() {


### PR DESCRIPTION
## Description

`Container::swap_contents` borrowed two `RefCell`s mutably. If the two references aliased the same container, the second `borrow_mut` panicked and aborted the VM thread. Move's borrow checker guarantees the two references are distinct, but a broken invariant should surface as a status, not a crash.

This uses `try_borrow_mut` and returns `UNKNOWN_INVARIANT_VIOLATION_ERROR` on the aliasing case instead.

## How Has This Been Tested?

Added a regression case to `test_mem_swap` that swaps a container reference with itself, for both a specialized vector and a generic container. Without the fix it panics; with the fix it returns `Err`.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive VM-runtime hardening that only changes behavior when an aliasing invariant is already broken; normal verified execution paths are unchanged.
> 
> **Overview**
> Hardens Move VM value operations when two mutable references alias the same underlying container—something the bytecode verifier is not supposed to allow, but that previously crashed the interpreter thread.
> 
> **`Container::swap_contents`** now uses `try_borrow_mut` (via a shared `swap!` macro) for all container kinds instead of paired `borrow_mut` calls. If both sides are the same `RefCell`, it returns an **invariant violation** with message `"cannot swap aliasing container references"` instead of panicking.
> 
> **`VectorRef::move_range`** applies the same pattern: concurrent mutable borrows on aliasing `from`/`to` vectors yield **`UNKNOWN_INVARIANT_VIOLATION_ERROR`** (`"cannot move range between aliasing vector references"`) rather than a borrow panic.
> 
> Regression coverage adds self-swap checks in `test_mem_swap` (specialized vector and generic container) and a new **`test_move_range_aliasing`** for moving a range on the same vector reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669937d248c0d734f2346bde987663404064a266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->