### PR TITLE
[cli] Default REST URLs to api.*.aptoslabs.com

### DIFF
--- a/crates/aptos-cli-common/src/options.rs
+++ b/crates/aptos-cli-common/src/options.rs
@@ -696,13 +696,13 @@ impl SaveFile {
 /// Options specific to using the Rest endpoint
 #[derive(Debug, Parser)]
 pub struct RestOptions {
-    /// URL to a fullnode on the network
+    /// URL to the REST API for the network
     ///
     /// Defaults to the URL in the `default` profile
     #[clap(long)]
     pub url: Option<reqwest::Url>,
 
-    /// Connection timeout in seconds, used for the REST endpoint of the fullnode
+    /// Connection timeout in seconds, used for the REST API endpoint
     #[clap(long, default_value_t = DEFAULT_EXPIRATION_SECS, alias = "connection-timeout-s")]
     pub connection_timeout_secs: u64,
 

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+- Change default REST URLs for `aptos init` from `fullnode.*.aptoslabs.com` to `api.*.aptoslabs.com` for mainnet, testnet, and devnet.
+
 ## [9.5.0]
 - Compiler now uses receiver style calls for macro-generated code.
 - Point `aptos update movefmt` at the new `aptos-labs/movefmt` repo and bump default movefmt version to 1.5.3.

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -19,10 +19,16 @@ use crate::{
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, ValidCryptoMaterialStringExt};
 use aptos_ledger;
+use aptos_rest_client::AptosBaseUrl;
 use async_trait::async_trait;
 use clap::Parser;
 use reqwest::Url;
 use std::{collections::BTreeMap, str::FromStr};
+
+/// REST API URL for a public network, without a trailing slash.
+fn public_rest_url(base: AptosBaseUrl) -> String {
+    base.to_url().as_str().trim_end_matches('/').to_string()
+}
 
 /// 1 APT (might not actually get that much, depending on the faucet)
 const NUM_DEFAULT_OCTAS: u64 = 100000000;
@@ -38,7 +44,7 @@ pub struct InitTool {
     #[clap(long)]
     pub network: Option<Network>,
 
-    /// URL to a fullnode on the network
+    /// URL to the REST API for the network
     #[clap(long)]
     pub rest_url: Option<Url>,
 
@@ -136,13 +142,11 @@ impl CliCommand<()> for InitTool {
         // Ensure that there is at least a REST URL set for the network
         match network {
             Network::Mainnet => {
-                profile_config.rest_url =
-                    Some("https://fullnode.mainnet.aptoslabs.com".to_string());
+                profile_config.rest_url = Some(public_rest_url(AptosBaseUrl::Mainnet));
                 profile_config.faucet_url = None;
             },
             Network::Testnet => {
-                profile_config.rest_url =
-                    Some("https://fullnode.testnet.aptoslabs.com".to_string());
+                profile_config.rest_url = Some(public_rest_url(AptosBaseUrl::Testnet));
                 // The faucet in testnet is only accessible with some kind of bypass.
                 // For regular users this can only really mean an auth token. So if
                 // there is no auth token set, we don't set the faucet URL. If the user
@@ -151,7 +155,7 @@ impl CliCommand<()> for InitTool {
                 profile_config.faucet_url = None;
             },
             Network::Devnet => {
-                profile_config.rest_url = Some("https://fullnode.devnet.aptoslabs.com".to_string());
+                profile_config.rest_url = Some(public_rest_url(AptosBaseUrl::Devnet));
                 profile_config.faucet_url = Some("https://faucet.devnet.aptoslabs.com".to_string());
             },
             Network::Local => {
@@ -451,3 +455,24 @@ impl InitTool {
 
 // Re-export from aptos-cli-common so existing `use crate::common::init::Network` paths work.
 pub use aptos_cli_common::Network;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_rest_urls_use_api_hostnames() {
+        assert_eq!(
+            public_rest_url(AptosBaseUrl::Mainnet),
+            "https://api.mainnet.aptoslabs.com"
+        );
+        assert_eq!(
+            public_rest_url(AptosBaseUrl::Testnet),
+            "https://api.testnet.aptoslabs.com"
+        );
+        assert_eq!(
+            public_rest_url(AptosBaseUrl::Devnet),
+            "https://api.devnet.aptoslabs.com"
+        );
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`aptos init` previously wrote `https://fullnode.{mainnet,testnet,devnet}.aptoslabs.com` into `.aptos/config.yaml`. Those defaults now use the public REST API hostnames (`https://api.{mainnet,testnet,devnet}.aptoslabs.com`), matching `aptos-rest-client::AptosBaseUrl`.

Existing profiles are unchanged; only new `aptos init` runs pick up the new URLs.

## How Has This Been Tested?

- Unit test `public_rest_urls_use_api_hostnames` asserts the three public-network defaults.
- `cargo test -p aptos --lib -- public_rest_urls_use_api_hostnames` passed locally.

## Key Areas to Review

- `crates/aptos/src/common/init.rs`: network REST URL defaults now come from `AptosBaseUrl` so they stay in sync with the rest client.
- Help text for `--rest-url` / `--url` now says REST API rather than fullnode.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55949d1d-c12f-4206-a968-2e670bc56a11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55949d1d-c12f-4206-a968-2e670bc56a11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

