### PR TITLE
[cli] Release Aptos CLI 9.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+- _No changes yet._
+
+## [9.5.1]
 - Change default REST URLs for `aptos init` from `fullnode.*.aptoslabs.com` to `api.*.aptoslabs.com` for mainnet, testnet, and devnet.
+- Improve CLI help text and crate README: document `--is-multi-step` and `--next-execution-hash` on governance proposals, and fix a 404 in the multisig payload mismatch error.
 
 ## [9.5.0]
 - Compiler now uses receiver style calls for macro-generated code.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "9.5.0"
+version = "9.5.1"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Patch release for **Aptos CLI 9.5.1** (9.5.0 → 9.5.1).

Ships user-facing CLI changes merged since `aptos-cli-v9.5.0`:

- `aptos init` now uses `api.*.aptoslabs.com` REST endpoints for mainnet, testnet, and devnet instead of `fullnode.*.aptoslabs.com` (#20442).
- Help text and crate README cleanup: document `--is-multi-step` and `--next-execution-hash` on governance proposals, and fix a 404 in the multisig payload mismatch error (#20368).

This PR only bumps the crate version and changelog:
- `crates/aptos/Cargo.toml` → `9.5.1`
- matching `Cargo.lock` entry
- `crates/aptos/CHANGELOG.md`: new `## [9.5.1]` section; `# Unreleased` placeholder

After merge, trigger the **Release CLI** workflow with `release_version=9.5.1` (uncheck dry run) to publish GitHub release assets and the Homebrew bump.

## How Has This Been Tested?

- `cargo check -p aptos` — finished `dev` profile, checking `aptos v9.5.1`
- `cargo test -p aptos --lib public_rest_urls_use_api_hostnames` — `ok. 1 passed; 0 failed`
- Version check matches `scripts/cli/build_cli_release.sh`: Cargo.toml extracts `9.5.1`
- No runtime logic in this diff; functional coverage lives on #20442 and #20368

## Key Areas to Review

- Version string consistency across `Cargo.toml` / `Cargo.lock`
- Changelog grouping under `## [9.5.1]` vs leftover notes under `# Unreleased`

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26f20d2d-5c54-45f8-a5c0-b396e3630b63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26f20d2d-5c54-45f8-a5c0-b396e3630b63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

