### PR TITLE
[github] Move Node 20 GitHub Actions to current runtimes

### DIFF
--- a/.github/actions/buildx-setup/action.yml
+++ b/.github/actions/buildx-setup/action.yml
@@ -10,13 +10,13 @@ runs:
       run: docker context create builders
 
     - name: setup docker buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # pin v3.12.0
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # pin v4.3.0
       with:
         endpoint: builders
         version: v0.31.1
         name: runs-on
         keep-state: true
-        config-inline: |
+        buildkitd-config-inline: |
           [worker.oci]
             gc = true
             gckeepstorage = 900000000000 # Use 900GB out of 1TB for builder storage

--- a/.github/actions/buildx-setup/action.yml
+++ b/.github/actions/buildx-setup/action.yml
@@ -10,7 +10,7 @@ runs:
       run: docker context create builders
 
     - name: setup docker buildx
-      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # pin v4.3.0
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       with:
         endpoint: builders
         version: v0.31.1

--- a/.github/actions/determine-or-use-target-branch-and-get-last-released-image/action.yaml
+++ b/.github/actions/determine-or-use-target-branch-and-get-last-released-image/action.yaml
@@ -32,7 +32,7 @@ runs:
   steps:
     # Checkout repository based on base branch or target branch
     - name: Checkout branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.base-branch || inputs.branch }}
         path: checkout_branch
@@ -61,7 +61,7 @@ runs:
     # Checkout the determined or target branch
     - name: Checkout target branch
       if: ${{ steps.set-target-branch.outputs.TARGET_BRANCH != inputs.branch }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ steps.set-target-branch.outputs.TARGET_BRANCH }}
         path: checkout_branch

--- a/.github/actions/determine-or-use-target-branch-and-get-last-released-image/action.yaml
+++ b/.github/actions/determine-or-use-target-branch-and-get-last-released-image/action.yaml
@@ -32,7 +32,7 @@ runs:
   steps:
     # Checkout repository based on base branch or target branch
     - name: Checkout branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         ref: ${{ inputs.base-branch || inputs.branch }}
         path: checkout_branch
@@ -61,7 +61,7 @@ runs:
     # Checkout the determined or target branch
     - name: Checkout target branch
       if: ${{ steps.set-target-branch.outputs.TARGET_BRANCH != inputs.branch }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         ref: ${{ steps.set-target-branch.outputs.TARGET_BRANCH }}
         path: checkout_branch

--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -77,7 +77,7 @@ runs:
 
     - id: auth
       name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@v3"
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         create_credentials_file: false
         token_format: "access_token"
@@ -87,21 +87,21 @@ runs:
         export_environment_variables: ${{ inputs.EXPORT_GCP_PROJECT_VARIABLES }}
 
     - name: Login to us-west1 Google Artifact Registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: us-west1-docker.pkg.dev
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Login to US multi-region Google Artifact Registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: us-docker.pkg.dev
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Login to ECR
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       if: inputs.AWS_ACCESS_KEY_ID != ''
       with:
         registry: ${{ inputs.AWS_DOCKER_ARTIFACT_REPO }}

--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -77,7 +77,7 @@ runs:
 
     - id: auth
       name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@v2"
+      uses: "google-github-actions/auth@v3"
       with:
         create_credentials_file: false
         token_format: "access_token"
@@ -87,21 +87,21 @@ runs:
         export_environment_variables: ${{ inputs.EXPORT_GCP_PROJECT_VARIABLES }}
 
     - name: Login to us-west1 Google Artifact Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         registry: us-west1-docker.pkg.dev
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Login to US multi-region Google Artifact Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         registry: us-docker.pkg.dev
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Login to ECR
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       if: inputs.AWS_ACCESS_KEY_ID != ''
       with:
         registry: ${{ inputs.AWS_DOCKER_ARTIFACT_REPO }}

--- a/.github/actions/get-latest-cli/action.yaml
+++ b/.github/actions/get-latest-cli/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
     - name: Get installation script
       shell: bash
       run: |

--- a/.github/actions/get-latest-cli/action.yaml
+++ b/.github/actions/get-latest-cli/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
     - name: Get installation script
       shell: bash
       run: |

--- a/.github/actions/get-latest-docker-image-tag/action.yml
+++ b/.github/actions/get-latest-docker-image-tag/action.yml
@@ -18,7 +18,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         ref: ${{ inputs.branch }}
         path: checkout_branch

--- a/.github/actions/get-latest-docker-image-tag/action.yml
+++ b/.github/actions/get-latest-docker-image-tag/action.yml
@@ -18,7 +18,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.branch }}
         path: checkout_branch

--- a/.github/actions/python-setup/action.yaml
+++ b/.github/actions/python-setup/action.yaml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: 3.10.12
 

--- a/.github/actions/python-setup/action.yaml
+++ b/.github/actions/python-setup/action.yaml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.10.12
 

--- a/.github/actions/wait-images-ci/action.yaml
+++ b/.github/actions/wait-images-ci/action.yaml
@@ -27,10 +27,10 @@ runs:
   using: composite
   steps:
     # Deps setup
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version-file: .node-version
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
 
     # The source code must be checkout out by the workflow that invokes this action.
     - name: Run wait-images-ci

--- a/.github/actions/wait-images-ci/action.yaml
+++ b/.github/actions/wait-images-ci/action.yaml
@@ -27,10 +27,10 @@ runs:
   using: composite
   steps:
     # Deps setup
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version-file: .node-version
-    - uses: pnpm/action-setup@v6
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     # The source code must be checkout out by the workflow that invokes this action.
     - name: Run wait-images-ci

--- a/.github/workflows/aptos-node-release.yaml
+++ b/.github/workflows/aptos-node-release.yaml
@@ -24,11 +24,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
 
       - name: Bump aptos-node version
         uses: aptos-labs/aptos-core/.github/actions/release-aptos-node@main

--- a/.github/workflows/aptos-node-release.yaml
+++ b/.github/workflows/aptos-node-release.yaml
@@ -24,11 +24,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.branch }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
 
       - name: Bump aptos-node version
         uses: aptos-labs/aptos-core/.github/actions/release-aptos-node@main

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -102,7 +102,7 @@ jobs:
             "${{ inputs.release_version }}" \
             "${{ inputs.skip_checks }}"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binary-builds-x86_64-unknown-linux-gnu
           path: |
@@ -126,7 +126,7 @@ jobs:
             "${{ inputs.release_version }}" \
             "${{ inputs.skip_checks }}"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binary-builds-aarch64-unknown-linux-gnu
           path: |
@@ -150,7 +150,7 @@ jobs:
             "${{ inputs.release_version }}" \
             "${{ inputs.skip_checks }}"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binary-builds-x86_64-apple-darwin
           path: |
@@ -174,7 +174,7 @@ jobs:
             "${{ inputs.release_version }}" \
             "${{ inputs.skip_checks }}"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binary-builds-aarch64-apple-darwin
           path: |
@@ -205,7 +205,7 @@ jobs:
             -SkipChecks $${{ inputs.skip_checks }}
         shell: powershell
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binary-builds-x86_64-pc-windows-msvc
           path: |
@@ -227,7 +227,7 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     steps:
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: binary-builds-*
           merge-multiple: true

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -89,7 +89,7 @@ jobs:
     name: "Build Linux x86_64"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.source_git_ref_override || github.sha }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -102,7 +102,7 @@ jobs:
             "${{ inputs.release_version }}" \
             "${{ inputs.skip_checks }}"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: binary-builds-x86_64-unknown-linux-gnu
           path: |
@@ -113,7 +113,7 @@ jobs:
     name: "Build Linux ARM64"
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.source_git_ref_override || github.sha }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -126,7 +126,7 @@ jobs:
             "${{ inputs.release_version }}" \
             "${{ inputs.skip_checks }}"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: binary-builds-aarch64-unknown-linux-gnu
           path: |
@@ -137,7 +137,7 @@ jobs:
     name: "Build macOS x86_64"
     runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.source_git_ref_override || github.sha }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -150,7 +150,7 @@ jobs:
             "${{ inputs.release_version }}" \
             "${{ inputs.skip_checks }}"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: binary-builds-x86_64-apple-darwin
           path: |
@@ -161,7 +161,7 @@ jobs:
     name: "Build macOS ARM64"
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.source_git_ref_override || github.sha }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -174,7 +174,7 @@ jobs:
             "${{ inputs.release_version }}" \
             "${{ inputs.skip_checks }}"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: binary-builds-aarch64-apple-darwin
           path: |
@@ -185,7 +185,7 @@ jobs:
     name: "Build Windows x86_64"
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.source_git_ref_override || github.sha }}
       # Ensure we use caching
@@ -205,7 +205,7 @@ jobs:
             -SkipChecks $${{ inputs.skip_checks }}
         shell: powershell
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: binary-builds-x86_64-pc-windows-msvc
           path: |
@@ -227,7 +227,7 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     steps:
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: binary-builds-*
           merge-multiple: true

--- a/.github/workflows/bump-release-version.yaml
+++ b/.github/workflows/bump-release-version.yaml
@@ -21,12 +21,12 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Determine next version and update aptos-node/Cargo.toml
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         id: determine-version
         with:
           script: |

--- a/.github/workflows/bump-release-version.yaml
+++ b/.github/workflows/bump-release-version.yaml
@@ -21,12 +21,12 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Determine next version and update aptos-node/Cargo.toml
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: determine-version
         with:
           script: |

--- a/.github/workflows/calibrate-execution-performance.yaml
+++ b/.github/workflows/calibrate-execution-performance.yaml
@@ -22,10 +22,10 @@ jobs:
       )
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Post calibration PR to Slack
         if: ${{ steps.create-pr.outputs.pull-request-number }}
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # pin@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.EXECUTION_PERF_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/cargo-metadata-upload.yaml
+++ b/.github/workflows/cargo-metadata-upload.yaml
@@ -13,10 +13,10 @@ jobs:
   cargo-metadata:
     runs-on: runs-on,cpu=4,ram=16,family=m7a+m7i-flex,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dsherret/rust-toolchain-file@v1
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/cargo-metadata-upload.yaml
+++ b/.github/workflows/cargo-metadata-upload.yaml
@@ -13,10 +13,10 @@ jobs:
   cargo-metadata:
     runs-on: runs-on,cpu=4,ram=16,family=m7a+m7i-flex,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: dsherret/rust-toolchain-file@v1
       - id: auth
-        uses: "google-github-actions/auth@v3"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/check-minimum-revision.yaml
+++ b/.github/workflows/check-minimum-revision.yaml
@@ -23,7 +23,7 @@ jobs:
   check-minimum-revision:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ env.GIT_SHA }}
           fetch-depth: 1000

--- a/.github/workflows/check-minimum-revision.yaml
+++ b/.github/workflows/check-minimum-revision.yaml
@@ -23,7 +23,7 @@ jobs:
   check-minimum-revision:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.GIT_SHA }}
           fetch-depth: 1000

--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}

--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}

--- a/.github/workflows/cli-external-deps.yaml
+++ b/.github/workflows/cli-external-deps.yaml
@@ -14,7 +14,7 @@ jobs:
   check-dynamic-deps:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}

--- a/.github/workflows/cli-external-deps.yaml
+++ b/.github/workflows/cli-external-deps.yaml
@@ -14,7 +14,7 @@ jobs:
   check-dynamic-deps:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -35,14 +35,14 @@ jobs:
     name: "Build Ubuntu 22.04 binary"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-22.04" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-builds-ubuntu-22.04
           path: aptos-cli-*.zip
@@ -52,14 +52,14 @@ jobs:
     name: "Build Ubuntu 24.04 binary"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-24.04" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-builds-ubuntu-24.04
           path: aptos-cli-*.zip
@@ -71,14 +71,14 @@ jobs:
     name: "Build Linux binary"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Linux" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "true"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-builds-linux
           path: aptos-cli-*.zip
@@ -88,14 +88,14 @@ jobs:
     name: "Build Linux ARM binary"
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Linux" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-builds-linux-arm
           path: aptos-cli-*.zip
@@ -104,14 +104,14 @@ jobs:
     name: "Build MacOS x86_64 binary"
     runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-builds-macos-x86-64
           path: aptos-cli-*.zip
@@ -120,14 +120,14 @@ jobs:
     name: "Build MacOS ARM binary"
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-builds-macos-arm
           path: aptos-cli-*.zip
@@ -136,7 +136,7 @@ jobs:
     name: "Build Windows binary"
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       # Ensure that long paths work
@@ -146,7 +146,7 @@ jobs:
       - name: Build CLI
         run: scripts\cli\build_cli_release.ps1
       - name: Upload Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-builds-windows
           path: aptos-cli-*.zip
@@ -168,7 +168,7 @@ jobs:
     if: ${{ !inputs.dry_run }}
     steps:
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: cli-builds-*
           merge-multiple: true

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -35,14 +35,14 @@ jobs:
     name: "Build Ubuntu 22.04 binary"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-22.04" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cli-builds-ubuntu-22.04
           path: aptos-cli-*.zip
@@ -52,14 +52,14 @@ jobs:
     name: "Build Ubuntu 24.04 binary"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-24.04" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cli-builds-ubuntu-24.04
           path: aptos-cli-*.zip
@@ -71,14 +71,14 @@ jobs:
     name: "Build Linux binary"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Linux" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "true"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cli-builds-linux
           path: aptos-cli-*.zip
@@ -88,14 +88,14 @@ jobs:
     name: "Build Linux ARM binary"
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Linux" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cli-builds-linux-arm
           path: aptos-cli-*.zip
@@ -104,14 +104,14 @@ jobs:
     name: "Build MacOS x86_64 binary"
     runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cli-builds-macos-x86-64
           path: aptos-cli-*.zip
@@ -120,14 +120,14 @@ jobs:
     name: "Build MacOS ARM binary"
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cli-builds-macos-arm
           path: aptos-cli-*.zip
@@ -136,7 +136,7 @@ jobs:
     name: "Build Windows binary"
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       # Ensure that long paths work
@@ -146,7 +146,7 @@ jobs:
       - name: Build CLI
         run: scripts\cli\build_cli_release.ps1
       - name: Upload Binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cli-builds-windows
           path: aptos-cli-*.zip
@@ -168,7 +168,7 @@ jobs:
     if: ${{ !inputs.dry_run }}
     steps:
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: cli-builds-*
           merge-multiple: true

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           days-before-stale: 45
           days-before-close: 15

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v10
         with:
           days-before-stale: 45
           days-before-close: 15

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write # required by actions/stale v10 to create/delete its progress cache
   # contents: write # only for delete-branch option
   issues: write
   pull-requests: write

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -41,7 +41,7 @@ jobs:
     # Run on a machine with more local storage for large docker images
     runs-on: runs-on,cpu=16,family=m6id,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
@@ -50,16 +50,16 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: .node-version
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Release Images
         env:

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -41,7 +41,7 @@ jobs:
     # Run on a machine with more local storage for large docker images
     runs-on: runs-on,cpu=16,family=m6id,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
@@ -50,16 +50,16 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Release Images
         env:

--- a/.github/workflows/coverage-move-only.yaml
+++ b/.github/workflows/coverage-move-only.yaml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 60
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: prepare move lang prover tooling.
         shell: bash
@@ -56,11 +56,11 @@ jobs:
       - run: cargo llvm-cov nextest --lcov --output-path lcov_unit.info --ignore-run-fail -p aptos-framework -p "move*"
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: lcov_unit
           path: lcov_unit.info
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: lcov_unit
       - name: Upload coverage to Codecov

--- a/.github/workflows/coverage-move-only.yaml
+++ b/.github/workflows/coverage-move-only.yaml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 60
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: prepare move lang prover tooling.
         shell: bash
@@ -56,11 +56,11 @@ jobs:
       - run: cargo llvm-cov nextest --lcov --output-path lcov_unit.info --ignore-run-fail -p aptos-framework -p "move*"
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: lcov_unit
           path: lcov_unit.info
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: lcov_unit
       - name: Upload coverage to Codecov

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 720
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -49,7 +49,7 @@ jobs:
           CVC5_EXE: /home/runner/bin/cvc5
           DOTNET_ROOT: /home/runner/.dotnet
           BOOGIE_EXE: /home/runner/.dotnet/tools/boogie
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: lcov_unit
           path: lcov_unit.info
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 720 # incremented from 240 due to execution time limit hit in cron
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -77,7 +77,7 @@ jobs:
           CVC5_EXE: /home/runner/bin/cvc5
           DOTNET_ROOT: /home/runner/.dotnet
           BOOGIE_EXE: /home/runner/.dotnet/tools/boogie
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: lcov_smoke
           path: lcov_smoke.info
@@ -93,11 +93,11 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v7
         with:
           name: lcov_unit
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: lcov_smoke
       - name: Upload coverage to Codecov

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 720
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -49,7 +49,7 @@ jobs:
           CVC5_EXE: /home/runner/bin/cvc5
           DOTNET_ROOT: /home/runner/.dotnet
           BOOGIE_EXE: /home/runner/.dotnet/tools/boogie
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: lcov_unit
           path: lcov_unit.info
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 720 # incremented from 240 due to execution time limit hit in cron
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -77,7 +77,7 @@ jobs:
           CVC5_EXE: /home/runner/bin/cvc5
           DOTNET_ROOT: /home/runner/.dotnet
           BOOGIE_EXE: /home/runner/.dotnet/tools/boogie
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: lcov_smoke
           path: lcov_smoke.info
@@ -93,11 +93,11 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v7
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: lcov_unit
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: lcov_smoke
       - name: Upload coverage to Codecov

--- a/.github/workflows/cut-release-branch.yaml
+++ b/.github/workflows/cut-release-branch.yaml
@@ -31,7 +31,7 @@ jobs:
   cut-release-branch:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.CUT_RELEASE_BRANCH_CREDENTIALS }}
           fetch-depth: 0

--- a/.github/workflows/cut-release-branch.yaml
+++ b/.github/workflows/cut-release-branch.yaml
@@ -31,7 +31,7 @@ jobs:
   cut-release-branch:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ secrets.CUT_RELEASE_BRANCH_CREDENTIALS }}
           fetch-depth: 0

--- a/.github/workflows/docker-build-rosetta.yaml
+++ b/.github/workflows/docker-build-rosetta.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: aptos-labs/aptos-core/.github/actions/buildx-setup@main
 

--- a/.github/workflows/docker-build-rosetta.yaml
+++ b/.github/workflows/docker-build-rosetta.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - uses: aptos-labs/aptos-core/.github/actions/buildx-setup@main
 

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -120,7 +120,7 @@ jobs:
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run the file change determinator
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
@@ -132,7 +132,7 @@ jobs:
     outputs:
       run_framework_upgrade_test: ${{ steps.determine_test_targets.outputs.run_framework_upgrade_test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Target determination must analyze the PR revision with full history.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -303,7 +303,7 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           ref: ${{ github.ref }}

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -120,7 +120,7 @@ jobs:
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Run the file change determinator
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
@@ -132,7 +132,7 @@ jobs:
     outputs:
       run_framework_upgrade_test: ${{ steps.determine_test_targets.outputs.run_framework_upgrade_test }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # Target determination must analyze the PR revision with full history.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -303,7 +303,7 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 1
           ref: ${{ github.ref }}

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}

--- a/.github/workflows/faucet-tests-main.yaml
+++ b/.github/workflows/faucet-tests-main.yaml
@@ -55,7 +55,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ env.GIT_SHA }}

--- a/.github/workflows/faucet-tests-main.yaml
+++ b/.github/workflows/faucet-tests-main.yaml
@@ -55,7 +55,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ env.GIT_SHA }}

--- a/.github/workflows/faucet-tests-prod.yaml
+++ b/.github/workflows/faucet-tests-prod.yaml
@@ -39,7 +39,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -62,7 +62,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/faucet-tests-prod.yaml
+++ b/.github/workflows/faucet-tests-prod.yaml
@@ -39,7 +39,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -62,7 +62,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -9,6 +9,6 @@ jobs:
   find-packages-with-undeclared-feature-dependencies:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - run: scripts/find-packages-with-undeclared-feature-dependencies.sh

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -9,6 +9,6 @@ jobs:
   find-packages-with-undeclared-feature-dependencies:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - run: scripts/find-packages-with-undeclared-feature-dependencies.sh

--- a/.github/workflows/forge-continuous-land-blocking-test.yaml
+++ b/.github/workflows/forge-continuous-land-blocking-test.yaml
@@ -47,7 +47,7 @@ jobs:
     needs: [permission-check]
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -103,7 +103,7 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           ref: ${{ github.ref }}

--- a/.github/workflows/forge-continuous-land-blocking-test.yaml
+++ b/.github/workflows/forge-continuous-land-blocking-test.yaml
@@ -47,7 +47,7 @@ jobs:
     needs: [permission-check]
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -103,7 +103,7 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 1
           ref: ${{ github.ref }}

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: Compute matrix
         id: set-matrix
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           TEST_NAME: ${{ inputs.TEST_NAME }}
         with:
@@ -177,7 +177,7 @@ jobs:
       BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
       BRANCH_HASH: ${{ steps.hash-branch.outputs.BRANCH_HASH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Determine branch based on cadence
         id: determine-test-branch

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: Compute matrix
         id: set-matrix
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           TEST_NAME: ${{ inputs.TEST_NAME }}
         with:
@@ -177,7 +177,7 @@ jobs:
       BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
       BRANCH_HASH: ${{ steps.hash-branch.outputs.BRANCH_HASH }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Determine branch based on cadence
         id: determine-test-branch

--- a/.github/workflows/fuzzer-data-update.yml
+++ b/.github/workflows/fuzzer-data-update.yml
@@ -19,16 +19,16 @@ jobs:
     runs-on: runs-on,cpu=16,family=m6id,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v3'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           version: '>= 418.0.0'
 

--- a/.github/workflows/fuzzer-data-update.yml
+++ b/.github/workflows/fuzzer-data-update.yml
@@ -19,16 +19,16 @@ jobs:
     runs-on: runs-on,cpu=16,family=m6id,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
         with:
           version: '>= 418.0.0'
 

--- a/.github/workflows/indexer-processor-testing.yaml
+++ b/.github/workflows/indexer-processor-testing.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -40,14 +40,14 @@ jobs:
         run: rustup update
 
       - id: auth
-        uses: "google-github-actions/auth@v3"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Prepare and Replace API Keys in Yaml
         id: api_key_tokens
-        uses: 'google-github-actions/get-secretmanager-secrets@v3'
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
         with:
           secrets: |-
             testnet_api_key:aptos-ci/TESTNET_INDEXER_API_KEY
@@ -141,7 +141,7 @@ jobs:
 
       - id: 'secrets'
         if: steps.diff_check.outputs.diff_found == 'true' && steps.diff_check.outputs.new_file_found == 'false'
-        uses: 'google-github-actions/get-secretmanager-secrets@v3'
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
         with:
           secrets: |-
             token:aptos-ci/github-actions-repository-dispatch

--- a/.github/workflows/indexer-processor-testing.yaml
+++ b/.github/workflows/indexer-processor-testing.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -40,14 +40,14 @@ jobs:
         run: rustup update
 
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Prepare and Replace API Keys in Yaml
         id: api_key_tokens
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        uses: 'google-github-actions/get-secretmanager-secrets@v3'
         with:
           secrets: |-
             testnet_api_key:aptos-ci/TESTNET_INDEXER_API_KEY
@@ -141,7 +141,7 @@ jobs:
 
       - id: 'secrets'
         if: steps.diff_check.outputs.diff_found == 'true' && steps.diff_check.outputs.new_file_found == 'false'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        uses: 'google-github-actions/get-secretmanager-secrets@v3'
         with:
           secrets: |-
             token:aptos-ci/github-actions-repository-dispatch

--- a/.github/workflows/indexer-protos-sdk-update.yaml
+++ b/.github/workflows/indexer-protos-sdk-update.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       changes: ${{ steps.check_changes.outputs.changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Install buf, which we use to generate code from the protos for Rust and TS.
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1.24.0
@@ -29,7 +29,7 @@ jobs:
         with:
           version: "25.x"
       # Set up pnpm.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       # Set up Poetry.
       - name: Install Python deps for generating code from protos
         uses: ./.github/actions/python-setup
@@ -67,7 +67,7 @@ jobs:
       )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Install buf, which we use to generate code from the protos for Rust and TS.
       - name: Install buf
@@ -90,13 +90,13 @@ jobs:
       
       - name: Google Cloud Auth
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
       - name: Get Secret Manager Secrets
         id: secrets
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        uses: 'google-github-actions/get-secretmanager-secrets@v3'
         with:
           secrets: |-
             token:aptos-ci/github-actions-repository-dispatch

--- a/.github/workflows/indexer-protos-sdk-update.yaml
+++ b/.github/workflows/indexer-protos-sdk-update.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       changes: ${{ steps.check_changes.outputs.changes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Install buf, which we use to generate code from the protos for Rust and TS.
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1.24.0
@@ -29,7 +29,7 @@ jobs:
         with:
           version: "25.x"
       # Set up pnpm.
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       # Set up Poetry.
       - name: Install Python deps for generating code from protos
         uses: ./.github/actions/python-setup
@@ -67,7 +67,7 @@ jobs:
       )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Install buf, which we use to generate code from the protos for Rust and TS.
       - name: Install buf
@@ -90,13 +90,13 @@ jobs:
       
       - name: Google Cloud Auth
         id: auth
-        uses: "google-github-actions/auth@v3"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
       - name: Get Secret Manager Secrets
         id: secrets
-        uses: 'google-github-actions/get-secretmanager-secrets@v3'
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
         with:
           secrets: |-
             token:aptos-ci/github-actions-repository-dispatch

--- a/.github/workflows/lean.yaml
+++ b/.github/workflows/lean.yaml
@@ -40,7 +40,7 @@ jobs:
   build-and-test:
     runs-on: runs-on,cpu=32,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Lean toolchain
         run: |

--- a/.github/workflows/lean.yaml
+++ b/.github/workflows/lean.yaml
@@ -40,7 +40,7 @@ jobs:
   build-and-test:
     runs-on: runs-on,cpu=32,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Lean toolchain
         run: |

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Run the file change determinator
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
@@ -44,7 +44,7 @@ jobs:
     needs: file_change_determinator
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           fetch-depth: 0 # get all the history because python-lint-tests requires it.
@@ -62,7 +62,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - run: python3 scripts/check-cryptohasher-symbols.py
 
   # Run all rust lints. This is a PR required job.
@@ -70,7 +70,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
@@ -87,7 +87,7 @@ jobs:
     needs: file_change_determinator
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - uses: EmbarkStudios/cargo-deny-action@v2
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -107,7 +107,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Run rust doc tests
         uses: ./.github/actions/rust-doc-tests
         with:
@@ -161,7 +161,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
@@ -179,7 +179,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
@@ -206,7 +206,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
       - name: Run dev_setup.sh
@@ -237,7 +237,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Install Move Prover tools
       - name: Run dev_setup.sh
         run: |
@@ -262,7 +262,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - name: Run aptos cached packages build test
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -275,7 +275,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - run: cargo nextest run --locked --workspace --exclude smoke-test --exclude aptos-testcases --exclude aptos-api --exclude aptos-executor-benchmark --exclude aptos-backup-cli --retries 3 --no-fail-fast -F consensus-only-perf-test
         env:
           RUST_MIN_STACK: 4297152
@@ -285,14 +285,14 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # prebuild aptos-node binary, so that tests don't start before node is built.
       # also prebuild aptos-node binary as a separate step to avoid feature unification issues
       - run: cargo build --locked --package=aptos-node -F consensus-only-perf-test --release && LOCAL_SWARM_NODE_RELEASE=1 CONSENSUS_ONLY_PERF_TEST=1 cargo nextest run --release --package smoke-test -E "test(test_consensus_only_with_txn_emitter)" --run-ignored all
 
       # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.
       - name: Upload smoke test logs for failed and flaky tests
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ failure() || success() }}
         with:
           name: failed-consensus-only-smoke-test-logs

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run the file change determinator
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
@@ -44,7 +44,7 @@ jobs:
     needs: file_change_determinator
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           fetch-depth: 0 # get all the history because python-lint-tests requires it.
@@ -62,7 +62,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: python3 scripts/check-cryptohasher-symbols.py
 
   # Run all rust lints. This is a PR required job.
@@ -70,7 +70,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
@@ -87,7 +87,7 @@ jobs:
     needs: file_change_determinator
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - uses: EmbarkStudios/cargo-deny-action@v2
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -107,7 +107,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run rust doc tests
         uses: ./.github/actions/rust-doc-tests
         with:
@@ -161,7 +161,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
@@ -179,7 +179,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
@@ -206,7 +206,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
       - name: Run dev_setup.sh
@@ -237,7 +237,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Install Move Prover tools
       - name: Run dev_setup.sh
         run: |
@@ -262,7 +262,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - name: Run aptos cached packages build test
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -275,7 +275,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: cargo nextest run --locked --workspace --exclude smoke-test --exclude aptos-testcases --exclude aptos-api --exclude aptos-executor-benchmark --exclude aptos-backup-cli --retries 3 --no-fail-fast -F consensus-only-perf-test
         env:
           RUST_MIN_STACK: 4297152
@@ -285,14 +285,14 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # prebuild aptos-node binary, so that tests don't start before node is built.
       # also prebuild aptos-node binary as a separate step to avoid feature unification issues
       - run: cargo build --locked --package=aptos-node -F consensus-only-perf-test --release && LOCAL_SWARM_NODE_RELEASE=1 CONSENSUS_ONLY_PERF_TEST=1 cargo nextest run --release --package smoke-test -E "test(test_consensus_only_with_txn_emitter)" --run-ignored all
 
       # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.
       - name: Upload smoke test logs for failed and flaky tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ failure() || success() }}
         with:
           name: failed-consensus-only-smoke-test-logs

--- a/.github/workflows/mono-move-micro-bench.yaml
+++ b/.github/workflows/mono-move-micro-bench.yaml
@@ -29,7 +29,7 @@ jobs:
     env:
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0 # Full history so the base ref is reachable.

--- a/.github/workflows/mono-move-micro-bench.yaml
+++ b/.github/workflows/mono-move-micro-bench.yaml
@@ -29,7 +29,7 @@ jobs:
     env:
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0 # Full history so the base ref is reachable.

--- a/.github/workflows/mono-move-miri.yaml
+++ b/.github/workflows/mono-move-miri.yaml
@@ -60,7 +60,7 @@ jobs:
       # this carefully.
       PROPTEST_CASES: ${{ github.event_name == 'pull_request' && '1' || '4' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Deliberately NOT the shared rust-setup action: it installs the stable
       # toolchain named by rust-toolchain.toml, and Miri is nightly-only.

--- a/.github/workflows/mono-move-miri.yaml
+++ b/.github/workflows/mono-move-miri.yaml
@@ -60,7 +60,7 @@ jobs:
       # this carefully.
       PROPTEST_CASES: ${{ github.event_name == 'pull_request' && '1' || '4' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Deliberately NOT the shared rust-setup action: it installs the stable
       # toolchain named by rust-toolchain.toml, and Miri is nightly-only.

--- a/.github/workflows/move-flow-release.yaml
+++ b/.github/workflows/move-flow-release.yaml
@@ -33,7 +33,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       source_sha: ${{ steps.resolve.outputs.sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.source_git_ref_override || github.sha }}
           fetch-depth: 0

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -51,7 +51,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ env.GIT_SHA }}
@@ -66,7 +66,7 @@ jobs:
           AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         if: ${{ !inputs.SKIP_JOB }}
         with:
           node-version-file: .node-version
@@ -74,7 +74,7 @@ jobs:
 
       # Self hosted runners don't have pnpm preinstalled.
       # https://github.com/actions/setup-node/issues/182
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         if: ${{ !inputs.SKIP_JOB }}
 
       # When using high-perf-docker, the CI is actually run with two containers

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -51,7 +51,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ env.GIT_SHA }}
@@ -66,7 +66,7 @@ jobs:
           AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: ${{ !inputs.SKIP_JOB }}
         with:
           node-version-file: .node-version
@@ -74,7 +74,7 @@ jobs:
 
       # Self hosted runners don't have pnpm preinstalled.
       # https://github.com/actions/setup-node/issues/182
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         if: ${{ !inputs.SKIP_JOB }}
 
       # When using high-perf-docker, the CI is actually run with two containers

--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     timeout-minutes: ${{ github.event_name == 'pull_request' && 10 || 480}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/move-prover-setup

--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     timeout-minutes: ${{ github.event_name == 'pull_request' && 10 || 480}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/move-prover-setup

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -14,11 +14,11 @@ jobs:
     if: github.repository == 'aptos-labs/aptos-core'
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - run: pnpm i && pnpm pruneGithubWorkflowRuns
         env:

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -14,11 +14,11 @@ jobs:
     if: github.repository == 'aptos-labs/aptos-core'
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: .node-version
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - run: pnpm i && pnpm pruneGithubWorkflowRuns
         env:

--- a/.github/workflows/rate-limit.yaml
+++ b/.github/workflows/rate-limit.yaml
@@ -39,7 +39,7 @@ jobs:
             }' > rate_limit.json
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }} # needed because gcloud storage is GA but under alpha surface on some images

--- a/.github/workflows/rate-limit.yaml
+++ b/.github/workflows/rate-limit.yaml
@@ -39,7 +39,7 @@ jobs:
             }' > rate_limit.json
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }} # needed because gcloud storage is GA but under alpha surface on some images

--- a/.github/workflows/run-fullnode-sync.yaml
+++ b/.github/workflows/run-fullnode-sync.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: runs-on,family=c5ad.8xlarge,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=false
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 300 }} # the default run is 300 minutes (5 hours). Specified here because workflow_dispatch uses string rather than number
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Dump all inputs to GITHUB_STEP_SUMMARY
         run: |
@@ -86,7 +86,7 @@ jobs:
           METRICS_DUMP_FILE_PATH: ${{ runner.temp }}/metrics
 
       - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ always() }}
         with:
           name: node_log
@@ -95,7 +95,7 @@ jobs:
           retention-days: 14
 
       - name: Upload the metrics dump as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ always() }}
         with:
           name: metrics
@@ -118,6 +118,6 @@ jobs:
       # Because we have to checkout the actions and then check out a different
       # git ref, it's possible the actions directory will be modified. So, we
       # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: actions

--- a/.github/workflows/run-fullnode-sync.yaml
+++ b/.github/workflows/run-fullnode-sync.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: runs-on,family=c5ad.8xlarge,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=false
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 300 }} # the default run is 300 minutes (5 hours). Specified here because workflow_dispatch uses string rather than number
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Dump all inputs to GITHUB_STEP_SUMMARY
         run: |
@@ -86,7 +86,7 @@ jobs:
           METRICS_DUMP_FILE_PATH: ${{ runner.temp }}/metrics
 
       - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ always() }}
         with:
           name: node_log
@@ -95,7 +95,7 @@ jobs:
           retention-days: 14
 
       - name: Upload the metrics dump as an artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ always() }}
         with:
           name: metrics
@@ -118,6 +118,6 @@ jobs:
       # Because we have to checkout the actions and then check out a different
       # git ref, it's possible the actions directory will be modified. So, we
       # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           path: actions

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -30,7 +30,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -30,7 +30,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -52,7 +52,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -71,7 +71,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -52,7 +52,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -71,7 +71,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -22,7 +22,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - run: semgrep ci
         env:
            SEMGREP_RULES: >-

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -22,7 +22,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: semgrep ci
         env:
            SEMGREP_RULES: >-

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -21,12 +21,12 @@ jobs:
     if: inputs.only_docs_changed != 'true'
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Build aptos-node
         run: cargo build --locked --package=aptos-node --features=failpoints,smoke-test --release
         shell: bash
       - name: Save aptos-node binary to cache
-        uses: runs-on/cache/save@v5
+        uses: runs-on/cache/save@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
         with:
           path: target/release/aptos-node
           key: smoke-aptos-node-${{ github.run_id }}
@@ -36,7 +36,7 @@ jobs:
     if: inputs.only_docs_changed != 'true'
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Build smoke test archive and helper binaries
         run: |
           # Build helper binaries needed by smoke tests
@@ -47,7 +47,7 @@ jobs:
           LOCAL_SWARM_NODE_RELEASE=1 cargo nextest archive --locked --release --package smoke-test --archive-file smoke-test-archive.tar.zst
         shell: bash
       - name: Save smoke test artifacts to cache
-        uses: runs-on/cache/save@v5
+        uses: runs-on/cache/save@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
         with:
           path: |
             target/release/aptos
@@ -65,7 +65,7 @@ jobs:
       matrix:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Run postgres database
         run: docker run --detach -p 5432:5432 cimg/postgres:14.2
@@ -73,14 +73,14 @@ jobs:
 
       # Restore pre-built artifacts from both parallel build jobs
       - name: Restore aptos-node binary from cache
-        uses: runs-on/cache/restore@v5
+        uses: runs-on/cache/restore@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
         with:
           path: target/release/aptos-node
           key: smoke-aptos-node-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Restore smoke test archive and helper binaries from cache
-        uses: runs-on/cache/restore@v5
+        uses: runs-on/cache/restore@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
         with:
           path: |
             target/release/aptos
@@ -105,7 +105,7 @@ jobs:
       # Upload logs on failure for debugging.
       - name: Upload smoke test logs for failed and flaky tests
         if: ${{ failure() || success() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: failed-smoke-test-logs-${{ matrix.partition }}
           include-hidden-files: true

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -21,12 +21,12 @@ jobs:
     if: inputs.only_docs_changed != 'true'
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build aptos-node
         run: cargo build --locked --package=aptos-node --features=failpoints,smoke-test --release
         shell: bash
       - name: Save aptos-node binary to cache
-        uses: runs-on/cache/save@v4
+        uses: runs-on/cache/save@v5
         with:
           path: target/release/aptos-node
           key: smoke-aptos-node-${{ github.run_id }}
@@ -36,7 +36,7 @@ jobs:
     if: inputs.only_docs_changed != 'true'
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build smoke test archive and helper binaries
         run: |
           # Build helper binaries needed by smoke tests
@@ -47,7 +47,7 @@ jobs:
           LOCAL_SWARM_NODE_RELEASE=1 cargo nextest archive --locked --release --package smoke-test --archive-file smoke-test-archive.tar.zst
         shell: bash
       - name: Save smoke test artifacts to cache
-        uses: runs-on/cache/save@v4
+        uses: runs-on/cache/save@v5
         with:
           path: |
             target/release/aptos
@@ -65,7 +65,7 @@ jobs:
       matrix:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run postgres database
         run: docker run --detach -p 5432:5432 cimg/postgres:14.2
@@ -73,14 +73,14 @@ jobs:
 
       # Restore pre-built artifacts from both parallel build jobs
       - name: Restore aptos-node binary from cache
-        uses: runs-on/cache/restore@v4
+        uses: runs-on/cache/restore@v5
         with:
           path: target/release/aptos-node
           key: smoke-aptos-node-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Restore smoke test archive and helper binaries from cache
-        uses: runs-on/cache/restore@v4
+        uses: runs-on/cache/restore@v5
         with:
           path: |
             target/release/aptos
@@ -105,7 +105,7 @@ jobs:
       # Upload logs on failure for debugging.
       - name: Upload smoke test logs for failed and flaky tests
         if: ${{ failure() || success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: failed-smoke-test-logs-${{ matrix.partition }}
           include-hidden-files: true

--- a/.github/workflows/test-copy-images-to-dockerhub.yaml
+++ b/.github/workflows/test-copy-images-to-dockerhub.yaml
@@ -18,11 +18,11 @@ jobs:
   test-copy-images:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - run: pnpm install
       - name: Test Release Images
         run: ./docker/test.sh

--- a/.github/workflows/test-copy-images-to-dockerhub.yaml
+++ b/.github/workflows/test-copy-images-to-dockerhub.yaml
@@ -18,11 +18,11 @@ jobs:
   test-copy-images:
     runs-on: 2cpu-gh-ubuntu24-x64
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: .node-version
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - run: pnpm install
       - name: Test Release Images
         run: ./docker/test.sh

--- a/.github/workflows/trigger-release-branch-validation.yaml
+++ b/.github/workflows/trigger-release-branch-validation.yaml
@@ -30,7 +30,7 @@ jobs:
       actions: write
     steps:
       - name: Trigger Forge Stable Workflow'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/trigger-release-branch-validation.yaml
+++ b/.github/workflows/trigger-release-branch-validation.yaml
@@ -30,7 +30,7 @@ jobs:
       actions: write
     steps:
       - name: Trigger Forge Stable Workflow'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -104,7 +104,7 @@ jobs:
   rust-all:
     runs-on: runs-on,cpu=64,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=large
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.GIT_SHA }}
 
@@ -136,7 +136,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -104,7 +104,7 @@ jobs:
   rust-all:
     runs-on: runs-on,cpu=64,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=large
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ env.GIT_SHA }}
 
@@ -136,7 +136,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: "google-github-actions/auth@v3"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -115,7 +115,7 @@ jobs:
     outputs:
       run_execution_performance_test: ${{ steps.determine_test_targets.outputs.run_execution_performance_test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.GIT_SHA }}
           fetch-depth: 0
@@ -129,7 +129,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.GIT_SHA }}
         if: ${{ inputs.IGNORE_TARGET_DETERMINATION || needs.test-target-determinator.outputs.run_execution_performance_test == 'true' }}

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -115,7 +115,7 @@ jobs:
     outputs:
       run_execution_performance_test: ${{ steps.determine_test_targets.outputs.run_execution_performance_test }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.GIT_SHA }}
           fetch-depth: 0
@@ -129,7 +129,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.GIT_SHA }}
         if: ${{ inputs.IGNORE_TARGET_DETERMINATION || needs.test-target-determinator.outputs.run_execution_performance_test == 'true' }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Post to Slack on failure
         if: ${{ failure() && inputs.NOTIFY_SLACK }}
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # pin@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.EXECUTION_PERF_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -155,14 +155,14 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}
           # get the last 10 commits if GIT_SHA is not specified
           fetch-depth: inputs.GIT_SHA != null && 0 || 10
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         if: ${{ !inputs.SKIP_JOB }}
 
       - name: Install python deps

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -155,14 +155,14 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}
           # get the last 10 commits if GIT_SHA is not specified
           fetch-depth: inputs.GIT_SHA != null && 0 || 10
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         if: ${{ !inputs.SKIP_JOB }}
 
       - name: Install python deps

--- a/.github/workflows/workflow-run-module-verify.yaml
+++ b/.github/workflows/workflow-run-module-verify.yaml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
     runs-on: ${{ inputs.RUNS_ON }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.GIT_SHA }}
 

--- a/.github/workflows/workflow-run-module-verify.yaml
+++ b/.github/workflows/workflow-run-module-verify.yaml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
     runs-on: ${{ inputs.RUNS_ON }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.GIT_SHA }}
 

--- a/.github/workflows/workflow-run-replay-verify-archive-storage-provision.yaml
+++ b/.github/workflows/workflow-run-replay-verify-archive-storage-provision.yaml
@@ -24,14 +24,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
       
       # Authenticate to Google Cloud the project is aptos-ci
       - name: Authenticate to Google Cloud
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
@@ -47,7 +47,7 @@ jobs:
           echo "CLOUDSDK_AUTH_ACCESS_TOKEN=${{ steps.auth.outputs.access_token }}" >> $GITHUB_ENV
       
       - name: Set up Cloud SDK
-        uses: "google-github-actions/setup-gcloud@v2"
+        uses: "google-github-actions/setup-gcloud@v3"
         with:
           install_components: "kubectl, gke-gcloud-auth-plugin"
       

--- a/.github/workflows/workflow-run-replay-verify-archive-storage-provision.yaml
+++ b/.github/workflows/workflow-run-replay-verify-archive-storage-provision.yaml
@@ -24,14 +24,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
       
       # Authenticate to Google Cloud the project is aptos-ci
       - name: Authenticate to Google Cloud
         id: auth
-        uses: "google-github-actions/auth@v3"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
@@ -47,7 +47,7 @@ jobs:
           echo "CLOUDSDK_AUTH_ACCESS_TOKEN=${{ steps.auth.outputs.access_token }}" >> $GITHUB_ENV
       
       - name: Set up Cloud SDK
-        uses: "google-github-actions/setup-gcloud@v3"
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           install_components: "kubectl, gke-gcloud-auth-plugin"
       

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -159,7 +159,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           # Match forge.find_recent_images' 100-commit search window.
@@ -178,7 +178,7 @@ jobs:
       # Authenticate to Google Cloud the project is aptos-ci with credentails files generated
       - name: Authenticate to Google Cloud
         id: auth
-        uses: "google-github-actions/auth@v3"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
@@ -194,7 +194,7 @@ jobs:
           echo "CLOUDSDK_AUTH_ACCESS_TOKEN=${{ steps.auth.outputs.access_token }}" >> $GITHUB_ENV
 
       - name: Set up Cloud SDK
-        uses: "google-github-actions/setup-gcloud@v3"
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           install_components: "kubectl, gke-gcloud-auth-plugin"
 
@@ -281,7 +281,7 @@ jobs:
 
       - name: Checkout private framework usage Pages site
         if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # pin@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: aptos-labs/aptos-core-private
           ref: gh-pages

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -159,7 +159,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           # Match forge.find_recent_images' 100-commit search window.
@@ -178,7 +178,7 @@ jobs:
       # Authenticate to Google Cloud the project is aptos-ci with credentails files generated
       - name: Authenticate to Google Cloud
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
@@ -194,7 +194,7 @@ jobs:
           echo "CLOUDSDK_AUTH_ACCESS_TOKEN=${{ steps.auth.outputs.access_token }}" >> $GITHUB_ENV
 
       - name: Set up Cloud SDK
-        uses: "google-github-actions/setup-gcloud@v2"
+        uses: "google-github-actions/setup-gcloud@v3"
         with:
           install_components: "kubectl, gke-gcloud-auth-plugin"
 
@@ -281,7 +281,7 @@ jobs:
 
       - name: Checkout private framework usage Pages site
         if: ${{ inputs.DRY_RUN == false && inputs.FRAMEWORK_USAGE }}
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pin@v4.4.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # pin@v6.1.0
         with:
           repository: aptos-labs/aptos-core-private
           ref: gh-pages

--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -101,13 +101,13 @@ jobs:
       job_ids: ${{ steps.gen-jobs.outputs.job_ids }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.GIT_SHA }}
 
       - name: Load cached aptos-debugger binary
         id: cache-aptos-debugger-binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # copy the binary to the root of the repo and cache it there, because rust-setup calls a cache-rust action
           # which cleans up the target directory in its post action
@@ -130,7 +130,7 @@ jobs:
           cp target/release/aptos-debugger .
 
       - name: Install GCloud SDK
-        uses: "google-github-actions/setup-gcloud@v2"
+        uses: "google-github-actions/setup-gcloud@v3"
         with:
           version: ">= 418.0.0"
           install_components: "kubectl,gke-gcloud-auth-plugin"
@@ -140,7 +140,7 @@ jobs:
         run: echo "ts=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Load cached backup storage metadata cache dir (and save back afterwards)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: metadata_cache
           key: metadata-cache-${{ inputs.BUCKET }}/${{ inputs.SUB_DIR }}-${{ steps.get-timestamp.outputs.ts }}
@@ -171,7 +171,7 @@ jobs:
           echo "job_ids=$(cat job_ids.json)" >> $GITHUB_OUTPUT
 
       - name: Cache backup storage config and job definition
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ${{ inputs.BACKUP_CONFIG_TEMPLATE_PATH }}
@@ -188,7 +188,7 @@ jobs:
         job_id: ${{ fromJson(needs.prepare.outputs.job_ids) }}
     steps:
       - name: Load cached aptos-debugger binary
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             aptos-debugger
@@ -196,14 +196,14 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Load cached backup storage metadata cache dir
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: metadata_cache
           key: metadata-cache-${{ inputs.BUCKET }}/${{ inputs.SUB_DIR }}-
           fail-on-cache-miss: true
 
       - name: Load cached backup storage config and job definitions
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ${{ inputs.BACKUP_CONFIG_TEMPLATE_PATH }}
@@ -212,7 +212,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Install GCloud SDK
-        uses: "google-github-actions/setup-gcloud@v2"
+        uses: "google-github-actions/setup-gcloud@v3"
         with:
           version: ">= 418.0.0"
           install_components: "kubectl,gke-gcloud-auth-plugin"

--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -101,13 +101,13 @@ jobs:
       job_ids: ${{ steps.gen-jobs.outputs.job_ids }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.GIT_SHA }}
 
       - name: Load cached aptos-debugger binary
         id: cache-aptos-debugger-binary
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # copy the binary to the root of the repo and cache it there, because rust-setup calls a cache-rust action
           # which cleans up the target directory in its post action
@@ -130,7 +130,7 @@ jobs:
           cp target/release/aptos-debugger .
 
       - name: Install GCloud SDK
-        uses: "google-github-actions/setup-gcloud@v3"
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           version: ">= 418.0.0"
           install_components: "kubectl,gke-gcloud-auth-plugin"
@@ -140,7 +140,7 @@ jobs:
         run: echo "ts=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Load cached backup storage metadata cache dir (and save back afterwards)
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: metadata_cache
           key: metadata-cache-${{ inputs.BUCKET }}/${{ inputs.SUB_DIR }}-${{ steps.get-timestamp.outputs.ts }}
@@ -171,7 +171,7 @@ jobs:
           echo "job_ids=$(cat job_ids.json)" >> $GITHUB_OUTPUT
 
       - name: Cache backup storage config and job definition
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ${{ inputs.BACKUP_CONFIG_TEMPLATE_PATH }}
@@ -188,7 +188,7 @@ jobs:
         job_id: ${{ fromJson(needs.prepare.outputs.job_ids) }}
     steps:
       - name: Load cached aptos-debugger binary
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             aptos-debugger
@@ -196,14 +196,14 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Load cached backup storage metadata cache dir
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: metadata_cache
           key: metadata-cache-${{ inputs.BUCKET }}/${{ inputs.SUB_DIR }}-
           fail-on-cache-miss: true
 
       - name: Load cached backup storage config and job definitions
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ${{ inputs.BACKUP_CONFIG_TEMPLATE_PATH }}
@@ -212,7 +212,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Install GCloud SDK
-        uses: "google-github-actions/setup-gcloud@v3"
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           version: ">= 418.0.0"
           install_components: "kubectl,gke-gcloud-auth-plugin"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

GitHub deprecated Node 20 as the JavaScript Actions runtime (forced onto Node 24 in June 2026). This updates workflows and composite actions that were still on Node 20-based action majors, then **hash-pins** those majors so tags cannot move.

Node.js for TypeScript CI jobs is unchanged: `actions/setup-node` still reads `.node-version` (currently Node 22).

Pinned majors (commit SHA + zizmor-style `# vX.Y.Z` comment):

| Action | Pin |
|---|---|
| `actions/checkout` | `d23441a4` **v6.1.0** |
| `actions/setup-node` | `24997072` **v6.5.0** |
| `actions/setup-python` | `ece7cb06` **v6.3.0** |
| `actions/cache` (+ save/restore) | `caa29612` **v5.1.0** |
| `runs-on/cache` (+ save/restore) | `88d90644` **v5.0.7** |
| `actions/upload-artifact` | `b7c566a7` **v6.0.0** |
| `actions/download-artifact` | `37930b1c` **v7.0.0** |
| `actions/github-script` | `ed597411` **v8.0.0** |
| `actions/stale` | `1e223db2` **v10.4.0** |
| `pnpm/action-setup` | `0ebf4713` **v6.0.9** |
| `docker/login-action` | `dbcb8138` **v4.6.0** |
| `docker/setup-buildx-action` | `37fe6310` **v4.3.0** (`config-inline` → `buildkitd-config-inline`) |
| `google-github-actions/auth` | `7c6bc770` **v3.0.0** |
| `google-github-actions/setup-gcloud` | `aa5489c8` **v3.0.1** |
| `google-github-actions/get-secretmanager-secrets` | `bc9c54b2` **v3.0.0** |

Follow-up after Bugbot: `close-stale-issues.yaml` now includes `actions: write` so `actions/stale` v10 can create/delete its progress cache.

Left unchanged: older pinned third-party actions such as `github/codeql-action@v2` and `codecov/codecov-action@v3`, which need a more careful product upgrade than a runtime bump. Reusable workflow/action refs to `aptos-labs/aptos-core@main` are also unchanged.

## How Has This Been Tested?

- Parsed all updated workflow/action YAML files with PyYAML.
- Ran **zizmor 1.29.0** online (`--collect=workflows,actions .github`) with a GitHub token so hash pins could be verified.

**zizmor results for these pins:** no `unpinned-uses` and no `ref-version-mismatch` / `impostor-commit` on the SHAs above.

Repo-wide zizmor still reports many **pre-existing** findings (template injection, `aptos-labs/aptos-core@main` reusable refs, older `# pin@` comments, `dsherret/rust-toolchain-file@v1`, etc.). Those are out of scope for this PR.

## Key Areas to Review

- Artifact upload/download majors (`upload-artifact@v6`, `download-artifact@v7`) should be compatible with the existing v4 artifact backend.
- `docker/setup-buildx-action` input rename: `config-inline` → `buildkitd-config-inline`.
- Self-hosted `runs-on` images must be on Actions Runner ≥ 2.327.1 for Node 24 JS actions.
- `actions/stale` v10 cache requires `actions: write`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ccb0b5a-c499-458f-8ee7-8d64479ae1bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ccb0b5a-c499-458f-8ee7-8d64479ae1bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

