### PR TITLE
[mono-move] CallBuilder API + direct Rust => runtime value conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,6 +5046,8 @@ dependencies = [
  "move-core-types",
  "move-model",
  "move-table-extension",
+ "move-value-view",
+ "move-value-view-derive",
  "move-vm-types",
  "num-bigint 0.3.3",
  "num-derive",
@@ -12934,7 +12936,6 @@ dependencies = [
 name = "mono-move-aptos-transaction-executor"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "aptos-cached-packages",
  "aptos-crypto",
  "aptos-gas-algebra",
@@ -12953,7 +12954,7 @@ dependencies = [
  "mono-move-output",
  "mono-move-runtime",
  "move-core-types",
- "serde",
+ "move-value-view",
  "thiserror 1.0.69",
  "triomphe",
 ]
@@ -13116,6 +13117,8 @@ dependencies = [
  "mono-move-global-context",
  "mono-move-loader",
  "move-core-types",
+ "move-value-view",
+ "move-value-view-derive",
  "num-bigint 0.3.3",
  "paste",
  "proptest",
@@ -13924,6 +13927,22 @@ dependencies = [
  "regex",
  "tempfile",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "move-value-view"
+version = "0.1.0"
+dependencies = [
+ "move-core-types",
+]
+
+[[package]]
+name = "move-value-view-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,8 @@ members = [
     "third_party/move/move-prover/lab",
     "third_party/move/move-prover/test-utils",
     "third_party/move/move-symbol-pool",
+    "third_party/move/move-value-view",
+    "third_party/move/move-value-view-derive",
     "third_party/move/move-vm/integration-tests",
     "third_party/move/move-vm/metrics",
     "third_party/move/move-vm/profiler",
@@ -930,6 +932,8 @@ move-bytecode-verifier-invalid-mutations = { path = "third_party/move/move-bytec
 move-command-line-common = { path = "third_party/move/move-command-line-common" }
 move-compiler-v2 = { path = "third_party/move/move-compiler-v2" }
 move-core-types = { path = "third_party/move/move-core/types" }
+move-value-view = { path = "third_party/move/move-value-view" }
+move-value-view-derive = { path = "third_party/move/move-value-view-derive" }
 move-coverage = { path = "third_party/move/tools/move-coverage" }
 move-decompiler = { path = "third_party/move/tools/move-decompiler" }
 move-docgen = { path = "third_party/move/tools/move-docgen" }

--- a/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
+++ b/third_party/move/mono-move/aptos-state-view-providers/src/lib.rs
@@ -272,15 +272,16 @@ impl<S: StateView> ResourceProvider for StateViewResourceProvider<'_, '_, S> {
 impl<S: StateView> AptosDataProvider for StateViewResourceProvider<'_, '_, S> {
     /// Loaded from the state view on first access, caching absence as well so a
     /// missing group is read at most once.
-    fn group_members(&self, group_key: &StateKey) -> Result<Option<Arc<GroupMembers>>> {
+    fn group_members(
+        &self,
+        group_key: &StateKey,
+    ) -> Result<Option<Arc<GroupMembers>>, ResourceProviderError> {
         if let Some(members) = self.inner.borrow().groups.get(group_key) {
             return Ok(members.clone());
         }
-        let members = match self
-            .state_view
-            .get_state_value(group_key)
-            .map_err(|e| anyhow!("group read failed: {e}"))?
-        {
+        let members = match self.state_view.get_state_value(group_key).map_err(|e| {
+            ResourceProviderError::InvariantViolation(format!("group read failed: {e}"))
+        })? {
             Some(value) => Some(Arc::new(decode_group_members(value.bytes(), self.guard)?)),
             None => None,
         };

--- a/third_party/move/mono-move/aptos-transaction-executor/Cargo.toml
+++ b/third_party/move/mono-move/aptos-transaction-executor/Cargo.toml
@@ -13,7 +13,6 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = { workspace = true }
 aptos-gas-algebra = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-types = { workspace = true }
@@ -27,7 +26,7 @@ mono-move-natives = { workspace = true }
 mono-move-output = { workspace = true }
 mono-move-runtime = { workspace = true }
 move-core-types = { workspace = true }
-serde = { workspace = true }
+move-value-view = { workspace = true }
 thiserror = { workspace = true }
 triomphe = { workspace = true }
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/calls.rs
@@ -1,255 +1,50 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Helpers for running Move functions inside the transaction's single
-//! interpreter context: parameter typing, argument placement, and the call
-//! entry points.
+//! Shared plumbing for running a Move function inside the transaction's
+//! single interpreter context.
 
-use anyhow::{anyhow, bail, Result};
-use mono_move_core::{
-    interner::InternedIdentifier,
-    types::{view_type, view_type_list, InternedType, InternedTypeList, Type},
-    Function, Interner, VMInternalError,
-};
-use mono_move_global_context::{ExecutionGuard, FunctionIrLookup, LoadedModule};
-use mono_move_runtime::{
-    error::{RuntimeError, RuntimeInvariantViolation},
-    InterpreterContext, RuntimeStatus,
-};
+use mono_move_core::{types::InternedTypeList, Function, Interner, VMInternalError};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_runtime::{CallBuilder, InterpreterContext, RuntimeStatus};
 use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
-/// The parameter types of a loaded module's function, instantiated with
-/// `ty_args`.
-//
-// TODO(perf, cleanup): `Function` does not carry its signature, so this
-// re-derives the parameters from the module IR on every call -- which is also
-// the only reason callers need the `LoadedModule`.
-pub fn param_types(
-    guard: &ExecutionGuard,
-    loaded: &LoadedModule,
-    function: InternedIdentifier,
-    ty_args: InternedTypeList,
-) -> Result<Vec<InternedType>> {
-    let FunctionIrLookup::Ir(ir) = loaded.get_function_ir(function) else {
-        bail!("function has no IR in its loaded module");
-    };
-    let params = loaded
-        .ir()
-        .module
-        .function_signature_at(ir.handle_idx)
-        .params;
-    Ok(view_type_list(guard.subst_type_list(params, ty_args)?).to_vec())
-}
-
-/// The return types of a loaded module's function, instantiated with
-/// `ty_args`.
-pub fn return_types(
-    guard: &ExecutionGuard,
-    loaded: &LoadedModule,
-    function: InternedIdentifier,
-    ty_args: InternedTypeList,
-) -> Result<Vec<InternedType>> {
-    let FunctionIrLookup::Ir(ir) = loaded.get_function_ir(function) else {
-        bail!("function has no IR in its loaded module");
-    };
-    let returns = loaded
-        .ir()
-        .module
-        .function_signature_at(ir.handle_idx)
-        .returns;
-    Ok(view_type_list(guard.subst_type_list(returns, ty_args)?).to_vec())
-}
-
-/// Fills the root frame of `func` from the signer and BCS-argument lists, in
-/// parameter order: `signer`/`&signer` parameters from the signer list,
-/// everything else deserialized from BCS.
-//
-// TODO(correctness): rework this part as a whole together with proper argument
-// validation.
-//
-// TODO(perf): don't mandate BCS-encoded arguments: a caller that already holds
-// the values (e.g. system function inputs) should be able to place them
-// directly, without the BCS round trip.
-pub fn place_args(
-    interp: &mut InterpreterContext<'_>,
-    func: &Function,
-    params: &[InternedType],
-    signer_bufs: &[[u8; AccountAddress::LENGTH]],
-    args: &[Vec<u8>],
-) -> Result<()> {
-    if func.param_slots.len() != params.len() {
-        bail!(
-            "lowered function has {} parameter slots but the signature has {} parameters",
-            func.param_slots.len(),
-            params.len()
-        );
-    }
-    let mut signers = signer_bufs.iter();
-    let mut args = args.iter();
-    let missing_signer = || anyhow!("not enough signers for the function");
-    // Signers must lead the parameter list, as the legacy VM requires.
-    let mut seen_argument = false;
-    let mut signer_params = 0;
-    for (slot, ty) in func.param_slots.iter().zip(params) {
-        let offset = slot.offset.0;
-        let view = view_type(*ty);
-        let is_signer_param = matches!(view, Type::Signer)
-            || matches!(view, Type::ImmutRef { inner } | Type::MutRef { inner }
-                if matches!(view_type(*inner), Type::Signer));
-        if is_signer_param {
-            if seen_argument {
-                bail!("a signer parameter follows an argument");
-            }
-            signer_params += 1;
-        } else {
-            seen_argument = true;
-        }
-        match view {
-            Type::Signer => {
-                let signer = signers.next().ok_or_else(missing_signer)?;
-                interp.set_root_arg(offset, signer);
-            },
-            Type::ImmutRef { inner } | Type::MutRef { inner }
-                if matches!(view_type(*inner), Type::Signer) =>
-            {
-                let signer = signers.next().ok_or_else(missing_signer)?;
-                // SAFETY: the signer buffers outlive the call, and sit outside
-                // the VM heap so the GC leaves the reference alone.
-                unsafe { interp.set_root_ref_arg(offset, signer.as_ptr()) };
-            },
-            // A reference to anything else cannot be built from a transaction
-            // argument, and a function value would let a payload pass something
-            // like `minter: || Coin`.
-            Type::ImmutRef { .. } | Type::MutRef { .. } => {
-                bail!("a reference to a non-signer is not a valid argument")
-            },
-            Type::Function { .. } => bail!("a function value is not a valid argument"),
-            // Substitution has already run, so a type parameter here means it
-            // failed.
-            Type::TypeParam { .. } => bail!("parameter type is still uninstantiated"),
-            Type::Bool
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::U128
-            | Type::U256
-            | Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::I128
-            | Type::I256
-            | Type::Address
-            | Type::Vector { .. }
-            // TODO(security, completeness): only the framework's constructible
-            // structs (`String`, `Object`, `Option`, ...) are valid arguments;
-            // everything else must be rejected. See the pre-coordinator gates in
-            // AGENTS.md.
-            | Type::Nominal { .. } => {
-                let arg = args
-                    .next()
-                    .ok_or_else(|| anyhow!("not enough arguments for the function"))?;
-                // SAFETY: `offset`/`ty` come from this function's own signature, so
-                // the slot is valid for the type's in-memory size.
-                unsafe { interp.deserialize_root_arg(offset, *ty, arg) }.map_err(|e| {
-                    anyhow!("failed to place argument at frame offset {}: {}", offset, e)
-                })?;
-            },
-        }
-    }
-    if args.next().is_some() {
-        bail!("too many arguments for the function");
-    }
-    // Like the legacy VM: a function with signer parameters requires exactly
-    // that many signers; one without ignores them.
-    if signer_params > 0 && signers.next().is_some() {
-        bail!("more signers than the function's signer parameters");
-    }
-    Ok(())
-}
-
-/// Loads `module::function<ty_args>`, places arguments, and runs it in the
-/// transaction's interpreter context, metered against the context's gas
+/// Resolves `module::function<ty_args>` by name, metered against the gas
 /// budget.
-pub fn call_function(
-    guard: &ExecutionGuard<'_>,
-    interp: &mut InterpreterContext<'_>,
+pub(crate) fn resolve_function_by_name<'a>(
+    guard: &ExecutionGuard<'a>,
+    interp: &mut InterpreterContext<'a>,
     address: &AccountAddress,
     module_name: &IdentStr,
     function_name: &IdentStr,
     ty_args: InternedTypeList,
-    signer_bufs: &[[u8; AccountAddress::LENGTH]],
-    args: &[Vec<u8>],
-) -> Result<RuntimeStatus, VMInternalError> {
+) -> Result<&'a Function, VMInternalError> {
     let module_id = guard.module_id_of(address, module_name);
     let function = guard.identifier_of(function_name);
-    let func_ptr = interp.load_function(module_id, function, ty_args)?;
-    // SAFETY: the pointer lives in a LoadedModule arena kept alive by the guard.
-    let func: &Function = unsafe { func_ptr.as_ref_unchecked() };
-
-    let loaded = interp
-        .read_set()
-        .get_loaded(guard.arena_ref_for_module_id(module_id))?;
-    let params = param_types(guard, loaded, function, ty_args).map_err(invariant_violation)?;
-
-    interp.prepare_call(func);
-    // TODO(correctness): rejecting an argument is a user error, not an invariant
-    // violation. It needs a real status once argument validation moves into the
-    // pre-execution checks.
-    place_args(interp, func, &params, signer_bufs, args).map_err(invariant_violation)?;
-
-    interp.run()
+    interp.load_function(module_id, function, ty_args)
 }
 
-/// An error that should not be reachable, as a VM error.
-pub(crate) fn invariant_violation(err: anyhow::Error) -> VMInternalError {
-    VMInternalError::new(RuntimeError::InvariantViolation(
-        RuntimeInvariantViolation::Unreachable(err.to_string()),
-    ))
-}
-
-/// Like `call_function`, but system code never consumes the transaction's gas
-/// budget, including its module loads.
-pub(crate) fn call_system_function_unmetered(
-    guard: &ExecutionGuard<'_>,
-    interp: &mut InterpreterContext<'_>,
+/// Calls `module::function<ty_args>` as system code: nothing consumes the
+/// transaction's gas budget, `signers` fill the leading signer parameters,
+/// and `place` fills the rest.
+pub(crate) fn call_system_function_unmetered<'a>(
+    guard: &ExecutionGuard<'a>,
+    interp: &mut InterpreterContext<'a>,
     address: &AccountAddress,
     module_name: &IdentStr,
     function_name: &IdentStr,
     ty_args: InternedTypeList,
-    signer_bufs: &[[u8; AccountAddress::LENGTH]],
-    args: &[Vec<u8>],
+    signers: &[AccountAddress],
+    place: impl FnOnce(&mut CallBuilder<'_, '_>) -> Result<(), VMInternalError>,
 ) -> Result<RuntimeStatus, VMInternalError> {
     interp.unmetered(|interp| {
-        call_function(
-            guard,
-            interp,
-            address,
-            module_name,
-            function_name,
-            ty_args,
-            signer_bufs,
-            args,
-        )
+        let func =
+            resolve_function_by_name(guard, interp, address, module_name, function_name, ty_args)?;
+        let mut call = interp.build_call(func)?;
+        for signer in signers {
+            call.signer(signer)?;
+        }
+        place(&mut call)?;
+        call.run()
     })
-}
-
-/// Reduces a completed call to success or the abort it ended in.
-pub(crate) fn into_result(
-    status: RuntimeStatus,
-) -> Result<(), crate::errors::MoveExecutionFailure> {
-    use crate::errors::MoveExecutionFailure;
-    match status {
-        RuntimeStatus::Success => Ok(()),
-        RuntimeStatus::Aborted {
-            code,
-            message,
-            location,
-        } => Err(MoveExecutionFailure::Abort {
-            code,
-            message,
-            location,
-        }),
-    }
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/errors.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/errors.rs
@@ -6,6 +6,10 @@ use aptos_types::{
     transaction::validation::ECANT_PAY_GAS_DEPOSIT,
 };
 use mono_move_core::VMInternalError;
+use mono_move_runtime::{
+    error::{RuntimeError, RuntimeInvariantViolation},
+    RuntimeStatus,
+};
 use move_core_types::vm_status::AbortLocation;
 use thiserror::Error;
 
@@ -108,6 +112,19 @@ pub enum ExecutionStatus {
     },
 }
 
+/// Why a transaction's arguments were rejected.
+#[derive(Debug)]
+pub enum InvalidArguments {
+    /// A signer parameter follows a non-signer one.
+    SignerAfterArgument,
+    /// The argument count does not match the function's parameters.
+    ArgumentCountMismatch,
+    /// The signer count does not match the function's signer parameters.
+    SignerCountMismatch,
+    /// An argument's bytes do not decode to its parameter's type.
+    UndecodableArgument,
+}
+
 /// How Move execution failed, whether it was the prologue, the payload, the
 /// epilogue, or the transaction as a whole. What a failure means for the
 /// transaction is the driver's call.
@@ -119,8 +136,33 @@ pub enum MoveExecutionFailure {
         message: Option<String>,
         location: AbortLocation,
     },
+    /// The transaction's arguments were rejected.
+    InvalidArguments(InvalidArguments),
     /// Execution failed with a VM error.
     RuntimeError(VMInternalError),
+}
+
+/// An error that should not be reachable, as a VM error.
+pub(crate) fn invariant_violation(detail: impl Into<String>) -> VMInternalError {
+    VMInternalError::new(RuntimeError::InvariantViolation(
+        RuntimeInvariantViolation::Unreachable(detail.into()),
+    ))
+}
+
+/// Reduces a completed call to success or the abort it ended in.
+pub(crate) fn call_result(status: RuntimeStatus) -> Result<(), MoveExecutionFailure> {
+    match status {
+        RuntimeStatus::Success => Ok(()),
+        RuntimeStatus::Aborted {
+            code,
+            message,
+            location,
+        } => Err(MoveExecutionFailure::Abort {
+            code,
+            message,
+            location,
+        }),
+    }
 }
 
 /// Whether an epilogue abort is the fee payer failing to cover the fee.

--- a/third_party/move/mono-move/aptos-transaction-executor/src/lib.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/lib.rs
@@ -19,7 +19,6 @@ mod providers;
 mod system_txns;
 mod user_txn;
 
-pub use calls::{call_function, param_types, place_args, return_types};
 pub use errors::{
     DiscardReason, ExecutionStage, ExecutionStatus, MaterializationError, MoveExecutionFailure,
     NoEffectsReason, PreExecutionCheckFailure, SystemTxnFailure,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/materialize/vm_status.rs
@@ -4,8 +4,8 @@
 //! Converts the typed outcome taxonomy into `VMStatus`.
 
 use crate::errors::{
-    is_cant_pay_fee_abort, DiscardReason, ExecutionStage, ExecutionStatus, MoveExecutionFailure,
-    PreExecutionCheckFailure,
+    is_cant_pay_fee_abort, DiscardReason, ExecutionStage, ExecutionStatus, InvalidArguments,
+    MoveExecutionFailure, PreExecutionCheckFailure,
 };
 use aptos_types::{
     error::{split_canonical, INVALID_ARGUMENT, INVALID_STATE, OUT_OF_RANGE},
@@ -149,6 +149,29 @@ pub(crate) fn executed_vm_status(status: &ExecutionStatus) -> VMStatus {
                 message: message.clone(),
             }
         },
+        // Like the sibling arms: only the payload stage legitimately faults
+        // the transaction's arguments.
+        MoveExecutionFailure::InvalidArguments(reason)
+            if matches!(stage, ExecutionStage::Payload) =>
+        {
+            VMStatus::error(
+                match reason {
+                    InvalidArguments::SignerAfterArgument => {
+                        StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE
+                    },
+                    InvalidArguments::ArgumentCountMismatch => {
+                        StatusCode::NUMBER_OF_ARGUMENTS_MISMATCH
+                    },
+                    InvalidArguments::SignerCountMismatch => {
+                        StatusCode::NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH
+                    },
+                    InvalidArguments::UndecodableArgument => {
+                        StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT
+                    },
+                },
+                None,
+            )
+        },
         MoveExecutionFailure::RuntimeError(err) if matches!(stage, ExecutionStage::Payload) => {
             internal_error_to_status(err)
         },
@@ -188,6 +211,10 @@ fn prologue_failure_to_status(failure: MoveExecutionFailure) -> VMStatus {
         } => (code, message, location),
         MoveExecutionFailure::RuntimeError(err) => {
             return unexpected_validation_error("prologue", err.to_string())
+        },
+        // The prologue takes no payload arguments.
+        failure @ MoveExecutionFailure::InvalidArguments(_) => {
+            return unexpected_validation_error("prologue", format!("{failure:?}"))
         },
     };
     if location != *ABORT_LOC_VALIDATION_MODULE {

--- a/third_party/move/mono-move/aptos-transaction-executor/src/providers.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/providers.rs
@@ -1,11 +1,13 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use anyhow::Result;
 use aptos_types::state_store::state_key::StateKey;
 use bytes::Bytes;
 use mono_move_core::{
-    intern_struct_tag, storage::resource_provider::ResourceProvider, types::InternedType, Interner,
+    intern_struct_tag,
+    storage::resource_provider::{ResourceProvider, ResourceProviderError},
+    types::InternedType,
+    Interner,
 };
 use move_core_types::language_storage::StructTag;
 use std::collections::{BTreeMap, HashMap};
@@ -16,7 +18,10 @@ use triomphe::Arc;
 pub trait AptosDataProvider: ResourceProvider {
     /// The stored members of the group behind `group_key`, as execution read
     /// them, or `None` if no group is stored there.
-    fn group_members(&self, group_key: &StateKey) -> Result<Option<Arc<GroupMembers>>>;
+    fn group_members(
+        &self,
+        group_key: &StateKey,
+    ) -> Result<Option<Arc<GroupMembers>>, ResourceProviderError>;
 }
 
 /// A resource group's members and their stored bytes. Unordered: the stored
@@ -27,10 +32,21 @@ pub trait AptosDataProvider: ResourceProvider {
 pub type GroupMembers = HashMap<InternedType, Bytes>;
 
 /// Decodes a group's stored blob, interning each member's struct tag.
-pub fn decode_group_members(blob: &[u8], interner: &impl Interner) -> Result<GroupMembers> {
-    let tagged: BTreeMap<StructTag, Bytes> = bcs::from_bytes(blob)?;
+pub fn decode_group_members(
+    blob: &[u8],
+    interner: &impl Interner,
+) -> Result<GroupMembers, ResourceProviderError> {
+    let invalid = |e: &dyn std::fmt::Display| {
+        ResourceProviderError::InvariantViolation(format!("malformed resource group: {e}"))
+    };
+    let tagged: BTreeMap<StructTag, Bytes> = bcs::from_bytes(blob).map_err(|e| invalid(&e))?;
     tagged
         .into_iter()
-        .map(|(tag, bytes)| Ok((intern_struct_tag(&tag, interner)?, bytes)))
+        .map(|(tag, bytes)| {
+            Ok((
+                intern_struct_tag(&tag, interner).map_err(|e| invalid(&e))?,
+                bytes,
+            ))
+        })
         .collect()
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/block_epilogue.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/block_epilogue.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use super::common::{call_block_function, serialize, system_txn_outcome, SystemTxnMetadata};
+use super::common::{call_block_function, system_txn_outcome, SystemTxnMetadata};
 use crate::{errors::NoEffectsReason, executor::AptosTransactionExecutor, outcome::TxnOutcome};
 use aptos_types::transaction::{BlockEpiloguePayload, FeeDistribution};
 use move_core_types::{ident_str, identifier::IdentStr};
+use move_value_view::IterAsMoveVector;
 
 const BLOCK_EPILOGUE: &IdentStr = ident_str!("block_epilogue");
 
@@ -35,19 +36,13 @@ impl<'guard> AptosTransactionExecutor<'guard> {
             } => fee_distribution,
         };
         let FeeDistribution::V0 { amount } = fee_distribution;
-        let (validator_indices, amounts): (Vec<u64>, Vec<u64>) = amount
-            .iter()
-            .map(|(index, amount)| (*index, *amount))
-            .unzip();
-        let args = match (serialize(&validator_indices), serialize(&amounts)) {
-            (Ok(validator_indices), Ok(amounts)) => [validator_indices, amounts],
-            (Err(failure), _) | (_, Err(failure)) => {
-                return TxnOutcome::ExecutedNoEffects(NoEffectsReason::BlockEpilogueFailed(failure))
-            },
-        };
         let txn_data = SystemTxnMetadata::for_block_epilogue(block_epilogue);
         let mut interp = self.system_session(&txn_data);
-        match call_block_function(&mut interp, self.guard, BLOCK_EPILOGUE, &args) {
+        let result = call_block_function(&mut interp, self.guard, BLOCK_EPILOGUE, |call| {
+            call.arg(&IterAsMoveVector(amount.keys().copied()))?;
+            call.arg(&IterAsMoveVector(amount.values().copied()))
+        });
+        match result {
             Ok(()) => system_txn_outcome(interp),
             Err(failure) => {
                 TxnOutcome::ExecutedNoEffects(NoEffectsReason::BlockEpilogueFailed(failure))

--- a/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/block_metadata.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/block_metadata.rs
@@ -1,21 +1,20 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use super::common::{call_block_function, serialize, system_txn_outcome, SystemTxnMetadata};
+use super::common::{call_block_function, system_txn_outcome, SystemTxnMetadata};
 use crate::{
-    calls::invariant_violation,
-    errors::{MoveExecutionFailure, SystemTxnFailure},
+    errors::{invariant_violation, MoveExecutionFailure, SystemTxnFailure},
     executor::AptosTransactionExecutor,
     outcome::TxnOutcome,
 };
-use anyhow::anyhow;
 use aptos_types::{
     block_metadata::BlockMetadata, block_metadata_ext::BlockMetadataExt, randomness::Randomness,
     transaction::AuxiliaryInfo,
 };
 use mono_move_global_context::ExecutionGuard;
-use mono_move_runtime::InterpreterContext;
+use mono_move_runtime::{CallBuilder, InterpreterContext};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use move_value_view::IterAsMoveVector;
 
 const BLOCK_PROLOGUE: &IdentStr = ident_str!("block_prologue");
 const BLOCK_PROLOGUE_EXT: &IdentStr = ident_str!("block_prologue_ext");
@@ -64,103 +63,79 @@ impl<'guard> AptosTransactionExecutor<'guard> {
     }
 }
 
-/// Arguments shared by every block-prologue variant.
-//
-// TODO(perf): place the arguments directly into the interpreter's heap,
-// avoiding the BCS round trip.
-#[allow(clippy::too_many_arguments)]
-fn block_prologue_common_args(
-    id: Vec<u8>,
-    epoch: u64,
-    round: u64,
-    proposer: AccountAddress,
-    failed_proposer_indices: &[u32],
-    previous_block_votes_bitvec: &[u8],
-    timestamp_usecs: u64,
-) -> Result<Vec<Vec<u8>>, MoveExecutionFailure> {
-    let hash = AccountAddress::from_bytes(&id)
-        .map_err(|e| invariant_violation(anyhow!("block id is not 32 bytes: {e}")))
-        .map_err(MoveExecutionFailure::RuntimeError)?;
-    let failed_proposer_indices: Vec<u64> = failed_proposer_indices
-        .iter()
-        .map(|index| u64::from(*index))
-        .collect();
-    Ok(vec![
-        serialize(&hash)?,
-        serialize(&epoch)?,
-        serialize(&round)?,
-        serialize(&proposer)?,
-        serialize(&failed_proposer_indices)?,
-        serialize(&previous_block_votes_bitvec)?,
-        serialize(&timestamp_usecs)?,
-    ])
+/// Places the arguments every block-prologue variant takes, after the VM
+/// signer `call_block_function` fills. A macro because the two metadata types
+/// share these accessors but no trait.
+macro_rules! place_prologue_common_args {
+    ($call:expr, $metadata:expr) => {{
+        let call: &mut CallBuilder<'_, '_> = $call;
+        let metadata = $metadata;
+        let hash = AccountAddress::from_bytes(metadata.id().as_slice())
+            .map_err(|e| invariant_violation(format!("block id is not 32 bytes: {e}")))?;
+        call.arg(&hash)?;
+        call.arg(&metadata.epoch())?;
+        call.arg(&metadata.round())?;
+        call.arg(&metadata.proposer())?;
+        call.arg(&IterAsMoveVector(
+            metadata
+                .failed_proposer_indices()
+                .iter()
+                .map(|index| u64::from(*index)),
+        ))?;
+        call.arg(&metadata.previous_block_votes_bitvec())?;
+        call.arg(&metadata.timestamp_usecs())
+    }};
 }
 
 /// Calls `0x1::block::block_prologue` with the block's consensus metadata.
-fn run_block_prologue(
-    interp: &mut InterpreterContext<'_>,
-    guard: &ExecutionGuard<'_>,
+fn run_block_prologue<'a>(
+    interp: &mut InterpreterContext<'a>,
+    guard: &ExecutionGuard<'a>,
     block_metadata: &BlockMetadata,
 ) -> Result<(), MoveExecutionFailure> {
-    let args = block_prologue_common_args(
-        block_metadata.id().to_vec(),
-        block_metadata.epoch(),
-        block_metadata.round(),
-        block_metadata.proposer(),
-        block_metadata.failed_proposer_indices(),
-        block_metadata.previous_block_votes_bitvec(),
-        block_metadata.timestamp_usecs(),
-    )?;
-    call_block_function(interp, guard, BLOCK_PROLOGUE, &args)
+    call_block_function(interp, guard, BLOCK_PROLOGUE, |call| {
+        place_prologue_common_args!(call, block_metadata)
+    })
 }
 
 /// Calls the `0x1::block::block_prologue_ext*` variant matching the extended
 /// metadata.
-fn run_block_prologue_ext(
-    interp: &mut InterpreterContext<'_>,
-    guard: &ExecutionGuard<'_>,
+fn run_block_prologue_ext<'a>(
+    interp: &mut InterpreterContext<'a>,
+    guard: &ExecutionGuard<'a>,
     block_metadata_ext: &BlockMetadataExt,
 ) -> Result<(), MoveExecutionFailure> {
-    let mut args = block_prologue_common_args(
-        block_metadata_ext.id().to_vec(),
-        block_metadata_ext.epoch(),
-        block_metadata_ext.round(),
-        block_metadata_ext.proposer(),
-        block_metadata_ext.failed_proposer_indices(),
-        block_metadata_ext.previous_block_votes_bitvec(),
-        block_metadata_ext.timestamp_usecs(),
-    )?;
-    let seed = |randomness: &Option<Randomness>| {
-        serialize(&randomness.as_ref().map(Randomness::randomness_cloned))
-    };
-    let function = match block_metadata_ext {
-        BlockMetadataExt::V0(_) => {
-            return Err(MoveExecutionFailure::RuntimeError(invariant_violation(
-                anyhow!("V0 metadata must run as a plain block-metadata transaction"),
-            )))
-        },
+    let seed =
+        |randomness: &Option<Randomness>| randomness.as_ref().map(Randomness::randomness_cloned);
+    match block_metadata_ext {
+        BlockMetadataExt::V0(_) => Err(MoveExecutionFailure::RuntimeError(invariant_violation(
+            "V0 metadata must run as a plain block-metadata transaction",
+        ))),
         BlockMetadataExt::V1(v1) => {
-            args.push(seed(&v1.randomness)?);
-            BLOCK_PROLOGUE_EXT
+            call_block_function(interp, guard, BLOCK_PROLOGUE_EXT, |call| {
+                place_prologue_common_args!(call, block_metadata_ext)?;
+                call.arg(&seed(&v1.randomness))
+            })
         },
         BlockMetadataExt::V2(v2) => {
-            args.push(seed(&v2.randomness)?);
-            args.push(serialize(
-                &v2.decryption_key
-                    .as_ref()
-                    .map(|key| key.decryption_key_cloned()),
-            )?);
-            BLOCK_PROLOGUE_EXT_V2
+            call_block_function(interp, guard, BLOCK_PROLOGUE_EXT_V2, |call| {
+                place_prologue_common_args!(call, block_metadata_ext)?;
+                call.arg(&seed(&v2.randomness))?;
+                call.arg(
+                    &v2.decryption_key
+                        .as_ref()
+                        .map(|key| key.decryption_key_cloned()),
+                )
+            })
         },
         BlockMetadataExt::V3(v3) => {
-            args.push(seed(&v3.randomness)?);
-            let payload = v3.decryption_payload.as_ref();
-            args.push(serialize(
-                &payload.map(|payload| payload.key.decryption_key_cloned()),
-            )?);
-            args.push(serialize(&payload.map(|payload| payload.decryption_round))?);
-            BLOCK_PROLOGUE_EXT_V3
+            call_block_function(interp, guard, BLOCK_PROLOGUE_EXT_V3, |call| {
+                place_prologue_common_args!(call, block_metadata_ext)?;
+                call.arg(&seed(&v3.randomness))?;
+                let payload = v3.decryption_payload.as_ref();
+                call.arg(&payload.map(|payload| payload.key.decryption_key_cloned()))?;
+                call.arg(&payload.map(|payload| payload.decryption_round))
+            })
         },
-    };
-    call_block_function(interp, guard, function, &args)
+    }
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/common.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/system_txns/common.rs
@@ -4,28 +4,29 @@
 //! Common utilities shared by all system transactions.
 
 use crate::{
-    calls::{call_system_function_unmetered, into_result, invariant_violation},
-    errors::{ExecutionStatus, MoveExecutionFailure},
+    calls::call_system_function_unmetered,
+    errors::{call_result, ExecutionStatus, MoveExecutionFailure},
     executor::AptosTransactionExecutor,
     natives::extensions_with,
     outcome::TxnOutcome,
 };
-use anyhow::anyhow;
 use aptos_types::{
     block_metadata::BlockMetadata,
     block_metadata_ext::BlockMetadataExt,
     fee_statement::FeeStatement,
     transaction::{BlockEpiloguePayload, SessionId},
 };
-use mono_move_core::{GasMeter, Interner};
+use mono_move_core::{GasMeter, Interner, VMInternalError};
 use mono_move_global_context::ExecutionGuard;
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
 use mono_move_natives::TransactionContextExtension;
-use mono_move_runtime::InterpreterContext;
+use mono_move_runtime::{CallBuilder, InterpreterContext};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
-use serde::Serialize;
 
 const BLOCK: &IdentStr = ident_str!("block");
+
+/// The VM's signer (`0x0`), which every `0x1::block` call runs as.
+pub(super) const VM_SIGNER: AccountAddress = AccountAddress::ZERO;
 
 /// A system transaction's session identity: what seeds its transaction
 /// context in place of user-transaction metadata.
@@ -89,7 +90,7 @@ impl<'a> AptosTransactionExecutor<'a> {
         // is supposed to run through `call_system_function_unmetered`, which
         // grants free execution, and in case it is not and anything accidentally
         // gets metered, it fails on the first charge.
-        InterpreterContext::new_idle(loader, GasMeter::new(0), self.data_provider, self.natives)
+        InterpreterContext::new(loader, GasMeter::new(0), self.data_provider, self.natives)
             .with_extensions(extensions_with(txn_context, self.usage))
     }
 }
@@ -103,19 +104,13 @@ pub(super) fn system_txn_outcome<'guard>(interp: InterpreterContext<'guard>) -> 
     }
 }
 
-/// BCS-encodes one system-call argument.
-pub(super) fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, MoveExecutionFailure> {
-    bcs::to_bytes(value)
-        .map_err(|e| invariant_violation(anyhow!("system call argument does not serialize: {e}")))
-        .map_err(MoveExecutionFailure::RuntimeError)
-}
-
-/// Calls `0x1::block::<function>` as the VM (`0x0`).
-pub(super) fn call_block_function(
-    interp: &mut InterpreterContext<'_>,
-    guard: &ExecutionGuard<'_>,
+/// Calls `0x1::block::<function>` as the VM, with `place` filling the call
+/// args after the VM signer.
+pub(super) fn call_block_function<'a>(
+    interp: &mut InterpreterContext<'a>,
+    guard: &ExecutionGuard<'a>,
     function: &IdentStr,
-    args: &[Vec<u8>],
+    place: impl FnOnce(&mut CallBuilder<'_, '_>) -> Result<(), VMInternalError>,
 ) -> Result<(), MoveExecutionFailure> {
     let status = call_system_function_unmetered(
         guard,
@@ -124,9 +119,9 @@ pub(super) fn call_block_function(
         BLOCK,
         function,
         guard.type_list_of(&[]),
-        &[AccountAddress::ZERO.into_bytes()],
-        args,
+        &[VM_SIGNER],
+        place,
     )
     .map_err(MoveExecutionFailure::RuntimeError)?;
-    into_result(status)
+    call_result(status)
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/src/user_txn/args.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/user_txn/args.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Placing a transaction payload's wire-format arguments -- signer addresses
+//! and BCS blobs -- onto an entry function's parameters.
+
+use crate::{
+    calls::resolve_function_by_name,
+    errors::{InvalidArguments, MoveExecutionFailure},
+};
+use mono_move_core::types::{is_signer_or_signer_immut_ref, InternedTypeList};
+use mono_move_global_context::ExecutionGuard;
+use mono_move_runtime::{CallBuilder, InterpreterContext, RuntimeError, RuntimeStatus};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
+
+/// Fills the call in parameter order: signer parameters from the sender and
+/// secondary signers, everything else from the transaction's BCS arguments.
+fn place_user_txn_args<'a>(
+    call: &mut CallBuilder<'a, '_>,
+    sender: &'a AccountAddress,
+    secondary_signers: &'a [AccountAddress],
+    args: &[Vec<u8>],
+) -> Result<(), MoveExecutionFailure> {
+    // Like AptosVM, check the parameter shape and both counts before decoding
+    // any argument: signers must lead the parameter list, and a function with
+    // signer parameters requires exactly that many signers while one without
+    // ignores them.
+    let mut signer_params = 0;
+    for (index, &ty) in call.param_tys().iter().enumerate() {
+        if is_signer_or_signer_immut_ref(ty) {
+            if index != signer_params {
+                return Err(MoveExecutionFailure::InvalidArguments(
+                    InvalidArguments::SignerAfterArgument,
+                ));
+            }
+            signer_params += 1;
+        }
+    }
+    if args.len() != call.param_tys().len() - signer_params {
+        return Err(MoveExecutionFailure::InvalidArguments(
+            InvalidArguments::ArgumentCountMismatch,
+        ));
+    }
+    if signer_params > 0 && 1 + secondary_signers.len() != signer_params {
+        return Err(MoveExecutionFailure::InvalidArguments(
+            InvalidArguments::SignerCountMismatch,
+        ));
+    }
+    // The sender fills the first signer parameter, secondary signers the
+    // rest. Placing a signer can only fail on a bug.
+    for signer in std::iter::once(sender)
+        .chain(secondary_signers)
+        .take(signer_params)
+    {
+        call.signer(signer)
+            .map_err(MoveExecutionFailure::RuntimeError)?;
+    }
+    for arg in args {
+        // Only a decode failure faults the argument's bytes; anything else
+        // (a non-decodable parameter type, an exhausted heap) is the VM's.
+        call.arg_bcs(arg).map_err(|err| {
+            if err
+                .downcast_ref::<RuntimeError>()
+                .is_some_and(RuntimeError::is_bcs_decode_error)
+            {
+                MoveExecutionFailure::InvalidArguments(InvalidArguments::UndecodableArgument)
+            } else {
+                MoveExecutionFailure::RuntimeError(err)
+            }
+        })?;
+    }
+    Ok(())
+}
+
+/// Runs the transaction's entry function on its wire-format arguments,
+/// metered against the transaction's gas budget.
+pub(crate) fn call_entry_function<'a>(
+    guard: &ExecutionGuard<'a>,
+    interp: &mut InterpreterContext<'a>,
+    address: &AccountAddress,
+    module_name: &IdentStr,
+    function_name: &IdentStr,
+    ty_args: InternedTypeList,
+    sender: &AccountAddress,
+    secondary_signers: &[AccountAddress],
+    args: &[Vec<u8>],
+) -> Result<RuntimeStatus, MoveExecutionFailure> {
+    let func =
+        resolve_function_by_name(guard, interp, address, module_name, function_name, ty_args)
+            .map_err(MoveExecutionFailure::RuntimeError)?;
+    let mut call = interp
+        .build_call(func)
+        .map_err(MoveExecutionFailure::RuntimeError)?;
+    place_user_txn_args(&mut call, sender, secondary_signers, args)?;
+    call.run().map_err(MoveExecutionFailure::RuntimeError)
+}

--- a/third_party/move/mono-move/aptos-transaction-executor/src/user_txn/execute.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/user_txn/execute.rs
@@ -5,13 +5,13 @@
 //! session hosting the prologue, the payload, and the epilogue.
 
 use super::{
+    args::call_entry_function,
     metadata::TxnMetadata,
     pre_execution_checks::PreExecutionChecker,
-    validation::{run_epilogue, run_prologue, TxnSigners},
+    validation::{run_epilogue, run_prologue, ValidationSigners},
 };
 use crate::{
-    calls::call_function,
-    errors::{DiscardReason, ExecutionStage, ExecutionStatus, MoveExecutionFailure},
+    errors::{call_result, DiscardReason, ExecutionStage, ExecutionStatus, MoveExecutionFailure},
     executor::AptosTransactionExecutor,
     natives::extensions_with,
     outcome::TxnOutcome,
@@ -26,7 +26,7 @@ use mono_move_core::{
 };
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
 use mono_move_natives::TransactionContextExtension;
-use mono_move_runtime::{InterpreterContext, RuntimeStatus};
+use mono_move_runtime::InterpreterContext;
 
 impl<'guard> AptosTransactionExecutor<'guard> {
     /// Executes one user transaction, returning its side effects unmaterialized (see [`TxnOutcome`]).
@@ -99,7 +99,7 @@ impl<'guard> AptosTransactionExecutor<'guard> {
         let extensions = transaction_extensions(&txn_data, self.usage);
 
         let max_gas = txn_data.max_gas_amount;
-        let mut interp = InterpreterContext::new_idle(
+        let mut interp = InterpreterContext::new(
             loader,
             // TODO(metering): MonoMove gas units are uncalibrated; budgeting
             // 1:1 against the transaction's gas units is a placeholder.
@@ -109,7 +109,7 @@ impl<'guard> AptosTransactionExecutor<'guard> {
         )
         .with_extensions(extensions);
 
-        let signers = TxnSigners::for_validation(&txn_data);
+        let signers = ValidationSigners::new(&txn_data);
 
         // ============================ Prologue ==============================
         // Validate the transaction (auth key, sequence number or nonce, fee coverage etc.)
@@ -153,7 +153,7 @@ impl<'guard> AptosTransactionExecutor<'guard> {
         // ============================ Epilogue ==============================
         // Transaction cleanup -- charge gas, bump sequence number etc.
         let fee_statement = placeholder_fee_statement(gas_used);
-        let epilogue = |interp: &mut InterpreterContext<'_>| {
+        let epilogue = |interp: &mut InterpreterContext<'guard>| {
             run_epilogue(
                 interp,
                 guard,
@@ -205,7 +205,7 @@ impl<'guard> AptosTransactionExecutor<'guard> {
 
     fn execute_entry_function(
         &self,
-        interp: &mut InterpreterContext<'_>,
+        interp: &mut InterpreterContext<'guard>,
         txn_data: &TxnMetadata,
         entry: &EntryFunction,
         ty_args: InternedTypeList,
@@ -216,32 +216,19 @@ impl<'guard> AptosTransactionExecutor<'guard> {
         // `transaction_arg_validation`.
 
         // TODO(completeness): multi-agent transactions are untested.
-        let signers = TxnSigners::for_payload(txn_data);
-
-        let status = call_function(
+        let status = call_entry_function(
             self.guard,
             interp,
             &entry.module().address,
             entry.module().name(),
             entry.function(),
             ty_args,
-            signers.as_slice(),
+            &txn_data.sender,
+            &txn_data.secondary_signers,
             entry.args(),
-        )
-        .map_err(MoveExecutionFailure::RuntimeError)?;
+        )?;
 
-        match status {
-            RuntimeStatus::Success => Ok(()),
-            RuntimeStatus::Aborted {
-                code,
-                message,
-                location,
-            } => Err(MoveExecutionFailure::Abort {
-                code,
-                message,
-                location,
-            }),
-        }
+        call_result(status)
     }
 }
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/user_txn/validation.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/user_txn/validation.rs
@@ -8,10 +8,9 @@
 
 use super::metadata::TxnMetadata;
 use crate::{
-    calls::{call_system_function_unmetered, into_result, invariant_violation},
-    errors::MoveExecutionFailure,
+    calls::call_system_function_unmetered,
+    errors::{call_result, MoveExecutionFailure},
 };
-use anyhow::anyhow;
 use aptos_types::{
     fee_statement::FeeStatement,
     transaction::{EpilogueArgs, PrologueArgs},
@@ -20,44 +19,35 @@ use mono_move_core::{Interner, VMInternalError};
 use mono_move_global_context::ExecutionGuard;
 use mono_move_runtime::{InterpreterContext, RuntimeStatus};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
-use serde::Serialize;
+use move_value_view::MoveValueView;
 
 const TRANSACTION_VALIDATION: &IdentStr = ident_str!("transaction_validation");
 const VERSIONED_PROLOGUE: &IdentStr = ident_str!("versioned_prologue");
 const VERSIONED_EPILOGUE: &IdentStr = ident_str!("versioned_epilogue");
 
-/// The signer buffers a Move call receives, in parameter order.
-pub(crate) struct TxnSigners(Vec<[u8; AccountAddress::LENGTH]>);
+/// The signers the prologue and epilogue take.
+pub(crate) struct ValidationSigners {
+    sender: AccountAddress,
+    fee_payer: AccountAddress,
+}
 
-impl TxnSigners {
-    /// Sender and fee payer, as the prologue and epilogue take them.
-    pub(crate) fn for_validation(txn_data: &TxnMetadata) -> Self {
-        let fee_payer = txn_data.fee_payer.unwrap_or(txn_data.sender);
-        Self(vec![txn_data.sender.into_bytes(), fee_payer.into_bytes()])
-    }
-
-    /// Sender and any secondary signers, as an entry function takes them.
-    pub(crate) fn for_payload(txn_data: &TxnMetadata) -> Self {
-        let mut signers = vec![txn_data.sender.into_bytes()];
-        signers.extend(txn_data.secondary_signers.iter().map(|s| s.into_bytes()));
-        Self(signers)
-    }
-
-    pub(crate) fn as_slice(&self) -> &[[u8; AccountAddress::LENGTH]] {
-        &self.0
+impl ValidationSigners {
+    pub(crate) fn new(txn_data: &TxnMetadata) -> Self {
+        Self {
+            sender: txn_data.sender,
+            fee_payer: txn_data.fee_payer.unwrap_or(txn_data.sender),
+        }
     }
 }
 
-/// Calls `0x1::transaction_validation::<function>(signers…, args)`.
-fn call_validation_function_unmetered(
-    guard: &ExecutionGuard<'_>,
-    interp: &mut InterpreterContext<'_>,
+/// Calls `0x1::transaction_validation::<function>(sender, fee_payer, args)`.
+fn call_validation_function_unmetered<'a>(
+    guard: &ExecutionGuard<'a>,
+    interp: &mut InterpreterContext<'a>,
     function: &IdentStr,
-    signers: &TxnSigners,
-    args: &impl Serialize,
+    signers: &ValidationSigners,
+    args: &impl MoveValueView,
 ) -> Result<RuntimeStatus, VMInternalError> {
-    let args_blob = bcs::to_bytes(args)
-        .map_err(|e| invariant_violation(anyhow!("validation args do not serialize: {e}")))?;
     call_system_function_unmetered(
         guard,
         interp,
@@ -65,15 +55,15 @@ fn call_validation_function_unmetered(
         TRANSACTION_VALIDATION,
         function,
         guard.type_list_of(&[]),
-        signers.as_slice(),
-        &[args_blob],
+        &[signers.sender, signers.fee_payer],
+        |call| call.arg(args),
     )
 }
 
-pub(crate) fn run_prologue(
-    interp: &mut InterpreterContext<'_>,
-    guard: &ExecutionGuard<'_>,
-    signers: &TxnSigners,
+pub(crate) fn run_prologue<'a>(
+    interp: &mut InterpreterContext<'a>,
+    guard: &ExecutionGuard<'a>,
+    signers: &ValidationSigners,
     txn_data: &TxnMetadata,
 ) -> Result<(), MoveExecutionFailure> {
     let args = PrologueArgs::V1 {
@@ -94,13 +84,13 @@ pub(crate) fn run_prologue(
     let status =
         call_validation_function_unmetered(guard, interp, VERSIONED_PROLOGUE, signers, &args)
             .map_err(MoveExecutionFailure::RuntimeError)?;
-    into_result(status)
+    call_result(status)
 }
 
-pub(crate) fn run_epilogue(
-    interp: &mut InterpreterContext<'_>,
-    guard: &ExecutionGuard<'_>,
-    signers: &TxnSigners,
+pub(crate) fn run_epilogue<'a>(
+    interp: &mut InterpreterContext<'a>,
+    guard: &ExecutionGuard<'a>,
+    signers: &ValidationSigners,
     txn_data: &TxnMetadata,
     fee_statement: FeeStatement,
     gas_units_remaining: u64,
@@ -116,5 +106,5 @@ pub(crate) fn run_epilogue(
     let status =
         call_validation_function_unmetered(guard, interp, VERSIONED_EPILOGUE, signers, &args)
             .map_err(MoveExecutionFailure::RuntimeError)?;
-    into_result(status)
+    call_result(status)
 }

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -401,13 +401,10 @@ fn extra_signers_rejected_like_v1() {
     );
 
     let v2_output = execute_v2(fx.get_state_view(), &txn);
-    assert!(
-        matches!(
-            v2_output.status(),
-            TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(_))
-        ),
-        "v2 did not reject the signer-count mismatch: {:?}",
-        v2_output.status()
+    assert_eq!(
+        v2_output.status(),
+        v1_output.status(),
+        "v2 rejected the signer-count mismatch differently"
     );
 
     // Write sets are not compared: the gas divergence leaves v1 with fee

--- a/third_party/move/mono-move/core/src/function.rs
+++ b/third_party/move/mono-move/core/src/function.rs
@@ -4,6 +4,7 @@
 use crate::{
     instruction::{CodeOffset, FrameOffset, MicroOp, SizedSlot, FRAME_METADATA_SIZE},
     interner::InternedModuleId,
+    types::InternedType,
 };
 use mono_move_alloc::{GlobalArenaPtr, LeakedBoxPtr};
 use move_binary_format::file_format::FunctionDefinitionIndex;
@@ -175,6 +176,8 @@ pub struct Function {
     pub entry_gas: u64,
     /// Per-parameter (aligned) frame slot, in declaration order.
     pub param_slots: Vec<SizedSlot>,
+    /// Per-parameter substituted type, parallel to `param_slots`.
+    pub param_tys: Vec<InternedType>,
     /// Byte size of the parameter region (includes padding in between parameters).
     pub param_region_size: usize,
     /// Size of the parameters + locals region. Frame metadata is stored

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -375,6 +375,34 @@ pub fn intrinsic_slot_size_and_align(ty: &Type) -> Option<(Size, Alignment)> {
     })
 }
 
+/// Whether `ty` is `signer` or `&signer`, the parameter shapes that fill from
+/// a transaction signer.
+pub fn is_signer_or_signer_immut_ref(ty: InternedType) -> bool {
+    match view_type(ty) {
+        Type::Signer => true,
+        Type::ImmutRef { inner } => matches!(view_type(*inner), Type::Signer),
+        Type::Bool
+        | Type::U8
+        | Type::U16
+        | Type::U32
+        | Type::U64
+        | Type::U128
+        | Type::U256
+        | Type::I8
+        | Type::I16
+        | Type::I32
+        | Type::I64
+        | Type::I128
+        | Type::I256
+        | Type::Address
+        | Type::MutRef { .. }
+        | Type::Vector { .. }
+        | Type::Nominal { .. }
+        | Type::Function { .. }
+        | Type::TypeParam { .. } => false,
+    }
+}
+
 impl Type {
     /// The short kind word for this type (`"u64"`, `"vector"`, `"struct"`, ...).
     /// Mirrors the legacy VM's `TypeTag::to_short_string`.

--- a/third_party/move/mono-move/core/src/value_layout.rs
+++ b/third_party/move/mono-move/core/src/value_layout.rs
@@ -21,7 +21,7 @@ use crate::{
     DescriptorId, MAX_ALIGN,
 };
 use bitflags::bitflags;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 /// Typed index into the program's [`ValueLayout`] table.
 #[repr(transparent)]
@@ -78,6 +78,25 @@ pub struct ValueLayout {
     pub flags: LayoutFlags,
     /// Describes layout's shape.
     pub kind: LayoutKind,
+}
+
+impl fmt::Display for ValueLayout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            LayoutKind::Bool => write!(f, "bool"),
+            LayoutKind::UnsignedInt => write!(f, "{}-byte unsigned integer", self.size),
+            LayoutKind::SignedInt => write!(f, "{}-byte signed integer", self.size),
+            LayoutKind::Address => write!(f, "address"),
+            LayoutKind::Signer => write!(f, "signer"),
+            LayoutKind::Struct { fields } => write!(f, "struct with {} fields", fields.len()),
+            LayoutKind::Vector { .. } => write!(f, "vector"),
+            LayoutKind::FrozenEnum { variants, .. } => {
+                write!(f, "enum with {} variants", variants.len())
+            },
+            LayoutKind::Ref => write!(f, "reference"),
+            LayoutKind::Function => write!(f, "function value"),
+        }
+    }
 }
 
 /// Layout information for a struct field.

--- a/third_party/move/mono-move/lean-link/src/engine.rs
+++ b/third_party/move/mono-move/lean-link/src/engine.rs
@@ -7,9 +7,8 @@
 //! an in-memory provider. Every call then runs in its own interpreter
 //! context — the same isolation shape as one transaction per session — with
 //! the request's gas budget re-armed per call, so outcomes depend only on
-//! the request. The execution core is the transaction executor's public call
-//! machinery; this module contributes the compile step and the orchestration
-//! only.
+//! the request. Calls are placed and run through the runtime's `CallBuilder`;
+//! this module contributes the compile step and the orchestration only.
 
 use crate::{
     marshal::{encode_bcs, parse_address, read_root_results},
@@ -21,15 +20,18 @@ use crate::{
 use bytes::Bytes;
 use codespan_reporting::term::termcolor::Buffer;
 use legacy_move_compiler::{compiled_unit::CompiledUnit, shared::known_attributes::KnownAttribute};
-use mono_move_aptos_transaction_executor::{call_function, production_natives, return_types};
+use mono_move_aptos_transaction_executor::production_natives;
 use mono_move_core::{
-    types::EMPTY_TYPE_LIST, ExecutionErrorKind, GasMeter, Interner, IntoExecutionError,
-    NoResourceProvider, VMInternalError, VMResult,
+    interner::InternedIdentifier,
+    types::{view_type_list, InternedType, InternedTypeList, EMPTY_TYPE_LIST},
+    ExecutionErrorKind, GasMeter, Interner, IntoExecutionError, NoResourceProvider,
+    VMInternalError, VMResult,
 };
-use mono_move_global_context::{ExecutionGuard, GlobalContext};
+use mono_move_global_context::{ExecutionGuard, FunctionIrLookup, GlobalContext, LoadedModule};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleProvider};
 use mono_move_runtime::{
-    error::RuntimeError, InterpreterContext, ProductionNativeRegistry, RuntimeStatus,
+    error::RuntimeError, InterpreterContext, InterpreterOptions, ProductionNativeRegistry,
+    RuntimeStatus,
 };
 use move_binary_format::CompiledModule;
 use move_compiler_v2::Options;
@@ -191,16 +193,13 @@ fn run_call<'guard>(
             }
         },
     };
-    let signer_bufs = match call
+    let signers = match call
         .signers
         .iter()
         .map(|signer| parse_address(signer))
         .collect::<Result<Vec<_>, _>>()
     {
-        Ok(signers) => signers
-            .into_iter()
-            .map(|address| address.into_bytes())
-            .collect::<Vec<_>>(),
+        Ok(signers) => signers,
         Err(message) => {
             return Outcome::Error {
                 stage: Stage::Abi,
@@ -216,37 +215,38 @@ fn run_call<'guard>(
         natives,
     );
     let gas_meter = GasMeter::new(limits.gas);
-    let mut interp = match limits.heap {
-        Some(heap_size) => InterpreterContext::new_idle_with_heap_size(
-            loader,
-            gas_meter,
-            &NoResourceProvider,
-            natives,
-            heap_size,
-        ),
-        None => InterpreterContext::new_idle(loader, gas_meter, &NoResourceProvider, natives),
-    };
-
-    let result = call_function(
-        guard,
-        &mut interp,
-        &address,
-        module_name.as_ident_str(),
-        function_name.as_ident_str(),
-        EMPTY_TYPE_LIST,
-        &signer_bufs,
-        &args,
+    let mut options = InterpreterOptions::default();
+    if let Some(heap_size) = limits.heap {
+        options.heap_size = heap_size;
+    }
+    let mut interp = InterpreterContext::new_with_options(
+        loader,
+        gas_meter,
+        &NoResourceProvider,
+        natives,
+        options,
     );
+
+    let module_id = guard.module_id_of(&address, module_name.as_ident_str());
+    let function_id = guard.identifier_of(function_name.as_ident_str());
+    let result = (|| {
+        let func = interp.load_function(module_id, function_id, EMPTY_TYPE_LIST)?;
+        let mut call = interp.build_call(func)?;
+        for signer in &signers {
+            call.signer(signer)?;
+        }
+        for arg in &args {
+            call.arg_bcs(arg)?;
+        }
+        call.run()
+    })();
     let gas_used = limits.gas.saturating_sub(interp.gas_balance());
     let gc_count = interp.gc_count();
 
     match result {
         Ok(RuntimeStatus::Success) => {
             // Resolve the callee's return types through the read set the
-            // call left behind, mirroring how the executor itself reaches
-            // the loaded module.
-            let module_id = guard.module_id_of(&address, module_name.as_ident_str());
-            let function_id = guard.identifier_of(function_name.as_ident_str());
+            // call left behind.
             let returns = match interp
                 .read_set()
                 .get_loaded(guard.arena_ref_for_module_id(module_id))
@@ -327,6 +327,28 @@ fn run_call<'guard>(
             }
         },
     }
+}
+
+/// The return types of a loaded module's function, instantiated with
+/// `ty_args`.
+fn return_types(
+    guard: &ExecutionGuard<'_>,
+    loaded: &LoadedModule,
+    function: InternedIdentifier,
+    ty_args: InternedTypeList,
+) -> Result<Vec<InternedType>, String> {
+    let FunctionIrLookup::Ir(ir) = loaded.get_function_ir(function) else {
+        return Err("function has no IR in its loaded module".to_string());
+    };
+    let returns = loaded
+        .ir()
+        .module
+        .function_signature_at(ir.handle_idx)
+        .returns;
+    let returns = guard
+        .subst_type_list(returns, ty_args)
+        .map_err(|error| error.to_string())?;
+    Ok(view_type_list(returns).to_vec())
 }
 
 /// Parses `0x…::module::function`.

--- a/third_party/move/mono-move/loader/src/loader.rs
+++ b/third_party/move/mono-move/loader/src/loader.rs
@@ -332,6 +332,8 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
                 }))
             },
         };
+        // TODO(security, metering): run the micro-op verifier on `function`
+        // here, once per cached lowering.
         Ok((function, function_ms))
     }
 }

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -21,11 +21,13 @@ mono-move-core = { workspace = true }
 mono-move-global-context = { workspace = true }
 mono-move-loader = { workspace = true }
 move-core-types = { workspace = true }
+move-value-view = { workspace = true }
 rand = { workspace = true }
 shared-dsa = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+move-value-view-derive = { workspace = true }
 num-bigint = { workspace = true }
 paste = { workspace = true }
 proptest = { workspace = true }

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -124,6 +124,47 @@ pub enum RuntimeError {
 const _: () = assert!(std::mem::size_of::<RuntimeError>() <= 48);
 const _: () = assert!(std::mem::align_of::<RuntimeError>() <= 8);
 
+impl RuntimeError {
+    /// Whether the error faults the BCS bytes being decoded, rather than the
+    /// VM or its limits.
+    pub fn is_bcs_decode_error(&self) -> bool {
+        use RuntimeError::*;
+        match self {
+            BCSEof
+            | BCSInvalidUleb
+            | BCSSequenceTooLong { .. }
+            | BCSRemainingInput { .. }
+            | BCSInvalidBool { .. }
+            | BCSSignerNotDeserializable => true,
+
+            ArithmeticOverflow { .. }
+            | ArithmeticUnderflow { .. }
+            | DivisionByZero { .. }
+            | ShiftAmountOutOfRange { .. }
+            | ArithmeticUnderOverflow { .. }
+            | DivisionOverflow { .. }
+            | NegateMinOverflow { .. }
+            | CastOutOfRange { .. }
+            | PopFromEmptyVector
+            | VecUnpackLengthMismatch { .. }
+            | VectorIndexOutOfBounds { .. }
+            | ResourceDoesNotExist { .. }
+            | ResourceAlreadyExists { .. }
+            | EnumVariantMismatch { .. }
+            | StackOverflow
+            | OutOfHeapMemory { .. }
+            | AllocationTooLarge { .. }
+            | VecAllocSizeOverflow
+            | InvalidAbortMessage { .. }
+            | AbortMessageTooLong { .. }
+            | StateKeyTypeTooDeep
+            | InvariantViolation(_)
+            | ResourceProvider(_)
+            | Unsupported(_) => false,
+        }
+    }
+}
+
 impl IntoExecutionError for RuntimeError {
     fn kind(&self) -> ExecutionErrorKind {
         use RuntimeError::*;
@@ -326,6 +367,12 @@ pub enum RuntimeInvariantViolation {
     #[error("type has no published layout")]
     ValueLayoutNotFound,
 
+    /// A Rust value placed as a call argument does not match its parameter's
+    /// layout. This is an invariant violation as the caller is expected to
+    /// ensure matching.
+    #[error("call argument mismatch: {0}")]
+    CallArgMismatch(String),
+
     #[error("unreachable: {0}")]
     Unreachable(String),
 
@@ -384,6 +431,9 @@ pub enum RuntimeInvariantViolation {
     #[error("rollback({requested}): only {available} checkpoint(s) on the stack")]
     RollbackUnderflow { requested: usize, available: usize },
 
+    /// A well-formed enum's tag is always in range, so an out-of-range tag —
+    /// read from an in-memory value or decoded from BCS — signals corruption,
+    /// not a legitimate runtime condition.
     #[error("enum tag {tag} out of range for {variant_count} variants")]
     EnumTagOutOfRange { tag: u64, variant_count: usize },
 

--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -17,8 +17,8 @@ use crate::{
     invariant_violation,
     memory::{
         read_descriptor, read_forwarding, read_obj_size, read_ptr, read_u64, read_vec_len,
-        write_descriptor, write_forwarding, write_object_header, write_ptr, write_u64,
-        MemoryRegion,
+        write_descriptor, write_enum_tag, write_forwarding, write_object_header, write_ptr,
+        write_u64, MemoryRegion,
     },
     types::{
         DEFAULT_HEAP_SIZE, FORWARDED_MARKER, META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET,
@@ -386,7 +386,7 @@ pub(crate) unsafe fn deserialize_or_gc<
     top_frame: TopFrame<'_>,
 ) -> VMResult<()> {
     // SAFETY: forwarded from this function's contract.
-    match unsafe { crate::value_utils::deserialize(layouts, heap, ty, bytes, dst) } {
+    match unsafe { crate::value_conv::bcs::deserialize(layouts, heap, ty, bytes, dst) } {
         Ok(()) => Ok(()),
         Err(AllocationError::RuntimeError(err)) => Err(VMInternalError::new(err)),
         Err(AllocationError::OutOfHeapMemory { .. }) => {
@@ -400,7 +400,7 @@ pub(crate) unsafe fn deserialize_or_gc<
                 top_frame,
             )?;
             // SAFETY: as above.
-            unsafe { crate::value_utils::deserialize(layouts, heap, ty, bytes, dst) }
+            unsafe { crate::value_conv::bcs::deserialize(layouts, heap, ty, bytes, dst) }
                 .map_err(|e| VMInternalError::new(e.into_runtime_error()))
         },
     }
@@ -567,10 +567,7 @@ pub(crate) fn alloc_vec<P: DescriptorProvider + ?Sized>(
     elem_size: u32,
     capacity_in_elems: u64,
 ) -> VMResult<*mut u8> {
-    let total_size = (capacity_in_elems as usize)
-        .checked_mul(elem_size as usize)
-        .and_then(|v| v.checked_add(OBJECT_HEADER_SIZE + VEC_DATA_OFFSET))
-        .ok_or(RuntimeError::VecAllocSizeOverflow)?;
+    let total_size = vec_alloc_size(capacity_in_elems, elem_size)?;
     // `length` defaults to 0 via heap_alloc's zero-init.
     alloc_sized(
         heap,
@@ -583,6 +580,47 @@ pub(crate) fn alloc_vec<P: DescriptorProvider + ?Sized>(
         total_size,
         descriptor_id,
     )
+}
+
+/// Total allocation size of a vector object holding `capacity_in_elems`
+/// elements.
+fn vec_alloc_size(capacity_in_elems: u64, elem_size: u32) -> Result<usize, RuntimeError> {
+    (capacity_in_elems as usize)
+        .checked_mul(elem_size as usize)
+        .and_then(|v| v.checked_add(OBJECT_HEADER_SIZE + VEC_DATA_OFFSET))
+        .ok_or(RuntimeError::VecAllocSizeOverflow)
+}
+
+/// Like [`alloc_vec`], but fails rather than triggering GC when the heap is
+/// full, and stamps `len` as the vector's length.
+pub(crate) fn alloc_vec_no_gc(
+    heap: &mut Heap,
+    descriptor_id: DescriptorId,
+    elem_size: u32,
+    len: u64,
+) -> AllocationResult<*mut u8> {
+    let vec_ptr = heap_alloc(heap, vec_alloc_size(len, elem_size)?, descriptor_id)?;
+    // SAFETY: the allocation stores the vector length at this offset.
+    unsafe { write_u64(vec_ptr, VEC_LENGTH_OFFSET, len) };
+    Ok(vec_ptr)
+}
+
+/// Allocates an enum object sized for its widest variant with `tag` stamped,
+/// failing rather than triggering GC when the heap is full.
+pub(crate) fn alloc_enum_no_gc(
+    heap: &mut Heap,
+    descriptor_id: DescriptorId,
+    tag: u64,
+    max_size_across_variants: usize,
+) -> AllocationResult<*mut u8> {
+    let obj_ptr = heap_alloc(
+        heap,
+        OBJECT_HEADER_SIZE + max_size_across_variants,
+        descriptor_id,
+    )?;
+    // SAFETY: the allocation has enough size to write the tag.
+    unsafe { write_enum_tag(obj_ptr, tag) };
+    Ok(obj_ptr)
 }
 
 /// Allocate a new zeroed heap object (struct or enum). Size comes from the

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -28,7 +28,8 @@ use crate::{
         META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
         VEC_PUSHBACK_INIT_CAPACITY,
     },
-    value_utils,
+    value_cmp, value_conv,
+    value_conv::rust::write_value,
 };
 use mono_move_core::{
     captured_values_size,
@@ -39,25 +40,29 @@ use mono_move_core::{
     },
     next_captured_value_offset,
     storage::resource_provider::InMemoryStorageKey,
-    types::{view_type, view_type_list, InternedType, InternedTypeList, Type},
-    CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, ConstantPoolIndex, DescriptorId,
-    FrameOffset, Function, FunctionPtr, FunctionRef, GasMeter, IntBinaryOp, IntCastOp, IntNegateOp,
-    IntOperand, IntShiftOp, IntTy, LayoutProvider, MicroOp, PackClosureOp, ResourceProvider,
-    ShiftOperand, VMInternalError, VMResult, VecPackOp, VecUnpackOp,
-    CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET,
-    CAPTURED_DATA_VALUES_SIZE_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID,
-    CLOSURE_FUNC_REF_OFFSET, CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET,
-    FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN,
-    OBJECT_HEADER_SIZE,
+    types::{
+        is_signer_or_signer_immut_ref, view_type, view_type_list, InternedType, InternedTypeList,
+        Type,
+    },
+    CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, ConstantPoolIndex, FrameOffset, Function,
+    FunctionRef, GasMeter, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand, IntShiftOp, IntTy,
+    LayoutProvider, MicroOp, PackClosureOp, ResourceProvider, ShiftOperand, VMInternalError,
+    VMResult, VecPackOp, VecUnpackOp, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
+    CAPTURED_DATA_VALUES_OFFSET, CAPTURED_DATA_VALUES_SIZE_OFFSET,
+    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID, CLOSURE_FUNC_REF_OFFSET,
+    CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
+    FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
 };
 use mono_move_global_context::ExecutionGuard;
 use mono_move_loader::{Loader, ModuleReadSet};
 use move_core_types::{
+    account_address::AccountAddress,
     identifier::Identifier,
     int256::{I256, U256},
     language_storage::ModuleId,
     vm_status::AbortLocation,
 };
+use move_value_view::MoveValueView;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{
     cell::Ref,
@@ -201,6 +206,108 @@ impl<'guard> SessionEffects<'guard> {
     }
 }
 
+/// Places one call's arguments, in parameter order. Every value is checked
+/// against its parameter's declared type.
+pub struct CallBuilder<'a, 'guard> {
+    interp: &'a mut InterpreterContext<'guard>,
+    func: &'a Function,
+    next_param: usize,
+}
+
+impl<'a> CallBuilder<'a, '_> {
+    /// The parameter types of the called function.
+    pub fn param_tys(&self) -> &[InternedType] {
+        &self.func.param_tys
+    }
+
+    /// Advances to the next parameter, returning its slot's address and type.
+    ///
+    /// There is no need to check the size of the slot as we've already checked
+    /// that the entire entry frame fits onto the stack in [`InterpreterContext::build_call`].
+    fn next_slot(&mut self) -> VMResult<(*mut u8, InternedType)> {
+        let index = self.next_param;
+        let (Some(slot), Some(ty)) = (
+            self.func.param_slots.get(index),
+            self.func.param_tys.get(index),
+        ) else {
+            invariant_violation!(Unreachable(
+                "more arguments than the function's parameters".to_string()
+            ));
+        };
+        self.next_param += 1;
+        // SAFETY: the offset is a parameter slot of the root frame, which
+        // `build_call` checked fits on the stack.
+        let dst = unsafe {
+            self.interp
+                .stack
+                .as_ptr()
+                .add(FRAME_METADATA_SIZE + usize::from(slot.offset))
+        };
+        Ok((dst, *ty))
+    }
+
+    /// Fills the next parameter with `signer`, by value or by reference as
+    /// the parameter declares. The address must outlive the call and sit
+    /// outside the VM heap, out of the GC's reach.
+    pub fn signer(&mut self, addr: &'a AccountAddress) -> VMResult<()> {
+        let (dst, ty) = self.next_slot()?;
+        if !is_signer_or_signer_immut_ref(ty) {
+            invariant_violation!(Unreachable("the parameter is not a signer".to_string()));
+        }
+        let addr_bytes: &'a [u8] = addr.as_ref();
+        if matches!(view_type(ty), Type::Signer) {
+            // SAFETY: the slot is 32 bytes wide per its type.
+            unsafe {
+                std::ptr::copy_nonoverlapping(addr_bytes.as_ptr(), dst, AccountAddress::LENGTH)
+            };
+        } else {
+            // `&signer`, per the predicate.
+            // SAFETY: the slot is a reference slot per its type, and the
+            // address outlives the call.
+            unsafe { write_fat_ptr(dst, 0usize, addr_bytes.as_ptr(), 0) };
+        }
+        Ok(())
+    }
+
+    /// Places a Rust value as the next parameter. Its shape must match the
+    /// parameter's Move type.
+    ///
+    /// On error, the parameter slot is left partially written and the call
+    /// must be abandoned.
+    pub fn arg<T: MoveValueView + ?Sized>(&mut self, value: &T) -> VMResult<()> {
+        let (dst, ty) = self.next_slot()?;
+        let guard = self.interp.loader.guard();
+        // SAFETY: `dst` and `ty` come from the function's own signature, so
+        // the slot is writable for the type's in-memory size.
+        unsafe {
+            write_value(guard, &mut self.interp.heap, ty, value, dst).map_err(VMInternalError::new)
+        }
+    }
+
+    /// Places a BCS-encoded argument.
+    ///
+    /// On error, the parameter slot is left partially written and the call
+    /// must be abandoned.
+    pub fn arg_bcs(&mut self, bytes: &[u8]) -> VMResult<()> {
+        let (dst, ty) = self.next_slot()?;
+        let guard = self.interp.loader.guard();
+        // SAFETY: `dst` and `ty` come from the function's own signature, so
+        // the slot is writable for the type's in-memory size.
+        unsafe { value_conv::bcs::deserialize_into(guard, &mut self.interp.heap, ty, bytes, dst) }
+    }
+
+    /// Runs the call once all parameters have been filled.
+    pub fn run(self) -> VMResult<RuntimeStatus> {
+        if self.next_param != self.func.param_slots.len() {
+            invariant_violation!(Unreachable(
+                "not enough arguments for the function".to_string()
+            ));
+        }
+        self.interp.prepare_call(self.func);
+        self.interp.run()
+    }
+}
+
 /// Materializes the [`AbortLocation`] naming the module that raised an abort.
 // TODO(completeness): return `AbortLocation::Script` for script aborts.
 fn abort_location(module_id: InternedModuleId) -> VMResult<AbortLocation> {
@@ -227,14 +334,8 @@ fn native_abort_location(name: &NativeName) -> VMResult<AbortLocation> {
 /// Per-transaction interpreter context with a unified call stack and a
 /// GC-managed heap: owns the transaction state (code loader and read-set, gas
 /// meter, native extensions, resource read-write set) and the machine state
-/// (stack, heap, VM registers). Interpreter sessions are [`Self::prepare_call`] /
-/// [`Self::reset`] calls on the same context, so state like the heap and the
-/// read-write set lives across sessions within one transaction.
-///
-/// Construction wires in the transaction inputs (loader, read-set and gas
-/// meter carried over from loading the entry function, resource provider,
-/// natives) and verifies the entry function; further sessions reuse the
-/// buffers via [`reset`](Self::reset).
+/// (stack, heap, VM registers). Each `build_call` is one session; the heap and
+/// read-write set live across the sessions of a transaction.
 pub struct InterpreterContext<'guard> {
     /// Per-transaction code loader; also the access point for the execution
     /// guard (descriptor/layout lookups). The loader's global-context
@@ -266,103 +367,47 @@ pub struct InterpreterContext<'guard> {
     rng: StdRng,
 }
 
+/// Construction options for an [`InterpreterContext`].
+//
+// TODO(cleanup): move into a VM-wide config outside the runtime crate once one
+// exists.
+pub struct InterpreterOptions {
+    /// The VM heap's capacity in bytes.
+    pub heap_size: usize,
+}
+
+impl Default for InterpreterOptions {
+    fn default() -> Self {
+        Self {
+            heap_size: DEFAULT_HEAP_SIZE,
+        }
+    }
+}
+
 impl<'guard> InterpreterContext<'guard> {
+    /// Creates a context with no call prepared, with default options.
     pub fn new(
         loader: Loader<'guard, 'guard>,
-        read_set: ModuleReadSet<'guard>,
         gas_meter: GasMeter,
         resource_provider: &'guard dyn ResourceProvider,
         natives: &'guard ProductionNativeRegistry,
-        entry: &Function,
     ) -> Self {
-        Self::with_heap_size(
+        Self::new_with_options(
             loader,
-            read_set,
             gas_meter,
             resource_provider,
             natives,
-            entry,
-            DEFAULT_HEAP_SIZE,
+            InterpreterOptions::default(),
         )
     }
 
-    /// Create a new context with a custom heap size (for testing GC pressure).
-    /// Verifies `entry` and installs it, ready for [`run`](Self::run); panics
-    /// if verification fails. `read_set` and `gas_meter` carry over the
-    /// entry-load state (the entry's module must be in the read-set for its
-    /// constants and call targets to resolve).
-    pub fn with_heap_size(
-        loader: Loader<'guard, 'guard>,
-        read_set: ModuleReadSet<'guard>,
-        gas_meter: GasMeter,
-        resource_provider: &'guard dyn ResourceProvider,
-        natives: &'guard ProductionNativeRegistry,
-        entry: &Function,
-        heap_size: usize,
-    ) -> Self {
-        let verification_errors = crate::verifier::verify_function(entry, loader.guard());
-        assert!(
-            verification_errors.is_empty(),
-            "verification failed:\n{}",
-            verification_errors
-                .iter()
-                .map(|e| format!("  {}", e))
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-
-        let stack = MemoryRegion::new_zeroed(DEFAULT_STACK_SIZE);
-        let base = stack.as_ptr();
-
-        unsafe {
-            write_u64(base, META_SAVED_PC_OFFSET, 0);
-            write_u64(base, META_SAVED_FP_OFFSET, 0);
-            write_ptr(base, META_SAVED_FUNC_PTR_OFFSET, null());
-        }
-
-        Self {
-            loader,
-            read_set,
-            gas_meter,
-            natives,
-            extensions: NativeExtensions::new(),
-            resource_provider,
-            registers: VMRegisters::new(&stack, entry),
-            stack,
-            heap: Heap::new(heap_size),
-            root_pool: RootPool::new(),
-            read_write_set: ResourceReadWriteSet::new(),
-            rng: StdRng::seed_from_u64(0),
-        }
-    }
-
-    /// Creates a context with no function installed and an empty read-set:
-    /// for drivers that resolve their first function through the context
-    /// itself. [`prepare_call`](Self::prepare_call) must run before execution.
-    pub fn new_idle(
+    /// Creates a context with no call prepared.
+    pub fn new_with_options(
         loader: Loader<'guard, 'guard>,
         gas_meter: GasMeter,
         resource_provider: &'guard dyn ResourceProvider,
         natives: &'guard ProductionNativeRegistry,
-    ) -> Self {
-        Self::new_idle_with_heap_size(
-            loader,
-            gas_meter,
-            resource_provider,
-            natives,
-            DEFAULT_HEAP_SIZE,
-        )
-    }
-
-    /// Creates an idle context with a custom heap size, bounding the bytes a
-    /// run may allocate before reporting exhaustion. Otherwise identical to
-    /// [`new_idle`](Self::new_idle).
-    pub fn new_idle_with_heap_size(
-        loader: Loader<'guard, 'guard>,
-        gas_meter: GasMeter,
-        resource_provider: &'guard dyn ResourceProvider,
-        natives: &'guard ProductionNativeRegistry,
-        heap_size: usize,
+        options: InterpreterOptions,
     ) -> Self {
         let stack = MemoryRegion::new_zeroed(DEFAULT_STACK_SIZE);
         let base = stack.as_ptr();
@@ -382,7 +427,7 @@ impl<'guard> InterpreterContext<'guard> {
             resource_provider,
             registers: VMRegisters::idle(&stack),
             stack,
-            heap: Heap::new(heap_size),
+            heap: Heap::new(options.heap_size),
             root_pool: RootPool::new(),
             read_write_set: ResourceReadWriteSet::new(),
             rng: StdRng::seed_from_u64(0),
@@ -405,14 +450,16 @@ impl<'guard> InterpreterContext<'guard> {
         module_id: InternedModuleId,
         name: InternedIdentifier,
         ty_args: InternedTypeList,
-    ) -> VMResult<FunctionPtr> {
-        self.loader.load_function(
+    ) -> VMResult<&'guard Function> {
+        let ptr = self.loader.load_function(
             &mut self.read_set,
             &mut self.gas_meter,
             module_id,
             name,
             ty_args,
-        )
+        )?;
+        // SAFETY: the function lives in an arena the guard keeps alive.
+        Ok(unsafe { ptr.as_ref_unchecked() })
     }
 
     /// Resolve a constant from `module_id`'s constant pool, returning its
@@ -524,16 +571,15 @@ impl<'guard> InterpreterContext<'guard> {
         result
     }
 
-    /// Reset the context to call a different function, preserving the heap.
-    ///
-    /// Use `set_root_arg` to place arguments before calling `run()`.
-    pub fn prepare_call(&mut self, func: &Function) {
+    /// Set up the context for executing the given function, initializing the
+    /// vm registers and the stack, while leaving the heap untouched.
+    fn prepare_call(&mut self, func: &Function) {
         let base = self.stack.as_ptr();
 
-        // Reset execution state to root frame.
         self.registers = VMRegisters::new(&self.stack, func);
 
-        // Re-write sentinel metadata so Return from root triggers Done.
+        // Sentinel metadata -- this is needed so we don't have to special-case
+        // the root frame.
         unsafe {
             write_u64(base, META_SAVED_PC_OFFSET, 0);
             write_u64(base, META_SAVED_FP_OFFSET, 0);
@@ -553,11 +599,13 @@ impl<'guard> InterpreterContext<'guard> {
         }
     }
 
-    /// Resets the context to run `func` again from a clean state, reusing the already-allocated
-    /// stack and heap buffers instead of reallocating them. Place arguments with
-    /// [`set_root_arg`](Self::set_root_arg) before calling [`run`](Self::run).
-    pub fn reset(&mut self, func: &Function, gas_budget: u64) {
-        self.prepare_call(func);
+    /// Wipes the transaction state but reuses the allocated buffers, so a
+    /// repeat-run harness keeps construction out of its measured loop.
+    /// Extensions are left installed.
+    ///
+    /// TODO(cleanup): figure out if there's a way to remove this without
+    /// affecting the benchmarks.
+    pub fn reset_for_test(&mut self, gas_budget: u64) {
         self.heap.reset();
         self.read_write_set = ResourceReadWriteSet::new();
         self.root_pool = RootPool::new();
@@ -566,21 +614,18 @@ impl<'guard> InterpreterContext<'guard> {
     }
 
     /// Read a u64 from the root frame's slot 0 (where the result lands).
-    pub fn root_result(&self) -> u64 {
+    pub fn root_result_u64_for_test(&self) -> u64 {
         unsafe { read_u64(self.stack.as_ptr(), FRAME_METADATA_SIZE) }
     }
 
     /// Read a u64 from the root frame at the given byte offset.
-    pub fn root_result_at(&self, offset: u32) -> u64 {
+    pub fn root_result_u64_at_for_test(&self, offset: u32) -> u64 {
         unsafe { read_u64(self.stack.as_ptr(), FRAME_METADATA_SIZE + offset as usize) }
     }
 
-    /// BCS-serializes the value a successfully completed root call returned,
-    /// by return type: the BCS inverse of
-    /// [`deserialize_root_arg`](Self::deserialize_root_arg), walking nested
-    /// heap objects through the guard's layout tables. Call only after a
-    /// successful [`run`](Self::run), with `ty` that call's return type; the
-    /// result lives at the start of the root frame's shared
+    /// BCS-serializes the value a successfully completed root call returned.
+    /// Call only after a successful run, with `ty` that call's return type;
+    /// the result lives at the start of the root frame's shared
     /// parameter/return region.
     pub fn serialize_root_result(&self, ty: InternedType) -> VMResult<Vec<u8>> {
         // SAFETY: the caller guarantees a completed call whose return value
@@ -588,7 +633,7 @@ impl<'guard> InterpreterContext<'guard> {
         // owns every reachable object, and the guard outlives the context.
         unsafe {
             let base = self.stack.as_ptr().add(FRAME_METADATA_SIZE);
-            value_utils::serialize(self.loader.guard(), base, ty)
+            value_conv::bcs::serialize(self.loader.guard(), base, ty)
         }
     }
 
@@ -636,93 +681,17 @@ impl<'guard> InterpreterContext<'guard> {
         }
     }
 
-    /// Copy argument bytes into the root frame at the given byte offset.
-    pub fn set_root_arg(&mut self, offset: u32, arg: &[u8]) {
-        unsafe {
-            let dst = self
-                .stack
-                .as_ptr()
-                .add(FRAME_METADATA_SIZE + offset as usize);
-            std::ptr::copy_nonoverlapping(arg.as_ptr(), dst, arg.len());
+    /// Starts a call to `func`. Fails if the function's frame does not fit on
+    /// the stack.
+    pub fn build_call<'a>(&'a mut self, func: &'a Function) -> VMResult<CallBuilder<'a, 'guard>> {
+        if FRAME_METADATA_SIZE + func.extended_frame_size > self.stack.len() {
+            return Err(VMInternalError::new(RuntimeError::StackOverflow));
         }
-    }
-
-    /// Place a reference to `target` in the root frame at the given byte offset.
-    ///
-    /// # Safety
-    ///
-    /// `target` must stay valid and pinned until the call finishes. Pointing
-    /// outside the VM heap also keeps it away from the GC.
-    pub unsafe fn set_root_ref_arg(&mut self, offset: u32, target: *const u8) {
-        // SAFETY: the offset is a parameter slot of the root frame, so it is
-        // within the stack and wide enough for a reference.
-        unsafe {
-            write_fat_ptr(
-                self.stack.as_ptr(),
-                FRAME_METADATA_SIZE + offset as usize,
-                target,
-                0,
-            )
-        };
-    }
-
-    /// Read a raw heap pointer from the root frame at the given byte offset.
-    pub fn root_heap_ptr(&self, offset: u32) -> *const u8 {
-        unsafe { read_ptr(self.stack.as_ptr(), FRAME_METADATA_SIZE + offset as usize) }
-    }
-
-    /// Deserialize a BCS-encoded argument of type `ty` into the root frame at `offset`, allocating
-    /// any nested heap data on this context's heap. Handles struct/vector arguments, unlike
-    /// [`set_root_arg`](Self::set_root_arg) (a raw copy for primitives only).
-    ///
-    /// # Safety
-    ///
-    /// `offset` and `ty` must correspond to a real parameter slot, and `ty` must not be a reference.
-    pub unsafe fn deserialize_root_arg(
-        &mut self,
-        offset: u32,
-        ty: InternedType,
-        bytes: &[u8],
-    ) -> VMResult<()> {
-        let dst = unsafe {
-            self.stack
-                .as_ptr()
-                .add(FRAME_METADATA_SIZE + offset as usize)
-        };
-        // SAFETY: `dst` is a slot in the root frame (caller guarantees offset/ty match a
-        // parameter); the guard is the LayoutProvider and `heap` is where nested data is boxed.
-        unsafe {
-            value_utils::deserialize_into(self.loader.guard(), &mut self.heap, ty, bytes, dst)
-        }
-    }
-
-    /// Allocate a vector of `u64` values on the heap and return its address
-    /// as a `u64` suitable for embedding in args. Useful for passing pre-built
-    /// data into a program without generating initialization micro-ops.
-    pub fn alloc_u64_vec(&mut self, descriptor_id: DescriptorId, values: &[u64]) -> VMResult<u64> {
-        if self.registers.is_idle() {
-            invariant_violation!(Unreachable(
-                "allocation on an idle context: no call was prepared".to_string()
-            ));
-        }
-        let n = values.len() as u64;
-        let ptr = alloc_vec!(
-            self,
-            self.registers.fp,
-            self.registers.pc,
-            self.registers.func,
-            descriptor_id,
-            8,
-            n
-        )?;
-        unsafe {
-            write_u64(ptr, VEC_LENGTH_OFFSET, n);
-            let data = ptr.add(VEC_DATA_OFFSET);
-            for (i, &v) in values.iter().enumerate() {
-                write_u64(data, i * 8, v);
-            }
-        }
-        Ok(ptr as u64)
+        Ok(CallBuilder {
+            interp: self,
+            func,
+            next_param: 0,
+        })
     }
 }
 
@@ -1322,7 +1291,7 @@ impl InterpreterContext<'_> {
         Ok(())
     }
 
-    pub fn run(&mut self) -> VMResult<RuntimeStatus> {
+    fn run(&mut self) -> VMResult<RuntimeStatus> {
         if self.registers.is_idle() {
             invariant_violation!(Unreachable(
                 "run on an idle context: no call was prepared".to_string()
@@ -1381,9 +1350,7 @@ impl InterpreterContext<'_> {
                         //   4. Patching:
                         //      If can patch caller, try it.
                         let target = self.load_function(module_id, func_name, ty_args)?;
-                        // SAFETY: `target` points to a `Function`, which is not reclaimed during
-                        // execution as guaranteed by the execution guard.
-                        self.call(func, &mut regs, target.as_ref_unchecked())?;
+                        self.call(func, &mut regs, target)?;
                         continue;
                     },
                     MicroOp::CallDirect { ptr } => {
@@ -1487,7 +1454,7 @@ impl InterpreterContext<'_> {
                         // vector slot holds a pointer read through to its heap data.
                         let a = fp.add(op.lhs.into());
                         let b = fp.add(op.rhs.into());
-                        let eq = value_utils::equals(self.loader.guard(), a, b, op.ty)?;
+                        let eq = value_cmp::equals(self.loader.guard(), a, b, op.ty)?;
                         self.cond_branch(
                             eq ^ op.negate,
                             op.target,
@@ -1503,7 +1470,7 @@ impl InterpreterContext<'_> {
                         // obtain the operand data pointers.
                         let (lb, lo) = read_fat_ptr(fp, op.lhs);
                         let (rb, ro) = read_fat_ptr(fp, op.rhs);
-                        let eq = value_utils::equals(
+                        let eq = value_cmp::equals(
                             self.loader.guard(),
                             lb.add(lo as usize),
                             rb.add(ro as usize),
@@ -2323,7 +2290,7 @@ impl InterpreterContext<'_> {
                         // vector slot holds a pointer read through to its heap data.
                         let a = fp.add(op.lhs.into());
                         let b = fp.add(op.rhs.into());
-                        let eq = value_utils::equals(self.loader.guard(), a, b, op.ty)?;
+                        let eq = value_cmp::equals(self.loader.guard(), a, b, op.ty)?;
                         write_bool(fp, op.dst, eq ^ op.negate);
                     },
                     MicroOp::ValueRefCmp(ref op) => {
@@ -2331,7 +2298,7 @@ impl InterpreterContext<'_> {
                         // obtain the operand data pointers.
                         let (lb, lo) = read_fat_ptr(fp, op.lhs);
                         let (rb, ro) = read_fat_ptr(fp, op.rhs);
-                        let eq = value_utils::equals(
+                        let eq = value_cmp::equals(
                             self.loader.guard(),
                             lb.add(lo as usize),
                             rb.add(ro as usize),
@@ -2920,12 +2887,12 @@ impl InterpreterContext<'_> {
                 FUNC_REF_TAG_RESOLVED => (&*(payload as *const Function), false),
                 FUNC_REF_TAG_UNRESOLVED => {
                     let func_ref = &*(payload as *const FunctionRef);
-                    let func_ptr = self.load_function(
+                    let func = self.load_function(
                         func_ref.module_id,
                         func_ref.func_name,
                         func_ref.ty_args,
                     )?;
-                    (func_ptr.as_ref_unchecked(), true)
+                    (func, true)
                 },
                 other => invariant_violation!(InvalidClosureFuncRefTag { tag: other }),
             };

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -10,13 +10,14 @@ mod interpreter;
 pub(crate) mod memory;
 mod native_context;
 mod types;
-mod value_utils;
+mod value_cmp;
+mod value_conv;
 mod verifier;
 
 pub use error::{ArithOp, GlobalStorageOp, ReportedIntValue, RuntimeError, RuntimeStatus, VecOp};
 pub use global_storage::{ResourceReadWriteSet, WriteClass};
 pub use heap::Heap;
-pub use interpreter::{InterpreterContext, SessionEffects};
+pub use interpreter::{CallBuilder, InterpreterContext, InterpreterOptions, SessionEffects};
 pub use memory::{
     read_ptr, read_u32, read_u64, vec_elem_ptr, write_object_header, write_ptr, write_u32,
     write_u64, MemoryRegion,
@@ -27,5 +28,5 @@ pub use native_context::{
     ProductionNativeRegistry,
 };
 pub use types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
-pub use value_utils::{deserialize_into, serialize};
-pub use verifier::{verify_function, verify_program, VerificationError};
+pub use value_conv::bcs::{deserialize_into, serialize};
+pub use verifier::{assert_verified, verify_function, verify_program, VerificationError};

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -502,12 +502,12 @@ impl NativeContext for ProductionNativeContext<'_> {
     unsafe fn bcs_serialize_value(&self, base: *const u8, ty: InternedType) -> VMResult<Vec<u8>> {
         // SAFETY: forwarded from this method's contract; serialization performs
         // no VM-heap allocation, so `base` stays valid throughout.
-        unsafe { crate::value_utils::serialize(self.layouts, base, ty) }
+        unsafe { crate::value_conv::bcs::serialize(self.layouts, base, ty) }
     }
 
     unsafe fn bcs_serialized_size(&self, base: *const u8, ty: InternedType) -> VMResult<usize> {
         // SAFETY: forwarded from this method's contract.
-        unsafe { crate::value_utils::serialized_size(self.layouts, base, ty) }
+        unsafe { crate::value_conv::bcs::serialized_size(self.layouts, base, ty) }
     }
 
     fn bcs_deserialize_value(&self, ty: InternedType, bytes: &[u8]) -> VMResult<Option<Vec<u8>>> {
@@ -582,13 +582,13 @@ impl NativeContext for ProductionNativeContext<'_> {
     }
 
     fn constant_serialized_size(&self, ty: InternedType) -> VMResult<Option<u64>> {
-        let size = crate::value_utils::fixed_serialized_size(self.layouts, ty)?;
+        let size = crate::value_conv::bcs::fixed_serialized_size(self.layouts, ty)?;
         Ok(size.map(|n| n as u64))
     }
 
     unsafe fn compare(&self, a: *const u8, b: *const u8, ty: InternedType) -> VMResult<Ordering> {
         // SAFETY: forwarded from this method's contract.
-        unsafe { crate::value_utils::compare(self.layouts, a, b, ty) }
+        unsafe { crate::value_cmp::compare(self.layouts, a, b, ty) }
     }
 
     unsafe fn new_enum<'a, V: VMValue<'a>>(

--- a/third_party/move/mono-move/runtime/src/value_cmp.rs
+++ b/third_party/move/mono-move/runtime/src/value_cmp.rs
@@ -1,0 +1,445 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Structural equality and ordering of two VM values, driven by their layout.
+//
+// TODO(correctness): the comparison fast paths assume a little-endian host.
+
+use crate::{
+    error::{RuntimeError, RuntimeInvariantViolation},
+    memory::{read_enum_tag, read_ptr, read_vec_len},
+    types::VEC_DATA_OFFSET,
+};
+use mono_move_core::{
+    types::InternedType, LayoutId, LayoutKind, LayoutProvider, VMInternalError, VMResult,
+    ENUM_DATA_OFFSET,
+};
+use move_core_types::int256::{I256, U256};
+use std::cmp::Ordering;
+
+/// Structural equality of two non-reference values of the given type.
+///
+/// # Safety
+///
+/// Input pointers `a` and `b` must point to fully initialized values of the
+/// given type.
+///
+/// # Precondition
+///
+/// For reference values, the caller must first read the reference to obtain
+/// the `base` pointer to the actual data; these walks operate on the pointee.
+pub unsafe fn equals<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    a: *const u8,
+    b: *const u8,
+    ty: InternedType,
+) -> VMResult<bool> {
+    let id = layouts.layout_id(ty).ok_or({
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+    })?;
+    // SAFETY: caller must enforce the safety precondition.
+    unsafe { equals_impl(layouts, a, b, id) }
+}
+
+/// Implementation of structural equality of two values of the given layout.
+///
+/// # Safety
+///
+/// Input pointers `a` and `b` must point to fully initialized values with the
+/// given layout.
+///
+/// # Precondition
+///
+/// For reference values, the caller must first read the reference to obtain
+/// the `base` pointer to the actual data; these walks operate on the pointee.
+pub(crate) unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    a: *const u8,
+    b: *const u8,
+    id: LayoutId,
+) -> VMResult<bool> {
+    // TODO(metering): This walk recurses on struct fields and vector elements; convert it
+    // to a non-recursive form to bound stack depth on deeply nested values.
+    let layout = layouts.layout(id).ok_or({
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+    })?;
+
+    if layout.has_no_pointers_no_padding() {
+        // SAFETY: both pointers must have layout's size and have no pointers,
+        // no padding.
+        return Ok(unsafe { bytes_cmp(a, b, layout.size as usize).is_eq() });
+    }
+
+    match &layout.kind {
+        LayoutKind::Bool
+        | LayoutKind::UnsignedInt
+        | LayoutKind::SignedInt
+        | LayoutKind::Address
+        | LayoutKind::Signer => Err(VMInternalError::new(RuntimeError::InvariantViolation(
+            RuntimeInvariantViolation::Unreachable(
+                "Primitive layouts must be handled by fast-path".to_string(),
+            ),
+        ))),
+        LayoutKind::Struct { fields } => {
+            for field in fields.iter() {
+                // SAFETY: value is a valid struct, so all fields lie at `offset`
+                // and are within bounds.
+                let eq = unsafe {
+                    equals_impl(
+                        layouts,
+                        a.add(field.offset as usize),
+                        b.add(field.offset as usize),
+                        field.id,
+                    )?
+                };
+                if !eq {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        },
+        LayoutKind::Vector { elem_id, .. } => {
+            // SAFETY: vector values hold 8-byte heap pointers pointing to
+            // their data for any well-typed value. The length is stored in
+            // the data pointed to.
+            let vec_a = unsafe { read_ptr(a, 0usize) };
+            let len_a = unsafe { read_vec_len(vec_a) };
+            let vec_b = unsafe { read_ptr(b, 0usize) };
+            let len_b = unsafe { read_vec_len(vec_b) };
+
+            if len_a != len_b {
+                return Ok(false);
+            }
+            if len_a == 0 {
+                return Ok(true);
+            }
+
+            let elem_layout = layouts.layout(*elem_id).ok_or({
+                RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+            })?;
+            let elem_size = elem_layout.size as usize;
+            if elem_layout.has_no_pointers_no_padding() {
+                // SAFETY: both vectors have same size specified by the layout.
+                let data_a = unsafe { vec_a.add(VEC_DATA_OFFSET) };
+                let data_b = unsafe { vec_b.add(VEC_DATA_OFFSET) };
+                return Ok(unsafe {
+                    bytes_cmp(data_a, data_b, len_a as usize * elem_size).is_eq()
+                });
+            }
+
+            for i in 0..len_a as usize {
+                // SAFETY: ith element lies within the vector data region,
+                // so the pointer is non-null and new pointer points within
+                // the data region. Lengths of `a` and `b` are the same.
+                let elem_a = unsafe { vec_a.add(VEC_DATA_OFFSET + i * elem_size) };
+                let elem_b = unsafe { vec_b.add(VEC_DATA_OFFSET + i * elem_size) };
+
+                // SAFETY: element pointers point to valid vector element
+                // values.
+                let eq = unsafe { equals_impl(layouts, elem_a, elem_b, *elem_id)? };
+                if !eq {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        },
+        LayoutKind::FrozenEnum { variants, .. } => {
+            // SAFETY: well-typed enum values hold non-null heap pointers and
+            // every enum object stores its data following the offset.
+            let obj_a = unsafe { read_ptr(a, 0usize) };
+            let obj_b = unsafe { read_ptr(b, 0usize) };
+            let tag_a = unsafe { read_enum_tag(obj_a) };
+            let tag_b = unsafe { read_enum_tag(obj_b) };
+
+            // Validate both tags before the equality check. An out-of-range tag
+            // is heap corruption and must fail closed even when the tags differ.
+            let variant_id = *variants.get(tag_a as usize).ok_or({
+                RuntimeError::InvariantViolation(RuntimeInvariantViolation::EnumTagOutOfRange {
+                    tag: tag_a,
+                    variant_count: variants.len(),
+                })
+            })?;
+            if tag_b as usize >= variants.len() {
+                return Err(VMInternalError::new(RuntimeError::InvariantViolation(
+                    RuntimeInvariantViolation::EnumTagOutOfRange {
+                        tag: tag_b,
+                        variant_count: variants.len(),
+                    },
+                )));
+            }
+
+            if tag_a != tag_b {
+                return Ok(false);
+            }
+
+            // SAFETY: both variant bodies live at the specified offset.
+            unsafe {
+                equals_impl(
+                    layouts,
+                    obj_a.add(ENUM_DATA_OFFSET),
+                    obj_b.add(ENUM_DATA_OFFSET),
+                    variant_id,
+                )
+            }
+        },
+        // TODO(completeness): function values are not yet supported.
+        LayoutKind::Function => Err(VMInternalError::new(RuntimeError::Unsupported(
+            "function values are not yet supported",
+        ))),
+        LayoutKind::Ref => Err(VMInternalError::new(RuntimeError::InvariantViolation(
+            RuntimeInvariantViolation::Unreachable(
+                "Equality runs on pointee types only".to_string(),
+            ),
+        ))),
+    }
+}
+
+/// Comparison of two values of the given type.
+///
+/// # Semantics
+///
+/// 1. Integers compare numerically.
+/// 2. Addresses or signers (also represented as an address) compare
+///    lexicographically over their bytes.
+/// 3. Vectors compare lexicographically (over smaller prefix)
+/// 4. Structs compare field-by-field.
+/// 5. Enums compare by variant tag first, then field-by-field over the
+///    matching variant's body.
+///
+/// # Safety
+///
+/// Input pointers `a` and `b` must point to fully initialized values with the
+/// given layout.
+///
+/// # Precondition
+///
+/// For reference values, the caller must first read the reference to obtain
+/// the `base` pointer to the actual data; these walks operate on the pointee.
+pub unsafe fn compare<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    a: *const u8,
+    b: *const u8,
+    ty: InternedType,
+) -> VMResult<Ordering> {
+    let id = layouts.layout_id(ty).ok_or({
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+    })?;
+    // SAFETY: caller must enforce the safety precondition.
+    unsafe { compare_impl(layouts, a, b, id) }
+}
+
+/// Implementation of structural comparison of two non-reference values of the
+/// given layout.
+///
+/// # Safety
+///
+/// Input pointers `a` and `b` must point to fully initialized values with the
+/// given layout.
+///
+/// # Precondition
+///
+/// For reference values, the caller must first read the reference to obtain
+/// the `base` pointer to the actual data; these walks operate on the pointee.
+pub(crate) unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    a: *const u8,
+    b: *const u8,
+    id: LayoutId,
+) -> VMResult<Ordering> {
+    // TODO(metering): This walk recurses on struct fields and vector elements; convert it
+    // to a non-recursive form to bound stack depth on deeply nested values.
+    let layout = layouts.layout(id).ok_or({
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+    })?;
+    match &layout.kind {
+        // A `bool` is a 1-byte `0`/`1` value, so it compares like a `u8`.
+        LayoutKind::Bool | LayoutKind::UnsignedInt => {
+            // Read the little-endian bytes into the native integer of the
+            // matching width and compare numerically. `from_le_bytes` keeps
+            // this correct on any host endianness.
+            //
+            // TODO(cleanup): These are unaligned, little-endian numeric reads, distinct
+            // from the aligned native-endian helpers in `memory.rs`. Endianness
+            // makes unifying the two non-trivial; revisit whether a shared set
+            // of typed read helpers can serve both.
+            //
+            // SAFETY: both pointers point to a valid `layout.size`-byte region.
+            Ok(unsafe {
+                match layout.size {
+                    1 => (*a).cmp(&*b),
+                    2 => u16::from_le_bytes(read_array(a)).cmp(&u16::from_le_bytes(read_array(b))),
+                    4 => u32::from_le_bytes(read_array(a)).cmp(&u32::from_le_bytes(read_array(b))),
+                    8 => u64::from_le_bytes(read_array(a)).cmp(&u64::from_le_bytes(read_array(b))),
+                    16 => {
+                        u128::from_le_bytes(read_array(a)).cmp(&u128::from_le_bytes(read_array(b)))
+                    },
+                    32 => {
+                        U256::from_le_bytes(read_array(a)).cmp(&U256::from_le_bytes(read_array(b)))
+                    },
+                    _ => {
+                        return Err(VMInternalError::new(RuntimeError::InvariantViolation(
+                            RuntimeInvariantViolation::Unreachable(
+                                "Unexpected unsigned integer width".to_string(),
+                            ),
+                        )))
+                    },
+                }
+            })
+        },
+        LayoutKind::SignedInt => {
+            // SAFETY: both pointers point to a valid `layout.size`-byte region.
+            Ok(unsafe {
+                match layout.size {
+                    1 => (*(a as *const i8)).cmp(&*(b as *const i8)),
+                    2 => i16::from_le_bytes(read_array(a)).cmp(&i16::from_le_bytes(read_array(b))),
+                    4 => i32::from_le_bytes(read_array(a)).cmp(&i32::from_le_bytes(read_array(b))),
+                    8 => i64::from_le_bytes(read_array(a)).cmp(&i64::from_le_bytes(read_array(b))),
+                    16 => {
+                        i128::from_le_bytes(read_array(a)).cmp(&i128::from_le_bytes(read_array(b)))
+                    },
+                    32 => {
+                        I256::from_le_bytes(read_array(a)).cmp(&I256::from_le_bytes(read_array(b)))
+                    },
+                    _ => {
+                        return Err(VMInternalError::new(RuntimeError::InvariantViolation(
+                            RuntimeInvariantViolation::Unreachable(
+                                "Unexpected signed integer width".to_string(),
+                            ),
+                        )))
+                    },
+                }
+            })
+        },
+        LayoutKind::Address | LayoutKind::Signer => {
+            // SAFETY: values are valid byte arrays of the size specified by
+            // the layout, as guaranteed by the precondition of this function.
+            Ok(unsafe { bytes_cmp(a, b, layout.size as usize) })
+        },
+        LayoutKind::Struct { fields } => {
+            for field in fields.iter() {
+                // SAFETY: value is a valid struct, so all fields lie at `offset`
+                // and are within bounds.
+                let ord = unsafe {
+                    compare_impl(
+                        layouts,
+                        a.add(field.offset as usize),
+                        b.add(field.offset as usize),
+                        field.id,
+                    )?
+                };
+                if ord.is_ne() {
+                    return Ok(ord);
+                }
+            }
+            Ok(Ordering::Equal)
+        },
+        LayoutKind::Vector { elem_id, .. } => {
+            // SAFETY: vector values hold 8-byte heap pointers pointing to
+            // their data for any well-typed value. The length is stored in
+            // the data pointed to.
+            let vec_a = unsafe { read_ptr(a, 0usize) };
+            let len_a = unsafe { read_vec_len(vec_a) };
+            let vec_b = unsafe { read_ptr(b, 0usize) };
+            let len_b = unsafe { read_vec_len(vec_b) };
+
+            let elem = layouts.layout(*elem_id).ok_or({
+                RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+            })?;
+            let elem_size = elem.size as usize;
+            for i in 0..len_a.min(len_b) as usize {
+                // SAFETY: ith element lies within the vector data region,
+                // so the pointer is non-null and new pointer points within
+                // the data region.
+                let elem_a = unsafe { vec_a.add(VEC_DATA_OFFSET + i * elem_size) };
+                let elem_b = unsafe { vec_b.add(VEC_DATA_OFFSET + i * elem_size) };
+
+                // SAFETY: element pointers point to valid values.
+                let ord = unsafe { compare_impl(layouts, elem_a, elem_b, *elem_id)? };
+                if ord.is_ne() {
+                    return Ok(ord);
+                }
+            }
+            Ok(len_a.cmp(&len_b))
+        },
+        LayoutKind::FrozenEnum { variants, .. } => {
+            // SAFETY: well-typed enum values hold non-null heap pointers and
+            // every enum object stores its tag followed by data payload.
+            let obj_a = unsafe { read_ptr(a, 0usize) };
+            let obj_b = unsafe { read_ptr(b, 0usize) };
+            let tag_a = unsafe { read_enum_tag(obj_a) };
+            let tag_b = unsafe { read_enum_tag(obj_b) };
+
+            // Validate both tags before ordering them. An out-of-range tag is
+            // heap corruption and must fail closed even when the tags differ.
+            let variant_id = *variants.get(tag_a as usize).ok_or({
+                RuntimeError::InvariantViolation(RuntimeInvariantViolation::EnumTagOutOfRange {
+                    tag: tag_a,
+                    variant_count: variants.len(),
+                })
+            })?;
+            if tag_b as usize >= variants.len() {
+                return Err(VMInternalError::new(RuntimeError::InvariantViolation(
+                    RuntimeInvariantViolation::EnumTagOutOfRange {
+                        tag: tag_b,
+                        variant_count: variants.len(),
+                    },
+                )));
+            }
+
+            let ord = tag_a.cmp(&tag_b);
+            if ord.is_ne() {
+                return Ok(ord);
+            }
+
+            // SAFETY: both variant bodies live at the specified offset.
+            unsafe {
+                compare_impl(
+                    layouts,
+                    obj_a.add(ENUM_DATA_OFFSET),
+                    obj_b.add(ENUM_DATA_OFFSET),
+                    variant_id,
+                )
+            }
+        },
+        // TODO(completeness): function values are not yet supported.
+        LayoutKind::Function => Err(VMInternalError::new(RuntimeError::Unsupported(
+            "function values are not yet supported",
+        ))),
+        LayoutKind::Ref => Err(VMInternalError::new(RuntimeError::InvariantViolation(
+            RuntimeInvariantViolation::Unreachable(
+                "Comparison runs on pointee types only".to_string(),
+            ),
+        ))),
+    }
+}
+
+/// Reads `N` bytes from the pointer into an array.
+///
+/// # Safety
+///
+/// Pointer must point to at least `N` readable, initialized bytes.
+#[inline(always)]
+unsafe fn read_array<const N: usize>(p: *const u8) -> [u8; N] {
+    // SAFETY: `[u8; N]` has alignment 1, so this unaligned read is valid given
+    // the caller's guarantee of `N` readable bytes at `p`.
+    unsafe { (p as *const [u8; N]).read_unaligned() }
+}
+
+/// Byte comparison of two `n`-byte regions.
+///
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// 1. Pointers are non-null.
+/// 2. Pointers point to a single allocation of `n` bytes, allocated.
+unsafe fn bytes_cmp(a: *const u8, b: *const u8, n: usize) -> Ordering {
+    // SAFETY: Caller guarantees non-null pointers of the specified length into
+    // a single allocation. The total size never overflows and the data is not
+    // being mutated.
+    unsafe {
+        let a = std::slice::from_raw_parts(a, n);
+        let b = std::slice::from_raw_parts(b, n);
+        a.cmp(b)
+    }
+}

--- a/third_party/move/mono-move/runtime/src/value_conv/bcs.rs
+++ b/third_party/move/mono-move/runtime/src/value_conv/bcs.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Operations over value trees driven by value layouts: BCS-serializing an
-//! in-memory value and reporting its serialized size (fixed when the type
-//! allows, otherwise computed by walking the value), deserializing BCS bytes
-//! back into the flat in-memory representation (allocating heap storage for
-//! vectors, and failing rather than running GC when heap space runs out), and
-//! comparing two values for structural equality and ordering.
+//! Converts between VM values and their BCS encoding: serializing an
+//! in-memory value and reporting its serialized size, and deserializing bytes
+//! back into the flat in-memory representation, allocating heap storage for
+//! vectors and failing rather than running GC when space runs out.
 //!
 //! TODO(correctness):
 //!   Current implementation works only for little-endian architectures,
@@ -15,25 +13,23 @@
 //!   big endian hosts.
 //!
 //! TODO(cleanup):
-//!   Unify these value walks (serialize, deserialize, equals, compare) under a
-//!   shared visitor/fold abstraction instead of four parallel recursive
-//!   implementations.
+//!   Unify the value walks (serialize, deserialize, equals, compare, and the
+//!   Rust value writer in `rust.rs`) under a shared visitor/fold abstraction
+//!   instead of parallel recursive implementations.
 //!
 //! TODO(testing):
 //!   Add differential tests for these walks against the existing Move VM.
 
 use crate::{
     error::{RuntimeError, RuntimeInvariantViolation},
-    heap::{heap_alloc, AllocationResult, Heap},
-    memory::{read_enum_tag, read_ptr, read_vec_len, write_enum_tag, write_ptr, write_u64},
-    types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
+    heap::{alloc_enum_no_gc, alloc_vec_no_gc, AllocationResult, Heap},
+    memory::{read_enum_tag, read_ptr, read_vec_len, write_ptr},
+    types::VEC_DATA_OFFSET,
 };
 use mono_move_core::{
-    types::InternedType, LayoutId, LayoutKind, LayoutProvider, VMInternalError, VMResult,
-    ValueLayout, ENUM_DATA_OFFSET, OBJECT_HEADER_SIZE,
+    types::InternedType, LayoutKind, LayoutProvider, VMInternalError, VMResult, ValueLayout,
+    ENUM_DATA_OFFSET,
 };
-use move_core_types::int256::{I256, U256};
-use std::cmp::Ordering;
 
 /// Returns the fixed BCS size of a value of the given type, or [`None`] when it
 /// is data-dependent (e.g., for vectors, enums, function values, etc.).
@@ -41,7 +37,9 @@ pub fn fixed_serialized_size<T: LayoutProvider + ?Sized>(
     layouts: &T,
     ty: InternedType,
 ) -> VMResult<Option<usize>> {
-    let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
+    let layout = layouts.layout_by_ty(ty).ok_or({
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+    })?;
     Ok(layout.fixed_serialized_size().map(|n| n as usize))
 }
 
@@ -51,7 +49,6 @@ pub fn fixed_serialized_size<T: LayoutProvider + ?Sized>(
 ///
 /// `base` must point to a fully initialized value of the given type, and must
 /// remain valid (with all reachable heap objects live) throughout the call.
-#[allow(dead_code)]
 pub unsafe fn serialized_size<T: LayoutProvider + ?Sized>(
     layouts: &T,
     base: *const u8,
@@ -69,13 +66,14 @@ pub unsafe fn serialized_size<T: LayoutProvider + ?Sized>(
 ///
 /// `base` must point to a fully initialized value of the given type, and must
 /// remain valid (with all reachable heap objects live) throughout the call.
-#[allow(dead_code)]
 pub unsafe fn serialize<T: LayoutProvider + ?Sized>(
     layouts: &T,
     base: *const u8,
     ty: InternedType,
 ) -> VMResult<Vec<u8>> {
-    let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
+    let layout = layouts.layout_by_ty(ty).ok_or({
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+    })?;
 
     let mut out = vec![];
     if let Some(serialized_size) = layout.fixed_serialized_size() {
@@ -116,12 +114,15 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
         | LayoutKind::UnsignedInt
         | LayoutKind::SignedInt
         | LayoutKind::Address
-        | LayoutKind::Signer => Err(VMInternalError::new(unreachable(
-            "Scalars serialize on the no-pointers-no-padding fast path and never reach this arm",
+        | LayoutKind::Signer => Err(VMInternalError::new(RuntimeError::InvariantViolation(
+            RuntimeInvariantViolation::Unreachable(
+                "Scalars serialize on the no-pointers-no-padding fast path and never reach this arm"
+                    .to_string(),
+            ),
         ))),
         LayoutKind::Struct { fields } => {
             for field in fields.iter() {
-                let field_layout = layouts.layout(field.id).ok_or_else(layout_not_found)?;
+                let field_layout = layouts.layout(field.id).ok_or(RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound))?;
                 // SAFETY: the field lies within `base`'s region at `offset`
                 // which holds for well-typed values, as guaranteed by the
                 // safety precondition of this function.
@@ -147,7 +148,7 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
                 return Ok(());
             }
 
-            let elem_layout = layouts.layout(*elem_id).ok_or_else(layout_not_found)?;
+            let elem_layout = layouts.layout(*elem_id).ok_or(RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound))?;
             let elem_size = elem_layout.size as usize;
             if elem_layout.has_no_pointers_no_padding() {
                 // TODO(correctness): breaks on big-endian hosts, for the same
@@ -183,381 +184,26 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
             let tag = unsafe { read_enum_tag(obj_ptr) };
             let variant_id = variants
                 .get(tag as usize)
-                .ok_or_else(|| enum_tag_out_of_range(tag, variants.len()))?;
+                .ok_or({
+                    RuntimeError::InvariantViolation(RuntimeInvariantViolation::EnumTagOutOfRange {
+                        tag,
+                        variant_count: variants.len(),
+                    })
+                })?;
             write_uleb128_len(out, tag);
 
-            let variant_layout = layouts.layout(*variant_id).ok_or_else(layout_not_found)?;
+            let variant_layout = layouts.layout(*variant_id).ok_or(RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound))?;
             // SAFETY: the variant body lives at the specified offset within
             // the object.
             unsafe { serialize_impl(layouts, obj_ptr.add(ENUM_DATA_OFFSET), variant_layout, out)? };
             Ok(())
         },
         // TODO(completeness): function values are not yet supported.
-        LayoutKind::Function => Err(VMInternalError::new(function_values_unsupported())),
-        LayoutKind::Ref => Err(VMInternalError::new(unreachable(
-            "References cannot be serialized",
+        LayoutKind::Function => Err(VMInternalError::new(RuntimeError::Unsupported(
+            "function values are not yet supported",
         ))),
-    }
-}
-
-/// Structural equality of two non-reference values of the given type.
-///
-/// # Safety
-///
-/// Input pointers `a` and `b` must point to fully initialized values of the
-/// given type.
-///
-/// # Precondition
-///
-/// For reference values, the caller must first read the reference to obtain
-/// the `base` pointer to the actual data; these walks operate on the pointee.
-#[allow(dead_code)]
-pub unsafe fn equals<T: LayoutProvider + ?Sized>(
-    layouts: &T,
-    a: *const u8,
-    b: *const u8,
-    ty: InternedType,
-) -> VMResult<bool> {
-    let id = layouts.layout_id(ty).ok_or_else(layout_not_found)?;
-    // SAFETY: caller must enforce the safety precondition.
-    unsafe { equals_impl(layouts, a, b, id) }
-}
-
-/// Implementation of structural equality of two values of the given layout.
-///
-/// # Safety
-///
-/// Input pointers `a` and `b` must point to fully initialized values with the
-/// given layout.
-///
-/// # Precondition
-///
-/// For reference values, the caller must first read the reference to obtain
-/// the `base` pointer to the actual data; these walks operate on the pointee.
-unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
-    layouts: &T,
-    a: *const u8,
-    b: *const u8,
-    id: LayoutId,
-) -> VMResult<bool> {
-    // TODO(metering): This walk recurses on struct fields and vector elements; convert it
-    // to a non-recursive form to bound stack depth on deeply nested values.
-    let layout = layouts.layout(id).ok_or_else(layout_not_found)?;
-
-    if layout.has_no_pointers_no_padding() {
-        // SAFETY: both pointers must have layout's size and have no pointers,
-        // no padding.
-        return Ok(unsafe { bytes_cmp(a, b, layout.size as usize).is_eq() });
-    }
-
-    match &layout.kind {
-        LayoutKind::Bool
-        | LayoutKind::UnsignedInt
-        | LayoutKind::SignedInt
-        | LayoutKind::Address
-        | LayoutKind::Signer => Err(VMInternalError::new(unreachable(
-            "Primitive layouts must be handled by fast-path",
-        ))),
-        LayoutKind::Struct { fields } => {
-            for field in fields.iter() {
-                // SAFETY: value is a valid struct, so all fields lie at `offset`
-                // and are within bounds.
-                let eq = unsafe {
-                    equals_impl(
-                        layouts,
-                        a.add(field.offset as usize),
-                        b.add(field.offset as usize),
-                        field.id,
-                    )?
-                };
-                if !eq {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
-        },
-        LayoutKind::Vector { elem_id, .. } => {
-            // SAFETY: vector values hold 8-byte heap pointers pointing to
-            // their data for any well-typed value. The length is stored in
-            // the data pointed to.
-            let vec_a = unsafe { read_ptr(a, 0usize) };
-            let len_a = unsafe { read_vec_len(vec_a) };
-            let vec_b = unsafe { read_ptr(b, 0usize) };
-            let len_b = unsafe { read_vec_len(vec_b) };
-
-            if len_a != len_b {
-                return Ok(false);
-            }
-            if len_a == 0 {
-                return Ok(true);
-            }
-
-            let elem_layout = layouts.layout(*elem_id).ok_or_else(layout_not_found)?;
-            let elem_size = elem_layout.size as usize;
-            if elem_layout.has_no_pointers_no_padding() {
-                // SAFETY: both vectors have same size specified by the layout.
-                let data_a = unsafe { vec_a.add(VEC_DATA_OFFSET) };
-                let data_b = unsafe { vec_b.add(VEC_DATA_OFFSET) };
-                return Ok(unsafe {
-                    bytes_cmp(data_a, data_b, len_a as usize * elem_size).is_eq()
-                });
-            }
-
-            for i in 0..len_a as usize {
-                // SAFETY: ith element lies within the vector data region,
-                // so the pointer is non-null and new pointer points within
-                // the data region. Lengths of `a` and `b` are the same.
-                let elem_a = unsafe { vec_a.add(VEC_DATA_OFFSET + i * elem_size) };
-                let elem_b = unsafe { vec_b.add(VEC_DATA_OFFSET + i * elem_size) };
-
-                // SAFETY: element pointers point to valid vector element
-                // values.
-                let eq = unsafe { equals_impl(layouts, elem_a, elem_b, *elem_id)? };
-                if !eq {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
-        },
-        LayoutKind::FrozenEnum { variants, .. } => {
-            // SAFETY: well-typed enum values hold non-null heap pointers and
-            // every enum object stores its data following the offset.
-            let obj_a = unsafe { read_ptr(a, 0usize) };
-            let obj_b = unsafe { read_ptr(b, 0usize) };
-            let tag_a = unsafe { read_enum_tag(obj_a) };
-            let tag_b = unsafe { read_enum_tag(obj_b) };
-
-            // Validate both tags before the equality check. An out-of-range tag
-            // is heap corruption and must fail closed even when the tags differ.
-            let variant_id = *variants
-                .get(tag_a as usize)
-                .ok_or_else(|| enum_tag_out_of_range(tag_a, variants.len()))?;
-            if tag_b as usize >= variants.len() {
-                return Err(VMInternalError::new(enum_tag_out_of_range(
-                    tag_b,
-                    variants.len(),
-                )));
-            }
-
-            if tag_a != tag_b {
-                return Ok(false);
-            }
-
-            // SAFETY: both variant bodies live at the specified offset.
-            unsafe {
-                equals_impl(
-                    layouts,
-                    obj_a.add(ENUM_DATA_OFFSET),
-                    obj_b.add(ENUM_DATA_OFFSET),
-                    variant_id,
-                )
-            }
-        },
-        // TODO(completeness): function values are not yet supported.
-        LayoutKind::Function => Err(VMInternalError::new(function_values_unsupported())),
-        LayoutKind::Ref => Err(VMInternalError::new(unreachable(
-            "Equality runs on pointee types only",
-        ))),
-    }
-}
-
-/// Comparison of two values of the given type.
-///
-/// # Semantics
-///
-/// 1. Integers compare numerically.
-/// 2. Addresses or signers (also represented as an address) compare
-///    lexicographically over their bytes.
-/// 3. Vectors compare lexicographically (over smaller prefix)
-/// 4. Structs compare field-by-field.
-/// 5. Enums compare by variant tag first, then field-by-field over the
-///    matching variant's body.
-///
-/// # Safety
-///
-/// Input pointers `a` and `b` must point to fully initialized values with the
-/// given layout.
-///
-/// # Precondition
-///
-/// For reference values, the caller must first read the reference to obtain
-/// the `base` pointer to the actual data; these walks operate on the pointee.
-#[allow(dead_code)]
-pub unsafe fn compare<T: LayoutProvider + ?Sized>(
-    layouts: &T,
-    a: *const u8,
-    b: *const u8,
-    ty: InternedType,
-) -> VMResult<Ordering> {
-    let id = layouts.layout_id(ty).ok_or_else(layout_not_found)?;
-    // SAFETY: caller must enforce the safety precondition.
-    unsafe { compare_impl(layouts, a, b, id) }
-}
-
-/// Implementation of structural comparison of two non-reference values of the
-/// given layout.
-///
-/// # Safety
-///
-/// Input pointers `a` and `b` must point to fully initialized values with the
-/// given layout.
-///
-/// # Precondition
-///
-/// For reference values, the caller must first read the reference to obtain
-/// the `base` pointer to the actual data; these walks operate on the pointee.
-unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
-    layouts: &T,
-    a: *const u8,
-    b: *const u8,
-    id: LayoutId,
-) -> VMResult<Ordering> {
-    // TODO(metering): This walk recurses on struct fields and vector elements; convert it
-    // to a non-recursive form to bound stack depth on deeply nested values.
-    let layout = layouts.layout(id).ok_or_else(layout_not_found)?;
-    match &layout.kind {
-        // A `bool` is a 1-byte `0`/`1` value, so it compares like a `u8`.
-        LayoutKind::Bool | LayoutKind::UnsignedInt => {
-            // Read the little-endian bytes into the native integer of the
-            // matching width and compare numerically. `from_le_bytes` keeps
-            // this correct on any host endianness.
-            //
-            // TODO(cleanup): These are unaligned, little-endian numeric reads, distinct
-            // from the aligned native-endian helpers in `memory.rs`. Endianness
-            // makes unifying the two non-trivial; revisit whether a shared set
-            // of typed read helpers can serve both.
-            //
-            // SAFETY: both pointers point to a valid `layout.size`-byte region.
-            Ok(unsafe {
-                match layout.size {
-                    1 => (*a).cmp(&*b),
-                    2 => u16::from_le_bytes(read_array(a)).cmp(&u16::from_le_bytes(read_array(b))),
-                    4 => u32::from_le_bytes(read_array(a)).cmp(&u32::from_le_bytes(read_array(b))),
-                    8 => u64::from_le_bytes(read_array(a)).cmp(&u64::from_le_bytes(read_array(b))),
-                    16 => {
-                        u128::from_le_bytes(read_array(a)).cmp(&u128::from_le_bytes(read_array(b)))
-                    },
-                    32 => {
-                        U256::from_le_bytes(read_array(a)).cmp(&U256::from_le_bytes(read_array(b)))
-                    },
-                    _ => {
-                        return Err(VMInternalError::new(unreachable(
-                            "Unexpected unsigned integer width",
-                        )))
-                    },
-                }
-            })
-        },
-        LayoutKind::SignedInt => {
-            // SAFETY: both pointers point to a valid `layout.size`-byte region.
-            Ok(unsafe {
-                match layout.size {
-                    1 => (*(a as *const i8)).cmp(&*(b as *const i8)),
-                    2 => i16::from_le_bytes(read_array(a)).cmp(&i16::from_le_bytes(read_array(b))),
-                    4 => i32::from_le_bytes(read_array(a)).cmp(&i32::from_le_bytes(read_array(b))),
-                    8 => i64::from_le_bytes(read_array(a)).cmp(&i64::from_le_bytes(read_array(b))),
-                    16 => {
-                        i128::from_le_bytes(read_array(a)).cmp(&i128::from_le_bytes(read_array(b)))
-                    },
-                    32 => {
-                        I256::from_le_bytes(read_array(a)).cmp(&I256::from_le_bytes(read_array(b)))
-                    },
-                    _ => {
-                        return Err(VMInternalError::new(unreachable(
-                            "Unexpected signed integer width",
-                        )))
-                    },
-                }
-            })
-        },
-        LayoutKind::Address | LayoutKind::Signer => {
-            // SAFETY: values are valid byte arrays of the size specified by
-            // the layout, as guaranteed by the precondition of this function.
-            Ok(unsafe { bytes_cmp(a, b, layout.size as usize) })
-        },
-        LayoutKind::Struct { fields } => {
-            for field in fields.iter() {
-                // SAFETY: value is a valid struct, so all fields lie at `offset`
-                // and are within bounds.
-                let ord = unsafe {
-                    compare_impl(
-                        layouts,
-                        a.add(field.offset as usize),
-                        b.add(field.offset as usize),
-                        field.id,
-                    )?
-                };
-                if ord.is_ne() {
-                    return Ok(ord);
-                }
-            }
-            Ok(Ordering::Equal)
-        },
-        LayoutKind::Vector { elem_id, .. } => {
-            // SAFETY: vector values hold 8-byte heap pointers pointing to
-            // their data for any well-typed value. The length is stored in
-            // the data pointed to.
-            let vec_a = unsafe { read_ptr(a, 0usize) };
-            let len_a = unsafe { read_vec_len(vec_a) };
-            let vec_b = unsafe { read_ptr(b, 0usize) };
-            let len_b = unsafe { read_vec_len(vec_b) };
-
-            let elem = layouts.layout(*elem_id).ok_or_else(layout_not_found)?;
-            let elem_size = elem.size as usize;
-            for i in 0..len_a.min(len_b) as usize {
-                // SAFETY: ith element lies within the vector data region,
-                // so the pointer is non-null and new pointer points within
-                // the data region.
-                let elem_a = unsafe { vec_a.add(VEC_DATA_OFFSET + i * elem_size) };
-                let elem_b = unsafe { vec_b.add(VEC_DATA_OFFSET + i * elem_size) };
-
-                // SAFETY: element pointers point to valid values.
-                let ord = unsafe { compare_impl(layouts, elem_a, elem_b, *elem_id)? };
-                if ord.is_ne() {
-                    return Ok(ord);
-                }
-            }
-            Ok(len_a.cmp(&len_b))
-        },
-        LayoutKind::FrozenEnum { variants, .. } => {
-            // SAFETY: well-typed enum values hold non-null heap pointers and
-            // every enum object stores its tag followed by data payload.
-            let obj_a = unsafe { read_ptr(a, 0usize) };
-            let obj_b = unsafe { read_ptr(b, 0usize) };
-            let tag_a = unsafe { read_enum_tag(obj_a) };
-            let tag_b = unsafe { read_enum_tag(obj_b) };
-
-            // Validate both tags before ordering them. An out-of-range tag is
-            // heap corruption and must fail closed even when the tags differ.
-            let variant_id = *variants
-                .get(tag_a as usize)
-                .ok_or_else(|| enum_tag_out_of_range(tag_a, variants.len()))?;
-            if tag_b as usize >= variants.len() {
-                return Err(VMInternalError::new(enum_tag_out_of_range(
-                    tag_b,
-                    variants.len(),
-                )));
-            }
-
-            let ord = tag_a.cmp(&tag_b);
-            if ord.is_ne() {
-                return Ok(ord);
-            }
-
-            // SAFETY: both variant bodies live at the specified offset.
-            unsafe {
-                compare_impl(
-                    layouts,
-                    obj_a.add(ENUM_DATA_OFFSET),
-                    obj_b.add(ENUM_DATA_OFFSET),
-                    variant_id,
-                )
-            }
-        },
-        // TODO(completeness): function values are not yet supported.
-        LayoutKind::Function => Err(VMInternalError::new(function_values_unsupported())),
-        LayoutKind::Ref => Err(VMInternalError::new(unreachable(
-            "Comparison runs on pointee types only",
+        LayoutKind::Ref => Err(VMInternalError::new(RuntimeError::InvariantViolation(
+            RuntimeInvariantViolation::Unreachable("References cannot be serialized".to_string()),
         ))),
     }
 }
@@ -588,7 +234,9 @@ pub unsafe fn deserialize<T: LayoutProvider + ?Sized>(
     bytes: &[u8],
     dst: *mut u8,
 ) -> AllocationResult<()> {
-    let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
+    let layout = layouts.layout_by_ty(ty).ok_or({
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+    })?;
     debug_assert!(
         dst.addr().is_multiple_of(layout.align as usize),
         "deserialize destination must meet the type's alignment"
@@ -667,14 +315,19 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
             unsafe { std::ptr::write(dst, byte) };
             Ok(())
         },
-        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => {
-            Err(unreachable("Integer and address layouts must be handled by fast-path").into())
-        },
+        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => Err(
+            RuntimeError::InvariantViolation(RuntimeInvariantViolation::Unreachable(
+                "Integer and address layouts must be handled by fast-path".to_string(),
+            ))
+            .into(),
+        ),
         // A signer is never deserialized.
         LayoutKind::Signer => Err(RuntimeError::BCSSignerNotDeserializable.into()),
         LayoutKind::Struct { fields } => {
             for field in fields.iter() {
-                let field_layout = layouts.layout(field.id).ok_or_else(layout_not_found)?;
+                let field_layout = layouts.layout(field.id).ok_or({
+                    RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+                })?;
                 // SAFETY: value is a valid struct, so all fields lie at `offset`
                 // and are within bounds. `dst` is correctly sized so there is
                 // enough space to write all fields.
@@ -707,22 +360,15 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
                 return Ok(());
             }
 
-            let elem_layout = layouts.layout(*elem_id).ok_or_else(layout_not_found)?;
+            let elem_layout = layouts.layout(*elem_id).ok_or({
+                RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+            })?;
             let elem_size = elem_layout.size as usize;
 
-            let data_size = (len as usize)
-                .checked_mul(elem_size)
-                .ok_or(RuntimeError::VecAllocSizeOverflow)?;
-            let total_size = data_size
-                .checked_add(OBJECT_HEADER_SIZE + VEC_DATA_OFFSET)
-                .ok_or(RuntimeError::VecAllocSizeOverflow)?;
-
             // An OOM here propagates as `AllocationError::OutOfHeapMemory`.
-            let vec_ptr = heap_alloc(heap, total_size, *descriptor_id)?;
-
-            // SAFETY: the allocated data must store length at this offset
-            // as guaranteed by the allocator.
-            unsafe { write_u64(vec_ptr, VEC_LENGTH_OFFSET, len) };
+            let vec_ptr = alloc_vec_no_gc(heap, *descriptor_id, elem_layout.size, len)?;
+            // The allocation checked this product against overflow.
+            let data_size = len as usize * elem_size;
 
             if elem_layout.all_byte_patterns_valid() {
                 // If every element byte pattern is valid, element bytes equal
@@ -771,18 +417,25 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
             // BCS encodes the variant index as a ULEB128 before the fields.
             let tag = read_uleb128_len(bytes, cursor)?;
             if tag >= variants.len() as u64 {
-                return Err(enum_tag_out_of_range(tag, variants.len()).into());
+                return Err(RuntimeError::InvariantViolation(
+                    RuntimeInvariantViolation::EnumTagOutOfRange {
+                        tag,
+                        variant_count: variants.len(),
+                    },
+                )
+                .into());
             }
 
-            let variant_layout = layouts
-                .layout(variants[tag as usize])
-                .ok_or_else(layout_not_found)?;
+            let variant_layout = layouts.layout(variants[tag as usize]).ok_or({
+                RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+            })?;
 
-            let total_size = OBJECT_HEADER_SIZE + *max_size_across_variants as usize;
-            let obj_ptr = heap_alloc(heap, total_size, *descriptor_id)?;
-
-            // SAFETY: the allocation has enough size to write the tag.
-            unsafe { write_enum_tag(obj_ptr, tag) };
+            let obj_ptr = alloc_enum_no_gc(
+                heap,
+                *descriptor_id,
+                tag,
+                *max_size_across_variants as usize,
+            )?;
 
             // SAFETY: variant body lives at the specified offset. The maximum
             // size was allocated so there is enough space to deserialize into.
@@ -803,39 +456,13 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
             Ok(())
         },
         // TODO(completeness): function values are not yet supported.
-        LayoutKind::Function => Err(function_values_unsupported().into()),
-        LayoutKind::Ref => Err(unreachable("References cannot be deserialized").into()),
-    }
-}
-
-/// Reads `N` bytes from the pointer into an array.
-///
-/// # Safety
-///
-/// Pointer must point to at least `N` readable, initialized bytes.
-#[inline(always)]
-unsafe fn read_array<const N: usize>(p: *const u8) -> [u8; N] {
-    // SAFETY: `[u8; N]` has alignment 1, so this unaligned read is valid given
-    // the caller's guarantee of `N` readable bytes at `p`.
-    unsafe { (p as *const [u8; N]).read_unaligned() }
-}
-
-/// Byte comparison of two `n`-byte regions.
-///
-/// # Safety
-///
-/// Behavior is undefined if any of the following conditions are violated:
-///
-/// 1. Pointers are non-null.
-/// 2. Pointers point to a single allocation of `n` bytes, allocated.
-unsafe fn bytes_cmp(a: *const u8, b: *const u8, n: usize) -> Ordering {
-    // SAFETY: Caller guarantees non-null pointers of the specified length into
-    // a single allocation. The total size never overflows and the data is not
-    // being mutated.
-    unsafe {
-        let a = std::slice::from_raw_parts(a, n);
-        let b = std::slice::from_raw_parts(b, n);
-        a.cmp(b)
+        LayoutKind::Function => {
+            Err(RuntimeError::Unsupported("function values are not yet supported").into())
+        },
+        LayoutKind::Ref => Err(RuntimeError::InvariantViolation(
+            RuntimeInvariantViolation::Unreachable("References cannot be deserialized".to_string()),
+        )
+        .into()),
     }
 }
 
@@ -899,34 +526,6 @@ fn read_uleb128_len(bytes: &[u8], cursor: &mut usize) -> Result<u64, RuntimeErro
     }
 }
 
-/// Invariant violation error when layout is not available during value walk.
-fn layout_not_found() -> RuntimeError {
-    RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
-}
-
-/// An invariant violation for an unreachable state.
-fn unreachable(message: &str) -> RuntimeError {
-    RuntimeError::InvariantViolation(RuntimeInvariantViolation::Unreachable(message.to_string()))
-}
-
-/// Function values are a valid Move feature that the value walks do not support
-/// yet. Surfaced as an error (never a panic) so callers can classify it as an
-/// unsupported construct instead of aborting.
-fn function_values_unsupported() -> RuntimeError {
-    RuntimeError::Unsupported("function values are not yet supported")
-}
-
-/// Invariant violation when an enum tag does not name a variant, whether read
-/// from an in-memory value or decoded from BCS. A well-formed enum's tag is
-/// always in range, so an out-of-range tag signals corruption, not a legitimate
-/// runtime condition.
-fn enum_tag_out_of_range(tag: u64, variant_count: usize) -> RuntimeError {
-    RuntimeError::InvariantViolation(RuntimeInvariantViolation::EnumTagOutOfRange {
-        tag,
-        variant_count,
-    })
-}
-
 // `#[repr(align(N))]` needs a literal, so `AlignedBuf` uses `u64` backing to
 // get `MAX_ALIGN`.
 //
@@ -943,25 +542,25 @@ const _: () = assert!(
 /// `vec![0u8; n]` is only byte-aligned, but the (de)serializers write pointer
 /// and integer fields as aligned 8-byte stores.
 #[cfg(test)]
-struct AlignedBuf {
+pub(crate) struct AlignedBuf {
     words: Vec<u64>,
     len: usize,
 }
 
 #[cfg(test)]
 impl AlignedBuf {
-    fn zeroed(len: usize) -> Self {
+    pub(crate) fn zeroed(len: usize) -> Self {
         Self {
             words: vec![0u64; len.div_ceil(std::mem::size_of::<u64>())],
             len,
         }
     }
 
-    fn as_mut_ptr(&mut self) -> *mut u8 {
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut u8 {
         self.words.as_mut_ptr().cast()
     }
 
-    fn as_ptr(&self) -> *const u8 {
+    pub(crate) fn as_ptr(&self) -> *const u8 {
         self.words.as_ptr().cast()
     }
 
@@ -974,7 +573,10 @@ impl AlignedBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::heap::AllocationError;
+    use crate::{
+        heap::AllocationError,
+        value_cmp::{compare_impl, equals_impl},
+    };
     use mono_move_core::{
         align_up_u32,
         types::U64_TY,
@@ -1872,6 +1474,7 @@ mod tests {
 #[cfg(test)]
 mod prop_tests {
     use super::*;
+    use crate::value_cmp::{compare, equals};
     use mono_move_core::{
         types::{
             ADDRESS_TY, BOOL_TY, I128_TY, I16_TY, I256_TY, I32_TY, I64_TY, I8_TY, U128_TY, U16_TY,

--- a/third_party/move/mono-move/runtime/src/value_conv/mod.rs
+++ b/third_party/move/mono-move/runtime/src/value_conv/mod.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Execution of user transactions.
+//! Conversions between VM values and the representations outside the VM.
 
-mod args;
-mod execute;
-mod metadata;
-mod pre_execution_checks;
-mod validation;
+pub(crate) mod bcs;
+pub(crate) mod rust;

--- a/third_party/move/mono-move/runtime/src/value_conv/rust.rs
+++ b/third_party/move/mono-move/runtime/src/value_conv/rust.rs
@@ -1,0 +1,863 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Writes a Rust value into the VM's in-memory representation, by visiting it
+//! through the Move value model.
+
+use crate::{
+    error::{RuntimeError, RuntimeInvariantViolation},
+    heap::{alloc_enum_no_gc, alloc_vec_no_gc, AllocationError, Heap},
+    memory::write_ptr,
+    types::VEC_DATA_OFFSET,
+};
+use mono_move_core::{
+    types::InternedType, FieldValueLayout, LayoutKind, LayoutProvider, ValueLayout,
+    ENUM_DATA_OFFSET,
+};
+use move_core_types::{
+    account_address::AccountAddress,
+    int256::{I256, U256},
+};
+use move_value_view::{FieldVisitor, MoveValueView, MoveValueVisitor, VectorElementVisitor};
+
+/// Writes `value` at `dst` as a VM value of type `ty`. Fails rather than
+/// triggering GC when the heap is full.
+///
+/// On error, `dst` is left partially written and must not be read. Heap
+/// objects allocated for it are simply abandoned.
+///
+/// # Safety
+///
+/// `dst` must be writable for `ty`'s in-memory size, meet the type's
+/// alignment, and outlive the call; `ty` must not be a reference.
+pub(crate) unsafe fn write_value<L: LayoutProvider + ?Sized, T: MoveValueView + ?Sized>(
+    layouts: &L,
+    heap: &mut Heap,
+    ty: InternedType,
+    value: &T,
+    dst: *mut u8,
+) -> Result<(), RuntimeError> {
+    let layout = layouts.layout_by_ty(ty).ok_or({
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+    })?;
+    debug_assert!(
+        dst.addr().is_multiple_of(layout.align as usize),
+        "write destination must meet the type's alignment"
+    );
+    value.visit(ValueWriter {
+        layouts,
+        heap,
+        layout,
+        dst,
+    })
+}
+
+/// Writes a single value of `layout` at `dst`.
+struct ValueWriter<'a, L: ?Sized> {
+    layouts: &'a L,
+    heap: &'a mut Heap,
+    layout: &'a ValueLayout,
+    dst: *mut u8,
+}
+
+/// Rejects vector lengths beyond what BCS can encode, matching the BCS path.
+//
+// TODO(metering): revisit whether this cap should be tighter. In practice the
+// heap size is what bounds these allocations.
+fn check_sequence_len(len: usize) -> Result<(), RuntimeError> {
+    if len as u64 > bcs::MAX_SEQUENCE_LENGTH as u64 {
+        return Err(RuntimeError::BCSSequenceTooLong { len: len as u64 });
+    }
+    Ok(())
+}
+
+impl<'a, L: LayoutProvider + ?Sized> ValueWriter<'a, L> {
+    /// The value's shape does not match this writer's target layout.
+    fn mismatch(&self, value: impl Into<String>) -> RuntimeError {
+        RuntimeError::InvariantViolation(RuntimeInvariantViolation::CallArgMismatch(format!(
+            "cannot write {} into a {} slot",
+            value.into(),
+            self.layout
+        )))
+    }
+
+    /// Writes an integer's little-endian bytes into a matching integer slot.
+    //
+    // TODO(correctness): assumes a little-endian host, as the BCS path does.
+    fn write_int(self, signed: bool, bytes: &[u8]) -> Result<(), RuntimeError> {
+        let kind_matches = match self.layout.kind {
+            LayoutKind::UnsignedInt => !signed,
+            LayoutKind::SignedInt => signed,
+            LayoutKind::Bool
+            | LayoutKind::Address
+            | LayoutKind::Signer
+            | LayoutKind::Struct { .. }
+            | LayoutKind::Vector { .. }
+            | LayoutKind::FrozenEnum { .. }
+            | LayoutKind::Ref
+            | LayoutKind::Function => false,
+        };
+        if !kind_matches || self.layout.size as usize != bytes.len() {
+            return Err(self.mismatch(format!(
+                "a {}-byte {} integer",
+                bytes.len(),
+                if signed { "signed" } else { "unsigned" }
+            )));
+        }
+        // SAFETY: `dst` is writable for the layout's size, checked equal to
+        // the byte count.
+        unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), self.dst, bytes.len()) };
+        Ok(())
+    }
+
+    /// Resolves the field list a struct or variant body lays out, checking that
+    /// it holds exactly the fields the value declares.
+    fn fields_of(
+        layout: &'a ValueLayout,
+        value: &'static str,
+        num_fields: usize,
+    ) -> Result<&'a [FieldValueLayout], RuntimeError> {
+        match &layout.kind {
+            LayoutKind::Struct { fields } if fields.len() == num_fields => Ok(fields),
+            LayoutKind::Struct { .. }
+            | LayoutKind::Bool
+            | LayoutKind::UnsignedInt
+            | LayoutKind::SignedInt
+            | LayoutKind::Address
+            | LayoutKind::Signer
+            | LayoutKind::Vector { .. }
+            | LayoutKind::FrozenEnum { .. }
+            | LayoutKind::Ref
+            | LayoutKind::Function => Err(RuntimeError::InvariantViolation(
+                RuntimeInvariantViolation::CallArgMismatch(format!(
+                    "cannot write a {num_fields}-field {value} into a {layout} slot"
+                )),
+            )),
+        }
+    }
+}
+
+impl<'a, L: LayoutProvider + ?Sized> MoveValueVisitor for ValueWriter<'a, L> {
+    type Elements = SeqWriter<'a, L>;
+    type Error = RuntimeError;
+    type Fields = FieldsWriter<'a, L>;
+    type Ok = ();
+
+    fn function_values_unsupported() -> RuntimeError {
+        RuntimeError::Unsupported("function values are not yet supported")
+    }
+
+    //======================================================================
+    // Scalars
+    //======================================================================
+
+    fn visit_bool(self, v: bool) -> Result<(), RuntimeError> {
+        if !matches!(self.layout.kind, LayoutKind::Bool) {
+            return Err(self.mismatch("a bool"));
+        }
+        // SAFETY: `dst` is writable for the 1-byte bool slot.
+        unsafe { std::ptr::write(self.dst, v as u8) };
+        Ok(())
+    }
+
+    fn visit_u8(self, v: u8) -> Result<(), RuntimeError> {
+        self.write_int(false, &v.to_le_bytes())
+    }
+
+    fn visit_u16(self, v: u16) -> Result<(), RuntimeError> {
+        self.write_int(false, &v.to_le_bytes())
+    }
+
+    fn visit_u32(self, v: u32) -> Result<(), RuntimeError> {
+        self.write_int(false, &v.to_le_bytes())
+    }
+
+    fn visit_u64(self, v: u64) -> Result<(), RuntimeError> {
+        self.write_int(false, &v.to_le_bytes())
+    }
+
+    fn visit_u128(self, v: u128) -> Result<(), RuntimeError> {
+        self.write_int(false, &v.to_le_bytes())
+    }
+
+    fn visit_u256(self, v: U256) -> Result<(), RuntimeError> {
+        self.write_int(false, &v.to_le_bytes())
+    }
+
+    fn visit_i8(self, v: i8) -> Result<(), RuntimeError> {
+        self.write_int(true, &v.to_le_bytes())
+    }
+
+    fn visit_i16(self, v: i16) -> Result<(), RuntimeError> {
+        self.write_int(true, &v.to_le_bytes())
+    }
+
+    fn visit_i32(self, v: i32) -> Result<(), RuntimeError> {
+        self.write_int(true, &v.to_le_bytes())
+    }
+
+    fn visit_i64(self, v: i64) -> Result<(), RuntimeError> {
+        self.write_int(true, &v.to_le_bytes())
+    }
+
+    fn visit_i128(self, v: i128) -> Result<(), RuntimeError> {
+        self.write_int(true, &v.to_le_bytes())
+    }
+
+    fn visit_i256(self, v: I256) -> Result<(), RuntimeError> {
+        self.write_int(true, &v.to_le_bytes())
+    }
+
+    fn visit_address(self, v: &AccountAddress) -> Result<(), RuntimeError> {
+        if !matches!(self.layout.kind, LayoutKind::Address)
+            || self.layout.size as usize != AccountAddress::LENGTH
+        {
+            return Err(self.mismatch("an address"));
+        }
+        // SAFETY: `dst` is writable for the layout's size, checked to be an
+        // address's length.
+        unsafe {
+            std::ptr::copy_nonoverlapping(v.as_ref().as_ptr(), self.dst, AccountAddress::LENGTH)
+        };
+        Ok(())
+    }
+
+    /// A signer is authority the VM grants, never a value a caller supplies:
+    /// `CallBuilder::signer` places one from a buffer that outlives the call.
+    fn visit_signer(self, _: &AccountAddress) -> Result<(), RuntimeError> {
+        Err(RuntimeError::InvariantViolation(
+            RuntimeInvariantViolation::CallArgMismatch(
+                "a signer cannot be supplied as a value".to_string(),
+            ),
+        ))
+    }
+
+    //======================================================================
+    // Vectors
+    //======================================================================
+
+    fn visit_bytes(self, v: &[u8]) -> Result<(), RuntimeError> {
+        let LayoutKind::Vector {
+            elem_id,
+            descriptor_id,
+        } = &self.layout.kind
+        else {
+            return Err(self.mismatch("a byte vector"));
+        };
+        let elem = self.layouts.layout(*elem_id).ok_or({
+            RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+        })?;
+        // TODO(completeness): `vector<bool>` and `vector<i8>` are rejected
+        // here, though the BCS path accepts the same bytes.
+        if !matches!(elem.kind, LayoutKind::UnsignedInt) || elem.size != 1 {
+            return Err(RuntimeError::InvariantViolation(
+                RuntimeInvariantViolation::CallArgMismatch(
+                    "a byte vector against a vector of non-byte elements".to_string(),
+                ),
+            ));
+        }
+        // TODO(cleanup): share the vector construction (null for empty, then
+        // allocate and fill) with `bcs::deserialize_impl`.
+        if v.is_empty() {
+            // The empty vector is the null pointer.
+            // SAFETY: `dst` is writable for the vector's pointer slot.
+            unsafe { write_ptr(self.dst, 0usize, std::ptr::null()) };
+            return Ok(());
+        }
+        check_sequence_len(v.len())?;
+        let vec_ptr = alloc_vec_no_gc(self.heap, *descriptor_id, 1, v.len() as u64)
+            .map_err(AllocationError::into_runtime_error)?;
+        // SAFETY: the data region was allocated for exactly `v.len()` bytes.
+        unsafe { std::ptr::copy_nonoverlapping(v.as_ptr(), vec_ptr.add(VEC_DATA_OFFSET), v.len()) };
+        // SAFETY: `dst` is writable for the vector's pointer slot.
+        unsafe { write_ptr(self.dst, 0usize, vec_ptr) };
+        Ok(())
+    }
+
+    fn visit_vector(self, len: usize) -> Result<SeqWriter<'a, L>, RuntimeError> {
+        let LayoutKind::Vector {
+            elem_id,
+            descriptor_id,
+        } = &self.layout.kind
+        else {
+            return Err(self.mismatch("a vector"));
+        };
+        let elem_layout = self.layouts.layout(*elem_id).ok_or({
+            RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+        })?;
+        check_sequence_len(len)?;
+        let vec_ptr = if len == 0 {
+            // The empty vector is the null pointer, written at `end()`.
+            std::ptr::null_mut()
+        } else {
+            alloc_vec_no_gc(self.heap, *descriptor_id, elem_layout.size, len as u64)
+                .map_err(AllocationError::into_runtime_error)?
+        };
+        Ok(SeqWriter {
+            layouts: self.layouts,
+            heap: self.heap,
+            elem_layout,
+            vec_ptr,
+            dst: self.dst,
+            expected: len,
+            written: 0,
+        })
+    }
+
+    //======================================================================
+    // Structs and enums
+    //======================================================================
+
+    fn visit_struct(self, num_fields: usize) -> Result<FieldsWriter<'a, L>, RuntimeError> {
+        let fields = Self::fields_of(self.layout, "struct", num_fields)?;
+        Ok(FieldsWriter {
+            layouts: self.layouts,
+            heap: self.heap,
+            fields,
+            base: self.dst,
+            next: 0,
+            finish: None,
+        })
+    }
+
+    fn visit_variant(
+        self,
+        tag: u32,
+        num_fields: usize,
+    ) -> Result<FieldsWriter<'a, L>, RuntimeError> {
+        let LayoutKind::FrozenEnum {
+            descriptor_id,
+            variants,
+            max_size_across_variants,
+        } = &self.layout.kind
+        else {
+            return Err(self.mismatch(format!("a {num_fields}-field enum variant")));
+        };
+        let variant_id = *variants.get(tag as usize).ok_or({
+            RuntimeError::InvariantViolation(RuntimeInvariantViolation::EnumTagOutOfRange {
+                tag: tag as u64,
+                variant_count: variants.len(),
+            })
+        })?;
+        let variant_layout = self.layouts.layout(variant_id).ok_or({
+            RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+        })?;
+        let fields = Self::fields_of(variant_layout, "variant body", num_fields)?;
+
+        let obj_ptr = alloc_enum_no_gc(
+            self.heap,
+            *descriptor_id,
+            tag as u64,
+            *max_size_across_variants as usize,
+        )
+        .map_err(AllocationError::into_runtime_error)?;
+        // SAFETY: the variant body lives at this offset within the allocation.
+        let data_ptr = unsafe { obj_ptr.add(ENUM_DATA_OFFSET) };
+        Ok(FieldsWriter {
+            layouts: self.layouts,
+            heap: self.heap,
+            fields,
+            base: data_ptr,
+            next: 0,
+            finish: Some((obj_ptr, self.dst)),
+        })
+    }
+}
+
+/// Writes a vector's elements into a preallocated vector object.
+struct SeqWriter<'a, L: ?Sized> {
+    layouts: &'a L,
+    heap: &'a mut Heap,
+    elem_layout: &'a ValueLayout,
+    /// Null for the empty vector.
+    vec_ptr: *mut u8,
+    /// The slot the vector pointer lands in.
+    dst: *mut u8,
+    expected: usize,
+    written: usize,
+}
+
+impl<L: LayoutProvider + ?Sized> VectorElementVisitor for SeqWriter<'_, L> {
+    type Error = RuntimeError;
+    type Ok = ();
+
+    fn element<T: MoveValueView + ?Sized>(&mut self, value: &T) -> Result<(), RuntimeError> {
+        if self.written >= self.expected {
+            return Err(RuntimeError::InvariantViolation(
+                RuntimeInvariantViolation::CallArgMismatch(format!(
+                    "a vector wrote more than its {} declared elements",
+                    self.expected
+                )),
+            ));
+        }
+        // SAFETY: the data region was allocated for `expected` elements and
+        // `written < expected`.
+        let elem_dst = unsafe {
+            self.vec_ptr
+                .add(VEC_DATA_OFFSET + self.written * self.elem_layout.size as usize)
+        };
+        value.visit(ValueWriter {
+            layouts: self.layouts,
+            heap: self.heap,
+            layout: self.elem_layout,
+            dst: elem_dst,
+        })?;
+        self.written += 1;
+        Ok(())
+    }
+
+    fn end(self) -> Result<(), RuntimeError> {
+        if self.written != self.expected {
+            return Err(RuntimeError::InvariantViolation(
+                RuntimeInvariantViolation::CallArgMismatch(format!(
+                    "a vector wrote {} of its {} declared elements",
+                    self.written, self.expected
+                )),
+            ));
+        }
+        // SAFETY: `dst` is writable for the vector's pointer slot.
+        unsafe { write_ptr(self.dst, 0usize, self.vec_ptr) };
+        Ok(())
+    }
+}
+
+/// Writes a struct's (or enum variant body's) fields in declaration order.
+struct FieldsWriter<'a, L: ?Sized> {
+    layouts: &'a L,
+    heap: &'a mut Heap,
+    fields: &'a [FieldValueLayout],
+    /// Base of the field region: the value's slot, or an enum's data region.
+    base: *mut u8,
+    next: usize,
+    /// Set for an enum variant: the object and the slot to link it into.
+    finish: Option<(*mut u8, *mut u8)>,
+}
+
+impl<L: LayoutProvider + ?Sized> FieldVisitor for FieldsWriter<'_, L> {
+    type Error = RuntimeError;
+    type Ok = ();
+
+    fn field<T: MoveValueView + ?Sized>(&mut self, value: &T) -> Result<(), RuntimeError> {
+        let field = self.fields.get(self.next).ok_or_else(|| {
+            RuntimeError::InvariantViolation(RuntimeInvariantViolation::CallArgMismatch(format!(
+                "a value wrote more than its {} declared fields",
+                self.fields.len()
+            )))
+        })?;
+        let layout = self.layouts.layout(field.id).ok_or({
+            RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
+        })?;
+        // SAFETY: a field offset lies within the field region, which was
+        // sized for the whole struct.
+        let dst = unsafe { self.base.add(field.offset as usize) };
+        value.visit(ValueWriter {
+            layouts: self.layouts,
+            heap: self.heap,
+            layout,
+            dst,
+        })?;
+        self.next += 1;
+        Ok(())
+    }
+
+    fn end(self) -> Result<(), RuntimeError> {
+        if self.next != self.fields.len() {
+            return Err(RuntimeError::InvariantViolation(
+                RuntimeInvariantViolation::CallArgMismatch(format!(
+                    "a value wrote {} of its {} declared fields",
+                    self.next,
+                    self.fields.len()
+                )),
+            ));
+        }
+        if let Some((obj_ptr, slot)) = self.finish {
+            // SAFETY: `slot` is writable for the enum's pointer slot.
+            unsafe { write_ptr(slot, 0usize, obj_ptr) };
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value_conv::bcs::AlignedBuf;
+    use mono_move_core::{
+        intern_type_tag, reserved_layout_id, types::Type, DescriptorId, LayoutFlags, LayoutId,
+    };
+    use mono_move_global_context::{ExecutionGuard, GlobalContext};
+    use move_core_types::{
+        identifier::Identifier,
+        language_storage::{StructTag, TypeTag},
+    };
+    use move_value_view::MoveValueView;
+    use move_value_view_derive::MoveValueView;
+    use serde::Serialize;
+
+    /// A pointer-slot layout, as vectors and enums use.
+    fn ptr_layout(kind: LayoutKind) -> ValueLayout {
+        ValueLayout::new(8, 8, None, LayoutFlags::empty(), kind)
+    }
+
+    fn struct_layout(size: u32, align: u32, fields: Vec<FieldValueLayout>) -> ValueLayout {
+        ValueLayout::new(
+            size,
+            align,
+            None,
+            LayoutFlags::empty(),
+            LayoutKind::Struct {
+                fields: fields.into_boxed_slice(),
+            },
+        )
+    }
+
+    fn field(offset: u32, id: LayoutId) -> FieldValueLayout {
+        FieldValueLayout { offset, id }
+    }
+
+    fn tag(module: &str, name: &str, type_args: Vec<TypeTag>) -> TypeTag {
+        TypeTag::Struct(Box::new(StructTag {
+            address: AccountAddress::ONE,
+            module: Identifier::new(module).unwrap(),
+            name: Identifier::new(name).unwrap(),
+            type_args,
+        }))
+    }
+
+    fn reserved(ty: &Type) -> LayoutId {
+        reserved_layout_id(ty).expect("reserved layout")
+    }
+
+    fn publish_vector(
+        guard: &ExecutionGuard<'_>,
+        elem_tag: &TypeTag,
+        elem_id: LayoutId,
+    ) -> InternedType {
+        let ty = intern_type_tag(&TypeTag::Vector(Box::new(elem_tag.clone())), guard).unwrap();
+        guard.publish_layout(
+            ty,
+            ptr_layout(LayoutKind::Vector {
+                elem_id,
+                descriptor_id: DescriptorId(0),
+            }),
+        );
+        ty
+    }
+
+    /// Publishes an `Option<elem>` mirroring the stdlib's `None`/`Some` enum.
+    fn publish_option(
+        guard: &ExecutionGuard<'_>,
+        elem_tag: &TypeTag,
+        elem_id: LayoutId,
+        elem_size: u32,
+    ) -> InternedType {
+        let ty = intern_type_tag(&tag("option", "Option", vec![elem_tag.clone()]), guard).unwrap();
+        let variants = guard.publish_variant_layouts(ty, vec![
+            struct_layout(0, 1, vec![]),
+            struct_layout(elem_size, elem_size.max(1), vec![field(0, elem_id)]),
+        ]);
+        guard.publish_layout(
+            ty,
+            ptr_layout(LayoutKind::FrozenEnum {
+                descriptor_id: DescriptorId(0),
+                variants,
+                max_size_across_variants: 8 + elem_size,
+            }),
+        );
+        ty
+    }
+
+    /// Checks that the model write and the BCS path agree byte for byte.
+    fn check<T: MoveValueView + Serialize + ?Sized>(
+        guard: &ExecutionGuard<'_>,
+        ty: InternedType,
+        value: &T,
+    ) {
+        let bytes = bcs::to_bytes(value).expect("value BCS-encodes");
+        let mut written_heap = Heap::new(1 << 20);
+        let mut decoded_heap = Heap::new(1 << 20);
+        let mut written_slot = AlignedBuf::zeroed(128);
+        let mut decoded_slot = AlignedBuf::zeroed(128);
+        // SAFETY: the slots are aligned and wider than any test type's
+        // in-memory size.
+        unsafe {
+            write_value(
+                guard,
+                &mut written_heap,
+                ty,
+                value,
+                written_slot.as_mut_ptr(),
+            )
+            .expect("write_value succeeds");
+            crate::value_conv::bcs::deserialize_into(
+                guard,
+                &mut decoded_heap,
+                ty,
+                &bytes,
+                decoded_slot.as_mut_ptr(),
+            )
+            .expect("deserialize_into succeeds");
+        }
+        let (written_slot, decoded_slot) = (written_slot.as_ptr(), decoded_slot.as_ptr());
+        // SAFETY: both slots hold initialized values of `ty` on live heaps.
+        let (written, decoded) = unsafe {
+            (
+                crate::value_conv::bcs::serialize(guard, written_slot, ty)
+                    .expect("the written value serializes"),
+                crate::value_conv::bcs::serialize(guard, decoded_slot, ty)
+                    .expect("the decoded value serializes"),
+            )
+        };
+        assert_eq!(written, bytes, "the model write diverges from the BCS path");
+        assert_eq!(decoded, bytes, "the BCS write does not round-trip");
+    }
+
+    #[test]
+    fn writes_every_integer_width() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        check(&guard, intern_type_tag(&TypeTag::U8, &guard).unwrap(), &7u8);
+        check(
+            &guard,
+            intern_type_tag(&TypeTag::U16, &guard).unwrap(),
+            &7u16,
+        );
+        check(
+            &guard,
+            intern_type_tag(&TypeTag::U32, &guard).unwrap(),
+            &7u32,
+        );
+        check(
+            &guard,
+            intern_type_tag(&TypeTag::U64, &guard).unwrap(),
+            &7u64,
+        );
+        check(
+            &guard,
+            intern_type_tag(&TypeTag::U128, &guard).unwrap(),
+            &7u128,
+        );
+        check(
+            &guard,
+            intern_type_tag(&TypeTag::U256, &guard).unwrap(),
+            &U256::from_le_bytes([9u8; 32]),
+        );
+        check(
+            &guard,
+            intern_type_tag(&TypeTag::Bool, &guard).unwrap(),
+            &true,
+        );
+    }
+
+    #[test]
+    fn writes_an_address_in_one_go() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let ty = intern_type_tag(&TypeTag::Address, &guard).unwrap();
+        check(&guard, ty, &AccountAddress::ONE);
+        check(
+            &guard,
+            ty,
+            &AccountAddress::from_hex_literal("0xbeef").unwrap(),
+        );
+    }
+
+    #[test]
+    fn writes_vectors() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let vec_u8 = publish_vector(&guard, &TypeTag::U8, reserved(&Type::U8));
+        let vec_u64 = publish_vector(&guard, &TypeTag::U64, reserved(&Type::U64));
+        // `Vec<u8>` takes the bulk-copy path, `Vec<u64>` the element loop.
+        check(&guard, vec_u8, &Vec::<u8>::new());
+        check(&guard, vec_u8, &vec![1u8, 2, 3, 4, 5]);
+        check(&guard, vec_u64, &Vec::<u64>::new());
+        check(&guard, vec_u64, &vec![1u64, 2, 3]);
+    }
+
+    #[test]
+    fn writes_a_string_as_a_wrapped_byte_vector() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let vec_u8 = publish_vector(&guard, &TypeTag::U8, reserved(&Type::U8));
+        let vec_u8_id = guard.layout_id(vec_u8).unwrap();
+        let string_ty = intern_type_tag(&tag("string", "String", vec![]), &guard).unwrap();
+        guard.publish_layout(string_ty, struct_layout(8, 8, vec![field(0, vec_u8_id)]));
+        check(&guard, string_ty, &"hello Move".to_string());
+        check(&guard, string_ty, &String::new());
+    }
+
+    #[test]
+    fn writes_options_as_enums() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let opt_u64 = publish_option(&guard, &TypeTag::U64, reserved(&Type::U64), 8);
+        check(&guard, opt_u64, &None::<u64>);
+        check(&guard, opt_u64, &Some(42u64));
+    }
+
+    #[derive(Serialize, MoveValueView)]
+    struct Metadata {
+        proposer: AccountAddress,
+        round: u64,
+        votes: Vec<u8>,
+        name: String,
+    }
+
+    #[test]
+    fn derives_for_a_struct() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let vec_u8 = publish_vector(&guard, &TypeTag::U8, reserved(&Type::U8));
+        let vec_u8_id = guard.layout_id(vec_u8).unwrap();
+        let string_ty = intern_type_tag(&tag("string", "String", vec![]), &guard).unwrap();
+        guard.publish_layout(string_ty, struct_layout(8, 8, vec![field(0, vec_u8_id)]));
+        let string_id = guard.layout_id(string_ty).unwrap();
+
+        let ty = intern_type_tag(&tag("m", "Metadata", vec![]), &guard).unwrap();
+        guard.publish_layout(
+            ty,
+            struct_layout(56, 8, vec![
+                field(0, reserved(&Type::Address)),
+                field(32, reserved(&Type::U64)),
+                field(40, vec_u8_id),
+                field(48, string_id),
+            ]),
+        );
+        check(&guard, ty, &Metadata {
+            proposer: AccountAddress::ONE,
+            round: 9,
+            votes: vec![1, 2, 3],
+            name: "block".to_string(),
+        });
+    }
+
+    #[derive(Serialize, MoveValueView)]
+    struct Wrapper<T> {
+        inner: T,
+    }
+
+    #[test]
+    fn derives_for_a_generic_struct() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let ty = intern_type_tag(&tag("m", "Wrapper", vec![]), &guard).unwrap();
+        guard.publish_layout(
+            ty,
+            struct_layout(8, 8, vec![field(0, reserved(&Type::U64))]),
+        );
+        check(&guard, ty, &Wrapper { inner: 7u64 });
+    }
+
+    #[derive(Serialize, MoveValueView)]
+    enum Protector {
+        Nonce(u64),
+        Pair { lo: u64, hi: u64 },
+        Nothing,
+    }
+
+    #[test]
+    fn derives_for_an_enum() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let ty = intern_type_tag(&tag("m", "Protector", vec![]), &guard).unwrap();
+        let variants = guard.publish_variant_layouts(ty, vec![
+            struct_layout(8, 8, vec![field(0, reserved(&Type::U64))]),
+            struct_layout(16, 8, vec![
+                field(0, reserved(&Type::U64)),
+                field(8, reserved(&Type::U64)),
+            ]),
+            struct_layout(0, 1, vec![]),
+        ]);
+        guard.publish_layout(
+            ty,
+            ptr_layout(LayoutKind::FrozenEnum {
+                descriptor_id: DescriptorId(0),
+                variants,
+                max_size_across_variants: 24,
+            }),
+        );
+        check(&guard, ty, &Protector::Nonce(7));
+        check(&guard, ty, &Protector::Pair { lo: 1, hi: 2 });
+        check(&guard, ty, &Protector::Nothing);
+    }
+
+    #[test]
+    fn rejects_shape_mismatches() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let u64_ty = intern_type_tag(&TypeTag::U64, &guard).unwrap();
+        let addr_ty = intern_type_tag(&TypeTag::Address, &guard).unwrap();
+        let mut heap = Heap::new(1 << 20);
+        let mut slot = AlignedBuf::zeroed(48);
+        // SAFETY: the slot is aligned and wider than any test type's
+        // in-memory size.
+        unsafe {
+            write_value(&guard, &mut heap, u64_ty, &1u32, slot.as_mut_ptr())
+                .expect_err("a u32 must not write as u64");
+            write_value(&guard, &mut heap, u64_ty, &vec![1u64], slot.as_mut_ptr())
+                .expect_err("a vector must not write as u64");
+            write_value(&guard, &mut heap, addr_ty, &1u64, slot.as_mut_ptr())
+                .expect_err("a u64 must not write as an address");
+            write_value(
+                &guard,
+                &mut heap,
+                u64_ty,
+                &AccountAddress::ONE,
+                slot.as_mut_ptr(),
+            )
+            .expect_err("an address must not write as u64");
+        }
+    }
+
+    #[test]
+    fn rejects_a_signer_supplied_as_a_value() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        let addr_ty = intern_type_tag(&TypeTag::Address, &guard).unwrap();
+        let signer = move_core_types::value::MoveValue::Signer(AccountAddress::ONE);
+        let mut heap = Heap::new(1 << 20);
+        let mut slot = AlignedBuf::zeroed(48);
+        // SAFETY: the slot is aligned and wider than an address's in-memory
+        // size.
+        unsafe {
+            write_value(&guard, &mut heap, addr_ty, &signer, slot.as_mut_ptr())
+                .expect_err("a signer must not be placed as an argument");
+            // The same address, as an address, still writes.
+            let address = move_core_types::value::MoveValue::Address(AccountAddress::ONE);
+            write_value(&guard, &mut heap, addr_ty, &address, slot.as_mut_ptr())
+                .expect("an address writes as an address");
+        }
+    }
+
+    #[test]
+    fn rejects_a_variant_whose_body_has_the_wrong_field_count() {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.try_execution_context(0).unwrap();
+        // `Some` carries one field, but this enum's second variant has two.
+        let ty = intern_type_tag(&tag("m", "Wrong", vec![]), &guard).unwrap();
+        let variants = guard.publish_variant_layouts(ty, vec![
+            struct_layout(0, 1, vec![]),
+            struct_layout(16, 8, vec![
+                field(0, reserved(&Type::U64)),
+                field(8, reserved(&Type::U64)),
+            ]),
+        ]);
+        guard.publish_layout(
+            ty,
+            ptr_layout(LayoutKind::FrozenEnum {
+                descriptor_id: DescriptorId(0),
+                variants,
+                max_size_across_variants: 24,
+            }),
+        );
+        let mut heap = Heap::new(1 << 20);
+        let mut slot = AlignedBuf::zeroed(48);
+        // SAFETY: the slot is aligned and wider than an enum's in-memory
+        // size.
+        unsafe {
+            write_value(&guard, &mut heap, ty, &Some(1u64), slot.as_mut_ptr())
+                .expect_err("`Some` must not fill a two-field variant body");
+        }
+    }
+}

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -1312,3 +1312,20 @@ impl<P: DescriptorProvider + LayoutProvider + ?Sized> FunctionVerifier<'_, P> {
         }
     }
 }
+
+/// Panics with the verifier's findings unless `function` verifies cleanly.
+pub fn assert_verified<P: DescriptorProvider + LayoutProvider + ?Sized>(
+    function: &Function,
+    provider: &P,
+) {
+    let errors = verify_function(function, provider);
+    assert!(
+        errors.is_empty(),
+        "verification failed:\n{}",
+        errors
+            .iter()
+            .map(|e| format!("  {}", e))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}

--- a/third_party/move/mono-move/runtime/tests/common/mod.rs
+++ b/third_party/move/mono-move/runtime/tests/common/mod.rs
@@ -8,13 +8,12 @@ use mono_move_core::{
     Function, GasMeter, NoModuleProvider, NoResourceProvider,
 };
 use mono_move_global_context::GlobalContext;
-use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
+use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
 use mono_move_runtime::{InterpreterContext, ProductionNativeRegistry};
 
 /// Runs `f` with a fresh [`InterpreterContext`] over an empty module provider
-/// and no natives, with `entry` verified and installed. A fresh
-/// [`GlobalContext`] is built per call so no cached module or interned state
-/// leaks between tests.
+/// and no natives, with `entry` verified. A fresh global context per call
+/// keeps cached module and interned state from leaking between tests.
 // Not every test binary that includes `common` uses the helper.
 #[allow(dead_code)]
 pub fn with_test_interpreter<R>(
@@ -34,13 +33,12 @@ pub fn with_test_interpreter<R>(
         LoadingPolicy::Lazy(LoweringPolicy::Lazy),
         &NoNatives,
     );
+    mono_move_runtime::assert_verified(entry, &guard);
     let mut interp = InterpreterContext::new(
         loader,
-        ModuleReadSet::new(),
         GasMeter::new(gas_budget),
         &NoResourceProvider,
         &natives,
-        entry,
     )
     .with_extensions(extensions);
     f(&mut interp)

--- a/third_party/move/mono-move/runtime/tests/extension_checkpoints.rs
+++ b/third_party/move/mono-move/runtime/tests/extension_checkpoints.rs
@@ -45,6 +45,7 @@ fn trivial_program() -> Function {
         code: Code::from_vec(vec![MicroOp::Return]),
         entry_gas: 0,
         param_slots: vec![],
+        param_tys: vec![],
         param_region_size: 0,
         param_and_local_sizes_sum: 40,
         extended_frame_size: 64,

--- a/third_party/move/mono-move/runtime/tests/int_ops.rs
+++ b/third_party/move/mono-move/runtime/tests/int_ops.rs
@@ -40,7 +40,7 @@ use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     native::NativeExtensions, Code, FrameLayoutInfo, FrameOffset as FO, Function,
     FunctionDefinitionIndex, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand, IntShiftOp, IntTy,
-    MicroOp, ShiftOperand, SortedSafePointEntries, FRAME_METADATA_SIZE,
+    MicroOp, ShiftOperand, SizedSlot, SortedSafePointEntries, FRAME_METADATA_SIZE,
 };
 use move_core_types::int256::{I256, U256};
 use num_bigint::{BigInt, Sign};
@@ -188,15 +188,44 @@ const SLOT_LHS: u32 = 32;
 const SLOT_RHS: u32 = 64;
 const FRAME_SIZE: u32 = 96;
 
-fn make_func(op: MicroOp) -> Function {
+/// The interned unsigned type of `width` bytes. It serves signed operands
+/// too: the widths match and every byte pattern is a valid integer.
+fn operand_ty(width: usize) -> mono_move_core::types::InternedType {
+    use mono_move_core::types as ty;
+    match width {
+        1 => ty::U8_TY,
+        2 => ty::U16_TY,
+        4 => ty::U32_TY,
+        8 => ty::U64_TY,
+        16 => ty::U128_TY,
+        32 => ty::U256_TY,
+        _ => panic!("unsupported operand width {width}"),
+    }
+}
+
+/// Builds the single-op function, with one parameter per non-empty operand.
+fn make_func(op: MicroOp, lhs_width: usize, rhs_width: usize) -> Function {
+    let mut param_slots = vec![];
+    let mut param_tys = vec![];
+    for (offset, width) in [(SLOT_LHS, lhs_width), (SLOT_RHS, rhs_width)] {
+        if width > 0 {
+            param_slots.push(SizedSlot {
+                offset: FO(offset),
+                size: width as u32,
+                align: width.min(8) as u32,
+            });
+            param_tys.push(operand_ty(width));
+        }
+    }
     Function {
         name: GlobalArenaPtr::from_static("op"),
         module_id: crate::program_module_id!("test"),
         def_idx: FunctionDefinitionIndex(0),
         code: Code::from_vec(vec![op, MicroOp::Return]),
         entry_gas: 0,
-        param_slots: vec![],
-        param_region_size: 0,
+        param_slots,
+        param_tys,
+        param_region_size: FRAME_SIZE as usize,
         param_and_local_sizes_sum: FRAME_SIZE as usize,
         extended_frame_size: FRAME_SIZE as usize + FRAME_METADATA_SIZE,
         zero_frame: false,
@@ -214,20 +243,23 @@ fn run_wide(
     rhs_bytes: &[u8],
     dst_size: usize,
 ) -> Result<Vec<u8>, anyhow::Error> {
-    let func = make_func(op);
+    let func = make_func(op, lhs_bytes.len(), rhs_bytes.len());
     common::with_test_interpreter(&func, u64::MAX, NativeExtensions::new(), |ctx| {
-        if !lhs_bytes.is_empty() {
-            ctx.set_root_arg(SLOT_LHS, lhs_bytes);
+        let mut call = ctx
+            .build_call(&func)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        for bytes in [lhs_bytes, rhs_bytes] {
+            if !bytes.is_empty() {
+                // A scalar's little-endian bytes are its BCS form.
+                call.arg_bcs(bytes).map_err(|e| anyhow::anyhow!("{}", e))?;
+            }
         }
-        if !rhs_bytes.is_empty() {
-            ctx.set_root_arg(SLOT_RHS, rhs_bytes);
-        }
-        ctx.run().map_err(|e| anyhow::anyhow!("{}", e))?;
+        call.run().map_err(|e| anyhow::anyhow!("{}", e))?;
 
         let mut out = vec![0u8; dst_size];
         let mut i = 0usize;
         while i < dst_size {
-            let word = ctx.root_result_at(SLOT_DST + i as u32);
+            let word = ctx.root_result_u64_at_for_test(SLOT_DST + i as u32);
             let bytes = word.to_ne_bytes();
             let copy_n = (dst_size - i).min(8);
             out[i..i + copy_n].copy_from_slice(&bytes[..copy_n]);

--- a/third_party/move/mono-move/runtime/tests/ref_test.rs
+++ b/third_party/move/mono-move/runtime/tests/ref_test.rs
@@ -44,6 +44,7 @@ fn ref_self_copy() {
         code: Code::from_vec(code),
         entry_gas: 0,
         param_slots: vec![],
+        param_tys: vec![],
         param_region_size: 0,
         param_and_local_sizes_sum: 32,
         extended_frame_size: 32 + FRAME_METADATA_SIZE,
@@ -53,8 +54,8 @@ fn ref_self_copy() {
     };
     let result =
         common::with_test_interpreter(&function, u64::MAX, NativeExtensions::new(), |ctx| {
-            ctx.run().unwrap();
-            ctx.root_result()
+            ctx.build_call(&function).unwrap().run().unwrap();
+            ctx.root_result_u64_for_test()
         });
 
     assert_eq!(

--- a/third_party/move/mono-move/runtime/tests/verifier_test.rs
+++ b/third_party/move/mono-move/runtime/tests/verifier_test.rs
@@ -3,14 +3,14 @@
 
 //! Tests for the static verifier (`verify_function`, `verify_descriptors`).
 
-mod common;
-
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     types::InternedType, Code, CodeOffset as CO, DescriptorId, DescriptorProvider, FrameLayoutInfo,
     FrameOffset as FO, Function, FunctionDefinitionIndex, LayoutId, LayoutProvider, MicroOp,
     SortedSafePointEntries, ValueLayout,
 };
+mod common;
+
 use mono_move_runtime::{verify_function, ObjectDescriptor, ObjectDescriptorTable};
 
 /// A descriptor table paired with an empty layout provider, to satisfy the
@@ -49,6 +49,7 @@ fn minimal_func() -> Function {
         code: Code::from_vec(vec![MicroOp::Return]),
         entry_gas: 0,
         param_slots: vec![],
+        param_tys: vec![],
         param_region_size: 0,
         param_and_local_sizes_sum: 8,
         extended_frame_size: 32,

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -1002,8 +1002,10 @@ pub fn try_lower_function(
     // net for now.
     safe_points.sort_by_key(|e| e.code_offset.0);
 
-    // Per-parameter (offset, size, align), in declaration order.
+    // Per-parameter (offset, size, align) and substituted type, in
+    // declaration order.
     let param_slots = ctx.home_slots[..func_ir.num_params as usize].to_vec();
+    let param_tys = view_type_list(ctx.home_types)[..func_ir.num_params as usize].to_vec();
     let param_and_local_sizes_sum = ctx.frame_data_size as usize;
     let extended_frame_size = ctx
         .call_sites
@@ -1028,6 +1030,7 @@ pub fn try_lower_function(
         code: Code::with_origins(code, origins),
         entry_gas,
         param_slots,
+        param_tys,
         param_region_size: derived.param_region_size as usize,
         param_and_local_sizes_sum,
         extended_frame_size,

--- a/third_party/move/mono-move/testsuite/src/engine.rs
+++ b/third_party/move/mono-move/testsuite/src/engine.rs
@@ -10,8 +10,8 @@ use crate::{
 use anyhow::{anyhow, bail, Error, Result};
 use mono_move_core::{
     native::{NativeExtensions, NoNatives},
-    types::EMPTY_TYPE_LIST,
-    Function, GasMeter, NoResourceProvider, VMInternalError,
+    types::{is_signer_or_signer_immut_ref, EMPTY_TYPE_LIST},
+    Function, GasMeter, NoResourceProvider, VMInternalError, VMResult,
 };
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
@@ -21,7 +21,8 @@ use mono_move_natives::{
     make_all_ristretto255_scalar_test_natives, make_all_test_natives, make_all_unit_test_natives,
 };
 use mono_move_runtime::{
-    InterpreterContext, ProductionContextFamily, ProductionNativeRegistry, RuntimeStatus,
+    CallBuilder, InterpreterContext, InterpreterOptions, ProductionContextFamily,
+    ProductionNativeRegistry, RuntimeStatus,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, vm_status::AbortLocation,
@@ -63,19 +64,41 @@ impl<'guard> MonoRunner<'guard> {
         self.gc_count
     }
 
-    /// Run the entry function once. `set_args` places arguments into the root
-    /// frame before execution; on success `extract_returns` reads results from
-    /// it.
+    /// Run the entry function once, filling its parameters in order: signer
+    /// parameters from `signers`, every other from `place_arg` called with
+    /// the argument's index. On success `extract_returns` reads the results.
     pub fn run<R>(
         &mut self,
-        set_args: impl FnOnce(&mut InterpreterContext<'guard>),
+        signers: &[AccountAddress],
+        mut place_arg: impl FnMut(&mut CallBuilder<'_, '_>, usize) -> VMResult<()>,
         extract_returns: impl FnOnce(&InterpreterContext<'guard>) -> R,
     ) -> RunResult<R> {
-        // Each run starts from a clean state with a full budget, reusing the
-        // already-allocated stack and heap buffers.
-        self.interp.reset(self.function, GAS_BUDGET);
-        set_args(&mut self.interp);
-        let result = match self.interp.run() {
+        // Each run is its own transaction: a clean state with a full budget,
+        // reusing the already-allocated stack and heap buffers.
+        self.interp.reset_for_test(GAS_BUDGET);
+        let function = self.function;
+        let outcome = (|| {
+            let mut call = self.interp.build_call(function)?;
+            let mut placed_signers = 0;
+            for (index, &ty) in function.param_tys.iter().enumerate() {
+                if is_signer_or_signer_immut_ref(ty) {
+                    let buf = signers
+                        .get(placed_signers)
+                        .expect("a signer per signer parameter");
+                    call.signer(buf)?;
+                    placed_signers += 1;
+                } else {
+                    place_arg(&mut call, index - placed_signers)?;
+                }
+            }
+            assert_eq!(
+                placed_signers,
+                signers.len(),
+                "more signers than signer parameters"
+            );
+            call.run()
+        })();
+        let result = match outcome {
             Err(err) => RunResult::Error(err),
             Ok(RuntimeStatus::Success) => RunResult::Success(extract_returns(&self.interp)),
             Ok(RuntimeStatus::Aborted {
@@ -93,17 +116,13 @@ impl<'guard> MonoRunner<'guard> {
     }
 
     /// Call an entry whose args are 8-byte words and that returns a single
-    /// 8-byte word. Each arg is written at a consecutive 8-byte offset; the
-    /// lone result is read from offset 0 as a raw `u64`. Callers reinterpret
-    /// those bits (e.g. `as i64`) when the entry's return type is signed.
+    /// 8-byte word. Arguments and the result are raw bit patterns, which the
+    /// caller reinterprets for signed types.
     pub fn call_words(&mut self, args: &[u64]) -> Result<u64> {
         match self.run(
-            |interp| {
-                for (index, value) in args.iter().enumerate() {
-                    interp.set_root_arg((index * 8) as u32, &value.to_le_bytes());
-                }
-            },
-            |interp| interp.root_result(),
+            &[],
+            |call, index| call.arg(&args[index]),
+            |interp| interp.root_result_u64_for_test(),
         ) {
             RunResult::Success(value) => Ok(value),
             RunResult::Aborted { code, message, .. } => match message {
@@ -165,39 +184,26 @@ pub fn with_mono_function<'guard, 'ctx, R>(
         .intern_identifier(function_name)
         .into_global_arena_ptr();
 
-    let mut read_set = ModuleReadSet::new();
-    let mut gas_meter = GasMeter::new(GAS_BUDGET);
-    // SAFETY: the pointer lives in a `LoadedModule`'s arena. While `guard` is
-    // held the global executable cache cannot enter maintenance, so no arena
-    // reset can happen for the duration of `body`.
-    let function =
-        match loader.load_function(&mut read_set, &mut gas_meter, id, func, EMPTY_TYPE_LIST) {
-            Ok(ptr) => unsafe { ptr.as_ref_unchecked() },
-            // Attached as the source rather than formatted in, so callers can
-            // recover the typed error.
-            Err(err) => return Err(Error::new(err).context("failed to load function")),
-        };
-
-    let interp = match heap_size {
-        Some(n) => InterpreterContext::with_heap_size(
-            loader,
-            read_set,
-            gas_meter,
-            &NoResourceProvider,
-            natives,
-            function,
-            n,
-        ),
-        None => InterpreterContext::new(
-            loader,
-            read_set,
-            gas_meter,
-            &NoResourceProvider,
-            natives,
-            function,
-        ),
+    let mut options = InterpreterOptions::default();
+    if let Some(n) = heap_size {
+        options.heap_size = n;
     }
+    let mut interp = InterpreterContext::new_with_options(
+        loader,
+        GasMeter::new(GAS_BUDGET),
+        &NoResourceProvider,
+        natives,
+        options,
+    )
     .with_extensions(extensions);
+    let function = match interp.load_function(id, func, EMPTY_TYPE_LIST) {
+        Ok(function) => function,
+        // Attached as the source rather than formatted in, so callers can
+        // recover the typed error.
+        Err(err) => return Err(Error::new(err).context("failed to load function")),
+    };
+    // TODO(correctness): remove once the loader verifies lowered functions itself.
+    mono_move_runtime::assert_verified(function, guard);
 
     let mut runner = MonoRunner {
         interp,

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -615,16 +615,19 @@ fn execute_function_v2(
         extensions,
         heap_size,
         |runner| {
+            // Split the directive's arguments in order: signers back the
+            // entry's signer parameters, the rest are placed as typed values.
+            let mut signers = Vec::new();
+            let mut values = Vec::new();
+            for (arg, kind) in args.iter().zip(arg_kinds.iter()) {
+                match kind.to_move_value(arg) {
+                    MoveValue::Signer(addr) => signers.push(addr),
+                    value => values.push(value),
+                }
+            }
             let result = runner.run(
-                |interpreter| {
-                    let mut offset: u32 = 0;
-                    for (arg, kind) in args.iter().zip(arg_kinds.iter()) {
-                        offset = mono_move_core::align_up_u32(offset, kind.align());
-                        let bytes = kind.parse_to_bytes(arg);
-                        interpreter.set_root_arg(offset, &bytes);
-                        offset += kind.size();
-                    }
-                },
+                &signers,
+                |call, index| call.arg(&values[index]),
                 |interpreter| {
                     let mut ret_off: u32 = 0;
                     let mut vals = Vec::with_capacity(return_kinds.len());
@@ -859,76 +862,7 @@ impl PrimitiveKind {
         }
     }
 
-    /// Parse `s` into the raw little-endian byte representation that
-    /// mono-move stores in a frame slot.
-    fn parse_to_bytes(self, s: &str) -> Vec<u8> {
-        match self {
-            PrimitiveKind::Bool => vec![parse_bool_arg(s) as u8],
-            PrimitiveKind::U8 => vec![s.parse::<u8>().expect("invalid u8 literal")],
-            PrimitiveKind::U16 => s
-                .parse::<u16>()
-                .expect("invalid u16 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::U32 => s
-                .parse::<u32>()
-                .expect("invalid u32 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::U64 => s
-                .parse::<u64>()
-                .expect("invalid u64 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::U128 => s
-                .parse::<u128>()
-                .expect("invalid u128 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::U256 => s
-                .parse::<U256>()
-                .expect("invalid u256 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::I8 => (s.parse::<i8>().expect("invalid i8 literal") as u8)
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::I16 => s
-                .parse::<i16>()
-                .expect("invalid i16 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::I32 => s
-                .parse::<i32>()
-                .expect("invalid i32 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::I64 => s
-                .parse::<i64>()
-                .expect("invalid i64 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::I128 => s
-                .parse::<i128>()
-                .expect("invalid i128 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::I256 => s
-                .parse::<I256>()
-                .expect("invalid i256 literal")
-                .to_le_bytes()
-                .to_vec(),
-            PrimitiveKind::Address | PrimitiveKind::Signer => AccountAddress::from_hex_literal(s)
-                .expect("invalid address literal")
-                .into_bytes()
-                .to_vec(),
-            PrimitiveKind::Utf8String | PrimitiveKind::ByteVector | PrimitiveKind::U64Vector => {
-                unreachable!("String / vector are return-only kinds")
-            },
-        }
-    }
-
-    /// Format `bytes` (in the same layout produced by `parse_to_bytes`) as a
+    /// Format the raw little-endian frame bytes of a returned scalar as a
     /// decimal string (or hex for addresses).
     fn format_bytes(self, bytes: &[u8]) -> String {
         match self {

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -14,11 +14,11 @@ use legacy_move_compiler::unit_test::{
     ExpectedFailure, ExpectedMoveError, NamedOrBytecodeModule, TestCase,
 };
 use mono_move_core::{
-    types::EMPTY_TYPE_LIST, ExecutionErrorKind, Function, GasMeter, Interner, IntoExecutionError,
-    VMInternalError,
+    types::{is_signer_or_signer_immut_ref, EMPTY_TYPE_LIST},
+    ExecutionErrorKind, GasMeter, Interner, IntoExecutionError, VMInternalError,
 };
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
-use mono_move_loader::{Loader, LoaderError, LoadingPolicy, LoweringPolicy, ModuleReadSet};
+use mono_move_loader::{Loader, LoaderError, LoadingPolicy, LoweringPolicy};
 use mono_move_runtime::{
     InterpreterContext, ProductionNativeRegistry, RuntimeError, RuntimeStatus,
 };
@@ -165,36 +165,43 @@ fn execute(
         .intern_identifier(IdentStr::new(&test.test_name).unwrap())
         .into_global_arena_ptr();
 
-    let mut read_set = ModuleReadSet::new();
-    let mut gas_meter = GasMeter::new(GAS_BUDGET);
-    // SAFETY: the pointer lives in a `LoadedModule`'s arena; while `guard` is
-    // held the executable cache cannot reset that arena.
-    let function = match loader.load_function(
-        &mut read_set,
-        &mut gas_meter,
-        module_id,
-        func,
-        EMPTY_TYPE_LIST,
-    ) {
-        Ok(ptr) => unsafe { ptr.as_ref_unchecked() },
-        Err(err) => return classify_error(&err),
-    };
-
     let mut interpreter = InterpreterContext::new(
         loader,
-        read_set,
-        gas_meter,
+        GasMeter::new(GAS_BUDGET),
         resource_provider,
         natives,
-        function,
     )
     // For Move unit tests, there is no user transaction context.
     .with_extensions(seed_extensions(false));
+    let function = match interpreter.load_function(module_id, func, EMPTY_TYPE_LIST) {
+        Ok(function) => function,
+        Err(err) => return classify_error(&err),
+    };
+    // TODO(correctness): remove once the loader verifies lowered functions itself.
+    mono_move_runtime::assert_verified(function, guard);
 
-    // Reference arguments point into this storage, so it must outlive `run()`.
-    let _ref_args = marshal_args(&mut interpreter, function, &test.arguments);
+    assert_eq!(
+        test.arguments.len(),
+        function.param_tys.len(),
+        "test argument count does not match the function's parameter count"
+    );
+    let outcome = (|| {
+        let mut call = interpreter.build_call(function)?;
+        for (arg, ty) in test.arguments.iter().zip(&function.param_tys) {
+            if is_signer_or_signer_immut_ref(*ty) {
+                // A signer parameter takes its address from the argument.
+                match arg {
+                    MoveValue::Signer(addr) | MoveValue::Address(addr) => call.signer(addr)?,
+                    other => panic!("a signer parameter got a non-address argument: {:?}", other),
+                }
+            } else {
+                call.arg(arg)?;
+            }
+        }
+        call.run()
+    })();
 
-    match interpreter.run() {
+    match outcome {
         Ok(RuntimeStatus::Success) => TestResult::Success,
         Ok(RuntimeStatus::Aborted {
             code,
@@ -206,76 +213,6 @@ fn execute(
             location,
         },
         Err(err) => classify_error(&err),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Argument marshalling
-// ---------------------------------------------------------------------------
-
-/// A reference is a 16-byte fat pointer (8-byte base + 8-byte offset).
-/// TODO(cleanup): this reference size should be a shared constant, not redefined here.
-const REFERENCE_SIZE: u32 = 16;
-
-/// Write each argument into the root frame at its parameter-slot offset,
-/// returning backing storage that reference arguments point into; the caller
-/// must keep it alive until execution finishes.
-// Each target is boxed for a stable heap address: the fat pointer stores that
-// address, so a `Vec<[u8; 32]>` (whose elements move on reallocation) won't do.
-#[allow(clippy::vec_box)]
-fn marshal_args(
-    interpreter: &mut InterpreterContext<'_>,
-    function: &Function,
-    args: &[MoveValue],
-) -> Vec<Box<[u8; 32]>> {
-    assert_eq!(
-        args.len(),
-        function.param_slots.len(),
-        "test argument count does not match the function's parameter count"
-    );
-
-    let mut ref_args = Vec::new();
-    for (arg, slot) in args.iter().zip(&function.param_slots) {
-        let bytes = match arg {
-            // A `&signer`/`&address` is a fat pointer to a target kept alive past `run()`.
-            MoveValue::Signer(addr) | MoveValue::Address(addr) if slot.size == REFERENCE_SIZE => {
-                let boxed_bytes = Box::new(addr.into_bytes());
-                let mut fat = vec![0u8; REFERENCE_SIZE as usize];
-                fat[..8].copy_from_slice(&(boxed_bytes.as_ptr().addr() as u64).to_ne_bytes());
-                ref_args.push(boxed_bytes);
-                fat
-            },
-            _ => inline_bytes(arg),
-        };
-        assert_eq!(
-            bytes.len() as u32,
-            slot.size,
-            "argument size does not match its parameter slot"
-        );
-        interpreter.set_root_arg(slot.offset.0, &bytes);
-    }
-    ref_args
-}
-
-fn inline_bytes(value: &MoveValue) -> Vec<u8> {
-    match value {
-        MoveValue::Bool(b) => vec![*b as u8],
-        MoveValue::U8(x) => vec![*x],
-        MoveValue::U16(x) => x.to_le_bytes().to_vec(),
-        MoveValue::U32(x) => x.to_le_bytes().to_vec(),
-        MoveValue::U64(x) => x.to_le_bytes().to_vec(),
-        MoveValue::U128(x) => x.to_le_bytes().to_vec(),
-        MoveValue::U256(x) => x.to_le_bytes().to_vec(),
-        MoveValue::I8(x) => vec![*x as u8],
-        MoveValue::I16(x) => x.to_le_bytes().to_vec(),
-        MoveValue::I32(x) => x.to_le_bytes().to_vec(),
-        MoveValue::I64(x) => x.to_le_bytes().to_vec(),
-        MoveValue::I128(x) => x.to_le_bytes().to_vec(),
-        MoveValue::I256(x) => x.to_le_bytes().to_vec(),
-        MoveValue::Address(a) | MoveValue::Signer(a) => a.into_bytes().to_vec(),
-        MoveValue::Vector(_) | MoveValue::Struct(_) | MoveValue::Closure(_) => {
-            panic!("test argument cannot be a heap value")
-        },
     }
 }
 

--- a/third_party/move/mono-move/testsuite/tests/cross_module_lazy_load.rs
+++ b/third_party/move/mono-move/testsuite/tests/cross_module_lazy_load.rs
@@ -11,7 +11,7 @@
 
 use mono_move_core::{types::EMPTY_TYPE_LIST, GasMeter};
 use mono_move_global_context::GlobalContext;
-use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
+use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
 use mono_move_runtime::{InterpreterContext, ProductionNativeRegistry};
 use mono_move_testsuite::InMemoryModuleProvider;
 use move_core_types::{account_address::AccountAddress, ident_str};
@@ -52,34 +52,28 @@ fn call_indirect_triggers_lazy_module_load() {
     let main_name = guard
         .intern_identifier(ident_str!("main"))
         .into_global_arena_ptr();
-    let mut read_set = ModuleReadSet::new();
-    let mut gas_meter = GasMeter::with_max_budget();
-    let main_ptr = loader
-        .load_function(
-            &mut read_set,
-            &mut gas_meter,
-            bar_id,
-            main_name,
-            EMPTY_TYPE_LIST,
-        )
-        .expect("bar::main should resolve");
-    assert_eq!(read_set.len(), 1, "only bar loaded so far");
-
-    // SAFETY: `main_ptr` came from the executable cache, which is kept
-    // alive by `guard` for the duration of this test.
-    let main_fn = unsafe { main_ptr.as_ref_unchecked() };
     let mut interp = InterpreterContext::new(
         loader,
-        read_set,
-        gas_meter,
+        GasMeter::with_max_budget(),
         &mono_move_core::NoResourceProvider,
         &natives,
-        main_fn,
     );
-    interp.set_root_arg(0, &41u64.to_le_bytes());
-    interp.run().expect("execution should succeed");
+    let main_fn = interp
+        .load_function(bar_id, main_name, EMPTY_TYPE_LIST)
+        .expect("bar::main should resolve");
+    assert_eq!(interp.read_set().len(), 1, "only bar loaded so far");
+    mono_move_runtime::assert_verified(main_fn, &guard);
+    let mut call = interp
+        .build_call(main_fn)
+        .expect("the root frame fits on the stack");
+    call.arg(&41u64).expect("argument placement succeeds");
+    call.run().expect("execution should succeed");
 
-    assert_eq!(interp.root_result(), 42, "expected foo::add_one(41) = 42");
+    assert_eq!(
+        interp.root_result_u64_for_test(),
+        42,
+        "expected foo::add_one(41) = 42"
+    );
 
     assert_eq!(
         interp.read_set().len(),

--- a/third_party/move/mono-move/testsuite/tests/gas_test.rs
+++ b/third_party/move/mono-move/testsuite/tests/gas_test.rs
@@ -41,27 +41,22 @@ module 0x1::test {
     let fib_name = guard
         .intern_identifier(ident_str!("fib"))
         .into_global_arena_ptr();
-    // Load with an effectively unbounded budget; the run itself gets a tiny
-    // budget of 10.
-    let mut read_set = ModuleReadSet::new();
-    let mut load_gas = GasMeter::with_max_budget();
-    let fib = loader
-        .load_function(&mut read_set, &mut load_gas, id, fib_name, EMPTY_TYPE_LIST)
-        .expect("load should succeed");
-
-    // SAFETY: `fib` is held alive by the executable cache via `guard`.
-    let fib = unsafe { fib.as_ref_unchecked() };
-
     let mut interpreter = InterpreterContext::new(
         loader,
-        read_set,
         GasMeter::new(10),
         &mono_move_core::NoResourceProvider,
         &natives,
-        fib,
     );
-    interpreter.set_root_arg(0, &10u64.to_le_bytes());
-    let err = interpreter.run().unwrap_err();
+    // Load with the budget suspended; the run itself gets a tiny budget of 10.
+    let fib = interpreter
+        .unmetered(|interp| interp.load_function(id, fib_name, EMPTY_TYPE_LIST))
+        .expect("load should succeed");
+    mono_move_runtime::assert_verified(fib, &guard);
+    let mut call = interpreter
+        .build_call(fib)
+        .expect("the root frame fits on the stack");
+    call.arg(&10u64).expect("argument placement succeeds");
+    let err = call.run().unwrap_err();
     assert!(err.downcast_ref::<GasExhaustedError>().is_some(),);
 }
 

--- a/third_party/move/move-value-view-derive/Cargo.toml
+++ b/third_party/move/move-value-view-derive/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "move-value-view-derive"
+description = "Derive macro for `MoveValueView`"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/third_party/move/move-value-view-derive/src/lib.rs
+++ b/third_party/move/move-value-view-derive/src/lib.rs
@@ -1,0 +1,119 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Derives `MoveValueView` for a struct or enum whose fields are themselves
+//! `MoveValueView`.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, punctuated::Punctuated, token::Comma, Data, DeriveInput, Fields, Index,
+    Variant,
+};
+
+#[proc_macro_derive(MoveValueView)]
+pub fn derive_move_value_view(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    // The generated body visits every field, so each generic type parameter
+    // must itself be viewable.
+    let mut generics = input.generics.clone();
+    for param in generics.type_params_mut() {
+        param
+            .bounds
+            .push(syn::parse_quote!(::move_value_view::MoveValueView));
+    }
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let body = match &input.data {
+        Data::Struct(data) => struct_visit_body(&data.fields),
+        Data::Enum(data) => enum_visit_body(&data.variants),
+        Data::Union(_) => {
+            return syn::Error::new_spanned(name, "`MoveValueView` cannot be derived for a union")
+                .to_compile_error()
+                .into()
+        },
+    };
+
+    quote! {
+        impl #impl_generics ::move_value_view::MoveValueView for #name #ty_generics #where_clause {
+            fn visit<V: ::move_value_view::MoveValueVisitor>(
+                &self,
+                visitor: V,
+            ) -> ::std::result::Result<V::Ok, V::Error> {
+                #body
+            }
+        }
+    }
+    .into()
+}
+
+fn struct_visit_body(fields: &Fields) -> proc_macro2::TokenStream {
+    let count = fields.len();
+    let accesses: Vec<_> = match fields {
+        Fields::Named(named) => named
+            .named
+            .iter()
+            .map(|f| {
+                let ident = f.ident.as_ref().expect("a named field has an identifier");
+                quote!(&self.#ident)
+            })
+            .collect(),
+        Fields::Unnamed(unnamed) => (0..unnamed.unnamed.len())
+            .map(|i| {
+                let index = Index::from(i);
+                quote!(&self.#index)
+            })
+            .collect(),
+        Fields::Unit => Vec::new(),
+    };
+    quote! {
+        let mut fields = ::move_value_view::MoveValueVisitor::visit_struct(visitor, #count)?;
+        #(::move_value_view::FieldVisitor::field(&mut fields, #accesses)?;)*
+        ::move_value_view::FieldVisitor::end(fields)
+    }
+}
+
+fn enum_visit_body(variants: &Punctuated<Variant, Comma>) -> proc_macro2::TokenStream {
+    let arms = variants.iter().enumerate().map(|(index, variant)| {
+        let index = index as u32;
+        let name = &variant.ident;
+        let count = variant.fields.len();
+        let binds = variant_bindings(&variant.fields);
+        let pattern = match &variant.fields {
+            Fields::Named(_) => quote!(Self::#name { #(#binds),* }),
+            Fields::Unnamed(_) => quote!(Self::#name(#(#binds),*)),
+            Fields::Unit => quote!(Self::#name),
+        };
+        quote! {
+            #pattern => {
+                let mut fields = ::move_value_view::MoveValueVisitor::visit_variant(
+                    visitor, #index, #count,
+                )?;
+                #(::move_value_view::FieldVisitor::field(&mut fields, #binds)?;)*
+                ::move_value_view::FieldVisitor::end(fields)
+            }
+        }
+    });
+    quote! { match self { #(#arms),* } }
+}
+
+fn variant_bindings(fields: &Fields) -> Vec<proc_macro2::TokenStream> {
+    match fields {
+        Fields::Named(named) => named
+            .named
+            .iter()
+            .map(|f| {
+                let ident = f.ident.as_ref().expect("a named field has an identifier");
+                quote!(#ident)
+            })
+            .collect(),
+        Fields::Unnamed(unnamed) => (0..unnamed.unnamed.len())
+            .map(|i| {
+                let ident = syn::Ident::new(&format!("field{i}"), proc_macro2::Span::call_site());
+                quote!(#ident)
+            })
+            .collect(),
+        Fields::Unit => Vec::new(),
+    }
+}

--- a/third_party/move/move-value-view/Cargo.toml
+++ b/third_party/move/move-value-view/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "move-value-view"
+description = "A data model of Move's value shapes, for converting Rust values into them"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+move-core-types = { workspace = true }

--- a/third_party/move/move-value-view/src/lib.rs
+++ b/third_party/move/move-value-view/src/lib.rs
@@ -1,0 +1,341 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! A data model of Move's value shapes.
+//!
+//! By implementing the [`MoveValueView`] trait, a Rust value describes itself
+//! to a visitor, which can then decide what to do with it.
+//!
+//! This is similar to serde's model, but with the following critical differences:
+//! - It is modeled after the Move VM's value model, without any unnecessary boilerplate.
+//! - It allows for efficient handling of byte arrays (`vector<u8>`).
+
+use move_core_types::{
+    account_address::AccountAddress,
+    int256::{I256, U256},
+};
+
+/// A Rust value with a Move counterpart.
+///
+/// Describes itself by calling the `visit_*` methods.
+pub trait MoveValueView {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error>;
+
+    /// Optional performance optimization.
+    ///
+    /// Reinterprets a slice of `Self`  as bytes, so a `vector<u8>` is written
+    /// in one copy rather than an element at a time.
+    #[doc(hidden)]
+    fn slice_as_bytes(_slice: &[Self]) -> Option<&[u8]>
+    where
+        Self: Sized,
+    {
+        None
+    }
+}
+
+/// Consumes the Move value that a [`MoveValueView`] describes.
+pub trait MoveValueVisitor: Sized {
+    type Ok;
+    type Error;
+    /// Consumes the fields of a struct or an enum variant body.
+    type Fields: FieldVisitor<Ok = Self::Ok, Error = Self::Error>;
+    /// Consumes the elements of a vector.
+    type Elements: VectorElementVisitor<Ok = Self::Ok, Error = Self::Error>;
+
+    fn visit_bool(self, v: bool) -> Result<Self::Ok, Self::Error>;
+
+    fn visit_u8(self, v: u8) -> Result<Self::Ok, Self::Error>;
+    fn visit_u16(self, v: u16) -> Result<Self::Ok, Self::Error>;
+    fn visit_u32(self, v: u32) -> Result<Self::Ok, Self::Error>;
+    fn visit_u64(self, v: u64) -> Result<Self::Ok, Self::Error>;
+    fn visit_u128(self, v: u128) -> Result<Self::Ok, Self::Error>;
+    fn visit_u256(self, v: U256) -> Result<Self::Ok, Self::Error>;
+
+    fn visit_i8(self, v: i8) -> Result<Self::Ok, Self::Error>;
+    fn visit_i16(self, v: i16) -> Result<Self::Ok, Self::Error>;
+    fn visit_i32(self, v: i32) -> Result<Self::Ok, Self::Error>;
+    fn visit_i64(self, v: i64) -> Result<Self::Ok, Self::Error>;
+    fn visit_i128(self, v: i128) -> Result<Self::Ok, Self::Error>;
+    fn visit_i256(self, v: I256) -> Result<Self::Ok, Self::Error>;
+
+    fn visit_address(self, v: &AccountAddress) -> Result<Self::Ok, Self::Error>;
+
+    /// A `signer`, which Move keeps distinct from the address it holds.
+    fn visit_signer(self, v: &AccountAddress) -> Result<Self::Ok, Self::Error>;
+
+    /// A `vector<u8>`, given whole.
+    fn visit_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error>;
+
+    /// A `vector<T>` of `len` elements, each described in turn.
+    fn visit_vector(self, len: usize) -> Result<Self::Elements, Self::Error>;
+
+    /// A struct with `num_fields` fields, each described in turn.
+    fn visit_struct(self, num_fields: usize) -> Result<Self::Fields, Self::Error>;
+
+    /// The enum variant with tag `tag`, whose body holds `num_fields` fields.
+    fn visit_variant(self, tag: u32, num_fields: usize) -> Result<Self::Fields, Self::Error>;
+
+    /// A function value, which no visitor writes today.
+    fn function_values_unsupported() -> Self::Error;
+}
+
+/// Receives a struct's or variant body's fields in declaration order.
+pub trait FieldVisitor {
+    type Ok;
+    type Error;
+
+    fn field<T: MoveValueView + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>;
+    fn end(self) -> Result<Self::Ok, Self::Error>;
+}
+
+/// Receives a vector's elements in order.
+pub trait VectorElementVisitor {
+    type Ok;
+    type Error;
+
+    fn element<T: MoveValueView + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>;
+    fn end(self) -> Result<Self::Ok, Self::Error>;
+}
+
+impl MoveValueView for bool {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_bool(*self)
+    }
+}
+
+impl MoveValueView for u8 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_u8(*self)
+    }
+
+    fn slice_as_bytes(slice: &[u8]) -> Option<&[u8]> {
+        Some(slice)
+    }
+}
+
+impl MoveValueView for u16 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_u16(*self)
+    }
+}
+
+impl MoveValueView for u32 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_u32(*self)
+    }
+}
+
+impl MoveValueView for u64 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_u64(*self)
+    }
+}
+
+impl MoveValueView for u128 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_u128(*self)
+    }
+}
+
+impl MoveValueView for U256 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_u256(*self)
+    }
+}
+
+impl MoveValueView for i8 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_i8(*self)
+    }
+}
+
+impl MoveValueView for i16 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_i16(*self)
+    }
+}
+
+impl MoveValueView for i32 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_i32(*self)
+    }
+}
+
+impl MoveValueView for i64 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_i64(*self)
+    }
+}
+
+impl MoveValueView for i128 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_i128(*self)
+    }
+}
+
+impl MoveValueView for I256 {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_i256(*self)
+    }
+}
+
+impl MoveValueView for AccountAddress {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        visitor.visit_address(self)
+    }
+}
+
+/// Move models a string as a struct holding its bytes.
+impl MoveValueView for str {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        let mut fields = visitor.visit_struct(1)?;
+        fields.field(self.as_bytes())?;
+        fields.end()
+    }
+}
+
+impl MoveValueView for String {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        self.as_str().visit(visitor)
+    }
+}
+
+/// Move's `Option` is an enum of `None` and `Some`; the pre-enum
+/// struct-of-vector representation is not supported.
+impl<T: MoveValueView> MoveValueView for Option<T> {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        match self {
+            None => visitor.visit_variant(0, 0)?.end(),
+            Some(value) => {
+                let mut fields = visitor.visit_variant(1, 1)?;
+                fields.field(value)?;
+                fields.end()
+            },
+        }
+    }
+}
+
+impl<T: MoveValueView> MoveValueView for [T] {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        if let Some(bytes) = T::slice_as_bytes(self) {
+            return visitor.visit_bytes(bytes);
+        }
+        let mut elements = visitor.visit_vector(self.len())?;
+        for element in self {
+            elements.element(element)?;
+        }
+        elements.end()
+    }
+}
+
+/// Views an exact-size iterator's items as a Move `vector`, so a projected
+/// sequence can be visited without collecting it first. `Clone` lets each
+/// visit consume a fresh copy of the iterator.
+pub struct IterAsMoveVector<I>(pub I);
+
+impl<T: MoveValueView, I: ExactSizeIterator<Item = T> + Clone> MoveValueView
+    for IterAsMoveVector<I>
+{
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        let iter = self.0.clone();
+        let mut elements = visitor.visit_vector(iter.len())?;
+        for item in iter {
+            elements.element(&item)?;
+        }
+        elements.end()
+    }
+}
+
+impl<T: MoveValueView> MoveValueView for Vec<T> {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        self.as_slice().visit(visitor)
+    }
+}
+
+impl<T: MoveValueView, const N: usize> MoveValueView for [T; N] {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        self.as_slice().visit(visitor)
+    }
+}
+
+impl<T: MoveValueView + ?Sized> MoveValueView for &T {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        (**self).visit(visitor)
+    }
+}
+
+impl<T: MoveValueView + ?Sized> MoveValueView for Box<T> {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        (**self).visit(visitor)
+    }
+}
+
+/// The dynamic Move value used by legacy VM, some other tools and tests
+impl MoveValueView for move_core_types::value::MoveValue {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        use move_core_types::value::MoveValue as MV;
+        match self {
+            MV::Bool(v) => visitor.visit_bool(*v),
+            MV::U8(v) => visitor.visit_u8(*v),
+            MV::U16(v) => visitor.visit_u16(*v),
+            MV::U32(v) => visitor.visit_u32(*v),
+            MV::U64(v) => visitor.visit_u64(*v),
+            MV::U128(v) => visitor.visit_u128(*v),
+            MV::U256(v) => visitor.visit_u256(*v),
+            MV::I8(v) => visitor.visit_i8(*v),
+            MV::I16(v) => visitor.visit_i16(*v),
+            MV::I32(v) => visitor.visit_i32(*v),
+            MV::I64(v) => visitor.visit_i64(*v),
+            MV::I128(v) => visitor.visit_i128(*v),
+            MV::I256(v) => visitor.visit_i256(*v),
+            MV::Address(v) => visitor.visit_address(v),
+            MV::Signer(v) => visitor.visit_signer(v),
+            MV::Vector(elements) => {
+                let mut vector = visitor.visit_vector(elements.len())?;
+                for element in elements {
+                    vector.element(element)?;
+                }
+                vector.end()
+            },
+            MV::Struct(v) => v.visit(visitor),
+            MV::Closure(_) => Err(V::function_values_unsupported()),
+        }
+    }
+}
+
+impl MoveValueView for move_core_types::value::MoveStruct {
+    fn visit<V: MoveValueVisitor>(&self, visitor: V) -> Result<V::Ok, V::Error> {
+        use move_core_types::value::MoveStruct as S;
+        match self {
+            S::Runtime(values) => {
+                let mut fields = visitor.visit_struct(values.len())?;
+                for value in values {
+                    fields.field(value)?;
+                }
+                fields.end()
+            },
+            S::WithFields(named) | S::WithTypes { _fields: named, .. } => {
+                let mut fields = visitor.visit_struct(named.len())?;
+                for (_, value) in named {
+                    fields.field(value)?;
+                }
+                fields.end()
+            },
+            S::RuntimeVariant(tag, values) => {
+                let mut fields = visitor.visit_variant(u32::from(*tag), values.len())?;
+                for value in values {
+                    fields.field(value)?;
+                }
+                fields.end()
+            },
+            S::WithVariantFields(_, tag, named) => {
+                let mut fields = visitor.visit_variant(u32::from(*tag), named.len())?;
+                for (_, value) in named {
+                    fields.field(value)?;
+                }
+                fields.end()
+            },
+        }
+    }
+}

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -13,7 +13,8 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [package.metadata.cargo-machete]
-ignored = ['poem-openapi']
+# `move-value-view` is only named inside the `MoveValueView` derive's expansion.
+ignored = ['move-value-view', 'poem-openapi']
 
 [features]
 default = []
@@ -63,6 +64,8 @@ move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-model = { workspace = true }
 move-table-extension = { workspace = true }
+move-value-view = { workspace = true }
+move-value-view-derive = { workspace = true }
 move-vm-types = { workspace = true }
 num-bigint = { workspace = true }
 num-derive = { workspace = true }

--- a/types/src/fee_statement.rs
+++ b/types/src/fee_statement.rs
@@ -3,6 +3,7 @@
 
 use crate::move_utils::move_event_v2::MoveEventV2Type;
 use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
+use move_value_view_derive::MoveValueView;
 use serde::{Deserialize, Serialize};
 
 /// Breakdown of fee charge and refund for a transaction.
@@ -26,7 +27,7 @@ use serde::{Deserialize, Serialize};
 /// This is meant to emitted as a module event.
 ///
 /// (keep this doc in sync with the `struct FeeStatement` in Move.)
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, MoveValueView)]
 pub struct FeeStatement {
     /// Total gas charge.
     total_charge_gas_units: u64,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -31,6 +31,7 @@ use aptos_crypto::{
     CryptoMaterialError, HashValue,
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
+use move_value_view_derive::MoveValueView;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use rand::Rng;
@@ -112,7 +113,9 @@ pub enum Auth<'a> {
     },
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize, MoveValueView,
+)]
 pub enum ReplayProtector {
     Nonce(u64),
     SequenceNumber(u64),
@@ -891,7 +894,7 @@ impl TransactionExecutableRef<'_> {
 /// limit (100 = 1x, 200 = 2x, 250 = 2.5x).
 ///
 /// INVARIANT: must match Move representation for BCS serialization.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, MoveValueView)]
 pub enum RequestedMultipliers {
     V1 {
         /// Execution-gas multiplier as percent of the base limit where 100 is 1x.
@@ -929,7 +932,7 @@ impl RequestedMultipliers {
 /// prologue.
 ///
 /// INVARIANT: must match Move representation for BCS serialization.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, MoveValueView)]
 pub enum UserTxnLimitsRequest {
     /// Fee payer owns a stake pool.
     StakePoolOwner { multipliers: RequestedMultipliers },

--- a/types/src/transaction/validation.rs
+++ b/types/src/transaction/validation.rs
@@ -15,9 +15,10 @@ use crate::{
     transaction::{ReplayProtector, UserTxnLimitsRequest},
 };
 use move_core_types::account_address::AccountAddress;
+use move_value_view_derive::MoveValueView;
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, MoveValueView)]
 pub enum PrologueArgs {
     V1 {
         needs_fee_payer_auth_check: bool,
@@ -35,7 +36,7 @@ pub enum PrologueArgs {
     },
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, MoveValueView)]
 pub enum EpilogueArgs {
     V1 {
         fee_statement: FeeStatement,


### PR DESCRIPTION
The executor already holds prologue, epilogue and block-metadata arguments as Rust values, but BCS-encoded each one just so the VM could decode it straight back into the same shape. This PR places them directly.

### The `CallBuilder` API

- `interp.build_call(func)` returns a builder that fills parameters in order, each write checked against the parameter's declared type; `run()` executes once all are placed.
- `signer(&AccountAddress)` fills a `signer` or `&signer` parameter (the reference points into the caller-owned address, so it must outlive the call). `&mut signer` is rejected, as in the legacy VM.
- `arg(&impl MoveValueView)` places a typed Rust value; `arg_bcs(bytes)` stays for user-transaction arguments, which really do arrive as bytes.
- User-transaction placement keeps the legacy VM's error precedence: signer prefix and argument counts are validated *before* any bytes are decoded, and only genuine BCS decode failures are blamed on the sender's bytes.
- `build_call` bounds the root frame against the stack before any placement.
- Context options that aren't simple field flips (heap size, read set) moved into `InterpreterOptions` / `new_with_options`.

### Rust → runtime values (new)

- New `move-value-view` crate: `MoveValueView` (a value describes its Move shape) + `MoveValueVisitor` (a consumer acts on it), with a derive alongside. The VM implements the visitor in `runtime/src/value_conv/rust.rs`.
- Started on `serde::Serialize`, moved off it: serde carries shapes Move doesn't have (unit, tuple, map, floats, ...) and lacks ones Move does (integers wider than `u128`, explicit variant indices), forcing `String`/`Option` to be guessed structurally from the layout.
- A value whose shape disagrees with the parameter's layout is an invariant violation — call arguments come from the embedder, not the wire.
- This is why `aptos-types` is touched: `PrologueArgs`, `EpilogueArgs` and friends derive `MoveValueView` next to `Serialize`. The crate lives under `third_party/move` because `aptos-types` and `mono-move-runtime` both need it and must not depend on each other; its only dependency is `move-core-types`.

### BCS → runtime values (moved, not changed)

- The former `value_utils.rs` split into `value_conv/bcs.rs` (serialize/deserialize) and `value_cmp.rs` (equality/ordering). Review as a code move.
- Only real delta: the vector/enum allocation prologues are now shared with the new writer as `alloc_vec_no_gc` / `alloc_enum_no_gc` in the heap module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how every MonoMove transaction stages arguments and surfaces validation errors; behavior is intended to match AptosVM but touches core execution and status mapping.
> 
> **Overview**
> Introduces a **`CallBuilder`** path on `InterpreterContext` so callers place parameters in order (`signer`, typed `arg` via **`MoveValueView`**, or `arg_bcs` for wire bytes) instead of manually packing BCS blobs and root-frame slots. System transactions (block metadata/epilogue, prologue/epilogue) now pass Rust values directly; user entry functions go through **`call_entry_function`** with signer/argument-count checks before decode and **`InvalidArguments`** mapped to legacy **`VMStatus`** codes.
> 
> Adds **`move-value-view`** (+ derive) and runtime **`value_conv/rust`** for Rust→VM layout-checked writes; splits the old value walks into **`value_conv/bcs`** and **`value_cmp`**, caches **`param_tys`** on lowered **`Function`**, and tightens resource-group/provider errors away from **`anyhow`**. **`InterpreterContext::new`** / **`InterpreterOptions`** replace the entry-function-bound constructors; the executor no longer exports the old **`call_function`** / **`place_args`** helpers (lean-link builds calls inline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 852f197a544350459fd6678d125cb1e9bc2403d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->