### PR TITLE
[move-vm] Exclude `interned_module_id` from `StructIdentifier` equality, hashing, and ordering

### DIFF
--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -270,9 +270,19 @@ impl StructType {
     }
 }
 
-#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+// `interned_module_id` is a pool-local cache key, not part of struct identity.
+// Equality, hashing, and ordering use the canonical `(module, name)` pair.
+#[derive(Derivative)]
+#[derivative(Debug, Clone, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct StructIdentifier {
     module: ModuleId,
+    #[derivative(
+        Debug = "ignore",
+        PartialEq = "ignore",
+        Hash = "ignore",
+        Ord = "ignore",
+        PartialOrd = "ignore"
+    )]
     interned_module_id: InternedModuleId,
     name: Identifier,
 }
@@ -2269,5 +2279,46 @@ mod unit_tests {
         let (_, _, vec_tag) = nested_vec_for_test(max_ty_size + 1);
         let err = assert_err!(ty_builder.create_ty(&vec_tag, no_op));
         assert_eq!(err.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
+    }
+
+    #[test]
+    fn test_struct_identifier_identity_is_interner_history_independent() {
+        use move_core_types::account_address::AccountAddress;
+        use std::{
+            cmp::Ordering,
+            hash::{DefaultHasher, Hash, Hasher},
+        };
+
+        fn hash_of(identifier: &StructIdentifier) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            identifier.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let alpha = ModuleId::new(AccountAddress::ONE, Identifier::new("alpha").unwrap());
+        let beta = ModuleId::new(AccountAddress::TWO, Identifier::new("beta").unwrap());
+        let name = Identifier::new("S").unwrap();
+
+        // Warm two pools in opposite orders, so the same module gets different interned ids.
+        let cold_pool = InternedModuleIdPool::new();
+        let cold_beta = StructIdentifier::new(&cold_pool, beta.clone(), name.clone());
+        let cold_alpha = StructIdentifier::new(&cold_pool, alpha.clone(), name.clone());
+
+        let warm_pool = InternedModuleIdPool::new();
+        let warm_alpha = StructIdentifier::new(&warm_pool, alpha, name.clone());
+        let warm_beta = StructIdentifier::new(&warm_pool, beta, name);
+
+        assert_ne!(
+            cold_alpha.interned_module_id(),
+            warm_alpha.interned_module_id()
+        );
+
+        // Identity, hashing, and ordering must not depend on interner history.
+        assert_eq!(cold_alpha, warm_alpha);
+        assert_eq!(cold_beta, warm_beta);
+        assert_eq!(hash_of(&cold_alpha), hash_of(&warm_alpha));
+        assert_eq!(cold_alpha.cmp(&warm_alpha), Ordering::Equal);
+        assert_eq!(cold_alpha.partial_cmp(&warm_alpha), Some(Ordering::Equal));
+        assert_eq!(cold_alpha.cmp(&cold_beta), warm_alpha.cmp(&warm_beta));
     }
 }

--- a/third_party/move/move-vm/types/src/module_id_interner.rs
+++ b/third_party/move/move-vm/types/src/module_id_interner.rs
@@ -4,7 +4,10 @@
 use crate::interner::ConcurrentBTreeInterner;
 use move_core_types::language_storage::ModuleId;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+// No `Ord`/`PartialOrd`: the wrapped index is assigned in first-seen order, so
+// its ordering depends on interner history and is not canonical. Order by
+// `ModuleId` instead.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct InternedModuleId(usize);
 
 pub struct InternedModuleIdPool {


### PR DESCRIPTION
## Description

- Removed ordering traits from `InternedModuleId` because its value reflects interner insertion history, not canonical module identity.
- Made `StructIdentifier` equality, hashing, and ordering depend only on its canonical `(module, name)` pair, treating the interned module ID solely as a cache key.
- Added regression coverage proving these semantics remain stable across differently warmed interners, including consistency between `Eq`, `Hash`, `Ord`, and `PartialOrd`.

## Key Areas to Review

- The use of `#[derive(Derivative)]` with field-level `ignore` attributes is the core mechanism for excluding `interned_module_id` from identity comparisons. Reviewers should confirm that the remaining fields (`module` and `name`) are sufficient to uniquely identify a struct across all use cases.
- Removing `Ord`/`PartialOrd` from `InternedModuleId` is a deliberate guard against future misuse. Any code that previously relied on ordering `InternedModuleId` values directly would now fail to compile, which is the intended behavior.

## Type of Change
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VM runtime type identity semantics used in maps and comparisons; low blast radius but correctness-critical for loader/type handling.
> 
> **Overview**
> Fixes incorrect **struct identity** in the Move VM when `StructIdentifier` was compared, hashed, or ordered using pool-local `interned_module_id` values that differ across `InternedModuleIdPool` warmup order.
> 
> `StructIdentifier` now uses `derivative` so **only** `(module, name)` define equality, hashing, and ordering; `interned_module_id` stays a cache field. **`Ord` / `PartialOrd` are removed from `InternedModuleId`** so callers cannot sort by non-canonical intern indices.
> 
> Adds **`test_struct_identifier_identity_is_interner_history_independent`** to lock in `Eq`, `Hash`, and `Ord` consistency across differently warmed pools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc6c1dce1259835165803984c42b51fbfb7f328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->