### PR TITLE
[block-stm] Harden layout compatibility

### DIFF
--- a/aptos-move/block-executor/src/value_exchange.rs
+++ b/aptos-move/block-executor/src/value_exchange.rs
@@ -191,24 +191,46 @@ where
         >,
     > {
         if value.is_deletion() {
-            None
-        } else {
-            self.does_value_need_exchange(value, layout, delayed_write_set_ids)
-                .map_or_else(
-                    |e| Some(Err(e)),
-                    |needs_exchange| {
-                        needs_exchange.then(|| {
-                            Ok((
-                                key.clone(),
-                                (
-                                    value.as_state_value_metadata().unwrap().clone(),
-                                    value.write_op_size().write_len().unwrap(),
-                                    layout.clone(),
-                                ),
-                            ))
-                        })
-                    },
-                )
+            return None;
+        }
+        match self.does_value_need_exchange(value, layout, delayed_write_set_ids) {
+            Err(e) => Some(Err(e)),
+            Ok(false) => None,
+            Ok(true) => {
+                // The delayed field ids in this value were created under the
+                // layout the key's base value was pinned under. Exchanging under
+                // a layout that is not compatible with the base would move a
+                // delayed field's byte offset or width and tear the value. The
+                // ptr_eq fast path skips the walk when the exchange layout is the
+                // base layout itself, which is the common self-consistent case.
+                //
+                // TODO: instead of discarding the block on a layout mismatch,
+                // rerun it sequentially with delayed field optimization turned
+                // off, the way the resource group bcs fallback works. With the
+                // optimization off there is no exchange step, so the mismatch
+                // cannot happen again. This needs a fresh AptosEnvironment::new
+                // and an empty module cache (a throwaway
+                // AptosModuleCacheManagerGuard::None). The aptos-vm caller has to
+                // build that environment, because the generic state view type
+                // here does not implement the StateView trait that
+                // AptosEnvironment::new needs.
+                if let Some(base) = self.base_value_layout(key) {
+                    if !TriompheArc::ptr_eq(layout, &base) && !layout.is_compatible_with(&base) {
+                        return Some(Err(code_invariant_error(format!(
+                            "Exchange layout is not compatible with the base layout for key {:?}",
+                            key
+                        ))));
+                    }
+                }
+                Some(Ok((
+                    key.clone(),
+                    (
+                        value.as_state_value_metadata().unwrap().clone(),
+                        value.write_op_size().write_len().unwrap(),
+                        layout.clone(),
+                    ),
+                )))
+            },
         }
     }
 }

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -1192,6 +1192,31 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         ret
     }
 
+    /// Returns the layout the base value for `key` was pinned under, if that
+    /// base carries delayed fields. The delayed field ids for a key are created
+    /// under this layout, so any layout used to later exchange the key must be
+    /// compatible with it, or the delayed fields shift byte offset or width.
+    /// Returns `None` if the key has no base value or the base has no layout.
+    pub(crate) fn base_value_layout(&self, key: &T::Key) -> Option<TriompheArc<MoveTypeLayout>> {
+        let value = match &self.latest_view {
+            // The base value is retained at the storage version (index 0), so
+            // read that entry directly rather than the latest write.
+            ViewState::Sync(state) => match state.versioned_map.data().fetch_data_no_record(key, 0)
+            {
+                Ok(MVDataOutput::Versioned(_, value)) => value,
+                Err(_) => return None,
+            },
+            // The unsync map holds a single entry per key, so the latest write
+            // overwrites the base. That entry is what the current transaction
+            // read, so its layout is the one to check against.
+            ViewState::Unsync(state) => state.unsync_map.fetch_data(key)?,
+        };
+        match value {
+            ValueWithLayout::Exchanged(_, Some(layout)) => Some(layout),
+            ValueWithLayout::Exchanged(_, None) | ValueWithLayout::RawFromStorage(_) => None,
+        }
+    }
+
     fn patch_base_value(
         &self,
         value: &T::Value,
@@ -1403,6 +1428,12 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         delayed_write_set_ids: &HashSet<DelayedFieldID>,
         skip: &HashSet<T::Key>,
     ) -> PartialVMResult<BTreeMap<T::Key, (StateValueMetadata, u64)>> {
+        // TODO: apply the same base-layout compatibility check to the group
+        // exchange path (here and in the sequential variant below). A group
+        // member's base layout lives in group_data keyed by (group_key, tag), so
+        // it needs its own lookup before the check in filter_value_for_exchange
+        // can move into does_value_need_exchange and cover both resources and
+        // groups.
         let reads_with_delayed_fields = parallel_state
             .captured_reads
             .borrow()
@@ -3294,6 +3325,111 @@ mod test {
             ))),
             Some(layout),
         );
+    }
+
+    // Builds a resource value carrying one delayed field id, plus the id and the
+    // layout it must be exchanged under.
+    fn exchange_test_value() -> (ValueType, DelayedFieldID, MoveTypeLayout) {
+        let id = DelayedFieldID::new_with_width(1000, 8);
+        let storage_layout =
+            create_struct_layout(create_aggregator_storage_layout(MoveTypeLayout::U64));
+        let value = create_struct_value(create_aggregator_value_u64(id.as_u64(), 30));
+        let state_value = create_state_value(&value, &storage_layout);
+        let test_value = TransactionWrite::from_state_value(Some(state_value));
+        let exchange_layout = create_struct_layout(create_aggregator_layout_u64());
+        (test_value, id, exchange_layout)
+    }
+
+    #[test]
+    fn filter_value_for_exchange_checks_base_layout_sequential() {
+        let (test_value, id, exchange_layout) = exchange_test_value();
+        let exchange_layout = TriompheArc::new(exchange_layout);
+        let ids = HashSet::from([id]);
+        let key = KeyType::<u32>(1);
+
+        // A base pinned under an incompatible layout must fail the check.
+        let holder = Holder::new(HashMap::new(), 1000);
+        holder.unsync_map.set_base_value(
+            key,
+            ValueWithLayout::Exchanged(
+                TriompheArc::new(test_value.clone()),
+                Some(TriompheArc::new(MoveTypeLayout::U64)),
+            ),
+        );
+        let view = create_sequential_latest_view(&holder);
+        assert!(matches!(
+            view.filter_value_for_exchange(&test_value, &exchange_layout, &ids, &key),
+            Some(Err(_))
+        ));
+
+        // A base pinned under a distinct but compatible layout must pass.
+        let holder = Holder::new(HashMap::new(), 1000);
+        holder.unsync_map.set_base_value(
+            key,
+            ValueWithLayout::Exchanged(
+                TriompheArc::new(test_value.clone()),
+                Some(TriompheArc::new(create_struct_layout(
+                    create_aggregator_layout_u64(),
+                ))),
+            ),
+        );
+        let view = create_sequential_latest_view(&holder);
+        assert!(matches!(
+            view.filter_value_for_exchange(&test_value, &exchange_layout, &ids, &key),
+            Some(Ok(_))
+        ));
+    }
+
+    #[test]
+    fn filter_value_for_exchange_checks_base_layout_parallel() {
+        let (test_value, id, exchange_layout) = exchange_test_value();
+        let exchange_layout = TriompheArc::new(exchange_layout);
+        let ids = HashSet::from([id]);
+        let key = KeyType::<u32>(1);
+
+        // A base pinned under an incompatible layout must fail the check.
+        let holder = ComparisonHolder::new(HashMap::new(), 1000);
+        holder.versioned_map.data().set_base_value(
+            key,
+            ValueWithLayout::Exchanged(
+                TriompheArc::new(test_value.clone()),
+                Some(TriompheArc::new(MoveTypeLayout::U64)),
+            ),
+            |_, _| {},
+        );
+        let views = holder.new_view();
+        assert!(matches!(
+            views.latest_view_par.filter_value_for_exchange(
+                &test_value,
+                &exchange_layout,
+                &ids,
+                &key
+            ),
+            Some(Err(_))
+        ));
+
+        // A base pinned under a distinct but compatible layout must pass.
+        let holder = ComparisonHolder::new(HashMap::new(), 1000);
+        holder.versioned_map.data().set_base_value(
+            key,
+            ValueWithLayout::Exchanged(
+                TriompheArc::new(test_value.clone()),
+                Some(TriompheArc::new(create_struct_layout(
+                    create_aggregator_layout_u64(),
+                ))),
+            ),
+            |_, _| {},
+        );
+        let views = holder.new_view();
+        assert!(matches!(
+            views.latest_view_par.filter_value_for_exchange(
+                &test_value,
+                &exchange_layout,
+                &ids,
+                &key
+            ),
+            Some(Ok(_))
+        ));
     }
 
     #[test]

--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -307,6 +307,24 @@ impl MoveTypeLayout {
     pub fn unfolded_node_count(&self) -> u64 {
         layout_unfolded_node_count(self, &mut LayoutCountCache::new())
     }
+
+    /// Returns true if `self` is the same layout as `other`, or if `self` only
+    /// differs by having extra enum variants added at the end, at any nesting
+    /// depth. Variants added at the end do not move any existing field, so bytes
+    /// written under `other` can still be read under `self`.
+    ///
+    /// This check is not symmetric. If `other` is a layout and `self` is that
+    /// same layout with one more variant added at the end, then
+    /// `self.is_compatible_with(other)` is true but
+    /// `other.is_compatible_with(self)` is false. Pass the newer layout as
+    /// `self` and the older pinned layout as `other`.
+    ///
+    /// Only the runtime struct forms (`Runtime`, `RuntimeVariants`) are
+    /// supported. The decorated forms are used for display and never reach
+    /// serialization, so they are always treated as incompatible.
+    pub fn is_compatible_with(&self, other: &Self) -> bool {
+        layout_compat(self, other, &mut LayoutCompatCache::new())
+    }
 }
 
 type LayoutCountCache = HashMap<*const MoveStructLayout, u64>;
@@ -539,6 +557,111 @@ fn variant_layout_eq(
             .iter()
             .zip(&b.fields)
             .all(|(x, y)| field_layout_eq(x, y, cache))
+}
+
+// Directional compatibility on the layout DAG, memoized the same way as
+// `layout_eq`. `a` (the newer layout) is compatible with `b` (the older pinned
+// layout) when they are identical, or when `a` only adds enum variants at the
+// end at any nesting depth. Since the relation is not symmetric, the cache key
+// keeps the argument order instead of normalizing it like the equality cache.
+type LayoutCompatCache = HashSet<(*const MoveStructLayout, *const MoveStructLayout)>;
+
+fn layout_compat(a: &MoveTypeLayout, b: &MoveTypeLayout, cache: &mut LayoutCompatCache) -> bool {
+    use MoveTypeLayout::*;
+    match (a, b) {
+        (Bool, Bool)
+        | (Address, Address)
+        | (Signer, Signer)
+        | (Function, Function)
+        | (U8, U8)
+        | (U16, U16)
+        | (U32, U32)
+        | (U64, U64)
+        | (U128, U128)
+        | (U256, U256)
+        | (I8, I8)
+        | (I16, I16)
+        | (I32, I32)
+        | (I64, I64)
+        | (I128, I128)
+        | (I256, I256) => true,
+        (Vector(x), Vector(y)) => layout_compat(x, y, cache),
+        (Native(ka, x), Native(kb, y)) => ka == kb && layout_compat(x, y, cache),
+        (Struct(x), Struct(y)) => arc_struct_layout_compat(x, y, cache),
+        // Listed exhaustively so adding a new variant forces an update here.
+        (Bool, _)
+        | (Address, _)
+        | (Signer, _)
+        | (Function, _)
+        | (U8, _)
+        | (U16, _)
+        | (U32, _)
+        | (U64, _)
+        | (U128, _)
+        | (U256, _)
+        | (I8, _)
+        | (I16, _)
+        | (I32, _)
+        | (I64, _)
+        | (I128, _)
+        | (I256, _)
+        | (Vector(_), _)
+        | (Native(_, _), _)
+        | (Struct(_), _) => false,
+    }
+}
+
+fn arc_struct_layout_compat(
+    a: &Arc<MoveStructLayout>,
+    b: &Arc<MoveStructLayout>,
+    cache: &mut LayoutCompatCache,
+) -> bool {
+    if Arc::ptr_eq(a, b) {
+        return true;
+    }
+    // Keep the argument order in the key. The relation is directional, so
+    // `(a, b)` and `(b, a)` are different queries.
+    let key = (Arc::as_ptr(a), Arc::as_ptr(b));
+    if cache.contains(&key) {
+        return true;
+    }
+    let result = struct_layout_compat(a, b, cache);
+    if result {
+        cache.insert(key);
+    }
+    result
+}
+
+fn struct_layout_compat(
+    a: &MoveStructLayout,
+    b: &MoveStructLayout,
+    cache: &mut LayoutCompatCache,
+) -> bool {
+    use MoveStructLayout::*;
+    match (a, b) {
+        (Runtime(xs), Runtime(ys)) => {
+            // No appended struct fields: the field count must match exactly.
+            xs.len() == ys.len() && xs.iter().zip(ys).all(|(x, y)| layout_compat(x, y, cache))
+        },
+        (RuntimeVariants(xs), RuntimeVariants(ys)) => {
+            // `a` may add variants at the end but must not drop any. Every
+            // variant `b` has must match the same-index variant in `a`; extra
+            // trailing variants in `a` are allowed and left unchecked.
+            xs.len() >= ys.len()
+                && xs.iter().zip(ys).all(|(vx, vy)| {
+                    vx.len() == vy.len()
+                        && vx.iter().zip(vy).all(|(x, y)| layout_compat(x, y, cache))
+                })
+        },
+        // Only the runtime forms reach serialization. The decorated forms are
+        // for display, so treat them as incompatible. Listed exhaustively so
+        // adding a new variant forces an update here.
+        (Runtime(_), _)
+        | (RuntimeVariants(_), _)
+        | (WithFields(_), _)
+        | (WithTypes { .. }, _)
+        | (WithVariants { .. }, _) => false,
+    }
 }
 
 impl MoveValue {
@@ -1217,5 +1340,172 @@ mod unfolded_node_count_tests {
             let layout = build(n);
             assert_eq!(layout.unfolded_node_count(), 3u64 * (1u64 << n) - 1);
         }
+    }
+}
+
+#[cfg(test)]
+mod is_compatible_with_tests {
+    use super::*;
+    use MoveTypeLayout::{Bool, U64, U8};
+
+    fn runtime(fields: Vec<MoveTypeLayout>) -> MoveTypeLayout {
+        MoveTypeLayout::new_struct(MoveStructLayout::Runtime(fields))
+    }
+
+    fn enum_layout(variants: Vec<Vec<MoveTypeLayout>>) -> MoveTypeLayout {
+        MoveTypeLayout::new_struct(MoveStructLayout::RuntimeVariants(variants))
+    }
+
+    /// Identical layouts are compatible in both directions, and scalars only
+    /// match themselves.
+    #[test]
+    fn identical_is_compatible_both_ways() {
+        let a = runtime(vec![U8, U64]);
+        let b = runtime(vec![U8, U64]);
+        assert!(a.is_compatible_with(&b));
+        assert!(b.is_compatible_with(&a));
+
+        assert!(U8.is_compatible_with(&U8));
+        assert!(!U8.is_compatible_with(&U64));
+    }
+
+    /// Vectors and native markers recurse into the element, and native marker
+    /// kinds must match.
+    #[test]
+    fn vectors_and_natives_recurse() {
+        let a = MoveTypeLayout::Vector(Box::new(U8));
+        let b = MoveTypeLayout::Vector(Box::new(U8));
+        assert!(a.is_compatible_with(&b));
+
+        let c = MoveTypeLayout::Vector(Box::new(U64));
+        assert!(!a.is_compatible_with(&c));
+
+        let agg = MoveTypeLayout::Native(IdentifierMappingKind::Aggregator, Box::new(U64));
+        let agg2 = MoveTypeLayout::Native(IdentifierMappingKind::Aggregator, Box::new(U64));
+        let snap = MoveTypeLayout::Native(IdentifierMappingKind::Snapshot, Box::new(U64));
+        assert!(agg.is_compatible_with(&agg2));
+        assert!(!agg.is_compatible_with(&snap));
+    }
+
+    /// A layout with extra trailing variants is compatible with the shorter one,
+    /// but not the other way round.
+    #[test]
+    fn appended_trailing_variant_is_directional() {
+        let base = enum_layout(vec![vec![U8], vec![U64]]);
+        let extended = enum_layout(vec![vec![U8], vec![U64], vec![Bool]]);
+        assert!(extended.is_compatible_with(&base));
+        assert!(!base.is_compatible_with(&extended));
+    }
+
+    /// Changing an existing field's type breaks compatibility both ways.
+    #[test]
+    fn changed_field_type_is_incompatible() {
+        let a = runtime(vec![U8, U64]);
+        let b = runtime(vec![U8, Bool]);
+        assert!(!a.is_compatible_with(&b));
+        assert!(!b.is_compatible_with(&a));
+    }
+
+    /// Appending a struct field moves later bytes, so it is incompatible both
+    /// ways (unlike appending an enum variant).
+    #[test]
+    fn appended_struct_field_is_incompatible() {
+        let a = runtime(vec![U8]);
+        let b = runtime(vec![U8, U64]);
+        assert!(!a.is_compatible_with(&b));
+        assert!(!b.is_compatible_with(&a));
+    }
+
+    /// Reordering fields breaks compatibility both ways.
+    #[test]
+    fn reordered_fields_are_incompatible() {
+        let a = runtime(vec![U8, U64]);
+        let b = runtime(vec![U64, U8]);
+        assert!(!a.is_compatible_with(&b));
+        assert!(!b.is_compatible_with(&a));
+    }
+
+    /// Dropping a variant that is not the last one changes the tag mapping, so
+    /// it is incompatible both ways.
+    #[test]
+    fn removed_non_trailing_variant_is_incompatible() {
+        let base = enum_layout(vec![vec![U8], vec![U64], vec![Bool]]);
+        let removed_middle = enum_layout(vec![vec![U8], vec![Bool]]);
+        assert!(!base.is_compatible_with(&removed_middle));
+        assert!(!removed_middle.is_compatible_with(&base));
+    }
+
+    /// Adding a field inside an existing variant moves bytes, so it is
+    /// incompatible both ways.
+    #[test]
+    fn variant_field_count_change_is_incompatible() {
+        let base = enum_layout(vec![vec![U8], vec![U64]]);
+        let changed = enum_layout(vec![vec![U8], vec![U64, Bool]]);
+        assert!(!base.is_compatible_with(&changed));
+        assert!(!changed.is_compatible_with(&base));
+    }
+
+    /// A struct and an enum never match.
+    #[test]
+    fn runtime_struct_vs_enum_is_incompatible() {
+        let s = runtime(vec![U8]);
+        let e = enum_layout(vec![vec![U8]]);
+        assert!(!s.is_compatible_with(&e));
+        assert!(!e.is_compatible_with(&s));
+    }
+
+    /// Trailing-variant growth nested inside a vector inside a struct is still
+    /// directional.
+    #[test]
+    fn nested_trailing_variant_growth_is_directional() {
+        fn build(extra: bool) -> MoveTypeLayout {
+            let mut variants = vec![vec![U8], vec![U64]];
+            if extra {
+                variants.push(vec![Bool]);
+            }
+            let inner_enum = enum_layout(variants);
+            let vec_of_enum = MoveTypeLayout::Vector(Box::new(inner_enum));
+            runtime(vec![U8, vec_of_enum])
+        }
+        let base = build(false);
+        let extended = build(true);
+        assert!(extended.is_compatible_with(&base));
+        assert!(!base.is_compatible_with(&extended));
+    }
+
+    /// A shared-`Arc` doubling DAG compared against a structurally-equal but
+    /// pointer-distinct copy stays linear. Without memoization this would expand
+    /// to `2^n` comparisons and never finish.
+    #[test]
+    fn doubling_dag_stays_linear() {
+        fn build(n: usize) -> MoveTypeLayout {
+            let mut current = Arc::new(MoveStructLayout::Runtime(vec![U8]));
+            for _ in 0..n {
+                let child = MoveTypeLayout::Struct(current);
+                current = Arc::new(MoveStructLayout::Runtime(vec![child; 2]));
+            }
+            MoveTypeLayout::Struct(current)
+        }
+        let a = build(40);
+        let b = build(40);
+        assert!(a.is_compatible_with(&b));
+        assert!(b.is_compatible_with(&a));
+    }
+
+    /// Decorated forms never reach serialization, so they are treated as
+    /// incompatible even against an identical copy.
+    #[test]
+    fn decorated_forms_are_incompatible() {
+        let field = MoveFieldLayout::new(Identifier::new("x").unwrap(), U8);
+        let a = MoveTypeLayout::new_struct(MoveStructLayout::WithFields(vec![field.clone()]));
+        // Distinct `Arc` with identical content, so the pointer fast path does
+        // not fire.
+        let b = MoveTypeLayout::new_struct(MoveStructLayout::WithFields(vec![field]));
+        assert!(!a.is_compatible_with(&b));
+        assert!(!b.is_compatible_with(&a));
+
+        let runtime_layout = runtime(vec![U8]);
+        assert!(!runtime_layout.is_compatible_with(&a));
+        assert!(!a.is_compatible_with(&runtime_layout));
     }
 }


### PR DESCRIPTION
## Description

During a block, an in-block module upgrade can change a resource type's `MoveTypeLayout`. A resource's bytes are serialized under the layout pinned when the resource is first read/exchanged in the block. The delayed-field exchange path later deserializes and re-serializes those bytes to swap aggregator identifiers for concrete values. If a later layout disagrees with the pinned one on the byte offset or width of any delayed field, the result is a torn view or a serialization error that can halt the whole block (the enum-OOR-tag / stale-layout DoS class).

Move upgrade compatibility only permits one relevant layout change: appending trailing variants to an enum. Appended trailing variants do not move any existing field's byte offset, so they are safe. Any other difference (changed field type, added struct field, reordered fields, removed variant) is unsafe. A plain layout-equality check would false-reject the legitimate upgrade and kill liveness, so this adds a dedicated compatibility relation, not equality.

Two changes:

1. `MoveTypeLayout::is_compatible_with(&self, other)` — a directional, memoized compatibility relation. Returns true iff `self` is identical to `other`, or differs only by trailing appended enum variants at any nesting depth. Only the runtime forms (`Runtime` / `RuntimeVariants`) are supported; decorated forms (`WithFields` / `WithTypes` / `WithVariants`) return false, since they are display-only and never reach serialization. Memoization mirrors the existing `equals` (pointer-identity cache, `Arc::ptr_eq` short-circuit, cache-on-success), with an **ordered** cache key because the relation is asymmetric.

2. A guard in `filter_value_for_exchange`: when a value is about to be exchanged under some layout, that layout must be compatible with the layout the key's base value was pinned under. The base layout is pinned write-once on first read, so it is the correct thing to check against. On mismatch we raise `code_invariant_error`, which the executor already turns into a parallel fallback / block discard. A new `LatestView::base_value_layout` helper fetches the pinned base layout for both sequential and parallel state.

Scope is intentionally narrow. The resource exchange path is covered. The group exchange path and the delayed-field-optimization-off sequential rerun are deferred with TODOs.

## How Has This Been Tested?

- `is_compatible_with` unit tests in `value.rs`: identical layouts (both directions), vector/native recursion, appended trailing variant is directional, changed field type / added struct field / reordered fields / removed non-trailing variant all incompatible, nested trailing-variant growth, a shared-`Arc` doubling DAG stays linear (no tree blowup), decorated forms return false against a distinct-Arc copy.
- `filter_value_for_exchange` tests in `view.rs` for sequential and parallel: an incompatible base layout yields `Some(Err(_))`; a distinct-but-compatible base yields `Some(Ok(_))`.

## Key Areas to Review

- The compatibility relation in `value.rs`: the ordered (non-normalized) cache key, and the exhaustive `Runtime` / `RuntimeVariants` arms with all other forms returning false.
- `base_value_layout` in `view.rs`: it reads the base entry (storage version, index 0) in the parallel path via `fetch_data_no_record(key, 0)`, and the single `unsync_map` entry in the sequential path.
- The `ptr_eq` fast path in `filter_value_for_exchange` — the recursive check only runs when the exchange layout differs from the pinned base (an in-block write under a newer layout).

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parallel VM state serialization invariants; mismatches correctly abort the block but false positives could hurt liveness on legitimate enum-append upgrades if compatibility is wrong.
> 
> **Overview**
> Hardens block-STM delayed-field **value exchange** so a later `MoveTypeLayout` cannot deserialize/re-serialize bytes that were pinned under an incompatible layout (which could tear delayed-field offsets or stall the block).
> 
> Adds **`MoveTypeLayout::is_compatible_with`**: a directional, memoized relation that treats layouts as compatible when they match or when the newer layout only appends trailing enum variants (the safe in-block upgrade case), without requiring full equality.
> 
> Before exchanging a resource, **`filter_value_for_exchange`** now loads the key’s pinned base layout via **`LatestView::base_value_layout`** and rejects the step with **`code_invariant_error`** unless the exchange layout is the same `Arc` or compatible with that base. Sequential and parallel base-layout lookup paths are covered; resource-group exchange is left as a TODO with matching tests for seq/par resource paths.
> 
> Unit tests exercise compatibility edge cases and the new exchange guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f98dad4d3c502c2aebee6362937427226ba3f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->