### PR TITLE
[mono-move] Make natives static or live in global context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13089,6 +13089,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "serde",
+ "shared-dsa",
  "thiserror 1.0.69",
 ]
 

--- a/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/executor.rs
@@ -22,8 +22,7 @@ use mono_move_runtime::ProductionNativeRegistry;
 /// `system_txns`.
 pub struct AptosTransactionExecutor<'a> {
     pub(crate) guard: &'a ExecutionGuard<'a>,
-    // TODO(cleanup): We are considering moving the native registry into the GlobalContext.
-    // This parameter may disappear once it moves there.
+    /// All native functions available for this executor.
     pub(crate) natives: &'a ProductionNativeRegistry,
     pub(crate) module_provider: &'a dyn ModuleProvider,
     pub(crate) data_provider: &'a dyn ResourceProvider,

--- a/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/src/natives.rs
@@ -2,41 +2,22 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_types::state_store::state_storage_usage::StateStorageUsage;
-use mono_move_core::{
-    native::{NativeExtensions, NativeName},
-    Interner,
-};
-use mono_move_global_context::ExecutionGuard;
+use mono_move_core::native::NativeExtensions;
 use mono_move_natives::{
-    make_all_production_natives, Dispatch, EventStore, ObjectContextExtension, RistrettoPointStore,
+    make_all_production_natives, EventStore, ObjectContextExtension, RistrettoPointStore,
     StorageUsageAtEpochBoundary, TransactionContextExtension,
 };
 use mono_move_runtime::{ProductionContextFamily, ProductionNativeRegistry};
+use std::sync::LazyLock;
 
 /// Builds the production native registry.
-pub fn production_natives(guard: &ExecutionGuard<'_>) -> ProductionNativeRegistry {
-    let mut natives = ProductionNativeRegistry::new();
-    natives
-        .register_all(
-            make_all_production_natives::<ProductionContextFamily>()
-                .into_iter()
-                .map(|(addr, module, function, dispatch, func)| {
-                    let module = guard.module_id_of(&addr, &module);
-                    let function = guard.identifier_of(&function);
-                    let name = match dispatch {
-                        Dispatch::Polymorphic => NativeName::Polymorphic { module, function },
-                        Dispatch::Monomorphic(ty_args) => NativeName::Monomorphic {
-                            module,
-                            function,
-                            ty_args: guard.type_list_of(ty_args),
-                        },
-                    };
-                    (name, func)
-                }),
-        )
-        .expect("natives have unique qualified names");
-    natives
+pub fn production_natives() -> &'static ProductionNativeRegistry {
+    &PRODUCTION_NATIVES
 }
+
+static PRODUCTION_NATIVES: LazyLock<ProductionNativeRegistry> = LazyLock::new(|| {
+    ProductionNativeRegistry::with_natives(make_all_production_natives::<ProductionContextFamily>())
+});
 
 /// The native extensions every transaction kind runs with, around its own
 /// transaction-context extension.

--- a/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
+++ b/third_party/move/mono-move/aptos-transaction-executor/tests/e2e.rs
@@ -84,14 +84,14 @@ fn execute_v2_with<S: StateView>(
     let guard = global_ctx
         .try_execution_context(0)
         .expect("execution context is available");
-    let natives = production_natives(&guard);
+    let natives = production_natives();
     let module_provider = StateViewModuleProvider::new(state);
     let data_provider = StateViewResourceProvider::new(&guard, state);
     let env = AptosEnvironment::new(state);
     let usage = state.get_usage().expect("usage is readable");
     let executor = AptosTransactionExecutor::new(
         &guard,
-        &natives,
+        natives,
         &module_provider,
         &data_provider,
         &env,

--- a/third_party/move/mono-move/core/src/native/mod.rs
+++ b/third_party/move/mono-move/core/src/native/mod.rs
@@ -15,8 +15,8 @@ pub use abi::{FrameSlot, NativeABI, NativeABIError};
 pub use context::NativeContext;
 pub use extension::{NativeExtension, NativeExtensions};
 pub use registry::{
-    NativeContextFamily, NativeFunction, NativeIdx, NativeName, NativeRegistry,
-    NativeRegistryError, NativeResolver, NoNatives,
+    Dispatch, NativeContextFamily, NativeDescriptor, NativeFunction, NativeIdx, NativeResolver,
+    NoNatives,
 };
 pub use result::{native_invariant_violation, native_vector_index_out_of_bounds, NativeStatus};
 pub use value::{Boxed, Opaque, Ref, TableHandle, VMValue, Vector};

--- a/third_party/move/mono-move/core/src/native/mod.rs
+++ b/third_party/move/mono-move/core/src/native/mod.rs
@@ -15,8 +15,7 @@ pub use abi::{FrameSlot, NativeABI, NativeABIError};
 pub use context::NativeContext;
 pub use extension::{NativeExtension, NativeExtensions};
 pub use registry::{
-    Dispatch, NativeContextFamily, NativeDescriptor, NativeFunction, NativeIdx, NativeResolver,
-    NoNatives,
+    Dispatch, NativeContextFamily, NativeFunction, NativeIdx, NativeName, NativeResolver, NoNatives,
 };
 pub use result::{native_invariant_violation, native_vector_index_out_of_bounds, NativeStatus};
 pub use value::{Boxed, Opaque, Ref, TableHandle, VMValue, Vector};

--- a/third_party/move/mono-move/core/src/native/registry.rs
+++ b/third_party/move/mono-move/core/src/native/registry.rs
@@ -1,57 +1,45 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Native function registry: a lookup table the VM uses to resolve a
-//! native function from either its fully-qualified name (during
-//! specialization) or its [`NativeIdx`] (at runtime dispatch).
+//! Native function registry primitives shared across the VM.
+//!
+//! - [`NativeFunction`], the raw fn-pointer type a runtime's registry stores,
+//!   and [`NativeIdx`], the position in that table.
+//! - [`NativeResolver`], the trait the loader and specializer use to resolve a
+//!   native call by its name and type arguments to its [`NativeIdx`].
 
 use super::context::NativeContext;
 use crate::{
     interner::{InternedIdentifier, InternedModuleId},
     native::NativeStatus,
-    types::InternedTypeList,
+    types::{InternedType, InternedTypeList},
     VMResult,
 };
-use shared_dsa::UnorderedMap;
-use thiserror::Error;
+use move_core_types::account_address::AccountAddress;
 
 /// Index into the natives registry's table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct NativeIdx(pub u32);
 
-/// Key under which a native is registered in a [`NativeRegistry`].
-///
-/// A native is either a template that serves every instantiation, or a body
-/// specialized to one concrete instantiation. The two variants let
-/// type-agnostic natives register once while type-sensitive natives register a
-/// separate body per concrete type. Resolution tries the monomorphic key first
-/// and falls back to the polymorphic one (see [`NativeRegistry::resolve`]).
+/// Describes how a native is dispatched.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NativeName {
-    /// One implementation for all instantiations.
-    Polymorphic {
-        module: InternedModuleId,
-        function: InternedIdentifier,
-    },
-    /// Implementation specialized to one concrete instantiation, matched only
-    /// when the call's type arguments equal `ty_args`.
-    Monomorphic {
-        module: InternedModuleId,
-        function: InternedIdentifier,
-        ty_args: InternedTypeList,
-    },
+pub enum Dispatch {
+    /// A native that serves every possible instantiation.
+    Polymorphic,
+    /// A native that is specialized to a single concrete instantiation or does
+    /// not carry type arguments at all.
+    Monomorphic(&'static [InternedType]),
 }
 
-impl NativeName {
-    /// The module the native is declared in.
-    pub fn module(&self) -> InternedModuleId {
-        match self {
-            NativeName::Polymorphic { module, .. } | NativeName::Monomorphic { module, .. } => {
-                *module
-            },
-        }
-    }
+/// Describes a natives function: its module address and name, function name
+/// and how it should be dispatched.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NativeDescriptor {
+    pub address: AccountAddress,
+    pub module: &'static str,
+    pub function: &'static str,
+    pub dispatch: Dispatch,
 }
 
 /// Describes a family of [`NativeContext`] types indexed by a lifetime.
@@ -71,9 +59,8 @@ pub trait NativeContextFamily {
 ///
 /// Without this, we cannot store native functions in a registry, which would
 /// otherwise mandate a fixed lifetime.
-pub type NativeFunction<F> = Box<
-    dyn for<'a> Fn(&<F as NativeContextFamily>::Of<'a>) -> VMResult<NativeStatus> + Send + Sync,
->;
+pub type NativeFunction<F> =
+    for<'a> fn(&<F as NativeContextFamily>::Of<'a>) -> VMResult<NativeStatus>;
 
 /// Resolves a native call to its [`NativeIdx`] from the callee's qualified name
 /// and the call's concrete type arguments.
@@ -98,114 +85,5 @@ impl NativeResolver for NoNatives {
         _ty_args: InternedTypeList,
     ) -> Option<NativeIdx> {
         None
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum NativeRegistryError {
-    #[error("native already registered under this name")]
-    DuplicateName,
-}
-
-/// A registered native: its fully-qualified name and function pointer.
-struct NativeEntry<F: NativeContextFamily> {
-    name: NativeName,
-    func: NativeFunction<F>,
-}
-
-/// Lookup table of native functions, generic over a [`NativeContextFamily`] `F`.
-pub struct NativeRegistry<F: NativeContextFamily> {
-    entries: Vec<NativeEntry<F>>,
-    by_name: UnorderedMap<NativeName, NativeIdx>,
-}
-
-impl<F: NativeContextFamily> NativeRegistry<F> {
-    /// Creates an empty native registry.
-    pub fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-            by_name: UnorderedMap::default(),
-        }
-    }
-
-    /// Number of registered natives.
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
-    /// Register a native under the given fully-qualified name.
-    pub fn register(
-        &mut self,
-        name: NativeName,
-        func: NativeFunction<F>,
-    ) -> Result<NativeIdx, NativeRegistryError> {
-        if self.by_name.contains_key(&name) {
-            return Err(NativeRegistryError::DuplicateName);
-        }
-        let idx = NativeIdx(self.entries.len() as u32);
-        self.entries.push(NativeEntry { name, func });
-        self.by_name.insert(name, idx);
-        Ok(idx)
-    }
-
-    /// Register many natives at once. Returns indices in input order;
-    /// short-circuits on the first error.
-    pub fn register_all<I>(&mut self, natives: I) -> Result<Vec<NativeIdx>, NativeRegistryError>
-    where
-        I: IntoIterator<Item = (NativeName, NativeFunction<F>)>,
-    {
-        natives
-            .into_iter()
-            .map(|(name, func)| self.register(name, func))
-            .collect()
-    }
-
-    /// Look up the function pointer for a [`NativeIdx`].
-    #[inline]
-    pub fn lookup_by_idx(&self, idx: NativeIdx) -> Option<&NativeFunction<F>> {
-        self.entries.get(idx.0 as usize).map(|entry| &entry.func)
-    }
-
-    /// The module of the native registered at [`NativeIdx`].
-    pub fn module_by_idx(&self, idx: NativeIdx) -> Option<InternedModuleId> {
-        self.name_by_idx(idx).map(|name| name.module())
-    }
-
-    /// The fully-qualified name of the native registered at [`NativeIdx`].
-    pub fn name_by_idx(&self, idx: NativeIdx) -> Option<NativeName> {
-        self.entries.get(idx.0 as usize).map(|entry| entry.name)
-    }
-
-    /// Look up the [`NativeIdx`] of a fully-qualified name.
-    pub fn lookup_by_name(&self, name: &NativeName) -> Option<NativeIdx> {
-        self.by_name.get(name).copied()
-    }
-}
-
-impl<F: NativeContextFamily> Default for NativeRegistry<F> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<F: NativeContextFamily> NativeResolver for NativeRegistry<F> {
-    /// Resolves the monomorphic registration for `ty_args` if one exists,
-    /// otherwise falls back to a polymorphic (template) registration.
-    fn resolve(
-        &self,
-        module: InternedModuleId,
-        function: InternedIdentifier,
-        ty_args: InternedTypeList,
-    ) -> Option<NativeIdx> {
-        self.lookup_by_name(&NativeName::Monomorphic {
-            module,
-            function,
-            ty_args,
-        })
-        .or_else(|| self.lookup_by_name(&NativeName::Polymorphic { module, function }))
     }
 }

--- a/third_party/move/mono-move/core/src/native/registry.rs
+++ b/third_party/move/mono-move/core/src/native/registry.rs
@@ -3,10 +3,11 @@
 
 //! Native function registry primitives shared across the VM.
 //!
-//! - [`NativeFunction`], the raw fn-pointer type a runtime's registry stores,
-//!   and [`NativeIdx`], the position in that table.
-//! - [`NativeResolver`], the trait the loader and specializer use to resolve a
-//!   native call by its name and type arguments to its [`NativeIdx`].
+//! A runtime keeps its natives in a table. Each one is stored as a raw function
+//! pointer, and its position in the table is its index. The loader and
+//! specializer take a native call, look at its name and type arguments, and ask
+//! for the matching index. This module holds the types and traits that make
+//! that lookup work.
 
 use super::context::NativeContext;
 use crate::{
@@ -29,13 +30,17 @@ pub enum Dispatch {
     Polymorphic,
     /// A native that is specialized to a single concrete instantiation or does
     /// not carry type arguments at all.
+    ///
+    /// Invariant: the slice holds only `'static` primitive type constants (e.g.
+    /// [`U64_TY`](crate::types::U64_TY)). It must never contain an arena-interned
+    /// type, since those do not outlive an execution guard.
     Monomorphic(&'static [InternedType]),
 }
 
-/// Describes a natives function: its module address and name, function name
+/// Describes a native function: its module address and name, function name
 /// and how it should be dispatched.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct NativeDescriptor {
+pub struct NativeName {
     pub address: AccountAddress,
     pub module: &'static str,
     pub function: &'static str,

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -9,7 +9,7 @@
 // Re-exported so the native list macros can name these via `$crate::...`
 // without callers having to add `mono-move-core` to their imports.
 use mono_move_core::native::NativeContextFamily;
-pub use mono_move_core::native::{Dispatch, NativeDescriptor, NativeFunction};
+pub use mono_move_core::native::{Dispatch, NativeFunction, NativeName};
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
 mod address_derivation;
@@ -81,9 +81,8 @@ pub use type_info::make_all_type_info_natives;
 pub use unit_test::make_all_unit_test_natives;
 pub use vector::make_all_vector_natives;
 
-/// One native registration: its descriptor (qualified name parts and dispatch
-/// kind), as well as the implementation.
-pub type NativeEntry<F> = (NativeDescriptor, NativeFunction<F>);
+/// One native registration: its name and its implementation.
+pub type NativeEntry<F> = (NativeName, NativeFunction<F>);
 
 /// All natives shipped with the production MonoMove VM. Additional native
 /// modules are concatenated here as they are implemented.
@@ -121,7 +120,8 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
 //
 // TODO(cleanup): replace with a proper parser. See if one already exists in
 // move-core-types.
-// TODO(cleanup): this can be a static function and check
+// TODO(cleanup): make this a `const fn` so malformed names are caught at
+// compile time rather than when the native list is built at startup.
 pub(crate) fn parse_qualified_native_name(
     qname: &'static str,
 ) -> (AccountAddress, &'static str, &'static str) {
@@ -173,13 +173,13 @@ macro_rules! native_entry {
         }
 
         let (address, module, function) = $crate::parse_qualified_native_name($qname);
-        let descriptor = $crate::NativeDescriptor {
+        let name = $crate::NativeName {
             address,
             module,
             function,
             dispatch: $dispatch,
         };
-        (descriptor, wrapper::<F> as $crate::NativeFunction<F>)
+        (name, wrapper::<F> as $crate::NativeFunction<F>)
     }};
 }
 pub(crate) use native_entry;
@@ -188,8 +188,11 @@ pub(crate) use native_entry;
 /// concrete instantiation, and the specializer resolves it from the call's type
 /// arguments. Each entry is either `(name, fn)` — empty type arguments (a
 /// non-generic native) — or `(name, &[ty, ...], fn)` to specialize on concrete
-/// type arguments. Each element of the type-argument slice must be a canonical
-/// primitive constant (e.g. `U64_TY`).
+/// type arguments. Each element of the type-argument slice must be a `'static`
+/// primitive type constant (e.g. `U64_TY`), never an arena-interned type.
+//
+// TODO(testing): debug-assert this in the registry builder instead of relying
+// on the doc invariant.
 ///
 /// Example:
 /// ```ignore

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -6,10 +6,10 @@
 //!
 //! [`NativeContext`]: mono_move_core::native::NativeContext
 
-// Re-exported so the `natives!` macro can name it via `$crate::NativeFunction`
+// Re-exported so the native list macros can name these via `$crate::...`
 // without callers having to add `mono-move-core` to their imports.
-pub use mono_move_core::native::NativeFunction;
-use mono_move_core::{native::NativeContextFamily, types::InternedType};
+use mono_move_core::native::NativeContextFamily;
+pub use mono_move_core::native::{Dispatch, NativeDescriptor, NativeFunction};
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
 mod address_derivation;
@@ -35,9 +35,11 @@ pub mod signer;
 pub mod state_storage;
 pub mod string;
 pub mod table;
+#[cfg(feature = "testing")]
 pub mod test_natives;
 pub mod transaction_context;
 pub mod type_info;
+#[cfg(feature = "testing")]
 pub mod unit_test;
 pub mod vector;
 
@@ -71,36 +73,17 @@ pub use signer::make_all_signer_natives;
 pub use state_storage::{make_all_state_storage_natives, StorageUsageAtEpochBoundary};
 pub use string::make_all_string_natives;
 pub use table::make_all_table_natives;
+#[cfg(feature = "testing")]
 pub use test_natives::{make_all_test_natives, native_u64_add, native_u64_identity};
 pub use transaction_context::{make_all_transaction_context_natives, TransactionContextExtension};
 pub use type_info::make_all_type_info_natives;
+#[cfg(feature = "testing")]
 pub use unit_test::make_all_unit_test_natives;
 pub use vector::make_all_vector_natives;
 
-/// How a native is dispatched against a call's type arguments. A native that
-/// works for any instantiation registers as [`Dispatch::Polymorphic`]; a native
-/// specialized to one concrete instantiation registers as
-/// [`Dispatch::Monomorphic`] carrying that instantiation's type arguments. The
-/// consumer interns these into a `NativeName` registry key.
-//
-// TODO(cleanup): this duplicates `NativeName`'s shape. We keep it separate because
-// `NativeName` holds arena-interned ids that require an `ExecutionGuard`, which
-// is unavailable when these tables are built statically. Revisit if interning
-// becomes available earlier.
-pub enum Dispatch {
-    Polymorphic,
-    Monomorphic(&'static [InternedType]),
-}
-
-/// One native registration: its qualified name parts, its dispatch kind, and
-/// the boxed implementation.
-pub type NativeEntry<F> = (
-    AccountAddress,
-    Identifier,
-    Identifier,
-    Dispatch,
-    NativeFunction<F>,
-);
+/// One native registration: its descriptor (qualified name parts and dispatch
+/// kind), as well as the implementation.
+pub type NativeEntry<F> = (NativeDescriptor, NativeFunction<F>);
 
 /// All natives shipped with the production MonoMove VM. Additional native
 /// modules are concatenated here as they are implemented.
@@ -138,17 +121,32 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
 //
 // TODO(cleanup): replace with a proper parser. See if one already exists in
 // move-core-types.
-pub(crate) fn parse_qualified_native_name(qname: &str) -> (AccountAddress, Identifier, Identifier) {
+// TODO(cleanup): this can be a static function and check
+pub(crate) fn parse_qualified_native_name(
+    qname: &'static str,
+) -> (AccountAddress, &'static str, &'static str) {
     let mut parts = qname.split("::");
     let addr_part = parts
         .next()
         .unwrap_or_else(|| panic!("malformed native name `{}`: missing address", qname));
-    let module_part = parts
+    let module = parts
         .next()
         .unwrap_or_else(|| panic!("malformed native name `{}`: missing module", qname));
-    let function_part = parts
+    if !Identifier::is_valid(module) {
+        panic!(
+            "malformed native name `{}`:` module name is not a valid identifier",
+            qname
+        );
+    }
+    let function = parts
         .next()
         .unwrap_or_else(|| panic!("malformed native name `{}`: missing function", qname));
+    if !Identifier::is_valid(function) {
+        panic!(
+            "malformed native name `{}`: function name is not a valid identifier",
+            qname
+        );
+    }
     assert!(
         parts.next().is_none(),
         "malformed native name `{}`: too many `::`-separated parts",
@@ -156,20 +154,32 @@ pub(crate) fn parse_qualified_native_name(qname: &str) -> (AccountAddress, Ident
     );
     let addr = AccountAddress::from_hex_literal(addr_part)
         .unwrap_or_else(|e| panic!("malformed native name `{}`: invalid address: {}", qname, e));
-    let module = Identifier::new(module_part)
-        .unwrap_or_else(|e| panic!("malformed native name `{}`: invalid module: {}", qname, e));
-    let function = Identifier::new(function_part)
-        .unwrap_or_else(|e| panic!("malformed native name `{}`: invalid function: {}", qname, e));
     (addr, module, function)
 }
 
-/// Builds one [`NativeEntry`]: parses the qualified name, boxes the function,
-/// and pairs it with the given [`Dispatch`]. Shared by the list macros below.
+/// Builds one [`NativeEntry`].
 macro_rules! native_entry {
     ($qname:expr, $dispatch:expr, $func:expr) => {{
-        let (addr, module, function) = $crate::parse_qualified_native_name($qname);
-        let func: $crate::NativeFunction<_> = ::std::boxed::Box::new(|ctx| $func(ctx));
-        (addr, module, function, $dispatch, func)
+        // The `wrapper` is a generic function whose lifetime is late-bound, so
+        // `wrapper::<F>` coerces to the higher-ranked:
+        // ```
+        //   for<'a> fn(&F::Of<'a>) -> ..
+        // ```
+        // that the native table stores.
+        fn wrapper<F: ::mono_move_core::native::NativeContextFamily>(
+            ctx: &<F as ::mono_move_core::native::NativeContextFamily>::Of<'_>,
+        ) -> ::mono_move_core::VMResult<::mono_move_core::native::NativeStatus> {
+            $func(ctx)
+        }
+
+        let (address, module, function) = $crate::parse_qualified_native_name($qname);
+        let descriptor = $crate::NativeDescriptor {
+            address,
+            module,
+            function,
+            dispatch: $dispatch,
+        };
+        (descriptor, wrapper::<F> as $crate::NativeFunction<F>)
     }};
 }
 pub(crate) use native_entry;
@@ -177,9 +187,9 @@ pub(crate) use native_entry;
 /// Builds a list of monomorphic natives: each body is registered for one
 /// concrete instantiation, and the specializer resolves it from the call's type
 /// arguments. Each entry is either `(name, fn)` — empty type arguments (a
-/// non-generic native) — or `(name, &[ty, ...], fn)` to specialize on the given
-/// static type arguments. The caller supplies the concrete types (e.g. the
-/// turbofished function and `&[U64_TY]`).
+/// non-generic native) — or `(name, &[ty, ...], fn)` to specialize on concrete
+/// type arguments. Each element of the type-argument slice must be a canonical
+/// primitive constant (e.g. `U64_TY`).
 ///
 /// Example:
 /// ```ignore

--- a/third_party/move/mono-move/replay-benchmark/src/v2.rs
+++ b/third_party/move/mono-move/replay-benchmark/src/v2.rs
@@ -29,7 +29,7 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
     let guard = ctx
         .try_execution_context(0)
         .ok_or_else(|| anyhow!("failed to acquire MonoMove execution guard"))?;
-    let natives = production_natives(&guard);
+    let natives = production_natives();
 
     let module_provider = StateViewModuleProvider::new(state_view);
     let data_provider = StateViewResourceProvider::new(&guard, state_view);
@@ -38,7 +38,7 @@ pub fn run(input: &BenchmarkInput, timing: &TimingConfig) -> Result<BenchmarkRun
     let usage = state_view.get_usage()?;
     let executor = AptosTransactionExecutor::new(
         &guard,
-        &natives,
+        natives,
         &module_provider,
         &data_provider,
         &env,

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -22,6 +22,7 @@ mono-move-global-context = { workspace = true }
 mono-move-loader = { workspace = true }
 move-core-types = { workspace = true }
 rand = { workspace = true }
+shared-dsa = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -31,8 +31,8 @@ use mono_move_core::{
     captured_values_size,
     interner::{module_id_of, InternedIdentifier, InternedModuleId},
     native::{
-        NativeABI, NativeExtension, NativeExtensions, NativeIdx, NativeStatus, ObjectHandle,
-        RootPool,
+        NativeABI, NativeDescriptor, NativeExtension, NativeExtensions, NativeIdx, NativeStatus,
+        ObjectHandle, RootPool,
     },
     next_captured_value_offset,
     storage::resource_provider::InMemoryStorageKey,
@@ -50,7 +50,9 @@ use mono_move_core::{
 use mono_move_global_context::ExecutionGuard;
 use mono_move_loader::{Loader, ModuleReadSet};
 use move_core_types::{
+    identifier::Identifier,
     int256::{I256, U256},
+    language_storage::ModuleId,
     vm_status::AbortLocation,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -207,6 +209,21 @@ fn abort_location(module_id: InternedModuleId) -> VMResult<AbortLocation> {
     }
 }
 
+/// Materializes the [`AbortLocation`] naming a native's own module from its
+/// descriptor. The descriptor's name parts are process-static literals, so the
+/// module name is always a valid identifier in practice.
+fn native_abort_location(descriptor: &NativeDescriptor) -> VMResult<AbortLocation> {
+    match Identifier::new(descriptor.module) {
+        Ok(module) => Ok(AbortLocation::Module(ModuleId::new(
+            descriptor.address,
+            module,
+        ))),
+        Err(_) => invariant_violation!(Unreachable(
+            "native module name is not a valid identifier".to_string()
+        )),
+    }
+}
+
 /// Per-transaction interpreter context with a unified call stack and a
 /// GC-managed heap: owns the transaction state (code loader and read-set, gas
 /// meter, native extensions, resource read-write set) and the machine state
@@ -227,11 +244,7 @@ pub struct InterpreterContext<'guard> {
     /// Read-set of the modules loaded by this transaction.
     read_set: ModuleReadSet<'guard>,
     pub(crate) gas_meter: GasMeter,
-    // TODO(cleanup): Move the native registry off the per-transaction context
-    // and onto a long-lived owner (e.g. the global context).
-    //
-    // TODO(correctness): Enforce that `natives` here and the `NativeResolver`
-    // passed to `loader` are the same instance.
+    /// A process-wide global native function table.
     natives: &'guard ProductionNativeRegistry,
     /// Per-transaction native extensions, shared across native calls.
     pub(crate) extensions: NativeExtensions,
@@ -1327,8 +1340,8 @@ impl InterpreterContext<'_> {
                             // Attribute the abort to the native's own module
                             // (not the caller's, which `regs.func` names here)
                             // — the same rule as a Move-level abort.
-                            let location = match self.natives.module_by_idx(native_idx) {
-                                Some(module_id) => abort_location(module_id)?,
+                            let location = match self.natives.name_by_idx(native_idx) {
+                                Some(descriptor) => native_abort_location(descriptor)?,
                                 None => invariant_violation!(NativeIdxOutOfBounds {
                                     idx: native_idx.0,
                                     registry_size: self.natives.len(),

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -31,7 +31,7 @@ use mono_move_core::{
     captured_values_size,
     interner::{module_id_of, InternedIdentifier, InternedModuleId},
     native::{
-        NativeABI, NativeDescriptor, NativeExtension, NativeExtensions, NativeIdx, NativeStatus,
+        NativeABI, NativeExtension, NativeExtensions, NativeIdx, NativeName, NativeStatus,
         ObjectHandle, RootPool,
     },
     next_captured_value_offset,
@@ -210,14 +210,11 @@ fn abort_location(module_id: InternedModuleId) -> VMResult<AbortLocation> {
 }
 
 /// Materializes the [`AbortLocation`] naming a native's own module from its
-/// descriptor. The descriptor's name parts are process-static literals, so the
-/// module name is always a valid identifier in practice.
-fn native_abort_location(descriptor: &NativeDescriptor) -> VMResult<AbortLocation> {
-    match Identifier::new(descriptor.module) {
-        Ok(module) => Ok(AbortLocation::Module(ModuleId::new(
-            descriptor.address,
-            module,
-        ))),
+/// name. The name's parts are process-static literals, so the module name is
+/// always a valid identifier in practice.
+fn native_abort_location(name: &NativeName) -> VMResult<AbortLocation> {
+    match Identifier::new(name.module) {
+        Ok(module) => Ok(AbortLocation::Module(ModuleId::new(name.address, module))),
         Err(_) => invariant_violation!(Unreachable(
             "native module name is not a valid identifier".to_string()
         )),
@@ -1341,7 +1338,7 @@ impl InterpreterContext<'_> {
                             // (not the caller's, which `regs.func` names here)
                             // — the same rule as a Move-level abort.
                             let location = match self.natives.name_by_idx(native_idx) {
-                                Some(descriptor) => native_abort_location(descriptor)?,
+                                Some(name) => native_abort_location(name)?,
                                 None => invariant_violation!(NativeIdxOutOfBounds {
                                     idx: native_idx.0,
                                     registry_size: self.natives.len(),

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -20,14 +20,14 @@ use crate::{
     types::{META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
 };
 use mono_move_core::{
-    interner::InternedModuleId,
+    interner::{view_module_id, InternedIdentifier, InternedModuleId},
     native::{
-        native_invariant_violation, Boxed, NativeABI, NativeContext, NativeContextFamily,
-        NativeExtension, NativeExtensions, NativeFunction, NativeRegistry, Opaque, Ref, RootPool,
-        TableHandle, VMValue, Vector,
+        native_invariant_violation, Boxed, Dispatch, NativeABI, NativeContext, NativeContextFamily,
+        NativeDescriptor, NativeExtension, NativeExtensions, NativeFunction, NativeIdx,
+        NativeResolver, Opaque, Ref, RootPool, TableHandle, VMValue, Vector,
     },
     storage::resource_provider::InMemoryStorageKey,
-    types::InternedType,
+    types::{view_name, view_type_list, InternedType, InternedTypeList},
     DescriptorId, DescriptorProvider, ExecutionErrorKind, Function, GasMeter, LayoutProvider,
     ResourceProvider, VMResult, ENUM_DATA_OFFSET, FRAME_METADATA_SIZE, OBJECT_HEADER_SIZE,
     TRIVIAL_DESCRIPTOR_ID,
@@ -36,6 +36,7 @@ use move_core_types::account_address::AccountAddress;
 use std::{
     cell::{Cell, RefMut, UnsafeCell},
     cmp::Ordering,
+    collections::HashMap,
     ptr::NonNull,
 };
 
@@ -799,8 +800,115 @@ impl NativeContextFamily for ProductionContextFamily {
     type Of<'a> = ProductionNativeContext<'a>;
 }
 
-/// Shorthand for the [`NativeRegistry`] used by the production VM.
-pub type ProductionNativeRegistry = NativeRegistry<ProductionContextFamily>;
-
 /// Shorthand for the [`NativeFunction`] used by the production VM.
 pub type ProductionNativeFunction = NativeFunction<ProductionContextFamily>;
+
+/// The registry of native function available. Stores a function table paired
+/// with a resolver that can map a native function (by its descriptor) to its
+/// index in the table or actual implementation.
+pub struct ProductionNativeRegistry {
+    funcs: Vec<ProductionNativeFunction>,
+    descriptors: Vec<NativeDescriptor>,
+    by_name: HashMap<NativeDescriptor, NativeIdx>,
+}
+
+impl ProductionNativeRegistry {
+    /// Builds a registry from native entries, placing each entry's function
+    /// pointer and descriptor at the same [`NativeIdx`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if two entries are register under the same key.
+    pub fn with_natives(entries: Vec<(NativeDescriptor, ProductionNativeFunction)>) -> Self {
+        let mut funcs = Vec::with_capacity(entries.len());
+        let mut descriptors = Vec::with_capacity(entries.len());
+        let mut by_name = HashMap::with_capacity(entries.len());
+        for (position, (descriptor, func)) in entries.into_iter().enumerate() {
+            let idx = NativeIdx(position as u32);
+            if by_name.insert(descriptor, idx).is_some() {
+                panic!(
+                    "native `{}::{}` registered more than once",
+                    descriptor.module, descriptor.function
+                );
+            }
+            funcs.push(func);
+            descriptors.push(descriptor);
+        }
+        Self {
+            funcs,
+            descriptors,
+            by_name,
+        }
+    }
+
+    /// A registry with no natives.
+    pub fn new() -> Self {
+        Self {
+            funcs: vec![],
+            descriptors: vec![],
+            by_name: HashMap::new(),
+        }
+    }
+
+    /// Number of registered natives.
+    pub fn len(&self) -> usize {
+        self.funcs.len()
+    }
+
+    /// Returns true if there are no registered native functions.
+    pub fn is_empty(&self) -> bool {
+        self.funcs.is_empty()
+    }
+
+    /// Returns the function pointer for a native, if one exists.
+    pub fn lookup_by_idx(&self, idx: NativeIdx) -> Option<ProductionNativeFunction> {
+        self.funcs.get(idx.0 as usize).copied()
+    }
+
+    /// Returns the descriptor of the native registered at the specified index.
+    pub fn name_by_idx(&self, idx: NativeIdx) -> Option<&NativeDescriptor> {
+        self.descriptors.get(idx.0 as usize)
+    }
+}
+
+impl Default for ProductionNativeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NativeResolver for ProductionNativeRegistry {
+    /// Resolves the native function's name to its registered index. If the
+    /// native is not registered, returns [`None`].
+    ///
+    /// When resolving generic natives, first checks if there is a native that
+    /// has already been instantiated (monomorphic). If such a native does not
+    /// exist, fallbacks to returning an index of the polymorphic implementation.
+    fn resolve(
+        &self,
+        module: InternedModuleId,
+        function: InternedIdentifier,
+        ty_args: InternedTypeList,
+    ) -> Option<NativeIdx> {
+        let module_id = view_module_id(module);
+        let address = *module_id.address();
+        let module = view_name(module_id.name());
+        let function = view_name(function);
+
+        let query = NativeDescriptor {
+            address,
+            module,
+            function,
+            dispatch: Dispatch::Monomorphic(view_type_list(ty_args)),
+        };
+        if let Some(idx) = self.by_name.get(&query) {
+            return Some(*idx);
+        }
+        self.by_name
+            .get(&NativeDescriptor {
+                dispatch: Dispatch::Polymorphic,
+                ..query
+            })
+            .copied()
+    }
+}

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -23,8 +23,8 @@ use mono_move_core::{
     interner::{view_module_id, InternedIdentifier, InternedModuleId},
     native::{
         native_invariant_violation, Boxed, Dispatch, NativeABI, NativeContext, NativeContextFamily,
-        NativeDescriptor, NativeExtension, NativeExtensions, NativeFunction, NativeIdx,
-        NativeResolver, Opaque, Ref, RootPool, TableHandle, VMValue, Vector,
+        NativeExtension, NativeExtensions, NativeFunction, NativeIdx, NativeName, NativeResolver,
+        Opaque, Ref, RootPool, TableHandle, VMValue, Vector,
     },
     storage::resource_provider::InMemoryStorageKey,
     types::{view_name, view_type_list, InternedType, InternedTypeList},
@@ -33,10 +33,10 @@ use mono_move_core::{
     TRIVIAL_DESCRIPTOR_ID,
 };
 use move_core_types::account_address::AccountAddress;
+use shared_dsa::UnorderedMap;
 use std::{
     cell::{Cell, RefMut, UnsafeCell},
     cmp::Ordering,
-    collections::HashMap,
     ptr::NonNull,
 };
 
@@ -803,40 +803,43 @@ impl NativeContextFamily for ProductionContextFamily {
 /// Shorthand for the [`NativeFunction`] used by the production VM.
 pub type ProductionNativeFunction = NativeFunction<ProductionContextFamily>;
 
-/// The registry of native function available. Stores a function table paired
-/// with a resolver that can map a native function (by its descriptor) to its
+/// The registry of native functions available. Stores a function table paired
+/// with a resolver that can map a native function (by its name) to its
 /// index in the table or actual implementation.
+//
+// TODO(cleanup): rename to `NativeRegistry`. There is a single registry, and
+// "production" is an overloaded, misused term.
 pub struct ProductionNativeRegistry {
     funcs: Vec<ProductionNativeFunction>,
-    descriptors: Vec<NativeDescriptor>,
-    by_name: HashMap<NativeDescriptor, NativeIdx>,
+    names: Vec<NativeName>,
+    by_name: UnorderedMap<NativeName, NativeIdx>,
 }
 
 impl ProductionNativeRegistry {
     /// Builds a registry from native entries, placing each entry's function
-    /// pointer and descriptor at the same [`NativeIdx`].
+    /// pointer and name at the same [`NativeIdx`].
     ///
     /// # Panics
     ///
     /// Panics if two entries are register under the same key.
-    pub fn with_natives(entries: Vec<(NativeDescriptor, ProductionNativeFunction)>) -> Self {
+    pub fn with_natives(entries: Vec<(NativeName, ProductionNativeFunction)>) -> Self {
         let mut funcs = Vec::with_capacity(entries.len());
-        let mut descriptors = Vec::with_capacity(entries.len());
-        let mut by_name = HashMap::with_capacity(entries.len());
-        for (position, (descriptor, func)) in entries.into_iter().enumerate() {
+        let mut names = Vec::with_capacity(entries.len());
+        let mut by_name = UnorderedMap::with_capacity(entries.len());
+        for (position, (name, func)) in entries.into_iter().enumerate() {
             let idx = NativeIdx(position as u32);
-            if by_name.insert(descriptor, idx).is_some() {
+            if by_name.insert(name, idx).is_some() {
                 panic!(
                     "native `{}::{}` registered more than once",
-                    descriptor.module, descriptor.function
+                    name.module, name.function
                 );
             }
             funcs.push(func);
-            descriptors.push(descriptor);
+            names.push(name);
         }
         Self {
             funcs,
-            descriptors,
+            names,
             by_name,
         }
     }
@@ -845,8 +848,8 @@ impl ProductionNativeRegistry {
     pub fn new() -> Self {
         Self {
             funcs: vec![],
-            descriptors: vec![],
-            by_name: HashMap::new(),
+            names: vec![],
+            by_name: UnorderedMap::new(),
         }
     }
 
@@ -865,9 +868,9 @@ impl ProductionNativeRegistry {
         self.funcs.get(idx.0 as usize).copied()
     }
 
-    /// Returns the descriptor of the native registered at the specified index.
-    pub fn name_by_idx(&self, idx: NativeIdx) -> Option<&NativeDescriptor> {
-        self.descriptors.get(idx.0 as usize)
+    /// Returns the name of the native registered at the specified index.
+    pub fn name_by_idx(&self, idx: NativeIdx) -> Option<&NativeName> {
+        self.names.get(idx.0 as usize)
     }
 }
 
@@ -895,7 +898,7 @@ impl NativeResolver for ProductionNativeRegistry {
         let module = view_name(module_id.name());
         let function = view_name(function);
 
-        let query = NativeDescriptor {
+        let query = NativeName {
             address,
             module,
             function,
@@ -905,7 +908,7 @@ impl NativeResolver for ProductionNativeRegistry {
             return Some(*idx);
         }
         self.by_name
-            .get(&NativeDescriptor {
+            .get(&NativeName {
                 dispatch: Dispatch::Polymorphic,
                 ..query
             })

--- a/third_party/move/mono-move/testsuite/src/engine.rs
+++ b/third_party/move/mono-move/testsuite/src/engine.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Result};
 use mono_move_core::{
-    native::{NativeExtensions, NativeName, NoNatives},
+    native::{NativeExtensions, NoNatives},
     types::EMPTY_TYPE_LIST,
-    Function, GasMeter, Interner, NoResourceProvider,
+    Function, GasMeter, NoResourceProvider,
 };
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
@@ -19,7 +19,6 @@ use mono_move_natives::{
     make_all_bls12381_test_natives, make_all_ed25519_test_natives,
     make_all_multi_ed25519_test_natives, make_all_production_natives,
     make_all_ristretto255_scalar_test_natives, make_all_test_natives, make_all_unit_test_natives,
-    Dispatch,
 };
 use mono_move_runtime::{
     InterpreterContext, ProductionContextFamily, ProductionNativeRegistry, RuntimeStatus,
@@ -28,6 +27,7 @@ use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, vm_status::AbortLocation,
 };
 use specializer::ModuleIR;
+use std::sync::LazyLock;
 
 /// Gas budget for engine runs. Effectively unbounded.
 const GAS_BUDGET: u64 = u64::MAX;
@@ -116,38 +116,23 @@ impl<'guard> MonoRunner<'guard> {
 }
 
 /// Build the native registry mono-move executes against: the synthetic test
-/// natives plus the real production natives, keyed by interned name.
-pub fn build_natives(guard: &ExecutionGuard<'_>) -> ProductionNativeRegistry {
-    let mut natives = ProductionNativeRegistry::new();
-    natives
-        .register_all(
-            make_all_test_natives::<ProductionContextFamily>()
-                .into_iter()
-                .chain(make_all_unit_test_natives::<ProductionContextFamily>())
-                .chain(make_all_ed25519_test_natives::<ProductionContextFamily>())
-                .chain(make_all_multi_ed25519_test_natives::<ProductionContextFamily>())
-                .chain(make_all_bls12381_test_natives::<ProductionContextFamily>())
-                .chain(make_all_ristretto255_scalar_test_natives::<
-                    ProductionContextFamily,
-                >())
-                .chain(make_all_production_natives::<ProductionContextFamily>())
-                .map(|(addr, module, function, dispatch, func)| {
-                    let module = guard.module_id_of(&addr, &module);
-                    let function = guard.identifier_of(&function);
-                    let name = match dispatch {
-                        Dispatch::Polymorphic => NativeName::Polymorphic { module, function },
-                        Dispatch::Monomorphic(ty_args) => NativeName::Monomorphic {
-                            module,
-                            function,
-                            ty_args: guard.type_list_of(ty_args),
-                        },
-                    };
-                    (name, func)
-                }),
-        )
-        .expect("natives have unique qualified names");
-    natives
+/// natives plus the real production natives.
+pub fn build_natives() -> &'static ProductionNativeRegistry {
+    &ALL_NATIVES
 }
+
+static ALL_NATIVES: LazyLock<ProductionNativeRegistry> = LazyLock::new(|| {
+    let mut natives = make_all_test_natives::<ProductionContextFamily>();
+    natives.extend(make_all_unit_test_natives::<ProductionContextFamily>());
+    natives.extend(make_all_ed25519_test_natives::<ProductionContextFamily>());
+    natives.extend(make_all_multi_ed25519_test_natives::<ProductionContextFamily>());
+    natives.extend(make_all_bls12381_test_natives::<ProductionContextFamily>());
+    natives.extend(make_all_ristretto255_scalar_test_natives::<
+        ProductionContextFamily,
+    >());
+    natives.extend(make_all_production_natives::<ProductionContextFamily>());
+    ProductionNativeRegistry::with_natives(natives)
+});
 
 /// Build the loader/native/interpreter stack over an existing guard and module
 /// provider, install `extensions`, load `address::module_name::function_name`,
@@ -164,13 +149,13 @@ pub fn with_mono_function<'guard, 'ctx, R>(
     heap_size: Option<usize>,
     body: impl FnOnce(&mut MonoRunner<'_>) -> R,
 ) -> Result<R> {
-    let natives = build_natives(guard);
+    let natives = build_natives();
 
     let loader = Loader::new_with_policy(
         guard,
         module_provider,
         LoadingPolicy::Lazy(LoweringPolicy::Lazy),
-        &natives,
+        natives,
     );
 
     let id = guard
@@ -197,7 +182,7 @@ pub fn with_mono_function<'guard, 'ctx, R>(
             read_set,
             gas_meter,
             &NoResourceProvider,
-            &natives,
+            natives,
             function,
             n,
         ),
@@ -206,7 +191,7 @@ pub fn with_mono_function<'guard, 'ctx, R>(
             read_set,
             gas_meter,
             &NoResourceProvider,
-            &natives,
+            natives,
             function,
         ),
     }

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -60,7 +60,7 @@ pub fn run_package_unit_tests(
 
     let ctx = GlobalContext::with_num_execution_workers(1);
     let guard = ctx.try_execution_context(0).expect("worker 0 is free");
-    let natives = build_natives(&guard);
+    let natives = build_natives();
 
     let mut module_provider = InMemoryModuleProvider::new();
     for info in test_plan.module_info.values() {
@@ -76,7 +76,7 @@ pub fn run_package_unit_tests(
                 &guard,
                 &module_provider,
                 &resource_provider,
-                &natives,
+                natives,
                 module_id,
                 test,
             );

--- a/third_party/move/mono-move/testsuite/tests/function_def_idx.rs
+++ b/third_party/move/mono-move/testsuite/tests/function_def_idx.rs
@@ -95,16 +95,10 @@ fn def_idx_stamped_and_resolvable_by_name() {
 
 #[test]
 fn registry_name_by_idx_round_trips() {
-    let ctx = GlobalContext::with_num_execution_workers(1);
-    let guard = ctx
-        .try_execution_context(0)
-        .expect("worker 0 execution context must be available");
-    let natives = build_natives(&guard);
+    let natives = build_natives();
     assert!(!natives.is_empty());
     for raw_idx in 0..natives.len() as u32 {
-        let idx = NativeIdx(raw_idx);
-        let name = natives.name_by_idx(idx).expect("index in range");
-        assert!(natives.module_by_idx(idx) == Some(name.module()));
+        assert!(natives.name_by_idx(NativeIdx(raw_idx)).is_some());
     }
     assert!(natives
         .name_by_idx(NativeIdx(natives.len() as u32))


### PR DESCRIPTION
## Description

Stops rebuilding the MonoMove native registry per transaction and simplifies the
registry down to a small set of primitives.

Before, `production_natives` rebuilt the whole registry on every
`AptosTransactionExecutor`: it boxed ~46 closures, allocated and interned every
qualified name into the arena, and built a name-keyed map. Now the registry is a
process-wide static built once, and native functions are stored as raw `fn`
pointers instead of boxed closures.

Main changes:

- **Native functions are raw `fn` pointers.** `NativeFunction<F>` changes from
  `Box<dyn for<'a> Fn(..) + Send + Sync>` to
  `for<'a> fn(&<F as NativeContextFamily>::Of<'a>) -> VMResult<NativeStatus>`.
  Pointers are `Copy` and always `Send + Sync`, so dispatch is one indirection
  with no box chase or vtable, and the `+ Send + Sync` bound is gone. The 85
  native bodies are unchanged; the `native_entry!` macro bridges each to the
  higher-ranked fn pointer with a generic late-bound wrapper.

- **The production registry is a process-wide static.** `production_natives()`
  returns `&'static ProductionNativeRegistry`, built once via `LazyLock` from
  `make_all_production_natives`. No per-executor allocation or interning.

- **Registry primitives split by layering.** `mono-move-core` keeps only the
  family-independent pieces: `NativeIdx`, `NativeFunction`, `NativeResolver`,
  `NoNatives`, plus the new `Dispatch` and `NativeDescriptor`. The family-typed
  `ProductionNativeRegistry` (function table + descriptors + resolver) lives in
  `mono-move-runtime`, which can name `ProductionContextFamily`.

- **Resolver keys natives by `NativeDescriptor` directly.** The registry holds a
  `HashMap<NativeDescriptor, NativeIdx>`. Descriptor name parts are
  `&'static str` and monomorphic type arguments are canonical primitive
  constants, so a call site's arena-backed name and type list match a
  descriptor's literals by content and pointer identity. `resolve` builds a
  query descriptor from the viewed call parts and does two lookups: the
  monomorphic registration for this instantiation, then the polymorphic
  fallback.

- **Dead abstractions removed.** `NativeName`, the generic `NativeRegistry<F>`,
  `NativeRegistryError`, and the `shared_dsa` / `thiserror` uses in
  `registry.rs` are gone.

## How Has This Been Tested?

`cargo build` of the affected crates is clean.
`RUST_MIN_STACK=1073741824 cargo nextest run -p mono-move-runtime
-p mono-move-testsuite` — 694 tests run, 694 passed, 0 skipped. The differential
suite exercises native resolution and dispatch end to end.

## Key Areas to Review

- The `native_entry!` wrapper coercion to the higher-ranked `for<'a> fn(&F::Of<'a>)`
  pointer (`natives/src/lib.rs`).
- The by-descriptor resolver in `runtime/src/native_context.rs`: correctness of
  the monomorphic-then-polymorphic lookup and the assumption that viewed name
  parts / type-arg primitives match descriptor literals by content and pointer.

## Type of Change
- [x] Refactoring
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM native resolution and dispatch on every native call; incorrect monomorphic/polymorphic lookup or name matching would mis-route or fail transactions, though behavior is intended to be equivalent to the prior per-guard registry.
> 
> **Overview**
> MonoMove stops rebuilding the native function table on every transaction and instead exposes a **process-wide registry** built once (`LazyLock` in `production_natives()` / testsuite `build_natives()`). Call sites no longer pass an `ExecutionGuard` to intern names when registering natives.
> 
> **Native dispatch is refactored for static tables:** implementations are stored as higher-ranked **`fn` pointers** (via `native_entry!` wrappers) instead of boxed closures. `mono-move-core` keeps slim registry primitives (`NativeIdx`, `Dispatch`, `NativeName` with `&'static str` keys and static monomorphic type slices); the generic `NativeRegistry` and arena-keyed `NativeName` enum are removed. **`ProductionNativeRegistry`** (function table + name map + `NativeResolver`) lives in **`mono-move-runtime`**, with monomorphic-then-polymorphic lookup from call-site interned names.
> 
> Executors, benchmarks, and tests take `&'static ProductionNativeRegistry`. Native abort attribution uses static `NativeName` metadata (`native_abort_location`). Test-only native modules are behind `cfg(feature = "testing")`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4862f0a0a2f72f2935286634b81a253e8e65f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->