### PR TITLE
[jemalloc] Disable HPA for tool binaries

### DIFF
--- a/crates/aptos-debugger/src/main.rs
+++ b/crates/aptos-debugger/src/main.rs
@@ -8,7 +8,7 @@ use aptos_push_metrics::MetricsPusher;
 use clap::Parser;
 
 #[cfg(unix)]
-aptos_jemalloc::setup_jemalloc!();
+aptos_jemalloc::setup_jemalloc_for_tools!();
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/aptos-jemalloc/src/lib.rs
+++ b/crates/aptos-jemalloc/src/lib.rs
@@ -9,40 +9,71 @@ mod metrics;
 #[cfg(unix)]
 pub use metrics::start_jemalloc_metrics_thread;
 
-/// Sets up jemalloc as the global allocator and configures `malloc_conf`.
-///
-/// Invoke at the top level of a binary crate (`main.rs`).
-/// The configuration can be overridden at runtime via the `MALLOC_CONF` environment variable.
+/// Shared body of the `setup_jemalloc*` macros. `$hpa` is the only setting that
+/// differs between profiles; everything else is deliberately identical so the two
+/// cannot drift apart.
 ///
 /// Configuration notes:
 ///   - `prof:true,lg_prof_sample:23` -- Heap profiling with an 8 MiB sampling interval.
 ///   - `percpu_arena:percpu` -- Per-CPU arenas to reduce cross-thread contention.
 ///     Also the default arena count without this setting (4x #CPUs) can be a bit excessive.
-///   - `hpa:true,metadata_thp:auto` -- Use Huge Pages to reduce dTLB misses (ignored on macOS).
+///   - `hpa,metadata_thp:auto` -- Use Huge Pages to reduce dTLB misses (ignored on macOS).
 ///   - `background_thread:true,max_background_threads:4` -- Background purging threads.
 ///   - `dirty_decay_ms:30000,muzzy_decay_ms:120000` -- Longer decay trades RSS for
 ///     fewer `madvise` syscalls.
 ///   - `lg_tcache_max:16,tcache_nslots_large:32` -- 64 KiB thread-cache ceiling,
 ///     since 40 KiB allocations are very hot (as of 02/06/2026) in the node.
 #[macro_export]
-macro_rules! setup_jemalloc {
-    () => {
+#[doc(hidden)]
+macro_rules! __setup_jemalloc_with_hpa {
+    ($hpa:literal) => {
         #[cfg(unix)]
         #[global_allocator]
         static ALLOC: $crate::jemallocator::Jemalloc = $crate::jemallocator::Jemalloc;
 
+        // `concat!` yields a plain `str`, so the NUL terminator is added explicitly.
         #[allow(unsafe_code, non_upper_case_globals)]
         #[cfg(unix)]
         #[used]
         #[unsafe(no_mangle)]
-        pub static mut malloc_conf: *const ::std::ffi::c_char = c"\
-              prof:true,lg_prof_sample:23,\
-              percpu_arena:percpu,\
-              hpa:true,metadata_thp:auto,\
-              background_thread:true,max_background_threads:4,\
-              dirty_decay_ms:30000,muzzy_decay_ms:120000,\
-              lg_tcache_max:16,tcache_nslots_large:32"
-            .as_ptr()
-            .cast();
+        pub static mut malloc_conf: *const ::std::ffi::c_char = concat!(
+            "prof:true,lg_prof_sample:23,",
+            "percpu_arena:percpu,",
+            $hpa,
+            ",metadata_thp:auto,",
+            "background_thread:true,max_background_threads:4,",
+            "dirty_decay_ms:30000,muzzy_decay_ms:120000,",
+            "lg_tcache_max:16,tcache_nslots_large:32\0"
+        )
+        .as_ptr()
+        .cast();
+    };
+}
+
+/// Sets up jemalloc as the global allocator and configures `malloc_conf` for the node.
+///
+/// Invoke at the top level of a binary crate (`main.rs`).
+/// The configuration can be overridden at runtime via the `MALLOC_CONF` environment variable.
+///
+/// Enables the huge page allocator. Use [`setup_jemalloc_for_tools`] instead for anything
+/// that is not the node or a benchmark standing in for it.
+#[macro_export]
+macro_rules! setup_jemalloc {
+    () => {
+        $crate::__setup_jemalloc_with_hpa!("hpa:true");
+    };
+}
+
+/// Same as [`setup_jemalloc`], but with jemalloc's huge page allocator disabled.
+///
+/// HPA has livelocked in `hpa_shard_maybe_do_deferred_work` in tool workloads,
+/// pinning a core indefinitely. Use [`setup_jemalloc`] for the node and node-like
+/// benchmarks.
+///
+/// This may already be fixed in the latest jemalloc; retest HPA when upgrading.
+#[macro_export]
+macro_rules! setup_jemalloc_for_tools {
+    () => {
+        $crate::__setup_jemalloc_with_hpa!("hpa:false");
     };
 }

--- a/testsuite/smoke-test/src/workspace_builder.rs
+++ b/testsuite/smoke-test/src/workspace_builder.rs
@@ -77,14 +77,8 @@ fn build_dir() -> PathBuf {
 }
 
 // Returns a `Command` for invoking the `aptos-debugger` binary.
-//
-// Sets `MALLOC_CONF=hpa:false` on the child to work around a jemalloc HPA deadlock that hangs the
-// subprocess on exit under concurrent load. All smoke-test call sites that spawn `aptos-debugger`
-// should use this helper.
 pub fn get_aptos_debugger_command() -> Command {
-    let mut cmd = Command::new(get_bin("aptos-debugger"));
-    cmd.env("MALLOC_CONF", "hpa:false");
-    cmd
+    Command::new(get_bin("aptos-debugger"))
 }
 
 // Path to a specified binary


### PR DESCRIPTION

Add a tool-specific allocator profile that disables HPA to avoid known livelocks while preserving HPA for the node and node-like benchmarks. Apply it to aptos-debugger so all invocations are protected without smoke-test-specific environment overrides.

The livelock occasionally causes things like backup tools to hang and triggers alerts to fire.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Allocator tuning for non-node binaries only; node behavior is unchanged and the change targets a known HPA livelock in tools.
> 
> **Overview**
> Introduces a **tool allocator profile** that keeps the same jemalloc `malloc_conf` as the node except **`hpa:false`**, via a shared internal macro so the two profiles cannot drift.
> 
> **`aptos-debugger`** now calls `setup_jemalloc_for_tools!()` instead of the node macro, so HPA stays off for every debugger run without test harness workarounds. **`setup_jemalloc!()`** still enables HPA for **`aptos-node`** and node-like benchmarks.
> 
> Smoke tests drop the **`MALLOC_CONF=hpa:false`** override in `get_aptos_debugger_command()` because the binary bakes in the safe profile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc46f328e2b43811c9e94673145b50120c5e7840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->