### PR TITLE
[mono-move] Simplify MonoMove integration

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -178,6 +178,7 @@ pub enum FeatureFlag {
     FunctionValueDispatch,
     DisableClosureBcsSerialization,
     LazyModuleInitialization,
+    EnableMonoMove,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -463,6 +464,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::DISABLE_CLOSURE_BCS_SERIALIZATION
             },
             FeatureFlag::LazyModuleInitialization => AptosFeatureFlag::LAZY_MODULE_INITIALIZATION,
+            FeatureFlag::EnableMonoMove => AptosFeatureFlag::ENABLE_MONO_MOVE,
         }
     }
 }
@@ -675,6 +677,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::DisableClosureBcsSerialization
             },
             AptosFeatureFlag::LAZY_MODULE_INITIALIZATION => FeatureFlag::LazyModuleInitialization,
+            AptosFeatureFlag::ENABLE_MONO_MOVE => FeatureFlag::EnableMonoMove,
         }
     }
 }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -3454,6 +3454,26 @@ pub struct AptosVMBlockExecutor {
 }
 
 impl AptosVMBlockExecutor {
+    /// Builds the local execution config from process-global VM settings.
+    fn default_local_config() -> BlockExecutorLocalConfig {
+        BlockExecutorLocalConfig {
+            blockstm_v2: AptosVM::get_blockstm_v2_enabled(),
+            concurrency_level: AptosVM::get_concurrency_level(),
+            allow_fallback: true,
+            discard_failed_blocks: AptosVM::get_discard_failed_blocks(),
+            module_cache_config: BlockExecutorModuleCacheLocalConfig::default(),
+            enable_pre_write: AptosVM::get_enable_pre_write(),
+        }
+    }
+
+    /// Creates a new block executor whose blocks run with the given local config
+    /// instead of the process-global VM settings.
+    pub fn new_with_local_config(local_config: BlockExecutorLocalConfig) -> Self {
+        Self {
+            module_cache_manager: AptosModuleCacheManager::new(local_config),
+        }
+    }
+
     /// Executes transactions with the specified [BlockExecutorConfig] and returns output for each
     /// one of them.
     pub fn execute_block_with_config(
@@ -3499,9 +3519,7 @@ impl AptosVMBlockExecutor {
 
 impl VMBlockExecutor for AptosVMBlockExecutor {
     fn new() -> Self {
-        Self {
-            module_cache_manager: AptosModuleCacheManager::new(),
-        }
+        Self::new_with_local_config(Self::default_local_config())
     }
 
     fn execute_block(
@@ -3512,14 +3530,7 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> BlockExecutionResult<SignatureVerifiedTransaction, TransactionOutput> {
         let config = BlockExecutorConfig {
-            local: BlockExecutorLocalConfig {
-                blockstm_v2: AptosVM::get_blockstm_v2_enabled(),
-                concurrency_level: AptosVM::get_concurrency_level(),
-                allow_fallback: true,
-                discard_failed_blocks: AptosVM::get_discard_failed_blocks(),
-                module_cache_config: BlockExecutorModuleCacheLocalConfig::default(),
-                enable_pre_write: AptosVM::get_enable_pre_write(),
-            },
+            local: self.module_cache_manager.local_config().clone(),
             onchain: onchain_config,
         };
         self.execute_block_with_config(txn_provider, state_view, config, transaction_slice_metadata)

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -421,11 +421,7 @@ impl<
         BLOCK_EXECUTOR_CONCURRENCY.set(config.local.concurrency_level as i64);
 
         let mut module_cache_manager_guard = module_cache_manager
-            .try_lock(
-                &state_view,
-                &config.local.module_cache_config,
-                transaction_slice_metadata,
-            )
+            .try_lock(&state_view, transaction_slice_metadata)
             .map_err(|status| BlockError::new(status.to_string()))?;
 
         let executor = BlockExecutor::<

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -147,7 +147,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                     aggr_overridden_state_view.as_ref(),
                     // Since we execute blocks in parallel, we cannot share module caches, so each
                     // thread has its own caches.
-                    &AptosModuleCacheManager::new(),
+                    &AptosModuleCacheManager::new(config.local.clone()),
                     config,
                     TransactionSliceMetadata::unknown(),
                     cross_shard_commit_sender,

--- a/aptos-move/block-executor/src/code_cache_global_manager.rs
+++ b/aptos-move/block-executor/src/code_cache_global_manager.rs
@@ -12,7 +12,7 @@ use crate::{
 use aptos_gas_schedule::gas_feature_versions::RELEASE_V1_34;
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorModuleCacheLocalConfig,
+        config::{BlockExecutorLocalConfig, BlockExecutorModuleCacheLocalConfig},
         transaction_slice_metadata::TransactionSliceMetadata,
     },
     error::PanicError,
@@ -178,16 +178,25 @@ where
 /// Module cache manager used by Aptos block executor. Ensures that only one thread has exclusive
 /// access to it at a time.
 pub struct AptosModuleCacheManager {
+    /// Local execution config bound to this manager. Block executors that own the
+    /// manager read it instead of process-global settings.
+    local_config: BlockExecutorLocalConfig,
     inner: Mutex<ModuleCacheManager<ModuleId, CompiledModule, Module, AptosModuleExtension>>,
 }
 
 impl AptosModuleCacheManager {
-    /// Returns a new manager in its default (empty) state.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    /// Returns a new manager in its default (empty) state, bound to the given
+    /// local execution config.
+    pub fn new(local_config: BlockExecutorLocalConfig) -> Self {
         Self {
+            local_config,
             inner: Mutex::new(ModuleCacheManager::new()),
         }
+    }
+
+    /// Returns the local execution config bound to this manager.
+    pub fn local_config(&self) -> &BlockExecutorLocalConfig {
+        &self.local_config
     }
 
     /// Tries to lock the manager. If succeeds, checks if the manager (caches, environment, etc.)
@@ -196,7 +205,6 @@ impl AptosModuleCacheManager {
     fn try_lock_inner(
         &self,
         state_view: &impl StateView,
-        config: &BlockExecutorModuleCacheLocalConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<AptosModuleCacheManagerGuard<'_>, VMStatus> {
         // Get the current environment from storage.
@@ -205,7 +213,11 @@ impl AptosModuleCacheManager {
 
         Ok(match self.inner.try_lock() {
             Some(mut guard) => {
-                guard.check_ready(storage_environment, config, transaction_slice_metadata)?;
+                guard.check_ready(
+                    storage_environment,
+                    &self.local_config.module_cache_config,
+                    transaction_slice_metadata,
+                )?;
                 AptosModuleCacheManagerGuard::Guard { guard }
             },
             None => {
@@ -226,15 +238,19 @@ impl AptosModuleCacheManager {
     pub fn try_lock(
         &self,
         state_view: &impl StateView,
-        config: &BlockExecutorModuleCacheLocalConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<AptosModuleCacheManagerGuard<'_>, VMStatus> {
-        let mut guard = self.try_lock_inner(state_view, config, transaction_slice_metadata)?;
+        let mut guard = self.try_lock_inner(state_view, transaction_slice_metadata)?;
 
         // To avoid cold starts, fetch the framework code. This ensures the state with 0 modules
         // cached is not possible for block execution (as long as the config enables the framework
         // prefetch).
-        if guard.module_cache().num_modules() == 0 && config.prefetch_framework_code {
+        if guard.module_cache().num_modules() == 0
+            && self
+                .local_config
+                .module_cache_config
+                .prefetch_framework_code
+        {
             prefetch_aptos_framework(state_view, &mut guard).map_err(|err| {
                 alert_or_println!("Failed to load Aptos framework to module cache: {:?}", err);
                 VMError::from(err).into_vm_status()
@@ -847,22 +863,22 @@ mod test {
 
     #[test]
     fn test_try_lock_inner_single_thread() {
-        let manager = AptosModuleCacheManager::new();
+        let manager = AptosModuleCacheManager::new(BlockExecutorLocalConfig::default());
 
         let state_view = MockStateView::empty();
-        let config = BlockExecutorModuleCacheLocalConfig::default();
         let metadata = TransactionSliceMetadata::block_from_u64(0, 1);
 
-        let guard = assert_ok!(manager.try_lock(&state_view, &config, metadata));
+        let guard = assert_ok!(manager.try_lock(&state_view, metadata));
         assert!(matches!(guard, AptosModuleCacheManagerGuard::Guard { .. }));
     }
 
     #[test]
     fn test_try_lock_inner_multiple_threads() {
-        let manager = Arc::new(AptosModuleCacheManager::new());
+        let manager = Arc::new(AptosModuleCacheManager::new(
+            BlockExecutorLocalConfig::default(),
+        ));
 
         let state_view = Arc::new(MockStateView::empty());
-        let config = Arc::new(BlockExecutorModuleCacheLocalConfig::default());
         let metadata = TransactionSliceMetadata::block_from_u64(0, 1);
 
         let counter = Arc::new(AtomicU64::new(0));
@@ -873,11 +889,10 @@ mod test {
             let handle = std::thread::spawn({
                 let manager = manager.clone();
                 let state_view = state_view.clone();
-                let config = config.clone();
                 let counter = counter.clone();
 
                 move || {
-                    let guard = assert_ok!(manager.try_lock_inner(&state_view, &config, metadata));
+                    let guard = assert_ok!(manager.try_lock_inner(&state_view, metadata));
 
                     // Wait for all threads to complete.
                     counter.fetch_add(1, Ordering::SeqCst);

--- a/aptos-move/e2e-move-tests/src/tests/serialize_effects_determinism.rs
+++ b/aptos-move/e2e-move-tests/src/tests/serialize_effects_determinism.rs
@@ -14,7 +14,8 @@ use aptos_package_builder::PackageBuilder;
 use aptos_types::{
     account_address::AccountAddress,
     block_executor::{
-        config::BlockExecutorConfig, transaction_slice_metadata::TransactionSliceMetadata,
+        config::{BlockExecutorConfig, BlockExecutorLocalConfig},
+        transaction_slice_metadata::TransactionSliceMetadata,
     },
     state_store::StateView,
     transaction::{
@@ -147,7 +148,7 @@ fn execute_block(
 #[test]
 fn cold_vs_warm_status_matches() {
     let (mut h, acc) = setup();
-    let manager = AptosModuleCacheManager::new();
+    let manager = AptosModuleCacheManager::new(BlockExecutorLocalConfig::default());
 
     // Block 1: Runs a transaction to warm up the cache.
     let sender = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
@@ -176,7 +177,7 @@ fn cold_vs_warm_status_matches() {
     let cold = execute_block(
         target,
         h.executor.get_state_view(),
-        &AptosModuleCacheManager::new(),
+        &AptosModuleCacheManager::new(BlockExecutorLocalConfig::default()),
         2,
         3,
     );

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -877,7 +877,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
                 &txn_provider,
                 &state_view,
                 self.module_cache_manager_opt()
-                    .unwrap_or(&AptosModuleCacheManager::new()),
+                    .unwrap_or(&AptosModuleCacheManager::new(config.local.clone())),
                 config,
                 metadata,
                 None,
@@ -924,15 +924,11 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     fn maybe_snapshot_hot_cache(
         &self,
         state_view: &(impl StateView + Sync),
-        local_cfg: &BlockExecutorModuleCacheLocalConfig,
         metadata: TransactionSliceMetadata,
     ) -> Option<ModuleHotCacheSnapshot> {
         match &self.block_state {
             BlockState::Fuzzing(shared) => {
-                let mut guard = shared
-                    .manager
-                    .try_lock(state_view, local_cfg, metadata)
-                    .unwrap();
+                let mut guard = shared.manager.try_lock(state_view, metadata).unwrap();
                 Some(guard.snapshot_hot_cache())
             },
             BlockState::None => None,
@@ -943,16 +939,12 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     fn maybe_rollback_hot_cache(
         &self,
         state_view: &(impl StateView + Sync),
-        local_cfg: &BlockExecutorModuleCacheLocalConfig,
         metadata: TransactionSliceMetadata,
         snapshot: Option<ModuleHotCacheSnapshot>,
     ) {
         if let Some(s) = snapshot {
             if let BlockState::Fuzzing(shared) = &self.block_state {
-                let mut guard = shared
-                    .manager
-                    .try_lock(state_view, local_cfg, metadata)
-                    .unwrap();
+                let mut guard = shared.manager.try_lock(state_view, metadata).unwrap();
                 guard.rollback_hot_cache(s);
             }
         }
@@ -1026,11 +1018,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         #[cfg(fuzzing)]
         {
             if mode == ExecutorMode::BothComparison {
-                snapshot = self.maybe_snapshot_hot_cache(
-                    state_view,
-                    &config.local.module_cache_config,
-                    metadata,
-                );
+                snapshot = self.maybe_snapshot_hot_cache(state_view, metadata);
                 assert!(
                     snapshot.is_some(),
                     "snapshot should be Some if mode is BothComparison"
@@ -1051,12 +1039,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         #[cfg(fuzzing)]
         {
             if mode == ExecutorMode::BothComparison {
-                self.maybe_rollback_hot_cache(
-                    state_view,
-                    &config.local.module_cache_config,
-                    metadata,
-                    snapshot.take(),
-                );
+                self.maybe_rollback_hot_cache(state_view, metadata, snapshot.take());
             }
         }
 

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -87,6 +87,13 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, BlockError> {
+        let local_config = BlockExecutorLocalConfig {
+            concurrency_level: NativeConfig::get_concurrency_level(),
+            enable_pre_write: false,
+            ..BlockExecutorLocalConfig::default_with_concurrency_level(
+                NativeConfig::get_concurrency_level(),
+            )
+        };
         AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block::<
             _,
             NoOpTransactionCommitHook<VMStatus>,
@@ -94,15 +101,9 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
         >(
             txn_provider,
             state_view,
-            &AptosModuleCacheManager::new(),
+            &AptosModuleCacheManager::new(local_config.clone()),
             BlockExecutorConfig {
-                local: BlockExecutorLocalConfig {
-                    concurrency_level: NativeConfig::get_concurrency_level(),
-                    enable_pre_write: false,
-                    ..BlockExecutorLocalConfig::default_with_concurrency_level(
-                        NativeConfig::get_concurrency_level(),
-                    )
-                },
+                local: local_config,
                 onchain: onchain_config,
             },
             transaction_slice_metadata,

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
@@ -7,6 +7,7 @@ use aptos_block_executor::code_cache_global_manager::AptosModuleCacheManager;
 use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
 use aptos_transaction_simulation::GENESIS_CHANGE_SET_HEAD;
 use aptos_types::{
+    block_executor::config::BlockExecutorLocalConfig,
     chain_id::ChainId,
     on_chain_config::{Features, TimedFeaturesBuilder},
     transaction::{
@@ -127,7 +128,9 @@ fn run_case(input: RunnableStateWithOperations) -> Result<(), Corpus> {
     // Enable runtime reference-safety checks for the Move VM
     // prod_configs::set_paranoid_ref_checks(true);
 
-    let module_cache_manager = AptosModuleCacheManager::new();
+    let module_cache_manager = AptosModuleCacheManager::new(
+        BlockExecutorLocalConfig::default_with_concurrency_level(FUZZER_CONCURRENCY_LEVEL),
+    );
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
     let mut vm = FakeExecutor::from_genesis_with_module_cache_manager(
         &VM_WRITE_SET,

--- a/third_party/move/mono-move/alloc/src/global_arena.rs
+++ b/third_party/move/mono-move/alloc/src/global_arena.rs
@@ -119,16 +119,9 @@ impl GlobalArenaPool {
     }
 
     /// Creates the specified number of arenas in the pool, each with the
-    /// specified capacity.
-    ///
-    /// # Panics
-    ///
-    /// - If number of arenas is zero, or larger than 128.
+    /// specified capacity. The number of arenas is clamped to at least 1.
     pub fn with_capacity_and_num_arenas(arena_capacity: usize, num_arenas: usize) -> Self {
-        // Number of arenas is ~ number of working threads. Upper bound by 128
-        // is good enough to accommodate most of the CPUs.
-        assert!(num_arenas > 0);
-        assert!(num_arenas <= 128);
+        let num_arenas = num_arenas.max(1);
 
         let arenas = (0..num_arenas)
             .map(|_| CachePadded::new(Mutex::new(Bump::with_capacity(arena_capacity))))

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -319,35 +319,20 @@ pub struct ArenaRef<'guard, T: ?Sized> {
 
 impl GlobalContext {
     /// Creates a new global context with the specified number of workers that
-    /// can acquire [`ExecutionGuard`] and default maintenance config.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of workers is 0, greater than 128 or is not a
-    /// power of two.
+    /// can acquire [`ExecutionGuard`] and default maintenance config. The number
+    /// of workers is clamped to at least 1.
     pub fn with_num_execution_workers(num_workers: usize) -> Self {
         Self::with_num_execution_workers_and_config(num_workers, MaintenanceConfig::default())
     }
 
     /// Creates a new global context with the specified number of execution
     /// workers that can acquire [`ExecutionGuard`] and the maintenance config.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of workers is 0, greater than 128 or is not a
-    /// power of two.
+    /// The number of workers is clamped to at least 1.
     pub fn with_num_execution_workers_and_config(
         num_workers: usize,
         maintenance_config: MaintenanceConfig,
     ) -> Self {
-        assert!(
-            num_workers > 0 && num_workers <= 128,
-            "Number of workers must be between 1 and 128, got {num_workers}"
-        );
-        assert!(
-            num_workers.is_power_of_two(),
-            "Number of workers must be a power of two, got {num_workers}"
-        );
+        let num_workers = num_workers.max(1);
 
         Self {
             ctx: Context {

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -64,6 +64,12 @@ pub struct BlockExecutorLocalConfig {
     pub enable_pre_write: bool,
 }
 
+impl Default for BlockExecutorLocalConfig {
+    fn default() -> Self {
+        Self::default_with_concurrency_level(1)
+    }
+}
+
 impl BlockExecutorLocalConfig {
     /// Returns a new config with specified concurrency level and:
     ///   - Allowed fallback to sequential execution from parallel.

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -225,6 +225,8 @@ pub enum FeatureFlag {
     /// (a module self-initializes on first use rather than via a genesis-time `init_module`).
     /// While disabled, that entry point aborts.
     LAZY_MODULE_INITIALIZATION = 127,
+    /// When enabled, new MonoMove VM is used for execution instead of the V1 Move VM.
+    ENABLE_MONO_MOVE = 128,
 }
 
 impl FeatureFlag {
@@ -588,6 +590,10 @@ impl Features {
 
     pub fn is_closure_bcs_serialization_disabled(&self) -> bool {
         self.is_enabled(FeatureFlag::DISABLE_CLOSURE_BCS_SERIALIZATION)
+    }
+
+    pub fn is_mono_move_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::ENABLE_MONO_MOVE)
     }
 
     pub fn get_max_identifier_size(&self) -> u64 {


### PR DESCRIPTION
## Description

Groundwork for wiring the MonoMove VM into block execution. Two independent changes:

**Feature flag.** Adds `ENABLE_MONO_MOVE = 128` with an `is_mono_move_enabled()` accessor and wires it through the release builder (both mapping directions plus the `EnableMonoMove` enum variant). When enabled, the new MonoMove VM will be used for execution instead of the V1 Move VM.

**Config bound to the executor.** Binds the local execution config to `AptosModuleCacheManager` at construction. The manager now stores a `BlockExecutorLocalConfig` and exposes it, so `AptosVMBlockExecutor` reads the concurrency level and other local settings from the manager instead of rebuilding them from process-global `AptosVM::get_*` settings on every block. Adds `AptosVMBlockExecutor::new_with_local_config` so a block executor can run with an explicit config (e.g. a chosen number of workers). `AptosModuleCacheManager::try_lock` no longer takes a module cache config argument, pulling it from the stored config. This gives `AptosModuleCacheManager` a home for the future MonoMove global context.

**Context panics removed.** `GlobalContext::with_num_execution_workers[_and_config]` and `GlobalArenaPool::with_capacity_and_num_arenas` no longer assert on the worker/arena count (power-of-two, upper bound of 128). They now clamp to at least 1.

## How Has This Been Tested?

- `cargo check` passes for `aptos-vm`, `aptos-block-executor`, `aptos-language-e2e-tests`, and the affected fuzz target.
- Existing tests updated for the new `AptosModuleCacheManager::new(local_config)` signature.

## Key Areas to Review

- `try_lock` now derives `module_cache_config` from the manager's stored `local_config` rather than the per-call config passed to the wrapper. In every current path the two share the same source, so there is no observable change; it only diverges if `execute_block_with_config` is called with a `module_cache_config` different from what the manager was constructed with.

## Type of Change
- [x] New feature
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes block-executor configuration plumbing (manager-bound local config vs per-call overrides) ahead of a gated VM swap; behavior should match current paths unless `execute_block_with_config` disagrees with the manager’s stored config.
> 
> **Overview**
> Prepares MonoMove integration by adding an on-chain **`ENABLE_MONO_MOVE`** feature flag (with release-builder mappings and `is_mono_move_enabled()`) for a future switch from the V1 Move VM to MonoMove; the diff does not yet route execution through MonoMove.
> 
> **Block executor config** is now owned by **`AptosModuleCacheManager`**: construction takes a `BlockExecutorLocalConfig`, `try_lock` reads module-cache settings from that stored config (no per-call override), and **`AptosVMBlockExecutor::new_with_local_config`** lets callers run blocks with explicit local settings instead of rebuilding from process-global `AptosVM::get_*` on every block. Default `VMBlockExecutor::new()` still mirrors today’s globals via `default_local_config()`.
> 
> MonoMove **`GlobalContext`** and **`GlobalArenaPool`** stop panicking on invalid worker/arena counts and clamp to at least 1. **`BlockExecutorLocalConfig`** gains a `Default` impl; tests, e2e harness, sharded executor, benchmarks, and fuzz targets are updated for `AptosModuleCacheManager::new(local_config)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44b93acf78d58baee8d0ed7546315433a97edef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->