### PR TITLE
[mono-move] Add MonoMove context to block executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "fail",
  "hashbrown 0.14.3",
  "itertools 0.13.0",
+ "mono-move-global-context",
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -9,7 +9,7 @@ use aptos_rest_client::Client;
 use aptos_types::{
     account_address::AccountAddress,
     block_executor::{
-        config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
+        config::{BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
         transaction_slice_metadata::TransactionSliceMetadata,
     },
     contract_event::ContractEvent,
@@ -546,15 +546,13 @@ fn execute_block_no_limit(
     state_view: &DebuggerStateView,
     concurrency_level: usize,
 ) -> Result<Vec<TransactionOutput>, BlockError> {
-    let executor = AptosVMBlockExecutor::new();
+    let local_config = BlockExecutorLocalConfig::default_with_concurrency_level(concurrency_level);
+    let executor = AptosVMBlockExecutor::new_with_local_config(local_config);
     executor
-        .execute_block_with_config(
+        .execute_block(
             txn_provider,
             state_view,
-            BlockExecutorConfig {
-                local: BlockExecutorLocalConfig::default_with_concurrency_level(concurrency_level),
-                onchain: BlockExecutorConfigFromOnchain::new_no_block_limit(), // TODO(HotState): will need to incorporate some features.
-            },
+            BlockExecutorConfigFromOnchain::new_no_block_limit(), // TODO(HotState): will need to incorporate some features.
             TransactionSliceMetadata::unknown(),
         )
         .map(BlockOutput::into_transaction_outputs_forced)

--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -210,12 +210,13 @@ where
         let block_size = txn_provider.num_txns();
         let timer = Instant::now();
 
-        let executor = AptosVMBlockExecutor::new();
+        let config = BlockExecutorConfig::new_maybe_block_limit(1, maybe_block_gas_limit);
+        let executor = AptosVMBlockExecutor::new_with_local_config(config.local);
         let output = executor
-            .execute_block_with_config(
+            .execute_block(
                 txn_provider,
                 self.state_view.as_ref(),
-                BlockExecutorConfig::new_maybe_block_limit(1, maybe_block_gas_limit),
+                config.onchain,
                 TransactionSliceMetadata::unknown(),
             )
             .expect("Sequential block execution should succeed")
@@ -259,15 +260,14 @@ where
         let block_size = txn_provider.num_txns();
         let timer = Instant::now();
 
-        let executor = AptosVMBlockExecutor::new();
+        let config =
+            BlockExecutorConfig::new_maybe_block_limit(concurrency_level, maybe_block_gas_limit);
+        let executor = AptosVMBlockExecutor::new_with_local_config(config.local);
         let output = executor
-            .execute_block_with_config(
+            .execute_block(
                 txn_provider,
                 self.state_view.as_ref(),
-                BlockExecutorConfig::new_maybe_block_limit(
-                    concurrency_level,
-                    maybe_block_gas_limit,
-                ),
+                config.onchain,
                 TransactionSliceMetadata::unknown(),
             )
             .expect("Parallel block execution should succeed")

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -3474,13 +3474,13 @@ impl AptosVMBlockExecutor {
         }
     }
 
-    /// Executes transactions with the specified [BlockExecutorConfig] and returns output for each
+    /// Executes transactions with the specified onchain config and returns output for each
     /// one of them.
-    pub fn execute_block_with_config(
+    fn execute_block_with_config(
         &self,
         txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo>,
         state_view: &(impl StateView + Sync),
-        config: BlockExecutorConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> BlockExecutionResult<SignatureVerifiedTransaction, TransactionOutput> {
         fail_point!("aptos_vm_block_executor::execute_block_with_config", |_| {
@@ -3505,7 +3505,10 @@ impl AptosVMBlockExecutor {
             txn_provider,
             state_view,
             &self.module_cache_manager,
-            config,
+            BlockExecutorConfig {
+                local: self.module_cache_manager.local_config().clone(),
+                onchain: onchain_config,
+            },
             transaction_slice_metadata,
             None,
         );
@@ -3529,11 +3532,12 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> BlockExecutionResult<SignatureVerifiedTransaction, TransactionOutput> {
-        let config = BlockExecutorConfig {
-            local: self.module_cache_manager.local_config().clone(),
-            onchain: onchain_config,
-        };
-        self.execute_block_with_config(txn_provider, state_view, config, transaction_slice_metadata)
+        self.execute_block_with_config(
+            txn_provider,
+            state_view,
+            onchain_config,
+            transaction_slice_metadata,
+        )
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, C: ExecutorClient<S>>(

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -42,6 +42,7 @@ dashmap = { workspace = true }
 derivative = { workspace = true }
 fail = { workspace = true }
 hashbrown = { workspace = true }
+mono-move-global-context = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-runtime = { workspace = true }

--- a/aptos-move/block-executor/src/code_cache_global_manager.rs
+++ b/aptos-move/block-executor/src/code_cache_global_manager.rs
@@ -22,6 +22,7 @@ use aptos_types::{
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_types::module_and_script_storage::AsAptosCodeStorage;
 use cfg_if::cfg_if;
+use mono_move_global_context::GlobalContext;
 use move_binary_format::{
     errors::{Location, VMError},
     CompiledModule,
@@ -181,16 +182,29 @@ pub struct AptosModuleCacheManager {
     /// Local execution config bound to this manager. Block executors that own the
     /// manager read it instead of process-global settings.
     local_config: BlockExecutorLocalConfig,
-    inner: Mutex<ModuleCacheManager<ModuleId, CompiledModule, Module, AptosModuleExtension>>,
+    /// MonoMove global context, shared with workers by cloning the `Arc`.
+    global_context: Arc<GlobalContext>,
+
+    /// **Used for V1 Move VM execution only.**
+    ///
+    /// Manages module and module-derived (types, etc.) cached information.
+    ///
+    /// TODO(cleanup): rename legacy / V1 data structures once everything is connected.
+    legacy_module_cache_manager:
+        Mutex<ModuleCacheManager<ModuleId, CompiledModule, Module, AptosModuleExtension>>,
 }
 
 impl AptosModuleCacheManager {
     /// Returns a new manager in its default (empty) state, bound to the given
     /// local execution config.
     pub fn new(local_config: BlockExecutorLocalConfig) -> Self {
+        let global_context = Arc::new(GlobalContext::with_num_execution_workers(
+            local_config.concurrency_level,
+        ));
         Self {
             local_config,
-            inner: Mutex::new(ModuleCacheManager::new()),
+            legacy_module_cache_manager: Mutex::new(ModuleCacheManager::new()),
+            global_context,
         }
     }
 
@@ -211,14 +225,17 @@ impl AptosModuleCacheManager {
         let storage_environment =
             AptosEnvironment::new_with_delayed_field_optimization_enabled(&state_view);
 
-        Ok(match self.inner.try_lock() {
+        Ok(match self.legacy_module_cache_manager.try_lock() {
             Some(mut guard) => {
                 guard.check_ready(
                     storage_environment,
                     &self.local_config.module_cache_config,
                     transaction_slice_metadata,
                 )?;
-                AptosModuleCacheManagerGuard::Guard { guard }
+                AptosModuleCacheManagerGuard::Guard {
+                    guard,
+                    global_context: self.global_context.clone(),
+                }
             },
             None => {
                 alert_or_println!("Locking module cache manager failed, fallback to empty caches");
@@ -228,6 +245,9 @@ impl AptosModuleCacheManager {
                 AptosModuleCacheManagerGuard::None {
                     environment: storage_environment,
                     module_cache: GlobalModuleCache::empty(),
+                    global_context: Arc::new(GlobalContext::with_num_execution_workers(
+                        self.local_config.concurrency_level,
+                    )),
                 }
             },
         })
@@ -242,10 +262,15 @@ impl AptosModuleCacheManager {
     ) -> Result<AptosModuleCacheManagerGuard<'_>, VMStatus> {
         let mut guard = self.try_lock_inner(state_view, transaction_slice_metadata)?;
 
+        // MonoMove uses its own code cache, so the legacy framework prefetch does not apply.
+        // TODO(completeness): prefetch framework for MonoMove into cache.
+        let mono_move_enabled = guard.environment().features().is_mono_move_enabled();
+
         // To avoid cold starts, fetch the framework code. This ensures the state with 0 modules
         // cached is not possible for block execution (as long as the config enables the framework
         // prefetch).
-        if guard.module_cache().num_modules() == 0
+        if !mono_move_enabled
+            && guard.module_cache().num_modules() == 0
             && self
                 .local_config
                 .module_cache_config
@@ -270,20 +295,22 @@ pub enum AptosModuleCacheManagerGuard<'a> {
             'a,
             ModuleCacheManager<ModuleId, CompiledModule, Module, AptosModuleExtension>,
         >,
+        global_context: Arc<GlobalContext>,
     },
     /// Either there is no [AptosModuleCacheManager], or acquiring the lock for it failed.
     None {
         environment: AptosEnvironment,
         module_cache: GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension>,
+        global_context: Arc<GlobalContext>,
     },
 }
 
-impl AptosModuleCacheManagerGuard<'_> {
+impl<'a> AptosModuleCacheManagerGuard<'a> {
     /// Returns the references to the environment. If environment is not set, panics.
     pub fn environment(&self) -> &AptosEnvironment {
         use AptosModuleCacheManagerGuard::*;
         match self {
-            Guard { guard } => guard
+            Guard { guard, .. } => guard
                 .environment
                 .as_ref()
                 .expect("Guard always has environment set"),
@@ -297,8 +324,18 @@ impl AptosModuleCacheManagerGuard<'_> {
     ) -> &GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension> {
         use AptosModuleCacheManagerGuard::*;
         match self {
-            Guard { guard } => &guard.module_cache,
+            Guard { guard, .. } => &guard.module_cache,
             None { module_cache, .. } => module_cache,
+        }
+    }
+
+    /// A shared handle to the MonoMove global context for this block. Cloned per
+    /// worker; the executor owns its clone, so no borrow of the guard is held.
+    pub fn global_context(&self) -> Arc<GlobalContext> {
+        use AptosModuleCacheManagerGuard::*;
+        match self {
+            Guard { global_context, .. } => global_context.clone(),
+            None { global_context, .. } => global_context.clone(),
         }
     }
 
@@ -308,7 +345,7 @@ impl AptosModuleCacheManagerGuard<'_> {
     ) -> &mut GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension> {
         use AptosModuleCacheManagerGuard::*;
         match self {
-            Guard { guard } => &mut guard.module_cache,
+            Guard { guard, .. } => &mut guard.module_cache,
             None { module_cache, .. } => module_cache,
         }
     }
@@ -328,6 +365,7 @@ impl AptosModuleCacheManagerGuard<'_> {
         AptosModuleCacheManagerGuard::None {
             environment: AptosEnvironment::new(state_view),
             module_cache: GlobalModuleCache::empty(),
+            global_context: Arc::new(GlobalContext::with_num_execution_workers(1)),
         }
     }
 
@@ -339,6 +377,7 @@ impl AptosModuleCacheManagerGuard<'_> {
         AptosModuleCacheManagerGuard::None {
             environment: AptosEnvironment::new_with_delayed_field_optimization_enabled(state_view),
             module_cache: GlobalModuleCache::empty(),
+            global_context: Arc::new(GlobalContext::with_num_execution_workers(1)),
         }
     }
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -936,7 +936,7 @@ where
         num_workers: usize,
         runtime_environment: &RuntimeEnvironment,
         scheduler: SchedulerWrapper,
-        shared_sync_params: &SharedSyncParams<T, E, S>,
+        shared_sync_params: &SharedSyncParams<'_, T, E, S>,
     ) -> Result<(), PanicOr<ParallelBlockExecutionError>> {
         let versioned_cache = shared_sync_params.versioned_cache;
         let last_input_output = shared_sync_params.last_input_output;
@@ -1012,7 +1012,7 @@ where
         scheduler: SchedulerWrapper,
         environment: &AptosEnvironment,
         executor: &E,
-        shared_sync_params: &SharedSyncParams<T, E, S>,
+        shared_sync_params: &SharedSyncParams<'_, T, E, S>,
     ) -> Result<CommittedOutput<E>, PanicError> {
         let last_input_output = shared_sync_params.last_input_output;
 
@@ -1073,7 +1073,7 @@ where
         txn_idx: TxnIndex,
         output_idx: TxnIndex,
         committed_output: CommittedOutput<E>,
-        shared_sync_params: &SharedSyncParams<T, E, S>,
+        shared_sync_params: &SharedSyncParams<'_, T, E, S>,
     ) -> Result<(), PanicError> {
         if output_idx < txn_idx {
             return Err(code_invariant_error(format!(
@@ -1098,7 +1098,7 @@ where
         block: &TP,
         scheduler: &Scheduler,
         skip_module_reads_validation: &AtomicBool,
-        shared_sync_params: &SharedSyncParams<T, E, S>,
+        shared_sync_params: &SharedSyncParams<'_, T, E, S>,
         num_workers: usize,
     ) -> Result<(), PanicOr<ParallelBlockExecutionError>> {
         let num_txns = block.num_txns();
@@ -1376,7 +1376,7 @@ where
         transaction_slice_metadata: &TransactionSliceMetadata,
         scheduler: SchedulerWrapper,
         environment: &AptosEnvironment,
-        shared_sync_params: &SharedSyncParams<T, E, S>,
+        shared_sync_params: &SharedSyncParams<'_, T, E, S>,
     ) -> Result<Option<T>, PanicError> {
         let _timer = PARALLEL_FINALIZE_SECONDS.start_timer();
         let mut maybe_block_epilogue_txn = None;
@@ -1600,11 +1600,14 @@ where
         WORKER_POOL.scope(num_workers as usize, |worker_id| {
             let worker_id = worker_id as u32;
             let environment = module_cache_manager_guard.environment();
+            let ctx = module_cache_manager_guard.global_context();
             let executor = {
                 let _init_timer = VM_INIT_SECONDS.start_timer();
                 E::init(
                     &environment.clone(),
+                    ctx,
                     shared_sync_params.base_view,
+                    worker_id,
                     async_runtime_checks_enabled,
                 )
             };
@@ -1786,11 +1789,14 @@ where
         WORKER_POOL.scope(num_workers, |worker_id| {
             let worker_id = worker_id as u32;
             let environment = module_cache_manager_guard.environment();
+            let ctx = module_cache_manager_guard.global_context();
             let executor = {
                 let _init_timer = VM_INIT_SECONDS.start_timer();
                 E::init(
                     &environment.clone(),
+                    ctx,
                     base_view,
+                    worker_id,
                     async_runtime_checks_enabled,
                 )
             };
@@ -2059,7 +2065,8 @@ where
 
         let init_timer = VM_INIT_SECONDS.start_timer();
         let environment = module_cache_manager_guard.environment();
-        let executor = E::init(environment, base_view, false);
+        let ctx = module_cache_manager_guard.global_context();
+        let executor = E::init(environment, ctx, base_view, 0, false);
         drop(init_timer);
 
         let runtime_environment = environment.runtime_environment();

--- a/aptos-move/block-executor/src/single_transaction_executor.rs
+++ b/aptos-move/block-executor/src/single_transaction_executor.rs
@@ -30,12 +30,18 @@ use aptos_types::{
 };
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_logging::{alert, prelude::*};
+use mono_move_global_context::GlobalContext;
 use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
 use move_vm_runtime::{Module, RuntimeEnvironment, TypeChecker};
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use serde::Serialize;
-use std::{cell::RefCell, fmt::Debug, hash::Hash, sync::atomic::AtomicU32};
+use std::{
+    cell::RefCell,
+    fmt::Debug,
+    hash::Hash,
+    sync::{atomic::AtomicU32, Arc},
+};
 
 /// Mode-invariant ingredients for a per-transaction view. The legacy code cache
 /// is isolated here; a VM with its own code caching ignores it.
@@ -79,7 +85,9 @@ pub trait SingleTransactionExecutor {
     /// in; VMs that do not defer runtime checks ignore it.
     fn init(
         environment: &AptosEnvironment,
+        ctx: Arc<GlobalContext>,
         state_view: &impl TStateView<Key = <Self::Txn as Transaction>::Key>,
+        worker_id: u32,
         async_runtime_checks_enabled: bool,
     ) -> Self;
 
@@ -178,7 +186,9 @@ impl<E: ExecutorTask> SingleTransactionExecutor for LegacyTransactionExecutor<E>
 
     fn init(
         environment: &AptosEnvironment,
+        _ctx: Arc<GlobalContext>,
         state_view: &impl TStateView<Key = <E::Txn as Transaction>::Key>,
+        _worker_id: u32,
         async_runtime_checks_enabled: bool,
     ) -> Self {
         Self {

--- a/aptos-move/e2e-move-tests/src/tests/hot_state.rs
+++ b/aptos-move/e2e-move-tests/src/tests/hot_state.rs
@@ -21,7 +21,7 @@ use aptos_language_e2e_tests::account::Account;
 use aptos_types::{
     account_config::{AccountResource, AggregatorV1Resource, CoinInfoResource},
     block_executor::{
-        config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
+        config::{BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
         transaction_slice_metadata::TransactionSliceMetadata,
     },
     chain_id::ChainId,
@@ -57,20 +57,18 @@ fn execute_and_get_hot_state_promotions(
     BTreeSet<StateKey>,
     BTreeSet<StateKey>,
 ) {
-    let config = BlockExecutorConfig {
-        local: BlockExecutorLocalConfig::default_with_concurrency_level(concurrency_level),
-        // The hot state accumulator requires `add_block_limit_outcome_onchain`;
-        // `with_features` turns on `hotness_in_epilogue` (in default features), which
-        // selects the V2 epilogue payload carrying `to_make_hot`.
-        onchain: BlockExecutorConfigFromOnchain::on_but_large_for_test()
-            .with_features(&Features::default()),
-    };
+    let local_config = BlockExecutorLocalConfig::default_with_concurrency_level(concurrency_level);
+    // The hot state accumulator requires `add_block_limit_outcome_onchain`;
+    // `with_features` turns on `hotness_in_epilogue` (in default features), which
+    // selects the V2 epilogue payload carrying `to_make_hot`.
+    let onchain_config =
+        BlockExecutorConfigFromOnchain::on_but_large_for_test().with_features(&Features::default());
     let txn_provider = DefaultTxnProvider::new_without_info(into_signature_verified_block(txns));
-    let block_output = AptosVMBlockExecutor::new()
-        .execute_block_with_config(
+    let block_output = AptosVMBlockExecutor::new_with_local_config(local_config)
+        .execute_block(
             &txn_provider,
             h.executor.get_state_view(),
-            config,
+            onchain_config,
             TransactionSliceMetadata::block(HashValue::zero(), HashValue::new([1; 32])),
         )
         .expect("Block execution should succeed");

--- a/aptos-move/replay-benchmark/src/commands/diff.rs
+++ b/aptos-move/replay-benchmark/src/commands/diff.rs
@@ -2,13 +2,16 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    commands::init_logger_and_metrics, diff::TransactionDiffBuilder, execution::execute_workload,
-    state_view::ReadSet, workload::Workload,
+    commands::init_logger_and_metrics,
+    diff::TransactionDiffBuilder,
+    execution::{execute_workload, local_config},
+    state_view::ReadSet,
+    workload::Workload,
 };
 use anyhow::{anyhow, bail};
 use aptos_logger::Level;
 use aptos_types::transaction::{TransactionBlock, TransactionOutput};
-use aptos_vm::{aptos_vm::AptosVMBlockExecutor, VMBlockExecutor};
+use aptos_vm::aptos_vm::AptosVMBlockExecutor;
 use clap::Parser;
 use std::path::PathBuf;
 use tokio::fs;
@@ -151,13 +154,12 @@ impl DiffCommand {
         workloads: &[Workload],
         inputs: &[ReadSet],
     ) -> Vec<Vec<TransactionOutput>> {
-        let executor = AptosVMBlockExecutor::new();
+        let executor =
+            AptosVMBlockExecutor::new_with_local_config(local_config(self.concurrency_level));
         workloads
             .iter()
             .zip(inputs)
-            .map(|(workload, input)| {
-                execute_workload(&executor, workload, input, self.concurrency_level)
-            })
+            .map(|(workload, input)| execute_workload(&executor, workload, input))
             .collect()
     }
 }

--- a/aptos-move/replay-benchmark/src/execution.rs
+++ b/aptos-move/replay-benchmark/src/execution.rs
@@ -4,13 +4,24 @@
 use crate::workload::Workload;
 use aptos_types::{
     block_executor::config::{
-        BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig,
+        BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig,
         BlockExecutorModuleCacheLocalConfig,
     },
     state_store::StateView,
     transaction::TransactionOutput,
 };
-use aptos_vm::aptos_vm::AptosVMBlockExecutor;
+use aptos_vm::{aptos_vm::AptosVMBlockExecutor, VMBlockExecutor};
+
+pub(crate) fn local_config(concurrency_level: usize) -> BlockExecutorLocalConfig {
+    BlockExecutorLocalConfig {
+        blockstm_v2: true,
+        concurrency_level,
+        allow_fallback: true,
+        discard_failed_blocks: false,
+        module_cache_config: BlockExecutorModuleCacheLocalConfig::default(),
+        enable_pre_write: true,
+    }
+}
 
 /// Runs a block of transactions from the workload on top of the specified state (sequentially or
 /// in parallel). Block execution should never fail.
@@ -18,26 +29,13 @@ pub(crate) fn execute_workload(
     executor: &AptosVMBlockExecutor,
     workload: &Workload,
     state_view: &(impl StateView + Sync),
-    concurrency_level: usize,
 ) -> Vec<TransactionOutput> {
-    let config = BlockExecutorConfig {
-        local: BlockExecutorLocalConfig {
-            blockstm_v2: true,
-            concurrency_level,
-            allow_fallback: true,
-            discard_failed_blocks: false,
-            module_cache_config: BlockExecutorModuleCacheLocalConfig::default(),
-            enable_pre_write: true,
-        },
-        // For replay, there is no block limit. TODO(HotState): may need to update this.
-        onchain: BlockExecutorConfigFromOnchain::on_but_large_for_test(),
-    };
-
     executor
-        .execute_block_with_config(
+        .execute_block(
             &workload.txn_provider,
             state_view,
-            config,
+            // For replay, there is no block limit. TODO(HotState): may need to update this.
+            BlockExecutorConfigFromOnchain::on_but_large_for_test(),
             workload.transaction_slice_metadata,
         )
         .unwrap_or_else(|err| {

--- a/aptos-move/replay-benchmark/src/generator.rs
+++ b/aptos-move/replay-benchmark/src/generator.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    execution::execute_workload,
+    execution::{execute_workload, local_config},
     overrides::OverrideConfig,
     state_view::{ReadSet, ReadSetCapturingStateView},
     workload::Workload,
@@ -10,7 +10,7 @@ use crate::{
 use aptos_logger::error;
 use aptos_move_debugger::aptos_debugger::AptosDebugger;
 use aptos_types::transaction::{TransactionBlock, Version};
-use aptos_vm::{aptos_vm::AptosVMBlockExecutor, VMBlockExecutor};
+use aptos_vm::aptos_vm::AptosVMBlockExecutor;
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -79,8 +79,11 @@ impl InputOutputDiffGenerator {
         let workload = Workload::from(txn_block);
 
         // First, we execute transactions without overrides.
-        let onchain_outputs =
-            execute_workload(&AptosVMBlockExecutor::new(), &workload, &state_view, 1);
+        let onchain_outputs = execute_workload(
+            &AptosVMBlockExecutor::new_with_local_config(local_config(1)),
+            &workload,
+            &state_view,
+        );
 
         // Check on-chain outputs do not modify the state we override. If so, benchmarking results
         // may not be correct.
@@ -104,10 +107,9 @@ impl InputOutputDiffGenerator {
 
         // Execute transactions with an override.
         execute_workload(
-            &AptosVMBlockExecutor::new(),
+            &AptosVMBlockExecutor::new_with_local_config(local_config(1)),
             &workload,
             &state_view_with_override,
-            1,
         );
         state_view_with_override.into_read_set()
     }

--- a/aptos-move/replay-benchmark/src/runner.rs
+++ b/aptos-move/replay-benchmark/src/runner.rs
@@ -1,8 +1,12 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{execution::execute_workload, state_view::ReadSet, workload::Workload};
-use aptos_vm::{aptos_vm::AptosVMBlockExecutor, VMBlockExecutor};
+use crate::{
+    execution::{execute_workload, local_config},
+    state_view::ReadSet,
+    workload::Workload,
+};
+use aptos_vm::aptos_vm::AptosVMBlockExecutor;
 use std::time::Instant;
 
 /// Represents a block for benchmarking: a workload consisting of a block of transactions with the
@@ -16,8 +20,8 @@ pub struct ReplayBlock {
 
 impl ReplayBlock {
     /// Executes the workload using the specified concurrency level.
-    pub(crate) fn run(&self, executor: &AptosVMBlockExecutor, concurrency_level: usize) {
-        execute_workload(executor, &self.workload, &self.inputs, concurrency_level);
+    pub(crate) fn run(&self, executor: &AptosVMBlockExecutor) {
+        execute_workload(executor, &self.workload, &self.inputs);
     }
 }
 
@@ -62,10 +66,11 @@ impl BenchmarkRunner {
             .collect::<Vec<_>>();
 
         for _ in 0..self.num_repeats {
-            let executor = AptosVMBlockExecutor::new();
+            let executor =
+                AptosVMBlockExecutor::new_with_local_config(local_config(concurrency_level));
             for (idx, block) in blocks.iter().enumerate() {
                 let start_time = Instant::now();
-                block.run(&executor, concurrency_level);
+                block.run(&executor);
                 let time = start_time.elapsed().as_micros();
                 times[idx].push(time);
             }
@@ -92,17 +97,18 @@ impl BenchmarkRunner {
     fn measure_overall_execution_time(&self, blocks: &[ReplayBlock], concurrency_level: usize) {
         let mut times = Vec::with_capacity(self.num_repeats);
         for _ in 0..self.num_repeats {
-            let executor = AptosVMBlockExecutor::new();
+            let executor =
+                AptosVMBlockExecutor::new_with_local_config(local_config(concurrency_level));
 
             // Warm-up.
             for block in &blocks[..self.num_blocks_to_skip] {
-                block.run(&executor, concurrency_level);
+                block.run(&executor);
             }
 
             // Actual measurement.
             let start_time = Instant::now();
             for block in &blocks[self.num_blocks_to_skip..] {
-                block.run(&executor, concurrency_level);
+                block.run(&executor);
             }
             let time = start_time.elapsed().as_micros();
             times.push(time);


### PR DESCRIPTION
## Description

Threads a MonoMove `GlobalContext` through the block executor so a future MonoMove VM has per-worker execution guards available. No behavior change for the legacy Move VM.

- The context lives in `AptosModuleCacheManager` as `Arc<GlobalContext>`, sized to the concurrency level (`with_num_execution_workers`). It is separate from the legacy module cache, which is now named `legacy_module_cache_manager` and documented as V1-only.
- `AptosModuleCacheManagerGuard` (both the `Guard` and the owned `None` variant) carries the `Arc<GlobalContext>`. The new `global_context()` accessor returns an owned `Arc` clone, so no borrow of the guard is held.
- The block executor shares the context across workers by cloning the `Arc`; each per-worker executor owns its clone. Exclusive access for maintenance is reclaimed via `Arc::get_mut` once all executors are dropped.
- `SingleTransactionExecutor::init` takes `ctx: Arc<GlobalContext>` and a worker id. A MonoMove executor keeps its clone for the block; the legacy adapter drops the `Arc`, holding no refcount, which keeps future `Arc::get_mut` maintenance sound.
- Framework prefetch is skipped when MonoMove is enabled, since MonoMove uses its own code cache (TODO left to prefetch the framework into the MonoMove cache).

`SingleTransactionExecutor` is lifetime-free: because each worker owns an `Arc` clone rather than a borrow, `BlockExecutor` carries no `'ctx` lifetime.

## How Has This Been Tested?

- `cargo check -p aptos-block-executor` (lib) and `--tests --features testing`.
- `cargo check -p aptos-vm -p e2e-move-tests`.
- Existing block-executor tests exercise the legacy path unchanged.

## Key Areas to Review

- Ownership model in `code_cache_global_manager.rs`: the `None` variant owns its own `Arc<GlobalContext>` (no leak, no shared borrow), and `global_context()` returns a clone rather than a reference so it does not conflict with `module_cache_mut()`.
- `Arc::get_mut`-based maintenance is not yet wired; it depends on a defined "all executors dropped" point. An executor must not hold both the `Arc` and a live `ExecutionGuard` derived from it — guards should be worker-loop stack locals.

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core block-executor worker initialization and VM executor APIs; behavior should match legacy when MonoMove is off, but incorrect context sharing could affect future MonoMove execution.
> 
> **Overview**
> **Plumbs MonoMove `GlobalContext` through the block executor** so future MonoMove workers can hold per-worker execution state, while the legacy Move VM path is unchanged.
> 
> `AptosModuleCacheManager` now owns an `Arc<GlobalContext>` sized to `concurrency_level`, alongside the V1-only `legacy_module_cache_manager`. Guards expose `global_context()` as an owned `Arc` clone for workers; parallel/sequential init passes `ctx` and `worker_id` into `SingleTransactionExecutor::init` (the legacy adapter ignores the context). **Framework prefetch is skipped when MonoMove is enabled** (TODO for MonoMove framework prefetch).
> 
> **Refactors block executor construction:** local settings are bound at `AptosVMBlockExecutor::new_with_local_config`; public `execute_block` only takes on-chain config and merges local config from the module cache manager. `execute_block_with_config` is private. Debugger, transaction benchmarks, replay-benchmark, and e2e hot-state tests are updated to the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1378d5c24aa24e97e323874af4f0d56cd9c687c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->