### PR TITLE
[consensus] Recover missing secret shares on request

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1598,6 +1598,15 @@ pub static DECRYPTION_PIPELINE_TXNS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static SECRET_SHARE_RECOVERY_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_consensus_secret_share_recovery_count",
+        "Count of reactive secret-share recovery outcomes by category.",
+        &["result"]
+    )
+    .unwrap()
+});
+
 /// The dense decryption round consumed by the most recent key-producing block.
 /// Decoupled from the consensus round; advances only on blocks that produce a
 /// decryption key. Watch alongside `TRUSTED_SETUP_NUM_ROUNDS` to track how much

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -5,7 +5,7 @@ use crate::{
     block_storage::{
         pending_blocks::PendingBlocks,
         tracing::{observe_block, BlockStage},
-        BlockStore,
+        BlockReader, BlockStore,
     },
     consensus_observer::publisher::consensus_publisher::ConsensusPublisher,
     counters,
@@ -51,7 +51,9 @@ use crate::{
             storage::interface::RandStorage,
             types::{AugmentedData, RandConfig},
         },
-        secret_sharing::verifier::SecretShareVerifier,
+        secret_sharing::{
+            secret_share_recovery::OrderedBlockSecretShareRecovery, verifier::SecretShareVerifier,
+        },
     },
     recovery_manager::RecoveryManager,
     round_manager::{RoundManager, UnverifiedEvent, VerifiedEvent},
@@ -916,13 +918,24 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             Arc::clone(&self.time_service),
             self.config.vote_back_pressure_limit,
             self.config.max_commit_gap,
-            payload_manager,
+            payload_manager.clone(),
             onchain_consensus_config.order_vote_enabled(),
             onchain_consensus_config.window_size(),
             self.pending_blocks.clone(),
             Some(pipeline_builder),
             self.config.skip_sync_small_gap_rounds,
         ));
+        if let Some(verifier) = secret_share_verifier.as_ref() {
+            let block_reader: Arc<dyn BlockReader> = block_store.clone();
+            self.execution_client.set_secret_share_recovery(Arc::new(
+                OrderedBlockSecretShareRecovery::new(
+                    self.author,
+                    verifier.config().clone(),
+                    payload_manager.clone(),
+                    block_reader,
+                ),
+            ));
+        }
 
         let failures_tracker = Arc::new(Mutex::new(ExponentialWindowFailureTracker::new(
             100,

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -23,8 +23,8 @@ use aptos_logger::{error, info, warn};
 use aptos_types::{
     decryption::{BlockTxnDecryptionKey, DecryptionPayload},
     secret_sharing::{
-        Ciphertext, DecryptionKey, EvalProof, SecretShare, SecretShareConfig, SecretShareMetadata,
-        SecretSharedKey,
+        Ciphertext, DecryptionKey, Digest, EvalProof, EvalProofsPromise, SecretShare,
+        SecretShareConfig, SecretShareMetadata, SecretSharedKey,
     },
     transaction::{
         encrypted_payload::{DecryptedPlaintext, DecryptionFailureReason, EncryptedPayload},
@@ -286,157 +286,73 @@ fn block_has_epoch_end_vtxn(block: &Block) -> bool {
     })
 }
 
-/// Validator path: derive key share, prepare ciphertexts, await the shared
-/// decryption key, and decrypt all encrypted transactions.
-async fn decrypt_validator_path(
-    encrypted_txns: Vec<SignedTransaction>,
-    regular_txns: Vec<SignedTransaction>,
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum SecretShareSelection {
+    NoEncryptedTransactions,
+    TrustedSetupExhausted,
+    EpochEnd,
+    Selected {
+        batch_limited_len: usize,
+        selected_len: usize,
+    },
+}
+
+/// Selects the exact encrypted-transaction prefix used to derive a block's
+/// secret share. Recovery calls this same helper so batch/execute limits and
+/// the early-exit ordering cannot drift from the normal pipeline.
+pub(crate) fn select_encrypted_txns_for_secret_share(
     block: &Block,
-    author: Author,
     secret_share_config: &SecretShareConfig,
-    derived_self_key_share_tx: oneshot::Sender<Option<SecretShare>>,
-    secret_shared_key_rx: oneshot::Receiver<Option<SecretSharedKey>>,
+    encrypted_txns_len: usize,
     max_txns_from_block_to_execute: Option<u64>,
-    block_gas_limit: Option<u64>,
-    chained_round: Option<u64>,
-) -> TaskResult<DecryptionResult> {
-    // The round that keys the digest. Round-tracked mode uses the dense
-    // counter chained from the parent; legacy mode (the on-chain resource
-    // doesn't exist yet) uses the consensus round, matching older binaries
-    // bit-for-bit so mixed validator sets derive identical digests.
-    let digest_round = chained_round.unwrap_or_else(|| block.round());
-    // Short-circuit if no encrypted transactions: skip all crypto operations
-    if encrypted_txns.is_empty() {
-        let _ = derived_self_key_share_tx.send(None);
-        return Ok(DecryptionResult {
-            decrypted_txns: Vec::new(),
-            retry_txns: Vec::new(),
-            regular_txns,
-            max_txns_from_block_to_execute,
-            block_gas_limit,
-            outcome: no_key_outcome(chained_round),
-        });
+    digest_round: u64,
+) -> SecretShareSelection {
+    if encrypted_txns_len == 0 {
+        return SecretShareSelection::NoEncryptedTransactions;
     }
 
-    // Trusted setup capacity check. In round-tracked mode the dense counter
-    // is compared, so empty blocks no longer consume capacity; legacy mode
-    // still burns one slot per consensus round.
     let num_rounds = secret_share_config.digest_key().num_rounds();
     counters::TRUSTED_SETUP_NUM_ROUNDS.set(num_rounds as i64);
     if digest_round >= num_rounds as u64 {
-        error!(
-            "Block round {} digest_round {} >= trusted setup num_rounds {}; marking {} encrypted txns as TrustedSetupExhausted",
-            block.round(),
-            digest_round,
-            num_rounds,
-            encrypted_txns.len()
-        );
-        let _ = derived_self_key_share_tx.send(None);
-        let failed_txns = mark_txns_failed_decryption(
-            encrypted_txns,
-            DecryptionFailureReason::TrustedSetupExhausted,
-        );
-        return Ok(DecryptionResult {
-            decrypted_txns: failed_txns,
-            retry_txns: Vec::new(),
-            regular_txns,
-            max_txns_from_block_to_execute,
-            block_gas_limit,
-            outcome: no_key_outcome(chained_round),
-        });
+        return SecretShareSelection::TrustedSetupExhausted;
     }
 
-    // Decrypting txns that the VM will skip after a NewEpochEvent leaks sender
-    // intent. If the block carries an epoch-ending vtxn, mark every encrypted
-    // txn as retry without performing any crypto work.
     if block_has_epoch_end_vtxn(block) {
-        info!(
-            "Block {} has epoch-ending vtxn; marking {} encrypted txns as EpochEndRetry",
-            block.round(),
-            encrypted_txns.len()
-        );
-        let _ = derived_self_key_share_tx.send(None);
-        let retry_txns =
-            mark_txns_failed_decryption(encrypted_txns, DecryptionFailureReason::EpochEndRetry);
-        return Ok(DecryptionResult {
-            decrypted_txns: Vec::new(),
-            retry_txns,
-            regular_txns,
-            max_txns_from_block_to_execute,
-            block_gas_limit,
-            outcome: no_key_outcome(chained_round),
-        });
+        return SecretShareSelection::EpochEnd;
     }
 
-    let max_encrypted_txns = secret_share_config.digest_key().max_batch_size();
-    let (encrypted_txns, batch_limit_exceeded_txns) = if encrypted_txns.len() > max_encrypted_txns {
-        warn!(
-            "Block {} has {} encrypted txns exceeding batch limit {}; marking excess as BatchLimitReached",
-            block.round(),
-            encrypted_txns.len(),
-            max_encrypted_txns,
-        );
-        let mut all = encrypted_txns;
-        let exceeded = all.split_off(max_encrypted_txns);
-        let exceeded =
-            mark_txns_failed_decryption(exceeded, DecryptionFailureReason::BatchLimitReached);
-        (all, exceeded)
-    } else {
-        (encrypted_txns, Vec::new())
-    };
-
-    // Cap the encrypted partition at max_txns_from_block_to_execute. The cap is
-    // applied pre-shuffle here; prepare_block later concats [decrypted, regular]
-    // and truncates at the same limit, so this is a conservative optimization:
-    // it may over-mark txns that would have survived shuffle, but it never
-    // under-decrypts, since ExecuteBlockLimitReached is a Retry status.
-    let (encrypted_txns, execute_limit_exceeded_txns) = match max_txns_from_block_to_execute {
-        Some(max) if (encrypted_txns.len() as u64) > max => {
-            let max = max as usize;
-            warn!(
-                "Block {} has {} encrypted txns exceeding execute-block limit {}; marking excess as ExecuteBlockLimitReached",
-                block.round(),
-                encrypted_txns.len(),
-                max,
-            );
-            let mut all = encrypted_txns;
-            let exceeded = all.split_off(max);
-            let exceeded = mark_txns_failed_decryption(
-                exceeded,
-                DecryptionFailureReason::ExecuteBlockLimitReached,
-            );
-            (all, exceeded)
-        },
-        _ => (encrypted_txns, Vec::new()),
-    };
-
-    // If the cap left no encrypted txns to decrypt, short-circuit before crypto.
-    if encrypted_txns.is_empty() {
-        let _ = derived_self_key_share_tx.send(None);
-        let retry_txns = [batch_limit_exceeded_txns, execute_limit_exceeded_txns].concat();
-        return Ok(DecryptionResult {
-            decrypted_txns: Vec::new(),
-            retry_txns,
-            regular_txns,
-            max_txns_from_block_to_execute,
-            block_gas_limit,
-            outcome: no_key_outcome(chained_round),
-        });
+    let batch_limited_len =
+        encrypted_txns_len.min(secret_share_config.digest_key().max_batch_size());
+    let selected_len = max_txns_from_block_to_execute
+        .map(|max| batch_limited_len.min(max as usize))
+        .unwrap_or(batch_limited_len);
+    SecretShareSelection::Selected {
+        batch_limited_len,
+        selected_len,
     }
+}
 
+/// Computes the digest and self-share for an already selected, ordered slice
+/// of encrypted transactions. Both the live pipeline and reactive recovery use
+/// this function to guarantee byte-identical metadata and shares.
+pub(crate) async fn derive_secret_share(
+    encrypted_txns: &[SignedTransaction],
+    block: &Block,
+    author: Author,
+    secret_share_config: &SecretShareConfig,
+    digest_round: u64,
+) -> anyhow::Result<(Vec<Ciphertext>, Digest, EvalProofsPromise, SecretShare)> {
     let txn_ciphertexts: Vec<Ciphertext> = encrypted_txns
         .iter()
         .map(|txn| {
-            // TODO(ibalajiarun): Avoid clone and use reference instead
             txn.payload()
                 .as_encrypted_payload()
-                .expect("must be a encrypted txn")
+                .expect("selected transaction must be encrypted")
                 .ciphertext()
                 .clone()
         })
         .collect();
 
-    // Safe: TrustedSetupExhausted check above guarantees digest_round < num_rounds.
     let digest_key = secret_share_config.digest_key_arc();
     let (txn_ciphertexts, digest, proofs_promise) = tokio::task::spawn_blocking(move || {
         monitor!(
@@ -457,19 +373,162 @@ async fn decrypt_validator_path(
         block.id(),
         digest.clone(),
     );
-
     let derived_key_share = monitor!(
         "decryption_derive_key_share",
         FPTXWeighted::derive_decryption_key_share(secret_share_config.msk_share(), &digest)?
     );
-    if derived_self_key_share_tx
-        .send(Some(SecretShare::new(
-            author,
-            metadata.clone(),
-            derived_key_share,
-        )))
-        .is_err()
-    {
+    let share = SecretShare::new(author, metadata, derived_key_share);
+
+    Ok((txn_ciphertexts, digest, proofs_promise, share))
+}
+
+/// Validator path: derive key share, prepare ciphertexts, await the shared
+/// decryption key, and decrypt all encrypted transactions.
+async fn decrypt_validator_path(
+    encrypted_txns: Vec<SignedTransaction>,
+    regular_txns: Vec<SignedTransaction>,
+    block: &Block,
+    author: Author,
+    secret_share_config: &SecretShareConfig,
+    derived_self_key_share_tx: oneshot::Sender<Option<SecretShare>>,
+    secret_shared_key_rx: oneshot::Receiver<Option<SecretSharedKey>>,
+    max_txns_from_block_to_execute: Option<u64>,
+    block_gas_limit: Option<u64>,
+    chained_round: Option<u64>,
+) -> TaskResult<DecryptionResult> {
+    // The round that keys the digest. Round-tracked mode uses the dense
+    // counter chained from the parent; legacy mode (the on-chain resource
+    // doesn't exist yet) uses the consensus round, matching older binaries
+    // bit-for-bit so mixed validator sets derive identical digests.
+    let digest_round = chained_round.unwrap_or_else(|| block.round());
+    let selection = select_encrypted_txns_for_secret_share(
+        block,
+        secret_share_config,
+        encrypted_txns.len(),
+        max_txns_from_block_to_execute,
+        digest_round,
+    );
+    let (batch_limited_len, selected_len) = match selection {
+        SecretShareSelection::NoEncryptedTransactions => {
+            let _ = derived_self_key_share_tx.send(None);
+            return Ok(DecryptionResult {
+                decrypted_txns: Vec::new(),
+                retry_txns: Vec::new(),
+                regular_txns,
+                max_txns_from_block_to_execute,
+                block_gas_limit,
+                outcome: no_key_outcome(chained_round),
+            });
+        },
+        SecretShareSelection::TrustedSetupExhausted => {
+            let num_rounds = secret_share_config.digest_key().num_rounds();
+            error!(
+                "Block round {} digest_round {} >= trusted setup num_rounds {}; marking {} encrypted txns as TrustedSetupExhausted",
+                block.round(),
+                digest_round,
+                num_rounds,
+                encrypted_txns.len()
+            );
+            let _ = derived_self_key_share_tx.send(None);
+            let failed_txns = mark_txns_failed_decryption(
+                encrypted_txns,
+                DecryptionFailureReason::TrustedSetupExhausted,
+            );
+            return Ok(DecryptionResult {
+                decrypted_txns: failed_txns,
+                retry_txns: Vec::new(),
+                regular_txns,
+                max_txns_from_block_to_execute,
+                block_gas_limit,
+                outcome: no_key_outcome(chained_round),
+            });
+        },
+        SecretShareSelection::EpochEnd => {
+            info!(
+                "Block {} has epoch-ending vtxn; marking {} encrypted txns as EpochEndRetry",
+                block.round(),
+                encrypted_txns.len()
+            );
+            let _ = derived_self_key_share_tx.send(None);
+            let retry_txns =
+                mark_txns_failed_decryption(encrypted_txns, DecryptionFailureReason::EpochEndRetry);
+            return Ok(DecryptionResult {
+                decrypted_txns: Vec::new(),
+                retry_txns,
+                regular_txns,
+                max_txns_from_block_to_execute,
+                block_gas_limit,
+                outcome: no_key_outcome(chained_round),
+            });
+        },
+        SecretShareSelection::Selected {
+            batch_limited_len,
+            selected_len,
+        } => (batch_limited_len, selected_len),
+    };
+
+    let (encrypted_txns, batch_limit_exceeded_txns) = if encrypted_txns.len() > batch_limited_len {
+        warn!(
+            "Block {} has {} encrypted txns exceeding batch limit {}; marking excess as BatchLimitReached",
+            block.round(),
+            encrypted_txns.len(),
+            batch_limited_len,
+        );
+        let mut all = encrypted_txns;
+        let exceeded = all.split_off(batch_limited_len);
+        let exceeded =
+            mark_txns_failed_decryption(exceeded, DecryptionFailureReason::BatchLimitReached);
+        (all, exceeded)
+    } else {
+        (encrypted_txns, Vec::new())
+    };
+
+    // Cap the encrypted partition at max_txns_from_block_to_execute. The cap is
+    // applied pre-shuffle here; prepare_block later concats [decrypted, regular]
+    // and truncates at the same limit, so this is a conservative optimization:
+    // it may over-mark txns that would have survived shuffle, but it never
+    // under-decrypts, since ExecuteBlockLimitReached is a Retry status.
+    let (encrypted_txns, execute_limit_exceeded_txns) = if encrypted_txns.len() > selected_len {
+        warn!(
+                "Block {} has {} encrypted txns exceeding execute-block limit {}; marking excess as ExecuteBlockLimitReached",
+                block.round(),
+                encrypted_txns.len(),
+                selected_len,
+            );
+        let mut all = encrypted_txns;
+        let exceeded = all.split_off(selected_len);
+        let exceeded = mark_txns_failed_decryption(
+            exceeded,
+            DecryptionFailureReason::ExecuteBlockLimitReached,
+        );
+        (all, exceeded)
+    } else {
+        (encrypted_txns, Vec::new())
+    };
+
+    // If the cap left no encrypted txns to decrypt, short-circuit before crypto.
+    if encrypted_txns.is_empty() {
+        let _ = derived_self_key_share_tx.send(None);
+        let retry_txns = [batch_limit_exceeded_txns, execute_limit_exceeded_txns].concat();
+        return Ok(DecryptionResult {
+            decrypted_txns: Vec::new(),
+            retry_txns,
+            regular_txns,
+            max_txns_from_block_to_execute,
+            block_gas_limit,
+            outcome: no_key_outcome(chained_round),
+        });
+    }
+
+    let (txn_ciphertexts, digest, proofs_promise, share) = derive_secret_share(
+        &encrypted_txns,
+        block,
+        author,
+        secret_share_config,
+        digest_round,
+    )
+    .await?;
+    if derived_self_key_share_tx.send(Some(share)).is_err() {
         return Err(
             anyhow!("derived_self_key_share_tx receiver dropped, pipeline likely aborted").into(),
         );
@@ -968,6 +1027,60 @@ mod tests {
         }
     }
 
+    async fn assert_pipeline_and_recovery_share_match(chained_round: Option<u64>) {
+        let ctx = TestContext::new_with_capacity(vec![100], 8, 16);
+        let block = make_block(None);
+        let author = ctx.authors[0];
+        let encrypted = vec![make_encrypted_txn(), make_encrypted_txn()];
+        let digest_round = chained_round.unwrap_or_else(|| block.round());
+
+        let (_, _, _, recovered) = derive_secret_share(
+            &encrypted,
+            &block,
+            author,
+            &ctx.secret_share_config,
+            digest_round,
+        )
+        .await
+        .expect("recovery derivation should succeed");
+
+        let (share_tx, share_rx) = oneshot::channel();
+        let (key_tx, key_rx) = oneshot::channel();
+        let block_for_pipeline = block.clone();
+        let config = ctx.secret_share_config.clone();
+        let pipeline = tokio::spawn(async move {
+            decrypt_validator_path(
+                encrypted,
+                vec![],
+                &block_for_pipeline,
+                author,
+                &config,
+                share_tx,
+                key_rx,
+                None,
+                None,
+                chained_round,
+            )
+            .await
+        });
+        let pipeline_share = share_rx
+            .await
+            .expect("pipeline should deliver a share")
+            .expect("encrypted block should have a share");
+        key_tx
+            .send(None)
+            .expect("pipeline should still be waiting for a key");
+        pipeline
+            .await
+            .expect("pipeline task should not panic")
+            .expect("pipeline should handle a missing key");
+
+        assert_eq!(
+            bcs::to_bytes(&pipeline_share).unwrap(),
+            bcs::to_bytes(&recovered).unwrap()
+        );
+    }
+
     // ---------- Helper functions and metrics ----------
 
     #[test]
@@ -1116,6 +1229,41 @@ mod tests {
     }
 
     // ---------- decrypt_encrypted_txns_inner routing ----------
+
+    #[tokio::test]
+    async fn recovery_derives_identical_share_in_round_tracked_mode() {
+        assert_pipeline_and_recovery_share_match(Some(3)).await;
+    }
+
+    #[tokio::test]
+    async fn recovery_derives_identical_share_in_legacy_mode() {
+        assert_pipeline_and_recovery_share_match(None).await;
+    }
+
+    #[test]
+    fn dense_round_replay_consumes_only_nonempty_selected_blocks() {
+        let ctx = TestContext::new_with_capacity(vec![100], 8, 16);
+        let block = make_block(None);
+        let mut next_round = 4;
+        for encrypted_len in [0, 2, 0, 1] {
+            if matches!(
+                select_encrypted_txns_for_secret_share(
+                    &block,
+                    &ctx.secret_share_config,
+                    encrypted_len,
+                    None,
+                    next_round,
+                ),
+                SecretShareSelection::Selected {
+                    selected_len: 1..,
+                    ..
+                }
+            ) {
+                next_round += 1;
+            }
+        }
+        assert_eq!(next_round, 6);
+    }
 
     #[tokio::test]
     async fn routing_disabled_marks_config_unavailable() {

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -23,7 +23,11 @@ use crate::{
             storage::interface::RandStorage,
             types::{AugmentedData, RandConfig, Share},
         },
-        secret_sharing::{secret_share_manager::SecretShareManager, verifier::SecretShareVerifier},
+        secret_sharing::{
+            secret_share_manager::SecretShareManager,
+            secret_share_recovery::{LateBoundSecretShareRecovery, SecretShareRecovery},
+            verifier::SecretShareVerifier,
+        },
     },
     state_computer::ExecutionProxy,
     state_replication::StateComputer,
@@ -124,6 +128,8 @@ pub trait TExecutionClient: Send + Sync {
 
     /// Returns a pipeline builder for the current epoch.
     fn pipeline_builder(&self, signer: Arc<ValidatorSigner>) -> PipelineBuilder;
+
+    fn set_secret_share_recovery(&self, _recovery: Arc<dyn SecretShareRecovery>) {}
 }
 
 struct BufferManagerHandle {
@@ -193,6 +199,7 @@ pub struct ExecutionProxyClient {
     rand_storage: Arc<dyn RandStorage<AugmentedData>>,
     consensus_observer_config: ConsensusObserverConfig,
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
+    secret_share_recovery: Arc<LateBoundSecretShareRecovery>,
 }
 
 impl ExecutionProxyClient {
@@ -218,6 +225,7 @@ impl ExecutionProxyClient {
             rand_storage,
             consensus_observer_config,
             consensus_publisher,
+            secret_share_recovery: Arc::new(LateBoundSecretShareRecovery::default()),
         }
     }
 
@@ -295,6 +303,7 @@ impl ExecutionProxyClient {
             self.bounded_executor.clone(),
             &self.consensus_config.secret_share_rb_config,
             self.consensus_config.secret_share_request_delay_ms,
+            self.secret_share_recovery.clone(),
         );
 
         tokio::spawn(secret_share_manager.start(
@@ -544,6 +553,7 @@ impl TExecutionClient for ExecutionProxyClient {
         secret_sharing_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingSecretShareRequest>,
         highest_committed_round: Round,
     ) {
+        self.secret_share_recovery.clear();
         let network_sender = Arc::new(NetworkSender::new(
             self.author,
             self.network_sender.clone(),
@@ -812,6 +822,10 @@ impl TExecutionClient for ExecutionProxyClient {
 
     fn pipeline_builder(&self, signer: Arc<ValidatorSigner>) -> PipelineBuilder {
         self.execution_proxy.pipeline_builder(signer)
+    }
+
+    fn set_secret_share_recovery(&self, recovery: Arc<dyn SecretShareRecovery>) {
+        self.secret_share_recovery.set(recovery);
     }
 }
 

--- a/consensus/src/rand/secret_sharing/mod.rs
+++ b/consensus/src/rand/secret_sharing/mod.rs
@@ -5,6 +5,7 @@ pub mod block_queue;
 pub mod network_messages;
 pub mod reliable_broadcast_state;
 pub mod secret_share_manager;
+pub mod secret_share_recovery;
 pub mod secret_share_store;
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    counters::DEC_QUEUE_SIZE,
+    counters::{DEC_QUEUE_SIZE, SECRET_SHARE_RECOVERY_COUNT},
     logging::{LogEvent, LogSchema},
     network::{IncomingSecretShareRequest, NetworkSender, TConsensusMsg},
     pipeline::buffer_manager::{OrderedBlocks, ResetAck, ResetRequest, ResetSignal},
@@ -10,6 +10,7 @@ use crate::{
         block_queue::{BlockQueue, QueueItem},
         network_messages::{SecretShareMessage, SecretShareRpc},
         reliable_broadcast_state::SecretShareAggregateState,
+        secret_share_recovery::SecretShareRecovery,
         secret_share_store::{SecretShareAggregationResult, SecretShareStore},
         types::RequestSecretShare,
         verifier::SecretShareVerifier,
@@ -27,8 +28,12 @@ use aptos_logger::{debug, error, info, spawn_named, warn};
 use aptos_network::{protocols::network::RpcError, ProtocolId};
 use aptos_reliable_broadcast::{DropGuard, ReliableBroadcast};
 use aptos_time_service::TimeService;
-use aptos_types::{epoch_state::EpochState, secret_sharing::SecretShareMetadata};
+use aptos_types::{
+    epoch_state::EpochState,
+    secret_sharing::{SecretShare, SecretShareMetadata},
+};
 use bytes::Bytes;
+use fail::fail_point;
 use futures::{
     future::{AbortHandle, Abortable},
     stream::FuturesUnordered,
@@ -38,7 +43,7 @@ use futures_channel::{
     mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
 use tokio_retry::strategy::ExponentialBackoff;
 
 pub type Sender<T> = UnboundedSender<T>;
@@ -46,6 +51,54 @@ pub type Receiver<T> = UnboundedReceiver<T>;
 
 type PendingDeriveFut =
     Pin<Box<dyn Future<Output = (Round, TaskResult<SecretShareResult>)> + Send>>;
+type RecoveryResponse = (ProtocolId, oneshot::Sender<Result<Bytes, RpcError>>);
+type RecoveryResult = (
+    SecretShareMetadata,
+    u64,
+    anyhow::Result<Option<SecretShare>>,
+);
+
+struct PendingRecoveryRequests<T> {
+    generation: u64,
+    requests: HashMap<SecretShareMetadata, Vec<T>>,
+}
+
+impl<T> Default for PendingRecoveryRequests<T> {
+    fn default() -> Self {
+        Self {
+            generation: 0,
+            requests: HashMap::new(),
+        }
+    }
+}
+
+impl<T> PendingRecoveryRequests<T> {
+    fn append_if_pending(&mut self, metadata: &SecretShareMetadata, request: T) -> Result<(), T> {
+        match self.requests.get_mut(metadata) {
+            Some(requests) => {
+                requests.push(request);
+                Ok(())
+            },
+            None => Err(request),
+        }
+    }
+
+    fn insert(&mut self, metadata: SecretShareMetadata, request: T) {
+        let previous = self.requests.insert(metadata, vec![request]);
+        debug_assert!(previous.is_none());
+    }
+
+    fn reset(&mut self) {
+        self.requests.clear();
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    fn take(&mut self, metadata: &SecretShareMetadata, generation: u64) -> Option<Vec<T>> {
+        (generation == self.generation)
+            .then(|| self.requests.remove(metadata))
+            .flatten()
+    }
+}
 
 pub struct SecretShareManager {
     author: Author,
@@ -55,6 +108,8 @@ pub struct SecretShareManager {
     reliable_broadcast: Arc<ReliableBroadcast<SecretShareMessage, ExponentialBackoff>>,
     network_sender: Arc<NetworkSender>,
     secret_share_request_delay_ms: u64,
+    recovery: Arc<dyn SecretShareRecovery>,
+    recovery_executor: BoundedExecutor,
 
     // local channel received from dec_store
     decision_rx: Receiver<SecretShareAggregationResult>,
@@ -64,6 +119,9 @@ pub struct SecretShareManager {
     secret_share_store: Arc<Mutex<SecretShareStore>>,
     block_queue: BlockQueue,
     pending_derives: FuturesUnordered<PendingDeriveFut>,
+    pending_recoveries: PendingRecoveryRequests<RecoveryResponse>,
+    recovery_result_tx: Sender<RecoveryResult>,
+    recovery_result_rx: Receiver<RecoveryResult>,
 }
 
 impl SecretShareManager {
@@ -76,6 +134,7 @@ impl SecretShareManager {
         bounded_executor: BoundedExecutor,
         rb_config: &ReliableBroadcastConfig,
         secret_share_request_delay_ms: u64,
+        recovery: Arc<dyn SecretShareRecovery>,
     ) -> Self {
         let rb_backoff_policy = ExponentialBackoff::from_millis(rb_config.backoff_policy_base_ms)
             .factor(rb_config.backoff_policy_factor)
@@ -88,9 +147,10 @@ impl SecretShareManager {
             rb_backoff_policy,
             TimeService::real(),
             Duration::from_millis(rb_config.rpc_timeout_ms),
-            bounded_executor,
+            bounded_executor.clone(),
         ));
         let (decision_tx, decision_rx) = unbounded();
+        let (recovery_result_tx, recovery_result_rx) = unbounded();
 
         let dec_store = Arc::new(Mutex::new(SecretShareStore::new(
             epoch_state.epoch,
@@ -107,6 +167,8 @@ impl SecretShareManager {
             reliable_broadcast,
             network_sender,
             secret_share_request_delay_ms,
+            recovery,
+            recovery_executor: bounded_executor,
 
             decision_rx,
             outgoing_blocks,
@@ -114,6 +176,9 @@ impl SecretShareManager {
             secret_share_store: dec_store,
             block_queue: BlockQueue::new(),
             pending_derives: FuturesUnordered::new(),
+            pending_recoveries: PendingRecoveryRequests::default(),
+            recovery_result_tx,
+            recovery_result_rx,
         }
     }
 
@@ -183,12 +248,18 @@ impl SecretShareManager {
         };
 
         let metadata = share.metadata().clone();
-        {
+        let drop_delivery = Self::drop_derived_share_delivery();
+        if !drop_delivery {
             let mut store = self.secret_share_store.lock();
             if let Err(e) = store.add_self_share(share.clone()) {
                 error!(round = round, "Failed to add self share to store: {:?}", e);
                 return;
             }
+        } else {
+            warn!(
+                round = round,
+                "Dropping derived self-share delivery due to failpoint"
+            );
         }
 
         info!(LogSchema::new(LogEvent::BroadcastSecretShare)
@@ -207,6 +278,14 @@ impl SecretShareManager {
                 "Secret share item not found for round {}", round
             );
         }
+    }
+
+    fn drop_derived_share_delivery() -> bool {
+        fail_point!(
+            "consensus::secret_share_manager::drop_derived_share_delivery",
+            |_| true
+        );
+        false
     }
 
     fn process_ready_blocks(&mut self, ready_blocks: Vec<OrderedBlocks>) {
@@ -234,6 +313,7 @@ impl SecretShareManager {
         };
         self.block_queue = BlockQueue::new();
         self.pending_derives = FuturesUnordered::new();
+        self.pending_recoveries.reset();
         self.secret_share_store.lock().reset(target_round);
         self.stop = matches!(signal, ResetSignal::Stop);
         let _ = tx.send(ResetAck::default());
@@ -297,6 +377,153 @@ impl SecretShareManager {
             .to_bytes(&msg)
             .expect("Message should be serializable into protocol")
             .into()));
+    }
+
+    fn schedule_recovery(&mut self, metadata: SecretShareMetadata, response: RecoveryResponse) {
+        let response = match self
+            .pending_recoveries
+            .append_if_pending(&metadata, response)
+        {
+            Ok(()) => {
+                SECRET_SHARE_RECOVERY_COUNT
+                    .with_label_values(&["deduplicated"])
+                    .inc();
+                return;
+            },
+            Err(response) => response,
+        };
+
+        let recovery = self.recovery.clone();
+        let result_tx = self.recovery_result_tx.clone();
+        let generation = self.pending_recoveries.generation;
+        let result_metadata = metadata.clone();
+        let task = async move {
+            let result = recovery.recover(result_metadata.clone()).await;
+            let _ = result_tx.unbounded_send((result_metadata, generation, result));
+        };
+        match self.recovery_executor.try_spawn(task) {
+            Ok(_) => {
+                self.pending_recoveries.insert(metadata, response);
+                SECRET_SHARE_RECOVERY_COUNT
+                    .with_label_values(&["scheduled"])
+                    .inc();
+            },
+            Err(_) => {
+                warn!(
+                    epoch = metadata.epoch,
+                    round = metadata.round,
+                    "Secret-share recovery executor is at capacity"
+                );
+                SECRET_SHARE_RECOVERY_COUNT
+                    .with_label_values(&["at_capacity"])
+                    .inc();
+            },
+        }
+    }
+
+    fn process_recovery_result(&mut self, result: RecoveryResult) {
+        let (metadata, generation, result) = result;
+        if generation != self.pending_recoveries.generation {
+            SECRET_SHARE_RECOVERY_COUNT
+                .with_label_values(&["stale"])
+                .inc();
+            return;
+        }
+        let Some(requesters) = self.pending_recoveries.take(&metadata, generation) else {
+            return;
+        };
+
+        let recovered_share = match result {
+            Ok(Some(share)) if share.metadata() == &metadata => share,
+            Ok(Some(_)) => {
+                warn!(
+                    epoch = metadata.epoch,
+                    round = metadata.round,
+                    "Recovered secret share has mismatched metadata"
+                );
+                SECRET_SHARE_RECOVERY_COUNT
+                    .with_label_values(&["metadata_mismatch"])
+                    .inc();
+                return;
+            },
+            Ok(None) => {
+                SECRET_SHARE_RECOVERY_COUNT
+                    .with_label_values(&["unavailable"])
+                    .inc();
+                return;
+            },
+            Err(error) => {
+                warn!(
+                    epoch = metadata.epoch,
+                    round = metadata.round,
+                    "Failed to recover secret share: {error:#}"
+                );
+                SECRET_SHARE_RECOVERY_COUNT
+                    .with_label_values(&["error"])
+                    .inc();
+                return;
+            },
+        };
+
+        let (share_to_send, inserted) = {
+            let mut store = self.secret_share_store.lock();
+            let already_present = matches!(store.get_self_share(&metadata), Ok(Some(_)));
+            let inserted = if already_present {
+                false
+            } else {
+                match store.add_self_share(recovered_share) {
+                    Ok(()) => true,
+                    Err(error) => {
+                        warn!(
+                            epoch = metadata.epoch,
+                            round = metadata.round,
+                            "Failed to add recovered self share: {error:#}"
+                        );
+                        false
+                    },
+                }
+            };
+            let share = match store.get_self_share(&metadata) {
+                Ok(share) => share,
+                Err(error) => {
+                    warn!(
+                        epoch = metadata.epoch,
+                        round = metadata.round,
+                        "Failed to read recovered self share: {error:#}"
+                    );
+                    None
+                },
+            };
+            (share, inserted)
+        };
+        let Some(share) = share_to_send else {
+            SECRET_SHARE_RECOVERY_COUNT
+                .with_label_values(&["store_conflict"])
+                .inc();
+            return;
+        };
+
+        for (protocol, response_sender) in requesters {
+            self.process_response(
+                protocol,
+                response_sender,
+                SecretShareMessage::Share(share.clone()),
+            );
+        }
+        if inserted {
+            let guard = self.spawn_share_requester_task(metadata.clone());
+            if let Some(item) = self.block_queue.item_mut(metadata.round) {
+                item.push_share_requester_handle(guard);
+            } else {
+                warn!(
+                    round = metadata.round,
+                    "Recovered secret share item not found in block queue"
+                );
+            }
+        }
+        SECRET_SHARE_RECOVERY_COUNT
+            .with_label_values(&["success"])
+            .inc();
     }
 
     async fn verification_task(
@@ -408,7 +635,7 @@ impl SecretShareManager {
         DropGuard::new(abort_handle)
     }
 
-    fn handle_incoming_msg(&self, rpc: SecretShareRpc) {
+    fn handle_incoming_msg(&mut self, rpc: SecretShareRpc) {
         let SecretShareRpc {
             msg,
             protocol,
@@ -432,6 +659,10 @@ impl SecretShareManager {
                         warn!(
                             "Self secret share could not be found for RPC request {}",
                             request.metadata().round
+                        );
+                        self.schedule_recovery(
+                            request.metadata().clone(),
+                            (protocol, response_sender),
                         );
                     },
                     Err(e) => {
@@ -508,6 +739,9 @@ impl SecretShareManager {
                 Some(request) = verified_msg_rx.next() => {
                     self.handle_incoming_msg(request);
                 }
+                Some(result) = self.recovery_result_rx.next() => {
+                    self.process_recovery_result(result);
+                }
                 _ = interval.tick().fuse() => {
                     self.observe_queue();
                 },
@@ -523,5 +757,32 @@ impl SecretShareManager {
     pub fn observe_queue(&self) {
         let queue = &self.block_queue.queue();
         DEC_QUEUE_SIZE.set(queue.len() as i64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PendingRecoveryRequests;
+    use crate::rand::secret_sharing::test_utils::create_metadata;
+
+    #[test]
+    fn pending_recovery_deduplicates_and_fans_out() {
+        let metadata = create_metadata(1, 10);
+        let mut pending = PendingRecoveryRequests::default();
+        assert_eq!(pending.append_if_pending(&metadata, 1), Err(1));
+        pending.insert(metadata.clone(), 1);
+        assert_eq!(pending.append_if_pending(&metadata, 2), Ok(()));
+        assert_eq!(pending.take(&metadata, 0), Some(vec![1, 2]));
+    }
+
+    #[test]
+    fn pending_recovery_reset_discards_stale_results() {
+        let metadata = create_metadata(1, 10);
+        let mut pending = PendingRecoveryRequests::default();
+        pending.insert(metadata.clone(), 1);
+        let stale_generation = pending.generation;
+        pending.reset();
+        assert!(pending.take(&metadata, stale_generation).is_none());
+        assert_eq!(pending.generation, stale_generation + 1);
     }
 }

--- a/consensus/src/rand/secret_sharing/secret_share_recovery.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_recovery.rs
@@ -1,0 +1,243 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    block_storage::BlockReader,
+    payload_manager::TPayloadManager,
+    pipeline::decryption_pipeline_builder::{
+        derive_secret_share, select_encrypted_txns_for_secret_share, SecretShareSelection,
+    },
+};
+use anyhow::{anyhow, ensure, Context};
+use aptos_consensus_types::pipelined_block::{DecryptionOutcome, PipelinedBlock};
+use aptos_infallible::RwLock;
+use aptos_types::secret_sharing::{Author, SecretShare, SecretShareConfig, SecretShareMetadata};
+use async_trait::async_trait;
+use futures::FutureExt;
+use std::sync::Arc;
+
+#[async_trait]
+pub trait SecretShareRecovery: Send + Sync {
+    async fn recover(&self, metadata: SecretShareMetadata) -> anyhow::Result<Option<SecretShare>>;
+}
+
+/// Startup creates the secret-share manager before the block store. This
+/// forwarding implementation lets the concrete, read-only recovery service be
+/// injected once the block store exists without coupling the manager to it.
+#[derive(Default)]
+pub struct LateBoundSecretShareRecovery {
+    inner: RwLock<Option<Arc<dyn SecretShareRecovery>>>,
+}
+
+impl LateBoundSecretShareRecovery {
+    pub fn clear(&self) {
+        *self.inner.write() = None;
+    }
+
+    pub fn set(&self, recovery: Arc<dyn SecretShareRecovery>) {
+        *self.inner.write() = Some(recovery);
+    }
+}
+
+#[async_trait]
+impl SecretShareRecovery for LateBoundSecretShareRecovery {
+    async fn recover(&self, metadata: SecretShareMetadata) -> anyhow::Result<Option<SecretShare>> {
+        let recovery = self
+            .inner
+            .read()
+            .clone()
+            .ok_or_else(|| anyhow!("secret-share recovery is not initialized"))?;
+        recovery.recover(metadata).await
+    }
+}
+
+pub struct OrderedBlockSecretShareRecovery {
+    author: Author,
+    secret_share_config: SecretShareConfig,
+    payload_manager: Arc<dyn TPayloadManager>,
+    block_reader: Arc<dyn BlockReader>,
+}
+
+impl OrderedBlockSecretShareRecovery {
+    pub fn new(
+        author: Author,
+        secret_share_config: SecretShareConfig,
+        payload_manager: Arc<dyn TPayloadManager>,
+        block_reader: Arc<dyn BlockReader>,
+    ) -> Self {
+        Self {
+            author,
+            secret_share_config,
+            payload_manager,
+            block_reader,
+        }
+    }
+
+    fn outcome_round(outcome: &DecryptionOutcome) -> anyhow::Result<Option<u64>> {
+        match outcome {
+            DecryptionOutcome::Disabled => Err(anyhow!("decryption is disabled")),
+            DecryptionOutcome::Legacy(_) => Ok(None),
+            DecryptionOutcome::RoundTracked {
+                next_decryption_round,
+                payload: _,
+            } => Ok(Some(*next_decryption_round)),
+        }
+    }
+
+    fn retained_parent_round(parent: &PipelinedBlock) -> anyhow::Result<Option<Option<u64>>> {
+        let Some(futures) = parent.pipeline_futs() else {
+            return Ok(None);
+        };
+        match futures.decryption_fut.now_or_never() {
+            Some(Ok(result)) => Self::outcome_round(&result.outcome).map(Some),
+            Some(Err(_)) => Ok(None),
+            None => Ok(None),
+        }
+    }
+
+    async fn materialize(
+        &self,
+        block: &PipelinedBlock,
+    ) -> anyhow::Result<(
+        Vec<aptos_types::transaction::SignedTransaction>,
+        Option<u64>,
+    )> {
+        self.payload_manager
+            .check_payload_availability(block.block())
+            .map_err(|missing| anyhow!("payload is unavailable locally: {missing:?}"))?;
+        let (txns, max_txns_from_block_to_execute, _block_gas_limit) = self
+            .payload_manager
+            .get_transactions(block.block(), None)
+            .await
+            .context("failed to materialize ordered block payload")?;
+        Ok((txns, max_txns_from_block_to_execute))
+    }
+
+    async fn reconstruct_parent_round(
+        &self,
+        commit_root: &PipelinedBlock,
+        ancestors: &[Arc<PipelinedBlock>],
+    ) -> anyhow::Result<Option<u64>> {
+        let seed = Self::retained_parent_round(commit_root)?
+            .ok_or_else(|| anyhow!("committed-root decryption outcome is unavailable"))?;
+        let Some(mut next_decryption_round) = seed else {
+            return Ok(None);
+        };
+
+        for block in ancestors {
+            let (txns, max_txns_from_block_to_execute) = self.materialize(block).await?;
+            let encrypted_txns_len = txns.iter().filter(|txn| txn.is_encrypted_txn()).count();
+            if matches!(
+                select_encrypted_txns_for_secret_share(
+                    block.block(),
+                    &self.secret_share_config,
+                    encrypted_txns_len,
+                    max_txns_from_block_to_execute,
+                    next_decryption_round,
+                ),
+                SecretShareSelection::Selected {
+                    selected_len: 1..,
+                    ..
+                }
+            ) {
+                next_decryption_round = next_decryption_round
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow!("decryption round overflow"))?;
+            }
+        }
+        Ok(Some(next_decryption_round))
+    }
+}
+
+#[async_trait]
+impl SecretShareRecovery for OrderedBlockSecretShareRecovery {
+    async fn recover(&self, requested: SecretShareMetadata) -> anyhow::Result<Option<SecretShare>> {
+        let commit_root = self.block_reader.commit_root();
+        let ordered_root = self.block_reader.ordered_root();
+        let canonical_path = self
+            .block_reader
+            .path_from_commit_root(ordered_root.id())
+            .ok_or_else(|| anyhow!("ordered root is not a descendant of the commit root"))?;
+
+        // Reject a moving-tree snapshot instead of accidentally accepting a
+        // block from a path that ceased to be canonical while it was read.
+        ensure!(
+            self.block_reader.commit_root().id() == commit_root.id()
+                && self.block_reader.ordered_root().id() == ordered_root.id(),
+            "block-store roots changed during recovery"
+        );
+
+        let target_index = canonical_path
+            .iter()
+            .position(|block| block.id() == requested.block_id)
+            .ok_or_else(|| anyhow!("requested block is not on the canonical ordered path"))?;
+        let target = &canonical_path[target_index];
+        ensure!(
+            target.epoch() == requested.epoch,
+            "requested epoch mismatch"
+        );
+        ensure!(
+            target.round() == requested.round,
+            "requested round mismatch"
+        );
+        ensure!(
+            target.timestamp_usecs() == requested.timestamp,
+            "requested timestamp mismatch"
+        );
+        ensure!(
+            target.id() == requested.block_id,
+            "requested block ID mismatch"
+        );
+
+        let parent = if target_index == 0 {
+            commit_root.as_ref()
+        } else {
+            canonical_path[target_index - 1].as_ref()
+        };
+        let chained_round = match Self::retained_parent_round(parent)? {
+            Some(round) => round,
+            None => {
+                self.reconstruct_parent_round(&commit_root, &canonical_path[..target_index])
+                    .await?
+            },
+        };
+        let digest_round = chained_round.unwrap_or_else(|| target.round());
+
+        let (txns, max_txns_from_block_to_execute) = self.materialize(target).await?;
+        let encrypted_txns: Vec<_> = txns
+            .into_iter()
+            .filter(|txn| txn.is_encrypted_txn())
+            .collect();
+        let selected_len = match select_encrypted_txns_for_secret_share(
+            target.block(),
+            &self.secret_share_config,
+            encrypted_txns.len(),
+            max_txns_from_block_to_execute,
+            digest_round,
+        ) {
+            SecretShareSelection::Selected { selected_len, .. } => {
+                if selected_len == 0 {
+                    return Ok(None);
+                }
+                selected_len
+            },
+            SecretShareSelection::NoEncryptedTransactions
+            | SecretShareSelection::TrustedSetupExhausted
+            | SecretShareSelection::EpochEnd => return Ok(None),
+        };
+
+        let (_, _, _, share) = derive_secret_share(
+            &encrypted_txns[..selected_len],
+            target.block(),
+            self.author,
+            &self.secret_share_config,
+            digest_round,
+        )
+        .await?;
+        ensure!(
+            share.metadata() == &requested,
+            "locally reconstructed metadata does not match the request"
+        );
+        Ok(Some(share))
+    }
+}

--- a/testsuite/smoke-test/src/decryption/secret_share_rpc_path.rs
+++ b/testsuite/smoke-test/src/decryption/secret_share_rpc_path.rs
@@ -9,17 +9,17 @@ use aptos_types::on_chain_config::{
 };
 use std::{sync::Arc, time::Duration};
 
-/// Verify that SecretShareMsg works via the RPC path (not just direct send).
+/// Verify that SecretShareMsg recovers a locally missing self-share via RPC.
 ///
 /// This test disables the direct-send broadcast of secret shares via a failpoint,
-/// forcing the system to rely on the RPC path. If the RPC handler for SecretShareMsg
-/// is missing, validators will not be able to exchange secret shares and the chain
-/// will stall.
+/// forcing the system to rely on the RPC path, and drops the original self-share
+/// delivery on one validator. That validator must reconstruct its share from its
+/// retained ordered block before the network can continue aggregating keys.
 #[tokio::test]
 async fn secret_share_rpc_path() {
     let epoch_duration_secs = 20;
 
-    let mut swarm = SwarmBuilder::new_local(4)
+    let mut swarm = SwarmBuilder::new_local(5)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
             config.api.failpoints_enabled = true;
@@ -62,6 +62,13 @@ async fn secret_share_rpc_path() {
             .await
             .expect("Failed to set failpoint");
     }
+    validator_clients[0]
+        .set_failpoint(
+            "consensus::secret_share_manager::drop_derived_share_delivery".to_string(),
+            "return".to_string(),
+        )
+        .await
+        .expect("Failed to drop the original self-share delivery");
 
     // Generate encrypted traffic to exercise the decryption / secret share path.
     info!("Emitting encrypted traffic with direct-send disabled...");
@@ -96,5 +103,5 @@ async fn secret_share_rpc_path() {
         .await
         .expect("Timed out waiting for epoch 3 — SecretShareMsg RPC path may be broken");
 
-    info!("All validators reached epoch 3 using only the RPC path for secret shares.");
+    info!("All validators reached epoch 3 after recovering the missing self-share.");
 }


### PR DESCRIPTION
## Description

Recover a validator's missing threshold-decryption self-share reactively when a peer requests it and the share is absent from the local cache.

The recovery path:

- validates that the requested block is on the current canonical ordered path
- reconstructs the encrypted transaction selection and counter state using the same helpers as the normal decryption pipeline
- supports both legacy consensus-round metadata and dense encrypted-block counters
- materializes payloads locally without retries and verifies the complete requested metadata, including the FPTX digest
- stores the recovered share before replying, without adding persistence or changing the wire protocol

Concurrent requests for identical metadata are deduplicated and fanned out after one bounded recovery operation. Pending work is generation-scoped and discarded across epoch resets.

## How Has This Been Tested?

- `cargo check -p aptos-consensus`
- `cargo check -p smoke-test`
- `cargo test -p aptos-consensus --lib` (430 passed, 9 ignored)
- `cargo clippy -p aptos-consensus --lib --no-deps` with repository check-cfg settings
- `cargo test -p smoke-test secret_share_rpc_path -- --nocapture`
  - five-validator swarm
  - secret-share direct-send disabled on every validator
  - original derived self-share dropped on one validator
  - 120/120 encrypted transactions committed
  - every validator advanced to the next epoch via RPC recovery

## Key Areas to Review

- Canonical-path validation and dense-counter replay in `secret_share_recovery.rs`.
- Shared transaction-selection and derivation helpers in `decryption_pipeline_builder.rs`.
- Request deduplication, generation reset, bounded scheduling, and store-before-reply behavior in `secret_share_manager.rs`.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
