### PR TITLE
[consensus] Persist secret shares for recovery

### DIFF
--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -17,7 +17,7 @@ use crate::{
     persistent_liveness_storage::StorageWriteProxy,
     pipeline::execution_client::{DummyExecutionClient, ExecutionProxyClient, TExecutionClient},
     quorum_store::quorum_store_db::QuorumStoreDB,
-    rand::rand_gen::storage::db::RandDb,
+    rand::{rand_gen::storage::db::RandDb, secret_sharing::storage::SecretShareDb},
     state_computer::ExecutionProxy,
     txn_notifier::MempoolNotifier,
     util::time_service::ClockTimeService,
@@ -83,6 +83,7 @@ pub fn start_consensus(
         runtime.handle().clone(),
     );
     let rand_storage = Arc::new(RandDb::new(node_config.storage.dir()));
+    let secret_share_storage = Arc::new(SecretShareDb::new(node_config.storage.dir()));
 
     let execution_client = Arc::new(ExecutionProxyClient::new(
         node_config.consensus.clone(),
@@ -92,6 +93,7 @@ pub fn start_consensus(
         consensus_network_client.clone(),
         bounded_executor.clone(),
         rand_storage.clone(),
+        secret_share_storage,
         node_config.consensus_observer,
         consensus_publisher.clone(),
     ));
@@ -167,6 +169,7 @@ pub fn start_consensus_observer(
         let bounded_executor =
             BoundedExecutor::new(32, consensus_observer_runtime.handle().clone());
         let rand_storage = Arc::new(RandDb::new(node_config.storage.dir()));
+        let secret_share_storage = Arc::new(SecretShareDb::new(node_config.storage.dir()));
         let execution_proxy_client = Arc::new(ExecutionProxyClient::new(
             node_config.consensus.clone(),
             Arc::new(execution_proxy),
@@ -175,6 +178,7 @@ pub fn start_consensus_observer(
             consensus_network_client,
             bounded_executor,
             rand_storage.clone(),
+            secret_share_storage,
             node_config.consensus_observer,
             consensus_publisher.clone(),
         ));

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1544,6 +1544,15 @@ pub static SECRET_SHARE_BAD_SHARES: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static SECRET_SHARE_STORAGE_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_consensus_secret_share_storage_events_count",
+        "Secret share storage operations by operation and result.",
+        &["operation", "result"]
+    )
+    .unwrap()
+});
+
 pub static CONSENSUS_PROPOSAL_PAYLOAD_AVAILABILITY: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_consensus_proposal_payload_availability_count",

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1544,15 +1544,6 @@ pub static SECRET_SHARE_BAD_SHARES: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static SECRET_SHARE_STORAGE_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "aptos_consensus_secret_share_storage_events_count",
-        "Secret share storage operations by operation and result.",
-        &["operation", "result"]
-    )
-    .unwrap()
-});
-
 pub static CONSENSUS_PROPOSAL_PAYLOAD_AVAILABILITY: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_consensus_proposal_payload_availability_count",

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1544,6 +1544,14 @@ pub static SECRET_SHARE_BAD_SHARES: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static SECRET_SHARE_RECOVERY_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_secret_share_recovery_count",
+        "Number of persisted secret shares served after an active-store miss."
+    )
+    .unwrap()
+});
+
 pub static CONSENSUS_PROPOSAL_PAYLOAD_AVAILABILITY: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_consensus_proposal_payload_availability_count",

--- a/consensus/src/logging.rs
+++ b/consensus/src/logging.rs
@@ -65,6 +65,7 @@ pub enum LogEvent {
     ReceiveSecretShare,
     BroadcastSecretShare,
     ReceiveReactiveSecretShare,
+    ServePersistedSecretShare,
 }
 
 impl LogSchema {

--- a/consensus/src/logging.rs
+++ b/consensus/src/logging.rs
@@ -61,6 +61,7 @@ pub enum LogEvent {
     ReceiveOptProposal,
     ProcessOptProposal,
     // secret sharing events
+    ReceiveSecretShareRequest,
     ReceiveSecretShare,
     BroadcastSecretShare,
     ReceiveReactiveSecretShare,

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -23,7 +23,11 @@ use crate::{
             storage::interface::RandStorage,
             types::{AugmentedData, RandConfig, Share},
         },
-        secret_sharing::{secret_share_manager::SecretShareManager, verifier::SecretShareVerifier},
+        secret_sharing::{
+            secret_share_manager::SecretShareManager,
+            storage::{LoadedSecretShare, SecretShareStorage, SecretShareStorageError},
+            verifier::SecretShareVerifier,
+        },
     },
     state_computer::ExecutionProxy,
     state_replication::StateComputer,
@@ -191,6 +195,7 @@ pub struct ExecutionProxyClient {
     // channels to buffer manager
     handle: Arc<RwLock<BufferManagerHandle>>,
     rand_storage: Arc<dyn RandStorage<AugmentedData>>,
+    secret_share_storage: Arc<dyn SecretShareStorage>,
     consensus_observer_config: ConsensusObserverConfig,
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
 }
@@ -204,6 +209,7 @@ impl ExecutionProxyClient {
         network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
         bounded_executor: BoundedExecutor,
         rand_storage: Arc<dyn RandStorage<AugmentedData>>,
+        secret_share_storage: Arc<dyn SecretShareStorage>,
         consensus_observer_config: ConsensusObserverConfig,
         consensus_publisher: Option<Arc<ConsensusPublisher>>,
     ) -> Self {
@@ -216,6 +222,7 @@ impl ExecutionProxyClient {
             bounded_executor,
             handle: Arc::new(RwLock::new(BufferManagerHandle::new())),
             rand_storage,
+            secret_share_storage,
             consensus_observer_config,
             consensus_publisher,
         }
@@ -272,6 +279,7 @@ impl ExecutionProxyClient {
         &self,
         epoch_state: &Arc<EpochState>,
         verifier: Arc<SecretShareVerifier>,
+        loaded_self_shares: Vec<LoadedSecretShare>,
         secret_sharing_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingSecretShareRequest>,
         highest_committed_round: u64,
         network_sender: &Arc<NetworkSender>,
@@ -292,6 +300,8 @@ impl ExecutionProxyClient {
             verifier,
             secret_ready_block_tx,
             network_sender.clone(),
+            self.secret_share_storage.clone(),
+            loaded_self_shares,
             self.bounded_executor.clone(),
             &self.consensus_config.secret_share_rb_config,
             self.consensus_config.secret_share_request_delay_ms,
@@ -383,6 +393,7 @@ impl ExecutionProxyClient {
         epoch_state: Arc<EpochState>,
         rand_config: Option<RandConfig>,
         secret_share_verifier: Option<Arc<SecretShareVerifier>>,
+        loaded_self_shares: Vec<LoadedSecretShare>,
         onchain_consensus_config: &OnChainConsensusConfig,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
         secret_sharing_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingSecretShareRequest>,
@@ -425,6 +436,7 @@ impl ExecutionProxyClient {
                 ) = self.make_secret_sharing_manager(
                     &epoch_state,
                     secret_share_verifier,
+                    loaded_self_shares,
                     secret_sharing_msg_rx,
                     highest_committed_round,
                     &network_sender,
@@ -467,6 +479,7 @@ impl ExecutionProxyClient {
                     self.make_secret_sharing_manager(
                         &epoch_state,
                         secret_sharing_config,
+                        loaded_self_shares,
                         secret_sharing_msg_rx,
                         highest_committed_round,
                         &network_sender,
@@ -544,6 +557,51 @@ impl TExecutionClient for ExecutionProxyClient {
         secret_sharing_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingSecretShareRequest>,
         highest_committed_round: Round,
     ) {
+        let epoch = epoch_state.epoch;
+        let prune_result = self.secret_share_storage.prune_before_epoch(epoch);
+        match prune_result {
+            Ok(()) => counters::SECRET_SHARE_STORAGE_EVENTS
+                .with_label_values(&["prune", "success"])
+                .inc(),
+            Err(error) => {
+                let result = match error {
+                    SecretShareStorageError::Conflict { .. } => "conflict",
+                    SecretShareStorageError::Corruption(_) => "corruption",
+                    SecretShareStorageError::Io(_) => "io_failure",
+                };
+                counters::SECRET_SHARE_STORAGE_EVENTS
+                    .with_label_values(&["prune", result])
+                    .inc();
+                error!(
+                    epoch = epoch,
+                    "Failed to prune old secret shares at epoch start: {error}"
+                );
+            },
+        }
+        let loaded_self_shares = if secret_share_verifier.is_some() {
+            match self.secret_share_storage.load_self_shares(epoch) {
+                Ok(shares) => {
+                    counters::SECRET_SHARE_STORAGE_EVENTS
+                        .with_label_values(&["load", "success"])
+                        .inc();
+                    shares
+                },
+                Err(error) => {
+                    let result = match &error {
+                        SecretShareStorageError::Conflict { .. } => "conflict",
+                        SecretShareStorageError::Corruption(_) => "corruption",
+                        SecretShareStorageError::Io(_) => "io_failure",
+                    };
+                    counters::SECRET_SHARE_STORAGE_EVENTS
+                        .with_label_values(&["load", result])
+                        .inc();
+                    panic!("Failed to load secret shares at epoch start: {error}");
+                },
+            }
+        } else {
+            Vec::new()
+        };
+
         let network_sender = Arc::new(NetworkSender::new(
             self.author,
             self.network_sender.clone(),
@@ -556,6 +614,7 @@ impl TExecutionClient for ExecutionProxyClient {
             epoch_state.clone(),
             rand_config,
             secret_share_verifier.clone(),
+            loaded_self_shares,
             onchain_consensus_config,
             rand_msg_rx,
             secret_sharing_msg_rx,

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -25,7 +25,7 @@ use crate::{
         },
         secret_sharing::{
             secret_share_manager::SecretShareManager,
-            storage::{LoadedSecretShare, SecretShareStorage, SecretShareStorageError},
+            storage::{LoadedSecretShare, SecretShareStorage},
             verifier::SecretShareVerifier,
         },
     },
@@ -558,45 +558,16 @@ impl TExecutionClient for ExecutionProxyClient {
         highest_committed_round: Round,
     ) {
         let epoch = epoch_state.epoch;
-        let prune_result = self.secret_share_storage.prune_before_epoch(epoch);
-        match prune_result {
-            Ok(()) => counters::SECRET_SHARE_STORAGE_EVENTS
-                .with_label_values(&["prune", "success"])
-                .inc(),
-            Err(error) => {
-                let result = match error {
-                    SecretShareStorageError::Conflict { .. } => "conflict",
-                    SecretShareStorageError::Corruption(_) => "corruption",
-                    SecretShareStorageError::Io(_) => "io_failure",
-                };
-                counters::SECRET_SHARE_STORAGE_EVENTS
-                    .with_label_values(&["prune", result])
-                    .inc();
-                error!(
-                    epoch = epoch,
-                    "Failed to prune old secret shares at epoch start: {error}"
-                );
-            },
+        if let Err(error) = self.secret_share_storage.prune_before_epoch(epoch) {
+            error!(
+                epoch = epoch,
+                "Failed to prune old secret shares at epoch start: {error}"
+            );
         }
         let loaded_self_shares = if secret_share_verifier.is_some() {
             match self.secret_share_storage.load_self_shares(epoch) {
-                Ok(shares) => {
-                    counters::SECRET_SHARE_STORAGE_EVENTS
-                        .with_label_values(&["load", "success"])
-                        .inc();
-                    shares
-                },
-                Err(error) => {
-                    let result = match &error {
-                        SecretShareStorageError::Conflict { .. } => "conflict",
-                        SecretShareStorageError::Corruption(_) => "corruption",
-                        SecretShareStorageError::Io(_) => "io_failure",
-                    };
-                    counters::SECRET_SHARE_STORAGE_EVENTS
-                        .with_label_values(&["load", result])
-                        .inc();
-                    panic!("Failed to load secret shares at epoch start: {error}");
-                },
+                Ok(shares) => shares,
+                Err(error) => panic!("Failed to load secret shares at epoch start: {error}"),
             }
         } else {
             Vec::new()

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -292,6 +292,13 @@ impl ExecutionProxyClient {
         let (reset_tx_to_secret_share_manager, reset_secret_share_manager_rx) =
             unbounded::<ResetRequest>();
 
+        let state_sync_round_gap = self.consensus_config.max_commit_gap.max(
+            self.consensus_config
+                .vote_back_pressure_limit
+                .saturating_mul(2),
+        );
+        let retention_rounds = state_sync_round_gap.saturating_mul(2);
+
         let secret_share_manager = SecretShareManager::new(
             self.author,
             epoch_state.clone(),
@@ -299,6 +306,8 @@ impl ExecutionProxyClient {
             secret_ready_block_tx,
             network_sender.clone(),
             self.secret_share_storage.clone(),
+            highest_committed_round,
+            retention_rounds,
             self.bounded_executor.clone(),
             &self.consensus_config.secret_share_rb_config,
             self.consensus_config.secret_share_request_delay_ms,

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -24,8 +24,7 @@ use crate::{
             types::{AugmentedData, RandConfig, Share},
         },
         secret_sharing::{
-            secret_share_manager::SecretShareManager,
-            storage::{LoadedSecretShare, SecretShareStorage},
+            secret_share_manager::SecretShareManager, storage::SecretShareStorage,
             verifier::SecretShareVerifier,
         },
     },
@@ -279,7 +278,6 @@ impl ExecutionProxyClient {
         &self,
         epoch_state: &Arc<EpochState>,
         verifier: Arc<SecretShareVerifier>,
-        loaded_self_shares: Vec<LoadedSecretShare>,
         secret_sharing_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingSecretShareRequest>,
         highest_committed_round: u64,
         network_sender: &Arc<NetworkSender>,
@@ -301,7 +299,6 @@ impl ExecutionProxyClient {
             secret_ready_block_tx,
             network_sender.clone(),
             self.secret_share_storage.clone(),
-            loaded_self_shares,
             self.bounded_executor.clone(),
             &self.consensus_config.secret_share_rb_config,
             self.consensus_config.secret_share_request_delay_ms,
@@ -393,7 +390,6 @@ impl ExecutionProxyClient {
         epoch_state: Arc<EpochState>,
         rand_config: Option<RandConfig>,
         secret_share_verifier: Option<Arc<SecretShareVerifier>>,
-        loaded_self_shares: Vec<LoadedSecretShare>,
         onchain_consensus_config: &OnChainConsensusConfig,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
         secret_sharing_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingSecretShareRequest>,
@@ -436,7 +432,6 @@ impl ExecutionProxyClient {
                 ) = self.make_secret_sharing_manager(
                     &epoch_state,
                     secret_share_verifier,
-                    loaded_self_shares,
                     secret_sharing_msg_rx,
                     highest_committed_round,
                     &network_sender,
@@ -479,7 +474,6 @@ impl ExecutionProxyClient {
                     self.make_secret_sharing_manager(
                         &epoch_state,
                         secret_sharing_config,
-                        loaded_self_shares,
                         secret_sharing_msg_rx,
                         highest_committed_round,
                         &network_sender,
@@ -557,22 +551,6 @@ impl TExecutionClient for ExecutionProxyClient {
         secret_sharing_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingSecretShareRequest>,
         highest_committed_round: Round,
     ) {
-        let epoch = epoch_state.epoch;
-        if let Err(error) = self.secret_share_storage.prune_before_epoch(epoch) {
-            error!(
-                epoch = epoch,
-                "Failed to prune old secret shares at epoch start: {error}"
-            );
-        }
-        let loaded_self_shares = if secret_share_verifier.is_some() {
-            match self.secret_share_storage.load_self_shares(epoch) {
-                Ok(shares) => shares,
-                Err(error) => panic!("Failed to load secret shares at epoch start: {error}"),
-            }
-        } else {
-            Vec::new()
-        };
-
         let network_sender = Arc::new(NetworkSender::new(
             self.author,
             self.network_sender.clone(),
@@ -585,7 +563,6 @@ impl TExecutionClient for ExecutionProxyClient {
             epoch_state.clone(),
             rand_config,
             secret_share_verifier.clone(),
-            loaded_self_shares,
             onchain_consensus_config,
             rand_msg_rx,
             secret_sharing_msg_rx,

--- a/consensus/src/rand/secret_sharing/mod.rs
+++ b/consensus/src/rand/secret_sharing/mod.rs
@@ -6,6 +6,7 @@ pub mod network_messages;
 pub mod reliable_broadcast_state;
 pub mod secret_share_manager;
 pub mod secret_share_store;
+pub mod storage;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub mod types;

--- a/consensus/src/rand/secret_sharing/mod.rs
+++ b/consensus/src/rand/secret_sharing/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod block_queue;
 pub mod network_messages;
+mod recovered_self_shares;
 pub mod reliable_broadcast_state;
 pub mod secret_share_manager;
 pub mod secret_share_store;

--- a/consensus/src/rand/secret_sharing/mod.rs
+++ b/consensus/src/rand/secret_sharing/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod block_queue;
 pub mod network_messages;
-mod recovered_self_shares;
+mod persisted_self_shares;
 pub mod reliable_broadcast_state;
 pub mod secret_share_manager;
 pub mod secret_share_store;

--- a/consensus/src/rand/secret_sharing/persisted_self_shares.rs
+++ b/consensus/src/rand/secret_sharing/persisted_self_shares.rs
@@ -9,18 +9,18 @@ use aptos_consensus_types::common::{Author, Round};
 use aptos_types::secret_sharing::{SecretShare, SecretShareMetadata};
 use std::{collections::HashMap, sync::Arc};
 
-struct RecoveredSelfShare {
+struct CachedSelfShare {
     share: SecretShare,
     verified: bool,
 }
 
-pub struct RecoveredSelfShares {
+pub struct PersistedSelfShares {
     storage: Arc<dyn SecretShareStorage>,
     retention_rounds: Round,
-    shares: HashMap<SecretShareKey, RecoveredSelfShare>,
+    shares: HashMap<SecretShareKey, CachedSelfShare>,
 }
 
-impl RecoveredSelfShares {
+impl PersistedSelfShares {
     pub fn new(
         epoch: u64,
         author: Author,
@@ -53,7 +53,7 @@ impl RecoveredSelfShares {
                 expired_keys.push(key);
                 continue;
             }
-            shares.insert(key, RecoveredSelfShare {
+            shares.insert(key, CachedSelfShare {
                 share,
                 verified: false,
             });
@@ -70,9 +70,11 @@ impl RecoveredSelfShares {
     }
 
     pub fn persist(&mut self, share: SecretShare) -> anyhow::Result<()> {
+        // Overwriting is safe: self-share derivation is deterministic, using the fixed epoch
+        // master-secret share and the block's deterministic ciphertext/round digest, with no RNG.
         self.storage.save_self_share(&share)?;
         self.shares
-            .insert(storage_key(share.metadata()), RecoveredSelfShare {
+            .insert(storage_key(share.metadata()), CachedSelfShare {
                 share,
                 verified: false,
             });

--- a/consensus/src/rand/secret_sharing/persisted_self_shares.rs
+++ b/consensus/src/rand/secret_sharing/persisted_self_shares.rs
@@ -1,23 +1,15 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::rand::secret_sharing::{
-    storage::{storage_key, SecretShareKey, SecretShareStorage},
-    verifier::SecretShareVerifier,
-};
+use crate::rand::secret_sharing::storage::{storage_key, SecretShareKey, SecretShareStorage};
 use aptos_consensus_types::common::{Author, Round};
 use aptos_types::secret_sharing::{SecretShare, SecretShareMetadata};
 use std::{collections::HashMap, sync::Arc};
 
-struct CachedSelfShare {
-    share: SecretShare,
-    verified: bool,
-}
-
 pub struct PersistedSelfShares {
     storage: Arc<dyn SecretShareStorage>,
     retention_rounds: Round,
-    shares: HashMap<SecretShareKey, CachedSelfShare>,
+    shares: HashMap<SecretShareKey, SecretShare>,
 }
 
 impl PersistedSelfShares {
@@ -54,10 +46,7 @@ impl PersistedSelfShares {
                 keys_to_prune.push(key);
                 continue;
             }
-            shares.insert(key, CachedSelfShare {
-                share,
-                verified: false,
-            });
+            shares.insert(key, share);
         }
         storage
             .prune_self_shares(&keys_to_prune)
@@ -74,11 +63,7 @@ impl PersistedSelfShares {
         // Overwriting is safe: self-share derivation is deterministic, using the fixed epoch
         // master-secret share and the block's deterministic ciphertext/round digest, with no RNG.
         self.storage.save_self_share(&share)?;
-        self.shares
-            .insert(storage_key(share.metadata()), CachedSelfShare {
-                share,
-                verified: false,
-            });
+        self.shares.insert(storage_key(share.metadata()), share);
         Ok(())
     }
 
@@ -87,9 +72,7 @@ impl PersistedSelfShares {
         let expired_keys = self
             .shares
             .iter()
-            .filter_map(|(key, recovered)| {
-                (recovered.share.round() < oldest_retained_round).then_some(*key)
-            })
+            .filter_map(|(key, share)| (share.round() < oldest_retained_round).then_some(*key))
             .collect::<Vec<_>>();
         if expired_keys.is_empty() {
             return;
@@ -102,23 +85,12 @@ impl PersistedSelfShares {
         }
     }
 
-    pub fn get(
-        &mut self,
-        metadata: &SecretShareMetadata,
-        verifier: &SecretShareVerifier,
-        author: &Author,
-    ) -> Option<SecretShare> {
-        let recovered = self.shares.get_mut(&storage_key(metadata))?;
-        if recovered.share.metadata() != metadata {
+    pub fn get(&self, metadata: &SecretShareMetadata) -> Option<SecretShare> {
+        let share = self.shares.get(&storage_key(metadata))?;
+        if share.metadata() != metadata {
             return None;
         }
-        if !recovered.verified {
-            verifier
-                .verify(&recovered.share, author)
-                .expect("Invalid persisted secret share");
-            recovered.verified = true;
-        }
-        Some(recovered.share.clone())
+        Some(share.clone())
     }
 
     #[cfg(test)]
@@ -129,12 +101,5 @@ impl PersistedSelfShares {
     #[cfg(test)]
     pub fn contains_key(&self, key: &SecretShareKey) -> bool {
         self.shares.contains_key(key)
-    }
-
-    #[cfg(test)]
-    pub fn is_verified(&self, key: &SecretShareKey) -> bool {
-        self.shares
-            .get(key)
-            .is_some_and(|recovered| recovered.verified)
     }
 }

--- a/consensus/src/rand/secret_sharing/persisted_self_shares.rs
+++ b/consensus/src/rand/secret_sharing/persisted_self_shares.rs
@@ -28,16 +28,18 @@ impl PersistedSelfShares {
         highest_committed_round: Round,
         retention_rounds: Round,
     ) -> Self {
-        storage
-            .prune_before_epoch(epoch)
-            .expect("Failed to prune old secret shares at epoch start");
         let oldest_retained_round = highest_committed_round.saturating_sub(retention_rounds);
-        let loaded_self_shares = storage
-            .load_self_shares(epoch)
+        let all_self_shares = storage
+            .get_all_self_shares()
             .expect("Failed to load secret shares at epoch start");
         let mut shares = HashMap::new();
-        let mut expired_keys = Vec::new();
-        for share in loaded_self_shares {
+        let mut keys_to_prune = Vec::new();
+        for share in all_self_shares {
+            let key = storage_key(share.metadata());
+            if share.epoch() < epoch {
+                keys_to_prune.push(key);
+                continue;
+            }
             assert_eq!(
                 share.epoch(),
                 epoch,
@@ -48,9 +50,8 @@ impl PersistedSelfShares {
                 &author,
                 "Persisted secret share has wrong author"
             );
-            let key = storage_key(share.metadata());
             if share.round() < oldest_retained_round {
-                expired_keys.push(key);
+                keys_to_prune.push(key);
                 continue;
             }
             shares.insert(key, CachedSelfShare {
@@ -59,8 +60,8 @@ impl PersistedSelfShares {
             });
         }
         storage
-            .prune_self_shares(&expired_keys)
-            .expect("Failed to prune expired secret shares at epoch start");
+            .prune_self_shares(&keys_to_prune)
+            .expect("Failed to prune stale secret shares at epoch start");
 
         Self {
             storage,

--- a/consensus/src/rand/secret_sharing/recovered_self_shares.rs
+++ b/consensus/src/rand/secret_sharing/recovered_self_shares.rs
@@ -1,16 +1,13 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::rand::secret_sharing::storage::{storage_key, SecretShareKey, SecretShareStorage};
+use crate::rand::secret_sharing::{
+    storage::{storage_key, SecretShareKey, SecretShareStorage},
+    verifier::SecretShareVerifier,
+};
 use aptos_consensus_types::common::{Author, Round};
-use aptos_logger::error;
 use aptos_types::secret_sharing::{SecretShare, SecretShareMetadata};
 use std::{collections::HashMap, sync::Arc};
-
-pub enum RecoveredShare {
-    Verified(SecretShare),
-    Unverified(SecretShare),
-}
 
 struct RecoveredSelfShare {
     share: SecretShare,
@@ -22,8 +19,6 @@ pub struct RecoveredSelfShares {
     storage: Arc<dyn SecretShareStorage>,
     retention_rounds: Round,
     shares: HashMap<SecretShareKey, RecoveredSelfShare>,
-    pending_epoch_prune: bool,
-    pending_prune_before_round: Option<Round>,
 }
 
 impl RecoveredSelfShares {
@@ -34,62 +29,31 @@ impl RecoveredSelfShares {
         highest_committed_round: Round,
         retention_rounds: Round,
     ) -> Self {
-        let pending_epoch_prune = if let Err(error) = storage.prune_before_epoch(epoch) {
-            error!(
-                epoch = epoch,
-                "Failed to prune old secret shares at epoch start; will retry: {error}"
-            );
-            true
-        } else {
-            false
-        };
+        storage.prune_before_epoch(epoch).unwrap_or_else(|error| {
+            panic!("Failed to prune old secret shares at epoch start: {error}")
+        });
         let oldest_retained_round = highest_committed_round.saturating_sub(retention_rounds);
-        let pending_prune_before_round =
-            if let Err(error) = storage.prune_before_round(epoch, oldest_retained_round) {
-                error!(
-                    epoch = epoch,
-                    oldest_retained_round = oldest_retained_round,
-                    "Failed to prune expired secret shares at epoch start; will retry: {error}"
-                );
-                Some(oldest_retained_round)
-            } else {
-                None
-            };
+        storage
+            .prune_before_round(epoch, oldest_retained_round)
+            .unwrap_or_else(|error| {
+                panic!("Failed to prune expired secret shares at epoch start: {error}")
+            });
 
         let loaded_self_shares = storage
             .load_self_shares(epoch)
             .unwrap_or_else(|error| panic!("Failed to load secret shares at epoch start: {error}"));
         let mut shares = HashMap::new();
-        for (key, loaded_share) in loaded_self_shares {
-            let share = match loaded_share {
-                Ok(share) => share,
-                Err(error) => {
-                    error!(
-                        epoch = key.0,
-                        block_id = key.1,
-                        "Deleting invalid persisted secret share: {error}"
-                    );
-                    Self::delete_or_panic(&storage, &key, "invalid");
-                    continue;
-                },
-            };
-            if share.epoch() != epoch || share.author() != &author {
-                error!(
-                    expected_epoch = epoch,
-                    share_epoch = share.epoch(),
-                    expected_author = author,
-                    share_author = share.author(),
-                    "Deleting persisted secret share with invalid identity"
-                );
-                Self::delete_or_panic(&storage, &key, "invalid identity");
-                continue;
-            }
-            // Enforce the retention window independently of whether physical
-            // database pruning succeeded.
-            if share.round() < oldest_retained_round {
-                continue;
-            }
-            shares.insert(key, RecoveredSelfShare {
+        for loaded_share in loaded_self_shares {
+            let share = loaded_share
+                .unwrap_or_else(|error| panic!("Invalid persisted secret share: {error}"));
+            assert!(
+                share.epoch() == epoch && share.author() == &author,
+                "Persisted secret share has invalid identity: expected epoch {epoch} and author \
+                 {author}, got epoch {} and author {}",
+                share.epoch(),
+                share.author(),
+            );
+            shares.insert(storage_key(share.metadata()), RecoveredSelfShare {
                 share,
                 verified: false,
             });
@@ -100,8 +64,6 @@ impl RecoveredSelfShares {
             storage,
             retention_rounds,
             shares,
-            pending_epoch_prune,
-            pending_prune_before_round,
         }
     }
 
@@ -122,70 +84,35 @@ impl RecoveredSelfShares {
         let previous_len = self.shares.len();
         self.shares
             .retain(|_, recovered| recovered.share.round() >= oldest_retained_round);
-        let removed_shares = self.shares.len() != previous_len;
-
-        if self.pending_epoch_prune {
-            if let Err(error) = self.storage.prune_before_epoch(self.epoch) {
-                error!(
-                    epoch = self.epoch,
-                    "Failed to retry pruning old secret shares: {error}"
-                );
-            } else {
-                self.pending_epoch_prune = false;
-            }
-        }
-
-        if removed_shares || self.pending_prune_before_round.is_some() {
-            let prune_before_round = self
-                .pending_prune_before_round
-                .unwrap_or_default()
-                .max(oldest_retained_round);
-            if let Err(error) = self
-                .storage
-                .prune_before_round(self.epoch, prune_before_round)
-            {
-                self.pending_prune_before_round = Some(prune_before_round);
-                error!(
-                    epoch = self.epoch,
-                    oldest_retained_round = prune_before_round,
-                    "Failed to prune expired secret shares; will retry: {error}"
-                );
-            } else {
-                self.pending_prune_before_round = None;
-            }
+        if self.shares.len() != previous_len {
+            self.storage
+                .prune_before_round(self.epoch, oldest_retained_round)
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "Failed to prune secret shares before round {oldest_retained_round}: \
+                         {error}"
+                    )
+                });
         }
     }
 
-    pub fn get(&self, metadata: &SecretShareMetadata) -> Option<RecoveredShare> {
-        let recovered = self.shares.get(&storage_key(metadata))?;
+    pub fn get(
+        &mut self,
+        metadata: &SecretShareMetadata,
+        verifier: &SecretShareVerifier,
+        author: &Author,
+    ) -> Option<SecretShare> {
+        let recovered = self.shares.get_mut(&storage_key(metadata))?;
         if recovered.share.metadata() != metadata {
             return None;
         }
-        if recovered.verified {
-            Some(RecoveredShare::Verified(recovered.share.clone()))
-        } else {
-            Some(RecoveredShare::Unverified(recovered.share.clone()))
+        if !recovered.verified {
+            verifier
+                .verify(&recovered.share, author)
+                .unwrap_or_else(|error| panic!("Invalid persisted secret share: {error}"));
+            recovered.verified = true;
         }
-    }
-
-    pub fn mark_verified(&mut self, key: &SecretShareKey) -> Option<SecretShare> {
-        let recovered = self.shares.get_mut(key)?;
-        recovered.verified = true;
         Some(recovered.share.clone())
-    }
-
-    pub fn delete_invalid(&mut self, key: &SecretShareKey) {
-        self.shares.remove(key);
-        Self::delete_or_panic(&self.storage, key, "cryptographically invalid");
-    }
-
-    fn delete_or_panic(storage: &Arc<dyn SecretShareStorage>, key: &SecretShareKey, reason: &str) {
-        storage.delete_self_share(key).unwrap_or_else(|error| {
-            panic!(
-                "Failed to delete {reason} persisted secret share for epoch {}, block {}: {error}",
-                key.0, key.1
-            )
-        });
     }
 
     #[cfg(test)]
@@ -203,104 +130,5 @@ impl RecoveredSelfShares {
         self.shares
             .get(key)
             .is_some_and(|recovered| recovered.verified)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::rand::secret_sharing::{
-        storage::{InMemorySecretShareStorage, LoadedSecretShare},
-        test_utils::{create_metadata, create_secret_share, TestContext},
-    };
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    struct FlakyPruneStorage {
-        inner: InMemorySecretShareStorage,
-        fail_round_prune_attempt: usize,
-        round_prune_attempts: AtomicUsize,
-    }
-
-    impl FlakyPruneStorage {
-        fn new(fail_round_prune_attempt: usize) -> Self {
-            Self {
-                inner: InMemorySecretShareStorage::new(),
-                fail_round_prune_attempt,
-                round_prune_attempts: AtomicUsize::new(0),
-            }
-        }
-    }
-
-    impl SecretShareStorage for FlakyPruneStorage {
-        fn save_self_share(&self, share: &SecretShare) -> anyhow::Result<()> {
-            self.inner.save_self_share(share)
-        }
-
-        fn delete_self_share(&self, key: &SecretShareKey) -> anyhow::Result<()> {
-            self.inner.delete_self_share(key)
-        }
-
-        fn load_self_shares(&self, epoch: u64) -> anyhow::Result<Vec<LoadedSecretShare>> {
-            self.inner.load_self_shares(epoch)
-        }
-
-        fn prune_before_epoch(&self, epoch: u64) -> anyhow::Result<()> {
-            self.inner.prune_before_epoch(epoch)
-        }
-
-        fn prune_before_round(&self, epoch: u64, round: Round) -> anyhow::Result<()> {
-            let attempt = self.round_prune_attempts.fetch_add(1, Ordering::Relaxed);
-            if attempt == self.fail_round_prune_attempt {
-                anyhow::bail!("injected round prune failure")
-            }
-            self.inner.prune_before_round(epoch, round)
-        }
-    }
-
-    #[test]
-    fn startup_filters_expired_shares_when_pruning_fails_and_retries() {
-        let ctx = TestContext::new(vec![1, 1, 1, 1]);
-        let storage = Arc::new(FlakyPruneStorage::new(0));
-        let old_metadata = create_metadata(ctx.epoch, 10);
-        let boundary_metadata = create_metadata(ctx.epoch, 20);
-        storage
-            .save_self_share(&create_secret_share(&ctx, 0, &old_metadata))
-            .unwrap();
-        storage
-            .save_self_share(&create_secret_share(&ctx, 0, &boundary_metadata))
-            .unwrap();
-
-        let mut recovered =
-            RecoveredSelfShares::new(ctx.epoch, ctx.authors[0], storage.clone(), 30, 10);
-
-        assert!(!recovered.contains_key(&storage_key(&old_metadata)));
-        assert!(recovered.contains_key(&storage_key(&boundary_metadata)));
-        assert_eq!(storage.load_self_shares(ctx.epoch).unwrap().len(), 2);
-
-        recovered.advance_retention(31);
-
-        assert_eq!(storage.round_prune_attempts.load(Ordering::Relaxed), 2);
-        assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
-    }
-
-    #[test]
-    fn runtime_pruning_failure_is_retried_after_cache_eviction() {
-        let ctx = TestContext::new(vec![1, 1, 1, 1]);
-        let storage = Arc::new(FlakyPruneStorage::new(1));
-        let metadata = create_metadata(ctx.epoch, 10);
-        storage
-            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
-            .unwrap();
-        let mut recovered =
-            RecoveredSelfShares::new(ctx.epoch, ctx.authors[0], storage.clone(), 10, 10);
-
-        recovered.advance_retention(21);
-        assert!(!recovered.contains_key(&storage_key(&metadata)));
-        assert_eq!(storage.load_self_shares(ctx.epoch).unwrap().len(), 1);
-
-        recovered.advance_retention(22);
-
-        assert_eq!(storage.round_prune_attempts.load(Ordering::Relaxed), 3);
-        assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
     }
 }

--- a/consensus/src/rand/secret_sharing/recovered_self_shares.rs
+++ b/consensus/src/rand/secret_sharing/recovered_self_shares.rs
@@ -168,10 +168,10 @@ impl RecoveredSelfShares {
         }
     }
 
-    pub fn mark_verified(&mut self, key: &SecretShareKey) {
-        if let Some(recovered) = self.shares.get_mut(key) {
-            recovered.verified = true;
-        }
+    pub fn mark_verified(&mut self, key: &SecretShareKey) -> Option<SecretShare> {
+        let recovered = self.shares.get_mut(key)?;
+        recovered.verified = true;
+        Some(recovered.share.clone())
     }
 
     pub fn delete_invalid(&mut self, key: &SecretShareKey) {

--- a/consensus/src/rand/secret_sharing/recovered_self_shares.rs
+++ b/consensus/src/rand/secret_sharing/recovered_self_shares.rs
@@ -1,0 +1,306 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::rand::secret_sharing::storage::{storage_key, SecretShareKey, SecretShareStorage};
+use aptos_consensus_types::common::{Author, Round};
+use aptos_logger::error;
+use aptos_types::secret_sharing::{SecretShare, SecretShareMetadata};
+use std::{collections::HashMap, sync::Arc};
+
+pub enum RecoveredShare {
+    Verified(SecretShare),
+    Unverified(SecretShare),
+}
+
+struct RecoveredSelfShare {
+    share: SecretShare,
+    verified: bool,
+}
+
+pub struct RecoveredSelfShares {
+    epoch: u64,
+    storage: Arc<dyn SecretShareStorage>,
+    retention_rounds: Round,
+    shares: HashMap<SecretShareKey, RecoveredSelfShare>,
+    pending_epoch_prune: bool,
+    pending_prune_before_round: Option<Round>,
+}
+
+impl RecoveredSelfShares {
+    pub fn new(
+        epoch: u64,
+        author: Author,
+        storage: Arc<dyn SecretShareStorage>,
+        highest_committed_round: Round,
+        retention_rounds: Round,
+    ) -> Self {
+        let pending_epoch_prune = if let Err(error) = storage.prune_before_epoch(epoch) {
+            error!(
+                epoch = epoch,
+                "Failed to prune old secret shares at epoch start; will retry: {error}"
+            );
+            true
+        } else {
+            false
+        };
+        let oldest_retained_round = highest_committed_round.saturating_sub(retention_rounds);
+        let pending_prune_before_round =
+            if let Err(error) = storage.prune_before_round(epoch, oldest_retained_round) {
+                error!(
+                    epoch = epoch,
+                    oldest_retained_round = oldest_retained_round,
+                    "Failed to prune expired secret shares at epoch start; will retry: {error}"
+                );
+                Some(oldest_retained_round)
+            } else {
+                None
+            };
+
+        let loaded_self_shares = storage
+            .load_self_shares(epoch)
+            .unwrap_or_else(|error| panic!("Failed to load secret shares at epoch start: {error}"));
+        let mut shares = HashMap::new();
+        for (key, loaded_share) in loaded_self_shares {
+            let share = match loaded_share {
+                Ok(share) => share,
+                Err(error) => {
+                    error!(
+                        epoch = key.0,
+                        block_id = key.1,
+                        "Deleting invalid persisted secret share: {error}"
+                    );
+                    Self::delete_or_panic(&storage, &key, "invalid");
+                    continue;
+                },
+            };
+            if share.epoch() != epoch || share.author() != &author {
+                error!(
+                    expected_epoch = epoch,
+                    share_epoch = share.epoch(),
+                    expected_author = author,
+                    share_author = share.author(),
+                    "Deleting persisted secret share with invalid identity"
+                );
+                Self::delete_or_panic(&storage, &key, "invalid identity");
+                continue;
+            }
+            // Enforce the retention window independently of whether physical
+            // database pruning succeeded.
+            if share.round() < oldest_retained_round {
+                continue;
+            }
+            shares.insert(key, RecoveredSelfShare {
+                share,
+                verified: false,
+            });
+        }
+
+        Self {
+            epoch,
+            storage,
+            retention_rounds,
+            shares,
+            pending_epoch_prune,
+            pending_prune_before_round,
+        }
+    }
+
+    pub fn persist(&mut self, share: SecretShare) -> anyhow::Result<()> {
+        self.storage.save_self_share(&share)?;
+        let round = share.round();
+        self.shares
+            .insert(storage_key(share.metadata()), RecoveredSelfShare {
+                share,
+                verified: false,
+            });
+        self.advance_retention(round);
+        Ok(())
+    }
+
+    pub fn advance_retention(&mut self, latest_round: Round) {
+        let oldest_retained_round = latest_round.saturating_sub(self.retention_rounds);
+        let previous_len = self.shares.len();
+        self.shares
+            .retain(|_, recovered| recovered.share.round() >= oldest_retained_round);
+        let removed_shares = self.shares.len() != previous_len;
+
+        if self.pending_epoch_prune {
+            if let Err(error) = self.storage.prune_before_epoch(self.epoch) {
+                error!(
+                    epoch = self.epoch,
+                    "Failed to retry pruning old secret shares: {error}"
+                );
+            } else {
+                self.pending_epoch_prune = false;
+            }
+        }
+
+        if removed_shares || self.pending_prune_before_round.is_some() {
+            let prune_before_round = self
+                .pending_prune_before_round
+                .unwrap_or_default()
+                .max(oldest_retained_round);
+            if let Err(error) = self
+                .storage
+                .prune_before_round(self.epoch, prune_before_round)
+            {
+                self.pending_prune_before_round = Some(prune_before_round);
+                error!(
+                    epoch = self.epoch,
+                    oldest_retained_round = prune_before_round,
+                    "Failed to prune expired secret shares; will retry: {error}"
+                );
+            } else {
+                self.pending_prune_before_round = None;
+            }
+        }
+    }
+
+    pub fn get(&self, metadata: &SecretShareMetadata) -> Option<RecoveredShare> {
+        let recovered = self.shares.get(&storage_key(metadata))?;
+        if recovered.share.metadata() != metadata {
+            return None;
+        }
+        if recovered.verified {
+            Some(RecoveredShare::Verified(recovered.share.clone()))
+        } else {
+            Some(RecoveredShare::Unverified(recovered.share.clone()))
+        }
+    }
+
+    pub fn mark_verified(&mut self, key: &SecretShareKey) {
+        if let Some(recovered) = self.shares.get_mut(key) {
+            recovered.verified = true;
+        }
+    }
+
+    pub fn delete_invalid(&mut self, key: &SecretShareKey) {
+        self.shares.remove(key);
+        Self::delete_or_panic(&self.storage, key, "cryptographically invalid");
+    }
+
+    fn delete_or_panic(storage: &Arc<dyn SecretShareStorage>, key: &SecretShareKey, reason: &str) {
+        storage.delete_self_share(key).unwrap_or_else(|error| {
+            panic!(
+                "Failed to delete {reason} persisted secret share for epoch {}, block {}: {error}",
+                key.0, key.1
+            )
+        });
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.shares.len()
+    }
+
+    #[cfg(test)]
+    pub fn contains_key(&self, key: &SecretShareKey) -> bool {
+        self.shares.contains_key(key)
+    }
+
+    #[cfg(test)]
+    pub fn is_verified(&self, key: &SecretShareKey) -> bool {
+        self.shares
+            .get(key)
+            .is_some_and(|recovered| recovered.verified)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rand::secret_sharing::{
+        storage::{InMemorySecretShareStorage, LoadedSecretShare},
+        test_utils::{create_metadata, create_secret_share, TestContext},
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct FlakyPruneStorage {
+        inner: InMemorySecretShareStorage,
+        fail_round_prune_attempt: usize,
+        round_prune_attempts: AtomicUsize,
+    }
+
+    impl FlakyPruneStorage {
+        fn new(fail_round_prune_attempt: usize) -> Self {
+            Self {
+                inner: InMemorySecretShareStorage::new(),
+                fail_round_prune_attempt,
+                round_prune_attempts: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl SecretShareStorage for FlakyPruneStorage {
+        fn save_self_share(&self, share: &SecretShare) -> anyhow::Result<()> {
+            self.inner.save_self_share(share)
+        }
+
+        fn delete_self_share(&self, key: &SecretShareKey) -> anyhow::Result<()> {
+            self.inner.delete_self_share(key)
+        }
+
+        fn load_self_shares(&self, epoch: u64) -> anyhow::Result<Vec<LoadedSecretShare>> {
+            self.inner.load_self_shares(epoch)
+        }
+
+        fn prune_before_epoch(&self, epoch: u64) -> anyhow::Result<()> {
+            self.inner.prune_before_epoch(epoch)
+        }
+
+        fn prune_before_round(&self, epoch: u64, round: Round) -> anyhow::Result<()> {
+            let attempt = self.round_prune_attempts.fetch_add(1, Ordering::Relaxed);
+            if attempt == self.fail_round_prune_attempt {
+                anyhow::bail!("injected round prune failure")
+            }
+            self.inner.prune_before_round(epoch, round)
+        }
+    }
+
+    #[test]
+    fn startup_filters_expired_shares_when_pruning_fails_and_retries() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let storage = Arc::new(FlakyPruneStorage::new(0));
+        let old_metadata = create_metadata(ctx.epoch, 10);
+        let boundary_metadata = create_metadata(ctx.epoch, 20);
+        storage
+            .save_self_share(&create_secret_share(&ctx, 0, &old_metadata))
+            .unwrap();
+        storage
+            .save_self_share(&create_secret_share(&ctx, 0, &boundary_metadata))
+            .unwrap();
+
+        let mut recovered =
+            RecoveredSelfShares::new(ctx.epoch, ctx.authors[0], storage.clone(), 30, 10);
+
+        assert!(!recovered.contains_key(&storage_key(&old_metadata)));
+        assert!(recovered.contains_key(&storage_key(&boundary_metadata)));
+        assert_eq!(storage.load_self_shares(ctx.epoch).unwrap().len(), 2);
+
+        recovered.advance_retention(31);
+
+        assert_eq!(storage.round_prune_attempts.load(Ordering::Relaxed), 2);
+        assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
+    }
+
+    #[test]
+    fn runtime_pruning_failure_is_retried_after_cache_eviction() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let storage = Arc::new(FlakyPruneStorage::new(1));
+        let metadata = create_metadata(ctx.epoch, 10);
+        storage
+            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
+            .unwrap();
+        let mut recovered =
+            RecoveredSelfShares::new(ctx.epoch, ctx.authors[0], storage.clone(), 10, 10);
+
+        recovered.advance_retention(21);
+        assert!(!recovered.contains_key(&storage_key(&metadata)));
+        assert_eq!(storage.load_self_shares(ctx.epoch).unwrap().len(), 1);
+
+        recovered.advance_retention(22);
+
+        assert_eq!(storage.round_prune_attempts.load(Ordering::Relaxed), 3);
+        assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
+    }
+}

--- a/consensus/src/rand/secret_sharing/recovered_self_shares.rs
+++ b/consensus/src/rand/secret_sharing/recovered_self_shares.rs
@@ -15,7 +15,6 @@ struct RecoveredSelfShare {
 }
 
 pub struct RecoveredSelfShares {
-    epoch: u64,
     storage: Arc<dyn SecretShareStorage>,
     retention_rounds: Round,
     shares: HashMap<SecretShareKey, RecoveredSelfShare>,
@@ -29,38 +28,41 @@ impl RecoveredSelfShares {
         highest_committed_round: Round,
         retention_rounds: Round,
     ) -> Self {
-        storage.prune_before_epoch(epoch).unwrap_or_else(|error| {
-            panic!("Failed to prune old secret shares at epoch start: {error}")
-        });
-        let oldest_retained_round = highest_committed_round.saturating_sub(retention_rounds);
         storage
-            .prune_before_round(epoch, oldest_retained_round)
-            .unwrap_or_else(|error| {
-                panic!("Failed to prune expired secret shares at epoch start: {error}")
-            });
-
+            .prune_before_epoch(epoch)
+            .expect("Failed to prune old secret shares at epoch start");
+        let oldest_retained_round = highest_committed_round.saturating_sub(retention_rounds);
         let loaded_self_shares = storage
             .load_self_shares(epoch)
-            .unwrap_or_else(|error| panic!("Failed to load secret shares at epoch start: {error}"));
+            .expect("Failed to load secret shares at epoch start");
         let mut shares = HashMap::new();
-        for loaded_share in loaded_self_shares {
-            let share = loaded_share
-                .unwrap_or_else(|error| panic!("Invalid persisted secret share: {error}"));
-            assert!(
-                share.epoch() == epoch && share.author() == &author,
-                "Persisted secret share has invalid identity: expected epoch {epoch} and author \
-                 {author}, got epoch {} and author {}",
+        let mut expired_keys = Vec::new();
+        for share in loaded_self_shares {
+            assert_eq!(
                 share.epoch(),
-                share.author(),
+                epoch,
+                "Persisted secret share has wrong epoch"
             );
-            shares.insert(storage_key(share.metadata()), RecoveredSelfShare {
+            assert_eq!(
+                share.author(),
+                &author,
+                "Persisted secret share has wrong author"
+            );
+            let key = storage_key(share.metadata());
+            if share.round() < oldest_retained_round {
+                expired_keys.push(key);
+                continue;
+            }
+            shares.insert(key, RecoveredSelfShare {
                 share,
                 verified: false,
             });
         }
+        storage
+            .prune_self_shares(&expired_keys)
+            .expect("Failed to prune expired secret shares at epoch start");
 
         Self {
-            epoch,
             storage,
             retention_rounds,
             shares,
@@ -69,30 +71,31 @@ impl RecoveredSelfShares {
 
     pub fn persist(&mut self, share: SecretShare) -> anyhow::Result<()> {
         self.storage.save_self_share(&share)?;
-        let round = share.round();
         self.shares
             .insert(storage_key(share.metadata()), RecoveredSelfShare {
                 share,
                 verified: false,
             });
-        self.advance_retention(round);
         Ok(())
     }
 
     pub fn advance_retention(&mut self, latest_round: Round) {
         let oldest_retained_round = latest_round.saturating_sub(self.retention_rounds);
-        let previous_len = self.shares.len();
-        self.shares
-            .retain(|_, recovered| recovered.share.round() >= oldest_retained_round);
-        if self.shares.len() != previous_len {
-            self.storage
-                .prune_before_round(self.epoch, oldest_retained_round)
-                .unwrap_or_else(|error| {
-                    panic!(
-                        "Failed to prune secret shares before round {oldest_retained_round}: \
-                         {error}"
-                    )
-                });
+        let expired_keys = self
+            .shares
+            .iter()
+            .filter_map(|(key, recovered)| {
+                (recovered.share.round() < oldest_retained_round).then_some(*key)
+            })
+            .collect::<Vec<_>>();
+        if expired_keys.is_empty() {
+            return;
+        }
+        self.storage
+            .prune_self_shares(&expired_keys)
+            .expect("Failed to prune expired secret shares");
+        for key in expired_keys {
+            self.shares.remove(&key);
         }
     }
 
@@ -109,7 +112,7 @@ impl RecoveredSelfShares {
         if !recovered.verified {
             verifier
                 .verify(&recovered.share, author)
-                .unwrap_or_else(|error| panic!("Invalid persisted secret share: {error}"));
+                .expect("Invalid persisted secret share");
             recovered.verified = true;
         }
         Some(recovered.share.clone())

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -59,6 +59,7 @@ pub struct SecretShareManager {
     reliable_broadcast: Arc<ReliableBroadcast<SecretShareMessage, ExponentialBackoff>>,
     network_sender: Arc<NetworkSender>,
     secret_share_storage: Arc<dyn SecretShareStorage>,
+    retention_rounds: Round,
     secret_share_request_delay_ms: u64,
 
     // local channel received from dec_store
@@ -80,6 +81,8 @@ impl SecretShareManager {
         outgoing_blocks: Sender<OrderedBlocks>,
         network_sender: Arc<NetworkSender>,
         secret_share_storage: Arc<dyn SecretShareStorage>,
+        highest_committed_round: Round,
+        retention_rounds: Round,
         bounded_executor: BoundedExecutor,
         rb_config: &ReliableBroadcastConfig,
         secret_share_request_delay_ms: u64,
@@ -109,6 +112,16 @@ impl SecretShareManager {
             error!(
                 epoch = epoch_state.epoch,
                 "Failed to prune old secret shares at epoch start: {error}"
+            );
+        }
+        let oldest_retained_round = highest_committed_round.saturating_sub(retention_rounds);
+        if let Err(error) =
+            secret_share_storage.prune_before_round(epoch_state.epoch, oldest_retained_round)
+        {
+            error!(
+                epoch = epoch_state.epoch,
+                oldest_retained_round = oldest_retained_round,
+                "Failed to prune expired secret shares at epoch start: {error}"
             );
         }
         let loaded_self_shares = secret_share_storage
@@ -152,6 +165,7 @@ impl SecretShareManager {
             reliable_broadcast,
             network_sender,
             secret_share_storage,
+            retention_rounds,
             secret_share_request_delay_ms,
 
             decision_rx,
@@ -255,6 +269,7 @@ impl SecretShareManager {
         }
         self.recovered_self_shares
             .insert(storage_key(share.metadata()), share.clone());
+        self.prune_expired_self_shares(round);
 
         let metadata = share.metadata().clone();
         {
@@ -279,6 +294,22 @@ impl SecretShareManager {
             warn!(
                 round = round,
                 "Secret share item not found for round {}", round
+            );
+        }
+    }
+
+    fn prune_expired_self_shares(&mut self, latest_round: Round) {
+        let oldest_retained_round = latest_round.saturating_sub(self.retention_rounds);
+        self.recovered_self_shares
+            .retain(|_, share| share.round() >= oldest_retained_round);
+        if let Err(error) = self
+            .secret_share_storage
+            .prune_before_round(self.epoch_state.epoch, oldest_retained_round)
+        {
+            error!(
+                epoch = self.epoch_state.epoch,
+                oldest_retained_round = oldest_retained_round,
+                "Failed to prune expired secret shares: {error}"
             );
         }
     }
@@ -660,12 +691,29 @@ mod tests {
         fn prune_before_epoch(&self, _epoch: u64) -> anyhow::Result<()> {
             Ok(())
         }
+
+        fn prune_before_round(&self, _epoch: u64, _round: Round) -> anyhow::Result<()> {
+            Ok(())
+        }
     }
 
     fn make_manager(
         ctx: &TestContext,
         local_index: usize,
         storage: Arc<dyn SecretShareStorage>,
+    ) -> (
+        SecretShareManager,
+        aptos_channel::Receiver<(Author, ProtocolId), PeerManagerRequest>,
+    ) {
+        make_manager_with_retention(ctx, local_index, storage, 0, 120)
+    }
+
+    fn make_manager_with_retention(
+        ctx: &TestContext,
+        local_index: usize,
+        storage: Arc<dyn SecretShareStorage>,
+        highest_committed_round: Round,
+        retention_rounds: Round,
     ) -> (
         SecretShareManager,
         aptos_channel::Receiver<(Author, ProtocolId), PeerManagerRequest>,
@@ -715,6 +763,8 @@ mod tests {
             outgoing_blocks,
             network_sender,
             storage,
+            highest_committed_round,
+            retention_rounds,
             bounded_executor,
             &ReliableBroadcastConfig::default(),
             1_000_000,
@@ -800,6 +850,37 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn test_retention_prunes_storage_and_recovery_cache() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let storage = Arc::new(InMemorySecretShareStorage::new());
+        let old_metadata = create_metadata(ctx.epoch, 10);
+        let boundary_metadata = create_metadata(ctx.epoch, 20);
+        storage
+            .save_self_share(&create_secret_share(&ctx, 0, &old_metadata))
+            .unwrap();
+        storage
+            .save_self_share(&create_secret_share(&ctx, 0, &boundary_metadata))
+            .unwrap();
+
+        let (manager, _) = make_manager_with_retention(&ctx, 0, storage.clone(), 30, 10);
+
+        let recovered = storage
+            .load_self_shares(ctx.epoch)
+            .unwrap()
+            .into_iter()
+            .collect::<anyhow::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].metadata(), &boundary_metadata);
+        assert!(!manager
+            .recovered_self_shares
+            .contains_key(&storage_key(&old_metadata)));
+        assert!(manager
+            .recovered_self_shares
+            .contains_key(&storage_key(&boundary_metadata)));
     }
 
     #[tokio::test]

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -224,6 +224,7 @@ impl SecretShareManager {
                     round = round,
                     "Self-share derive returned None (no encrypted txns), resolving round"
                 );
+                self.prune_expired_self_shares(round);
                 if let Some(item) = self.block_queue.item_mut(round) {
                     item.resolve_round_without_key(round);
                 }
@@ -303,8 +304,12 @@ impl SecretShareManager {
 
     fn prune_expired_self_shares(&mut self, latest_round: Round) {
         let oldest_retained_round = latest_round.saturating_sub(self.retention_rounds);
+        let previous_len = self.recovered_self_shares.len();
         self.recovered_self_shares
             .retain(|_, recovered| recovered.share.round() >= oldest_retained_round);
+        if self.recovered_self_shares.len() == previous_len {
+            return;
+        }
         if let Err(error) = self
             .secret_share_storage
             .prune_before_round(self.epoch_state.epoch, oldest_retained_round)
@@ -365,14 +370,17 @@ impl SecretShareManager {
 
     fn process_reset(&mut self, request: ResetRequest) {
         let ResetRequest { tx, signal } = request;
-        let target_round = match signal {
-            ResetSignal::Stop => 0,
-            ResetSignal::TargetRound(round) => round,
+        let (target_round, stop) = match signal {
+            ResetSignal::Stop => (0, true),
+            ResetSignal::TargetRound(round) => (round, false),
         };
+        if !stop {
+            self.prune_expired_self_shares(target_round);
+        }
         self.block_queue = BlockQueue::new();
         self.pending_derives = FuturesUnordered::new();
         self.secret_share_store.lock().reset(target_round);
-        self.stop = matches!(signal, ResetSignal::Stop);
+        self.stop = stop;
         let _ = tx.send(ResetAck::default());
     }
 
@@ -917,6 +925,47 @@ mod tests {
         assert!(manager
             .recovered_self_shares
             .contains_key(&storage_key(&boundary_metadata)));
+    }
+
+    #[tokio::test]
+    async fn test_no_share_round_advances_retention() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let storage = Arc::new(InMemorySecretShareStorage::new());
+        let metadata = create_metadata(ctx.epoch, 10);
+        storage
+            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
+            .unwrap();
+        let (mut manager, _) = make_manager_with_retention(&ctx, 0, storage.clone(), 10, 10);
+
+        manager.process_completed_derive(21, Ok(None));
+
+        assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
+        assert!(!manager
+            .recovered_self_shares
+            .contains_key(&storage_key(&metadata)));
+    }
+
+    #[tokio::test]
+    async fn test_target_round_reset_advances_retention() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let storage = Arc::new(InMemorySecretShareStorage::new());
+        let metadata = create_metadata(ctx.epoch, 10);
+        storage
+            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
+            .unwrap();
+        let (mut manager, _) = make_manager_with_retention(&ctx, 0, storage.clone(), 10, 10);
+        let (tx, rx) = oneshot::channel();
+
+        manager.process_reset(ResetRequest {
+            tx,
+            signal: ResetSignal::TargetRound(21),
+        });
+        rx.await.unwrap();
+
+        assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
+        assert!(!manager
+            .recovered_self_shares
+            .contains_key(&storage_key(&metadata)));
     }
 
     #[tokio::test]

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    counters::{DEC_QUEUE_SIZE, SECRET_SHARE_STORAGE_EVENTS},
+    counters::DEC_QUEUE_SIZE,
     logging::{LogEvent, LogSchema},
     network::{IncomingSecretShareRequest, NetworkSender, TConsensusMsg},
     pipeline::buffer_manager::{OrderedBlocks, ResetAck, ResetRequest, ResetSignal},
@@ -11,7 +11,7 @@ use crate::{
         network_messages::{SecretShareMessage, SecretShareRpc},
         reliable_broadcast_state::SecretShareAggregateState,
         secret_share_store::{SecretShareAggregationResult, SecretShareStore},
-        storage::{storage_key, SecretShareKey, SecretShareStorage, SecretShareStorageError},
+        storage::{storage_key, SecretShareKey, SecretShareStorage},
         types::RequestSecretShare,
         verifier::SecretShareVerifier,
     },
@@ -50,14 +50,6 @@ pub type Receiver<T> = UnboundedReceiver<T>;
 
 type PendingDeriveFut =
     Pin<Box<dyn Future<Output = (Round, TaskResult<SecretShareResult>)> + Send>>;
-
-fn storage_error_label(error: &SecretShareStorageError) -> &'static str {
-    match error {
-        SecretShareStorageError::Conflict { .. } => "conflict",
-        SecretShareStorageError::Corruption(_) => "corruption",
-        SecretShareStorageError::Io(_) => "io_failure",
-    }
-}
 
 pub struct SecretShareManager {
     author: Author,
@@ -127,17 +119,11 @@ impl SecretShareManager {
             let share = match loaded_share {
                 Ok(share) => share,
                 Err(error) => {
-                    SECRET_SHARE_STORAGE_EVENTS
-                        .with_label_values(&["recovery", storage_error_label(&error)])
-                        .inc();
                     error!("Ignoring invalid persisted secret share: {error}");
                     continue;
                 },
             };
             if share.epoch() != epoch_state.epoch || share.author() != &author {
-                SECRET_SHARE_STORAGE_EVENTS
-                    .with_label_values(&["recovery", "corruption"])
-                    .inc();
                 error!(
                     expected_epoch = epoch_state.epoch,
                     share_epoch = share.epoch(),
@@ -148,9 +134,6 @@ impl SecretShareManager {
                 continue;
             }
             if let Err(error) = verifier.verify(&share, &author) {
-                SECRET_SHARE_STORAGE_EVENTS
-                    .with_label_values(&["recovery", "corruption"])
-                    .inc();
                 error!(
                     epoch = share.epoch(),
                     round = share.round(),
@@ -158,9 +141,6 @@ impl SecretShareManager {
                 );
                 continue;
             }
-            SECRET_SHARE_STORAGE_EVENTS
-                .with_label_values(&["recovery", "loaded"])
-                .inc();
             recovered_self_shares.insert(storage_key(share.metadata()), share);
         }
 
@@ -265,9 +245,6 @@ impl SecretShareManager {
         }
 
         if let Err(error) = self.secret_share_storage.save_self_share(&share) {
-            SECRET_SHARE_STORAGE_EVENTS
-                .with_label_values(&["write", storage_error_label(&error)])
-                .inc();
             error!(
                 epoch = share.epoch(),
                 round = round,
@@ -276,9 +253,6 @@ impl SecretShareManager {
             );
             return;
         }
-        SECRET_SHARE_STORAGE_EVENTS
-            .with_label_values(&["write", "success"])
-            .inc();
         self.recovered_self_shares
             .insert(storage_key(share.metadata()), share.clone());
 
@@ -551,18 +525,11 @@ impl SecretShareManager {
                     .filter(|share| share.metadata() == request.metadata())
                     .cloned();
                 if let Some(share) = recovered_share {
-                    SECRET_SHARE_STORAGE_EVENTS
-                        .with_label_values(&["recovery", "success"])
-                        .inc();
                     self.process_response(
                         protocol,
                         response_sender,
                         SecretShareMessage::Share(share),
                     );
-                } else {
-                    SECRET_SHARE_STORAGE_EVENTS
-                        .with_label_values(&["recovery", "miss"])
-                        .inc();
                 }
             },
             SecretShareMessage::Share(share) => {
@@ -658,7 +625,10 @@ mod tests {
     use crate::{
         network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
         rand::secret_sharing::{
-            storage::{InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb},
+            storage::{
+                InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb,
+                SecretShareStorageError,
+            },
             test_utils::{
                 create_bad_secret_share, create_metadata, create_secret_share, TestContext,
             },

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -11,10 +11,7 @@ use crate::{
         network_messages::{SecretShareMessage, SecretShareRpc},
         reliable_broadcast_state::SecretShareAggregateState,
         secret_share_store::{SecretShareAggregationResult, SecretShareStore},
-        storage::{
-            storage_key, LoadedSecretShare, SecretShareKey, SecretShareStorage,
-            SecretShareStorageError,
-        },
+        storage::{storage_key, SecretShareKey, SecretShareStorage, SecretShareStorageError},
         types::RequestSecretShare,
         verifier::SecretShareVerifier,
     },
@@ -91,7 +88,6 @@ impl SecretShareManager {
         outgoing_blocks: Sender<OrderedBlocks>,
         network_sender: Arc<NetworkSender>,
         secret_share_storage: Arc<dyn SecretShareStorage>,
-        loaded_self_shares: Vec<LoadedSecretShare>,
         bounded_executor: BoundedExecutor,
         rb_config: &ReliableBroadcastConfig,
         secret_share_request_delay_ms: u64,
@@ -117,6 +113,15 @@ impl SecretShareManager {
             verifier.clone(),
             decision_tx,
         )));
+        if let Err(error) = secret_share_storage.prune_before_epoch(epoch_state.epoch) {
+            error!(
+                epoch = epoch_state.epoch,
+                "Failed to prune old secret shares at epoch start: {error}"
+            );
+        }
+        let loaded_self_shares = secret_share_storage
+            .load_self_shares(epoch_state.epoch)
+            .unwrap_or_else(|error| panic!("Failed to load secret shares at epoch start: {error}"));
         let mut recovered_self_shares = HashMap::new();
         for loaded_share in loaded_self_shares {
             let share = match loaded_share {
@@ -653,7 +658,7 @@ mod tests {
     use crate::{
         network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
         rand::secret_sharing::{
-            storage::{InMemorySecretShareStorage, SecretShareDb},
+            storage::{InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb},
             test_utils::{
                 create_bad_secret_share, create_metadata, create_secret_share, TestContext,
             },
@@ -739,7 +744,6 @@ mod tests {
         ));
         let (outgoing_blocks, _) = unbounded();
         let bounded_executor = BoundedExecutor::new(4, tokio::runtime::Handle::current());
-        let loaded_self_shares = storage.load_self_shares(ctx.epoch).unwrap();
         let manager = SecretShareManager::new(
             ctx.authors[local_index],
             Arc::new(EpochState {
@@ -753,7 +757,6 @@ mod tests {
             outgoing_blocks,
             network_sender,
             storage,
-            loaded_self_shares,
             bounded_executor,
             &ReliableBroadcastConfig::default(),
             1_000_000,

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    counters::DEC_QUEUE_SIZE,
+    counters::{DEC_QUEUE_SIZE, SECRET_SHARE_STORAGE_EVENTS},
     logging::{LogEvent, LogSchema},
     network::{IncomingSecretShareRequest, NetworkSender, TConsensusMsg},
     pipeline::buffer_manager::{OrderedBlocks, ResetAck, ResetRequest, ResetSignal},
@@ -11,6 +11,10 @@ use crate::{
         network_messages::{SecretShareMessage, SecretShareRpc},
         reliable_broadcast_state::SecretShareAggregateState,
         secret_share_store::{SecretShareAggregationResult, SecretShareStore},
+        storage::{
+            storage_key, LoadedSecretShare, SecretShareKey, SecretShareStorage,
+            SecretShareStorageError,
+        },
         types::RequestSecretShare,
         verifier::SecretShareVerifier,
     },
@@ -27,7 +31,10 @@ use aptos_logger::{debug, error, info, spawn_named, warn};
 use aptos_network::{protocols::network::RpcError, ProtocolId};
 use aptos_reliable_broadcast::{DropGuard, ReliableBroadcast};
 use aptos_time_service::TimeService;
-use aptos_types::{epoch_state::EpochState, secret_sharing::SecretShareMetadata};
+use aptos_types::{
+    epoch_state::EpochState,
+    secret_sharing::{SecretShare, SecretShareMetadata},
+};
 use bytes::Bytes;
 use futures::{
     future::{AbortHandle, Abortable},
@@ -38,7 +45,7 @@ use futures_channel::{
     mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
 use tokio_retry::strategy::ExponentialBackoff;
 
 pub type Sender<T> = UnboundedSender<T>;
@@ -47,6 +54,14 @@ pub type Receiver<T> = UnboundedReceiver<T>;
 type PendingDeriveFut =
     Pin<Box<dyn Future<Output = (Round, TaskResult<SecretShareResult>)> + Send>>;
 
+fn storage_error_label(error: &SecretShareStorageError) -> &'static str {
+    match error {
+        SecretShareStorageError::Conflict { .. } => "conflict",
+        SecretShareStorageError::Corruption(_) => "corruption",
+        SecretShareStorageError::Io(_) => "io_failure",
+    }
+}
+
 pub struct SecretShareManager {
     author: Author,
     epoch_state: Arc<EpochState>,
@@ -54,6 +69,7 @@ pub struct SecretShareManager {
     verifier: Arc<SecretShareVerifier>,
     reliable_broadcast: Arc<ReliableBroadcast<SecretShareMessage, ExponentialBackoff>>,
     network_sender: Arc<NetworkSender>,
+    secret_share_storage: Arc<dyn SecretShareStorage>,
     secret_share_request_delay_ms: u64,
 
     // local channel received from dec_store
@@ -62,6 +78,7 @@ pub struct SecretShareManager {
     outgoing_blocks: Sender<OrderedBlocks>,
     // local state
     secret_share_store: Arc<Mutex<SecretShareStore>>,
+    recovered_self_shares: HashMap<SecretShareKey, SecretShare>,
     block_queue: BlockQueue,
     pending_derives: FuturesUnordered<PendingDeriveFut>,
 }
@@ -73,6 +90,8 @@ impl SecretShareManager {
         verifier: Arc<SecretShareVerifier>,
         outgoing_blocks: Sender<OrderedBlocks>,
         network_sender: Arc<NetworkSender>,
+        secret_share_storage: Arc<dyn SecretShareStorage>,
+        loaded_self_shares: Vec<LoadedSecretShare>,
         bounded_executor: BoundedExecutor,
         rb_config: &ReliableBroadcastConfig,
         secret_share_request_delay_ms: u64,
@@ -88,7 +107,7 @@ impl SecretShareManager {
             rb_backoff_policy,
             TimeService::real(),
             Duration::from_millis(rb_config.rpc_timeout_ms),
-            bounded_executor,
+            bounded_executor.clone(),
         ));
         let (decision_tx, decision_rx) = unbounded();
 
@@ -98,6 +117,47 @@ impl SecretShareManager {
             verifier.clone(),
             decision_tx,
         )));
+        let mut recovered_self_shares = HashMap::new();
+        for loaded_share in loaded_self_shares {
+            let share = match loaded_share {
+                Ok(share) => share,
+                Err(error) => {
+                    SECRET_SHARE_STORAGE_EVENTS
+                        .with_label_values(&["recovery", storage_error_label(&error)])
+                        .inc();
+                    error!("Ignoring invalid persisted secret share: {error}");
+                    continue;
+                },
+            };
+            if share.epoch() != epoch_state.epoch || share.author() != &author {
+                SECRET_SHARE_STORAGE_EVENTS
+                    .with_label_values(&["recovery", "corruption"])
+                    .inc();
+                error!(
+                    expected_epoch = epoch_state.epoch,
+                    share_epoch = share.epoch(),
+                    expected_author = author,
+                    share_author = share.author(),
+                    "Ignoring persisted secret share with invalid identity"
+                );
+                continue;
+            }
+            if let Err(error) = verifier.verify(&share, &author) {
+                SECRET_SHARE_STORAGE_EVENTS
+                    .with_label_values(&["recovery", "corruption"])
+                    .inc();
+                error!(
+                    epoch = share.epoch(),
+                    round = share.round(),
+                    "Ignoring cryptographically invalid persisted secret share: {error}"
+                );
+                continue;
+            }
+            SECRET_SHARE_STORAGE_EVENTS
+                .with_label_values(&["recovery", "loaded"])
+                .inc();
+            recovered_self_shares.insert(storage_key(share.metadata()), share);
+        }
 
         Self {
             author,
@@ -106,12 +166,14 @@ impl SecretShareManager {
             verifier,
             reliable_broadcast,
             network_sender,
+            secret_share_storage,
             secret_share_request_delay_ms,
 
             decision_rx,
             outgoing_blocks,
 
             secret_share_store: dec_store,
+            recovered_self_shares,
             block_queue: BlockQueue::new(),
             pending_derives: FuturesUnordered::new(),
         }
@@ -153,8 +215,8 @@ impl SecretShareManager {
         Ok(())
     }
 
-    /// Handles a completed self-share derivation: updates the store, broadcasts
-    /// the share, and spawns the share requester task.
+    /// Handles a completed self-share derivation. The synchronous database write
+    /// must succeed before the share enters either memory cache or the network.
     fn process_completed_derive(&mut self, round: Round, result: TaskResult<SecretShareResult>) {
         let share = match result {
             Ok(Some(share)) => share,
@@ -181,6 +243,39 @@ impl SecretShareManager {
                 return;
             },
         };
+
+        if share.author() != &self.author
+            || share.epoch() != self.epoch_state.epoch
+            || share.round() != round
+        {
+            error!(
+                epoch = self.epoch_state.epoch,
+                round = round,
+                share_epoch = share.epoch(),
+                share_round = share.round(),
+                share_author = share.author(),
+                "Derived self share has invalid identity or metadata"
+            );
+            return;
+        }
+
+        if let Err(error) = self.secret_share_storage.save_self_share(&share) {
+            SECRET_SHARE_STORAGE_EVENTS
+                .with_label_values(&["write", storage_error_label(&error)])
+                .inc();
+            error!(
+                epoch = share.epoch(),
+                round = round,
+                block_id = share.metadata().block_id,
+                "CRITICAL: Failed to persist self secret share: {error}"
+            );
+            return;
+        }
+        SECRET_SHARE_STORAGE_EVENTS
+            .with_label_values(&["write", "success"])
+            .inc();
+        self.recovered_self_shares
+            .insert(storage_key(share.metadata()), share.clone());
 
         let metadata = share.metadata().clone();
         {
@@ -408,7 +503,7 @@ impl SecretShareManager {
         DropGuard::new(abort_handle)
     }
 
-    fn handle_incoming_msg(&self, rpc: SecretShareRpc) {
+    fn handle_incoming_msg(&mut self, rpc: SecretShareRpc) {
         let SecretShareRpc {
             msg,
             protocol,
@@ -416,27 +511,53 @@ impl SecretShareManager {
         } = rpc;
         match msg {
             SecretShareMessage::RequestShare(request) => {
+                if request.metadata().epoch != self.epoch_state.epoch {
+                    warn!(
+                        requested_epoch = request.metadata().epoch,
+                        current_epoch = self.epoch_state.epoch,
+                        "Rejecting secret share request from old or future epoch"
+                    );
+                    return;
+                }
                 let result = self
                     .secret_share_store
                     .lock()
                     .get_self_share(request.metadata());
-                match result {
-                    Ok(Some(share)) => {
-                        self.process_response(
-                            protocol,
-                            response_sender,
-                            SecretShareMessage::Share(share),
-                        );
+                let active_share = match result {
+                    Ok(Some(share)) => Some(share),
+                    Ok(None) => None,
+                    Err(error) => {
+                        debug!("Self share not available in active store: {error}");
+                        None
                     },
-                    Ok(None) => {
-                        warn!(
-                            "Self secret share could not be found for RPC request {}",
-                            request.metadata().round
-                        );
-                    },
-                    Err(e) => {
-                        warn!("[SecretShareManager] Failed to get share: {}", e);
-                    },
+                };
+                if let Some(share) = active_share {
+                    self.process_response(
+                        protocol,
+                        response_sender,
+                        SecretShareMessage::Share(share),
+                    );
+                    return;
+                }
+
+                let recovered_share = self
+                    .recovered_self_shares
+                    .get(&storage_key(request.metadata()))
+                    .filter(|share| share.metadata() == request.metadata())
+                    .cloned();
+                if let Some(share) = recovered_share {
+                    SECRET_SHARE_STORAGE_EVENTS
+                        .with_label_values(&["recovery", "success"])
+                        .inc();
+                    self.process_response(
+                        protocol,
+                        response_sender,
+                        SecretShareMessage::Share(share),
+                    );
+                } else {
+                    SECRET_SHARE_STORAGE_EVENTS
+                        .with_label_values(&["recovery", "miss"])
+                        .inc();
                 }
             },
             SecretShareMessage::Share(share) => {
@@ -523,5 +644,397 @@ impl SecretShareManager {
     pub fn observe_queue(&self) {
         let queue = &self.block_queue.queue();
         DEC_QUEUE_SIZE.set(queue.len() as i64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
+        rand::secret_sharing::{
+            storage::{InMemorySecretShareStorage, SecretShareDb},
+            test_utils::{
+                create_bad_secret_share, create_metadata, create_secret_share, TestContext,
+            },
+        },
+    };
+    use aptos_channels::{aptos_channel, message_queues::QueueStyle};
+    use aptos_config::{
+        config::ReliableBroadcastConfig,
+        network_id::{NetworkId, PeerNetworkId},
+    };
+    use aptos_network::{
+        application::{interface::NetworkClient, storage::PeersAndMetadata},
+        peer_manager::{ConnectionRequestSender, PeerManagerRequest, PeerManagerRequestSender},
+        protocols::{network::NewNetworkSender, wire::handshake::v1::ProtocolIdSet},
+        transport::ConnectionMetadata,
+    };
+    use aptos_temppath::TempPath;
+    use maplit::hashmap;
+    use std::iter::FromIterator;
+
+    struct FailingStorage;
+
+    impl SecretShareStorage for FailingStorage {
+        fn save_self_share(
+            &self,
+            _share: &SecretShare,
+        ) -> crate::rand::secret_sharing::storage::Result<()> {
+            Err(SecretShareStorageError::Io("injected failure".into()))
+        }
+
+        fn load_self_shares(
+            &self,
+            _epoch: u64,
+        ) -> crate::rand::secret_sharing::storage::Result<Vec<LoadedSecretShare>> {
+            Ok(Vec::new())
+        }
+
+        fn prune_before_epoch(
+            &self,
+            _epoch: u64,
+        ) -> crate::rand::secret_sharing::storage::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_manager(
+        ctx: &TestContext,
+        local_index: usize,
+        storage: Arc<dyn SecretShareStorage>,
+    ) -> (
+        SecretShareManager,
+        aptos_channel::Receiver<(Author, ProtocolId), PeerManagerRequest>,
+    ) {
+        let peers_and_metadata = PeersAndMetadata::new(&[NetworkId::Validator]);
+        for peer in &ctx.authors {
+            let peer_network_id = PeerNetworkId::new(NetworkId::Validator, *peer);
+            let mut connection_metadata = ConnectionMetadata::mock(*peer);
+            connection_metadata.application_protocols = ProtocolIdSet::from_iter(DIRECT_SEND);
+            peers_and_metadata
+                .insert_connection_metadata(peer_network_id, connection_metadata)
+                .unwrap();
+        }
+
+        let (network_reqs_tx, network_reqs_rx) = aptos_channel::new(QueueStyle::FIFO, 16, None);
+        let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 16, None);
+        let network_sender = aptos_network::protocols::network::NetworkSender::new(
+            PeerManagerRequestSender::new(network_reqs_tx),
+            ConnectionRequestSender::new(connection_reqs_tx),
+        );
+        let network_client = NetworkClient::new(
+            DIRECT_SEND.into(),
+            RPC.into(),
+            hashmap! { NetworkId::Validator => network_sender },
+            peers_and_metadata,
+        );
+        let consensus_network_client = ConsensusNetworkClient::new(network_client);
+        let (self_sender, _) = aptos_channels::new_unbounded_test();
+        let network_sender = Arc::new(NetworkSender::new(
+            ctx.authors[local_index],
+            consensus_network_client,
+            self_sender,
+            ctx.validator_verifier.clone(),
+        ));
+        let (outgoing_blocks, _) = unbounded();
+        let bounded_executor = BoundedExecutor::new(4, tokio::runtime::Handle::current());
+        let loaded_self_shares = storage.load_self_shares(ctx.epoch).unwrap();
+        let manager = SecretShareManager::new(
+            ctx.authors[local_index],
+            Arc::new(EpochState {
+                epoch: ctx.epoch,
+                verifier: ctx.validator_verifier.clone(),
+            }),
+            Arc::new(SecretShareVerifier::new(
+                ctx.secret_share_config.clone(),
+                true,
+            )),
+            outgoing_blocks,
+            network_sender,
+            storage,
+            loaded_self_shares,
+            bounded_executor,
+            &ReliableBroadcastConfig::default(),
+            1_000_000,
+        );
+        (manager, network_reqs_rx)
+    }
+
+    fn request_rpc(
+        metadata: SecretShareMetadata,
+    ) -> (SecretShareRpc, oneshot::Receiver<Result<Bytes, RpcError>>) {
+        let (response_sender, response_rx) = oneshot::channel();
+        (
+            SecretShareRpc {
+                msg: SecretShareMessage::RequestShare(RequestSecretShare::new(metadata)),
+                protocol: ProtocolId::ConsensusRpcBcs,
+                response_sender,
+            },
+            response_rx,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_write_completes_before_cache_and_broadcast() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let storage = Arc::new(InMemorySecretShareStorage::new());
+        let (mut manager, mut network_rx) = make_manager(&ctx, 0, storage.clone());
+        let metadata = create_metadata(ctx.epoch, 10);
+        let share = create_secret_share(&ctx, 0, &metadata);
+        manager
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+
+        manager.process_completed_derive(metadata.round, Ok(Some(share.clone())));
+
+        let persisted = storage
+            .load_self_shares(ctx.epoch)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.metadata(), &metadata);
+        assert_eq!(
+            manager
+                .recovered_self_shares
+                .get(&storage_key(&metadata))
+                .unwrap()
+                .metadata(),
+            &metadata
+        );
+        assert!(manager
+            .secret_share_store
+            .lock()
+            .get_self_share(&metadata)
+            .unwrap()
+            .is_some());
+        assert!(network_rx.next().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_write_failure_prevents_publication() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut manager, mut network_rx) = make_manager(&ctx, 0, Arc::new(FailingStorage));
+        let metadata = create_metadata(ctx.epoch, 10);
+        let share = create_secret_share(&ctx, 0, &metadata);
+        manager
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+
+        manager.process_completed_derive(metadata.round, Ok(Some(share)));
+
+        assert!(manager
+            .secret_share_store
+            .lock()
+            .get_self_share(&metadata)
+            .unwrap()
+            .is_none());
+        assert!(manager.recovered_self_shares.is_empty());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), network_rx.next())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_preserves_recovered_self_shares() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let storage = Arc::new(InMemorySecretShareStorage::new());
+        let (mut manager, mut network_rx) = make_manager(&ctx, 0, storage.clone());
+        let metadata = create_metadata(ctx.epoch, 10);
+        let share = create_secret_share(&ctx, 0, &metadata);
+        manager
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+        manager.process_completed_derive(metadata.round, Ok(Some(share)));
+        assert!(network_rx.next().await.is_some());
+
+        let (tx, rx) = oneshot::channel();
+        manager.process_reset(ResetRequest {
+            tx,
+            signal: ResetSignal::TargetRound(metadata.round),
+        });
+        rx.await.unwrap();
+
+        assert_eq!(manager.recovered_self_shares.len(), 1);
+        assert!(manager
+            .secret_share_store
+            .lock()
+            .get_self_share(&metadata)
+            .unwrap()
+            .is_none());
+
+        let (request, response) = request_rpc(metadata.clone());
+        manager.handle_incoming_msg(request);
+        assert!(response.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_uses_preloaded_share() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let storage = Arc::new(InMemorySecretShareStorage::new());
+        let metadata = create_metadata(ctx.epoch, 10);
+        let share = create_secret_share(&ctx, 0, &metadata);
+        storage.save_self_share(&share).unwrap();
+        let (mut manager, _) = make_manager(&ctx, 0, storage.clone());
+        manager
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+        let (request_1, response_1) = request_rpc(metadata.clone());
+        let (request_2, response_2) = request_rpc(metadata.clone());
+
+        manager.handle_incoming_msg(request_1);
+        manager.handle_incoming_msg(request_2);
+
+        for response in [response_1, response_2] {
+            let bytes = response.await.unwrap().unwrap();
+            let message: ConsensusMsg = ProtocolId::ConsensusRpcBcs.from_bytes(&bytes).unwrap();
+            let SecretShareMessage::Share(recovered) =
+                SecretShareMessage::from_network_message(message).unwrap()
+            else {
+                panic!("expected a secret share response")
+            };
+            assert_eq!(recovered.metadata(), &metadata);
+            assert_eq!(recovered.author(), &ctx.authors[0]);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invalid_recovered_records_and_requests_are_rejected() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 10);
+
+        let wrong_author_storage = Arc::new(InMemorySecretShareStorage::new());
+        wrong_author_storage
+            .save_self_share(&create_secret_share(&ctx, 1, &metadata))
+            .unwrap();
+        let (mut manager, _) = make_manager(&ctx, 0, wrong_author_storage);
+        manager
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+        let (request, response) = request_rpc(metadata.clone());
+        manager.handle_incoming_msg(request);
+        assert!(response.await.is_err());
+
+        let bad_crypto_storage = Arc::new(InMemorySecretShareStorage::new());
+        bad_crypto_storage
+            .save_self_share(&create_bad_secret_share(&ctx, 0, &metadata))
+            .unwrap();
+        let (mut manager, _) = make_manager(&ctx, 0, bad_crypto_storage);
+        manager
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+        let (request, response) = request_rpc(metadata.clone());
+        manager.handle_incoming_msg(request);
+        assert!(response.await.is_err());
+
+        let forged_storage = Arc::new(InMemorySecretShareStorage::new());
+        forged_storage
+            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
+            .unwrap();
+        let (mut manager, _) = make_manager(&ctx, 0, forged_storage.clone());
+        manager
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+        let mut forged_metadata = metadata.clone();
+        forged_metadata.timestamp += 1;
+        let (request, response) = request_rpc(forged_metadata);
+        manager.handle_incoming_msg(request);
+        assert!(response.await.is_err());
+
+        let old_epoch_metadata = create_metadata(ctx.epoch - 1, metadata.round);
+        let (request, response) = request_rpc(old_epoch_metadata);
+        manager.handle_incoming_msg(request);
+        assert!(response.await.is_err());
+
+        let corrupt_storage = Arc::new(InMemorySecretShareStorage::new());
+        corrupt_storage.insert_raw(storage_key(&metadata), vec![0xFF, 0xFF]);
+        let (mut manager, _) = make_manager(&ctx, 0, corrupt_storage);
+        manager
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+        let (request, response) = request_rpc(metadata);
+        manager.handle_incoming_msg(request);
+        assert!(response.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_persisted_threshold_recovers_after_restart_and_lost_handoff() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 10);
+        let mut peer_paths = Vec::new();
+
+        // These three authors formed the threshold that made the original
+        // decryption possible. Persist their shares, then drop the databases to
+        // model full process shutdown.
+        for author_index in 0..3 {
+            let path = TempPath::new();
+            {
+                let db = SecretShareDb::new(&path);
+                db.save_self_share(&create_secret_share(&ctx, author_index, &metadata))
+                    .unwrap();
+            }
+            peer_paths.push(path);
+        }
+
+        // The fourth validator lost its original pipeline handoff. After its
+        // restart/replay, its own derivation succeeds and it requests the
+        // threshold authors' shares from their freshly restarted managers.
+        let target_storage = Arc::new(InMemorySecretShareStorage::new());
+        let (mut target, _) = make_manager(&ctx, 3, target_storage);
+        target
+            .secret_share_store
+            .lock()
+            .update_highest_known_round(metadata.round);
+        target.process_completed_derive(
+            metadata.round,
+            Ok(Some(create_secret_share(&ctx, 3, &metadata))),
+        );
+
+        for (author_index, path) in peer_paths.iter().enumerate() {
+            let restarted_storage = Arc::new(SecretShareDb::new(path));
+            let (mut restarted_peer, _) = make_manager(&ctx, author_index, restarted_storage);
+            restarted_peer
+                .secret_share_store
+                .lock()
+                .update_highest_known_round(metadata.round);
+            let (request, response) = request_rpc(metadata.clone());
+            restarted_peer.handle_incoming_msg(request);
+
+            let bytes = response.await.unwrap().unwrap();
+            let message: ConsensusMsg = ProtocolId::ConsensusRpcBcs.from_bytes(&bytes).unwrap();
+            let SecretShareMessage::Share(recovered) =
+                SecretShareMessage::from_network_message(message).unwrap()
+            else {
+                panic!("expected a secret share response")
+            };
+            target
+                .secret_share_store
+                .lock()
+                .add_share(recovered)
+                .unwrap();
+        }
+
+        let result = tokio::time::timeout(Duration::from_secs(5), target.decision_rx.next())
+            .await
+            .expect("timed out waiting for reconstructed key")
+            .expect("secret share decision channel closed");
+        match result {
+            SecretShareAggregationResult::Success(key) => assert_eq!(key.metadata, metadata),
+            SecretShareAggregationResult::Failure { .. } => {
+                panic!("persisted threshold did not reconstruct the key")
+            },
+        }
     }
 }

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -260,13 +260,12 @@ impl SecretShareManager {
         }
 
         if let Err(error) = self.secret_share_storage.save_self_share(&share) {
-            error!(
-                epoch = share.epoch(),
-                round = round,
-                block_id = share.metadata().block_id,
-                "CRITICAL: Failed to persist self secret share: {error}"
+            panic!(
+                "Failed to persist self secret share for epoch {}, round {}, block {}: {error}",
+                share.epoch(),
+                round,
+                share.metadata().block_id,
             );
-            return;
         }
         self.recovered_self_shares
             .insert(storage_key(share.metadata()), RecoveredSelfShare {
@@ -880,8 +879,11 @@ mod tests {
             .lock()
             .update_highest_known_round(metadata.round);
 
-        manager.process_completed_derive(metadata.round, Ok(Some(share)));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            manager.process_completed_derive(metadata.round, Ok(Some(share)));
+        }));
 
+        assert!(result.is_err());
         assert!(manager
             .secret_share_store
             .lock()

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -51,6 +51,11 @@ pub type Receiver<T> = UnboundedReceiver<T>;
 type PendingDeriveFut =
     Pin<Box<dyn Future<Output = (Round, TaskResult<SecretShareResult>)> + Send>>;
 
+struct RecoveredSelfShare {
+    share: SecretShare,
+    verified: bool,
+}
+
 pub struct SecretShareManager {
     author: Author,
     epoch_state: Arc<EpochState>,
@@ -68,7 +73,7 @@ pub struct SecretShareManager {
     outgoing_blocks: Sender<OrderedBlocks>,
     // local state
     secret_share_store: Arc<Mutex<SecretShareStore>>,
-    recovered_self_shares: HashMap<SecretShareKey, SecretShare>,
+    recovered_self_shares: HashMap<SecretShareKey, RecoveredSelfShare>,
     block_queue: BlockQueue,
     pending_derives: FuturesUnordered<PendingDeriveFut>,
 }
@@ -146,15 +151,10 @@ impl SecretShareManager {
                 );
                 continue;
             }
-            if let Err(error) = verifier.verify(&share, &author) {
-                error!(
-                    epoch = share.epoch(),
-                    round = share.round(),
-                    "Ignoring cryptographically invalid persisted secret share: {error}"
-                );
-                continue;
-            }
-            recovered_self_shares.insert(storage_key(share.metadata()), share);
+            recovered_self_shares.insert(storage_key(share.metadata()), RecoveredSelfShare {
+                share,
+                verified: false,
+            });
         }
 
         Self {
@@ -268,7 +268,10 @@ impl SecretShareManager {
             return;
         }
         self.recovered_self_shares
-            .insert(storage_key(share.metadata()), share.clone());
+            .insert(storage_key(share.metadata()), RecoveredSelfShare {
+                share: share.clone(),
+                verified: false,
+            });
         self.prune_expired_self_shares(round);
 
         let metadata = share.metadata().clone();
@@ -301,7 +304,7 @@ impl SecretShareManager {
     fn prune_expired_self_shares(&mut self, latest_round: Round) {
         let oldest_retained_round = latest_round.saturating_sub(self.retention_rounds);
         self.recovered_self_shares
-            .retain(|_, share| share.round() >= oldest_retained_round);
+            .retain(|_, recovered| recovered.share.round() >= oldest_retained_round);
         if let Err(error) = self
             .secret_share_storage
             .prune_before_round(self.epoch_state.epoch, oldest_retained_round)
@@ -312,6 +315,35 @@ impl SecretShareManager {
                 "Failed to prune expired secret shares: {error}"
             );
         }
+    }
+
+    fn get_recovered_self_share(&mut self, metadata: &SecretShareMetadata) -> Option<SecretShare> {
+        let key = storage_key(metadata);
+        let verification_error = {
+            let recovered = self.recovered_self_shares.get_mut(&key)?;
+            if recovered.share.metadata() != metadata {
+                return None;
+            }
+            if recovered.verified {
+                return Some(recovered.share.clone());
+            }
+            match self.verifier.verify(&recovered.share, &self.author) {
+                Ok(()) => {
+                    recovered.verified = true;
+                    return Some(recovered.share.clone());
+                },
+                Err(error) => error,
+            }
+        };
+
+        self.recovered_self_shares.remove(&key);
+        error!(
+            epoch = metadata.epoch,
+            round = metadata.round,
+            block_id = metadata.block_id,
+            "Rejecting cryptographically invalid persisted secret share: {verification_error}"
+        );
+        None
     }
 
     fn process_ready_blocks(&mut self, ready_blocks: Vec<OrderedBlocks>) {
@@ -550,11 +582,7 @@ impl SecretShareManager {
                     return;
                 }
 
-                let recovered_share = self
-                    .recovered_self_shares
-                    .get(&storage_key(request.metadata()))
-                    .filter(|share| share.metadata() == request.metadata())
-                    .cloned();
+                let recovered_share = self.get_recovered_self_share(request.metadata());
                 if let Some(share) = recovered_share {
                     self.process_response(
                         protocol,
@@ -813,8 +841,16 @@ mod tests {
                 .recovered_self_shares
                 .get(&storage_key(&metadata))
                 .unwrap()
+                .share
                 .metadata(),
             &metadata
+        );
+        assert!(
+            !manager
+                .recovered_self_shares
+                .get(&storage_key(&metadata))
+                .unwrap()
+                .verified
         );
         assert!(manager
             .secret_share_store
@@ -915,6 +951,13 @@ mod tests {
         let (request, response) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request);
         assert!(response.await.unwrap().is_ok());
+        assert!(
+            manager
+                .recovered_self_shares
+                .get(&storage_key(&metadata))
+                .unwrap()
+                .verified
+        );
     }
 
     #[tokio::test]
@@ -929,10 +972,24 @@ mod tests {
             .secret_share_store
             .lock()
             .update_highest_known_round(metadata.round);
+        assert!(
+            !manager
+                .recovered_self_shares
+                .get(&storage_key(&metadata))
+                .unwrap()
+                .verified
+        );
         let (request_1, response_1) = request_rpc(metadata.clone());
-        let (request_2, response_2) = request_rpc(metadata.clone());
-
         manager.handle_incoming_msg(request_1);
+        assert!(
+            manager
+                .recovered_self_shares
+                .get(&storage_key(&metadata))
+                .unwrap()
+                .verified
+        );
+
+        let (request_2, response_2) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_2);
 
         for response in [response_1, response_2] {
@@ -975,9 +1032,15 @@ mod tests {
             .secret_share_store
             .lock()
             .update_highest_known_round(metadata.round);
+        assert!(manager
+            .recovered_self_shares
+            .contains_key(&storage_key(&metadata)));
         let (request, response) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request);
         assert!(response.await.is_err());
+        assert!(!manager
+            .recovered_self_shares
+            .contains_key(&storage_key(&metadata)));
 
         let forged_storage = Arc::new(InMemorySecretShareStorage::new());
         forged_storage

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -625,10 +625,7 @@ mod tests {
     use crate::{
         network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
         rand::secret_sharing::{
-            storage::{
-                InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb,
-                SecretShareStorageError,
-            },
+            storage::{InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb},
             test_utils::{
                 create_bad_secret_share, create_metadata, create_secret_share, TestContext,
             },
@@ -652,24 +649,15 @@ mod tests {
     struct FailingStorage;
 
     impl SecretShareStorage for FailingStorage {
-        fn save_self_share(
-            &self,
-            _share: &SecretShare,
-        ) -> crate::rand::secret_sharing::storage::Result<()> {
-            Err(SecretShareStorageError::Io("injected failure".into()))
+        fn save_self_share(&self, _share: &SecretShare) -> anyhow::Result<()> {
+            anyhow::bail!("injected failure")
         }
 
-        fn load_self_shares(
-            &self,
-            _epoch: u64,
-        ) -> crate::rand::secret_sharing::storage::Result<Vec<LoadedSecretShare>> {
+        fn load_self_shares(&self, _epoch: u64) -> anyhow::Result<Vec<LoadedSecretShare>> {
             Ok(Vec::new())
         }
 
-        fn prune_before_epoch(
-            &self,
-            _epoch: u64,
-        ) -> crate::rand::secret_sharing::storage::Result<()> {
+        fn prune_before_epoch(&self, _epoch: u64) -> anyhow::Result<()> {
             Ok(())
         }
     }

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    counters::DEC_QUEUE_SIZE,
+    counters::{DEC_QUEUE_SIZE, SECRET_SHARE_RECOVERY_COUNT},
     logging::{LogEvent, LogSchema},
     network::{IncomingSecretShareRequest, NetworkSender, TConsensusMsg},
     pipeline::buffer_manager::{OrderedBlocks, ResetAck, ResetRequest, ResetSignal},
@@ -273,6 +273,11 @@ impl SecretShareManager {
             self.persisted_self_shares
                 .get(request.metadata(), &self.verifier, &self.author)
         {
+            info!(LogSchema::new(LogEvent::ServePersistedSecretShare)
+                .author(self.author)
+                .epoch(request.metadata().epoch)
+                .round(request.metadata().round));
+            SECRET_SHARE_RECOVERY_COUNT.inc();
             self.process_response(protocol, response_sender, SecretShareMessage::Share(share));
         }
     }

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -232,15 +232,46 @@ impl SecretShareManager {
         self.persisted_self_shares.advance_retention(latest_round);
     }
 
-    fn process_recovered_share_request(
+    fn handle_share_request(
         &mut self,
-        metadata: &SecretShareMetadata,
+        request: RequestSecretShare,
         protocol: ProtocolId,
         response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
     ) {
-        if let Some(share) = self
-            .persisted_self_shares
-            .get(metadata, &self.verifier, &self.author)
+        info!(LogSchema::new(LogEvent::ReceiveSecretShareRequest)
+            .author(self.author)
+            .epoch(request.metadata().epoch)
+            .round(request.metadata().round));
+
+        if request.metadata().epoch != self.epoch_state.epoch {
+            warn!(
+                requested_epoch = request.metadata().epoch,
+                current_epoch = self.epoch_state.epoch,
+                "Rejecting secret share request from old or future epoch"
+            );
+            return;
+        }
+
+        let result = self
+            .secret_share_store
+            .lock()
+            .get_self_share(request.metadata());
+        let active_share = match result {
+            Ok(Some(share)) => Some(share),
+            Ok(None) => None,
+            Err(error) => {
+                debug!("Self share not available in active store: {error}");
+                None
+            },
+        };
+        if let Some(share) = active_share {
+            self.process_response(protocol, response_sender, SecretShareMessage::Share(share));
+            return;
+        }
+
+        if let Some(share) =
+            self.persisted_self_shares
+                .get(request.metadata(), &self.verifier, &self.author)
         {
             self.process_response(protocol, response_sender, SecretShareMessage::Share(share));
         }
@@ -458,36 +489,7 @@ impl SecretShareManager {
         } = rpc;
         match msg {
             SecretShareMessage::RequestShare(request) => {
-                if request.metadata().epoch != self.epoch_state.epoch {
-                    warn!(
-                        requested_epoch = request.metadata().epoch,
-                        current_epoch = self.epoch_state.epoch,
-                        "Rejecting secret share request from old or future epoch"
-                    );
-                    return;
-                }
-                let result = self
-                    .secret_share_store
-                    .lock()
-                    .get_self_share(request.metadata());
-                let active_share = match result {
-                    Ok(Some(share)) => Some(share),
-                    Ok(None) => None,
-                    Err(error) => {
-                        debug!("Self share not available in active store: {error}");
-                        None
-                    },
-                };
-                if let Some(share) = active_share {
-                    self.process_response(
-                        protocol,
-                        response_sender,
-                        SecretShareMessage::Share(share),
-                    );
-                    return;
-                }
-
-                self.process_recovered_share_request(request.metadata(), protocol, response_sender);
+                self.handle_share_request(request, protocol, response_sender)
             },
             SecretShareMessage::Share(share) => {
                 info!(LogSchema::new(LogEvent::ReceiveSecretShare)

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -269,10 +269,7 @@ impl SecretShareManager {
             return;
         }
 
-        if let Some(share) =
-            self.persisted_self_shares
-                .get(request.metadata(), &self.verifier, &self.author)
-        {
+        if let Some(share) = self.persisted_self_shares.get(request.metadata()) {
             info!(LogSchema::new(LogEvent::ServePersistedSecretShare)
                 .author(self.author)
                 .epoch(request.metadata().epoch)
@@ -590,9 +587,7 @@ mod tests {
         network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
         rand::secret_sharing::{
             storage::{storage_key, InMemorySecretShareStorage, SecretShareDb, SecretShareKey},
-            test_utils::{
-                create_bad_secret_share, create_metadata, create_secret_share, TestContext,
-            },
+            test_utils::{create_metadata, create_secret_share, TestContext},
         },
     };
     use aptos_channels::{aptos_channel, message_queues::QueueStyle};
@@ -740,9 +735,6 @@ mod tests {
         assert!(manager
             .persisted_self_shares
             .contains_key(&storage_key(&metadata)));
-        assert!(!manager
-            .persisted_self_shares
-            .is_verified(&storage_key(&metadata)));
         assert!(manager
             .secret_share_store
             .lock()
@@ -888,9 +880,6 @@ mod tests {
         let (request, response) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request);
         assert!(response.await.unwrap().is_ok());
-        assert!(manager
-            .persisted_self_shares
-            .is_verified(&storage_key(&metadata)));
     }
 
     #[tokio::test]
@@ -905,14 +894,8 @@ mod tests {
             .secret_share_store
             .lock()
             .update_highest_known_round(metadata.round);
-        assert!(!manager
-            .persisted_self_shares
-            .is_verified(&storage_key(&metadata)));
         let (request_1, response_1) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_1);
-        assert!(manager
-            .persisted_self_shares
-            .is_verified(&storage_key(&metadata)));
         let (request_2, response_2) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_2);
 
@@ -930,7 +913,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_invalid_recovered_records_fail_stop_and_requests_are_rejected() {
+    async fn test_wrong_author_and_invalid_requests_are_rejected() {
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
         let metadata = create_metadata(ctx.epoch, 10);
 
@@ -940,24 +923,6 @@ mod tests {
             .unwrap();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             make_manager(&ctx, 0, wrong_author_storage)
-        }));
-        assert!(result.is_err());
-
-        let bad_crypto_storage = Arc::new(InMemorySecretShareStorage::new());
-        bad_crypto_storage
-            .save_self_share(&create_bad_secret_share(&ctx, 0, &metadata))
-            .unwrap();
-        let (mut manager, _) = make_manager(&ctx, 0, bad_crypto_storage);
-        manager
-            .secret_share_store
-            .lock()
-            .update_highest_known_round(metadata.round);
-        assert!(manager
-            .persisted_self_shares
-            .contains_key(&storage_key(&metadata)));
-        let (request, _) = request_rpc(metadata.clone());
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            manager.handle_incoming_msg(request)
         }));
         assert!(result.is_err());
 

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -613,12 +613,8 @@ mod tests {
             anyhow::bail!("injected failure")
         }
 
-        fn load_self_shares(&self, _epoch: u64) -> anyhow::Result<Vec<SecretShare>> {
+        fn get_all_self_shares(&self) -> anyhow::Result<Vec<SecretShare>> {
             Ok(Vec::new())
-        }
-
-        fn prune_before_epoch(&self, _epoch: u64) -> anyhow::Result<()> {
-            Ok(())
         }
 
         fn prune_self_shares(&self, _keys: &[SecretShareKey]) -> anyhow::Result<()> {
@@ -730,7 +726,7 @@ mod tests {
         manager.process_completed_derive(metadata.round, Ok(Some(share.clone())));
 
         let persisted = storage
-            .load_self_shares(ctx.epoch)
+            .get_all_self_shares()
             .unwrap()
             .into_iter()
             .next()
@@ -785,8 +781,12 @@ mod tests {
     async fn test_retention_prunes_storage_and_recovery_cache() {
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
         let storage = Arc::new(InMemorySecretShareStorage::new());
+        let previous_epoch_metadata = create_metadata(ctx.epoch - 1, 30);
         let old_metadata = create_metadata(ctx.epoch, 10);
         let boundary_metadata = create_metadata(ctx.epoch, 20);
+        storage
+            .save_self_share(&create_secret_share(&ctx, 0, &previous_epoch_metadata))
+            .unwrap();
         storage
             .save_self_share(&create_secret_share(&ctx, 0, &old_metadata))
             .unwrap();
@@ -796,9 +796,12 @@ mod tests {
 
         let (manager, _) = make_manager_with_retention(&ctx, 0, storage.clone(), 30, 10);
 
-        let recovered = storage.load_self_shares(ctx.epoch).unwrap();
+        let recovered = storage.get_all_self_shares().unwrap();
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered[0].metadata(), &boundary_metadata);
+        assert!(!manager
+            .persisted_self_shares
+            .contains_key(&storage_key(&previous_epoch_metadata)));
         assert!(!manager
             .persisted_self_shares
             .contains_key(&storage_key(&old_metadata)));
@@ -819,7 +822,7 @@ mod tests {
 
         manager.process_completed_derive(21, Ok(None));
 
-        assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
+        assert!(storage.get_all_self_shares().unwrap().is_empty());
         assert!(!manager
             .persisted_self_shares
             .contains_key(&storage_key(&metadata)));
@@ -842,7 +845,7 @@ mod tests {
         });
         rx.await.unwrap();
 
-        assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
+        assert!(storage.get_all_self_shares().unwrap().is_empty());
         assert!(!manager
             .persisted_self_shares
             .contains_key(&storage_key(&metadata)));

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -12,7 +12,7 @@ use crate::{
         recovered_self_shares::{RecoveredSelfShares, RecoveredShare},
         reliable_broadcast_state::SecretShareAggregateState,
         secret_share_store::{SecretShareAggregationResult, SecretShareStore},
-        storage::SecretShareStorage,
+        storage::{storage_key, SecretShareKey, SecretShareStorage},
         types::RequestSecretShare,
         verifier::SecretShareVerifier,
     },
@@ -29,10 +29,7 @@ use aptos_logger::{debug, error, info, spawn_named, warn};
 use aptos_network::{protocols::network::RpcError, ProtocolId};
 use aptos_reliable_broadcast::{DropGuard, ReliableBroadcast};
 use aptos_time_service::TimeService;
-use aptos_types::{
-    epoch_state::EpochState,
-    secret_sharing::{SecretShare, SecretShareMetadata},
-};
+use aptos_types::{epoch_state::EpochState, secret_sharing::SecretShareMetadata};
 use bytes::Bytes;
 use futures::{
     future::{AbortHandle, Abortable},
@@ -43,7 +40,7 @@ use futures_channel::{
     mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
 use tokio_retry::strategy::ExponentialBackoff;
 
 pub type Sender<T> = UnboundedSender<T>;
@@ -51,6 +48,13 @@ pub type Receiver<T> = UnboundedReceiver<T>;
 
 type PendingDeriveFut =
     Pin<Box<dyn Future<Output = (Round, TaskResult<SecretShareResult>)> + Send>>;
+type PendingRecoveredShareVerificationFut =
+    Pin<Box<dyn Future<Output = (SecretShareKey, anyhow::Result<()>)> + Send>>;
+
+struct PendingRecoveredShareResponse {
+    protocol: ProtocolId,
+    response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
+}
 
 pub struct SecretShareManager {
     author: Author,
@@ -59,6 +63,7 @@ pub struct SecretShareManager {
     verifier: Arc<SecretShareVerifier>,
     reliable_broadcast: Arc<ReliableBroadcast<SecretShareMessage, ExponentialBackoff>>,
     network_sender: Arc<NetworkSender>,
+    bounded_executor: BoundedExecutor,
     secret_share_request_delay_ms: u64,
 
     // local channel received from dec_store
@@ -68,6 +73,8 @@ pub struct SecretShareManager {
     // local state
     secret_share_store: Arc<Mutex<SecretShareStore>>,
     recovered_self_shares: RecoveredSelfShares,
+    pending_recovered_share_verifications: FuturesUnordered<PendingRecoveredShareVerificationFut>,
+    pending_recovered_share_responses: HashMap<SecretShareKey, Vec<PendingRecoveredShareResponse>>,
     block_queue: BlockQueue,
     pending_derives: FuturesUnordered<PendingDeriveFut>,
 }
@@ -122,6 +129,7 @@ impl SecretShareManager {
             verifier,
             reliable_broadcast,
             network_sender,
+            bounded_executor,
             secret_share_request_delay_ms,
 
             decision_rx,
@@ -129,6 +137,8 @@ impl SecretShareManager {
 
             secret_share_store: dec_store,
             recovered_self_shares,
+            pending_recovered_share_verifications: FuturesUnordered::new(),
+            pending_recovered_share_responses: HashMap::new(),
             block_queue: BlockQueue::new(),
             pending_derives: FuturesUnordered::new(),
         }
@@ -254,25 +264,82 @@ impl SecretShareManager {
         self.recovered_self_shares.advance_retention(latest_round);
     }
 
-    fn get_recovered_self_share(&mut self, metadata: &SecretShareMetadata) -> Option<SecretShare> {
-        let key = crate::rand::secret_sharing::storage::storage_key(metadata);
-        match self.recovered_self_shares.get(metadata)? {
-            RecoveredShare::Verified(share) => Some(share),
-            RecoveredShare::Unverified(share) => match self.verifier.verify(&share, &self.author) {
-                Ok(()) => {
-                    self.recovered_self_shares.mark_verified(&key);
-                    Some(share)
-                },
-                Err(verification_error) => {
-                    self.recovered_self_shares.delete_invalid(&key);
-                    error!(
-                        epoch = metadata.epoch,
-                        round = metadata.round,
-                        block_id = metadata.block_id,
-                        "Rejecting cryptographically invalid persisted secret share: {verification_error}"
-                    );
-                    None
-                },
+    fn process_recovered_share_request(
+        &mut self,
+        metadata: &SecretShareMetadata,
+        protocol: ProtocolId,
+        response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
+    ) {
+        let key = storage_key(metadata);
+        match self.recovered_self_shares.get(metadata) {
+            Some(RecoveredShare::Verified(share)) => {
+                self.process_response(protocol, response_sender, SecretShareMessage::Share(share));
+            },
+            Some(RecoveredShare::Unverified(share)) => {
+                let responses = self
+                    .pending_recovered_share_responses
+                    .entry(key)
+                    .or_default();
+                // Keep waiters bounded even if one peer repeatedly requests the
+                // same share while its verification is in flight.
+                let max_responses = self.epoch_state.verifier.len();
+                if responses.len() >= max_responses {
+                    return;
+                }
+                responses.push(PendingRecoveredShareResponse {
+                    protocol,
+                    response_sender,
+                });
+                if responses.len() > 1 {
+                    return;
+                }
+
+                let verifier = self.verifier.clone();
+                let author = self.author;
+                let bounded_executor = self.bounded_executor.clone();
+                self.pending_recovered_share_verifications
+                    .push(Box::pin(async move {
+                        let handle = bounded_executor
+                            .spawn_blocking(move || verifier.verify(&share, &author))
+                            .await;
+                        let result = handle
+                            .await
+                            .expect("Recovered secret share verification task panicked");
+                        (key, result)
+                    }));
+            },
+            None => {},
+        }
+    }
+
+    fn process_recovered_share_verification(
+        &mut self,
+        key: SecretShareKey,
+        result: anyhow::Result<()>,
+    ) {
+        let responses = self
+            .pending_recovered_share_responses
+            .remove(&key)
+            .unwrap_or_default();
+        match result {
+            Ok(()) => {
+                if let Some(share) = self.recovered_self_shares.mark_verified(&key) {
+                    for response in responses {
+                        self.process_response(
+                            response.protocol,
+                            response.response_sender,
+                            SecretShareMessage::Share(share.clone()),
+                        );
+                    }
+                }
+            },
+            Err(verification_error) => {
+                self.recovered_self_shares.delete_invalid(&key);
+                error!(
+                    epoch = key.0,
+                    block_id = key.1,
+                    "Rejecting cryptographically invalid persisted secret share: {verification_error}"
+                );
             },
         }
     }
@@ -516,14 +583,7 @@ impl SecretShareManager {
                     return;
                 }
 
-                let recovered_share = self.get_recovered_self_share(request.metadata());
-                if let Some(share) = recovered_share {
-                    self.process_response(
-                        protocol,
-                        response_sender,
-                        SecretShareMessage::Share(share),
-                    );
-                }
+                self.process_recovered_share_request(request.metadata(), protocol, response_sender);
             },
             SecretShareMessage::Share(share) => {
                 info!(LogSchema::new(LogEvent::ReceiveSecretShare)
@@ -577,6 +637,9 @@ impl SecretShareManager {
                 }
                 Some((round, result)) = self.pending_derives.next() => {
                     self.process_completed_derive(round, result);
+                }
+                Some((key, result)) = self.pending_recovered_share_verifications.next() => {
+                    self.process_recovered_share_verification(key, result);
                 }
                 Some(reset) = reset_rx.next() => {
                     let mut dropped = 0;
@@ -639,6 +702,7 @@ mod tests {
         transport::ConnectionMetadata,
     };
     use aptos_temppath::TempPath;
+    use aptos_types::secret_sharing::SecretShare;
     use maplit::hashmap;
     use std::iter::FromIterator;
 
@@ -753,6 +817,15 @@ mod tests {
             },
             response_rx,
         )
+    }
+
+    async fn complete_recovered_share_verification(manager: &mut SecretShareManager) {
+        let (key, result) = manager
+            .pending_recovered_share_verifications
+            .next()
+            .await
+            .expect("expected a pending recovered share verification");
+        manager.process_recovered_share_verification(key, result);
     }
 
     #[tokio::test]
@@ -927,6 +1000,7 @@ mod tests {
 
         let (request, response) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request);
+        complete_recovered_share_verification(&mut manager).await;
         assert!(response.await.unwrap().is_ok());
         assert!(manager
             .recovered_self_shares
@@ -934,7 +1008,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_miss_uses_preloaded_share() {
+    async fn test_cache_miss_verification_is_deduplicated() {
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
         let storage = Arc::new(InMemorySecretShareStorage::new());
         let metadata = create_metadata(ctx.epoch, 10);
@@ -950,12 +1024,13 @@ mod tests {
             .is_verified(&storage_key(&metadata)));
         let (request_1, response_1) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_1);
+        let (request_2, response_2) = request_rpc(metadata.clone());
+        manager.handle_incoming_msg(request_2);
+        assert_eq!(manager.pending_recovered_share_verifications.len(), 1);
+        complete_recovered_share_verification(&mut manager).await;
         assert!(manager
             .recovered_self_shares
             .is_verified(&storage_key(&metadata)));
-
-        let (request_2, response_2) = request_rpc(metadata.clone());
-        manager.handle_incoming_msg(request_2);
 
         for response in [response_1, response_2] {
             let bytes = response.await.unwrap().unwrap();
@@ -1009,6 +1084,11 @@ mod tests {
             .contains_key(&storage_key(&metadata)));
         let (request, response) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request);
+        assert_eq!(manager.pending_recovered_share_verifications.len(), 1);
+        assert!(manager
+            .recovered_self_shares
+            .contains_key(&storage_key(&metadata)));
+        complete_recovered_share_verification(&mut manager).await;
         assert!(response.await.is_err());
         assert!(!manager
             .recovered_self_shares
@@ -1102,6 +1182,7 @@ mod tests {
                 .update_highest_known_round(metadata.round);
             let (request, response) = request_rpc(metadata.clone());
             restarted_peer.handle_incoming_msg(request);
+            complete_recovered_share_verification(&mut restarted_peer).await;
 
             let bytes = response.await.unwrap().unwrap();
             let message: ConsensusMsg = ProtocolId::ConsensusRpcBcs.from_bytes(&bytes).unwrap();

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -9,7 +9,7 @@ use crate::{
     rand::secret_sharing::{
         block_queue::{BlockQueue, QueueItem},
         network_messages::{SecretShareMessage, SecretShareRpc},
-        recovered_self_shares::RecoveredSelfShares,
+        persisted_self_shares::PersistedSelfShares,
         reliable_broadcast_state::SecretShareAggregateState,
         secret_share_store::{SecretShareAggregationResult, SecretShareStore},
         storage::SecretShareStorage,
@@ -64,7 +64,7 @@ pub struct SecretShareManager {
     outgoing_blocks: Sender<OrderedBlocks>,
     // local state
     secret_share_store: Arc<Mutex<SecretShareStore>>,
-    recovered_self_shares: RecoveredSelfShares,
+    persisted_self_shares: PersistedSelfShares,
     block_queue: BlockQueue,
     pending_derives: FuturesUnordered<PendingDeriveFut>,
 }
@@ -104,7 +104,7 @@ impl SecretShareManager {
             verifier.clone(),
             decision_tx,
         )));
-        let recovered_self_shares = RecoveredSelfShares::new(
+        let persisted_self_shares = PersistedSelfShares::new(
             epoch_state.epoch,
             author,
             secret_share_storage,
@@ -125,7 +125,7 @@ impl SecretShareManager {
             outgoing_blocks,
 
             secret_share_store: dec_store,
-            recovered_self_shares,
+            persisted_self_shares,
             block_queue: BlockQueue::new(),
             pending_derives: FuturesUnordered::new(),
         }
@@ -197,7 +197,7 @@ impl SecretShareManager {
             },
         };
 
-        self.recovered_self_shares
+        self.persisted_self_shares
             .persist(share.clone())
             .expect("Failed to persist self secret share");
         self.prune_expired_self_shares(round);
@@ -229,7 +229,7 @@ impl SecretShareManager {
     }
 
     fn prune_expired_self_shares(&mut self, latest_round: Round) {
-        self.recovered_self_shares.advance_retention(latest_round);
+        self.persisted_self_shares.advance_retention(latest_round);
     }
 
     fn process_recovered_share_request(
@@ -239,7 +239,7 @@ impl SecretShareManager {
         response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
     ) {
         if let Some(share) = self
-            .recovered_self_shares
+            .persisted_self_shares
             .get(metadata, &self.verifier, &self.author)
         {
             self.process_response(protocol, response_sender, SecretShareMessage::Share(share));
@@ -735,10 +735,10 @@ mod tests {
             .unwrap();
         assert_eq!(persisted.metadata(), &metadata);
         assert!(manager
-            .recovered_self_shares
+            .persisted_self_shares
             .contains_key(&storage_key(&metadata)));
         assert!(!manager
-            .recovered_self_shares
+            .persisted_self_shares
             .is_verified(&storage_key(&metadata)));
         assert!(manager
             .secret_share_store
@@ -771,7 +771,7 @@ mod tests {
             .get_self_share(&metadata)
             .unwrap()
             .is_none());
-        assert_eq!(manager.recovered_self_shares.len(), 0);
+        assert_eq!(manager.persisted_self_shares.len(), 0);
         assert!(
             tokio::time::timeout(Duration::from_millis(10), network_rx.next())
                 .await
@@ -798,10 +798,10 @@ mod tests {
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered[0].metadata(), &boundary_metadata);
         assert!(!manager
-            .recovered_self_shares
+            .persisted_self_shares
             .contains_key(&storage_key(&old_metadata)));
         assert!(manager
-            .recovered_self_shares
+            .persisted_self_shares
             .contains_key(&storage_key(&boundary_metadata)));
     }
 
@@ -819,7 +819,7 @@ mod tests {
 
         assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
         assert!(!manager
-            .recovered_self_shares
+            .persisted_self_shares
             .contains_key(&storage_key(&metadata)));
     }
 
@@ -842,7 +842,7 @@ mod tests {
 
         assert!(storage.load_self_shares(ctx.epoch).unwrap().is_empty());
         assert!(!manager
-            .recovered_self_shares
+            .persisted_self_shares
             .contains_key(&storage_key(&metadata)));
     }
 
@@ -867,7 +867,7 @@ mod tests {
         });
         rx.await.unwrap();
 
-        assert_eq!(manager.recovered_self_shares.len(), 1);
+        assert_eq!(manager.persisted_self_shares.len(), 1);
         assert!(manager
             .secret_share_store
             .lock()
@@ -879,7 +879,7 @@ mod tests {
         manager.handle_incoming_msg(request);
         assert!(response.await.unwrap().is_ok());
         assert!(manager
-            .recovered_self_shares
+            .persisted_self_shares
             .is_verified(&storage_key(&metadata)));
     }
 
@@ -896,12 +896,12 @@ mod tests {
             .lock()
             .update_highest_known_round(metadata.round);
         assert!(!manager
-            .recovered_self_shares
+            .persisted_self_shares
             .is_verified(&storage_key(&metadata)));
         let (request_1, response_1) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_1);
         assert!(manager
-            .recovered_self_shares
+            .persisted_self_shares
             .is_verified(&storage_key(&metadata)));
         let (request_2, response_2) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_2);
@@ -943,7 +943,7 @@ mod tests {
             .lock()
             .update_highest_known_round(metadata.round);
         assert!(manager
-            .recovered_self_shares
+            .persisted_self_shares
             .contains_key(&storage_key(&metadata)));
         let (request, _) = request_rpc(metadata.clone());
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -133,11 +133,21 @@ impl SecretShareManager {
             .load_self_shares(epoch_state.epoch)
             .unwrap_or_else(|error| panic!("Failed to load secret shares at epoch start: {error}"));
         let mut recovered_self_shares = HashMap::new();
-        for loaded_share in loaded_self_shares {
+        for (key, loaded_share) in loaded_self_shares {
             let share = match loaded_share {
                 Ok(share) => share,
                 Err(error) => {
-                    error!("Ignoring invalid persisted secret share: {error}");
+                    error!(
+                        epoch = key.0,
+                        block_id = key.1,
+                        "Deleting invalid persisted secret share: {error}"
+                    );
+                    secret_share_storage.delete_self_share(&key).unwrap_or_else(|delete_error| {
+                        panic!(
+                            "Failed to delete invalid persisted secret share for epoch {}, block {}: {delete_error}",
+                            key.0, key.1
+                        )
+                    });
                     continue;
                 },
             };
@@ -147,11 +157,17 @@ impl SecretShareManager {
                     share_epoch = share.epoch(),
                     expected_author = author,
                     share_author = share.author(),
-                    "Ignoring persisted secret share with invalid identity"
+                    "Deleting persisted secret share with invalid identity"
                 );
+                secret_share_storage.delete_self_share(&key).unwrap_or_else(|delete_error| {
+                    panic!(
+                        "Failed to delete persisted secret share with invalid identity for epoch {}, block {}: {delete_error}",
+                        key.0, key.1
+                    )
+                });
                 continue;
             }
-            recovered_self_shares.insert(storage_key(share.metadata()), RecoveredSelfShare {
+            recovered_self_shares.insert(key, RecoveredSelfShare {
                 share,
                 verified: false,
             });
@@ -341,6 +357,14 @@ impl SecretShareManager {
         };
 
         self.recovered_self_shares.remove(&key);
+        self.secret_share_storage
+            .delete_self_share(&key)
+            .unwrap_or_else(|delete_error| {
+                panic!(
+                    "Failed to delete cryptographically invalid persisted secret share for epoch {}, block {}: {delete_error}",
+                    key.0, key.1
+                )
+            });
         error!(
             epoch = metadata.epoch,
             round = metadata.round,
@@ -719,6 +743,10 @@ mod tests {
             anyhow::bail!("injected failure")
         }
 
+        fn delete_self_share(&self, _key: &SecretShareKey) -> anyhow::Result<()> {
+            Ok(())
+        }
+
         fn load_self_shares(&self, _epoch: u64) -> anyhow::Result<Vec<LoadedSecretShare>> {
             Ok(Vec::new())
         }
@@ -841,6 +869,7 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
+            .1
             .unwrap();
         assert_eq!(persisted.metadata(), &metadata);
         assert_eq!(
@@ -917,6 +946,7 @@ mod tests {
             .load_self_shares(ctx.epoch)
             .unwrap()
             .into_iter()
+            .map(|(_, share)| share)
             .collect::<anyhow::Result<Vec<_>>>()
             .unwrap();
         assert_eq!(recovered.len(), 1);
@@ -1065,7 +1095,14 @@ mod tests {
         wrong_author_storage
             .save_self_share(&create_secret_share(&ctx, 1, &metadata))
             .unwrap();
-        let (mut manager, _) = make_manager(&ctx, 0, wrong_author_storage);
+        let (mut manager, _) = make_manager(&ctx, 0, wrong_author_storage.clone());
+        assert!(wrong_author_storage
+            .load_self_shares(ctx.epoch)
+            .unwrap()
+            .is_empty());
+        wrong_author_storage
+            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
+            .unwrap();
         manager
             .secret_share_store
             .lock()
@@ -1078,7 +1115,7 @@ mod tests {
         bad_crypto_storage
             .save_self_share(&create_bad_secret_share(&ctx, 0, &metadata))
             .unwrap();
-        let (mut manager, _) = make_manager(&ctx, 0, bad_crypto_storage);
+        let (mut manager, _) = make_manager(&ctx, 0, bad_crypto_storage.clone());
         manager
             .secret_share_store
             .lock()
@@ -1092,6 +1129,13 @@ mod tests {
         assert!(!manager
             .recovered_self_shares
             .contains_key(&storage_key(&metadata)));
+        assert!(bad_crypto_storage
+            .load_self_shares(ctx.epoch)
+            .unwrap()
+            .is_empty());
+        bad_crypto_storage
+            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
+            .unwrap();
 
         let forged_storage = Arc::new(InMemorySecretShareStorage::new());
         forged_storage
@@ -1115,7 +1159,14 @@ mod tests {
 
         let corrupt_storage = Arc::new(InMemorySecretShareStorage::new());
         corrupt_storage.insert_raw(storage_key(&metadata), vec![0xFF, 0xFF]);
-        let (mut manager, _) = make_manager(&ctx, 0, corrupt_storage);
+        let (mut manager, _) = make_manager(&ctx, 0, corrupt_storage.clone());
+        assert!(corrupt_storage
+            .load_self_shares(ctx.epoch)
+            .unwrap()
+            .is_empty());
+        corrupt_storage
+            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
+            .unwrap();
         manager
             .secret_share_store
             .lock()

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -9,10 +9,10 @@ use crate::{
     rand::secret_sharing::{
         block_queue::{BlockQueue, QueueItem},
         network_messages::{SecretShareMessage, SecretShareRpc},
-        recovered_self_shares::{RecoveredSelfShares, RecoveredShare},
+        recovered_self_shares::RecoveredSelfShares,
         reliable_broadcast_state::SecretShareAggregateState,
         secret_share_store::{SecretShareAggregationResult, SecretShareStore},
-        storage::{storage_key, SecretShareKey, SecretShareStorage},
+        storage::SecretShareStorage,
         types::RequestSecretShare,
         verifier::SecretShareVerifier,
     },
@@ -40,7 +40,7 @@ use futures_channel::{
     mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 use tokio_retry::strategy::ExponentialBackoff;
 
 pub type Sender<T> = UnboundedSender<T>;
@@ -48,13 +48,6 @@ pub type Receiver<T> = UnboundedReceiver<T>;
 
 type PendingDeriveFut =
     Pin<Box<dyn Future<Output = (Round, TaskResult<SecretShareResult>)> + Send>>;
-type PendingRecoveredShareVerificationFut =
-    Pin<Box<dyn Future<Output = (SecretShareKey, anyhow::Result<()>)> + Send>>;
-
-struct PendingRecoveredShareResponse {
-    protocol: ProtocolId,
-    response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
-}
 
 pub struct SecretShareManager {
     author: Author,
@@ -63,7 +56,6 @@ pub struct SecretShareManager {
     verifier: Arc<SecretShareVerifier>,
     reliable_broadcast: Arc<ReliableBroadcast<SecretShareMessage, ExponentialBackoff>>,
     network_sender: Arc<NetworkSender>,
-    bounded_executor: BoundedExecutor,
     secret_share_request_delay_ms: u64,
 
     // local channel received from dec_store
@@ -73,8 +65,6 @@ pub struct SecretShareManager {
     // local state
     secret_share_store: Arc<Mutex<SecretShareStore>>,
     recovered_self_shares: RecoveredSelfShares,
-    pending_recovered_share_verifications: FuturesUnordered<PendingRecoveredShareVerificationFut>,
-    pending_recovered_share_responses: HashMap<SecretShareKey, Vec<PendingRecoveredShareResponse>>,
     block_queue: BlockQueue,
     pending_derives: FuturesUnordered<PendingDeriveFut>,
 }
@@ -129,7 +119,6 @@ impl SecretShareManager {
             verifier,
             reliable_broadcast,
             network_sender,
-            bounded_executor,
             secret_share_request_delay_ms,
 
             decision_rx,
@@ -137,8 +126,6 @@ impl SecretShareManager {
 
             secret_share_store: dec_store,
             recovered_self_shares,
-            pending_recovered_share_verifications: FuturesUnordered::new(),
-            pending_recovered_share_responses: HashMap::new(),
             block_queue: BlockQueue::new(),
             pending_derives: FuturesUnordered::new(),
         }
@@ -270,77 +257,11 @@ impl SecretShareManager {
         protocol: ProtocolId,
         response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
     ) {
-        let key = storage_key(metadata);
-        match self.recovered_self_shares.get(metadata) {
-            Some(RecoveredShare::Verified(share)) => {
-                self.process_response(protocol, response_sender, SecretShareMessage::Share(share));
-            },
-            Some(RecoveredShare::Unverified(share)) => {
-                let responses = self
-                    .pending_recovered_share_responses
-                    .entry(key)
-                    .or_default();
-                // Keep waiters bounded even if one peer repeatedly requests the
-                // same share while its verification is in flight.
-                let max_responses = self.epoch_state.verifier.len();
-                if responses.len() >= max_responses {
-                    return;
-                }
-                responses.push(PendingRecoveredShareResponse {
-                    protocol,
-                    response_sender,
-                });
-                if responses.len() > 1 {
-                    return;
-                }
-
-                let verifier = self.verifier.clone();
-                let author = self.author;
-                let bounded_executor = self.bounded_executor.clone();
-                self.pending_recovered_share_verifications
-                    .push(Box::pin(async move {
-                        let handle = bounded_executor
-                            .spawn_blocking(move || verifier.verify(&share, &author))
-                            .await;
-                        let result = handle
-                            .await
-                            .expect("Recovered secret share verification task panicked");
-                        (key, result)
-                    }));
-            },
-            None => {},
-        }
-    }
-
-    fn process_recovered_share_verification(
-        &mut self,
-        key: SecretShareKey,
-        result: anyhow::Result<()>,
-    ) {
-        let responses = self
-            .pending_recovered_share_responses
-            .remove(&key)
-            .unwrap_or_default();
-        match result {
-            Ok(()) => {
-                if let Some(share) = self.recovered_self_shares.mark_verified(&key) {
-                    for response in responses {
-                        self.process_response(
-                            response.protocol,
-                            response.response_sender,
-                            SecretShareMessage::Share(share.clone()),
-                        );
-                    }
-                }
-            },
-            Err(verification_error) => {
-                self.recovered_self_shares.delete_invalid(&key);
-                error!(
-                    epoch = key.0,
-                    block_id = key.1,
-                    "Rejecting cryptographically invalid persisted secret share: {verification_error}"
-                );
-            },
+        if let Some(share) = self
+            .recovered_self_shares
+            .get(metadata, &self.verifier, &self.author)
+        {
+            self.process_response(protocol, response_sender, SecretShareMessage::Share(share));
         }
     }
 
@@ -638,9 +559,6 @@ impl SecretShareManager {
                 Some((round, result)) = self.pending_derives.next() => {
                     self.process_completed_derive(round, result);
                 }
-                Some((key, result)) = self.pending_recovered_share_verifications.next() => {
-                    self.process_recovered_share_verification(key, result);
-                }
                 Some(reset) = reset_rx.next() => {
                     let mut dropped = 0;
                     while matches!(incoming_blocks.try_next(), Ok(Some(_))) {
@@ -681,10 +599,7 @@ mod tests {
     use crate::{
         network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
         rand::secret_sharing::{
-            storage::{
-                storage_key, InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb,
-                SecretShareKey,
-            },
+            storage::{storage_key, InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb},
             test_utils::{
                 create_bad_secret_share, create_metadata, create_secret_share, TestContext,
             },
@@ -711,10 +626,6 @@ mod tests {
     impl SecretShareStorage for FailingStorage {
         fn save_self_share(&self, _share: &SecretShare) -> anyhow::Result<()> {
             anyhow::bail!("injected failure")
-        }
-
-        fn delete_self_share(&self, _key: &SecretShareKey) -> anyhow::Result<()> {
-            Ok(())
         }
 
         fn load_self_shares(&self, _epoch: u64) -> anyhow::Result<Vec<LoadedSecretShare>> {
@@ -819,15 +730,6 @@ mod tests {
         )
     }
 
-    async fn complete_recovered_share_verification(manager: &mut SecretShareManager) {
-        let (key, result) = manager
-            .pending_recovered_share_verifications
-            .next()
-            .await
-            .expect("expected a pending recovered share verification");
-        manager.process_recovered_share_verification(key, result);
-    }
-
     #[tokio::test]
     async fn test_write_completes_before_cache_and_broadcast() {
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
@@ -848,7 +750,6 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .1
             .unwrap();
         assert_eq!(persisted.metadata(), &metadata);
         assert!(manager
@@ -915,7 +816,6 @@ mod tests {
             .load_self_shares(ctx.epoch)
             .unwrap()
             .into_iter()
-            .map(|(_, share)| share)
             .collect::<anyhow::Result<Vec<_>>>()
             .unwrap();
         assert_eq!(recovered.len(), 1);
@@ -1000,7 +900,6 @@ mod tests {
 
         let (request, response) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request);
-        complete_recovered_share_verification(&mut manager).await;
         assert!(response.await.unwrap().is_ok());
         assert!(manager
             .recovered_self_shares
@@ -1008,7 +907,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_miss_verification_is_deduplicated() {
+    async fn test_cache_miss_uses_preloaded_share() {
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
         let storage = Arc::new(InMemorySecretShareStorage::new());
         let metadata = create_metadata(ctx.epoch, 10);
@@ -1024,13 +923,11 @@ mod tests {
             .is_verified(&storage_key(&metadata)));
         let (request_1, response_1) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_1);
-        let (request_2, response_2) = request_rpc(metadata.clone());
-        manager.handle_incoming_msg(request_2);
-        assert_eq!(manager.pending_recovered_share_verifications.len(), 1);
-        complete_recovered_share_verification(&mut manager).await;
         assert!(manager
             .recovered_self_shares
             .is_verified(&storage_key(&metadata)));
+        let (request_2, response_2) = request_rpc(metadata.clone());
+        manager.handle_incoming_msg(request_2);
 
         for response in [response_1, response_2] {
             let bytes = response.await.unwrap().unwrap();
@@ -1046,7 +943,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_invalid_recovered_records_and_requests_are_rejected() {
+    async fn test_invalid_recovered_records_fail_stop_and_requests_are_rejected() {
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
         let metadata = create_metadata(ctx.epoch, 10);
 
@@ -1054,27 +951,16 @@ mod tests {
         wrong_author_storage
             .save_self_share(&create_secret_share(&ctx, 1, &metadata))
             .unwrap();
-        let (mut manager, _) = make_manager(&ctx, 0, wrong_author_storage.clone());
-        assert!(wrong_author_storage
-            .load_self_shares(ctx.epoch)
-            .unwrap()
-            .is_empty());
-        wrong_author_storage
-            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
-            .unwrap();
-        manager
-            .secret_share_store
-            .lock()
-            .update_highest_known_round(metadata.round);
-        let (request, response) = request_rpc(metadata.clone());
-        manager.handle_incoming_msg(request);
-        assert!(response.await.is_err());
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            make_manager(&ctx, 0, wrong_author_storage)
+        }));
+        assert!(result.is_err());
 
         let bad_crypto_storage = Arc::new(InMemorySecretShareStorage::new());
         bad_crypto_storage
             .save_self_share(&create_bad_secret_share(&ctx, 0, &metadata))
             .unwrap();
-        let (mut manager, _) = make_manager(&ctx, 0, bad_crypto_storage.clone());
+        let (mut manager, _) = make_manager(&ctx, 0, bad_crypto_storage);
         manager
             .secret_share_store
             .lock()
@@ -1082,24 +968,11 @@ mod tests {
         assert!(manager
             .recovered_self_shares
             .contains_key(&storage_key(&metadata)));
-        let (request, response) = request_rpc(metadata.clone());
-        manager.handle_incoming_msg(request);
-        assert_eq!(manager.pending_recovered_share_verifications.len(), 1);
-        assert!(manager
-            .recovered_self_shares
-            .contains_key(&storage_key(&metadata)));
-        complete_recovered_share_verification(&mut manager).await;
-        assert!(response.await.is_err());
-        assert!(!manager
-            .recovered_self_shares
-            .contains_key(&storage_key(&metadata)));
-        assert!(bad_crypto_storage
-            .load_self_shares(ctx.epoch)
-            .unwrap()
-            .is_empty());
-        bad_crypto_storage
-            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
-            .unwrap();
+        let (request, _) = request_rpc(metadata.clone());
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            manager.handle_incoming_msg(request)
+        }));
+        assert!(result.is_err());
 
         let forged_storage = Arc::new(InMemorySecretShareStorage::new());
         forged_storage
@@ -1123,21 +996,10 @@ mod tests {
 
         let corrupt_storage = Arc::new(InMemorySecretShareStorage::new());
         corrupt_storage.insert_raw(storage_key(&metadata), vec![0xFF, 0xFF]);
-        let (mut manager, _) = make_manager(&ctx, 0, corrupt_storage.clone());
-        assert!(corrupt_storage
-            .load_self_shares(ctx.epoch)
-            .unwrap()
-            .is_empty());
-        corrupt_storage
-            .save_self_share(&create_secret_share(&ctx, 0, &metadata))
-            .unwrap();
-        manager
-            .secret_share_store
-            .lock()
-            .update_highest_known_round(metadata.round);
-        let (request, response) = request_rpc(metadata);
-        manager.handle_incoming_msg(request);
-        assert!(response.await.is_err());
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            make_manager(&ctx, 0, corrupt_storage)
+        }));
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -1182,7 +1044,6 @@ mod tests {
                 .update_highest_known_round(metadata.round);
             let (request, response) = request_rpc(metadata.clone());
             restarted_peer.handle_incoming_msg(request);
-            complete_recovered_share_verification(&mut restarted_peer).await;
 
             let bytes = response.await.unwrap().unwrap();
             let message: ConsensusMsg = ProtocolId::ConsensusRpcBcs.from_bytes(&bytes).unwrap();

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -197,29 +197,10 @@ impl SecretShareManager {
             },
         };
 
-        if share.author() != &self.author
-            || share.epoch() != self.epoch_state.epoch
-            || share.round() != round
-        {
-            error!(
-                epoch = self.epoch_state.epoch,
-                round = round,
-                share_epoch = share.epoch(),
-                share_round = share.round(),
-                share_author = share.author(),
-                "Derived self share has invalid identity or metadata"
-            );
-            return;
-        }
-
-        if let Err(error) = self.recovered_self_shares.persist(share.clone()) {
-            panic!(
-                "Failed to persist self secret share for epoch {}, round {}, block {}: {error}",
-                share.epoch(),
-                round,
-                share.metadata().block_id,
-            );
-        }
+        self.recovered_self_shares
+            .persist(share.clone())
+            .expect("Failed to persist self secret share");
+        self.prune_expired_self_shares(round);
         let metadata = share.metadata().clone();
         {
             let mut store = self.secret_share_store.lock();
@@ -284,17 +265,19 @@ impl SecretShareManager {
 
     fn process_reset(&mut self, request: ResetRequest) {
         let ResetRequest { tx, signal } = request;
-        let (target_round, stop) = match signal {
-            ResetSignal::Stop => (0, true),
-            ResetSignal::TargetRound(round) => (round, false),
+        let target_round = match signal {
+            ResetSignal::Stop => {
+                self.stop = true;
+                0
+            },
+            ResetSignal::TargetRound(round) => {
+                self.prune_expired_self_shares(round);
+                round
+            },
         };
-        if !stop {
-            self.prune_expired_self_shares(target_round);
-        }
         self.block_queue = BlockQueue::new();
         self.pending_derives = FuturesUnordered::new();
         self.secret_share_store.lock().reset(target_round);
-        self.stop = stop;
         let _ = tx.send(ResetAck::default());
     }
 
@@ -599,7 +582,7 @@ mod tests {
     use crate::{
         network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
         rand::secret_sharing::{
-            storage::{storage_key, InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb},
+            storage::{storage_key, InMemorySecretShareStorage, SecretShareDb, SecretShareKey},
             test_utils::{
                 create_bad_secret_share, create_metadata, create_secret_share, TestContext,
             },
@@ -628,7 +611,7 @@ mod tests {
             anyhow::bail!("injected failure")
         }
 
-        fn load_self_shares(&self, _epoch: u64) -> anyhow::Result<Vec<LoadedSecretShare>> {
+        fn load_self_shares(&self, _epoch: u64) -> anyhow::Result<Vec<SecretShare>> {
             Ok(Vec::new())
         }
 
@@ -636,7 +619,7 @@ mod tests {
             Ok(())
         }
 
-        fn prune_before_round(&self, _epoch: u64, _round: Round) -> anyhow::Result<()> {
+        fn prune_self_shares(&self, _keys: &[SecretShareKey]) -> anyhow::Result<()> {
             Ok(())
         }
     }
@@ -749,7 +732,6 @@ mod tests {
             .unwrap()
             .into_iter()
             .next()
-            .unwrap()
             .unwrap();
         assert_eq!(persisted.metadata(), &metadata);
         assert!(manager
@@ -812,12 +794,7 @@ mod tests {
 
         let (manager, _) = make_manager_with_retention(&ctx, 0, storage.clone(), 30, 10);
 
-        let recovered = storage
-            .load_self_shares(ctx.epoch)
-            .unwrap()
-            .into_iter()
-            .collect::<anyhow::Result<Vec<_>>>()
-            .unwrap();
+        let recovered = storage.load_self_shares(ctx.epoch).unwrap();
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered[0].metadata(), &boundary_metadata);
         assert!(!manager
@@ -993,13 +970,6 @@ mod tests {
         let (request, response) = request_rpc(old_epoch_metadata);
         manager.handle_incoming_msg(request);
         assert!(response.await.is_err());
-
-        let corrupt_storage = Arc::new(InMemorySecretShareStorage::new());
-        corrupt_storage.insert_raw(storage_key(&metadata), vec![0xFF, 0xFF]);
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            make_manager(&ctx, 0, corrupt_storage)
-        }));
-        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -9,9 +9,10 @@ use crate::{
     rand::secret_sharing::{
         block_queue::{BlockQueue, QueueItem},
         network_messages::{SecretShareMessage, SecretShareRpc},
+        recovered_self_shares::{RecoveredSelfShares, RecoveredShare},
         reliable_broadcast_state::SecretShareAggregateState,
         secret_share_store::{SecretShareAggregationResult, SecretShareStore},
-        storage::{storage_key, SecretShareKey, SecretShareStorage},
+        storage::SecretShareStorage,
         types::RequestSecretShare,
         verifier::SecretShareVerifier,
     },
@@ -42,7 +43,7 @@ use futures_channel::{
     mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 use tokio_retry::strategy::ExponentialBackoff;
 
 pub type Sender<T> = UnboundedSender<T>;
@@ -51,11 +52,6 @@ pub type Receiver<T> = UnboundedReceiver<T>;
 type PendingDeriveFut =
     Pin<Box<dyn Future<Output = (Round, TaskResult<SecretShareResult>)> + Send>>;
 
-struct RecoveredSelfShare {
-    share: SecretShare,
-    verified: bool,
-}
-
 pub struct SecretShareManager {
     author: Author,
     epoch_state: Arc<EpochState>,
@@ -63,8 +59,6 @@ pub struct SecretShareManager {
     verifier: Arc<SecretShareVerifier>,
     reliable_broadcast: Arc<ReliableBroadcast<SecretShareMessage, ExponentialBackoff>>,
     network_sender: Arc<NetworkSender>,
-    secret_share_storage: Arc<dyn SecretShareStorage>,
-    retention_rounds: Round,
     secret_share_request_delay_ms: u64,
 
     // local channel received from dec_store
@@ -73,7 +67,7 @@ pub struct SecretShareManager {
     outgoing_blocks: Sender<OrderedBlocks>,
     // local state
     secret_share_store: Arc<Mutex<SecretShareStore>>,
-    recovered_self_shares: HashMap<SecretShareKey, RecoveredSelfShare>,
+    recovered_self_shares: RecoveredSelfShares,
     block_queue: BlockQueue,
     pending_derives: FuturesUnordered<PendingDeriveFut>,
 }
@@ -113,65 +107,13 @@ impl SecretShareManager {
             verifier.clone(),
             decision_tx,
         )));
-        if let Err(error) = secret_share_storage.prune_before_epoch(epoch_state.epoch) {
-            error!(
-                epoch = epoch_state.epoch,
-                "Failed to prune old secret shares at epoch start: {error}"
-            );
-        }
-        let oldest_retained_round = highest_committed_round.saturating_sub(retention_rounds);
-        if let Err(error) =
-            secret_share_storage.prune_before_round(epoch_state.epoch, oldest_retained_round)
-        {
-            error!(
-                epoch = epoch_state.epoch,
-                oldest_retained_round = oldest_retained_round,
-                "Failed to prune expired secret shares at epoch start: {error}"
-            );
-        }
-        let loaded_self_shares = secret_share_storage
-            .load_self_shares(epoch_state.epoch)
-            .unwrap_or_else(|error| panic!("Failed to load secret shares at epoch start: {error}"));
-        let mut recovered_self_shares = HashMap::new();
-        for (key, loaded_share) in loaded_self_shares {
-            let share = match loaded_share {
-                Ok(share) => share,
-                Err(error) => {
-                    error!(
-                        epoch = key.0,
-                        block_id = key.1,
-                        "Deleting invalid persisted secret share: {error}"
-                    );
-                    secret_share_storage.delete_self_share(&key).unwrap_or_else(|delete_error| {
-                        panic!(
-                            "Failed to delete invalid persisted secret share for epoch {}, block {}: {delete_error}",
-                            key.0, key.1
-                        )
-                    });
-                    continue;
-                },
-            };
-            if share.epoch() != epoch_state.epoch || share.author() != &author {
-                error!(
-                    expected_epoch = epoch_state.epoch,
-                    share_epoch = share.epoch(),
-                    expected_author = author,
-                    share_author = share.author(),
-                    "Deleting persisted secret share with invalid identity"
-                );
-                secret_share_storage.delete_self_share(&key).unwrap_or_else(|delete_error| {
-                    panic!(
-                        "Failed to delete persisted secret share with invalid identity for epoch {}, block {}: {delete_error}",
-                        key.0, key.1
-                    )
-                });
-                continue;
-            }
-            recovered_self_shares.insert(key, RecoveredSelfShare {
-                share,
-                verified: false,
-            });
-        }
+        let recovered_self_shares = RecoveredSelfShares::new(
+            epoch_state.epoch,
+            author,
+            secret_share_storage,
+            highest_committed_round,
+            retention_rounds,
+        );
 
         Self {
             author,
@@ -180,8 +122,6 @@ impl SecretShareManager {
             verifier,
             reliable_broadcast,
             network_sender,
-            secret_share_storage,
-            retention_rounds,
             secret_share_request_delay_ms,
 
             decision_rx,
@@ -275,7 +215,7 @@ impl SecretShareManager {
             return;
         }
 
-        if let Err(error) = self.secret_share_storage.save_self_share(&share) {
+        if let Err(error) = self.recovered_self_shares.persist(share.clone()) {
             panic!(
                 "Failed to persist self secret share for epoch {}, round {}, block {}: {error}",
                 share.epoch(),
@@ -283,13 +223,6 @@ impl SecretShareManager {
                 share.metadata().block_id,
             );
         }
-        self.recovered_self_shares
-            .insert(storage_key(share.metadata()), RecoveredSelfShare {
-                share: share.clone(),
-                verified: false,
-            });
-        self.prune_expired_self_shares(round);
-
         let metadata = share.metadata().clone();
         {
             let mut store = self.secret_share_store.lock();
@@ -318,60 +251,30 @@ impl SecretShareManager {
     }
 
     fn prune_expired_self_shares(&mut self, latest_round: Round) {
-        let oldest_retained_round = latest_round.saturating_sub(self.retention_rounds);
-        let previous_len = self.recovered_self_shares.len();
-        self.recovered_self_shares
-            .retain(|_, recovered| recovered.share.round() >= oldest_retained_round);
-        if self.recovered_self_shares.len() == previous_len {
-            return;
-        }
-        if let Err(error) = self
-            .secret_share_storage
-            .prune_before_round(self.epoch_state.epoch, oldest_retained_round)
-        {
-            error!(
-                epoch = self.epoch_state.epoch,
-                oldest_retained_round = oldest_retained_round,
-                "Failed to prune expired secret shares: {error}"
-            );
-        }
+        self.recovered_self_shares.advance_retention(latest_round);
     }
 
     fn get_recovered_self_share(&mut self, metadata: &SecretShareMetadata) -> Option<SecretShare> {
-        let key = storage_key(metadata);
-        let verification_error = {
-            let recovered = self.recovered_self_shares.get_mut(&key)?;
-            if recovered.share.metadata() != metadata {
-                return None;
-            }
-            if recovered.verified {
-                return Some(recovered.share.clone());
-            }
-            match self.verifier.verify(&recovered.share, &self.author) {
+        let key = crate::rand::secret_sharing::storage::storage_key(metadata);
+        match self.recovered_self_shares.get(metadata)? {
+            RecoveredShare::Verified(share) => Some(share),
+            RecoveredShare::Unverified(share) => match self.verifier.verify(&share, &self.author) {
                 Ok(()) => {
-                    recovered.verified = true;
-                    return Some(recovered.share.clone());
+                    self.recovered_self_shares.mark_verified(&key);
+                    Some(share)
                 },
-                Err(error) => error,
-            }
-        };
-
-        self.recovered_self_shares.remove(&key);
-        self.secret_share_storage
-            .delete_self_share(&key)
-            .unwrap_or_else(|delete_error| {
-                panic!(
-                    "Failed to delete cryptographically invalid persisted secret share for epoch {}, block {}: {delete_error}",
-                    key.0, key.1
-                )
-            });
-        error!(
-            epoch = metadata.epoch,
-            round = metadata.round,
-            block_id = metadata.block_id,
-            "Rejecting cryptographically invalid persisted secret share: {verification_error}"
-        );
-        None
+                Err(verification_error) => {
+                    self.recovered_self_shares.delete_invalid(&key);
+                    error!(
+                        epoch = metadata.epoch,
+                        round = metadata.round,
+                        block_id = metadata.block_id,
+                        "Rejecting cryptographically invalid persisted secret share: {verification_error}"
+                    );
+                    None
+                },
+            },
+        }
     }
 
     fn process_ready_blocks(&mut self, ready_blocks: Vec<OrderedBlocks>) {
@@ -715,7 +618,10 @@ mod tests {
     use crate::{
         network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
         rand::secret_sharing::{
-            storage::{InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb},
+            storage::{
+                storage_key, InMemorySecretShareStorage, LoadedSecretShare, SecretShareDb,
+                SecretShareKey,
+            },
             test_utils::{
                 create_bad_secret_share, create_metadata, create_secret_share, TestContext,
             },
@@ -872,22 +778,12 @@ mod tests {
             .1
             .unwrap();
         assert_eq!(persisted.metadata(), &metadata);
-        assert_eq!(
-            manager
-                .recovered_self_shares
-                .get(&storage_key(&metadata))
-                .unwrap()
-                .share
-                .metadata(),
-            &metadata
-        );
-        assert!(
-            !manager
-                .recovered_self_shares
-                .get(&storage_key(&metadata))
-                .unwrap()
-                .verified
-        );
+        assert!(manager
+            .recovered_self_shares
+            .contains_key(&storage_key(&metadata)));
+        assert!(!manager
+            .recovered_self_shares
+            .is_verified(&storage_key(&metadata)));
         assert!(manager
             .secret_share_store
             .lock()
@@ -919,7 +815,7 @@ mod tests {
             .get_self_share(&metadata)
             .unwrap()
             .is_none());
-        assert!(manager.recovered_self_shares.is_empty());
+        assert_eq!(manager.recovered_self_shares.len(), 0);
         assert!(
             tokio::time::timeout(Duration::from_millis(10), network_rx.next())
                 .await
@@ -1032,13 +928,9 @@ mod tests {
         let (request, response) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request);
         assert!(response.await.unwrap().is_ok());
-        assert!(
-            manager
-                .recovered_self_shares
-                .get(&storage_key(&metadata))
-                .unwrap()
-                .verified
-        );
+        assert!(manager
+            .recovered_self_shares
+            .is_verified(&storage_key(&metadata)));
     }
 
     #[tokio::test]
@@ -1053,22 +945,14 @@ mod tests {
             .secret_share_store
             .lock()
             .update_highest_known_round(metadata.round);
-        assert!(
-            !manager
-                .recovered_self_shares
-                .get(&storage_key(&metadata))
-                .unwrap()
-                .verified
-        );
+        assert!(!manager
+            .recovered_self_shares
+            .is_verified(&storage_key(&metadata)));
         let (request_1, response_1) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_1);
-        assert!(
-            manager
-                .recovered_self_shares
-                .get(&storage_key(&metadata))
-                .unwrap()
-                .verified
-        );
+        assert!(manager
+            .recovered_self_shares
+            .is_verified(&storage_key(&metadata)));
 
         let (request_2, response_2) = request_rpc(metadata.clone());
         manager.handle_incoming_msg(request_2);

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -1,0 +1,262 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::{
+    schema::{SecretShareSchema, SECRET_SHARE_CF_NAME},
+    storage_key, LoadedSecretShare, Result, SecretShareStorage, SecretShareStorageError,
+};
+use aptos_infallible::Mutex;
+use aptos_logger::info;
+use aptos_schemadb::{batch::SchemaBatch, Options, DB};
+use aptos_storage_interface::AptosDbError;
+use aptos_types::secret_sharing::SecretShare;
+use std::{path::Path, sync::Arc, time::Instant};
+
+pub const SECRET_SHARE_DB_NAME: &str = "secret_share_db";
+const MAX_TOTAL_WAL_SIZE_BYTES: u64 = 256 << 20;
+
+pub struct SecretShareDb {
+    db: Arc<DB>,
+    write_lock: Mutex<()>,
+}
+
+impl SecretShareDb {
+    pub fn new<P: AsRef<Path>>(db_root_path: P) -> Self {
+        let path = db_root_path.as_ref().join(SECRET_SHARE_DB_NAME);
+        let instant = Instant::now();
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        opts.set_max_total_wal_size(MAX_TOTAL_WAL_SIZE_BYTES);
+        let db = Arc::new(
+            DB::open(
+                path.clone(),
+                SECRET_SHARE_DB_NAME,
+                vec![SECRET_SHARE_CF_NAME],
+                opts,
+            )
+            .expect("SecretShareDb open failed; unable to continue"),
+        );
+
+        info!(
+            "Opened SecretShareDb at {:?} in {} ms",
+            path,
+            instant.elapsed().as_millis()
+        );
+
+        Self {
+            db,
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    fn map_db_error(error: AptosDbError) -> SecretShareStorageError {
+        match error {
+            AptosDbError::BcsError(message)
+            | AptosDbError::ParseIntError(message)
+            | AptosDbError::Other(message) => SecretShareStorageError::Corruption(message),
+            AptosDbError::NotFound(message)
+            | AptosDbError::RocksDbIncompleteResult(message)
+            | AptosDbError::OtherRocksDbError(message)
+            | AptosDbError::IoError(message)
+            | AptosDbError::RecvError(message) => SecretShareStorageError::Io(message),
+            AptosDbError::TooManyRequested(requested, max) => SecretShareStorageError::Io(format!(
+                "too many records requested: {requested}, max {max}"
+            )),
+            AptosDbError::MissingRootError(version) => {
+                SecretShareStorageError::Io(format!("missing root at version {version}"))
+            },
+            AptosDbError::LedgerPruned {
+                data_type,
+                version,
+                min_available_version,
+            } => SecretShareStorageError::Io(format!(
+                "{data_type} at version {version} pruned below {min_available_version}"
+            )),
+            AptosDbError::EventPruned {
+                requested_seq_num,
+                min_available_seq_num,
+            } => SecretShareStorageError::Io(format!(
+                "event {requested_seq_num} pruned below {min_available_seq_num}"
+            )),
+        }
+    }
+}
+
+impl SecretShareStorage for SecretShareDb {
+    fn save_self_share(&self, share: &SecretShare) -> Result<()> {
+        let key = storage_key(share.metadata());
+        let serialized = bcs::to_bytes(share)
+            .map_err(|error| SecretShareStorageError::Corruption(error.to_string()))?;
+        let _guard = self.write_lock.lock();
+
+        match self
+            .db
+            .get::<SecretShareSchema>(&key)
+            .map_err(Self::map_db_error)?
+        {
+            Some(existing) if existing == serialized => Ok(()),
+            Some(_) => Err(SecretShareStorageError::Conflict {
+                epoch: key.0,
+                block_id: key.1,
+            }),
+            None => {
+                let mut batch = SchemaBatch::new();
+                batch
+                    .put::<SecretShareSchema>(&key, &serialized)
+                    .map_err(Self::map_db_error)?;
+                self.db.write_schemas(batch).map_err(Self::map_db_error)
+            },
+        }
+    }
+
+    fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
+        let mut iter = self
+            .db
+            .iter::<SecretShareSchema>()
+            .map_err(Self::map_db_error)?;
+        iter.seek_to_first();
+
+        let mut shares = Vec::new();
+        for entry in iter {
+            let (key, serialized) = match entry.map_err(Self::map_db_error) {
+                Ok(entry) => entry,
+                Err(error @ SecretShareStorageError::Corruption(_)) => {
+                    shares.push(Err(error));
+                    continue;
+                },
+                Err(error) => return Err(error),
+            };
+            if key.0 != epoch {
+                continue;
+            }
+            let share = bcs::from_bytes::<SecretShare>(&serialized)
+                .map_err(|error| SecretShareStorageError::Corruption(error.to_string()))
+                .and_then(|share| {
+                    if storage_key(share.metadata()) == key {
+                        Ok(share)
+                    } else {
+                        Err(SecretShareStorageError::Corruption(format!(
+                            "stored key does not match secret share metadata for epoch {}, block {}",
+                            key.0, key.1
+                        )))
+                    }
+                });
+            shares.push(share);
+        }
+        Ok(shares)
+    }
+
+    fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
+        let _guard = self.write_lock.lock();
+        let mut iter = self
+            .db
+            .iter::<SecretShareSchema>()
+            .map_err(Self::map_db_error)?;
+        iter.seek_to_first();
+
+        let mut batch = SchemaBatch::new();
+        let mut has_deletes = false;
+        for entry in iter {
+            let (key, _) = entry.map_err(Self::map_db_error)?;
+            if key.0 < epoch {
+                batch
+                    .delete::<SecretShareSchema>(&key)
+                    .map_err(Self::map_db_error)?;
+                has_deletes = true;
+            }
+        }
+        if has_deletes {
+            self.db.write_schemas(batch).map_err(Self::map_db_error)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rand::secret_sharing::test_utils::{
+        create_metadata, create_secret_share, TestContext,
+    };
+    use aptos_temppath::TempPath;
+
+    #[test]
+    fn test_idempotent_write_conflict_and_restart() {
+        let temp_path = TempPath::new();
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 10);
+        let share = create_secret_share(&ctx, 0, &metadata);
+
+        {
+            let db = SecretShareDb::new(&temp_path);
+            db.save_self_share(&share).unwrap();
+            db.save_self_share(&share).unwrap();
+
+            let mut conflicting = share.clone();
+            conflicting.metadata.timestamp += 1;
+            assert!(matches!(
+                db.save_self_share(&conflicting),
+                Err(SecretShareStorageError::Conflict { .. })
+            ));
+        }
+
+        let reopened = SecretShareDb::new(&temp_path);
+        let recovered = reopened
+            .load_self_shares(ctx.epoch)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            bcs::to_bytes(&recovered).unwrap(),
+            bcs::to_bytes(&share).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_prune_before_epoch() {
+        let temp_path = TempPath::new();
+        let db = SecretShareDb::new(&temp_path);
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let old_metadata = create_metadata(ctx.epoch, 10);
+        let new_metadata = create_metadata(ctx.epoch + 1, 11);
+        db.save_self_share(&create_secret_share(&ctx, 0, &old_metadata))
+            .unwrap();
+        db.save_self_share(&create_secret_share(&ctx, 0, &new_metadata))
+            .unwrap();
+
+        db.prune_before_epoch(ctx.epoch + 1).unwrap();
+
+        let recovered = db
+            .load_self_shares(ctx.epoch + 1)
+            .unwrap()
+            .into_iter()
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].metadata(), &new_metadata);
+    }
+
+    #[test]
+    fn test_corrupt_record_is_rejected() {
+        let temp_path = TempPath::new();
+        let db = SecretShareDb::new(&temp_path);
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let valid_metadata = create_metadata(ctx.epoch, 10);
+        db.save_self_share(&create_secret_share(&ctx, 0, &valid_metadata))
+            .unwrap();
+        let corrupt_metadata = create_metadata(ctx.epoch, 11);
+        let key = storage_key(&corrupt_metadata);
+        let mut batch = SchemaBatch::new();
+        batch
+            .put::<SecretShareSchema>(&key, &vec![0xFF, 0xFF])
+            .unwrap();
+        db.db.write_schemas(batch).unwrap();
+
+        let records = db.load_self_shares(ctx.epoch).unwrap();
+        assert_eq!(records.iter().filter(|record| record.is_ok()).count(), 1);
+        assert_eq!(records.iter().filter(|record| record.is_err()).count(), 1);
+    }
+}

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -3,12 +3,12 @@
 
 use super::{
     schema::{SecretShareSchema, SECRET_SHARE_CF_NAME},
-    storage_key, LoadedSecretShare, Result, SecretShareStorage, SecretShareStorageError,
+    storage_key, LoadedSecretShare, SecretShareStorage,
 };
+use anyhow::{bail, ensure, Result};
 use aptos_infallible::Mutex;
 use aptos_logger::info;
 use aptos_schemadb::{batch::SchemaBatch, Options, DB};
-use aptos_storage_interface::AptosDbError;
 use aptos_types::secret_sharing::SecretShare;
 use std::{path::Path, sync::Arc, time::Instant};
 
@@ -49,99 +49,56 @@ impl SecretShareDb {
             write_lock: Mutex::new(()),
         }
     }
-
-    fn map_db_error(error: AptosDbError) -> SecretShareStorageError {
-        match error {
-            AptosDbError::BcsError(message)
-            | AptosDbError::ParseIntError(message)
-            | AptosDbError::Other(message) => SecretShareStorageError::Corruption(message),
-            AptosDbError::NotFound(message)
-            | AptosDbError::RocksDbIncompleteResult(message)
-            | AptosDbError::OtherRocksDbError(message)
-            | AptosDbError::IoError(message)
-            | AptosDbError::RecvError(message) => SecretShareStorageError::Io(message),
-            AptosDbError::TooManyRequested(requested, max) => SecretShareStorageError::Io(format!(
-                "too many records requested: {requested}, max {max}"
-            )),
-            AptosDbError::MissingRootError(version) => {
-                SecretShareStorageError::Io(format!("missing root at version {version}"))
-            },
-            AptosDbError::LedgerPruned {
-                data_type,
-                version,
-                min_available_version,
-            } => SecretShareStorageError::Io(format!(
-                "{data_type} at version {version} pruned below {min_available_version}"
-            )),
-            AptosDbError::EventPruned {
-                requested_seq_num,
-                min_available_seq_num,
-            } => SecretShareStorageError::Io(format!(
-                "event {requested_seq_num} pruned below {min_available_seq_num}"
-            )),
-        }
-    }
 }
 
 impl SecretShareStorage for SecretShareDb {
     fn save_self_share(&self, share: &SecretShare) -> Result<()> {
         let key = storage_key(share.metadata());
-        let serialized = bcs::to_bytes(share)
-            .map_err(|error| SecretShareStorageError::Corruption(error.to_string()))?;
+        let serialized = bcs::to_bytes(share)?;
         let _guard = self.write_lock.lock();
 
-        match self
-            .db
-            .get::<SecretShareSchema>(&key)
-            .map_err(Self::map_db_error)?
-        {
+        match self.db.get::<SecretShareSchema>(&key)? {
             Some(existing) if existing == serialized => Ok(()),
-            Some(_) => Err(SecretShareStorageError::Conflict {
-                epoch: key.0,
-                block_id: key.1,
-            }),
+            Some(_) => bail!(
+                "conflicting secret share for epoch {}, block {}",
+                key.0,
+                key.1
+            ),
             None => {
                 let mut batch = SchemaBatch::new();
-                batch
-                    .put::<SecretShareSchema>(&key, &serialized)
-                    .map_err(Self::map_db_error)?;
-                self.db.write_schemas(batch).map_err(Self::map_db_error)
+                batch.put::<SecretShareSchema>(&key, &serialized)?;
+                self.db.write_schemas(batch)?;
+                Ok(())
             },
         }
     }
 
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
-        let mut iter = self
-            .db
-            .iter::<SecretShareSchema>()
-            .map_err(Self::map_db_error)?;
+        let mut iter = self.db.iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut shares = Vec::new();
         for entry in iter {
-            let (key, serialized) = match entry.map_err(Self::map_db_error) {
+            let (key, serialized) = match entry {
                 Ok(entry) => entry,
-                Err(error @ SecretShareStorageError::Corruption(_)) => {
-                    shares.push(Err(error));
+                Err(error) => {
+                    shares.push(Err(error.into()));
                     continue;
                 },
-                Err(error) => return Err(error),
             };
             if key.0 != epoch {
                 continue;
             }
-            let share = bcs::from_bytes::<SecretShare>(&serialized)
-                .map_err(|error| SecretShareStorageError::Corruption(error.to_string()))
-                .and_then(|share| {
-                    if storage_key(share.metadata()) == key {
-                        Ok(share)
-                    } else {
-                        Err(SecretShareStorageError::Corruption(format!(
-                            "stored key does not match secret share metadata for epoch {}, block {}",
-                            key.0, key.1
-                        )))
-                    }
-                });
+            let share = (|| {
+                let share = bcs::from_bytes::<SecretShare>(&serialized)?;
+                ensure!(
+                    storage_key(share.metadata()) == key,
+                    "stored key does not match secret share metadata for epoch {}, block {}",
+                    key.0,
+                    key.1
+                );
+                Ok(share)
+            })();
             shares.push(share);
         }
         Ok(shares)
@@ -149,25 +106,20 @@ impl SecretShareStorage for SecretShareDb {
 
     fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
         let _guard = self.write_lock.lock();
-        let mut iter = self
-            .db
-            .iter::<SecretShareSchema>()
-            .map_err(Self::map_db_error)?;
+        let mut iter = self.db.iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut batch = SchemaBatch::new();
         let mut has_deletes = false;
         for entry in iter {
-            let (key, _) = entry.map_err(Self::map_db_error)?;
+            let (key, _) = entry?;
             if key.0 < epoch {
-                batch
-                    .delete::<SecretShareSchema>(&key)
-                    .map_err(Self::map_db_error)?;
+                batch.delete::<SecretShareSchema>(&key)?;
                 has_deletes = true;
             }
         }
         if has_deletes {
-            self.db.write_schemas(batch).map_err(Self::map_db_error)?;
+            self.db.write_schemas(batch)?;
         }
         Ok(())
     }
@@ -195,10 +147,11 @@ mod tests {
 
             let mut conflicting = share.clone();
             conflicting.metadata.timestamp += 1;
-            assert!(matches!(
-                db.save_self_share(&conflicting),
-                Err(SecretShareStorageError::Conflict { .. })
-            ));
+            assert!(db
+                .save_self_share(&conflicting)
+                .unwrap_err()
+                .to_string()
+                .contains("conflicting secret share"));
         }
 
         let reopened = SecretShareDb::new(&temp_path);

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -6,6 +6,7 @@ use super::{
     storage_key, LoadedSecretShare, SecretShareStorage,
 };
 use anyhow::{bail, ensure, Result};
+use aptos_consensus_types::common::Round;
 use aptos_infallible::Mutex;
 use aptos_logger::info;
 use aptos_schemadb::{batch::SchemaBatch, Options, DB};
@@ -123,6 +124,31 @@ impl SecretShareStorage for SecretShareDb {
         }
         Ok(())
     }
+
+    fn prune_before_round(&self, epoch: u64, round: Round) -> Result<()> {
+        let _guard = self.write_lock.lock();
+        let mut iter = self.db.iter::<SecretShareSchema>()?;
+        iter.seek_to_first();
+
+        let mut batch = SchemaBatch::new();
+        let mut has_deletes = false;
+        for entry in iter {
+            let (key, serialized) = entry?;
+            if key.0 != epoch {
+                continue;
+            }
+            // Leave malformed records for the load path to report and reject.
+            if bcs::from_bytes::<SecretShare>(&serialized).is_ok_and(|share| share.round() < round)
+            {
+                batch.delete::<SecretShareSchema>(&key)?;
+                has_deletes = true;
+            }
+        }
+        if has_deletes {
+            self.db.write_schemas(batch)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -190,6 +216,29 @@ mod tests {
             .unwrap();
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered[0].metadata(), &new_metadata);
+    }
+
+    #[test]
+    fn test_prune_before_round() {
+        let temp_path = TempPath::new();
+        let db = SecretShareDb::new(&temp_path);
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        for round in [10, 20, 30] {
+            let metadata = create_metadata(ctx.epoch, round);
+            db.save_self_share(&create_secret_share(&ctx, 0, &metadata))
+                .unwrap();
+        }
+
+        db.prune_before_round(ctx.epoch, 20).unwrap();
+
+        let mut recovered_rounds = db
+            .load_self_shares(ctx.epoch)
+            .unwrap()
+            .into_iter()
+            .map(|share| share.unwrap().round())
+            .collect::<Vec<_>>();
+        recovered_rounds.sort_unstable();
+        assert_eq!(recovered_rounds, vec![20, 30]);
     }
 
     #[test]

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -3,7 +3,7 @@
 
 use super::{
     schema::{SecretShareSchema, SECRET_SHARE_CF_NAME},
-    storage_key, LoadedSecretShare, SecretShareStorage,
+    storage_key, LoadedSecretShare, SecretShareKey, SecretShareStorage,
 };
 use anyhow::{bail, ensure, Result};
 use aptos_consensus_types::common::Round;
@@ -74,19 +74,21 @@ impl SecretShareStorage for SecretShareDb {
         }
     }
 
+    fn delete_self_share(&self, key: &SecretShareKey) -> Result<()> {
+        let _guard = self.write_lock.lock();
+        let mut batch = SchemaBatch::new();
+        batch.delete::<SecretShareSchema>(key)?;
+        self.db.write_schemas(batch)?;
+        Ok(())
+    }
+
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
         let mut iter = self.db.iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut shares = Vec::new();
         for entry in iter {
-            let (key, serialized) = match entry {
-                Ok(entry) => entry,
-                Err(error) => {
-                    shares.push(Err(error.into()));
-                    continue;
-                },
-            };
+            let (key, serialized) = entry?;
             if key.0 != epoch {
                 continue;
             }
@@ -100,7 +102,7 @@ impl SecretShareStorage for SecretShareDb {
                 );
                 Ok(share)
             })();
-            shares.push(share);
+            shares.push((key, share));
         }
         Ok(shares)
     }
@@ -187,11 +189,26 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
+            .1
             .unwrap();
         assert_eq!(
             bcs::to_bytes(&recovered).unwrap(),
             bcs::to_bytes(&share).unwrap()
         );
+    }
+
+    #[test]
+    fn test_delete_self_share() {
+        let temp_path = TempPath::new();
+        let db = SecretShareDb::new(&temp_path);
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 10);
+        db.save_self_share(&create_secret_share(&ctx, 0, &metadata))
+            .unwrap();
+
+        db.delete_self_share(&storage_key(&metadata)).unwrap();
+
+        assert!(db.load_self_shares(ctx.epoch).unwrap().is_empty());
     }
 
     #[test]
@@ -212,6 +229,7 @@ mod tests {
             .load_self_shares(ctx.epoch + 1)
             .unwrap()
             .into_iter()
+            .map(|(_, share)| share)
             .collect::<Result<Vec<_>>>()
             .unwrap();
         assert_eq!(recovered.len(), 1);
@@ -235,7 +253,7 @@ mod tests {
             .load_self_shares(ctx.epoch)
             .unwrap()
             .into_iter()
-            .map(|share| share.unwrap().round())
+            .map(|(_, share)| share.unwrap().round())
             .collect::<Vec<_>>();
         recovered_rounds.sort_unstable();
         assert_eq!(recovered_rounds, vec![20, 30]);
@@ -258,7 +276,13 @@ mod tests {
         db.db.write_schemas(batch).unwrap();
 
         let records = db.load_self_shares(ctx.epoch).unwrap();
-        assert_eq!(records.iter().filter(|record| record.is_ok()).count(), 1);
-        assert_eq!(records.iter().filter(|record| record.is_err()).count(), 1);
+        assert_eq!(
+            records.iter().filter(|(_, record)| record.is_ok()).count(),
+            1
+        );
+        assert_eq!(
+            records.iter().filter(|(_, record)| record.is_err()).count(),
+            1
+        );
     }
 }

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -89,7 +89,7 @@ impl SecretShareStorage for SecretShareDb {
             }
         }
         if has_deletes {
-            self.db.write_schemas(batch)?;
+            self.db.write_schemas_relaxed(batch)?;
         }
         Ok(())
     }
@@ -100,7 +100,7 @@ impl SecretShareStorage for SecretShareDb {
             batch.delete::<SecretShareSchema>(key)?;
         }
         if !keys.is_empty() {
-            self.db.write_schemas(batch)?;
+            self.db.write_schemas_relaxed(batch)?;
         }
         Ok(())
     }

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -3,7 +3,7 @@
 
 use super::{
     schema::{SecretShareSchema, SECRET_SHARE_CF_NAME},
-    storage_key, LoadedSecretShare, SecretShareKey, SecretShareStorage,
+    storage_key, LoadedSecretShare, SecretShareStorage,
 };
 use anyhow::{bail, ensure, Result};
 use aptos_consensus_types::common::Round;
@@ -84,21 +84,19 @@ impl SecretShareStorage for SecretShareDb {
         }
     }
 
-    fn delete_self_share(&self, key: &SecretShareKey) -> Result<()> {
-        let _guard = self.write_lock.lock();
-        let mut batch = SchemaBatch::new();
-        batch.delete::<SecretShareSchema>(key)?;
-        self.db().write_schemas(batch)?;
-        Ok(())
-    }
-
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
         let mut iter = self.db().iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut shares = Vec::new();
         for entry in iter {
-            let (key, serialized) = entry?;
+            let (key, serialized) = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    shares.push(Err(error.into()));
+                    continue;
+                },
+            };
             if key.0 != epoch {
                 continue;
             }
@@ -112,7 +110,7 @@ impl SecretShareStorage for SecretShareDb {
                 );
                 Ok(share)
             })();
-            shares.push((key, share));
+            shares.push(share);
         }
         Ok(shares)
     }
@@ -210,26 +208,11 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .1
             .unwrap();
         assert_eq!(
             bcs::to_bytes(&recovered).unwrap(),
             bcs::to_bytes(&share).unwrap()
         );
-    }
-
-    #[test]
-    fn test_delete_self_share() {
-        let temp_path = TempPath::new();
-        let db = SecretShareDb::new(&temp_path);
-        let ctx = TestContext::new(vec![1, 1, 1, 1]);
-        let metadata = create_metadata(ctx.epoch, 10);
-        db.save_self_share(&create_secret_share(&ctx, 0, &metadata))
-            .unwrap();
-
-        db.delete_self_share(&storage_key(&metadata)).unwrap();
-
-        assert!(db.load_self_shares(ctx.epoch).unwrap().is_empty());
     }
 
     #[test]
@@ -250,7 +233,6 @@ mod tests {
             .load_self_shares(ctx.epoch + 1)
             .unwrap()
             .into_iter()
-            .map(|(_, share)| share)
             .collect::<Result<Vec<_>>>()
             .unwrap();
         assert_eq!(recovered.len(), 1);
@@ -274,7 +256,7 @@ mod tests {
             .load_self_shares(ctx.epoch)
             .unwrap()
             .into_iter()
-            .map(|(_, share)| share.unwrap().round())
+            .map(|share| share.unwrap().round())
             .collect::<Vec<_>>();
         recovered_rounds.sort_unstable();
         assert_eq!(recovered_rounds, vec![20, 30]);
@@ -297,13 +279,7 @@ mod tests {
         db.db().write_schemas(batch).unwrap();
 
         let records = db.load_self_shares(ctx.epoch).unwrap();
-        assert_eq!(
-            records.iter().filter(|(_, record)| record.is_ok()).count(),
-            1
-        );
-        assert_eq!(
-            records.iter().filter(|(_, record)| record.is_err()).count(),
-            1
-        );
+        assert_eq!(records.iter().filter(|record| record.is_ok()).count(), 1);
+        assert_eq!(records.iter().filter(|record| record.is_err()).count(), 1);
     }
 }

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -11,44 +11,54 @@ use aptos_infallible::Mutex;
 use aptos_logger::info;
 use aptos_schemadb::{batch::SchemaBatch, Options, DB};
 use aptos_types::secret_sharing::SecretShare;
-use std::{path::Path, sync::Arc, time::Instant};
+use std::{
+    path::{Path, PathBuf},
+    sync::OnceLock,
+    time::Instant,
+};
 
 pub const SECRET_SHARE_DB_NAME: &str = "secret_share_db";
 const MAX_TOTAL_WAL_SIZE_BYTES: u64 = 256 << 20;
 
 pub struct SecretShareDb {
-    db: Arc<DB>,
+    path: PathBuf,
+    db: OnceLock<DB>,
     write_lock: Mutex<()>,
 }
 
 impl SecretShareDb {
     pub fn new<P: AsRef<Path>>(db_root_path: P) -> Self {
-        let path = db_root_path.as_ref().join(SECRET_SHARE_DB_NAME);
+        Self {
+            path: db_root_path.as_ref().join(SECRET_SHARE_DB_NAME),
+            db: OnceLock::new(),
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    fn db(&self) -> &DB {
+        self.db.get_or_init(|| self.open_db())
+    }
+
+    fn open_db(&self) -> DB {
         let instant = Instant::now();
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
         opts.set_max_total_wal_size(MAX_TOTAL_WAL_SIZE_BYTES);
-        let db = Arc::new(
-            DB::open(
-                path.clone(),
-                SECRET_SHARE_DB_NAME,
-                vec![SECRET_SHARE_CF_NAME],
-                opts,
-            )
-            .expect("SecretShareDb open failed; unable to continue"),
-        );
+        let db = DB::open(
+            self.path.clone(),
+            SECRET_SHARE_DB_NAME,
+            vec![SECRET_SHARE_CF_NAME],
+            opts,
+        )
+        .expect("SecretShareDb open failed; unable to continue");
 
         info!(
             "Opened SecretShareDb at {:?} in {} ms",
-            path,
+            self.path,
             instant.elapsed().as_millis()
         );
-
-        Self {
-            db,
-            write_lock: Mutex::new(()),
-        }
+        db
     }
 }
 
@@ -58,7 +68,7 @@ impl SecretShareStorage for SecretShareDb {
         let serialized = bcs::to_bytes(share)?;
         let _guard = self.write_lock.lock();
 
-        match self.db.get::<SecretShareSchema>(&key)? {
+        match self.db().get::<SecretShareSchema>(&key)? {
             Some(existing) if existing == serialized => Ok(()),
             Some(_) => bail!(
                 "conflicting secret share for epoch {}, block {}",
@@ -68,7 +78,7 @@ impl SecretShareStorage for SecretShareDb {
             None => {
                 let mut batch = SchemaBatch::new();
                 batch.put::<SecretShareSchema>(&key, &serialized)?;
-                self.db.write_schemas(batch)?;
+                self.db().write_schemas(batch)?;
                 Ok(())
             },
         }
@@ -78,12 +88,12 @@ impl SecretShareStorage for SecretShareDb {
         let _guard = self.write_lock.lock();
         let mut batch = SchemaBatch::new();
         batch.delete::<SecretShareSchema>(key)?;
-        self.db.write_schemas(batch)?;
+        self.db().write_schemas(batch)?;
         Ok(())
     }
 
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
-        let mut iter = self.db.iter::<SecretShareSchema>()?;
+        let mut iter = self.db().iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut shares = Vec::new();
@@ -109,7 +119,7 @@ impl SecretShareStorage for SecretShareDb {
 
     fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
         let _guard = self.write_lock.lock();
-        let mut iter = self.db.iter::<SecretShareSchema>()?;
+        let mut iter = self.db().iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut batch = SchemaBatch::new();
@@ -122,14 +132,14 @@ impl SecretShareStorage for SecretShareDb {
             }
         }
         if has_deletes {
-            self.db.write_schemas(batch)?;
+            self.db().write_schemas(batch)?;
         }
         Ok(())
     }
 
     fn prune_before_round(&self, epoch: u64, round: Round) -> Result<()> {
         let _guard = self.write_lock.lock();
-        let mut iter = self.db.iter::<SecretShareSchema>()?;
+        let mut iter = self.db().iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut batch = SchemaBatch::new();
@@ -147,7 +157,7 @@ impl SecretShareStorage for SecretShareDb {
             }
         }
         if has_deletes {
-            self.db.write_schemas(batch)?;
+            self.db().write_schemas(batch)?;
         }
         Ok(())
     }
@@ -160,6 +170,17 @@ mod tests {
         create_metadata, create_secret_share, TestContext,
     };
     use aptos_temppath::TempPath;
+
+    #[test]
+    fn test_database_opens_lazily() {
+        let temp_path = TempPath::new();
+        let db = SecretShareDb::new(&temp_path);
+        assert!(db.db.get().is_none());
+
+        db.load_self_shares(1).unwrap();
+
+        assert!(db.db.get().is_some());
+    }
 
     #[test]
     fn test_idempotent_write_conflict_and_restart() {
@@ -273,7 +294,7 @@ mod tests {
         batch
             .put::<SecretShareSchema>(&key, &vec![0xFF, 0xFF])
             .unwrap();
-        db.db.write_schemas(batch).unwrap();
+        db.db().write_schemas(batch).unwrap();
 
         let records = db.load_self_shares(ctx.epoch).unwrap();
         assert_eq!(

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -54,16 +54,13 @@ impl SecretShareStorage for SecretShareDb {
         Ok(())
     }
 
-    fn load_self_shares(&self, epoch: u64) -> Result<Vec<SecretShare>> {
+    fn get_all_self_shares(&self) -> Result<Vec<SecretShare>> {
         let mut iter = self.db.iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut shares = Vec::new();
         for entry in iter {
             let (key, share) = entry?;
-            if key.epoch != epoch {
-                continue;
-            }
             ensure!(
                 storage_key(share.metadata()) == key,
                 "stored key does not match secret share metadata for epoch {}, block {}",
@@ -73,25 +70,6 @@ impl SecretShareStorage for SecretShareDb {
             shares.push(share);
         }
         Ok(shares)
-    }
-
-    fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
-        let mut iter = self.db.iter::<SecretShareSchema>()?;
-        iter.seek_to_first();
-
-        let mut batch = SchemaBatch::new();
-        let mut has_deletes = false;
-        for entry in iter {
-            let (key, _) = entry?;
-            if key.epoch < epoch {
-                batch.delete::<SecretShareSchema>(&key)?;
-                has_deletes = true;
-            }
-        }
-        if has_deletes {
-            self.db.write_schemas_relaxed(batch)?;
-        }
-        Ok(())
     }
 
     fn prune_self_shares(&self, keys: &[SecretShareKey]) -> Result<()> {
@@ -133,7 +111,7 @@ mod tests {
 
         let reopened = SecretShareDb::new(&temp_path);
         let recovered = reopened
-            .load_self_shares(ctx.epoch)
+            .get_all_self_shares()
             .unwrap()
             .into_iter()
             .next()
@@ -147,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prune_before_epoch() {
+    fn test_load_all_self_shares() {
         let temp_path = TempPath::new();
         let db = SecretShareDb::new(&temp_path);
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
@@ -158,11 +136,14 @@ mod tests {
         db.save_self_share(&create_secret_share(&ctx, 0, &new_metadata))
             .unwrap();
 
-        db.prune_before_epoch(ctx.epoch + 1).unwrap();
-
-        let recovered = db.load_self_shares(ctx.epoch + 1).unwrap();
-        assert_eq!(recovered.len(), 1);
-        assert_eq!(recovered[0].metadata(), &new_metadata);
+        let mut recovered_epochs = db
+            .get_all_self_shares()
+            .unwrap()
+            .into_iter()
+            .map(|share| share.epoch())
+            .collect::<Vec<_>>();
+        recovered_epochs.sort_unstable();
+        assert_eq!(recovered_epochs, vec![ctx.epoch, ctx.epoch + 1]);
     }
 
     #[test]
@@ -179,7 +160,7 @@ mod tests {
         db.prune_self_shares(&[storage_key(&metadata[0])]).unwrap();
 
         let mut recovered_rounds = db
-            .load_self_shares(ctx.epoch)
+            .get_all_self_shares()
             .unwrap()
             .into_iter()
             .map(|share| share.round())
@@ -208,6 +189,6 @@ mod tests {
             .unwrap();
         db.db.write_schemas(batch).unwrap();
 
-        assert!(db.load_self_shares(ctx.epoch).is_err());
+        assert!(db.get_all_self_shares().is_err());
     }
 }

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -9,52 +9,40 @@ use anyhow::{ensure, Result};
 use aptos_logger::info;
 use aptos_schemadb::{batch::SchemaBatch, Options, DB};
 use aptos_types::secret_sharing::SecretShare;
-use std::{
-    path::{Path, PathBuf},
-    sync::OnceLock,
-    time::Instant,
-};
+use std::{path::Path, sync::Arc, time::Instant};
 
 pub const SECRET_SHARE_DB_NAME: &str = "secret_share_db";
 const MAX_TOTAL_WAL_SIZE_BYTES: u64 = 256 << 20;
 
 pub struct SecretShareDb {
-    path: PathBuf,
-    db: OnceLock<DB>,
+    db: Arc<DB>,
 }
 
 impl SecretShareDb {
     pub fn new<P: AsRef<Path>>(db_root_path: P) -> Self {
-        Self {
-            path: db_root_path.as_ref().join(SECRET_SHARE_DB_NAME),
-            db: OnceLock::new(),
-        }
-    }
-
-    fn db(&self) -> &DB {
-        self.db.get_or_init(|| self.open_db())
-    }
-
-    fn open_db(&self) -> DB {
+        let path = db_root_path.as_ref().join(SECRET_SHARE_DB_NAME);
         let instant = Instant::now();
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
         opts.set_max_total_wal_size(MAX_TOTAL_WAL_SIZE_BYTES);
-        let db = DB::open(
-            self.path.clone(),
-            SECRET_SHARE_DB_NAME,
-            vec![SECRET_SHARE_CF_NAME],
-            opts,
-        )
-        .expect("SecretShareDb open failed; unable to continue");
+        let db = Arc::new(
+            DB::open(
+                path.clone(),
+                SECRET_SHARE_DB_NAME,
+                vec![SECRET_SHARE_CF_NAME],
+                opts,
+            )
+            .expect("SecretShareDb open failed; unable to continue"),
+        );
 
         info!(
             "Opened SecretShareDb at {:?} in {} ms",
-            self.path,
+            path,
             instant.elapsed().as_millis()
         );
-        db
+
+        Self { db }
     }
 }
 
@@ -62,12 +50,12 @@ impl SecretShareStorage for SecretShareDb {
     fn save_self_share(&self, share: &SecretShare) -> Result<()> {
         let mut batch = SchemaBatch::new();
         batch.put::<SecretShareSchema>(&storage_key(share.metadata()), share)?;
-        self.db().write_schemas(batch)?;
+        self.db.write_schemas(batch)?;
         Ok(())
     }
 
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<SecretShare>> {
-        let mut iter = self.db().iter::<SecretShareSchema>()?;
+        let mut iter = self.db.iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut shares = Vec::new();
@@ -88,7 +76,7 @@ impl SecretShareStorage for SecretShareDb {
     }
 
     fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
-        let mut iter = self.db().iter::<SecretShareSchema>()?;
+        let mut iter = self.db.iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut batch = SchemaBatch::new();
@@ -101,7 +89,7 @@ impl SecretShareStorage for SecretShareDb {
             }
         }
         if has_deletes {
-            self.db().write_schemas(batch)?;
+            self.db.write_schemas(batch)?;
         }
         Ok(())
     }
@@ -112,7 +100,7 @@ impl SecretShareStorage for SecretShareDb {
             batch.delete::<SecretShareSchema>(key)?;
         }
         if !keys.is_empty() {
-            self.db().write_schemas(batch)?;
+            self.db.write_schemas(batch)?;
         }
         Ok(())
     }
@@ -125,17 +113,6 @@ mod tests {
         create_metadata, create_secret_share, TestContext,
     };
     use aptos_temppath::TempPath;
-
-    #[test]
-    fn test_database_opens_lazily() {
-        let temp_path = TempPath::new();
-        let db = SecretShareDb::new(&temp_path);
-        assert!(db.db.get().is_none());
-
-        db.load_self_shares(1).unwrap();
-
-        assert!(db.db.get().is_some());
-    }
 
     #[test]
     fn test_overwrite_and_restart() {
@@ -229,7 +206,7 @@ mod tests {
                 0xFF, 0xFF,
             ])
             .unwrap();
-        db.db().write_schemas(batch).unwrap();
+        db.db.write_schemas(batch).unwrap();
 
         assert!(db.load_self_shares(ctx.epoch).is_err());
     }

--- a/consensus/src/rand/secret_sharing/storage/db.rs
+++ b/consensus/src/rand/secret_sharing/storage/db.rs
@@ -3,11 +3,9 @@
 
 use super::{
     schema::{SecretShareSchema, SECRET_SHARE_CF_NAME},
-    storage_key, LoadedSecretShare, SecretShareStorage,
+    storage_key, SecretShareKey, SecretShareStorage,
 };
-use anyhow::{bail, ensure, Result};
-use aptos_consensus_types::common::Round;
-use aptos_infallible::Mutex;
+use anyhow::{ensure, Result};
 use aptos_logger::info;
 use aptos_schemadb::{batch::SchemaBatch, Options, DB};
 use aptos_types::secret_sharing::SecretShare;
@@ -23,7 +21,6 @@ const MAX_TOTAL_WAL_SIZE_BYTES: u64 = 256 << 20;
 pub struct SecretShareDb {
     path: PathBuf,
     db: OnceLock<DB>,
-    write_lock: Mutex<()>,
 }
 
 impl SecretShareDb {
@@ -31,7 +28,6 @@ impl SecretShareDb {
         Self {
             path: db_root_path.as_ref().join(SECRET_SHARE_DB_NAME),
             db: OnceLock::new(),
-            write_lock: Mutex::new(()),
         }
     }
 
@@ -64,59 +60,34 @@ impl SecretShareDb {
 
 impl SecretShareStorage for SecretShareDb {
     fn save_self_share(&self, share: &SecretShare) -> Result<()> {
-        let key = storage_key(share.metadata());
-        let serialized = bcs::to_bytes(share)?;
-        let _guard = self.write_lock.lock();
-
-        match self.db().get::<SecretShareSchema>(&key)? {
-            Some(existing) if existing == serialized => Ok(()),
-            Some(_) => bail!(
-                "conflicting secret share for epoch {}, block {}",
-                key.0,
-                key.1
-            ),
-            None => {
-                let mut batch = SchemaBatch::new();
-                batch.put::<SecretShareSchema>(&key, &serialized)?;
-                self.db().write_schemas(batch)?;
-                Ok(())
-            },
-        }
+        let mut batch = SchemaBatch::new();
+        batch.put::<SecretShareSchema>(&storage_key(share.metadata()), share)?;
+        self.db().write_schemas(batch)?;
+        Ok(())
     }
 
-    fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
+    fn load_self_shares(&self, epoch: u64) -> Result<Vec<SecretShare>> {
         let mut iter = self.db().iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
         let mut shares = Vec::new();
         for entry in iter {
-            let (key, serialized) = match entry {
-                Ok(entry) => entry,
-                Err(error) => {
-                    shares.push(Err(error.into()));
-                    continue;
-                },
-            };
-            if key.0 != epoch {
+            let (key, share) = entry?;
+            if key.epoch != epoch {
                 continue;
             }
-            let share = (|| {
-                let share = bcs::from_bytes::<SecretShare>(&serialized)?;
-                ensure!(
-                    storage_key(share.metadata()) == key,
-                    "stored key does not match secret share metadata for epoch {}, block {}",
-                    key.0,
-                    key.1
-                );
-                Ok(share)
-            })();
+            ensure!(
+                storage_key(share.metadata()) == key,
+                "stored key does not match secret share metadata for epoch {}, block {}",
+                key.epoch,
+                key.block_id
+            );
             shares.push(share);
         }
         Ok(shares)
     }
 
     fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
-        let _guard = self.write_lock.lock();
         let mut iter = self.db().iter::<SecretShareSchema>()?;
         iter.seek_to_first();
 
@@ -124,7 +95,7 @@ impl SecretShareStorage for SecretShareDb {
         let mut has_deletes = false;
         for entry in iter {
             let (key, _) = entry?;
-            if key.0 < epoch {
+            if key.epoch < epoch {
                 batch.delete::<SecretShareSchema>(&key)?;
                 has_deletes = true;
             }
@@ -135,26 +106,12 @@ impl SecretShareStorage for SecretShareDb {
         Ok(())
     }
 
-    fn prune_before_round(&self, epoch: u64, round: Round) -> Result<()> {
-        let _guard = self.write_lock.lock();
-        let mut iter = self.db().iter::<SecretShareSchema>()?;
-        iter.seek_to_first();
-
+    fn prune_self_shares(&self, keys: &[SecretShareKey]) -> Result<()> {
         let mut batch = SchemaBatch::new();
-        let mut has_deletes = false;
-        for entry in iter {
-            let (key, serialized) = entry?;
-            if key.0 != epoch {
-                continue;
-            }
-            // Leave malformed records for the load path to report and reject.
-            if bcs::from_bytes::<SecretShare>(&serialized).is_ok_and(|share| share.round() < round)
-            {
-                batch.delete::<SecretShareSchema>(&key)?;
-                has_deletes = true;
-            }
+        for key in keys {
+            batch.delete::<SecretShareSchema>(key)?;
         }
-        if has_deletes {
+        if !keys.is_empty() {
             self.db().write_schemas(batch)?;
         }
         Ok(())
@@ -181,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    fn test_idempotent_write_conflict_and_restart() {
+    fn test_overwrite_and_restart() {
         let temp_path = TempPath::new();
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
         let metadata = create_metadata(ctx.epoch, 10);
@@ -192,13 +149,9 @@ mod tests {
             db.save_self_share(&share).unwrap();
             db.save_self_share(&share).unwrap();
 
-            let mut conflicting = share.clone();
-            conflicting.metadata.timestamp += 1;
-            assert!(db
-                .save_self_share(&conflicting)
-                .unwrap_err()
-                .to_string()
-                .contains("conflicting secret share"));
+            let mut replacement = share.clone();
+            replacement.metadata.timestamp += 1;
+            db.save_self_share(&replacement).unwrap();
         }
 
         let reopened = SecretShareDb::new(&temp_path);
@@ -207,11 +160,12 @@ mod tests {
             .unwrap()
             .into_iter()
             .next()
-            .unwrap()
             .unwrap();
+        let mut expected = share;
+        expected.metadata.timestamp += 1;
         assert_eq!(
             bcs::to_bytes(&recovered).unwrap(),
-            bcs::to_bytes(&share).unwrap()
+            bcs::to_bytes(&expected).unwrap()
         );
     }
 
@@ -229,34 +183,29 @@ mod tests {
 
         db.prune_before_epoch(ctx.epoch + 1).unwrap();
 
-        let recovered = db
-            .load_self_shares(ctx.epoch + 1)
-            .unwrap()
-            .into_iter()
-            .collect::<Result<Vec<_>>>()
-            .unwrap();
+        let recovered = db.load_self_shares(ctx.epoch + 1).unwrap();
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered[0].metadata(), &new_metadata);
     }
 
     #[test]
-    fn test_prune_before_round() {
+    fn test_prune_self_shares() {
         let temp_path = TempPath::new();
         let db = SecretShareDb::new(&temp_path);
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
-        for round in [10, 20, 30] {
-            let metadata = create_metadata(ctx.epoch, round);
-            db.save_self_share(&create_secret_share(&ctx, 0, &metadata))
+        let metadata = [10, 20, 30].map(|round| create_metadata(ctx.epoch, round));
+        for metadata in &metadata {
+            db.save_self_share(&create_secret_share(&ctx, 0, metadata))
                 .unwrap();
         }
 
-        db.prune_before_round(ctx.epoch, 20).unwrap();
+        db.prune_self_shares(&[storage_key(&metadata[0])]).unwrap();
 
         let mut recovered_rounds = db
             .load_self_shares(ctx.epoch)
             .unwrap()
             .into_iter()
-            .map(|share| share.unwrap().round())
+            .map(|share| share.round())
             .collect::<Vec<_>>();
         recovered_rounds.sort_unstable();
         assert_eq!(recovered_rounds, vec![20, 30]);
@@ -264,6 +213,8 @@ mod tests {
 
     #[test]
     fn test_corrupt_record_is_rejected() {
+        use aptos_schemadb::batch::WriteBatch;
+
         let temp_path = TempPath::new();
         let db = SecretShareDb::new(&temp_path);
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
@@ -274,12 +225,12 @@ mod tests {
         let key = storage_key(&corrupt_metadata);
         let mut batch = SchemaBatch::new();
         batch
-            .put::<SecretShareSchema>(&key, &vec![0xFF, 0xFF])
+            .raw_put(SECRET_SHARE_CF_NAME, bcs::to_bytes(&key).unwrap(), vec![
+                0xFF, 0xFF,
+            ])
             .unwrap();
         db.db().write_schemas(batch).unwrap();
 
-        let records = db.load_self_shares(ctx.epoch).unwrap();
-        assert_eq!(records.iter().filter(|record| record.is_ok()).count(), 1);
-        assert_eq!(records.iter().filter(|record| record.is_err()).count(), 1);
+        assert!(db.load_self_shares(ctx.epoch).is_err());
     }
 }

--- a/consensus/src/rand/secret_sharing/storage/in_memory.rs
+++ b/consensus/src/rand/secret_sharing/storage/in_memory.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::{
+    storage_key, LoadedSecretShare, Result, SecretShareKey, SecretShareStorage,
+    SecretShareStorageError,
+};
+use aptos_infallible::Mutex;
+use aptos_types::secret_sharing::SecretShare;
+use std::collections::HashMap;
+
+pub struct InMemorySecretShareStorage {
+    shares: Mutex<HashMap<SecretShareKey, Vec<u8>>>,
+}
+
+impl InMemorySecretShareStorage {
+    pub fn new() -> Self {
+        Self {
+            shares: Mutex::new(HashMap::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_raw(&self, key: SecretShareKey, value: Vec<u8>) {
+        self.shares.lock().insert(key, value);
+    }
+}
+
+impl Default for InMemorySecretShareStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SecretShareStorage for InMemorySecretShareStorage {
+    fn save_self_share(&self, share: &SecretShare) -> Result<()> {
+        let key = storage_key(share.metadata());
+        let serialized = bcs::to_bytes(share)
+            .map_err(|error| SecretShareStorageError::Corruption(error.to_string()))?;
+        let mut shares = self.shares.lock();
+        match shares.get(&key) {
+            Some(existing) if existing == &serialized => Ok(()),
+            Some(_) => Err(SecretShareStorageError::Conflict {
+                epoch: key.0,
+                block_id: key.1,
+            }),
+            None => {
+                shares.insert(key, serialized);
+                Ok(())
+            },
+        }
+    }
+
+    fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
+        Ok(self
+            .shares
+            .lock()
+            .iter()
+            .filter(|((stored_epoch, _), _)| *stored_epoch == epoch)
+            .map(|(key, serialized)| {
+                bcs::from_bytes::<SecretShare>(serialized)
+                    .map_err(|error| SecretShareStorageError::Corruption(error.to_string()))
+                    .and_then(|share| {
+                        if storage_key(share.metadata()) == *key {
+                            Ok(share)
+                        } else {
+                            Err(SecretShareStorageError::Corruption(format!(
+                                "stored key does not match secret share metadata for epoch {}, block {}",
+                                key.0, key.1
+                            )))
+                        }
+                    })
+            })
+            .collect())
+    }
+
+    fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
+        self.shares
+            .lock()
+            .retain(|(stored_epoch, _), _| *stored_epoch >= epoch);
+        Ok(())
+    }
+}

--- a/consensus/src/rand/secret_sharing/storage/in_memory.rs
+++ b/consensus/src/rand/secret_sharing/storage/in_memory.rs
@@ -1,10 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use super::{
-    storage_key, LoadedSecretShare, Result, SecretShareKey, SecretShareStorage,
-    SecretShareStorageError,
-};
+use super::{storage_key, LoadedSecretShare, SecretShareKey, SecretShareStorage};
+use anyhow::{bail, ensure, Result};
 use aptos_infallible::Mutex;
 use aptos_types::secret_sharing::SecretShare;
 use std::collections::HashMap;
@@ -35,15 +33,15 @@ impl Default for InMemorySecretShareStorage {
 impl SecretShareStorage for InMemorySecretShareStorage {
     fn save_self_share(&self, share: &SecretShare) -> Result<()> {
         let key = storage_key(share.metadata());
-        let serialized = bcs::to_bytes(share)
-            .map_err(|error| SecretShareStorageError::Corruption(error.to_string()))?;
+        let serialized = bcs::to_bytes(share)?;
         let mut shares = self.shares.lock();
         match shares.get(&key) {
             Some(existing) if existing == &serialized => Ok(()),
-            Some(_) => Err(SecretShareStorageError::Conflict {
-                epoch: key.0,
-                block_id: key.1,
-            }),
+            Some(_) => bail!(
+                "conflicting secret share for epoch {}, block {}",
+                key.0,
+                key.1
+            ),
             None => {
                 shares.insert(key, serialized);
                 Ok(())
@@ -58,18 +56,14 @@ impl SecretShareStorage for InMemorySecretShareStorage {
             .iter()
             .filter(|((stored_epoch, _), _)| *stored_epoch == epoch)
             .map(|(key, serialized)| {
-                bcs::from_bytes::<SecretShare>(serialized)
-                    .map_err(|error| SecretShareStorageError::Corruption(error.to_string()))
-                    .and_then(|share| {
-                        if storage_key(share.metadata()) == *key {
-                            Ok(share)
-                        } else {
-                            Err(SecretShareStorageError::Corruption(format!(
-                                "stored key does not match secret share metadata for epoch {}, block {}",
-                                key.0, key.1
-                            )))
-                        }
-                    })
+                let share = bcs::from_bytes::<SecretShare>(serialized)?;
+                ensure!(
+                    storage_key(share.metadata()) == *key,
+                    "stored key does not match secret share metadata for epoch {}, block {}",
+                    key.0,
+                    key.1
+                );
+                Ok(share)
             })
             .collect())
     }

--- a/consensus/src/rand/secret_sharing/storage/in_memory.rs
+++ b/consensus/src/rand/secret_sharing/storage/in_memory.rs
@@ -3,6 +3,7 @@
 
 use super::{storage_key, LoadedSecretShare, SecretShareKey, SecretShareStorage};
 use anyhow::{bail, ensure, Result};
+use aptos_consensus_types::common::Round;
 use aptos_infallible::Mutex;
 use aptos_types::secret_sharing::SecretShare;
 use std::collections::HashMap;
@@ -72,6 +73,16 @@ impl SecretShareStorage for InMemorySecretShareStorage {
         self.shares
             .lock()
             .retain(|(stored_epoch, _), _| *stored_epoch >= epoch);
+        Ok(())
+    }
+
+    fn prune_before_round(&self, epoch: u64, round: Round) -> Result<()> {
+        self.shares.lock().retain(|(stored_epoch, _), serialized| {
+            *stored_epoch != epoch
+                || bcs::from_bytes::<SecretShare>(serialized)
+                    .map(|share| share.round() >= round)
+                    .unwrap_or(true)
+        });
         Ok(())
     }
 }

--- a/consensus/src/rand/secret_sharing/storage/in_memory.rs
+++ b/consensus/src/rand/secret_sharing/storage/in_memory.rs
@@ -50,11 +50,6 @@ impl SecretShareStorage for InMemorySecretShareStorage {
         }
     }
 
-    fn delete_self_share(&self, key: &SecretShareKey) -> Result<()> {
-        self.shares.lock().remove(key);
-        Ok(())
-    }
-
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
         Ok(self
             .shares
@@ -62,17 +57,14 @@ impl SecretShareStorage for InMemorySecretShareStorage {
             .iter()
             .filter(|((stored_epoch, _), _)| *stored_epoch == epoch)
             .map(|(key, serialized)| {
-                let share = (|| {
-                    let share = bcs::from_bytes::<SecretShare>(serialized)?;
-                    ensure!(
-                        storage_key(share.metadata()) == *key,
-                        "stored key does not match secret share metadata for epoch {}, block {}",
-                        key.0,
-                        key.1
-                    );
-                    Ok(share)
-                })();
-                (*key, share)
+                let share = bcs::from_bytes::<SecretShare>(serialized)?;
+                ensure!(
+                    storage_key(share.metadata()) == *key,
+                    "stored key does not match secret share metadata for epoch {}, block {}",
+                    key.0,
+                    key.1
+                );
+                Ok(share)
             })
             .collect())
     }

--- a/consensus/src/rand/secret_sharing/storage/in_memory.rs
+++ b/consensus/src/rand/secret_sharing/storage/in_memory.rs
@@ -1,15 +1,14 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use super::{storage_key, LoadedSecretShare, SecretShareKey, SecretShareStorage};
-use anyhow::{bail, ensure, Result};
-use aptos_consensus_types::common::Round;
+use super::{storage_key, SecretShareKey, SecretShareStorage};
+use anyhow::Result;
 use aptos_infallible::Mutex;
 use aptos_types::secret_sharing::SecretShare;
 use std::collections::HashMap;
 
 pub struct InMemorySecretShareStorage {
-    shares: Mutex<HashMap<SecretShareKey, Vec<u8>>>,
+    shares: Mutex<HashMap<SecretShareKey, SecretShare>>,
 }
 
 impl InMemorySecretShareStorage {
@@ -17,11 +16,6 @@ impl InMemorySecretShareStorage {
         Self {
             shares: Mutex::new(HashMap::new()),
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn insert_raw(&self, key: SecretShareKey, value: Vec<u8>) {
-        self.shares.lock().insert(key, value);
     }
 }
 
@@ -34,55 +28,30 @@ impl Default for InMemorySecretShareStorage {
 impl SecretShareStorage for InMemorySecretShareStorage {
     fn save_self_share(&self, share: &SecretShare) -> Result<()> {
         let key = storage_key(share.metadata());
-        let serialized = bcs::to_bytes(share)?;
-        let mut shares = self.shares.lock();
-        match shares.get(&key) {
-            Some(existing) if existing == &serialized => Ok(()),
-            Some(_) => bail!(
-                "conflicting secret share for epoch {}, block {}",
-                key.0,
-                key.1
-            ),
-            None => {
-                shares.insert(key, serialized);
-                Ok(())
-            },
-        }
+        self.shares.lock().insert(key, share.clone());
+        Ok(())
     }
 
-    fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
+    fn load_self_shares(&self, epoch: u64) -> Result<Vec<SecretShare>> {
         Ok(self
             .shares
             .lock()
             .iter()
-            .filter(|((stored_epoch, _), _)| *stored_epoch == epoch)
-            .map(|(key, serialized)| {
-                let share = bcs::from_bytes::<SecretShare>(serialized)?;
-                ensure!(
-                    storage_key(share.metadata()) == *key,
-                    "stored key does not match secret share metadata for epoch {}, block {}",
-                    key.0,
-                    key.1
-                );
-                Ok(share)
-            })
+            .filter(|(key, _)| key.epoch == epoch)
+            .map(|(_, share)| share.clone())
             .collect())
     }
 
     fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
-        self.shares
-            .lock()
-            .retain(|(stored_epoch, _), _| *stored_epoch >= epoch);
+        self.shares.lock().retain(|key, _| key.epoch >= epoch);
         Ok(())
     }
 
-    fn prune_before_round(&self, epoch: u64, round: Round) -> Result<()> {
-        self.shares.lock().retain(|(stored_epoch, _), serialized| {
-            *stored_epoch != epoch
-                || bcs::from_bytes::<SecretShare>(serialized)
-                    .map(|share| share.round() >= round)
-                    .unwrap_or(true)
-        });
+    fn prune_self_shares(&self, keys: &[SecretShareKey]) -> Result<()> {
+        let mut shares = self.shares.lock();
+        for key in keys {
+            shares.remove(key);
+        }
         Ok(())
     }
 }

--- a/consensus/src/rand/secret_sharing/storage/in_memory.rs
+++ b/consensus/src/rand/secret_sharing/storage/in_memory.rs
@@ -50,6 +50,11 @@ impl SecretShareStorage for InMemorySecretShareStorage {
         }
     }
 
+    fn delete_self_share(&self, key: &SecretShareKey) -> Result<()> {
+        self.shares.lock().remove(key);
+        Ok(())
+    }
+
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>> {
         Ok(self
             .shares
@@ -57,14 +62,17 @@ impl SecretShareStorage for InMemorySecretShareStorage {
             .iter()
             .filter(|((stored_epoch, _), _)| *stored_epoch == epoch)
             .map(|(key, serialized)| {
-                let share = bcs::from_bytes::<SecretShare>(serialized)?;
-                ensure!(
-                    storage_key(share.metadata()) == *key,
-                    "stored key does not match secret share metadata for epoch {}, block {}",
-                    key.0,
-                    key.1
-                );
-                Ok(share)
+                let share = (|| {
+                    let share = bcs::from_bytes::<SecretShare>(serialized)?;
+                    ensure!(
+                        storage_key(share.metadata()) == *key,
+                        "stored key does not match secret share metadata for epoch {}, block {}",
+                        key.0,
+                        key.1
+                    );
+                    Ok(share)
+                })();
+                (*key, share)
             })
             .collect())
     }

--- a/consensus/src/rand/secret_sharing/storage/in_memory.rs
+++ b/consensus/src/rand/secret_sharing/storage/in_memory.rs
@@ -32,19 +32,8 @@ impl SecretShareStorage for InMemorySecretShareStorage {
         Ok(())
     }
 
-    fn load_self_shares(&self, epoch: u64) -> Result<Vec<SecretShare>> {
-        Ok(self
-            .shares
-            .lock()
-            .iter()
-            .filter(|(key, _)| key.epoch == epoch)
-            .map(|(_, share)| share.clone())
-            .collect())
-    }
-
-    fn prune_before_epoch(&self, epoch: u64) -> Result<()> {
-        self.shares.lock().retain(|key, _| key.epoch >= epoch);
-        Ok(())
+    fn get_all_self_shares(&self) -> Result<Vec<SecretShare>> {
+        Ok(self.shares.lock().values().cloned().collect())
     }
 
     fn prune_self_shares(&self, keys: &[SecretShareKey]) -> Result<()> {

--- a/consensus/src/rand/secret_sharing/storage/mod.rs
+++ b/consensus/src/rand/secret_sharing/storage/mod.rs
@@ -6,26 +6,14 @@ mod db;
 mod in_memory;
 mod schema;
 
+use anyhow::Result;
 use aptos_crypto::HashValue;
 use aptos_types::secret_sharing::{SecretShare, SecretShareMetadata};
 pub use db::SecretShareDb;
 #[cfg(test)]
 pub use in_memory::InMemorySecretShareStorage;
-use thiserror::Error;
 
 pub type SecretShareKey = (u64, HashValue);
-
-#[derive(Debug, Error)]
-pub enum SecretShareStorageError {
-    #[error("conflicting secret share for epoch {epoch}, block {block_id}")]
-    Conflict { epoch: u64, block_id: HashValue },
-    #[error("corrupt secret share storage record: {0}")]
-    Corruption(String),
-    #[error("secret share storage I/O failure: {0}")]
-    Io(String),
-}
-
-pub type Result<T> = std::result::Result<T, SecretShareStorageError>;
 pub type LoadedSecretShare = Result<SecretShare>;
 
 pub trait SecretShareStorage: Send + Sync + 'static {

--- a/consensus/src/rand/secret_sharing/storage/mod.rs
+++ b/consensus/src/rand/secret_sharing/storage/mod.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+mod db;
+#[cfg(test)]
+mod in_memory;
+mod schema;
+
+use aptos_crypto::HashValue;
+use aptos_types::secret_sharing::{SecretShare, SecretShareMetadata};
+pub use db::SecretShareDb;
+#[cfg(test)]
+pub use in_memory::InMemorySecretShareStorage;
+use thiserror::Error;
+
+pub type SecretShareKey = (u64, HashValue);
+
+#[derive(Debug, Error)]
+pub enum SecretShareStorageError {
+    #[error("conflicting secret share for epoch {epoch}, block {block_id}")]
+    Conflict { epoch: u64, block_id: HashValue },
+    #[error("corrupt secret share storage record: {0}")]
+    Corruption(String),
+    #[error("secret share storage I/O failure: {0}")]
+    Io(String),
+}
+
+pub type Result<T> = std::result::Result<T, SecretShareStorageError>;
+pub type LoadedSecretShare = Result<SecretShare>;
+
+pub trait SecretShareStorage: Send + Sync + 'static {
+    fn save_self_share(&self, share: &SecretShare) -> Result<()>;
+
+    fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>>;
+
+    fn prune_before_epoch(&self, epoch: u64) -> Result<()>;
+}
+
+pub(crate) fn storage_key(metadata: &SecretShareMetadata) -> SecretShareKey {
+    (metadata.epoch, metadata.block_id)
+}

--- a/consensus/src/rand/secret_sharing/storage/mod.rs
+++ b/consensus/src/rand/secret_sharing/storage/mod.rs
@@ -7,6 +7,7 @@ mod in_memory;
 mod schema;
 
 use anyhow::Result;
+use aptos_consensus_types::common::Round;
 use aptos_crypto::HashValue;
 use aptos_types::secret_sharing::{SecretShare, SecretShareMetadata};
 pub use db::SecretShareDb;
@@ -22,6 +23,8 @@ pub trait SecretShareStorage: Send + Sync + 'static {
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>>;
 
     fn prune_before_epoch(&self, epoch: u64) -> Result<()>;
+
+    fn prune_before_round(&self, epoch: u64, round: Round) -> Result<()>;
 }
 
 pub(crate) fn storage_key(metadata: &SecretShareMetadata) -> SecretShareKey {

--- a/consensus/src/rand/secret_sharing/storage/mod.rs
+++ b/consensus/src/rand/secret_sharing/storage/mod.rs
@@ -15,10 +15,12 @@ pub use db::SecretShareDb;
 pub use in_memory::InMemorySecretShareStorage;
 
 pub type SecretShareKey = (u64, HashValue);
-pub type LoadedSecretShare = Result<SecretShare>;
+pub type LoadedSecretShare = (SecretShareKey, Result<SecretShare>);
 
 pub trait SecretShareStorage: Send + Sync + 'static {
     fn save_self_share(&self, share: &SecretShare) -> Result<()>;
+
+    fn delete_self_share(&self, key: &SecretShareKey) -> Result<()>;
 
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>>;
 

--- a/consensus/src/rand/secret_sharing/storage/mod.rs
+++ b/consensus/src/rand/secret_sharing/storage/mod.rs
@@ -23,9 +23,7 @@ pub struct SecretShareKey {
 pub trait SecretShareStorage: Send + Sync + 'static {
     fn save_self_share(&self, share: &SecretShare) -> Result<()>;
 
-    fn load_self_shares(&self, epoch: u64) -> Result<Vec<SecretShare>>;
-
-    fn prune_before_epoch(&self, epoch: u64) -> Result<()>;
+    fn get_all_self_shares(&self) -> Result<Vec<SecretShare>>;
 
     fn prune_self_shares(&self, keys: &[SecretShareKey]) -> Result<()>;
 }

--- a/consensus/src/rand/secret_sharing/storage/mod.rs
+++ b/consensus/src/rand/secret_sharing/storage/mod.rs
@@ -15,12 +15,10 @@ pub use db::SecretShareDb;
 pub use in_memory::InMemorySecretShareStorage;
 
 pub type SecretShareKey = (u64, HashValue);
-pub type LoadedSecretShare = (SecretShareKey, Result<SecretShare>);
+pub type LoadedSecretShare = Result<SecretShare>;
 
 pub trait SecretShareStorage: Send + Sync + 'static {
     fn save_self_share(&self, share: &SecretShare) -> Result<()>;
-
-    fn delete_self_share(&self, key: &SecretShareKey) -> Result<()>;
 
     fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>>;
 

--- a/consensus/src/rand/secret_sharing/storage/mod.rs
+++ b/consensus/src/rand/secret_sharing/storage/mod.rs
@@ -7,26 +7,32 @@ mod in_memory;
 mod schema;
 
 use anyhow::Result;
-use aptos_consensus_types::common::Round;
 use aptos_crypto::HashValue;
 use aptos_types::secret_sharing::{SecretShare, SecretShareMetadata};
 pub use db::SecretShareDb;
 #[cfg(test)]
 pub use in_memory::InMemorySecretShareStorage;
+use serde::{Deserialize, Serialize};
 
-pub type SecretShareKey = (u64, HashValue);
-pub type LoadedSecretShare = Result<SecretShare>;
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct SecretShareKey {
+    pub epoch: u64,
+    pub block_id: HashValue,
+}
 
 pub trait SecretShareStorage: Send + Sync + 'static {
     fn save_self_share(&self, share: &SecretShare) -> Result<()>;
 
-    fn load_self_shares(&self, epoch: u64) -> Result<Vec<LoadedSecretShare>>;
+    fn load_self_shares(&self, epoch: u64) -> Result<Vec<SecretShare>>;
 
     fn prune_before_epoch(&self, epoch: u64) -> Result<()>;
 
-    fn prune_before_round(&self, epoch: u64, round: Round) -> Result<()>;
+    fn prune_self_shares(&self, keys: &[SecretShareKey]) -> Result<()>;
 }
 
 pub(crate) fn storage_key(metadata: &SecretShareMetadata) -> SecretShareKey {
-    (metadata.epoch, metadata.block_id)
+    SecretShareKey {
+        epoch: metadata.epoch,
+        block_id: metadata.block_id,
+    }
 }

--- a/consensus/src/rand/secret_sharing/storage/schema.rs
+++ b/consensus/src/rand/secret_sharing/storage/schema.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::SecretShareKey;
+use aptos_schemadb::{
+    define_schema,
+    schema::{KeyCodec, ValueCodec},
+    ColumnFamilyName,
+};
+
+pub const SECRET_SHARE_CF_NAME: ColumnFamilyName = "secret_share";
+
+define_schema!(
+    SecretShareSchema,
+    SecretShareKey,
+    Vec<u8>,
+    SECRET_SHARE_CF_NAME
+);
+
+impl KeyCodec<SecretShareSchema> for SecretShareKey {
+    fn encode_key(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(bcs::to_bytes(self)?)
+    }
+
+    fn decode_key(data: &[u8]) -> anyhow::Result<Self> {
+        Ok(bcs::from_bytes(data)?)
+    }
+}
+
+impl ValueCodec<SecretShareSchema> for Vec<u8> {
+    fn encode_value(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(self.clone())
+    }
+
+    fn decode_value(data: &[u8]) -> anyhow::Result<Self> {
+        Ok(data.to_vec())
+    }
+}

--- a/consensus/src/rand/secret_sharing/storage/schema.rs
+++ b/consensus/src/rand/secret_sharing/storage/schema.rs
@@ -7,13 +7,14 @@ use aptos_schemadb::{
     schema::{KeyCodec, ValueCodec},
     ColumnFamilyName,
 };
+use aptos_types::secret_sharing::SecretShare;
 
 pub const SECRET_SHARE_CF_NAME: ColumnFamilyName = "secret_share";
 
 define_schema!(
     SecretShareSchema,
     SecretShareKey,
-    Vec<u8>,
+    SecretShare,
     SECRET_SHARE_CF_NAME
 );
 
@@ -27,12 +28,12 @@ impl KeyCodec<SecretShareSchema> for SecretShareKey {
     }
 }
 
-impl ValueCodec<SecretShareSchema> for Vec<u8> {
+impl ValueCodec<SecretShareSchema> for SecretShare {
     fn encode_value(&self) -> anyhow::Result<Vec<u8>> {
-        Ok(self.clone())
+        Ok(bcs::to_bytes(self)?)
     }
 
     fn decode_value(data: &[u8]) -> anyhow::Result<Self> {
-        Ok(data.to_vec())
+        Ok(bcs::from_bytes(data)?)
     }
 }

--- a/consensus/src/rand/secret_sharing/test_utils.rs
+++ b/consensus/src/rand/secret_sharing/test_utils.rs
@@ -11,13 +11,14 @@ use aptos_types::{
         Digest, MasterSecretKeyShare, SecretShare, SecretShareConfig, SecretShareMetadata,
         SecretSharedKey,
     },
-    validator_verifier::random_validator_verifier_with_voting_power,
+    validator_verifier::{random_validator_verifier_with_voting_power, ValidatorVerifier},
 };
 use std::sync::Arc;
 
 pub struct TestContext {
     pub authors: Vec<Author>,
     pub epoch: u64,
+    pub validator_verifier: Arc<ValidatorVerifier>,
     pub secret_share_config: SecretShareConfig,
     pub msk_shares: Vec<MasterSecretKeyShare>,
 }
@@ -46,8 +47,9 @@ impl TestContext {
             FPTXWeighted::setup_for_testing(8, max_batch_size, num_rounds, &tc)
                 .expect("Failed to setup crypto");
 
+        let validator_verifier = Arc::new(validator_verifier);
         let secret_share_config = SecretShareConfig::new(
-            Arc::new(validator_verifier),
+            validator_verifier.clone(),
             Arc::new(dk),
             msk_shares[0].clone(),
             vks,
@@ -58,6 +60,7 @@ impl TestContext {
         Self {
             authors,
             epoch: 1,
+            validator_verifier,
             secret_share_config,
             msk_shares,
         }

--- a/consensus/src/rand/secret_sharing/verifier.rs
+++ b/consensus/src/rand/secret_sharing/verifier.rs
@@ -63,6 +63,17 @@ impl SecretShareVerifier {
         Ok(())
     }
 
+    pub fn verify(&self, share: &SecretShare, sender: &Author) -> anyhow::Result<()> {
+        ensure!(
+            share.author() == sender,
+            "Author {} does not match sender {}",
+            share.author(),
+            sender
+        );
+        self.verify_structural(share)?;
+        share.verify(&self.config)
+    }
+
     pub fn optimistic_verify(&self, share: &SecretShare, sender: &Author) -> anyhow::Result<()> {
         ensure!(
             share.author() == sender,

--- a/types/src/secret_sharing.rs
+++ b/types/src/secret_sharing.rs
@@ -56,7 +56,7 @@ impl SecretShareMetadata {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SecretShare {
     pub author: Author,
     pub metadata: SecretShareMetadata,

--- a/types/src/secret_sharing.rs
+++ b/types/src/secret_sharing.rs
@@ -56,7 +56,7 @@ impl SecretShareMetadata {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SecretShare {
     pub author: Author,
     pub metadata: SecretShareMetadata,


### PR DESCRIPTION
## Description

Persist locally authored decryption shares so validators can serve them after an SSM reset or process restart.

- Add a dedicated `secret_share_db` with one column family keyed by `(epoch, block_id)` and typed `SecretShare` values.
- Persist self-shares synchronously before inserting them into memory or broadcasting them.
- Use normal SchemaDB overwrite semantics for repeated writes of the same key.
- Load all records in one startup scan, retain current-epoch records, and prune stale records in one relaxed batch.
- Retain a bounded round window and prune expired records with exact-key batch deletes.
- Treat storage, pruning, malformed-record, and wrong-author failures as fatal.
- Reject requests for the wrong epoch or non-matching metadata.
- Serve cache misses from the preloaded in-memory persistence map without request-time database reads.
- Log and count successful persisted-share recovery responses.

## How Has This Been Tested?

- `cargo test -p aptos-consensus rand::secret_sharing` (50 passed)
- `cargo check -p aptos-consensus`
- `cargo clippy -p aptos-consensus --all-targets --no-deps`
- `cargo +nightly fmt --check`
- `git diff --check`

Tests cover write-before-publication, fail-stop write handling, overwrite behavior, reset and restart recovery, exact metadata checks, wrong author and epoch, malformed records, bounded retention, and threshold reconstruction after a lost pipeline handoff.

## Key Areas to Review

- The synchronous RocksDB write in `SecretShareManager::process_completed_derive`; publication only follows a successful durable write.
- One-scan startup loading, validation, and pruning of persisted shares.
- Bounded retention on normal rounds, empty rounds, and state-sync resets.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
