### PR TITLE
[block-stm] Remove ordering from in-memory keys

### DIFF
--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1199,7 +1199,7 @@ where
 /// to decide whether the transaction must re-execute. Abstracts the concrete
 /// read-set representation so the executor does not depend on a specific VM's form.
 pub trait TxnInput: Send + Sync {
-    type Key: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + Debug + 'static;
+    type Key: Send + Sync + Clone + Hash + Eq + Debug + 'static;
     type Tag: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + Debug + Serialize + 'static;
     type Value: SpeculativeValue + 'static;
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -104,9 +104,6 @@ where
     L: TransactionCommitHook<CommittedOutput<E>>,
     TP: TxnProvider<T, A> + Sync,
     A: AuxiliaryInfoTrait,
-    // The block epilogue persists the hot keys as storage keys; the in-memory key
-    // converts to the storage key at that boundary (identity for the legacy VM).
-    <T as BlockExecutableTransaction>::Key: From<E::Key>,
 {
     /// The caller needs to ensure that concurrency_level > 1 (0 is illegal and 1 should
     /// be handled by sequential execution) and that concurrency_level <= num_cpus.
@@ -1432,7 +1429,12 @@ where
                 )));
             }
 
+            let executor = maybe_executor.as_ref().ok_or_else(|| {
+                code_invariant_error("Block epilogue txn requires executor to be initialized")
+            })?;
+
             if let Some(epilogue_txn) = self.generate_block_epilogue_if_needed(
+                executor,
                 signature_verified_block,
                 transaction_slice_metadata,
                 final_results.dereference().iter(),
@@ -1461,10 +1463,6 @@ where
                     // Fallback if no transactions in block
                     A::new_empty()
                 };
-
-                let executor = maybe_executor.as_ref().ok_or_else(|| {
-                    code_invariant_error("Block epilogue txn requires executor to be initialized")
-                })?;
 
                 let module_cache = shared_sync_params.global_module_cache;
                 let runtime_environment = environment.runtime_environment();
@@ -1875,7 +1873,7 @@ where
         signature_verified_block: &TP,
         outputs: impl Iterator<Item = &'a CommittedOutput<E>>,
         epilogue_txn_idx: TxnIndex,
-        block_end_info: TBlockEndInfoExt<E::Key>,
+        block_end_info: TBlockEndInfoExt<T::Key>,
         features: &Features,
     ) -> Result<T, PanicError> {
         // TODO(grao): Remove this check once AIP-88 is fully enabled.
@@ -1943,12 +1941,7 @@ where
             }
         }
         let fee_distribution = FeeDistribution::new(amount);
-        // Convert the in-memory hot keys to storage keys for the on-chain epilogue.
         let (inner, to_make_hot) = block_end_info.into_parts();
-        let to_make_hot = to_make_hot
-            .into_iter()
-            .map(<T::Key>::from)
-            .collect::<BTreeSet<_>>();
         if self.config.onchain.hotness_in_epilogue() {
             Ok(T::block_epilogue_v2(
                 block_id,
@@ -2295,12 +2288,14 @@ where
                     transaction_slice_metadata.append_state_checkpoint_to_block()
                 {
                     if !has_reconfig {
+                        let block_end_info = block_limit_processor
+                            .get_block_end_info(|k| executor.materialize_storage_key(k.clone()))?;
                         block_epilogue_txn = Some(self.gen_block_epilogue(
                             block_id,
                             signature_verified_block,
                             ret.iter(),
                             idx as TxnIndex,
-                            block_limit_processor.get_block_end_info(),
+                            block_end_info,
                             module_cache_manager_guard.environment().features(),
                         )?);
                     } else {
@@ -2446,6 +2441,7 @@ where
     /// changes are either all applied to shared state or will never be applied.
     fn generate_block_epilogue_if_needed<'a>(
         &self,
+        executor: &E,
         block: &TP,
         transaction_slice_metadata: &TransactionSliceMetadata,
         outputs: impl Iterator<Item = &'a CommittedOutput<E>>,
@@ -2457,12 +2453,15 @@ where
         // like state sync or replay, the BlockEpilogue txn should already in the input
         // and we don't need to add one here.
         if let Some(block_id) = transaction_slice_metadata.append_state_checkpoint_to_block() {
+            let block_end_info = block_limit_processor
+                .acquire()
+                .get_block_end_info(|k| executor.materialize_storage_key(k.clone()))?;
             let epilogue_txn = self.gen_block_epilogue(
                 block_id,
                 block,
                 outputs,
                 epilogue_txn_idx,
-                block_limit_processor.acquire().get_block_end_info(),
+                block_end_info,
                 environment.features(),
             )?;
 

--- a/aptos-move/block-executor/src/hot_state_op_accumulator.rs
+++ b/aptos-move/block-executor/src/hot_state_op_accumulator.rs
@@ -5,6 +5,7 @@
 
 use crate::counters::HOT_STATE_OP_ACCUMULATOR_COUNTER as COUNTER;
 use aptos_metrics_core::IntCounterVecHelper;
+use aptos_types::error::PanicError;
 use std::{collections::BTreeSet, fmt::Debug, hash::Hash};
 
 pub struct BlockHotStateOpAccumulator<Key> {
@@ -12,10 +13,9 @@ pub struct BlockHotStateOpAccumulator<Key> {
     /// `hot_since_version` one is already hot but last refresh is far in the history) as the side
     /// effect of the block epilogue.
     ///
-    /// Unordered: `StateKey`'s `Hash`/`Eq` use the precomputed key hash and `Arc` pointer
-    /// equality, while `Ord` dereferences and compares key contents, so a per-read `BTreeSet`
-    /// insert is comparatively costly. The deterministic order the epilogue needs is imposed
-    /// once, when the cap is applied in `get_keys_to_make_hot`.
+    /// Unordered: the in-memory `Key` has no deterministic order, and its `Hash`/`Eq` are cheaper
+    /// than materializing the storage key on every read. The deterministic order the epilogue
+    /// needs is imposed once, when keys are converted to storage keys in `get_keys_to_make_hot`.
     to_make_hot: hashbrown::HashSet<Key>,
     /// Keep track of all the keys that are written to across the whole block, these keys are made
     /// hot (or have a refreshed `hot_since_version`) immediately at the version they got changed,
@@ -27,7 +27,7 @@ pub struct BlockHotStateOpAccumulator<Key> {
 
 impl<Key> BlockHotStateOpAccumulator<Key>
 where
-    Key: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + Debug,
+    Key: Send + Sync + Clone + Hash + Eq + Debug,
 {
     /// TODO(HotState): make on-chain config. Also consider capping by total key size instead of
     /// number.
@@ -69,25 +69,31 @@ where
         }
     }
 
-    pub fn get_keys_to_make_hot(&self) -> BTreeSet<Key> {
-        let num_eligible = self.to_make_hot.len();
-        if num_eligible <= self.max_promotions_per_block {
-            // Under the cap: collecting into the BTreeSet imposes the deterministic order.
-            return self.to_make_hot.iter().cloned().collect();
+    /// Converts each eligible in-memory key to its storage key and returns the promotion set
+    /// ordered by storage key. Ordering on the storage key (rather than the non-deterministic
+    /// in-memory key) makes the cap select the same subset on every node.
+    pub fn get_keys_to_make_hot<O, F>(&self, convert: F) -> Result<BTreeSet<O>, PanicError>
+    where
+        O: Ord,
+        F: Fn(&Key) -> Result<O, PanicError>,
+    {
+        let eligible = self
+            .to_make_hot
+            .iter()
+            .map(convert)
+            .collect::<Result<BTreeSet<O>, _>>()?;
+        if eligible.len() <= self.max_promotions_per_block {
+            return Ok(eligible);
         }
         COUNTER.inc_with_by(
             &["promotions_dropped_over_cap"],
-            (num_eligible - self.max_promotions_per_block) as u64,
+            (eligible.len() - self.max_promotions_per_block) as u64,
         );
-        // Over the cap: keep the smallest keys. `to_make_hot` is unordered, so sort before
-        // applying the cap to select the same subset regardless of read/iteration order.
-        let mut eligible = self.to_make_hot.iter().collect::<Vec<_>>();
-        eligible.sort_unstable();
-        eligible
+        // Over the cap: keep the smallest storage keys.
+        Ok(eligible
             .into_iter()
             .take(self.max_promotions_per_block)
-            .cloned()
-            .collect()
+            .collect())
     }
 }
 
@@ -123,8 +129,8 @@ mod tests {
         }
 
         let expected = set(&[0, 1, 2]);
-        assert_eq!(forward.get_keys_to_make_hot(), expected);
-        assert_eq!(reverse.get_keys_to_make_hot(), expected);
+        assert_eq!(forward.get_keys_to_make_hot(|k| Ok(*k)).unwrap(), expected);
+        assert_eq!(reverse.get_keys_to_make_hot(|k| Ok(*k)).unwrap(), expected);
     }
 
     #[test]
@@ -135,7 +141,7 @@ mod tests {
         accu.add_transaction([2u64].iter(), [1u64, 2, 3].iter());
         // A read of an already-written key in a later txn is likewise ignored.
         read(&mut accu, &[2]);
-        assert_eq!(accu.get_keys_to_make_hot(), set(&[1, 3]));
+        assert_eq!(accu.get_keys_to_make_hot(|k| Ok(*k)).unwrap(), set(&[1, 3]));
     }
 
     #[test]
@@ -143,6 +149,6 @@ mod tests {
         let mut accu = BlockHotStateOpAccumulator::<u64>::new_with_config(100);
         read(&mut accu, &[1, 2]);
         write(&mut accu, &[1]);
-        assert_eq!(accu.get_keys_to_make_hot(), set(&[2]));
+        assert_eq!(accu.get_keys_to_make_hot(|k| Ok(*k)).unwrap(), set(&[2]));
     }
 }

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -7,6 +7,7 @@ use crate::{
 use aptos_logger::{info, warn};
 use aptos_metrics_core::IntCounterVecHelper;
 use aptos_types::{
+    error::PanicError,
     fee_statement::FeeStatement,
     on_chain_config::BlockGasLimitType,
     transaction::block_epilogue::{BlockEndInfo, TBlockEndInfoExt},
@@ -37,7 +38,7 @@ pub struct BlockGasLimitProcessor<K, T> {
 
 impl<K, T> BlockGasLimitProcessor<K, T>
 where
-    K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + Debug + 'static,
+    K: Send + Sync + Clone + Hash + Eq + Debug + 'static,
     T: Eq + Hash + Debug + 'static,
 {
     pub fn new(
@@ -299,7 +300,14 @@ where
         self.finish_update_counters_and_log_info(false, num_committed, num_total, 1)
     }
 
-    pub(crate) fn get_block_end_info(&self) -> TBlockEndInfoExt<K> {
+    pub(crate) fn get_block_end_info<O, F>(
+        &self,
+        convert: F,
+    ) -> Result<TBlockEndInfoExt<O>, PanicError>
+    where
+        O: Debug + Ord,
+        F: Fn(&K) -> Result<O, PanicError>,
+    {
         let inner = BlockEndInfo::V0 {
             block_gas_limit_reached: self
                 .block_gas_limit()
@@ -318,22 +326,25 @@ where
             block_approx_output_size: self.get_accumulated_approx_output_size(),
         };
 
-        let to_make_hot = self.get_keys_to_make_hot();
+        let to_make_hot = self.get_keys_to_make_hot(convert)?;
         if self.hot_state_op_accumulator.is_some() {
             counters::HOT_STATE_PROMOTIONS_PER_BLOCK.observe(to_make_hot.len() as f64);
         }
-        TBlockEndInfoExt::new(inner, to_make_hot)
+        Ok(TBlockEndInfoExt::new(inner, to_make_hot))
     }
 
-    fn get_keys_to_make_hot(&self) -> BTreeSet<K> {
-        if self.hot_state_op_accumulator.is_none() {
-            warn!("BlockHotStateOpAccumulator is not set.");
+    fn get_keys_to_make_hot<O, F>(&self, convert: F) -> Result<BTreeSet<O>, PanicError>
+    where
+        O: Ord,
+        F: Fn(&K) -> Result<O, PanicError>,
+    {
+        match self.hot_state_op_accumulator.as_ref() {
+            Some(acc) => acc.get_keys_to_make_hot(convert),
+            None => {
+                warn!("BlockHotStateOpAccumulator is not set.");
+                Ok(BTreeSet::new())
+            },
         }
-
-        self.hot_state_op_accumulator
-            .as_ref()
-            .map(|x| x.get_keys_to_make_hot())
-            .unwrap_or_default()
     }
 }
 

--- a/aptos-move/block-executor/src/single_transaction_executor.rs
+++ b/aptos-move/block-executor/src/single_transaction_executor.rs
@@ -73,7 +73,7 @@ pub enum ViewMode<'a, I: TxnInput> {
 pub trait SingleTransactionExecutor {
     type Txn: Transaction;
     type AuxiliaryInfo: AuxiliaryInfoTrait;
-    type Key: Ord + Send + Sync + Clone + Hash + Debug + 'static;
+    type Key: Eq + Send + Sync + Clone + Hash + Debug + 'static;
     type Tag: Ord + Send + Sync + Clone + Hash + Debug + Serialize + 'static;
     type Value: SpeculativeValue + 'static;
 
@@ -130,6 +130,13 @@ pub trait SingleTransactionExecutor {
     fn pre_write_values(_txn: &Self::Txn) -> Vec<(Self::Key, Self::Value)> {
         vec![]
     }
+
+    /// Materializes a VM in-memory key into the storage key persisted at the
+    /// block epilogue.
+    fn materialize_storage_key(
+        &self,
+        key: Self::Key,
+    ) -> Result<<Self::Txn as Transaction>::Key, PanicError>;
 }
 
 /// Builds the legacy `LatestView` from the view ingredients.
@@ -285,5 +292,12 @@ impl<E: ExecutorTask> SingleTransactionExecutor for LegacyTransactionExecutor<E>
         ValueWithLayout<<E::Txn as Transaction>::Value>,
     )> {
         E::pre_write_values(txn)
+    }
+
+    fn materialize_storage_key(
+        &self,
+        key: Self::Key,
+    ) -> Result<<E::Txn as Transaction>::Key, PanicError> {
+        Ok(key)
     }
 }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -125,7 +125,7 @@ pub trait ExecutorTask {
 /// against the map); `Txn` provides the storage-side key/value/event types.
 pub trait TxnOutput: Send + Debug {
     type Txn: Transaction;
-    type Key: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + Debug + 'static;
+    type Key: Send + Sync + Clone + Hash + Eq + Debug + 'static;
     type Tag: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + Debug + Serialize + 'static;
     type Value: SpeculativeValue + 'static;
     /// The materialized output produced from this (speculative) output.

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -856,7 +856,9 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, Option<UserTxn>)>) -> (Vec<Txn>, 
             });
         }
         if let Some(epi_txn) = epilogue {
-            let to_make_hot = op_accu.get_keys_to_make_hot();
+            let to_make_hot = op_accu
+                .get_keys_to_make_hot(|k| Ok(k.clone()))
+                .expect("Identity conversion to storage key cannot fail");
 
             state_by_version.append_version(
                 epi_txn.writes.iter().map(|(k, v)| (k, v.as_ref())),


### PR DESCRIPTION
## Description

The in-memory (Block-STM map) key no longer needs to be `Ord`. It was
required only to build the deterministic hot-state promotion set persisted
at the block epilogue. For MonoMove the in-memory key is interned and
pointer-based, so its `Ord` is not deterministic across nodes; ordering the
promotion set by it would be non-deterministic.

This adds `SingleTransactionExecutor::materialize_storage_key`, so each VM
maps its in-memory key to the storage key, and orders the promotion set on
the storage key (which has a real, deterministic `Ord`) instead. As a
result, `Ord`/`PartialOrd` is dropped from the in-memory key across
`SingleTransactionExecutor::Key`, `TxnInput::Key`, `TxnOutput::Key`,
`BlockGasLimitProcessor`, and `BlockHotStateOpAccumulator`, and the
`<T>::Key: From<E::Key>` bound is removed.

For the legacy VM the in-memory key *is* the storage key, so the converter
is the identity and behavior is unchanged.

No new dependencies.

## How Has This Been Tested?

- `RUST_MIN_STACK=1073741824 cargo nextest run -p aptos-block-executor`:
  265/265 pass, including `test_block_epilogue_happy_path` and the
  gas-limit combinatorial/group tests that exercise the epilogue path.
- Updated the `hot_state_op_accumulator` unit tests
  (`cap_selects_smallest_keys_independent_of_order`,
  `written_keys_are_not_promoted`, `write_after_read_removes_promotion`) to
  the converter form.
- `cargo check -p aptos-block-executor --tests` and
  `cargo check -p aptos-vm --tests` compile.

## Key Areas to Review

- `BlockHotStateOpAccumulator::get_keys_to_make_hot`: the cap now selects
  the smallest *storage* keys (deterministic across nodes) rather than the
  in-memory keys. For the legacy VM the converter is the identity, so the
  persisted set is unchanged.
- Removing `Ord` from `SingleTransactionExecutor::Key` also removed the
  `Eq` supertrait that `Ord` provided; `Eq` is re-added explicitly (the
  MV/unsync maps and the gas-limit processor need it).
- `generate_block_epilogue_if_needed` now takes `Option<&E>`; the executor
  is unwrapped only inside the `append_state_checkpoint_to_block()` branch,
  so it is required exactly when an epilogue txn is generated — same
  behavior as before.
- The converter short-circuits on the first `PanicError` in the
  `collect::<Result<BTreeSet<O>, _>>()`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which keys are promoted when the per-block cap applies (now by storage key, not in-memory key), which must match on every validator; legacy VM path is unchanged via identity conversion.
> 
> **Overview**
> **Block-STM in-memory map keys no longer need `Ord`.** Hot-state promotion for the block epilogue used to sort/cap keys in memory; that breaks for MonoMove-style interned keys whose order is not deterministic across nodes.
> 
> The PR adds **`SingleTransactionExecutor::materialize_storage_key`** so each VM converts its in-memory key to the persisted **storage key** at epilogue time. `BlockHotStateOpAccumulator::get_keys_to_make_hot` and `BlockGasLimitProcessor::get_block_end_info` now take a converter and build an ordered `BTreeSet` of **storage** keys (cap keeps the smallest storage keys). Parallel and sequential epilogue paths pass `executor.materialize_storage_key`; the legacy adapter uses identity, so behavior there stays the same.
> 
> Related cleanup: drop the `BlockExecutor` bound `<T>::Key: From<E::Key>`, use `TBlockEndInfoExt<T::Key>` in `gen_block_epilogue`, and thread `&E` into `generate_block_epilogue_if_needed` only when building the epilogue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d3371f50ffa260c7f12cc6ca2d56f8e1f673665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->