### PR TITLE
[storage] Activate restored hot state snapshots

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,7 +23,6 @@ xclippy = [
   # toolchain bump mechanical. TODO: clean these up separately.
   "-Aclippy::chunks_exact_to_as_chunks",
   "-Aclippy::explicit_counter_loop",
-  "-Aclippy::extra_unused_lifetimes",
   "-Aclippy::manual_checked_ops",
   "-Aclippy::manual_filter",
   "-Aclippy::map_or_identity",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,7 +24,6 @@ xclippy = [
   "-Aclippy::chunks_exact_to_as_chunks",
   "-Aclippy::explicit_counter_loop",
   "-Aclippy::manual_checked_ops",
-  "-Aclippy::manual_filter",
   "-Aclippy::map_or_identity",
   "-Aclippy::missing_spin_loop",
   "-Aclippy::needless_return_with_question_mark",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,7 +24,6 @@ xclippy = [
   "-Aclippy::chunks_exact_to_as_chunks",
   "-Aclippy::explicit_counter_loop",
   "-Aclippy::manual_checked_ops",
-  "-Aclippy::map_or_identity",
   "-Aclippy::missing_spin_loop",
   "-Aclippy::needless_return_with_question_mark",
   "-Aclippy::question_mark",

--- a/crates/aptos-dkg/src/utils/mod.rs
+++ b/crates/aptos-dkg/src/utils/mod.rs
@@ -130,7 +130,7 @@ pub fn pairing_g2_g1(lhs: &G2Affine, rhs: &G1Affine) -> Gt {
     pairing(rhs, lhs)
 }
 
-pub trait HasMultiExp: for<'a> Sized + Clone {
+pub trait HasMultiExp: Sized + Clone {
     fn multi_exp_slice(bases: &[Self], scalars: &[blstrs::Scalar]) -> Self;
 
     fn multi_exp_iter<'a, 'b, I>(

--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -301,6 +301,7 @@ impl AptosDB {
         db_dir: &StorageDirPaths,
         target_version: Version,
     ) -> Result<()> {
+        // TODO(HotState): Preserve hot state during truncation and pass its config to catch-up.
         let delete_hot_state_on_restart = true;
         let (ledger_db, hot_state_merkle_db, state_merkle_db, hot_state_kv_db, state_kv_db) =
             Self::open_dbs(

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
+use aptos_logger::info;
 use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::batch::SchemaBatch;
 use aptos_storage_interface::{
@@ -257,6 +258,7 @@ impl DbWriter for AptosDB {
             // state kv and SMT should use shared way of committing.
             self.ledger_db.write_schemas(ledger_db_batch)?;
 
+            // A restored snapshot provides no readable history before its version.
             self.ledger_pruner.save_min_readable_version(version)?;
             self.state_store
                 .state_pruner
@@ -270,8 +272,24 @@ impl DbWriter for AptosDB {
                 .state_pruner
                 .state_kv_pruner
                 .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_state_merkle_pruner
+                .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_epoch_snapshot_pruner
+                .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_state_kv_pruner
+                .save_min_readable_version(version)?;
 
             restore_utils::update_latest_ledger_info(self.ledger_db.metadata_db(), ledger_infos)?;
+            info!(
+                version = version,
+                "Finalizing state snapshot restore: pruners seeded, resetting state store."
+            );
             self.state_store.reset();
 
             Ok(())

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -71,7 +71,7 @@ impl FastSyncStorageWrapper {
                 .ledger_db
                 .metadata_db()
                 .get_synced_version()?
-                .map_or(0, |v| v)
+                .unwrap_or(0)
                 == 0)
         {
             db_dir.push(SECONDARY_DB_DIR);

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -5,6 +5,7 @@ use crate::{
     common::{spawn_commit_pipeline, BufferedStateCore, BufferedStateExtras},
     metrics::{LATEST_CHECKPOINT_VERSION, OTHER_TIMERS_SECONDS},
     state_store::{
+        hot_state::LoadedHotState,
         persisted_state::PersistedState,
         state_merkle_batch_committer::StateMerkleBatchCommitter,
         state_snapshot_committer::{
@@ -17,6 +18,7 @@ use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
 use aptos_storage_interface::state_store::{
     empty_hot_state_updates,
+    state_summary::StateSummary,
     state_with_summary::{LedgerStateWithSummary, StateWithSummary},
     HotStateShardUpdates, HotStateUpdates,
 };
@@ -99,15 +101,17 @@ impl BufferedStateExtras<SnapshotToCommit, StateWithSummary> for HotStateAccumul
 impl BufferedState {
     pub(crate) fn new_at_snapshot(
         state_db: &Arc<StateDb>,
-        last_snapshot: StateWithSummary,
+        hot_state: LoadedHotState,
+        summary: StateSummary,
         target_items: usize,
         out_current_state: Arc<Mutex<LedgerStateWithSummary>>,
         out_persisted_state: PersistedState,
     ) -> Self {
         let arc_state_db = Arc::clone(state_db);
+        // Install before starting the snapshot pipeline so its commits use the loaded base.
+        let last_snapshot = out_persisted_state.install_snapshot(hot_state, summary);
         *out_current_state.lock() =
             LedgerStateWithSummary::new_at_checkpoint(last_snapshot.clone());
-        out_persisted_state.hack_reset(last_snapshot.clone());
 
         let merklize_state_db = Arc::clone(&arc_state_db);
         let persisted_state_clone = out_persisted_state.clone();

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::metrics::{
-    COUNTER, GAUGE, HOT_STATE_SHARD_GAUGE, OTHER_TIMERS_SECONDS, SHARD_NAME_BY_ID,
+use crate::{
+    metrics::{COUNTER, GAUGE, HOT_STATE_SHARD_GAUGE, OTHER_TIMERS_SECONDS, SHARD_NAME_BY_ID},
+    state_kv_db::LoadedHotStateShard,
 };
 use anyhow::{ensure, Result};
 use aptos_config::config::HotStateConfig;
@@ -11,10 +12,15 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::{IntCounterVecHelper, IntGaugeVecHelper, TimerHelper};
 use aptos_storage_interface::state_store::{
-    state::State, state_delta::StateDelta, state_view::hot_state_view::HotStateView,
+    state::{HotStateMetadata, State},
+    state_delta::StateDelta,
+    state_view::hot_state_view::HotStateView,
 };
 use aptos_types::{
-    state_store::{hot_state::THotStateSlot, state_slot::StateSlot, NUM_STATE_SHARDS},
+    state_store::{
+        hot_state::THotStateSlot, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
+        NUM_STATE_SHARDS,
+    },
     transaction::Version,
 };
 #[cfg(test)]
@@ -145,12 +151,56 @@ impl HotStateView for LayeredHotStateView {
     }
 }
 
+/// Snapshot rows paired with their version and reconstructed LRU metadata.
+/// Keeping them together prevents installing metadata with a different set of rows.
+pub(crate) struct LoadedHotState {
+    state: State,
+    shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+}
+
+impl LoadedHotState {
+    pub(crate) fn new(
+        version: Version,
+        usage: StateStorageUsage,
+        config: HotStateConfig,
+        loaded: [LoadedHotStateShard; NUM_STATE_SHARDS],
+    ) -> Self {
+        let metadata = std::array::from_fn(|i| {
+            HotStateMetadata::new(
+                loaded[i].head,
+                loaded[i].tail,
+                loaded[i].num_items,
+                loaded[i].total_value_bytes,
+            )
+        });
+        Self {
+            state: State::new_at_version_with_hot_state_metadata(
+                Some(version),
+                usage,
+                config,
+                metadata,
+            ),
+            shards: loaded.map(|shard| shard.map),
+        }
+    }
+
+    /// Builds an empty base while preserving the supplied state's layer family.
+    pub(crate) fn empty(state: State) -> Self {
+        assert!((0..NUM_STATE_SHARDS).all(|i| state.num_hot_items(i) == 0));
+        let shards = std::array::from_fn(|_| DashMap::new());
+        Self { state, shards }
+    }
+
+    pub(crate) fn state(&self) -> &State {
+        &self.state
+    }
+}
+
 enum CommitMsg {
     Commit(State),
-    /// Sent by `hack_reset` to synchronously reset the Committer's `merged_state` and `old_views`.
-    /// The caller blocks on `ack` until the Committer has finished processing the reset.
-    HackReset {
-        state: State,
+    /// Acknowledged after the new base and matching state are published.
+    InstallSnapshot {
+        snapshot: LoadedHotState,
         ack: Sender<()>,
     },
 }
@@ -162,27 +212,18 @@ struct CommittedSnapshot {
 }
 
 pub struct HotState {
-    base: Arc<HotStateBase>,
     committed: Arc<Mutex<CommittedSnapshot>>,
     commit_tx: SyncSender<CommitMsg>,
-    /// Updated by the Committer after each successful DashMap merge. Tests use this to wait for
-    /// the merge to complete before inspecting DashMaps. Only read by test helpers.
+    /// Next version represented by the base, updated after merges and snapshot installation.
+    /// Tests use it to wait before inspecting the base.
     #[cfg(test)]
     merged_version: Arc<AtomicU64>,
 }
 
 impl HotState {
-    pub fn new(state: State, config: HotStateConfig) -> Self {
-        let empty_shards =
-            std::array::from_fn(|_| DashMap::with_capacity(config.max_items_per_shard));
-        Self::new_from_loaded(state, empty_shards)
-    }
-
-    pub fn new_from_loaded(
-        state: State,
-        loaded_shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
-    ) -> Self {
-        let base = Arc::new(HotStateBase::from_loaded(loaded_shards));
+    pub fn new_empty(state: State) -> Self {
+        let LoadedHotState { state, shards } = LoadedHotState::empty(state);
+        let base = Arc::new(HotStateBase::from_loaded(shards));
         let view = Arc::new(LayeredHotStateView {
             delta: None,
             base: Arc::clone(&base),
@@ -193,14 +234,13 @@ impl HotState {
         }));
         let merged_version = Arc::new(AtomicU64::new(state.next_version()));
         let commit_tx = Committer::spawn(
-            Arc::clone(&base),
+            base,
             Arc::clone(&committed),
             state,
             Arc::clone(&merged_version),
         );
 
         Self {
-            base,
             committed,
             commit_tx,
             #[cfg(test)]
@@ -208,26 +248,19 @@ impl HotState {
         }
     }
 
-    pub(crate) fn hack_reset(&self, state: State) {
-        {
-            let mut committed = self.committed.lock();
-            committed.state = state.clone();
-            // Reset view to base-only (no delta). hack_reset is only called when no commits are in
-            // flight, so DashMaps and committed state are in sync from the readers' perspective.
-            committed.view = Arc::new(LayeredHotStateView {
-                delta: None,
-                base: Arc::clone(&self.base),
-            });
-        }
-        // Synchronously reset the Committer's merged_state and old_views. Block until processed,
-        // so the caller has a hard guarantee that no stale Committer state remains.
+    /// Publishes a snapshot synchronously; existing reader views remain valid.
+    /// Callers must wait for queued commits to be processed and prevent new commits until return.
+    pub(crate) fn install_snapshot(&self, snapshot: LoadedHotState) {
         let (ack_tx, ack_rx) = std::sync::mpsc::channel();
         self.commit_tx
-            .send(CommitMsg::HackReset { state, ack: ack_tx })
-            .expect("Failed to send reset to hot state committer.");
+            .send(CommitMsg::InstallSnapshot {
+                snapshot,
+                ack: ack_tx,
+            })
+            .expect("Failed to send snapshot installation to hot state committer.");
         ack_rx
             .recv()
-            .expect("Failed to receive reset ack from hot state committer.");
+            .expect("Failed to receive snapshot installation ack from hot state committer.");
     }
 
     pub fn get_committed(&self) -> (Arc<dyn HotStateView>, State) {
@@ -254,9 +287,12 @@ impl HotState {
         }
     }
 
+    /// Returns merged base entries; committed deltas may still be pending.
     #[cfg(test)]
     pub fn get_all_entries(&self, shard_id: usize) -> BTreeMap<HashValue, StateSlot> {
-        self.base.shards[shard_id].iter().collect()
+        self.committed.lock().view.base.shards[shard_id]
+            .iter()
+            .collect()
     }
 }
 
@@ -299,11 +335,11 @@ struct Committer {
     /// is deferred.
     merged_state: State,
 
-    /// Weak refs to all previously published views. Merge is deferred until every one is dropped
-    /// (strong_count == 0). See struct doc.
+    /// Weak refs to previously published views of the current base. Merges wait until these
+    /// readers release their views (strong_count == 0). See struct doc.
     old_views: Vec<Weak<LayeredHotStateView>>,
 
-    /// Shared with HotState; updated after each successful DashMap merge.
+    /// Next version represented by the base, shared with HotState in tests.
     merged_version: Arc<AtomicU64>,
 }
 
@@ -407,26 +443,18 @@ impl Committer {
         info!("HotState committer quitting.");
     }
 
-    /// Process a `HackReset` message: synchronize `merged_state` / `old_views` with the caller and
-    /// ack.
-    ///
-    /// `HackReset` is a hack used by `hack_reset` and is only sent when no commits are in flight,
-    /// so it must be the sole message in the channel. `next_to_commit` asserts this before
-    /// calling.
-    ///
-    // TODO(HotState): The DashMaps and the LRU metadata in `State` are loaded together (from
-    // `load_hot_state_kvs`) but arrive here through separate paths — the DashMaps via
-    // `new_from_loaded` at `PersistedState` construction, the `State` via `hack_reset`. The
-    // assertions below guard against the two getting out of sync. Consider passing them
-    // together through a single path to make consistency structural.
-    fn handle_reset(&mut self, state: State, ack: Sender<()>) {
+    fn install_snapshot(&mut self, snapshot: LoadedHotState) {
+        let LoadedHotState { state, shards } = snapshot;
+        // Retained views need their original base for keys outside their deltas.
+        self.base = Arc::new(HotStateBase::from_loaded(shards));
+
         for i in 0..NUM_STATE_SHARDS {
             let head = state.latest_hot_key(i);
             let tail = state.oldest_hot_key(i);
             assert_eq!(
                 self.base.shards[i].len(),
                 state.num_hot_items(i),
-                "Shard {i}: DashMap/metadata item count mismatch on reset.",
+                "Shard {i}: DashMap/metadata item count mismatch on snapshot installation.",
             );
             match (head, tail) {
                 (None, None) => assert_eq!(
@@ -459,24 +487,40 @@ impl Committer {
         self.merged_state = state;
         self.merged_version
             .store(self.merged_state.next_version(), Ordering::Release);
+        // Views of the old base cannot block merges into the new one.
         self.old_views.clear();
-        let _ = ack.send(());
+
+        {
+            let mut committed = self.committed.lock();
+            committed.state = self.merged_state.clone();
+            // The loaded base already represents this state, so the view needs no delta.
+            committed.view = Arc::new(LayeredHotStateView {
+                delta: None,
+                base: Arc::clone(&self.base),
+            });
+        }
+
+        self.report_size_metrics();
+        self.report_age_metrics();
+        info!(
+            next_version = self.merged_state.next_version(),
+            num_items = self.base.len(),
+            "HotState snapshot installed.",
+        );
     }
 
     fn next_to_commit(&mut self) -> Option<State> {
-        // Block until we receive the first Commit, retrying merges on timeout.
-        // HackReset messages are processed inline — they are only sent when no commits are in
-        // flight, so we assert the channel is empty after processing one.
+        // Wait for commits, retrying deferred merges on timeout.
         let first = loop {
             match self.rx.recv_timeout(DEFERRED_MERGE_RETRY_INTERVAL) {
                 Ok(CommitMsg::Commit(state)) => break state,
-                Ok(CommitMsg::HackReset { state, ack }) => {
+                Ok(CommitMsg::InstallSnapshot { snapshot, ack }) => {
                     assert!(
                         self.rx.try_recv().is_err(),
-                        "HackReset must be the only message in the channel — \
-                         hack_reset is only valid when no commits are in flight."
+                        "Snapshot installation requires an empty commit queue."
                     );
-                    self.handle_reset(state, ack);
+                    self.install_snapshot(snapshot);
+                    let _ = ack.send(());
                 },
                 Err(RecvTimeoutError::Timeout) => {
                     self.try_merge();
@@ -485,7 +529,7 @@ impl Committer {
             }
         };
 
-        // Drain backlog — only the latest Commit matters. HackReset must not appear here.
+        // Each queued state subsumes earlier commits, so only the newest needs publication.
         let mut ret = first;
         let mut n_backlog = 0;
         while let Ok(msg) = self.rx.try_recv() {
@@ -494,11 +538,8 @@ impl Committer {
                     n_backlog += 1;
                     ret = state;
                 },
-                CommitMsg::HackReset { .. } => {
-                    unreachable!(
-                        "HackReset must not appear alongside Commit messages — \
-                         hack_reset is only valid when no commits are in flight."
-                    );
+                CommitMsg::InstallSnapshot { .. } => {
+                    unreachable!("Snapshot installation requires all commits to finish.");
                 },
             }
         }
@@ -601,10 +642,17 @@ impl Committer {
             debug_assert!(self.validate_lru(shard_id).is_ok());
         }
 
-        let total_items = self.base.len();
         COUNTER.inc_with_by(&["hot_state_insert"], n_insert);
         COUNTER.inc_with_by(&["hot_state_update"], n_update);
         COUNTER.inc_with_by(&["hot_state_evict"], n_evict);
+
+        self.report_size_metrics();
+        self.report_age_metrics();
+    }
+
+    /// Reports item count and key/value bytes in the base, excluding deferred deltas.
+    fn report_size_metrics(&self) {
+        let total_items = self.base.len();
         GAUGE.set_with(&["hot_state_items"], total_items as i64);
         GAUGE.set_with(
             &["hot_state_key_bytes"],
@@ -614,8 +662,6 @@ impl Committer {
             &["hot_state_value_bytes"],
             self.total_value_bytes.iter().sum::<usize>() as i64,
         );
-
-        self.report_age_metrics();
     }
 
     /// Reports per-shard MRU/LRU `hot_since_version` gauges and aggregate max/min LRU across shards.
@@ -917,7 +963,7 @@ mod tests {
     #[test]
     fn test_deferred_merge_basic() {
         let state0 = State::new_empty(TEST_CONFIG);
-        let hot_state = HotState::new(state0.clone(), TEST_CONFIG);
+        let hot_state = HotState::new_empty(state0.clone());
 
         let state1 = build_empty_descendant(&state0, &state0, 0);
         hot_state.enqueue_commit(state1);
@@ -930,7 +976,7 @@ mod tests {
     #[test]
     fn test_deferred_merge_with_lingering_reader() {
         let state0 = State::new_empty(TEST_CONFIG);
-        let hot_state = HotState::new(state0.clone(), TEST_CONFIG);
+        let hot_state = HotState::new_empty(state0.clone());
 
         // Grab a view — this reader holds a strong ref to the initial view.
         let (held_view, _) = hot_state.get_committed();
@@ -977,7 +1023,7 @@ mod tests {
     #[test]
     fn test_try_merge_tracks_replaced_view() {
         let state0 = State::new_empty(TEST_CONFIG);
-        let hot_state = HotState::new(state0.clone(), TEST_CONFIG);
+        let hot_state = HotState::new_empty(state0.clone());
 
         // Hold the initial view (V0_clean). This blocks merge while S1 is committed,
         // keeping V1_delta in committed.view long enough for us to grab it.
@@ -1039,7 +1085,7 @@ mod tests {
     #[test]
     fn test_commit_with_advanced_base_layer() {
         let state0 = State::new_empty(TEST_CONFIG);
-        let hot_state = HotState::new(state0.clone(), TEST_CONFIG);
+        let hot_state = HotState::new_empty(state0.clone());
 
         // Hold a view to block all merges (merged_state stays at S0).
         let (held_view, _) = hot_state.get_committed();
@@ -1071,7 +1117,7 @@ mod tests {
     #[test]
     fn test_rapid_commits_with_lingering_reader() {
         let state0 = State::new_empty(TEST_CONFIG);
-        let hot_state = HotState::new(state0.clone(), TEST_CONFIG);
+        let hot_state = HotState::new_empty(state0.clone());
 
         // Grab a view.
         let (held_view, _) = hot_state.get_committed();

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -20,7 +20,9 @@ use crate::{
     state_kv_db::StateKvDb,
     state_merkle_db::StateMerkleDb,
     state_restore::{StateSnapshotRestore, StateSnapshotRestoreMode, StateValueWriter},
-    state_store::{buffered_state::BufferedState, persisted_state::PersistedState},
+    state_store::{
+        buffered_state::BufferedState, hot_state::LoadedHotState, persisted_state::PersistedState,
+    },
     state_value_chunk::{
         build_hot_value_chunk_proof, build_value_chunk_proof, jmt_leaves_with_values,
         value_chunk_with_proof,
@@ -56,7 +58,7 @@ use aptos_scratchpad::SparseMerkleTree;
 use aptos_storage_interface::{
     db_ensure as ensure, db_other_bail as bail,
     state_store::{
-        state::{HotStateMetadata, LedgerState, State},
+        state::{LedgerState, State},
         state_summary::{ProvableStateSummary, StateSummary},
         state_update_refs::{PerVersionStateUpdateRefs, StateUpdateRefs},
         state_view::{
@@ -482,18 +484,12 @@ impl StateStore {
         let current_state = Arc::new(Mutex::new(LedgerStateWithSummary::new_empty(
             hot_state_config,
         )));
-        let (persisted_state, hot_state_metadata) = if empty_buffered_state_for_restore {
-            (
-                PersistedState::new_empty(hot_state_config),
-                Default::default(),
-            )
-        } else {
-            Self::load_hot_state_or_empty(&state_db, hot_state_config)
-        };
+        let persisted_state = PersistedState::new_empty(hot_state_config);
         let buffered_state = if empty_buffered_state_for_restore {
             BufferedState::new_at_snapshot(
                 &state_db,
-                StateWithSummary::new_empty(hot_state_config),
+                LoadedHotState::empty(State::new_empty(hot_state_config)),
+                StateSummary::new_empty(hot_state_config),
                 buffered_state_target_items,
                 current_state.clone(),
                 persisted_state.clone(),
@@ -506,7 +502,6 @@ impl StateStore {
                 /*check_max_versions_after_snapshot=*/ true,
                 current_state.clone(),
                 persisted_state.clone(),
-                hot_state_metadata,
                 hot_state_config,
             )
             .expect("buffered state creation failed.")
@@ -725,10 +720,6 @@ impl StateStore {
         let current_state = Arc::new(Mutex::new(LedgerStateWithSummary::new_empty(
             HotStateConfig::default(),
         )));
-        // TODO(HotState): When hot state persistence is needed for this path, load hot state
-        // KV from DB via `load_hot_state_or_empty` and pass the real persisted state and
-        // metadata, instead of empty defaults. This will let both `hot_state_merkle_db` and
-        // `state_merkle_db` catch up correctly during replay.
         let _ = Self::create_buffered_state_from_latest_snapshot(
             &state_db,
             0,
@@ -736,15 +727,14 @@ impl StateStore {
             /*check_max_versions_after_snapshot=*/ false,
             current_state.clone(),
             PersistedState::new_empty(HotStateConfig::default()),
-            Default::default(),
             HotStateConfig::default(),
         )?;
         let base_version = current_state.lock().version();
         Ok(base_version)
     }
 
-    /// Creates a `BufferedState` from the latest state snapshot, replaying write sets
-    /// between the snapshot and the committed version.
+    /// Loads the latest snapshot as the persisted base, then replays later committed writes.
+    /// Startup and restore share this path so rows, LRU metadata, and roots use the same version.
     fn create_buffered_state_from_latest_snapshot(
         state_db: &Arc<StateDb>,
         buffered_state_target_items: usize,
@@ -752,7 +742,6 @@ impl StateStore {
         check_max_versions_after_snapshot: bool,
         out_current_state: Arc<Mutex<LedgerStateWithSummary>>,
         out_persisted_state: PersistedState,
-        hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
         hot_state_config: HotStateConfig,
     ) -> Result<BufferedState> {
         let num_transactions = state_db
@@ -779,10 +768,12 @@ impl StateStore {
         } else {
             *SPARSE_MERKLE_PLACEHOLDER_HASH
         };
-        let hot_state_root_hash = if !hot_state_config.delete_on_restart
+        let usage = state_db.get_state_storage_usage(latest_snapshot_version)?;
+        // TODO(HotState): honor restored snapshots even when delete_on_restart is enabled.
+        let (hot_state, hot_state_root_hash) = if !hot_state_config.delete_on_restart
             && let Some(version) = latest_snapshot_version
         {
-            match state_db
+            let hot_state_root_hash = match state_db
                 .hot_state_merkle_db
                 .get_root_hash_option(version)
                 .expect("Failed to query hot state root hash on initialization.")
@@ -805,23 +796,32 @@ impl StateStore {
                     );
                     *SPARSE_MERKLE_PLACEHOLDER_HASH
                 },
-            }
+            };
+            let hot_state = LoadedHotState::new(
+                version,
+                usage,
+                hot_state_config,
+                state_db.hot_state_kv_db.load_hot_state_kvs(version)?,
+            );
+            (hot_state, hot_state_root_hash)
         } else {
-            *SPARSE_MERKLE_PLACEHOLDER_HASH
+            let hot_state = LoadedHotState::empty(State::new_at_version(
+                latest_snapshot_version,
+                usage,
+                hot_state_config,
+            ));
+            (hot_state, *SPARSE_MERKLE_PLACEHOLDER_HASH)
         };
-        let usage = state_db.get_state_storage_usage(latest_snapshot_version)?;
-
-        let state = StateWithSummary::new_at_version_with_hot_state_metadata(
+        let summary = StateSummary::new_at_version(
             latest_snapshot_version,
-            hot_state_root_hash,
-            latest_snapshot_root_hash,
-            usage,
+            SparseMerkleTree::new(hot_state_root_hash),
+            SparseMerkleTree::new(latest_snapshot_root_hash),
             hot_state_config,
-            hot_state_metadata,
         );
         let mut buffered_state = BufferedState::new_at_snapshot(
             state_db,
-            state.clone(),
+            hot_state,
+            summary,
             buffered_state_target_items,
             out_current_state.clone(),
             out_persisted_state.clone(),
@@ -978,77 +978,10 @@ impl StateStore {
         Ok(())
     }
 
-    /// Tries to load the hot state from DB at the latest snapshot version. Returns an empty
-    /// persisted state when loading is not applicable (disabled, no DB, no snapshot).
-    ///
-    /// Returns:
-    ///   - `PersistedState` — fed into `BufferedState` as the base hot state.
-    ///   - `[HotStateMetadata; NUM_STATE_SHARDS]` — per-shard LRU metadata for seeding
-    ///     the speculative `State` (which diverges from the `PersistedState`'s `State`
-    ///     during replay).
-    fn load_hot_state_or_empty(
-        state_db: &Arc<StateDb>,
-        hot_state_config: HotStateConfig,
-    ) -> (PersistedState, [HotStateMetadata; NUM_STATE_SHARDS]) {
-        let empty = || {
-            (
-                PersistedState::new_empty(hot_state_config),
-                Default::default(),
-            )
-        };
-
-        if hot_state_config.delete_on_restart {
-            return empty();
-        }
-        let snapshot_version = match state_db
-            .state_merkle_db
-            .get_state_snapshot_version_before(Version::MAX)
-            .expect("Failed to query latest snapshot on initialization.")
-        {
-            Some(v) => v,
-            None => return empty(),
-        };
-
-        let loaded = state_db
-            .hot_state_kv_db
-            .load_hot_state_kvs(snapshot_version)
-            .expect("Failed to load hot state KVs from DB.");
-        let metadata = std::array::from_fn(|i| {
-            HotStateMetadata::new(
-                loaded[i].head,
-                loaded[i].tail,
-                loaded[i].num_items,
-                loaded[i].total_value_bytes,
-            )
-        });
-        let dashmaps = loaded.map(|s| s.map);
-        let usage = state_db
-            .get_state_storage_usage(Some(snapshot_version))
-            .expect("Failed to query state storage usage on initialization.");
-        let state = State::new_at_version_with_hot_state_metadata(
-            Some(snapshot_version),
-            usage,
-            hot_state_config,
-            metadata.clone(),
-        );
-
-        (
-            PersistedState::new_from_loaded(state, hot_state_config, dashmaps),
-            metadata,
-        )
-    }
-
     pub fn reset(&self) {
-        // Drain + shut down the old pipeline against the *current*
-        // chain family before `create_buffered_state_from_latest_snapshot`
-        // repoints `current_state` at a new MapLayer family. Doing
-        // the shutdown lazily via `Drop` would let the old thread's
-        // drop-time `sync_commit` read the new family and panic on
-        // `is_descendant_of`.
+        // Flush and stop the snapshot pipeline before replacing current_state's layer family.
+        // Its final sync_commit must use the old family to compute valid deltas.
         self.buffered_state.lock().quit();
-        // TODO(HotState): restore does not reconstruct the hot state yet, so we pass empty
-        // metadata here. This is safe because callers (restore / state-sync) open the DB with
-        // `empty_buffered_state_for_restore`, so the DashMaps are always empty.
         *self.buffered_state.lock() = Self::create_buffered_state_from_latest_snapshot(
             &self.state_db,
             self.buffered_state_target_items,
@@ -1056,7 +989,6 @@ impl StateStore {
             true,
             self.current_state.clone(),
             self.persisted_state.clone(),
-            Default::default(),
             self.hot_state_config,
         )
         .expect("buffered state creation failed.");
@@ -1627,7 +1559,10 @@ impl StateStore {
             last_checkpoint.clone(),
         );
 
-        self.persisted_state.hack_reset(last_checkpoint.clone());
+        self.persisted_state.install_snapshot(
+            LoadedHotState::empty(last_checkpoint.state().clone()),
+            last_checkpoint_summary,
+        );
         *self.current_state_locked() = current;
         self.buffered_state
             .lock()

--- a/storage/aptosdb/src/state_store/persisted_state.rs
+++ b/storage/aptosdb/src/state_store/persisted_state.rs
@@ -1,9 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{metrics::OTHER_TIMERS_SECONDS, state_store::hot_state::HotState};
+use crate::{
+    metrics::OTHER_TIMERS_SECONDS,
+    state_store::hot_state::{HotState, LoadedHotState},
+};
 use aptos_config::config::HotStateConfig;
-use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::SUBTREE_DROPPER;
@@ -11,8 +13,6 @@ use aptos_storage_interface::state_store::{
     state::State, state_summary::StateSummary, state_view::hot_state_view::HotStateView,
     state_with_summary::StateWithSummary,
 };
-use aptos_types::state_store::{state_slot::StateSlot, NUM_STATE_SHARDS};
-use dashmap::DashMap;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -26,17 +26,7 @@ impl PersistedState {
 
     pub fn new_empty(config: HotStateConfig) -> Self {
         let state = State::new_empty(config);
-        let hot_state = Arc::new(HotState::new(state, config));
-        let summary = Arc::new(Mutex::new(StateSummary::new_empty(config)));
-        Self { hot_state, summary }
-    }
-
-    pub fn new_from_loaded(
-        state: State,
-        config: HotStateConfig,
-        loaded_shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
-    ) -> Self {
-        let hot_state = Arc::new(HotState::new_from_loaded(state, loaded_shards));
+        let hot_state = Arc::new(HotState::new_empty(state));
         let summary = Arc::new(Mutex::new(StateSummary::new_empty(config)));
         Self { hot_state, summary }
     }
@@ -74,10 +64,18 @@ impl PersistedState {
         self.hot_state.enqueue_commit(state);
     }
 
-    // n.b. Can only be used when no on the fly commit is in the queue.
-    pub fn hack_reset(&self, state_with_summary: StateWithSummary) {
-        let (state, summary) = state_with_summary.into_inner();
+    /// Installs a snapshot synchronously and returns it for seeding subsequent commits.
+    /// Requires no queued or concurrent hot-state commits.
+    pub(crate) fn install_snapshot(
+        &self,
+        hot_state: LoadedHotState,
+        summary: StateSummary,
+    ) -> StateWithSummary {
+        assert_eq!(hot_state.state().version(), summary.version());
+        let snapshot = StateWithSummary::new(hot_state.state().clone(), summary.clone());
+        // As in `set`, publish the summary before readers can observe the matching hot state.
         *self.summary.lock() = summary;
-        self.hot_state.hack_reset(state);
+        self.hot_state.install_snapshot(hot_state);
+        snapshot
     }
 }

--- a/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
@@ -3,7 +3,7 @@
 
 //! Tests for the hot state snapshot APIs used by fast sync to serve and restore hot state.
 
-use crate::{db::test_helper::arb_blocks_to_commit_with_params, AptosDB};
+use crate::{db::test_helper::arb_blocks_to_commit_with_params, pruner::PrunerManager, AptosDB};
 use aptos_config::config::{
     HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
@@ -12,14 +12,17 @@ use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_jellyfish_merkle::{
     mock_tree_store::MockTreeStore, restore::JellyfishMerkleRestore, JellyfishMerkleTree,
 };
-use aptos_storage_interface::{DbReader, DbWriter, Result as DbResult};
+use aptos_storage_interface::{DbReader, DbWriter, Result as DbResult, StateKind};
 use aptos_temppath::TempPath;
 use aptos_types::{
-    ledger_info::LedgerInfoWithSignatures,
+    aggregate_signature::AggregateSignature,
+    block_info::BlockInfo,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     state_store::{
         hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::StateValue,
+        NUM_STATE_SHARDS,
     },
     transaction::{
         BlockEndInfo, ExecutionStatus, Transaction, TransactionAuxiliaryData, TransactionInfo,
@@ -28,7 +31,11 @@ use aptos_types::{
     write_set::WriteSet,
 };
 use proptest::prelude::*;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 fn key(seed: &str) -> StateKey {
     StateKey::raw(seed.as_bytes())
@@ -469,6 +476,26 @@ fn open_persistent_hot_state_db(path: &TempPath) -> AptosDB {
     .unwrap()
 }
 
+/// Restores cold state so reset can discover the snapshot version.
+fn restore_cold_state(src: &AptosDB, dst: &AptosDB, version: Version) {
+    let root_hash = src.state_store.get_root_hash(version).unwrap();
+    let num_items = src
+        .get_state_item_count(version, StateKind::MainState)
+        .unwrap();
+    let mut receiver = dst
+        .get_state_snapshot_receiver(version, root_hash, StateKind::MainState)
+        .unwrap();
+    let mut first_index = 0;
+    while first_index < num_items {
+        let chunk = src
+            .get_state_value_chunk_with_proof(version, first_index, 2, StateKind::MainState)
+            .unwrap();
+        first_index += chunk.raw_values.len();
+        receiver.add_chunk(chunk.raw_values, chunk.proof).unwrap();
+    }
+    receiver.finish_box().unwrap();
+}
+
 #[test]
 fn test_hot_state_restore() {
     let tmp_src = TempPath::new();
@@ -487,6 +514,8 @@ fn test_hot_state_restore() {
 
     let tmp_dst = TempPath::new();
     let dst = open_persistent_hot_state_db(&tmp_dst);
+    let (empty_view, empty_state) = dst.get_persisted_state().unwrap();
+    restore_cold_state(&src, &dst, version);
     let mut receiver = dst
         .get_hot_state_snapshot_receiver(version, root_hash)
         .unwrap();
@@ -496,6 +525,45 @@ fn test_hot_state_restore() {
             .unwrap();
     }
     receiver.finish_box().unwrap();
+    let ledger_info = LedgerInfoWithSignatures::new(
+        LedgerInfo::new(
+            BlockInfo::new(
+                0,
+                0,
+                HashValue::zero(),
+                src.get_accumulator_root_hash(version).unwrap(),
+                version,
+                0,
+                None,
+            ),
+            HashValue::zero(),
+        ),
+        AggregateSignature::empty(),
+    );
+    dst.finalize_state_snapshot(
+        version,
+        src.get_transaction_outputs(version, 1, version).unwrap(),
+        &[ledger_info],
+    )
+    .unwrap();
+
+    let pruners = &dst.state_store.state_pruner;
+    assert_eq!(
+        pruners.hot_state_merkle_pruner.get_min_readable_version(),
+        version
+    );
+    assert_eq!(
+        pruners.hot_epoch_snapshot_pruner.get_min_readable_version(),
+        version
+    );
+    assert_eq!(
+        pruners.hot_state_kv_pruner.get_min_readable_version(),
+        version
+    );
+    assert_eq!(empty_state.version(), None);
+    for (key, _) in &expected {
+        assert!(empty_view.get_state_slot(key.crypto_hash_ref()).is_none());
+    }
 
     // The restored DB serves the same snapshot.
     assert_eq!(
@@ -507,6 +575,131 @@ fn test_hot_state_restore() {
         dst.state_store
             .hot_state_merkle_db
             .get_root_hash(version)
+            .unwrap(),
+        root_hash
+    );
+
+    // Finalization must activate the restored hot state before returning.
+    assert_hot_state_activated(&dst, &expected, root_hash);
+
+    // Retain a base view across a reset and subsequent writes.
+    let (restored_view, restored_state) = dst.get_persisted_state().unwrap();
+    dst.state_store.reset();
+    assert_hot_state_activated(&dst, &expected, root_hash);
+
+    // Retain this view to keep the next commit's delta from merging into its base.
+    let (before_write_view, _) = dst.get_persisted_state().unwrap();
+    let txn = block_epilogue_txn(vec![
+        (key("a"), None),
+        (key("b"), Some(val(b"b-new"))),
+        (key("f"), Some(val(b"f-new"))),
+    ]);
+    src.save_transactions_for_test(std::slice::from_ref(&txn), version + 1, None, true)
+        .unwrap();
+    dst.save_transactions_for_test(&[txn], version + 1, None, true)
+        .unwrap();
+    // The snapshot commit can finish before the hot-state committer publishes its view.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let (delta_view, delta_state) = loop {
+        let persisted = dst.get_persisted_state().unwrap();
+        if persisted.1.version() == Some(version + 1) {
+            break persisted;
+        }
+        assert!(Instant::now() < deadline, "hot state commit did not finish");
+        std::thread::sleep(Duration::from_millis(1));
+    };
+    let expected_after_write = collect_paged(&src, version + 1, usize::MAX);
+    dst.state_store.reset();
+
+    // Updating a key outside the retained delta must preserve its fall-through reads.
+    let txn = block_epilogue_txn(vec![(key("c"), Some(val(b"c-new")))]);
+    src.save_transactions_for_test(std::slice::from_ref(&txn), version + 2, None, true)
+        .unwrap();
+    dst.save_transactions_for_test(&[txn], version + 2, None, true)
+        .unwrap();
+    let hot_state = dst.state_store.persisted_state.get_hot_state();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let entries = hot_state.get_all_entries(key("c").get_shard_id());
+        if entries
+            .get(key("c").crypto_hash_ref())
+            .and_then(|slot| slot.as_state_value_opt())
+            == Some(&val(b"c-new"))
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "old views blocked the new base's merge"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    assert_eq!(restored_state.version(), Some(version));
+    for (key, hot_value) in &expected {
+        for view in [&restored_view, &before_write_view] {
+            assert_eq!(
+                view.get_state_slot(key.crypto_hash_ref())
+                    .unwrap()
+                    .as_state_value_opt(),
+                hot_value.value_opt()
+            );
+        }
+    }
+    assert_eq!(delta_state.version(), Some(version + 1));
+    for (key, hot_value) in &expected_after_write {
+        assert_eq!(
+            delta_view
+                .get_state_slot(key.crypto_hash_ref())
+                .unwrap()
+                .as_state_value_opt(),
+            hot_value.value_opt()
+        );
+    }
+
+    let expected_root = src
+        .state_store
+        .hot_state_merkle_db
+        .get_root_hash(version + 2)
+        .unwrap();
+    let expected_final = collect_paged(&src, version + 2, usize::MAX);
+    assert_eq!(
+        dst.state_store.get_root_hash(version + 2).unwrap(),
+        src.state_store.get_root_hash(version + 2).unwrap()
+    );
+    assert_hot_state_activated(&dst, &expected_final, expected_root);
+    drop(hot_state);
+    drop(dst);
+    let reopened = open_persistent_hot_state_db(&tmp_dst);
+    assert_hot_state_activated(&reopened, &expected_final, expected_root);
+}
+
+/// Checks hot entries and the current summary root.
+fn assert_hot_state_activated(
+    db: &AptosDB,
+    expected: &[(StateKey, HotStateValue)],
+    root_hash: HashValue,
+) {
+    let (hot_view, state) = db.get_persisted_state().unwrap();
+    let num_hot_items: usize = (0..NUM_STATE_SHARDS)
+        .map(|shard_id| state.num_hot_items(shard_id))
+        .sum();
+    assert_eq!(num_hot_items, expected.len());
+    for (key, hot_value) in expected {
+        let slot = hot_view
+            .get_state_slot(key.crypto_hash_ref())
+            .expect("restored key must be hot");
+        assert_eq!(slot.as_state_value_opt(), hot_value.value_opt());
+        assert_eq!(
+            slot.expect_hot_since_version(),
+            hot_value.hot_since_version()
+        );
+    }
+    assert_eq!(
+        db.state_store
+            .current_state_locked()
+            .summary()
+            .hot_root_hash()
             .unwrap(),
         root_hash
     );

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::state_store::persisted_state::PersistedState;
+use crate::state_store::{hot_state::LoadedHotState, persisted_state::PersistedState};
 use aptos_block_executor::hot_state_op_accumulator::BlockHotStateOpAccumulator;
 use aptos_config::config::HotStateConfig;
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -897,7 +897,10 @@ fn replay_chunks_pipelined(chunks: Vec<Chunk>, state_by_version: Arc<StateByVers
     let current_state = Arc::new(Mutex::new(empty.clone()));
 
     let persisted_state = PersistedState::new_empty(TEST_CONFIG);
-    persisted_state.hack_reset(empty.deref().clone());
+    persisted_state.install_snapshot(
+        LoadedHotState::empty(empty.state().clone()),
+        empty.summary().clone(),
+    );
 
     let (to_summary_update, from_state_update) = channel();
     let (to_db_commit, from_summary_update) = channel();

--- a/storage/scratchpad/src/sparse_merkle/node.rs
+++ b/storage/scratchpad/src/sparse_merkle/node.rs
@@ -189,13 +189,9 @@ impl SubTree {
     pub fn get_node_if_in_mem(&self, min_generation: u64) -> Option<Arc<Node>> {
         match self {
             Self::Empty => None,
-            Self::NonEmpty { root, .. } => root.get_if_in_mem().and_then(|n| {
-                if n.generation >= min_generation {
-                    Some(n)
-                } else {
-                    None
-                }
-            }),
+            Self::NonEmpty { root, .. } => root
+                .get_if_in_mem()
+                .filter(|n| n.generation >= min_generation),
         }
     }
 

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -3374,7 +3374,7 @@ impl TypeUnificationError {
             | TypeUnificationError::MissingAbilities(loc, ..) => Some(loc.clone()),
             _ => None,
         }
-        .and_then(|loc| if loc.is_default() { None } else { Some(loc) })
+        .filter(|loc| !loc.is_default())
     }
 
     /// Return the message for this error.

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -58,7 +58,7 @@ impl ValidatorSigner {
     /// information.
     /// This takes an optional seed, which it initializes to
     /// `test_utils::TEST_SEED` if passed `None`
-    pub fn random(opt_rng_seed: impl for<'a> Into<Option<[u8; 32]>>) -> Self {
+    pub fn random(opt_rng_seed: impl Into<Option<[u8; 32]>>) -> Self {
         let mut rng = StdRng::from_seed(opt_rng_seed.into().unwrap_or(TEST_SEED));
         Self::new(
             AccountAddress::random(),


### PR DESCRIPTION

Load hot KV rows together with their version and LRU metadata through a
shared startup and restore path. Install each snapshot on the committer
with a fresh base, so existing reader views remain stable while subsequent
commits can advance independently. Move the loaded maps directly into the
base to avoid reinserting their entries.

Initialize hot pruner readable versions when finalizing a restore, and
refresh hot-state size and age metrics on snapshot installation.

Cover finalization, retained base and delta views across resets, writes
after restore, and reopening the restored database.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes hot-state RCU, snapshot installation, and restore finalization in AptosDB—incorrect ordering or metadata mismatch could corrupt reads or pruner bounds; extensive new tests mitigate but this is core storage infrastructure.
> 
> **Overview**
> **Restored hot state is now wired end-to-end** so fast sync / snapshot restore can serve and execute against the same in-memory hot cache as normal startup.
> 
> Hot KV rows, version, usage, and per-shard LRU metadata are loaded together as `LoadedHotState` and installed through a single **`install_snapshot`** path (replacing the old `hack_reset` split between DashMaps and `State`). The background committer swaps in a fresh base map without re-inserting entries, keeps existing reader views valid, and refreshes size/age metrics on install.
> 
> **Startup and `BufferedState`** now seed persisted state via `install_snapshot` before the snapshot pipeline runs, with `create_buffered_state_from_latest_snapshot` loading hot KVs when persistence is enabled.
> 
> **`finalize_state_snapshot`** sets min-readable versions on the hot merkle, epoch snapshot, and KV pruners (restored history before the snapshot version is not readable), logs, then **`state_store.reset()`** to rebuild buffered state from the restored snapshot.
> 
> Tests cover cold+hot restore, finalization, pruner seeding, retained base/delta views across reset and writes, and DB reopen. Minor mechanical cleanups include Clippy allowlist tweaks for Rust 1.98 and small style/signature fixes elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e8441291c8652a61227dcdac5516b458387d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->