### PR TITLE
[state-sync] Request hot state snapshots from peers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -29,7 +29,6 @@ xclippy = [
   "-Aclippy::question_mark",
   "-Aclippy::single_range_in_vec_init",
   "-Aclippy::unnecessary_sort_by",
-  "-Aclippy::unneeded_wildcard_pattern",
   "-Aclippy::useless_borrows_in_formatting",
 ]
 x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,7 +28,6 @@ xclippy = [
   "-Aclippy::needless_return_with_question_mark",
   "-Aclippy::question_mark",
   "-Aclippy::single_range_in_vec_init",
-  "-Aclippy::unnecessary_sort_by",
 ]
 x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 build-perf = ["build", "--profile", "performance", "--config", ".cargo/performance.toml"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -31,7 +31,6 @@ xclippy = [
   "-Aclippy::unnecessary_sort_by",
   "-Aclippy::unneeded_wildcard_pattern",
   "-Aclippy::useless_borrows_in_formatting",
-  "-Aclippy::while_let_loop",
 ]
 x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 build-perf = ["build", "--profile", "performance", "--config", ".cargo/performance.toml"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -29,7 +29,6 @@ xclippy = [
   "-Aclippy::question_mark",
   "-Aclippy::single_range_in_vec_init",
   "-Aclippy::unnecessary_sort_by",
-  "-Aclippy::useless_borrows_in_formatting",
 ]
 x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 build-perf = ["build", "--profile", "performance", "--config", ".cargo/performance.toml"]

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -952,7 +952,7 @@ impl TryFrom<&MoveType> for TypeTag {
             MoveType::Reference { .. } | MoveType::Unparsable(_) => {
                 return Err(anyhow::anyhow!(
                     "Invalid move type for converting into `TypeTag`: {:?}",
-                    &tag
+                    tag
                 ))
             },
         };

--- a/aptos-move/aptos-gas-calibration/src/measurements.rs
+++ b/aptos-move/aptos-gas-calibration/src/measurements.rs
@@ -166,11 +166,11 @@ fn compile_and_run_samples_asm(
                     executor.add_module(&module_id, module_blob);
 
                     for func_identifier in func_identifiers {
-                        println!("Benchmarking {}::{}\n", &identifier, func_identifier.0);
+                        println!("Benchmarking {}::{}\n", identifier, func_identifier.0);
 
                         gas_measurement
                             .equation_names
-                            .push(format!("{}::{}", &identifier, func_identifier.0));
+                            .push(format!("{}::{}", identifier, func_identifier.0));
 
                         let elapsed = executor
                             .exec_func_record_running_time(

--- a/aptos-move/aptos-gas-calibration/src/measurements_helpers.rs
+++ b/aptos-move/aptos-gas-calibration/src/measurements_helpers.rs
@@ -146,7 +146,7 @@ pub fn record_gas_usage(
         );
         gas_measurement
             .equation_names
-            .push(format!("{}::{}", &identifier, &func_identifier.0));
+            .push(format!("{}::{}", identifier, func_identifier.0));
 
         // publish package similar to create_publish_package in harness.rs
         println!("Signing txn for module... ");

--- a/aptos-move/aptos-gas-profiling/src/report.rs
+++ b/aptos-move/aptos-gas-profiling/src/report.rs
@@ -8,6 +8,7 @@ use chrono::Local;
 use handlebars::Handlebars;
 use serde_json::{json, Map, Value};
 use std::{
+    cmp::Reverse,
     fmt::{self, Write},
     fs,
     path::Path,
@@ -252,7 +253,7 @@ impl TransactionGasLog {
 
         // Dependencies (execution category - loading modules is CPU work)
         let mut deps = self.exec_io.dependencies.clone();
-        deps.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));
+        deps.sort_by_key(|dep| Reverse(dep.cost));
         data.insert(
             "deps".to_string(),
             Value::Array(
@@ -394,7 +395,7 @@ impl TransactionGasLog {
 
         // Storage fees & refunds for state changes
         let mut storage_writes = self.storage.write_set_storage.clone();
-        storage_writes.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));
+        storage_writes.sort_by_key(|write| Reverse(write.cost));
         data.insert(
             "storage-writes".to_string(),
             Value::Array(
@@ -425,7 +426,7 @@ impl TransactionGasLog {
 
         // Storage fees for events
         let mut storage_events = self.storage.events.clone();
-        storage_events.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));
+        storage_events.sort_by_key(|event| Reverse(event.cost));
         data.insert(
             "storage-events".to_string(),
             Value::Array(

--- a/aptos-move/aptos-release-builder/src/simulate.rs
+++ b/aptos-move/aptos-release-builder/src/simulate.rs
@@ -259,14 +259,14 @@ fn patch_aptos_governance(
             .ok_or_else(|| {
                 anyhow!(
                     "failed to locate `fun {}`",
-                    &*FUNC_NAME_RESOLVE_MULTI_STEP_PROPOSAL
+                    *FUNC_NAME_RESOLVE_MULTI_STEP_PROPOSAL
                 )
             })?;
         func_def.acquires_global_resources = vec![];
         let code = func_def.code.as_mut().ok_or_else(|| {
             anyhow!(
                 "`fun {}` must have a Move-defined body",
-                &*FUNC_NAME_RESOLVE_MULTI_STEP_PROPOSAL
+                *FUNC_NAME_RESOLVE_MULTI_STEP_PROPOSAL
             )
         })?;
 

--- a/aptos-move/aptos-transaction-simulation-session/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/state_store.rs
@@ -91,7 +91,7 @@ impl std::fmt::Display for HumanReadable<&StateKey> {
 
 impl std::fmt::Display for HumanReadable<StateKey> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &HumanReadable(&self.0))
+        write!(f, "{}", HumanReadable(&self.0))
     }
 }
 

--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -446,7 +446,7 @@ impl Scheduler {
         } else {
             return Err(code_invariant_error(format!(
                 "Status {:?} at block epilogue txn {} not ExecutionHalted",
-                &*status, block_epilogue_idx
+                *status, block_epilogue_idx
             )));
         }
 
@@ -985,7 +985,7 @@ impl Scheduler {
             ExecutionStatus::ExecutionHalted(_) => Ok(false),
             _ => Err(code_invariant_error(format!(
                 "Unexpected status {:?} in suspend",
-                &*status,
+                *status,
             ))),
         }
     }
@@ -1005,7 +1005,7 @@ impl Scheduler {
             ExecutionStatus::ExecutionHalted(_) => Ok(()),
             _ => Err(code_invariant_error(format!(
                 "Unexpected status {:?} in resume",
-                &*status,
+                *status,
             ))),
         }
     }
@@ -1031,7 +1031,7 @@ impl Scheduler {
             },
             _ => Err(code_invariant_error(format!(
                 "Expected Executing incarnation {incarnation}, got {:?}",
-                &*status,
+                *status,
             ))),
         }
     }
@@ -1056,7 +1056,7 @@ impl Scheduler {
             },
             _ => Err(code_invariant_error(format!(
                 "Expected Aborting incarnation {incarnation}, got {:?}",
-                &*status,
+                *status,
             ))),
         }
     }

--- a/aptos-move/cli/src/commands.rs
+++ b/aptos-move/cli/src/commands.rs
@@ -1344,7 +1344,7 @@ impl CliCommand<TransactionSummary> for PublishPackage {
         if self.chunked_publish_option.chunked_publish {
             let chunked_package_payloads: ChunkedPublishPayloads = (&self).async_try_into().await?;
 
-            let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", &chunked_package_payloads.payloads.len());
+            let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", chunked_package_payloads.payloads.len());
             println!("{}", message.bold());
             submit_chunked_publish_transactions(
                 chunked_package_payloads.payloads,
@@ -1524,7 +1524,7 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
                 .map(bcs::serialized_size)
                 .sum::<Result<usize, _>>()?;
             println!("package size {} bytes", size);
-            let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", &payloads.len());
+            let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", payloads.len());
             println!("{}", message.bold());
 
             submit_chunked_publish_transactions(
@@ -1643,7 +1643,7 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
                 .map(bcs::serialized_size)
                 .sum::<Result<usize, _>>()?;
             println!("package size {} bytes", size);
-            let message = format!("Upgrading package in chunked mode will submit {} transactions for staging and upgrading code.\n", &payloads.len());
+            let message = format!("Upgrading package in chunked mode will submit {} transactions for staging and upgrading code.\n", payloads.len());
             println!("{}", message.bold());
             submit_chunked_publish_transactions(
                 payloads,
@@ -1783,7 +1783,7 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
                 .map(bcs::serialized_size)
                 .sum::<Result<usize, _>>()?;
             println!("package size {} bytes", size);
-            let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", &payloads.len());
+            let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", payloads.len());
             println!("{}", message.bold());
 
             submit_chunked_publish_transactions(
@@ -1947,7 +1947,7 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
                 .map(bcs::serialized_size)
                 .sum::<Result<usize, _>>()?;
             println!("package size {} bytes", size);
-            let message = format!("Upgrading package in chunked mode will submit {} transactions for staging and upgrading code.\n", &payloads.len());
+            let message = format!("Upgrading package in chunked mode will submit {} transactions for staging and upgrading code.\n", payloads.len());
             println!("{}", message.bold());
             submit_chunked_publish_transactions(
                 payloads,
@@ -2040,7 +2040,7 @@ async fn submit_chunked_publish_transactions(
                         "Failed".to_string()
                     }
                 });
-                println!("Transaction executed: {} ({})\n", status, &tx_hash);
+                println!("Transaction executed: {} ({})\n", status, tx_hash);
                 tx_hashes.push(tx_hash);
                 publishing_result = Ok(tx_summary);
             },
@@ -2155,7 +2155,7 @@ impl CliCommand<TransactionSummary> for ClearStagingArea {
             .await?;
         println!(
             "Cleaning up resource {}::large_packages::StagingArea under account {}.",
-            &large_packages_module_address, account_address,
+            large_packages_module_address, account_address,
         );
         let payload = large_packages_cleanup_staging_area(large_packages_module_address);
         dispatch_transaction(payload, &self.txn_options, &self.env).await

--- a/aptos-move/e2e-move-test-harness/src/lib.rs
+++ b/aptos-move/e2e-move-test-harness/src/lib.rs
@@ -1289,12 +1289,16 @@ macro_rules! assert_abort {
         ));
     }};
     ($s:expr, $c:pat $(,)?) => {{
-        assert!(matches!(
-            $s,
-            aptos_types::transaction::TransactionStatus::Keep(
-                aptos_types::transaction::ExecutionStatus::MoveAbort { code: $c, .. }
-            ),
-        ));
+        // `$c` is allowed to be `_`, which makes `code: _` redundant with `..`.
+        #[allow(clippy::unneeded_wildcard_pattern)]
+        {
+            assert!(matches!(
+                $s,
+                aptos_types::transaction::TransactionStatus::Keep(
+                    aptos_types::transaction::ExecutionStatus::MoveAbort { code: $c, .. }
+                ),
+            ));
+        }
     }};
     ($s:expr, $c:ident, $($arg:tt)+) => {{
         assert!(
@@ -1309,15 +1313,19 @@ macro_rules! assert_abort {
         );
     }};
     ($s:expr, $c:pat, $($arg:tt)+) => {{
-        assert!(
-            matches!(
-                $s,
-                aptos_types::transaction::TransactionStatus::Keep(
-                    aptos_types::transaction::ExecutionStatus::MoveAbort { code: $c, .. }
+        // `$c` is allowed to be `_`, which makes `code: _` redundant with `..`.
+        #[allow(clippy::unneeded_wildcard_pattern)]
+        {
+            assert!(
+                matches!(
+                    $s,
+                    aptos_types::transaction::TransactionStatus::Keep(
+                        aptos_types::transaction::ExecutionStatus::MoveAbort { code: $c, .. }
+                    ),
                 ),
-            ),
-            $($arg)+
-        );
+                $($arg)+
+            );
+        }
     }};
 }
 

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -1587,7 +1587,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
                 .unwrap_or_else(|e| {
                     panic!(
                         "Error calling {}.{}: {}",
-                        &module_id,
+                        module_id,
                         function_name,
                         e.into_vm_status()
                     )

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -353,14 +353,14 @@ pub fn start_test_environment_node(
     println!("\tAptos root key path: {:?}", aptos_root_key_path);
     println!("\tWaypoint: {}", config.base.waypoint.genesis_waypoint());
     println!("\tChainId: {}", ChainId::test().id());
-    println!("\tREST API endpoint: http://{}", &config.api.address);
+    println!("\tREST API endpoint: http://{}", config.api.address);
     println!(
         "\tMetrics endpoint: http://{}:{}/metrics",
-        &config.inspection_service.address, &config.inspection_service.port
+        config.inspection_service.address, config.inspection_service.port
     );
     println!(
         "\tAptosnet fullnode network endpoint: {}",
-        &config.full_node_networks[0].listen_address
+        config.full_node_networks[0].listen_address
     );
     if config.indexer_grpc.enabled {
         println!(

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -99,7 +99,7 @@ impl ConfigSanitizer for SafetyRulesConfig {
             if chain_id.is_mainnet() && !safety_rules_config.service.is_local() {
                 return Err(Error::ConfigSanitizerFailed(
                     sanitizer_name,
-                    format!("The safety rules service should be set to local in mainnet for optimal performance! Given config: {:?}", &safety_rules_config.service)
+                    format!("The safety rules service should be set to local in mainnet for optimal performance! Given config: {:?}", safety_rules_config.service)
                 ));
             }
 

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -96,14 +96,14 @@ fn try_bind(port: Option<u16>) -> ::std::io::Result<u16> {
 fn lock_path() -> String {
     format!(
         "/tmp/aptos-port-counter.{}.lock",
-        &NEXTEST_RUN_ID.clone().unwrap()
+        NEXTEST_RUN_ID.clone().unwrap()
     )
 }
 
 fn counter_path() -> String {
     format!(
         "/tmp/aptos-port-counter.{}",
-        &NEXTEST_RUN_ID.clone().unwrap()
+        NEXTEST_RUN_ID.clone().unwrap()
     )
 }
 

--- a/crates/aptos-crypto-derive/src/lib.rs
+++ b/crates/aptos-crypto-derive/src/lib.rs
@@ -351,10 +351,7 @@ pub fn derive_enum_signature(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(CryptoHasher)]
 pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-    let hasher_name = Ident::new(
-        &format!("{}Hasher", &item.ident.to_string()),
-        Span::call_site(),
-    );
+    let hasher_name = Ident::new(&format!("{}Hasher", item.ident), Span::call_site());
     let snake_name = camel_to_snake(&item.ident.to_string());
     let static_seed_name = Ident::new(
         &format!("{}_SEED", snake_name.to_uppercase()),
@@ -441,7 +438,7 @@ pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
 pub fn bcs_crypto_hash_dispatch(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let name = &ast.ident;
-    let hasher_name = Ident::new(&format!("{}Hasher", &name.to_string()), Span::call_site());
+    let hasher_name = Ident::new(&format!("{}Hasher", name), Span::call_site());
     let error_msg = syn::LitStr::new(
         &format!("BCS serialization of {} should not fail", name),
         Span::call_site(),

--- a/crates/aptos-crypto/src/multi_ed25519.rs
+++ b/crates/aptos-crypto/src/multi_ed25519.rs
@@ -358,7 +358,7 @@ impl MultiEd25519Signature {
         }
 
         let mut sorted_signatures = signatures;
-        sorted_signatures.sort_by(|a, b| a.1.cmp(&b.1));
+        sorted_signatures.sort_by_key(|sig| sig.1);
 
         let mut bitmap = [0u8; BITMAP_NUM_OF_BYTES];
 

--- a/crates/aptos-crypto/src/weighted_config.rs
+++ b/crates/aptos-crypto/src/weighted_config.rs
@@ -280,7 +280,7 @@ impl<TC: ThresholdConfig> WeightedConfig<TC> {
             .map(|(i, w)| (self.get_player(i), *w))
             .collect::<Vec<(Player, usize)>>();
 
-        player_and_weights.sort_by(|a, b| a.1.cmp(&b.1));
+        player_and_weights.sort_by_key(|pw| pw.1);
         player_and_weights
     }
 

--- a/crates/aptos-faucet/core/src/funder/transfer.rs
+++ b/crates/aptos-faucet/core/src/funder/transfer.rs
@@ -362,7 +362,7 @@ pub struct MinimumFunds(pub u64);
 
 impl std::fmt::Display for MinimumFunds {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", &self.0)
+        write!(f, "{}", self.0)
     }
 }
 
@@ -382,7 +382,7 @@ pub struct AmountToFund(pub u64);
 
 impl std::fmt::Display for AmountToFund {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", &self.0)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/aptos-inspection-service/src/inspection_client.rs
+++ b/crates/aptos-inspection-service/src/inspection_client.rs
@@ -99,8 +99,8 @@ impl InspectionClient {
                 (Ok(iv), Ok(fv)) => Ok((k, MetricValue::I64orF64(iv, fv))),
                 (Err(_), Err(_)) => Err(anyhow::format_err!(
                     "Failed to parse stat value to i64 or f64 {}: {}",
-                    &k,
-                    &v
+                    k,
+                    v
                 )),
             })
             .collect()

--- a/crates/aptos-logger/src/tracing_adapter.rs
+++ b/crates/aptos-logger/src/tracing_adapter.rs
@@ -50,12 +50,12 @@ impl SpanData {
 
 impl tracing::field::Visit for SpanData {
     fn record_str(&mut self, field: &Field, value: &str) {
-        let name = format!("{}.{}", self.prefix, &field.name());
+        let name = format!("{}.{}", self.prefix, field.name());
         self.data.insert(name, value.to_string());
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        let name = format!("{}.{}", self.prefix, &field.name());
+        let name = format!("{}.{}", self.prefix, field.name());
         self.data.insert(name, format!("{:?}", value));
     }
 }

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -102,7 +102,7 @@ async fn build_block(
 
     // Ensure the transactions are sorted in order, this is required by Rosetta
     // NOTE: sorting may be pretty expensive, depending on the size of the block
-    transactions.sort_by(|first, second| first.metadata.version.0.cmp(&second.metadata.version.0));
+    transactions.sort_by_key(|txn| txn.metadata.version.0);
 
     Ok(Block {
         block_identifier,

--- a/crates/aptos-warp-webserver/src/error.rs
+++ b/crates/aptos-warp-webserver/src/error.rs
@@ -71,7 +71,7 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", self.status_code(), &self.message)?;
+        write!(f, "{}: {}", self.status_code(), self.message)?;
         if let Some(val) = &self.aptos_ledger_version {
             write!(f, "\nAptos ledger version: {}", val)?;
         }

--- a/crates/aptos/src/node/analyze/analyze_validators.rs
+++ b/crates/aptos/src/node/analyze/analyze_validators.rs
@@ -370,7 +370,7 @@ impl AnalyzeValidators {
             if event.round() != expected_round {
                 println!(
                     "Missing failed AccountAddresss : {} {:?}",
-                    previous_round, &event
+                    previous_round, event
                 );
                 assert!(expected_round < event.round());
                 trimmed_rounds += event.round() - expected_round;

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs
@@ -161,7 +161,7 @@ impl RunnableConfig for IndexerGrpcDataServiceConfig {
 
         println!(
             ">>>> Starting Redis connection: {:?}",
-            &self.redis_read_replica_address.0
+            self.redis_read_replica_address.0
         );
         let redis_conn = redis::Client::open(self.redis_read_replica_address.0.clone())?
             .get_tokio_connection_manager()
@@ -189,7 +189,7 @@ impl RunnableConfig for IndexerGrpcDataServiceConfig {
             .send_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);
-        println!(">>>> Starting gRPC server: {:?}", &svc);
+        println!(">>>> Starting gRPC server: {:?}", svc);
 
         let svc_clone = svc.clone();
         let reflection_service_clone = reflection_service.clone();

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -596,7 +596,7 @@ fn ensure_sequential_transactions(mut batches: Vec<Vec<Transaction>>) -> Vec<Tra
     }
 
     // Sort by the first version per batch, ascending
-    batches.sort_by(|a, b| a.first().unwrap().version.cmp(&b.first().unwrap().version));
+    batches.sort_by_key(|b| b.first().unwrap().version);
     let first_version = batches.first().unwrap().first().unwrap().version;
     let last_version = batches.last().unwrap().last().unwrap().version;
     let mut transactions: Vec<Transaction> = vec![];

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/src/processor.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/src/processor.rs
@@ -205,7 +205,7 @@ impl Processor {
                 match futures::future::try_join_all(tasks).await {
                     Ok(mut res) => {
                         // Check for gaps
-                        res.sort_by(|a, b| a.0.cmp(&b.0));
+                        res.sort_by_key(|a| a.0);
                         let mut prev_start = None;
                         let mut prev_end = None;
 

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/src/managed_node.rs
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/src/managed_node.rs
@@ -40,15 +40,13 @@ impl ManagedNode {
         let node_dir = get_derived_test_dir(&node_data_dir)?.join(INDEXER_TESTING_FOLDER);
         // By default, we don't reuse the testnet folder.
         if node_dir.exists() {
-            remove_dir_all(node_dir.as_path()).await.context(format!(
-                "Failed to remove testnet folder at {:?}",
-                &node_dir
-            ))?;
+            remove_dir_all(node_dir.as_path())
+                .await
+                .context(format!("Failed to remove testnet folder at {:?}", node_dir))?;
         }
-        create_dir_all(node_dir.as_path()).await.context(format!(
-            "Failed to create testnet folder at {:?}",
-            &node_dir
-        ))?;
+        create_dir_all(node_dir.as_path())
+            .await
+            .context(format!("Failed to create testnet folder at {:?}", node_dir))?;
         let rng = StdRng::from_seed(DEFAULT_SEED);
         let node = build_node_config(rng, &node_config_path, &None, false, node_dir.clone())
             .context("Failed to build node config")?;

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/src/script_transaction_generator.rs
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/src/script_transaction_generator.rs
@@ -98,7 +98,7 @@ impl ScriptTransactions {
         let cmd = create_compile_script_cmd(script_current_dir.clone());
         let compile_output = cmd.execute().await.context(format!(
             "Failed to compile the script: {:?}",
-            &script_current_dir
+            script_current_dir
         ))?;
 
         // Use the script location from CompileScript output (script.mv in package root).
@@ -108,7 +108,7 @@ impl ScriptTransactions {
         let cmd = create_run_script_cmd(compiled_script_path);
         let transaction_summary = cmd.execute().await.context(format!(
             "Failed to run the script: {:?}",
-            &script_current_dir
+            script_current_dir
         ))?;
         sender_account
             .delete_profile_file(&script_path)
@@ -118,7 +118,7 @@ impl ScriptTransactions {
         if let Some(true) = transaction_summary.success {
             Ok(transaction_summary.version.unwrap())
         } else {
-            anyhow::bail!("Failed to execute the script: {:?}", &script_current_dir);
+            anyhow::bail!("Failed to execute the script: {:?}", script_current_dir);
         }
     }
 

--- a/keyless/pepper/service/src/dedicated_handlers/pepper_request.rs
+++ b/keyless/pepper/service/src/dedicated_handlers/pepper_request.rs
@@ -211,14 +211,14 @@ async fn create_pepper_input(
             None => {
                 return Err(PepperServiceError::UnexpectedError(format!(
                     "The issuer {} and aud {} correspond to an account recovery manager, but no aud override was provided!",
-                    &iss, &claims_aud
+                    iss, claims_aud
                 )));
             },
         }
     } else if let Some(aud_override) = aud_override {
         return Err(PepperServiceError::UnexpectedError(format!(
             "The issuer {} and aud {} do not correspond to an account recovery manager, but an aud override was provided: {}!",
-            &iss, &claims_aud, &aud_override
+            iss, claims_aud, aud_override
         )));
     } else {
         claims_aud // Use the aud directly from the claims

--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -34,10 +34,11 @@ use aptos_storage_interface::{DbReader, StateKind};
 use aptos_storage_service_client::StorageServiceClient;
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
-        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        NumberOfStatesRequestV2, StateValuesWithProofRequest, StateValuesWithProofRequestV2,
-        StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, HotStateValuesWithProofRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+        NewTransactionsWithProofRequest, NumberOfStatesRequestV2, StateValuesWithProofRequest,
+        StateValuesWithProofRequestV2, StorageServiceRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
@@ -52,7 +53,7 @@ use aptos_time_service::TimeService;
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use arc_swap::ArcSwap;
@@ -1095,6 +1096,33 @@ impl AptosDataClientInterface for AptosDataClient {
                 Ok(response.map(|response| response.state_value_chunk_with_proof))
             },
         }
+    }
+
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> crate::error::Result<Response<u64>> {
+        let data_request = DataRequest::GetNumberOfHotStatesAtVersion(version);
+        self.create_and_send_storage_request(request_timeout_ms, data_request)
+            .await
+    }
+
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> crate::error::Result<Response<HotStateValueChunkWithProof>> {
+        let data_request =
+            DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
+                version,
+                start_index,
+                end_index,
+            });
+        self.create_and_send_storage_request(request_timeout_ms, data_request)
+            .await
     }
 
     async fn get_transaction_outputs_with_proof(

--- a/state-sync/aptos-data-client/src/global_summary.rs
+++ b/state-sync/aptos-data-client/src/global_summary.rs
@@ -106,7 +106,7 @@ impl fmt::Debug for AdvertisedData {
         write!(
             f,
             "epoch_ending_ledger_infos: {:?}, states: {:?}, synced_ledger_infos: [{}], transactions: {:?}, transaction_outputs: {:?}",
-            &self.epoch_ending_ledger_infos, &self.states, synced_ledger_infos, &self.transactions, &self.transaction_outputs
+            self.epoch_ending_ledger_infos, self.states, synced_ledger_infos, self.transactions, self.transaction_outputs
         )
     }
 }

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -6,7 +6,7 @@ use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{responses::TransactionOrOutputListWithProofV2, Epoch};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use async_trait::async_trait;
@@ -90,6 +90,23 @@ pub trait AptosDataClientInterface {
         request_timeout_ms: u64,
         kind: StateKind,
     ) -> error::Result<Response<StateValueChunkWithProof>>;
+
+    /// Fetches the number of hot states at the specified version.
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<u64>>;
+
+    /// Fetches a single hot state value chunk with proof, containing the values
+    /// from start to end index (inclusive) at the specified version.
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<HotStateValueChunkWithProof>>;
 
     /// Fetches a transaction output list with proof, with transaction
     /// outputs from start to end versions (inclusive). The proof is relative
@@ -268,6 +285,7 @@ impl<T> Response<T> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResponsePayload {
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
+    HotStateValuesWithProof(HotStateValueChunkWithProof),
     NewTransactionOutputsWithProof((TransactionOutputListWithProofV2, LedgerInfoWithSignatures)),
     NewTransactionsWithProof((TransactionListWithProofV2, LedgerInfoWithSignatures)),
     NumberOfStates(u64),
@@ -282,6 +300,7 @@ impl ResponsePayload {
     pub fn get_label(&self) -> &'static str {
         match self {
             Self::EpochEndingLedgerInfos(_) => "epoch_ending_ledger_infos",
+            Self::HotStateValuesWithProof(_) => "hot_state_values_with_proof",
             Self::NewTransactionOutputsWithProof(_) => "new_transaction_outputs_with_proof",
             Self::NewTransactionsWithProof(_) => "new_transactions_with_proof",
             Self::NumberOfStates(_) => "number_of_states",
@@ -297,6 +316,9 @@ impl ResponsePayload {
         match self {
             Self::EpochEndingLedgerInfos(epoch_ending_ledger_infos) => {
                 epoch_ending_ledger_infos.len()
+            },
+            Self::HotStateValuesWithProof(hot_state_values_with_proof) => {
+                hot_state_values_with_proof.raw_values.len()
             },
             Self::NewTransactionOutputsWithProof((outputs_with_proof, _)) => {
                 outputs_with_proof.get_num_outputs()
@@ -323,6 +345,12 @@ impl ResponsePayload {
 impl From<StateValueChunkWithProof> for ResponsePayload {
     fn from(inner: StateValueChunkWithProof) -> Self {
         Self::StateValuesWithProof(inner)
+    }
+}
+
+impl From<HotStateValueChunkWithProof> for ResponsePayload {
+    fn from(inner: HotStateValueChunkWithProof) -> Self {
+        Self::HotStateValuesWithProof(inner)
     }
 }
 

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -36,7 +36,7 @@ use aptos_storage_service_types::{
 use aptos_time_service::{MockTimeService, TimeService};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
     PeerId,
 };
@@ -316,6 +316,20 @@ mock! {
             request_timeout_ms: u64,
             kind: StateKind,
         ) -> Result<Response<StateValueChunkWithProof>>;
+
+        async fn get_number_of_hot_states(
+            &self,
+            version: Version,
+            request_timeout_ms: u64,
+        ) -> Result<Response<u64>>;
+
+        async fn get_hot_state_values_with_proof(
+            &self,
+            version: u64,
+            start_index: u64,
+            end_index: u64,
+            request_timeout_ms: u64,
+        ) -> Result<Response<HotStateValueChunkWithProof>>;
 
         async fn get_transaction_outputs_with_proof(
             &self,

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -2223,6 +2223,10 @@ fn create_data_notification(
         // The number of states is consumed internally by the engine for chunk
         // planning; it is never surfaced to the consumer as a notification.
         ResponsePayload::NumberOfStates(_) => invalid_response_type!(client_response_type),
+        // TODO(HotState): hot state values are not streamed yet.
+        ResponsePayload::HotStateValuesWithProof(_) => {
+            invalid_response_type!(client_response_type)
+        },
         ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
             DataPayload::EpochEndingLedgerInfos(ledger_infos)
         },

--- a/state-sync/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/data-streaming-service/src/tests/utils.rs
@@ -16,9 +16,10 @@ use aptos_logger::Level;
 use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
-        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, HotStateValuesWithProofRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+        NewTransactionsWithProofRequest, StateValuesWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
@@ -35,6 +36,7 @@ use aptos_types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::SparseMerkleRangeProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -64,6 +66,7 @@ use tokio::time::timeout;
 pub const MAX_NOTIFICATION_TIMEOUT_SECS: u64 = 10;
 pub const MAX_RESPONSE_ID: u64 = 100000;
 pub const TOTAL_NUM_STATE_VALUES: u64 = 2000;
+pub const TOTAL_NUM_HOT_STATE_VALUES: u64 = 100;
 
 /// Test constants for advertised data
 pub const MIN_ADVERTISED_EPOCH_END: u64 = 100;
@@ -328,6 +331,54 @@ impl AptosDataClientInterface for MockAptosDataClient {
         Ok(create_data_client_response(state_value_chunk_with_proof))
     }
 
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: Version,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> Result<Response<HotStateValueChunkWithProof>, aptos_data_client::error::Error> {
+        // Verify the request timeout
+        let data_request =
+            DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
+                version,
+                start_index,
+                end_index,
+            });
+        self.verify_request_timeout_value(request_timeout_ms, false, false, data_request);
+
+        // Emulate network latencies
+        self.emulate_network_latencies().await;
+
+        // Calculate the last index based on if we should limit the chunk size
+        let end_index = self.calculate_last_index(start_index, end_index);
+
+        // Create hot state keys and values according to the given indices
+        let mut hot_state_keys_and_values = vec![];
+        for _ in start_index..=end_index {
+            hot_state_keys_and_values.push((
+                StateKey::raw(HashValue::random().as_ref()),
+                HotStateValue::new(Some(StateValue::from(vec![])), version),
+            ));
+        }
+
+        // Create a hot state value chunk with proof
+        let hot_state_value_chunk_with_proof = HotStateValueChunkWithProof {
+            first_index: start_index,
+            last_index: end_index,
+            first_key: HashValue::random(),
+            last_key: HashValue::random(),
+            raw_values: hot_state_keys_and_values,
+            proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
+        };
+
+        // Create and send a data client response
+        Ok(create_data_client_response(
+            hot_state_value_chunk_with_proof,
+        ))
+    }
+
     async fn get_epoch_ending_ledger_infos(
         &self,
         start_epoch: Epoch,
@@ -542,6 +593,22 @@ impl AptosDataClientInterface for MockAptosDataClient {
 
         // Create and send a data client response
         Ok(create_data_client_response(TOTAL_NUM_STATE_VALUES))
+    }
+
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> Result<Response<u64>, aptos_data_client::error::Error> {
+        // Verify the request timeout
+        let data_request = DataRequest::GetNumberOfHotStatesAtVersion(version);
+        self.verify_request_timeout_value(request_timeout_ms, false, false, data_request);
+
+        // Emulate network latencies
+        self.emulate_network_latencies().await;
+
+        // Create and send a data client response
+        Ok(create_data_client_response(TOTAL_NUM_HOT_STATE_VALUES))
     }
 
     async fn get_transaction_outputs_with_proof(

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -45,7 +45,7 @@ impl Cmd {
                 !backup_checkpoint_dir.exists(),
                 "Backup dir already exists."
             );
-            println!("Creating backup at: {:?}", &backup_checkpoint_dir);
+            println!("Creating backup at: {:?}", backup_checkpoint_dir);
             fs::create_dir_all(&backup_checkpoint_dir)?;
             AptosDB::create_checkpoint(&self.db_dir, backup_checkpoint_dir)?;
             println!("Done!");

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -629,7 +629,7 @@ impl StateKvDb {
         mut entries: Vec<(HashValue, Version, StateSlotKind)>,
     ) -> LoadedHotStateShard {
         // Index 0 = oldest (LRU tail), last = newest (MRU head).
-        entries.sort_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
+        entries.sort_by_key(|e| (e.1, e.0));
 
         let num_items = entries.len();
         let map = DashMap::with_capacity(num_items);

--- a/storage/backup/backup-cli/src/storage/command_adapter/command.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/command.rs
@@ -81,12 +81,12 @@ impl SpawnedCommand {
         ensure!(
             child.stdin.is_some(),
             "child.stdin is None. cmd: {:?}",
-            &command,
+            command,
         );
         ensure!(
             child.stdout.is_some(),
             "child.stdout is None. cmd: {:?}",
-            &command,
+            command,
         );
 
         Ok(Self { command, child })

--- a/testsuite/forge/src/backend/k8s/chaos.rs
+++ b/testsuite/forge/src/backend/k8s/chaos.rs
@@ -107,13 +107,13 @@ impl K8sSwarm {
 
             network_chaos_specs.push(format!(
                 include_str!(DELAY_NETWORK_CHAOS_TEMPLATE!()),
-                name = &group_network_delay.name,
+                name = group_network_delay.name,
                 namespace = self.kube_namespace,
                 latency_ms = group_network_delay.latency_ms,
                 jitter_ms = group_network_delay.jitter_ms,
                 correlation_percentage = group_network_delay.correlation_percentage,
-                instance_labels = &source_instance_labels,
-                target_instance_labels = &target_instance_labels,
+                instance_labels = source_instance_labels,
+                target_instance_labels = target_instance_labels,
             ));
         }
         Ok(network_chaos_specs.join("\n---\n"))
@@ -171,17 +171,17 @@ impl K8sSwarm {
 
             network_chaos_specs.push(format!(
                 include_str!(NETEM_CHAOS_TEMPLATE!()),
-                name = &group_netem.name,
+                name = group_netem.name,
                 namespace = self.kube_namespace,
                 delay_latency_ms = group_netem.delay_latency_ms,
                 delay_jitter_ms = group_netem.delay_jitter_ms,
                 delay_correlation_percentage = group_netem.delay_correlation_percentage,
                 loss_percentage = group_netem.loss_percentage,
                 loss_correlation_percentage = group_netem.loss_correlation_percentage,
-                instance_labels = &source_instance_labels,
-                target_instance_labels = &target_instance_labels,
+                instance_labels = source_instance_labels,
+                target_instance_labels = target_instance_labels,
                 rate = group_netem.rate_in_mbps,
-                service_targets = &service_targets,
+                service_targets = service_targets,
             ));
         }
 
@@ -200,11 +200,11 @@ impl K8sSwarm {
 
             cpu_stress_specs.push(format!(
                 include_str!(CPU_STRESS_CHAOS_TEMPLATE!()),
-                name = &group_cpu_stress.name,
+                name = group_cpu_stress.name,
                 namespace = self.kube_namespace,
                 num_workers = group_cpu_stress.num_workers,
                 load_per_worker = group_cpu_stress.load_per_worker,
-                instance_labels = &instance_labels,
+                instance_labels = instance_labels,
             ));
         }
 

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -62,7 +62,7 @@ pub fn dump_string_to_file(
     tmp_dir: &TempDir,
 ) -> Result<String> {
     let file_path = tmp_dir.path().join(file_name.clone());
-    info!("Wrote content to: {:?}", &file_path);
+    info!("Wrote content to: {:?}", file_path);
     let mut file = File::create(file_path).expect("Could not create file in temp dir");
     file.write_all(&content.into_bytes())
         .expect("Could not write to file");
@@ -92,13 +92,13 @@ async fn tail_job_logs(
         .map_err(|e| LogJobError::FinalError(format!("Failed to get job status: {}", e)))?;
 
     let status = genesis_job.status.expect("Job status not found");
-    info!("Job {} status: {:?}", &job_name, status);
+    info!("Job {} status: {:?}", job_name, status);
     match status.active {
         Some(active) => {
             if active < 1 {
                 return Err(LogJobError::RetryableError(format!(
                     "Job {} has no active pods. Maybe it has not started yet",
-                    &job_name
+                    job_name
                 )));
             }
             // try tailing the logs of the genesis job
@@ -110,7 +110,7 @@ async fn tail_job_logs(
                     "logs",
                     "--tail=10", // in case of connection reset we only want the last few lines to avoid spam
                     "-f",
-                    format!("job/{}", &job_name).as_str(),
+                    format!("job/{}", job_name).as_str(),
                 ])
                 .stdout(Stdio::piped())
                 .spawn()
@@ -129,7 +129,7 @@ async fn tail_job_logs(
             while let Some(line) = reader.next_line().await.transpose() {
                 match line {
                     Ok(line) => {
-                        info!("[{}]: {}", &job_name, line); // Add a prefix to each line
+                        info!("[{}]: {}", job_name, line); // Add a prefix to each line
                     },
                     Err(e) => {
                         return Err(LogJobError::RetryableError(format!(
@@ -143,22 +143,22 @@ async fn tail_job_logs(
                 LogJobError::RetryableError(format!("Error waiting for command: {}", e))
             })?;
         },
-        None => info!("Job {} has no active pods running", &job_name),
+        None => info!("Job {} has no active pods running", job_name),
     }
     match status.succeeded {
         Some(_) => {
-            info!("Job {} succeeded!", &job_name);
+            info!("Job {} succeeded!", job_name);
             return Ok(());
         },
-        None => info!("Job {} has no succeeded pods", &job_name),
+        None => info!("Job {} has no succeeded pods", job_name),
     }
     if status.failed.is_some() {
-        info!("Job {} failed!", &job_name);
-        return Err(LogJobError::FinalError(format!("Job {} failed", &job_name)));
+        info!("Job {} failed!", job_name);
+        return Err(LogJobError::FinalError(format!("Job {} failed", job_name)));
     }
     Err(LogJobError::RetryableError(format!(
         "Job {} has no succeeded or failed pods. Maybe it has not started yet.",
-        &job_name
+        job_name
     )))
 }
 
@@ -348,21 +348,21 @@ async fn delete_k8s_cluster(kube_namespace: String) -> Result<()> {
             // delete the management configmap
             let configmap: Api<ConfigMap> = Api::namespaced(client.clone(), &kube_namespace);
             let management_configmap_name =
-                format!("{}-{}", MANAGEMENT_CONFIGMAP_PREFIX, &kube_namespace);
+                format!("{}-{}", MANAGEMENT_CONFIGMAP_PREFIX, kube_namespace);
             match configmap
                 .delete(&management_configmap_name, &DeleteParams::default())
                 .await
             {
                 Ok(_) => info!(
                     "Deleted default management configmap: {}",
-                    &management_configmap_name
+                    management_configmap_name
                 ),
                 // if configmap not found, assume it's already been deleted and make clean-up idempotent
                 Err(KubeError::Api(api_err)) => {
                     if api_err.code == 404 {
                         info!(
                             "Could not find configmap {}, continuing",
-                            &management_configmap_name
+                            management_configmap_name
                         );
                     } else {
                         bail!(api_err);
@@ -900,12 +900,12 @@ pub async fn create_namespace(
             if api_err.message.contains("object is being deleted") {
                 return Err(ApiError::RetryableError(format!(
                     "Namespace {} is being deleted (Terminating), will retry",
-                    &kube_namespace_name
+                    kube_namespace_name
                 )));
             }
             info!(
                 "Namespace {} already exists, continuing with it",
-                &kube_namespace_name
+                kube_namespace_name
             );
         } else if api_err.code == 401 {
             return Err(ApiError::FinalError(
@@ -916,7 +916,7 @@ pub async fn create_namespace(
         } else {
             return Err(ApiError::RetryableError(format!(
                 "Failed to use existing namespace {}: {:?}",
-                &kube_namespace_name, api_err
+                kube_namespace_name, api_err
             )));
         }
     }
@@ -949,7 +949,7 @@ pub async fn create_management_configmap(
         Some(kube_namespace.clone()),
     ));
 
-    let management_configmap_name = format!("{}-{}", MANAGEMENT_CONFIGMAP_PREFIX, &kube_namespace);
+    let management_configmap_name = format!("{}-{}", MANAGEMENT_CONFIGMAP_PREFIX, kube_namespace);
     let mut data: BTreeMap<String, String> = BTreeMap::new();
     let start = SystemTime::now();
     let cleanup_time = (start
@@ -975,12 +975,12 @@ pub async fn create_management_configmap(
         if api_err.code == 409 {
             info!(
                 "Configmap {} already exists, continuing with it",
-                &management_configmap_name
+                management_configmap_name
             );
         } else {
             bail!(
                 "Failed to use existing management configmap {}: {:?}",
-                &kube_namespace,
+                kube_namespace,
                 api_err
             );
         }
@@ -1022,7 +1022,7 @@ pub async fn cleanup_cluster_with_management(dry_run: bool) -> Result<()> {
                 return false;
             }
             if let Some(data) = &configmap.data {
-                info!("Got configmap {} with data: {:?}", &configmap_name, data);
+                info!("Got configmap {} with data: {:?}", configmap_name, data);
                 return check_namespace_for_cleanup(
                     data,
                     configmap_namespace,

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -197,7 +197,7 @@ impl Factory for K8sFactory {
             let new_era = generate_new_era();
             info!(
                 "Creating new era {} in namespace {}",
-                &new_era, &self.kube_namespace
+                new_era, self.kube_namespace
             );
 
             // Testnet install phase

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -293,7 +293,7 @@ impl Node for K8sNode {
     fn inspection_service_endpoint(&self) -> Url {
         Url::parse(&format!(
             "http://{}:{}",
-            &self.service_name(),
+            self.service_name(),
             self.rest_api_port()
         ))
         .unwrap()

--- a/testsuite/forge/src/backend/k8s/stateful_set.rs
+++ b/testsuite/forge/src/backend/k8s/stateful_set.rs
@@ -124,27 +124,27 @@ async fn check_stateful_set_status(
                                 if let Some(waiting_reason) = &waiting.reason {
                                     match waiting_reason.as_str() {
                                         "ImagePullBackOff" => {
-                                            info!("Pod {} has ImagePullBackOff", &pod_name);
+                                            info!("Pod {} has ImagePullBackOff", pod_name);
                                             return Err(WorkloadScalingError::FinalError(
                                                 "ImagePullBackOff".to_string(),
                                             ));
                                         },
                                         "CrashLoopBackOff" => {
-                                            info!("Pod {} has CrashLoopBackOff", &pod_name);
+                                            info!("Pod {} has CrashLoopBackOff", pod_name);
                                             return Err(WorkloadScalingError::FinalError(
                                                 "CrashLoopBackOff".to_string(),
                                             ));
                                         },
                                         "ErrImagePull" => {
-                                            info!("Pod {} has ErrImagePull", &pod_name);
+                                            info!("Pod {} has ErrImagePull", pod_name);
                                             return Err(WorkloadScalingError::FinalError(
                                                 "ErrImagePull".to_string(),
                                             ));
                                         },
                                         _ => {
-                                            info!("Waiting for pod {}", &pod_name);
+                                            info!("Waiting for pod {}", pod_name);
                                             return Err(WorkloadScalingError::RetryableError(
-                                                format!("Waiting for pod {}", &pod_name),
+                                                format!("Waiting for pod {}", pod_name),
                                             ));
                                         },
                                     }
@@ -154,16 +154,16 @@ async fn check_stateful_set_status(
                     }
                 }
                 if let Some(phase) = status.phase.as_ref() {
-                    info!("Pod {} at phase {}", &pod_name, phase)
+                    info!("Pod {} at phase {}", pod_name, phase)
                 }
                 Err(WorkloadScalingError::RetryableError(format!(
                     "Retry due to pod {} status {:?}",
-                    &pod_name, status
+                    pod_name, status
                 )))
             } else {
                 Err(WorkloadScalingError::FinalError(format!(
                     "Pod {} status not found",
-                    &pod_name
+                    pod_name
                 )))
             }
         },
@@ -191,7 +191,7 @@ pub async fn set_stateful_set_image_tag(
     let image_repo = get_stateful_set_image(&sts)?.name;
 
     // replace the image tag
-    let new_image = format!("{}:{}", &image_repo, &image_tag);
+    let new_image = format!("{}:{}", image_repo, image_tag);
 
     // set the image using kubectl
     // patching the node spec may not work
@@ -201,8 +201,8 @@ pub async fn set_stateful_set_image_tag(
             &kube_namespace,
             "set",
             "image",
-            &format!("statefulset/{}", &stateful_set_name),
-            &format!("{}={}", &container_name, &new_image),
+            &format!("statefulset/{}", stateful_set_name),
+            &format!("{}={}", container_name, new_image),
         ])
         .status()
         .expect("Failed to set image for StatefulSet");
@@ -294,7 +294,7 @@ pub async fn check_for_container_restart(
                             bail!(
                                 "Container {} in pod {} restarted {} times ",
                                 container_status.name,
-                                &pod_name,
+                                pod_name,
                                 container_status.restart_count
                             );
                         }

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -542,7 +542,7 @@ fn parse_service_name_from_stateful_set_name(
     let cap = re.captures(stateful_set_name).unwrap();
     let service_base_name = format!("{}-{}", &cap[1], &cap[2]);
     if enable_haproxy {
-        format!("{}-{}", &service_base_name, HAPROXY_SERVICE_SUFFIX)
+        format!("{}-{}", service_base_name, HAPROXY_SERVICE_SUFFIX)
     } else {
         service_base_name
     }
@@ -564,7 +564,7 @@ fn get_k8s_node_from_stateful_set(
     // if we're not using port-forward and expecting to hit the service directly, we should use the full service name
     // since the test runner may be in a separate namespace
     if !use_port_forward {
-        service_name = format!("{}.{}.svc", &service_name, &namespace);
+        service_name = format!("{}.{}.svc", service_name, namespace);
     }
 
     // Append the cluster name if its a multi-cluster deployment
@@ -574,7 +574,7 @@ fn get_k8s_node_from_stateful_set(
         .as_ref()
         .and_then(|labels| labels.get("multicluster/targetcluster"))
     {
-        format!("{}.{}", &service_name, &target_cluster_name)
+        format!("{}.{}", service_name, target_cluster_name)
     } else {
         service_name
     };
@@ -598,7 +598,7 @@ fn get_k8s_node_from_stateful_set(
         .tag;
 
     K8sNode {
-        name: format!("{}-{}", &node_type, index),
+        name: format!("{}-{}", node_type, index),
         stateful_set_name: stateful_set_name.clone(),
         // TODO: fetch this from running node
         peer_id: PeerId::random(),
@@ -728,7 +728,7 @@ pub async fn nodes_healthcheck(nodes: Vec<&K8sNode>) -> Result<Vec<String>> {
                     },
                     Err(err) => {
                         let err = anyhow::Error::from(err);
-                        info!("Node {} unhealthy: {}", node.name(), &err);
+                        info!("Node {} unhealthy: {}", node.name(), err);
                         Err(err)
                     },
                 }

--- a/testsuite/forge/src/backend/k8s_deployer/deployer.rs
+++ b/testsuite/forge/src/backend/k8s_deployer/deployer.rs
@@ -193,7 +193,7 @@ impl ForgeDeployerManager {
     /// Errors are logged and ignored since the resources may not exist.
     async fn cleanup_deployer_resources(&self) {
         let name = self.get_name();
-        info!("Cleaning up pre-existing deployer resources for: {}", &name);
+        info!("Cleaning up pre-existing deployer resources for: {}", name);
 
         let force_delete = DeleteParams {
             grace_period_seconds: Some(0),
@@ -202,27 +202,27 @@ impl ForgeDeployerManager {
 
         // Delete the job first, then the configmap (reverse order of creation)
         match self.jobs_api.delete(&name, &force_delete).await {
-            Ok(_) => info!("Deleted pre-existing deployer job: {}", &name),
+            Ok(_) => info!("Deleted pre-existing deployer job: {}", name),
             Err(kube::Error::Api(api_err)) if api_err.code == 404 => {
-                info!("No pre-existing deployer job found: {}", &name);
+                info!("No pre-existing deployer job found: {}", name);
             },
             Err(e) => {
                 info!(
                     "Failed to delete pre-existing deployer job {}: {:?}. Continuing anyway.",
-                    &name, e
+                    name, e
                 );
             },
         }
 
         match self.config_maps_api.delete(&name, &force_delete).await {
-            Ok(_) => info!("Deleted pre-existing deployer configmap: {}", &name),
+            Ok(_) => info!("Deleted pre-existing deployer configmap: {}", name),
             Err(kube::Error::Api(api_err)) if api_err.code == 404 => {
-                info!("No pre-existing deployer configmap found: {}", &name);
+                info!("No pre-existing deployer configmap found: {}", name);
             },
             Err(e) => {
                 info!(
                     "Failed to delete pre-existing deployer configmap {}: {:?}. Continuing anyway.",
-                    &name, e
+                    name, e
                 );
             },
         }
@@ -273,12 +273,12 @@ impl ForgeDeployerManager {
     async fn ensure_namespace_prepared(&self) -> Result<(), ApiError> {
         info!("Ensuring namespace is prepared");
         let namespace = self.build_namespace();
-        info!("Creating namespace: {}", &namespace.name());
+        info!("Creating namespace: {}", namespace.name());
         maybe_create_k8s_resource(self.namespace_api.clone(), namespace.clone()).await?;
         let service_account = self.build_service_account();
         info!(
             "Creating service account and role binding: {}",
-            &service_account.name()
+            service_account.name()
         );
         maybe_create_k8s_resource(self.serviceaccount_api.clone(), service_account).await?;
         let role_binding = self.build_role_binding();

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -602,10 +602,7 @@ impl SuccessCriteriaChecker {
             || gap_info.non_epoch_time_gap.max_gap
                 > chain_progress_threshold.max_non_epoch_no_progress_secs
         {
-            bail!(
-                "Failed non-epoch-change chain progress check. {}",
-                &gap_text
-            );
+            bail!("Failed non-epoch-change chain progress check. {}", gap_text);
         }
         info!("Passed non-epoch-change progress check. {}", gap_text);
 
@@ -615,7 +612,7 @@ impl SuccessCriteriaChecker {
         {
             bail!(
                 "Failed epoch-change chain progress check. {}",
-                &epoch_gap_text
+                epoch_gap_text
             );
         }
         info!("Passed epoch-change progress check. {}", epoch_gap_text);

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -50,7 +50,7 @@ fn analyze_serde_formats() {
                     key,
                     corpus,
                     e.get(),
-                    &value,
+                    value,
                 ),
             }
         }

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -1103,7 +1103,7 @@ async fn print_account_resource<T: DeserializeOwned + Debug>(
         .await;
 
     let rsrc = maybe_response.unwrap().into_inner();
-    println!("{}: {:?}", message, &rsrc);
+    println!("{}: {:?}", message, rsrc);
 
     rsrc
 }

--- a/testsuite/testcases/src/forge_setup_test.rs
+++ b/testsuite/testcases/src/forge_setup_test.rs
@@ -49,7 +49,7 @@ impl NetworkTest for ForgeSetupTest {
             for _ in 0..10 {
                 let query = format!(
                     "{}{{instance=\"{}\",type=\"synced\"}}",
-                    STATE_SYNC_VERSION_COUNTER_NAME, &fullnode_name
+                    STATE_SYNC_VERSION_COUNTER_NAME, fullnode_name
                 );
                 info!("PromQL Query {}", query);
                 let r = swarm.query_metrics(&query, None, None).await?;

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -94,7 +94,7 @@ impl NetworkTest for StateSyncFullnodeFastSyncPerformance {
             let fullnode_name = swarm.full_nodes().next().unwrap().name();
             format!(
                 "{}{{instance=\"{}\"}}",
-                NUM_STATE_VALUE_COUNTER_NAME, &fullnode_name
+                NUM_STATE_VALUE_COUNTER_NAME, fullnode_name
             )
         };
 

--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -546,7 +546,7 @@ fn read_table_contents<'a>(
 /// Tables cannot have duplicates, must cover the entire blob and must be disjoint.
 fn check_tables(tables: &mut Vec<Table>, binary_len: usize) -> BinaryLoaderResult<u32> {
     // there is no real reason to pass a mutable reference but we are sorting next line
-    tables.sort_by(|t1, t2| t1.offset.cmp(&t2.offset));
+    tables.sort_by_key(|t| t.offset);
 
     let mut current_offset: u32 = 0;
     let mut table_types = HashSet::new();

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/ast.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/ast.rs
@@ -991,7 +991,7 @@ impl fmt::Display for AttributeName_ {
 
 impl fmt::Display for ModuleIdent_ {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}::{}", self.address, &self.module)
+        write!(f, "{}::{}", self.address, self.module)
     }
 }
 

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/ast.rs
@@ -1196,7 +1196,7 @@ impl fmt::Display for LeadingNameAccess_ {
 
 impl fmt::Display for ModuleIdent_ {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}::{}", self.address, &self.module)
+        write!(f, "{}::{}", self.address, self.module)
     }
 }
 

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/mod.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/mod.rs
@@ -61,7 +61,7 @@ pub(crate) fn parse_program(
         }
         // sort the filenames so errors about redefinitions, or other inter-file conflicts, are
         // deterministic
-        res.sort_by(|p1, p2| p1.path.cmp(&p2.path));
+        res.sort_by_key(|p| p.path);
         Ok(res)
     }
 

--- a/third_party/move/move-compiler-v2/src/logging.rs
+++ b/third_party/move/move-compiler-v2/src/logging.rs
@@ -147,7 +147,7 @@ fn format_record_file(
         "[{} {}] {}",
         record.level(),
         record.module_path().unwrap_or_default(),
-        &record.args()
+        record.args()
     )
 }
 
@@ -162,7 +162,7 @@ fn format_record_file_ts(
         now.format("%H:%M:%S"),
         record.level(),
         record.module_path().unwrap_or_default(),
-        &record.args()
+        record.args()
     )
 }
 
@@ -178,7 +178,7 @@ fn format_record_colored(
         Level::Debug => "DEBUG".cyan().bold(),
         Level::Trace => "TRACE".normal(),
     };
-    write!(w, "[{}] {}", level_color, &record.args())
+    write!(w, "[{}] {}", level_color, record.args())
 }
 
 fn format_record_colored_ts(
@@ -198,6 +198,6 @@ fn format_record_colored_ts(
         "[{} {}] {}",
         now.format("%H:%M:%S"),
         level_color,
-        &record.args()
+        record.args()
     )
 }

--- a/third_party/move/move-core/types/src/identifier.rs
+++ b/third_party/move/move-core/types/src/identifier.rs
@@ -202,7 +202,7 @@ impl Deref for Identifier {
 
 impl fmt::Display for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", &self.0)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/third_party/move/move-ir/types/src/ast.rs
+++ b/third_party/move/move-ir/types/src/ast.rs
@@ -1246,13 +1246,13 @@ impl fmt::Display for ModuleDefinition {
 
 impl fmt::Display for ImportDefinition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "import {} as {}", &self.ident, &self.alias)
+        write!(f, "import {} as {}", self.ident, self.alias)
     }
 }
 
 impl fmt::Display for ModuleDependency {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Dependency({}, ", &self.name)?;
+        write!(f, "Dependency({}, ", self.name)?;
         for sdep in &self.structs {
             writeln!(f, "{}, ", sdep)?
         }
@@ -1273,7 +1273,7 @@ impl fmt::Display for StructDependency {
                 .map(|a| format!("{}", a))
                 .collect::<Vec<_>>()
                 .join(" "),
-            &self.name,
+            self.name,
             format_struct_type_formals(&self.type_formals)
         )
     }
@@ -1281,7 +1281,7 @@ impl fmt::Display for StructDependency {
 
 impl fmt::Display for FunctionDependency {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FunctionDep({}{}", &self.name, &self.signature)
+        write!(f, "FunctionDep({}{}", self.name, self.signature)
     }
 }
 
@@ -1306,7 +1306,7 @@ impl fmt::Display for Constant {
         write!(
             f,
             "const {}: {} = {}",
-            &self.name.0,
+            self.name.0,
             self.signature,
             format_move_value(&self.value)
         )
@@ -1374,7 +1374,7 @@ impl fmt::Display for FunctionBody {
                 }
                 writeln!(f, "]")?;
                 for (label, block) in code {
-                    writeln!(f, "{}:", &label)?;
+                    writeln!(f, "{}:", label)?;
                     for instr in block {
                         writeln!(f, "  {}", instr)?;
                     }
@@ -1702,10 +1702,10 @@ impl fmt::Display for Bytecode_ {
             Bytecode_::Pop => write!(f, "Pop"),
             Bytecode_::Ret => write!(f, "Ret"),
             Bytecode_::Nop(None) => write!(f, "Nop"),
-            Bytecode_::Nop(Some(s)) => write!(f, "Nop {}", &s.0),
-            Bytecode_::BrTrue(lbl) => write!(f, "BrTrue {}", &lbl.0),
-            Bytecode_::BrFalse(lbl) => write!(f, "BrFalse {}", &lbl.0),
-            Bytecode_::Branch(lbl) => write!(f, "Branch {}", &lbl.0),
+            Bytecode_::Nop(Some(s)) => write!(f, "Nop {}", s.0),
+            Bytecode_::BrTrue(lbl) => write!(f, "BrTrue {}", lbl.0),
+            Bytecode_::BrFalse(lbl) => write!(f, "BrFalse {}", lbl.0),
+            Bytecode_::Branch(lbl) => write!(f, "Branch {}", lbl.0),
             Bytecode_::LdU8(u) => write!(f, "LdU8 {}", u),
             Bytecode_::LdU16(u) => write!(f, "LdU16 {}", u),
             Bytecode_::LdU32(u) => write!(f, "LdU32 {}", u),
@@ -1721,7 +1721,7 @@ impl fmt::Display for Bytecode_ {
             Bytecode_::LdTrue => write!(f, "LdTrue"),
             Bytecode_::LdFalse => write!(f, "LdFalse"),
             Bytecode_::LdConst(ty, v) => write!(f, "LdConst<{}> {}", ty, format_move_value(v)),
-            Bytecode_::LdNamedConst(n) => write!(f, "LdNamedConst {}", &n.0),
+            Bytecode_::LdNamedConst(n) => write!(f, "LdNamedConst {}", n.0),
             Bytecode_::CopyLoc(v) => write!(f, "CopyLoc {}", v),
             Bytecode_::MoveLoc(v) => write!(f, "MoveLoc {}", v),
             Bytecode_::StLoc(v) => write!(f, "StLoc {}", v),

--- a/third_party/move/move-ir/types/src/location.rs
+++ b/third_party/move/move-ir/types/src/location.rs
@@ -220,13 +220,13 @@ impl<T: Ord> Ord for Spanned<T> {
 
 impl<T: fmt::Display> fmt::Display for Spanned<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", &self.value)
+        write!(f, "{}", self.value)
     }
 }
 
 impl<T: fmt::Debug> fmt::Debug for Spanned<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", &self.value)
+        write!(f, "{:?}", self.value)
     }
 }
 

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -543,7 +543,7 @@ impl ModuleBuilder<'_, '_> {
         if self.parent.const_table.contains_key(&qsym) {
             self.parent.env.error(
                 &self.parent.to_loc(&name.loc()),
-                &format!("duplicate declaration of const `{}`", &name.value()),
+                &format!("duplicate declaration of const `{}`", name.value()),
             )
         }
         let (move_visibility, has_package_visibility) = match def.visibility {
@@ -592,7 +592,7 @@ impl ModuleBuilder<'_, '_> {
         {
             self.parent.env.error(
                 &self.parent.to_loc(&name.loc()),
-                &format!("duplicate declaration of `{}`", &name.value()),
+                &format!("duplicate declaration of `{}`", name.value()),
             )
         }
         let struct_id = StructId::new(qsym.symbol);
@@ -641,7 +641,7 @@ impl ModuleBuilder<'_, '_> {
         if self.parent.fun_table.contains_key(&qsym) {
             self.parent.env.error(
                 &self.parent.to_loc(&name.loc()),
-                &format!("duplicate declaration of `{}`", &name.value()),
+                &format!("duplicate declaration of `{}`", name.value()),
             )
         }
         let fun_id = FunId::new(qsym.symbol);
@@ -3645,10 +3645,10 @@ impl ModuleBuilder<'_, '_> {
             if let Some(old_loc) = ty_params_defined.get(&symbol) {
                 builder
                     .parent
-                    .error(&loc, &format!("duplicate declaration of `{}`", &name.value));
+                    .error(&loc, &format!("duplicate declaration of `{}`", name.value));
                 builder.parent.note(
                     old_loc,
-                    &format!("previous declaration of `{}`", &name.value),
+                    &format!("previous declaration of `{}`", name.value),
                 );
                 None
             } else {

--- a/third_party/move/move-model/src/exp_simplifier.rs
+++ b/third_party/move/move-model/src/exp_simplifier.rs
@@ -4973,12 +4973,9 @@ impl<'a, 'env, G: ExpGenerator<'env>> ExpRewriterFunctions for ExpSimplifier<'a,
         if let Operation::Select(mid, sid, fid) = oper {
             let mut base = &args[0];
             let mut skipped = false;
-            loop {
-                let ExpData::Call(_, Operation::UpdateField(mid2, sid2, fid2), inner_args) =
-                    base.as_ref()
-                else {
-                    break;
-                };
+            while let ExpData::Call(_, Operation::UpdateField(mid2, sid2, fid2), inner_args) =
+                base.as_ref()
+            {
                 if mid != mid2 || sid != sid2 {
                     break;
                 }

--- a/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -1783,14 +1783,14 @@ impl ModelValue {
             )),
             Type::Primitive(PrimitiveType::Address) => {
                 let addr = BigInt::parse_bytes(&self.extract_literal()?.clone().into_bytes(), 10)?;
-                Some(PrettyDoc::text(format!("0x{}", &addr.to_str_radix(16))))
+                Some(PrettyDoc::text(format!("0x{}", addr.to_str_radix(16))))
             },
             Type::Primitive(PrimitiveType::Signer) => {
                 let l = self.extract_list("$signer")?;
                 let addr = BigInt::parse_bytes(&l[0].extract_literal()?.clone().into_bytes(), 10)?;
                 Some(PrettyDoc::text(format!(
                     "signer{{0x{}}}",
-                    &addr.to_str_radix(16)
+                    addr.to_str_radix(16)
                 )))
             },
             Type::Vector(param) => self.pretty_vector(wrapper, model, param),

--- a/third_party/move/move-prover/boogie-backend/src/options.rs
+++ b/third_party/move/move-prover/boogie-backend/src/options.rs
@@ -341,10 +341,10 @@ impl BoogieOptions {
         if self.use_cvc5 {
             add(&[
                 "-proverOpt:SOLVER=cvc5",
-                &format!("-proverOpt:PROVER_PATH={}", &self.cvc5_exe),
+                &format!("-proverOpt:PROVER_PATH={}", self.cvc5_exe),
             ]);
         } else {
-            add(&[&format!("-proverOpt:PROVER_PATH={}", &self.z3_exe)]);
+            add(&[&format!("-proverOpt:PROVER_PATH={}", self.z3_exe)]);
         }
         if self.use_smt_array_theory {
             if matches!(self.vector_theory, VectorTheory::SmtArray) {

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
@@ -8087,11 +8087,8 @@ impl<'env> SpecInferenceAnalyzer<'env> {
             let mut conditions: Vec<Exp> = vec![];
             let mut block = def_block;
 
-            loop {
-                let Some(idom) = dom.immediate_dominator(block) else {
-                    break; // reached entry
-                };
-
+            // Terminates at the entry block, which has no dominator.
+            while let Some(idom) = dom.immediate_dominator(block) {
                 // Check if the dominator block ends with a Branch
                 let idom_range = fwd_cfg.code_range(idom);
                 if !idom_range.is_empty() {

--- a/third_party/move/move-prover/src/inference.rs
+++ b/third_party/move/move-prover/src/inference.rs
@@ -48,6 +48,7 @@ use move_stackless_bytecode::{
     function_target_pipeline::FunctionTargetsHolder, print_targets_with_annotations_for_test,
 };
 use std::{
+    cmp::Reverse,
     collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
@@ -502,7 +503,7 @@ fn output_to_files(env: &GlobalEnv, inferred_sym: Symbol, options: &Options) -> 
             // multiple new spec blocks all targeting `module_close_insert_pos`),
             // stable sort preserves declaration order — concatenate them into a
             // single insertion so `insert_str` produces the correct order.
-            insertions.sort_by(|a, b| b.0.cmp(&a.0));
+            insertions.sort_by_key(|a| Reverse(a.0));
             let mut merged = source;
             let mut i = 0;
             while i < insertions.len() {
@@ -896,7 +897,7 @@ fn output_unified(env: &GlobalEnv, inferred_sym: Symbol, options: &Options) -> a
 
         // Sort insertions by byte offset in reverse order so earlier offsets
         // aren't invalidated by prior insertions.
-        insertions.sort_by(|a, b| b.0.cmp(&a.0));
+        insertions.sort_by_key(|a| Reverse(a.0));
 
         let mut result = source;
         for (offset, text) in &insertions {

--- a/third_party/move/move-prover/src/package_prove.rs
+++ b/third_party/move/move-prover/src/package_prove.rs
@@ -127,7 +127,7 @@ pub fn run_move_prover(
         bail!(
             "move prover options must not specify sources as those are given \
                      by the package system. Did you meant to prefix `{}` with `-t`?",
-            &options.move_sources[0]
+            options.move_sources[0]
         );
     }
     if !options.move_deps.is_empty() {

--- a/third_party/move/move-vm/runtime/src/logging.rs
+++ b/third_party/move/move-vm/runtime/src/logging.rs
@@ -15,7 +15,7 @@ pub fn expect_no_verification_errors(err: VMError) -> VMError {
             let message = format!(
                 "Unexpected verifier/deserialization error! This likely means there is code \
                 stored on chain that is unverifiable!\nError: {:?}",
-                &err
+                err
             );
             let (
                 _old_status,

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -2384,7 +2384,7 @@ impl ContainerRef {
                         return Err(PartialVMError::new(
                             StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
                         )
-                        .with_message(format!("cannot borrow vector element {:?}", &v[idx])))
+                        .with_message(format!("cannot borrow vector element {:?}", v[idx])))
                     },
                 }
             },
@@ -2418,7 +2418,7 @@ impl ContainerRef {
                         )
                         .with_message(format!(
                             "cannot borrow struct / locals element {:?}",
-                            &v[idx]
+                            v[idx]
                         )))
                     },
                 }
@@ -2522,7 +2522,7 @@ impl Locals {
 
             Value::ContainerRef(_) | Value::Invalid | Value::IndexedRef(_) => Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(format!("cannot borrow local {:?}", &v[idx])),
+                    .with_message(format!("cannot borrow local {:?}", v[idx])),
             ),
         }
     }
@@ -4801,7 +4801,7 @@ impl Display for ContainerRef {
             Self::Global {
                 status,
                 container: _,
-            } => write!(f, "(&container -- {:?})", &*status.borrow()),
+            } => write!(f, "(&container -- {:?})", *status.borrow()),
         }
     }
 }

--- a/third_party/move/tools/move-asm/src/assembler.rs
+++ b/third_party/move/tools/move-asm/src/assembler.rs
@@ -423,7 +423,7 @@ impl<'a> Assembler<'a> {
                     }
                 })
                 .collect();
-            locals.sort_by(|e1, e2| e1.0.cmp(&e2.0));
+            locals.sort_by_key(|e| e.0);
             let res = self
                 .builder
                 .signature_index(locals.into_iter().map(|(_, ty)| ty).collect());

--- a/third_party/move/tools/move-docgen/src/docgen.rs
+++ b/third_party/move/tools/move-docgen/src/docgen.rs
@@ -1474,7 +1474,7 @@ impl<'env> Docgen<'env> {
             self.gen_call_diagram(func_env.get_qualified_id(), true);
             self.begin_collapsed(&format!(
                 "Show all the functions that \"{}\" calls",
-                &func_name
+                func_name
             ));
             self.image(&format!(
                 "img/{}_forward_call_graph.svg",
@@ -1485,7 +1485,7 @@ impl<'env> Docgen<'env> {
             self.gen_call_diagram(func_env.get_qualified_id(), false);
             self.begin_collapsed(&format!(
                 "Show all the functions that call \"{}\"",
-                &func_name
+                func_name
             ));
             self.image(&format!(
                 "img/{}_backward_call_graph.svg",

--- a/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -646,7 +646,7 @@ impl ResolvingPackage {
                 if other.value != addr_value.value {
                     bail!(
                         "Named address '{}' in dependency '{}' is already set to '{}' but was then reassigned to '{}'",
-                        &addr_name,
+                        addr_name,
                         dep_name,
                         match other.value.take() {
                             None => "unassigned".to_string(),

--- a/types/src/keyless/openid_sig.rs
+++ b/types/src/keyless/openid_sig.rs
@@ -94,7 +94,7 @@ impl OpenIdSig {
                         .is_allowed_override_aud(&claims.oidc_claims.aud)
                         .is_ok(),
                     "{} is not an allow-listed override aud",
-                    &claims.oidc_claims.aud
+                    claims.oidc_claims.aud
                 );
                 idc_aud_val
             },

--- a/types/src/mempool_status.rs
+++ b/types/src/mempool_status.rs
@@ -38,9 +38,9 @@ impl MempoolStatus {
 
 impl fmt::Display for MempoolStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", &self.code)?;
+        write!(f, "{}", self.code)?;
         if !self.message.is_empty() {
-            write!(f, " - {}", &self.message)?;
+            write!(f, " - {}", self.message)?;
         }
         Ok(())
     }

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -219,7 +219,7 @@ impl AccountInfoUniverse {
                 AccountInfo::new(private_key, consensus_private_key)
             })
             .collect();
-        accounts.sort_by(|a, b| a.address.cmp(&b.address));
+        accounts.sort_by_key(|a| a.address);
         let validator_signer = ValidatorSigner::new(
             accounts[0].address,
             Arc::new(accounts[0].consensus_private_key.clone()),


### PR DESCRIPTION

Add the data client requests for the hot state snapshot APIs the storage
service already serves, so the streaming service can build a hot state
stream on top of them in a follow-up.

Hot state gets its own methods rather than a `StateKind` arm because its
chunks carry `HotStateValue` leaves. The response payload variant is
rejected by the stream engine for now since no stream produces it yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New state-sync request/response paths touch peer data fetching; behavior is gated until streaming consumes them, but mistakes could affect sync clients. Widespread style-only edits are low risk individually but increase review noise across critical packages.
> 
> **Overview**
> Adds **peer-facing hot state snapshot plumbing** in the Aptos data client so state sync can request hot-state counts and proof chunks separately from regular state (`HotStateValue` leaves), with new `ResponsePayload` variants and mock/test harness support. The data streaming service still **rejects** hot-state responses until a dedicated stream is built.
> 
> The rest of the diff is largely **mechanical Clippy compliance** after re-enabling several lints in `.cargo/config.toml`: dropping needless borrows in `format!`/`write!`, `sort_by` → `sort_by_key` (often with `Reverse`), `while let` refactors, and a targeted `#[allow]` around abort-test macros that intentionally use `code: _`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4563aa04a0a7b5036d03afe55ee4e85f2331bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->