### PR TITLE
[state-sync] Stream hot state snapshots

### DIFF
--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -34,10 +34,11 @@ use aptos_storage_interface::{DbReader, StateKind};
 use aptos_storage_service_client::StorageServiceClient;
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
-        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        NumberOfStatesRequestV2, StateValuesWithProofRequest, StateValuesWithProofRequestV2,
-        StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, HotStateValuesWithProofRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+        NewTransactionsWithProofRequest, NumberOfStatesRequestV2, StateValuesWithProofRequest,
+        StateValuesWithProofRequestV2, StorageServiceRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
@@ -52,7 +53,7 @@ use aptos_time_service::TimeService;
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use arc_swap::ArcSwap;
@@ -1095,6 +1096,33 @@ impl AptosDataClientInterface for AptosDataClient {
                 Ok(response.map(|response| response.state_value_chunk_with_proof))
             },
         }
+    }
+
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> crate::error::Result<Response<u64>> {
+        let data_request = DataRequest::GetNumberOfHotStatesAtVersion(version);
+        self.create_and_send_storage_request(request_timeout_ms, data_request)
+            .await
+    }
+
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> crate::error::Result<Response<HotStateValueChunkWithProof>> {
+        let data_request =
+            DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
+                version,
+                start_index,
+                end_index,
+            });
+        self.create_and_send_storage_request(request_timeout_ms, data_request)
+            .await
     }
 
     async fn get_transaction_outputs_with_proof(

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -6,7 +6,7 @@ use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{responses::TransactionOrOutputListWithProofV2, Epoch};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use async_trait::async_trait;
@@ -90,6 +90,24 @@ pub trait AptosDataClientInterface {
         request_timeout_ms: u64,
         kind: StateKind,
     ) -> error::Result<Response<StateValueChunkWithProof>>;
+
+    /// Fetches the number of hot states at the specified version.
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<u64>>;
+
+    /// Fetches a single hot state value chunk with proof, containing the values
+    /// from start to end index (inclusive) at the specified version. Otherwise
+    /// behaves like `get_state_values_with_proof`.
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<HotStateValueChunkWithProof>>;
 
     /// Fetches a transaction output list with proof, with transaction
     /// outputs from start to end versions (inclusive). The proof is relative
@@ -268,6 +286,7 @@ impl<T> Response<T> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResponsePayload {
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
+    HotStateValuesWithProof(HotStateValueChunkWithProof),
     NewTransactionOutputsWithProof((TransactionOutputListWithProofV2, LedgerInfoWithSignatures)),
     NewTransactionsWithProof((TransactionListWithProofV2, LedgerInfoWithSignatures)),
     NumberOfStates(u64),
@@ -282,6 +301,7 @@ impl ResponsePayload {
     pub fn get_label(&self) -> &'static str {
         match self {
             Self::EpochEndingLedgerInfos(_) => "epoch_ending_ledger_infos",
+            Self::HotStateValuesWithProof(_) => "hot_state_values_with_proof",
             Self::NewTransactionOutputsWithProof(_) => "new_transaction_outputs_with_proof",
             Self::NewTransactionsWithProof(_) => "new_transactions_with_proof",
             Self::NumberOfStates(_) => "number_of_states",
@@ -297,6 +317,9 @@ impl ResponsePayload {
         match self {
             Self::EpochEndingLedgerInfos(epoch_ending_ledger_infos) => {
                 epoch_ending_ledger_infos.len()
+            },
+            Self::HotStateValuesWithProof(hot_state_values_with_proof) => {
+                hot_state_values_with_proof.raw_values.len()
             },
             Self::NewTransactionOutputsWithProof((outputs_with_proof, _)) => {
                 outputs_with_proof.get_num_outputs()
@@ -323,6 +346,12 @@ impl ResponsePayload {
 impl From<StateValueChunkWithProof> for ResponsePayload {
     fn from(inner: StateValueChunkWithProof) -> Self {
         Self::StateValuesWithProof(inner)
+    }
+}
+
+impl From<HotStateValueChunkWithProof> for ResponsePayload {
+    fn from(inner: HotStateValueChunkWithProof) -> Self {
+        Self::HotStateValuesWithProof(inner)
     }
 }
 

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -36,7 +36,7 @@ use aptos_storage_service_types::{
 use aptos_time_service::{MockTimeService, TimeService};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
     PeerId,
 };
@@ -316,6 +316,20 @@ mock! {
             request_timeout_ms: u64,
             kind: StateKind,
         ) -> Result<Response<StateValueChunkWithProof>>;
+
+        async fn get_number_of_hot_states(
+            &self,
+            version: Version,
+            request_timeout_ms: u64,
+        ) -> Result<Response<u64>>;
+
+        async fn get_hot_state_values_with_proof(
+            &self,
+            version: u64,
+            start_index: u64,
+            end_index: u64,
+            request_timeout_ms: u64,
+        ) -> Result<Response<HotStateValueChunkWithProof>>;
 
         async fn get_transaction_outputs_with_proof(
             &self,

--- a/state-sync/data-streaming-service/src/data_notification.rs
+++ b/state-sync/data-streaming-service/src/data_notification.rs
@@ -6,7 +6,7 @@ use aptos_data_client::interface::{Response, ResponsePayload};
 use aptos_storage_interface::StateKind;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use std::{
@@ -46,6 +46,7 @@ pub enum DataPayload {
     ContinuousTransactionsWithProof(LedgerInfoWithSignatures, TransactionListWithProofV2),
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
     EndOfStream,
+    HotStateValuesWithProof(HotStateValueChunkWithProof),
     StateValuesWithProof(StateKind, StateValueChunkWithProof),
     TransactionOutputsWithProof(TransactionOutputListWithProofV2),
     TransactionsWithProof(TransactionListWithProofV2),
@@ -55,8 +56,10 @@ pub enum DataPayload {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataClientRequest {
     EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest),
+    HotStateValuesWithProof(HotStateValuesWithProofRequest),
     NewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest),
     NewTransactionsWithProof(NewTransactionsWithProofRequest),
+    NumberOfHotStates(Version),
     NumberOfStates(NumberOfStatesRequest),
     StateValuesWithProof(StateValuesWithProofRequest),
     TransactionsWithProof(TransactionsWithProofRequest),
@@ -73,8 +76,10 @@ impl DataClientRequest {
     pub fn get_label(&self) -> &'static str {
         match self {
             Self::EpochEndingLedgerInfos(_) => "epoch_ending_ledger_infos",
+            Self::HotStateValuesWithProof(_) => "hot_state_values_with_proof",
             Self::NewTransactionOutputsWithProof(_) => "new_transaction_outputs_with_proof",
             Self::NewTransactionsWithProof(_) => "new_transactions_with_proof",
+            Self::NumberOfHotStates(_) => "number_of_hot_states",
             Self::NumberOfStates(_) => "number_of_states",
             Self::StateValuesWithProof(_) => "state_values_with_proof",
             Self::TransactionsWithProof(_) => "transactions_with_proof",
@@ -127,6 +132,14 @@ pub struct StateValuesWithProofRequest {
     pub start_index: u64,
     pub end_index: u64,
     pub state_kind: StateKind,
+}
+
+/// A request for fetching hot state values at a version.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HotStateValuesWithProofRequest {
+    pub version: Version,
+    pub start_index: u64,
+    pub end_index: u64,
 }
 
 /// A client request for fetching epoch ending ledger infos.

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -5,9 +5,10 @@ use crate::{
     data_notification,
     data_notification::{
         DataClientRequest, DataNotification, DataPayload, EpochEndingLedgerInfosRequest,
-        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
-        NewTransactionsWithProofRequest, NotificationId, NumberOfStatesRequest,
-        StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
+        HotStateValuesWithProofRequest, NewTransactionOutputsWithProofRequest,
+        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest, NotificationId,
+        NumberOfStatesRequest, StateValuesWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
         TransactionsWithProofRequest,
@@ -36,6 +37,7 @@ use aptos_logger::prelude::*;
 #[cfg(test)]
 use aptos_storage_interface::StateKind;
 use aptos_time_service::{TimeService, TimeServiceTrait};
+use aptos_types::transaction::Version;
 use futures::{channel::mpsc, stream::FusedStream, SinkExt, Stream};
 use std::{
     cmp::min,
@@ -1048,6 +1050,9 @@ pub(crate) fn create_missing_data_request(
         DataClientRequest::StateValuesWithProof(request) => {
             create_missing_state_values_request(request, response_payload)
         },
+        DataClientRequest::HotStateValuesWithProof(request) => {
+            create_missing_hot_state_values_request(request, response_payload)
+        },
         DataClientRequest::TransactionsWithProof(request) => {
             create_missing_transactions_request(request, response_payload)
         },
@@ -1152,6 +1157,46 @@ fn create_missing_state_values_request(
 /// Creates and returns a missing transactions request if the given client
 /// response doesn't satisfy the original request. If the request is satisfied,
 /// None is returned.
+/// Creates and returns a missing hot state values request if the response is short.
+fn create_missing_hot_state_values_request(
+    request: &HotStateValuesWithProofRequest,
+    response_payload: &ResponsePayload,
+) -> Result<Option<DataClientRequest>, Error> {
+    let num_requested = request
+        .end_index
+        .checked_sub(request.start_index)
+        .and_then(|v| v.checked_add(1))
+        .ok_or_else(|| {
+            Error::IntegerOverflow("Number of requested hot states has overflown!".into())
+        })?;
+
+    match response_payload {
+        ResponsePayload::HotStateValuesWithProof(chunk) => {
+            let num_received = chunk.raw_values.len() as u64;
+            if num_received < num_requested {
+                let start_index = request
+                    .start_index
+                    .checked_add(num_received)
+                    .ok_or_else(|| Error::IntegerOverflow("Start index has overflown!".into()))?;
+                Ok(Some(DataClientRequest::HotStateValuesWithProof(
+                    HotStateValuesWithProofRequest {
+                        version: request.version,
+                        start_index,
+                        end_index: request.end_index,
+                    },
+                )))
+            } else {
+                Ok(None)
+            }
+        },
+        payload => Err(Error::AptosDataClientResponseIsInvalid(format!(
+            "Invalid response payload found for hot state values request: {:?}",
+            payload
+        ))),
+    }
+}
+
+/// Creates and returns a missing transactions request if the response is short.
 fn create_missing_transactions_request(
     request: &TransactionsWithProofRequest,
     response_payload: &ResponsePayload,
@@ -1325,10 +1370,16 @@ fn sanity_check_client_response_type(
                 ResponsePayload::NewTransactionOutputsWithProof(_)
             )
         },
-        DataClientRequest::NumberOfStates(_) => {
+        DataClientRequest::NumberOfHotStates(_) | DataClientRequest::NumberOfStates(_) => {
             matches!(
                 data_client_response.payload,
                 ResponsePayload::NumberOfStates(_)
+            )
+        },
+        DataClientRequest::HotStateValuesWithProof(_) => {
+            matches!(
+                data_client_response.payload,
+                ResponsePayload::HotStateValuesWithProof(_)
             )
         },
         DataClientRequest::StateValuesWithProof(_) => {
@@ -1445,8 +1496,15 @@ fn spawn_request_task<T: AptosDataClientInterface + Send + Clone + 'static>(
                 )
                 .await
             },
+            DataClientRequest::NumberOfHotStates(version) => {
+                get_number_of_hot_states(aptos_data_client, version, request_timeout_ms).await
+            },
             DataClientRequest::NumberOfStates(request) => {
                 get_number_of_states(aptos_data_client, request, request_timeout_ms).await
+            },
+            DataClientRequest::HotStateValuesWithProof(request) => {
+                get_hot_state_values_with_proof(aptos_data_client, request, request_timeout_ms)
+                    .await
             },
             DataClientRequest::StateValuesWithProof(request) => {
                 get_states_values_with_proof(aptos_data_client, request, request_timeout_ms).await
@@ -1525,6 +1583,33 @@ async fn get_states_values_with_proof<T: AptosDataClientInterface + Send + Clone
         )
         .await?;
     Ok(client_response.map(ResponsePayload::StateValuesWithProof))
+}
+
+async fn get_hot_state_values_with_proof<T: AptosDataClientInterface + Send + Clone + 'static>(
+    aptos_data_client: T,
+    request: HotStateValuesWithProofRequest,
+    request_timeout_ms: u64,
+) -> Result<Response<ResponsePayload>, aptos_data_client::error::Error> {
+    let client_response = aptos_data_client
+        .get_hot_state_values_with_proof(
+            request.version,
+            request.start_index,
+            request.end_index,
+            request_timeout_ms,
+        )
+        .await?;
+    Ok(client_response.map(ResponsePayload::HotStateValuesWithProof))
+}
+
+async fn get_number_of_hot_states<T: AptosDataClientInterface + Send + Clone + 'static>(
+    aptos_data_client: T,
+    version: Version,
+    request_timeout_ms: u64,
+) -> Result<Response<ResponsePayload>, aptos_data_client::error::Error> {
+    let client_response = aptos_data_client
+        .get_number_of_hot_states(version, request_timeout_ms)
+        .await?;
+    Ok(client_response.map(ResponsePayload::NumberOfStates))
 }
 
 async fn get_epoch_ending_ledger_infos<T: AptosDataClientInterface + Send + Clone + 'static>(

--- a/state-sync/data-streaming-service/src/dynamic_prefetching.rs
+++ b/state-sync/data-streaming-service/src/dynamic_prefetching.rs
@@ -4,7 +4,7 @@
 use crate::{metrics, stream_engine::StreamEngine};
 use aptos_config::config::{DataStreamingServiceConfig, DynamicPrefetchingConfig};
 #[cfg(test)]
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use std::{
     cmp::{max, min},
@@ -695,7 +695,7 @@ mod test {
         let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version: 0,
             start_index: 0,
-            state_kind: StateKind::MainState,
+            snapshot_kind: SnapshotKind::State(StateKind::MainState),
         });
 
         // Create and return the stream engine

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -2223,6 +2223,10 @@ fn create_data_notification(
         // The number of states is consumed internally by the engine for chunk
         // planning; it is never surfaced to the consumer as a notification.
         ResponsePayload::NumberOfStates(_) => invalid_response_type!(client_response_type),
+        // Hot state values are not streamed yet.
+        ResponsePayload::HotStateValuesWithProof(_) => {
+            invalid_response_type!(client_response_type)
+        },
         ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
             DataPayload::EpochEndingLedgerInfos(ledger_infos)
         },

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -5,15 +5,16 @@ use crate::{
     data_notification::{
         DataClientRequest,
         DataClientRequest::{
-            EpochEndingLedgerInfos, NewTransactionOutputsWithProof,
-            NewTransactionsOrOutputsWithProof, NewTransactionsWithProof, NumberOfStates,
-            StateValuesWithProof, SubscribeTransactionOutputsWithProof,
+            EpochEndingLedgerInfos, HotStateValuesWithProof, NewTransactionOutputsWithProof,
+            NewTransactionsOrOutputsWithProof, NewTransactionsWithProof, NumberOfHotStates,
+            NumberOfStates, StateValuesWithProof, SubscribeTransactionOutputsWithProof,
             SubscribeTransactionsOrOutputsWithProof, SubscribeTransactionsWithProof,
             TransactionOutputsWithProof, TransactionsOrOutputsWithProof, TransactionsWithProof,
         },
         DataNotification, DataPayload, EpochEndingLedgerInfosRequest,
-        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
-        NewTransactionsWithProofRequest, NumberOfStatesRequest, StateValuesWithProofRequest,
+        HotStateValuesWithProofRequest, NewTransactionOutputsWithProofRequest,
+        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
+        NumberOfStatesRequest, StateValuesWithProofRequest,
         SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
@@ -33,7 +34,7 @@ use aptos_data_client::{
 };
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
 use aptos_logger::prelude::*;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use enum_dispatch::enum_dispatch;
 use std::{cmp, cmp::min, sync::Arc};
@@ -170,7 +171,7 @@ pub struct StateStreamEngine {
     pub request: GetAllStatesRequest,
 
     // Which snapshot store this engine streams
-    pub kind: StateKind,
+    pub kind: SnapshotKind,
 
     // True iff a request has been created to fetch the number of states
     pub state_num_requested: bool,
@@ -194,7 +195,7 @@ impl StateStreamEngine {
     fn new(request: &GetAllStatesRequest) -> Result<Self, Error> {
         Ok(StateStreamEngine {
             request: request.clone(),
-            kind: request.state_kind,
+            kind: request.snapshot_kind,
             state_num_requested: false,
             number_of_states: None,
             next_stream_index: request.start_index,
@@ -215,6 +216,12 @@ impl StateStreamEngine {
                             Error::IntegerOverflow("Next request index has overflown!".into())
                         })?;
                 },
+                HotStateValuesWithProof(request) => {
+                    self.next_request_index =
+                        request.end_index.checked_add(1).ok_or_else(|| {
+                            Error::IntegerOverflow("Next request index has overflown!".into())
+                        })?;
+                },
                 request => invalid_client_request!(request, self),
             }
         }
@@ -225,6 +232,87 @@ impl StateStreamEngine {
         self.number_of_states.ok_or_else(|| {
             Error::UnexpectedErrorEncountered("Number of states is not initialized!".into())
         })
+    }
+
+    /// Shared chunk-response handling for the `StateValuesWithProof` and
+    /// `HotStateValuesWithProof` responses.
+    fn process_state_chunk(
+        &mut self,
+        start_index: u64,
+        end_index: u64,
+        last_received_index: u64,
+        client_response_payload: ResponsePayload,
+        notification_id_generator: Arc<U64IdGenerator>,
+    ) -> Result<Option<DataNotification>, Error> {
+        let last_received_index = bound_by_range(last_received_index, start_index, end_index);
+
+        // Update the next stream index
+        self.next_stream_index = last_received_index
+            .checked_add(1)
+            .ok_or_else(|| Error::IntegerOverflow("Next stream index has overflown!".into()))?;
+
+        // Check if the stream is complete
+        let last_stream_index = self
+            .get_number_of_states()?
+            .checked_sub(1)
+            .ok_or_else(|| Error::IntegerOverflow("End index has overflown!".into()))?;
+        if last_received_index >= last_stream_index {
+            self.stream_is_complete = true;
+        }
+
+        // Create a new data notification
+        let data_notification = create_data_notification(
+            notification_id_generator,
+            client_response_payload,
+            None,
+            self.clone().into(),
+        )?;
+        Ok(Some(data_notification))
+    }
+
+    /// Shared handling for the `NumberOfStates` and `NumberOfHotStates` responses.
+    fn handle_number_of_states(
+        &mut self,
+        request_version: Version,
+        client_response_payload: ResponsePayload,
+    ) -> Result<(), Error> {
+        if let ResponsePayload::NumberOfStates(number_of_states) = client_response_payload {
+            info!(
+                (LogSchema::new(LogEntry::ReceivedDataResponse)
+                    .event(LogEvent::Success)
+                    .message(&format!(
+                        "Received number of states at version: {:?}. Total states: {:?}",
+                        request_version, number_of_states
+                    )))
+            );
+            self.state_num_requested = false;
+
+            // Sanity check the response before saving it.
+            if number_of_states < self.next_request_index {
+                return Err(Error::NoDataToFetch(format!(
+                    "The next state index to fetch is higher than the \
+                    total number of states. Next index: {:?}, total states: {:?}",
+                    self.next_request_index, number_of_states
+                )));
+            }
+            // The number of states is an internal planning value, not
+            // consumer data. An empty tree (count 0) has no chunks: just
+            // end the stream (no notification). The bootstrapper detects
+            // the zero-chunk end and verifies emptiness against the
+            // committed snapshot root. Main state at a real snapshot is
+            // never empty, so a 0 there is an invalid response.
+            if number_of_states == 0 {
+                if self.kind == SnapshotKind::State(StateKind::MainState) {
+                    return Err(Error::AptosDataClientResponseIsInvalid(
+                        "Received a state count of 0 for the main state snapshot!".into(),
+                    ));
+                }
+                self.stream_is_complete = true;
+                return Ok(());
+            }
+            self.number_of_states = Some(number_of_states);
+        }
+        Ok(())
     }
 }
 
@@ -282,10 +370,15 @@ impl DataStreamEngine for StateStreamEngine {
 
         // Return the request
         self.state_num_requested = true;
-        let number_request = DataClientRequest::NumberOfStates(NumberOfStatesRequest {
-            version: self.request.version,
-            state_kind: self.kind,
-        });
+        let number_request = match self.kind {
+            SnapshotKind::State(state_kind) => {
+                DataClientRequest::NumberOfStates(NumberOfStatesRequest {
+                    version: self.request.version,
+                    state_kind,
+                })
+            },
+            SnapshotKind::HotState => DataClientRequest::NumberOfHotStates(self.request.version),
+        };
         Ok(vec![number_request])
     }
 
@@ -320,7 +413,7 @@ impl DataStreamEngine for StateStreamEngine {
                     request.end_index,
                 )?;
 
-                // Identify the last received state index and bound it appropriately
+                // Identify the last received state index
                 let last_received_index = match &client_response_payload {
                     ResponsePayload::StateValuesWithProof(state_values_with_proof) => {
                         // Verify that we received at least one state value
@@ -336,69 +429,51 @@ impl DataStreamEngine for StateStreamEngine {
                     },
                     _ => invalid_response_type!(client_response_payload),
                 };
-                let last_received_index =
-                    bound_by_range(last_received_index, request.start_index, request.end_index);
-
-                // Update the next stream index
-                self.next_stream_index = last_received_index.checked_add(1).ok_or_else(|| {
-                    Error::IntegerOverflow("Next stream index has overflown!".into())
-                })?;
-
-                // Check if the stream is complete
-                let last_stream_index = self
-                    .get_number_of_states()?
-                    .checked_sub(1)
-                    .ok_or_else(|| Error::IntegerOverflow("End index has overflown!".into()))?;
-                if last_received_index >= last_stream_index {
-                    self.stream_is_complete = true;
-                }
-
-                // Create a new data notification
-                let data_notification = create_data_notification(
-                    notification_id_generator,
+                return self.process_state_chunk(
+                    request.start_index,
+                    request.end_index,
+                    last_received_index,
                     client_response_payload,
-                    None,
-                    self.clone().into(),
+                    notification_id_generator,
+                );
+            },
+            HotStateValuesWithProof(request) => {
+                // Verify the client request indices
+                verify_client_request_indices(
+                    self.next_stream_index,
+                    request.start_index,
+                    request.end_index,
                 )?;
-                return Ok(Some(data_notification));
+
+                // Identify the last received state index
+                let last_received_index = match &client_response_payload {
+                    ResponsePayload::HotStateValuesWithProof(hot_state_values_with_proof) => {
+                        // Verify that we received at least one hot state value
+                        if hot_state_values_with_proof.raw_values.is_empty() {
+                            return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                                "Received an empty hot state values response! Request: {:?}",
+                                client_request
+                            )));
+                        }
+
+                        // Get the last received state index
+                        hot_state_values_with_proof.last_index
+                    },
+                    _ => invalid_response_type!(client_response_payload),
+                };
+                return self.process_state_chunk(
+                    request.start_index,
+                    request.end_index,
+                    last_received_index,
+                    client_response_payload,
+                    notification_id_generator,
+                );
             },
             NumberOfStates(request) => {
-                if let ResponsePayload::NumberOfStates(number_of_states) = client_response_payload {
-                    info!(
-                        (LogSchema::new(LogEntry::ReceivedDataResponse)
-                            .event(LogEvent::Success)
-                            .message(&format!(
-                                "Received number of states at version: {:?}. Total states: {:?}",
-                                request.version, number_of_states
-                            )))
-                    );
-                    self.state_num_requested = false;
-
-                    // Sanity check the response before saving it.
-                    if number_of_states < self.next_request_index {
-                        return Err(Error::NoDataToFetch(format!(
-                            "The next state index to fetch is higher than the \
-                            total number of states. Next index: {:?}, total states: {:?}",
-                            self.next_request_index, number_of_states
-                        )));
-                    }
-                    // The number of states is an internal planning value, not
-                    // consumer data. An empty tree (count 0) has no chunks: just
-                    // end the stream (no notification). The bootstrapper detects
-                    // the zero-chunk end and verifies emptiness against the
-                    // committed snapshot root. Main state at a real snapshot is
-                    // never empty, so a 0 there is an invalid response.
-                    if number_of_states == 0 {
-                        if self.kind == StateKind::MainState {
-                            return Err(Error::AptosDataClientResponseIsInvalid(
-                                "Received a state count of 0 for the main state snapshot!".into(),
-                            ));
-                        }
-                        self.stream_is_complete = true;
-                        return Ok(None);
-                    }
-                    self.number_of_states = Some(number_of_states);
-                }
+                self.handle_number_of_states(request.version, client_response_payload)?;
+            },
+            NumberOfHotStates(version) => {
+                self.handle_number_of_states(*version, client_response_payload)?;
             },
             request => invalid_client_request!(request, self),
         }
@@ -2125,13 +2200,18 @@ fn create_data_client_request(
     stream_engine: &StreamEngine,
 ) -> Result<DataClientRequest, Error> {
     let data_client_request = match stream_engine {
-        StreamEngine::StateStreamEngine(stream_engine) => {
-            StateValuesWithProof(StateValuesWithProofRequest {
+        StreamEngine::StateStreamEngine(stream_engine) => match stream_engine.kind {
+            SnapshotKind::State(state_kind) => StateValuesWithProof(StateValuesWithProofRequest {
                 version: stream_engine.request.version,
                 start_index,
                 end_index,
-                state_kind: stream_engine.kind,
-            })
+                state_kind,
+            }),
+            SnapshotKind::HotState => HotStateValuesWithProof(HotStateValuesWithProofRequest {
+                version: stream_engine.request.version,
+                start_index,
+                end_index,
+            }),
         },
         StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => {
             let target_ledger_info_version = stream_engine
@@ -2215,17 +2295,22 @@ fn create_data_notification(
     let client_response_type = client_response.get_label();
     let data_payload = match client_response {
         ResponsePayload::StateValuesWithProof(states_chunk) => match &stream_engine {
-            StreamEngine::StateStreamEngine(engine) => {
-                DataPayload::StateValuesWithProof(engine.kind, states_chunk)
+            StreamEngine::StateStreamEngine(engine) => match engine.kind {
+                SnapshotKind::State(state_kind) => {
+                    DataPayload::StateValuesWithProof(state_kind, states_chunk)
+                },
+                SnapshotKind::HotState => invalid_response_type!(client_response_type),
             },
             _ => invalid_response_type!(client_response_type),
         },
         // The number of states is consumed internally by the engine for chunk
         // planning; it is never surfaced to the consumer as a notification.
         ResponsePayload::NumberOfStates(_) => invalid_response_type!(client_response_type),
-        // Hot state values are not streamed yet.
-        ResponsePayload::HotStateValuesWithProof(_) => {
-            invalid_response_type!(client_response_type)
+        ResponsePayload::HotStateValuesWithProof(hot_states_chunk) => match &stream_engine {
+            StreamEngine::StateStreamEngine(engine) if engine.kind == SnapshotKind::HotState => {
+                DataPayload::HotStateValuesWithProof(hot_states_chunk)
+            },
+            _ => invalid_response_type!(client_response_type),
         },
         ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
             DataPayload::EpochEndingLedgerInfos(ledger_infos)

--- a/state-sync/data-streaming-service/src/streaming_client.rs
+++ b/state-sync/data-streaming-service/src/streaming_client.rs
@@ -6,7 +6,7 @@ use crate::{
     data_stream::{DataStreamId, DataStreamListener},
     error::Error,
 };
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::SnapshotKind;
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use async_trait::async_trait;
 use futures::{
@@ -34,16 +34,16 @@ pub type Epoch = u64;
 /// is the responsibility of the client to terminate the stream using this API.
 #[async_trait]
 pub trait DataStreamingClient {
-    /// Fetches the state values (of the given kind) at the specified version. If
-    /// `start_index` is specified, the state values will be fetched starting at
-    /// the `start_index` (inclusive). Otherwise, the start index will 0.
-    /// The specified version must be an epoch ending version, otherwise an
-    /// error will be returned. State proofs are at the same version.
+    /// Fetches the state values (of the given snapshot kind) at the specified
+    /// version. If `start_index` is specified, the state values will be fetched
+    /// starting at the `start_index` (inclusive). Otherwise, the start index
+    /// will 0. The specified version must be an epoch ending version, otherwise
+    /// an error will be returned. State proofs are at the same version.
     async fn get_all_state_values(
         &self,
         version: Version,
         start_index: Option<u64>,
-        state_kind: StateKind,
+        snapshot_kind: SnapshotKind,
     ) -> Result<DataStreamListener, Error>;
 
     /// Fetches all epoch ending ledger infos starting at `start_epoch`
@@ -210,12 +210,12 @@ pub struct GetAllEpochEndingLedgerInfosRequest {
     pub start_epoch: Epoch,
 }
 
-/// A client request for fetching all states (of the given kind) at a version.
+/// A client request for fetching all states (of the given snapshot kind) at a version.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GetAllStatesRequest {
     pub version: Version,
     pub start_index: u64,
-    pub state_kind: StateKind,
+    pub snapshot_kind: SnapshotKind,
 }
 
 /// A client request for fetching all transactions with proofs.
@@ -341,13 +341,13 @@ impl DataStreamingClient for StreamingServiceClient {
         &self,
         version: u64,
         start_index: Option<u64>,
-        state_kind: StateKind,
+        snapshot_kind: SnapshotKind,
     ) -> Result<DataStreamListener, Error> {
         let start_index = start_index.unwrap_or(0);
         let client_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version,
             start_index,
-            state_kind,
+            snapshot_kind,
         });
         self.send_request_and_await_response(client_request).await
     }

--- a/state-sync/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/streaming_service.rs
@@ -513,7 +513,7 @@ mod streaming_service_tests {
     };
     use aptos_channels::{aptos_channel, message_queues::QueueStyle};
     use aptos_config::config::DataStreamingServiceConfig;
-    use aptos_storage_interface::StateKind;
+    use aptos_storage_interface::{SnapshotKind, StateKind};
     use futures::{
         channel::{oneshot, oneshot::Receiver},
         FutureExt, StreamExt,
@@ -809,7 +809,7 @@ mod streaming_service_tests {
         let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version: MIN_ADVERTISED_STATES,
             start_index: 0,
-            state_kind: StateKind::MainState,
+            snapshot_kind: SnapshotKind::State(StateKind::MainState),
         });
         create_request_message_and_receiver(stream_request)
     }

--- a/state-sync/data-streaming-service/src/tests/client_requests.rs
+++ b/state-sync/data-streaming-service/src/tests/client_requests.rs
@@ -12,7 +12,7 @@ use crate::{
 use aptos_config::config::{DataStreamingServiceConfig, DynamicPrefetchingConfig};
 use aptos_data_client::global_summary::GlobalDataSummary;
 use aptos_id_generator::U64IdGenerator;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_storage_service_types::responses::CompleteDataRange;
 use std::sync::Arc;
 
@@ -62,7 +62,7 @@ fn create_client_requests_state_values_stream() {
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index,
-        state_kind: StateKind::MainState,
+        snapshot_kind: SnapshotKind::State(StateKind::MainState),
     });
 
     // Create a global data summary with a single state range

--- a/state-sync/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/data-streaming-service/src/tests/data_stream.rs
@@ -39,7 +39,7 @@ use aptos_data_client::{
 };
 use aptos_id_generator::U64IdGenerator;
 use aptos_infallible::Mutex;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_storage_service_types::responses::CompleteDataRange;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
@@ -3320,7 +3320,7 @@ fn create_state_value_stream(
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index: 0,
-        state_kind: StateKind::MainState,
+        snapshot_kind: SnapshotKind::State(StateKind::MainState),
     });
     let (data_stream, data_stream_listener, _) =
         create_data_stream(data_client_config, streaming_service_config, stream_request);

--- a/state-sync/data-streaming-service/src/tests/missing_data.rs
+++ b/state-sync/data-streaming-service/src/tests/missing_data.rs
@@ -23,7 +23,7 @@ use aptos_config::config::DataStreamingServiceConfig;
 use aptos_crypto::HashValue;
 use aptos_data_client::{global_summary::GlobalDataSummary, interface::ResponsePayload};
 use aptos_id_generator::U64IdGenerator;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_storage_service_types::responses::CompleteDataRange;
 use aptos_types::{
     proof::{SparseMerkleRangeProof, TransactionInfoListWithProof},
@@ -517,7 +517,7 @@ fn transform_state_values_stream_notifications() {
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index,
-        state_kind: StateKind::MainState,
+        snapshot_kind: SnapshotKind::State(StateKind::MainState),
     });
 
     // Create a global data summary with a single state range

--- a/state-sync/data-streaming-service/src/tests/streaming_client.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_client.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     tests::utils::{create_ledger_info, initialize_logger},
 };
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use claims::assert_ok;
 use futures::{channel::mpsc, executor::block_on, FutureExt, StreamExt};
 use std::thread::JoinHandle;
@@ -46,7 +46,7 @@ fn test_get_all_states() {
     let expected_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version: request_version,
         start_index: 0,
-        state_kind: StateKind::MainState,
+        snapshot_kind: SnapshotKind::State(StateKind::MainState),
     });
 
     // Spawn a new server thread to handle any stream requests
@@ -56,7 +56,7 @@ fn test_get_all_states() {
     let response = block_on(streaming_service_client.get_all_state_values(
         request_version,
         None,
-        StateKind::MainState,
+        SnapshotKind::State(StateKind::MainState),
     ));
     assert_ok!(response);
 }

--- a/state-sync/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_service.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 use aptos_config::config::{AptosDataClientConfig, DataStreamingServiceConfig};
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_time_service::TimeService;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -40,12 +40,46 @@ async fn test_notifications_state_values() {
 
     // Request a state value stream and get a data stream listener
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES, None, StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await
         .unwrap();
 
     // Verify that the stream listener receives all state value notifications
     verify_continuous_state_value_notifications(&mut stream_listener).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_notifications_hot_state_values() {
+    let streaming_client = create_streaming_client_and_service();
+    let mut stream_listener = streaming_client
+        .get_all_state_values(MAX_ADVERTISED_STATES, None, SnapshotKind::HotState)
+        .await
+        .unwrap();
+
+    let mut next_expected_index = 0;
+    loop {
+        let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
+        match data_notification.data_payload {
+            DataPayload::HotStateValuesWithProof(hot_state_values_with_proof) => {
+                assert_eq!(hot_state_values_with_proof.first_index, next_expected_index);
+                let num_hot_values = hot_state_values_with_proof.raw_values.len() as u64;
+                assert_eq!(
+                    hot_state_values_with_proof.last_index,
+                    next_expected_index + num_hot_values - 1
+                );
+                next_expected_index += num_hot_values;
+            },
+            DataPayload::EndOfStream => {
+                assert_eq!(next_expected_index, TOTAL_NUM_STATE_VALUES);
+                return;
+            },
+            data_payload => unexpected_payload_type!(data_payload),
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -55,7 +89,11 @@ async fn test_notifications_state_values_limited_chunks() {
 
     // Request a new state value stream starting at the next expected index
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES, Some(0), StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES,
+            Some(0),
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await
         .unwrap();
 
@@ -74,7 +112,7 @@ async fn test_notifications_state_values_multiple_streams() {
         .get_all_state_values(
             MAX_ADVERTISED_STATES,
             Some(next_expected_index),
-            StateKind::MainState,
+            SnapshotKind::State(StateKind::MainState),
         )
         .await
         .unwrap();
@@ -109,7 +147,7 @@ async fn test_notifications_state_values_multiple_streams() {
                         .get_all_state_values(
                             MAX_ADVERTISED_STATES,
                             Some(next_expected_index),
-                            StateKind::MainState,
+                            SnapshotKind::State(StateKind::MainState),
                         )
                         .await
                         .unwrap();
@@ -1255,19 +1293,31 @@ async fn test_stream_states() {
 
     // Request a state value stream and verify we get a data stream listener
     let result = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES - 1, None, StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES - 1,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await;
     assert_ok!(result);
 
     // Request a stream where states are missing (we are lower than advertised)
     let result = streaming_client
-        .get_all_state_values(MIN_ADVERTISED_STATES - 1, None, StateKind::MainState)
+        .get_all_state_values(
+            MIN_ADVERTISED_STATES - 1,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await;
     assert_matches!(result, Err(Error::DataIsUnavailable(_)));
 
     // Request a stream where states are missing (we are higher than advertised)
     let result = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_EPOCH_END + 1, None, StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_EPOCH_END + 1,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await;
     assert_matches!(result, Err(Error::DataIsUnavailable(_)));
 }
@@ -1566,7 +1616,11 @@ async fn test_terminate_stream() {
 
     // Request a state value stream
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES - 1, None, StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES - 1,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await
         .unwrap();
 

--- a/state-sync/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/data-streaming-service/src/tests/utils.rs
@@ -16,9 +16,10 @@ use aptos_logger::Level;
 use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
-        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, HotStateValuesWithProofRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+        NewTransactionsWithProofRequest, StateValuesWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
@@ -35,6 +36,7 @@ use aptos_types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::SparseMerkleRangeProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -328,6 +330,54 @@ impl AptosDataClientInterface for MockAptosDataClient {
         Ok(create_data_client_response(state_value_chunk_with_proof))
     }
 
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: Version,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> Result<Response<HotStateValueChunkWithProof>, aptos_data_client::error::Error> {
+        // Verify the request timeout
+        let data_request =
+            DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
+                version,
+                start_index,
+                end_index,
+            });
+        self.verify_request_timeout_value(request_timeout_ms, false, false, data_request);
+
+        // Emulate network latencies
+        self.emulate_network_latencies().await;
+
+        // Calculate the last index based on if we should limit the chunk size
+        let end_index = self.calculate_last_index(start_index, end_index);
+
+        // Create hot state keys and values according to the given indices
+        let mut hot_state_keys_and_values = vec![];
+        for _ in start_index..=end_index {
+            hot_state_keys_and_values.push((
+                StateKey::raw(HashValue::random().as_ref()),
+                HotStateValue::new(Some(StateValue::from(vec![])), version),
+            ));
+        }
+
+        // Create a hot state value chunk with proof
+        let hot_state_value_chunk_with_proof = HotStateValueChunkWithProof {
+            first_index: start_index,
+            last_index: end_index,
+            first_key: HashValue::random(),
+            last_key: HashValue::random(),
+            raw_values: hot_state_keys_and_values,
+            proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
+        };
+
+        // Create and send a data client response
+        Ok(create_data_client_response(
+            hot_state_value_chunk_with_proof,
+        ))
+    }
+
     async fn get_epoch_ending_ledger_infos(
         &self,
         start_epoch: Epoch,
@@ -535,6 +585,22 @@ impl AptosDataClientInterface for MockAptosDataClient {
     ) -> Result<Response<u64>, aptos_data_client::error::Error> {
         // Verify the request timeout
         let data_request = DataRequest::GetNumberOfStatesAtVersion(version);
+        self.verify_request_timeout_value(request_timeout_ms, false, false, data_request);
+
+        // Emulate network latencies
+        self.emulate_network_latencies().await;
+
+        // Create and send a data client response
+        Ok(create_data_client_response(TOTAL_NUM_STATE_VALUES))
+    }
+
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> Result<Response<u64>, aptos_data_client::error::Error> {
+        // Verify the request timeout
+        let data_request = DataRequest::GetNumberOfHotStatesAtVersion(version);
         self.verify_request_timeout_value(request_timeout_ms, false, false, data_request);
 
         // Emulate network latencies

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -21,7 +21,7 @@ use aptos_data_streaming_service::{
     streaming_client::{DataStreamingClient, NotificationAndFeedback, NotificationFeedback},
 };
 use aptos_logger::{prelude::*, sample::SampleRate};
-use aptos_storage_interface::{DbReader, StateKind};
+use aptos_storage_interface::{DbReader, SnapshotKind, StateKind};
 use aptos_types::{
     epoch_change::Verifier,
     epoch_state::EpochState,
@@ -745,7 +745,7 @@ impl<
             .get_all_state_values(
                 target_ledger_info_version,
                 Some(next_state_index_to_process),
-                kind,
+                SnapshotKind::State(kind),
             )
             .await?;
         self.active_data_stream = Some(data_stream);

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -27,7 +27,7 @@ use aptos_data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     streaming_client::{NotificationAndFeedback, NotificationFeedback},
 };
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_time_service::TimeService;
 use aptos_types::{
     transaction::{TransactionOutputListWithProofV2, Version},
@@ -1070,7 +1070,7 @@ async fn test_snapshot_sync_epoch_change() {
         .with(
             eq(target_version),
             eq(Some(last_persisted_index)),
-            eq(StateKind::MainState),
+            eq(SnapshotKind::State(StateKind::MainState)),
         )
         .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
@@ -1134,7 +1134,11 @@ async fn test_snapshot_sync_epoch_change_genesis() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(target_version), eq(Some(0)), eq(StateKind::MainState))
+        .with(
+            eq(target_version),
+            eq(Some(0)),
+            eq(SnapshotKind::State(StateKind::MainState)),
+        )
         .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
     // Create the mock metadata storage
@@ -1197,7 +1201,11 @@ async fn test_snapshot_sync_state_values_invalid_chunk_retries() {
         mock_streaming_client
             .expect_get_all_state_values()
             .times(1)
-            .with(always(), eq(Some(0)), eq(StateKind::MainState))
+            .with(
+                always(),
+                eq(Some(0)),
+                eq(SnapshotKind::State(StateKind::MainState)),
+            )
             .return_once(move |_, _, _| Ok(data_stream_listener))
             .in_sequence(&mut expectation_sequence);
     }
@@ -1292,7 +1300,7 @@ async fn test_snapshot_sync_epoch_change_genesis_restart() {
         .with(
             eq(target_version),
             eq(Some(last_persisted_index)),
-            eq(StateKind::MainState),
+            eq(SnapshotKind::State(StateKind::MainState)),
         )
         .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
@@ -1364,7 +1372,7 @@ async fn test_snapshot_sync_existing_state() {
         .with(
             eq(highest_version),
             eq(Some(last_persisted_index)),
-            eq(StateKind::MainState),
+            eq(SnapshotKind::State(StateKind::MainState)),
         )
         .return_once(move |_, _, _| Ok(data_stream_listener_1))
         .in_sequence(&mut expectation_sequence);
@@ -1387,7 +1395,7 @@ async fn test_snapshot_sync_existing_state() {
         .with(
             eq(highest_version),
             eq(Some(last_persisted_index)),
-            eq(StateKind::MainState),
+            eq(SnapshotKind::State(StateKind::MainState)),
         )
         .return_once(move |_, _, _| Ok(data_stream_listener_2))
         .in_sequence(&mut expectation_sequence);
@@ -1469,7 +1477,11 @@ async fn test_snapshot_sync_fresh_state() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(highest_version), eq(Some(0)), eq(StateKind::MainState))
+        .with(
+            eq(highest_version),
+            eq(Some(0)),
+            eq(SnapshotKind::State(StateKind::MainState)),
+        )
         .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
     // Create the mock metadata storage

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -17,7 +17,7 @@ use aptos_data_streaming_service::{
 use aptos_executor_types::{ChunkCommitNotification, ChunkExecutorTrait};
 use aptos_storage_interface::{
     chunk_to_commit::ChunkToCommit, DbReader, DbReaderWriter, DbWriter, LedgerSummary, Result,
-    StateKind, StateSnapshotReceiver,
+    SnapshotKind, StateKind, StateSnapshotReceiver,
 };
 use aptos_types::{
     epoch_change::EpochChangeProof,
@@ -363,7 +363,7 @@ mock! {
             &self,
             version: Version,
             start_index: Option<u64>,
-            state_kind: StateKind,
+            snapshot_kind: SnapshotKind,
         ) -> AnyhowResult<DataStreamListener, aptos_data_streaming_service::error::Error>;
 
         async fn get_all_epoch_ending_ledger_infos(

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -270,6 +270,18 @@ impl DbWriter for AptosDB {
                 .state_pruner
                 .state_kv_pruner
                 .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_state_merkle_pruner
+                .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_epoch_snapshot_pruner
+                .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_state_kv_pruner
+                .save_min_readable_version(version)?;
 
             restore_utils::update_latest_ledger_info(self.ledger_db.metadata_db(), ledger_infos)?;
             self.state_store.reset();

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -71,6 +71,13 @@ where
         self.inner.remove(key)
     }
 
+    fn replace(&self, map: DashMap<K, V>) {
+        self.inner.clear();
+        for (key, value) in map {
+            self.inner.insert(key, value);
+        }
+    }
+
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -153,6 +160,12 @@ enum CommitMsg {
         state: State,
         ack: Sender<()>,
     },
+    /// Sent by `reset_base_shards` to replace the base DashMaps' contents on the Committer
+    /// thread. Like `HackReset`, only valid when no commits are in flight.
+    ResetBase {
+        shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+        ack: Sender<()>,
+    },
 }
 
 /// Bundles the committed `State` with a `HotStateView` that is consistent with it.
@@ -228,6 +241,25 @@ impl HotState {
         ack_rx
             .recv()
             .expect("Failed to receive reset ack from hot state committer.");
+    }
+
+    /// Replaces the base DashMaps' contents with `shards`. Blocks until the Committer has done
+    /// so. Must be followed by `hack_reset` with the matching `State`, which re-validates the
+    /// LRU metadata against the new contents.
+    pub(crate) fn reset_base_shards(
+        &self,
+        shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+    ) {
+        let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+        self.commit_tx
+            .send(CommitMsg::ResetBase {
+                shards,
+                ack: ack_tx,
+            })
+            .expect("Failed to send base reset to hot state committer.");
+        ack_rx
+            .recv()
+            .expect("Failed to receive base reset ack from hot state committer.");
     }
 
     pub fn get_committed(&self) -> (Arc<dyn HotStateView>, State) {
@@ -478,6 +510,17 @@ impl Committer {
                     );
                     self.handle_reset(state, ack);
                 },
+                Ok(CommitMsg::ResetBase { shards, ack }) => {
+                    assert!(
+                        self.rx.try_recv().is_err(),
+                        "ResetBase must be the only message in the channel — \
+                         reset_base_shards is only valid when no commits are in flight."
+                    );
+                    for (shard, loaded) in self.base.shards.iter().zip(shards) {
+                        shard.replace(loaded);
+                    }
+                    let _ = ack.send(());
+                },
                 Err(RecvTimeoutError::Timeout) => {
                     self.try_merge();
                 },
@@ -494,10 +537,10 @@ impl Committer {
                     n_backlog += 1;
                     ret = state;
                 },
-                CommitMsg::HackReset { .. } => {
+                CommitMsg::HackReset { .. } | CommitMsg::ResetBase { .. } => {
                     unreachable!(
-                        "HackReset must not appear alongside Commit messages — \
-                         hack_reset is only valid when no commits are in flight."
+                        "Reset messages must not appear alongside Commit messages — \
+                         resets are only valid when no commits are in flight."
                     );
                 },
             }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -82,6 +82,7 @@ use aptos_types::{
     transaction::Version,
 };
 use claims::{assert_ge, assert_le};
+use dashmap::DashMap;
 use itertools::Itertools;
 use rayon::prelude::*;
 use std::{
@@ -990,24 +991,46 @@ impl StateStore {
         state_db: &Arc<StateDb>,
         hot_state_config: HotStateConfig,
     ) -> (PersistedState, [HotStateMetadata; NUM_STATE_SHARDS]) {
-        let empty = || {
-            (
+        match Self::try_load_hot_state_kvs(state_db, hot_state_config) {
+            None => (
                 PersistedState::new_empty(hot_state_config),
                 Default::default(),
-            )
-        };
-
-        if hot_state_config.delete_on_restart {
-            return empty();
+            ),
+            Some((snapshot_version, shards, metadata)) => {
+                let usage = state_db
+                    .get_state_storage_usage(Some(snapshot_version))
+                    .expect("Failed to query state storage usage on initialization.");
+                let state = State::new_at_version_with_hot_state_metadata(
+                    Some(snapshot_version),
+                    usage,
+                    hot_state_config,
+                    metadata.clone(),
+                );
+                (
+                    PersistedState::new_from_loaded(state, hot_state_config, shards),
+                    metadata,
+                )
+            },
         }
-        let snapshot_version = match state_db
+    }
+
+    /// Loads the hot state KV shards and per-shard LRU metadata at the latest snapshot
+    /// version. `None` when loading is not applicable (disabled, no snapshot).
+    fn try_load_hot_state_kvs(
+        state_db: &Arc<StateDb>,
+        hot_state_config: HotStateConfig,
+    ) -> Option<(
+        Version,
+        [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+        [HotStateMetadata; NUM_STATE_SHARDS],
+    )> {
+        if hot_state_config.delete_on_restart {
+            return None;
+        }
+        let snapshot_version = state_db
             .state_merkle_db
             .get_state_snapshot_version_before(Version::MAX)
-            .expect("Failed to query latest snapshot on initialization.")
-        {
-            Some(v) => v,
-            None => return empty(),
-        };
+            .expect("Failed to query latest snapshot on initialization.")?;
 
         let loaded = state_db
             .hot_state_kv_db
@@ -1021,21 +1044,7 @@ impl StateStore {
                 loaded[i].total_value_bytes,
             )
         });
-        let dashmaps = loaded.map(|s| s.map);
-        let usage = state_db
-            .get_state_storage_usage(Some(snapshot_version))
-            .expect("Failed to query state storage usage on initialization.");
-        let state = State::new_at_version_with_hot_state_metadata(
-            Some(snapshot_version),
-            usage,
-            hot_state_config,
-            metadata.clone(),
-        );
-
-        (
-            PersistedState::new_from_loaded(state, hot_state_config, dashmaps),
-            metadata,
-        )
+        Some((snapshot_version, loaded.map(|s| s.map), metadata))
     }
 
     pub fn reset(&self) {
@@ -1046,9 +1055,16 @@ impl StateStore {
         // drop-time `sync_commit` read the new family and panic on
         // `is_descendant_of`.
         self.buffered_state.lock().quit();
-        // TODO(HotState): restore does not reconstruct the hot state yet, so we pass empty
-        // metadata here. This is safe because callers (restore / state-sync) open the DB with
-        // `empty_buffered_state_for_restore`, so the DashMaps are always empty.
+        // A restore may have written a hot state snapshot since the DB was opened, so
+        // reload it into the in-memory hot state before rebuilding the buffered state.
+        // TODO(HotState): A restore must load this snapshot even when
+        // `delete_on_restart` is set.
+        let (shards, hot_state_metadata) =
+            match Self::try_load_hot_state_kvs(&self.state_db, self.hot_state_config) {
+                Some((_version, shards, metadata)) => (shards, metadata),
+                None => (std::array::from_fn(|_| DashMap::new()), Default::default()),
+            };
+        self.persisted_state.reset_hot_state_shards(shards);
         *self.buffered_state.lock() = Self::create_buffered_state_from_latest_snapshot(
             &self.state_db,
             self.buffered_state_target_items,
@@ -1056,7 +1072,7 @@ impl StateStore {
             true,
             self.current_state.clone(),
             self.persisted_state.clone(),
-            Default::default(),
+            hot_state_metadata,
             self.hot_state_config,
         )
         .expect("buffered state creation failed.");

--- a/storage/aptosdb/src/state_store/persisted_state.rs
+++ b/storage/aptosdb/src/state_store/persisted_state.rs
@@ -74,6 +74,17 @@ impl PersistedState {
         self.hot_state.enqueue_commit(state);
     }
 
+    /// Replaces the base hot state shards, e.g. with what a restore wrote. Must be followed by
+    /// `hack_reset` with the matching LRU metadata.
+    ///
+    /// n.b. Can only be used when no on the fly commit is in the queue.
+    pub fn reset_hot_state_shards(
+        &self,
+        shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+    ) {
+        self.hot_state.reset_base_shards(shards);
+    }
+
     // n.b. Can only be used when no on the fly commit is in the queue.
     pub fn hack_reset(&self, state_with_summary: StateWithSummary) {
         let (state, summary) = state_with_summary.into_inner();

--- a/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
@@ -12,7 +12,7 @@ use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_jellyfish_merkle::{
     mock_tree_store::MockTreeStore, restore::JellyfishMerkleRestore, JellyfishMerkleTree,
 };
-use aptos_storage_interface::{DbReader, DbWriter, Result as DbResult};
+use aptos_storage_interface::{DbReader, DbWriter, Result as DbResult, StateKind};
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -20,6 +20,7 @@ use aptos_types::{
         hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::StateValue,
+        NUM_STATE_SHARDS,
     },
     transaction::{
         BlockEndInfo, ExecutionStatus, Transaction, TransactionAuxiliaryData, TransactionInfo,
@@ -469,6 +470,27 @@ fn open_persistent_hot_state_db(path: &TempPath) -> AptosDB {
     .unwrap()
 }
 
+/// Restores the cold state snapshot at `version` from `src` into `dst`, which `reset` needs
+/// to locate the latest snapshot.
+fn restore_cold_state(src: &AptosDB, dst: &AptosDB, version: Version) {
+    let root_hash = src.state_store.get_root_hash(version).unwrap();
+    let num_items = src
+        .get_state_item_count(version, StateKind::MainState)
+        .unwrap();
+    let mut receiver = dst
+        .get_state_snapshot_receiver(version, root_hash, StateKind::MainState)
+        .unwrap();
+    let mut first_index = 0;
+    while first_index < num_items {
+        let chunk = src
+            .get_state_value_chunk_with_proof(version, first_index, 2, StateKind::MainState)
+            .unwrap();
+        first_index += chunk.raw_values.len();
+        receiver.add_chunk(chunk.raw_values, chunk.proof).unwrap();
+    }
+    receiver.finish_box().unwrap();
+}
+
 #[test]
 fn test_hot_state_restore() {
     let tmp_src = TempPath::new();
@@ -487,6 +509,7 @@ fn test_hot_state_restore() {
 
     let tmp_dst = TempPath::new();
     let dst = open_persistent_hot_state_db(&tmp_dst);
+    restore_cold_state(&src, &dst, version);
     let mut receiver = dst
         .get_hot_state_snapshot_receiver(version, root_hash)
         .unwrap();
@@ -496,6 +519,7 @@ fn test_hot_state_restore() {
             .unwrap();
     }
     receiver.finish_box().unwrap();
+    dst.state_store.reset();
 
     // The restored DB serves the same snapshot.
     assert_eq!(
@@ -507,6 +531,31 @@ fn test_hot_state_restore() {
         dst.state_store
             .hot_state_merkle_db
             .get_root_hash(version)
+            .unwrap(),
+        root_hash
+    );
+
+    // `reset` reloaded the restored hot state into memory.
+    let (hot_view, state) = dst.get_persisted_state().unwrap();
+    let num_hot_items: usize = (0..NUM_STATE_SHARDS)
+        .map(|shard_id| state.num_hot_items(shard_id))
+        .sum();
+    assert_eq!(num_hot_items, expected.len());
+    for (key, hot_value) in &expected {
+        let slot = hot_view
+            .get_state_slot(key.crypto_hash_ref())
+            .expect("restored key must be hot");
+        assert_eq!(slot.as_state_value_opt(), hot_value.value_opt());
+        assert_eq!(
+            slot.expect_hot_since_version(),
+            hot_value.hot_since_version()
+        );
+    }
+    assert_eq!(
+        dst.state_store
+            .current_state_locked()
+            .summary()
+            .hot_root_hash()
             .unwrap(),
         root_hash
     );

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -49,7 +49,10 @@ use crate::{
         state_with_summary::LedgerWithSummary,
     },
 };
-pub use aptos_types::{block_info::BlockHeight, state_store::StateKind};
+pub use aptos_types::{
+    block_info::BlockHeight,
+    state_store::{SnapshotKind, StateKind},
+};
 pub use errors::AptosDbError;
 pub use ledger_summary::LedgerSummary;
 

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -38,6 +38,13 @@ pub enum StateKind {
     Position,
 }
 
+/// Identifies a snapshot store streamed by state sync. Hot state has a distinct leaf type and API.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum SnapshotKind {
+    State(StateKind),
+    HotState,
+}
+
 pub type StateViewResult<T, E = StateViewError> = std::result::Result<T, E>;
 
 /// A trait that defines a read-only snapshot of the global state. It is passed to the VM for


### PR DESCRIPTION

Extend the state snapshot stream to cover the hot state tree, so fast
sync can download it in a follow-up.

- `SnapshotKind { State(StateKind), HotState }` parameterizes the
  `GetAllStates` stream request end to end; the hot variant streams
  `HotStateValue` chunks via the new `NumberOfHotStates` and
  `HotStateValuesWithProof` client requests.
- A zero state count completes the hot stream without notifications, as
  the position stream already did; the main state still rejects an
  empty snapshot.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/20481).
* #20483
* #20482
* __->__ #20481
* #20480
* #20479