### PR TITLE
[state-sync] Fast sync hot state

### DIFF
--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -34,10 +34,11 @@ use aptos_storage_interface::{DbReader, StateKind};
 use aptos_storage_service_client::StorageServiceClient;
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
-        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        NumberOfStatesRequestV2, StateValuesWithProofRequest, StateValuesWithProofRequestV2,
-        StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, HotStateValuesWithProofRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+        NewTransactionsWithProofRequest, NumberOfStatesRequestV2, StateValuesWithProofRequest,
+        StateValuesWithProofRequestV2, StorageServiceRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
@@ -52,7 +53,7 @@ use aptos_time_service::TimeService;
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use arc_swap::ArcSwap;
@@ -1095,6 +1096,33 @@ impl AptosDataClientInterface for AptosDataClient {
                 Ok(response.map(|response| response.state_value_chunk_with_proof))
             },
         }
+    }
+
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> crate::error::Result<Response<u64>> {
+        let data_request = DataRequest::GetNumberOfHotStatesAtVersion(version);
+        self.create_and_send_storage_request(request_timeout_ms, data_request)
+            .await
+    }
+
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> crate::error::Result<Response<HotStateValueChunkWithProof>> {
+        let data_request =
+            DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
+                version,
+                start_index,
+                end_index,
+            });
+        self.create_and_send_storage_request(request_timeout_ms, data_request)
+            .await
     }
 
     async fn get_transaction_outputs_with_proof(

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -6,7 +6,7 @@ use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{responses::TransactionOrOutputListWithProofV2, Epoch};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use async_trait::async_trait;
@@ -90,6 +90,24 @@ pub trait AptosDataClientInterface {
         request_timeout_ms: u64,
         kind: StateKind,
     ) -> error::Result<Response<StateValueChunkWithProof>>;
+
+    /// Fetches the number of hot states at the specified version.
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<u64>>;
+
+    /// Fetches a single hot state value chunk with proof, containing the values
+    /// from start to end index (inclusive) at the specified version. Otherwise
+    /// behaves like `get_state_values_with_proof`.
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<HotStateValueChunkWithProof>>;
 
     /// Fetches a transaction output list with proof, with transaction
     /// outputs from start to end versions (inclusive). The proof is relative
@@ -268,6 +286,7 @@ impl<T> Response<T> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResponsePayload {
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
+    HotStateValuesWithProof(HotStateValueChunkWithProof),
     NewTransactionOutputsWithProof((TransactionOutputListWithProofV2, LedgerInfoWithSignatures)),
     NewTransactionsWithProof((TransactionListWithProofV2, LedgerInfoWithSignatures)),
     NumberOfStates(u64),
@@ -282,6 +301,7 @@ impl ResponsePayload {
     pub fn get_label(&self) -> &'static str {
         match self {
             Self::EpochEndingLedgerInfos(_) => "epoch_ending_ledger_infos",
+            Self::HotStateValuesWithProof(_) => "hot_state_values_with_proof",
             Self::NewTransactionOutputsWithProof(_) => "new_transaction_outputs_with_proof",
             Self::NewTransactionsWithProof(_) => "new_transactions_with_proof",
             Self::NumberOfStates(_) => "number_of_states",
@@ -297,6 +317,9 @@ impl ResponsePayload {
         match self {
             Self::EpochEndingLedgerInfos(epoch_ending_ledger_infos) => {
                 epoch_ending_ledger_infos.len()
+            },
+            Self::HotStateValuesWithProof(hot_state_values_with_proof) => {
+                hot_state_values_with_proof.raw_values.len()
             },
             Self::NewTransactionOutputsWithProof((outputs_with_proof, _)) => {
                 outputs_with_proof.get_num_outputs()
@@ -323,6 +346,12 @@ impl ResponsePayload {
 impl From<StateValueChunkWithProof> for ResponsePayload {
     fn from(inner: StateValueChunkWithProof) -> Self {
         Self::StateValuesWithProof(inner)
+    }
+}
+
+impl From<HotStateValueChunkWithProof> for ResponsePayload {
+    fn from(inner: HotStateValueChunkWithProof) -> Self {
+        Self::HotStateValuesWithProof(inner)
     }
 }
 

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -36,7 +36,7 @@ use aptos_storage_service_types::{
 use aptos_time_service::{MockTimeService, TimeService};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
     PeerId,
 };
@@ -316,6 +316,20 @@ mock! {
             request_timeout_ms: u64,
             kind: StateKind,
         ) -> Result<Response<StateValueChunkWithProof>>;
+
+        async fn get_number_of_hot_states(
+            &self,
+            version: Version,
+            request_timeout_ms: u64,
+        ) -> Result<Response<u64>>;
+
+        async fn get_hot_state_values_with_proof(
+            &self,
+            version: u64,
+            start_index: u64,
+            end_index: u64,
+            request_timeout_ms: u64,
+        ) -> Result<Response<HotStateValueChunkWithProof>>;
 
         async fn get_transaction_outputs_with_proof(
             &self,

--- a/state-sync/data-streaming-service/src/data_notification.rs
+++ b/state-sync/data-streaming-service/src/data_notification.rs
@@ -6,7 +6,7 @@ use aptos_data_client::interface::{Response, ResponsePayload};
 use aptos_storage_interface::StateKind;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use std::{
@@ -46,6 +46,7 @@ pub enum DataPayload {
     ContinuousTransactionsWithProof(LedgerInfoWithSignatures, TransactionListWithProofV2),
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
     EndOfStream,
+    HotStateValuesWithProof(HotStateValueChunkWithProof),
     StateValuesWithProof(StateKind, StateValueChunkWithProof),
     TransactionOutputsWithProof(TransactionOutputListWithProofV2),
     TransactionsWithProof(TransactionListWithProofV2),
@@ -55,8 +56,10 @@ pub enum DataPayload {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataClientRequest {
     EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest),
+    HotStateValuesWithProof(HotStateValuesWithProofRequest),
     NewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest),
     NewTransactionsWithProof(NewTransactionsWithProofRequest),
+    NumberOfHotStates(Version),
     NumberOfStates(NumberOfStatesRequest),
     StateValuesWithProof(StateValuesWithProofRequest),
     TransactionsWithProof(TransactionsWithProofRequest),
@@ -73,8 +76,10 @@ impl DataClientRequest {
     pub fn get_label(&self) -> &'static str {
         match self {
             Self::EpochEndingLedgerInfos(_) => "epoch_ending_ledger_infos",
+            Self::HotStateValuesWithProof(_) => "hot_state_values_with_proof",
             Self::NewTransactionOutputsWithProof(_) => "new_transaction_outputs_with_proof",
             Self::NewTransactionsWithProof(_) => "new_transactions_with_proof",
+            Self::NumberOfHotStates(_) => "number_of_hot_states",
             Self::NumberOfStates(_) => "number_of_states",
             Self::StateValuesWithProof(_) => "state_values_with_proof",
             Self::TransactionsWithProof(_) => "transactions_with_proof",
@@ -127,6 +132,14 @@ pub struct StateValuesWithProofRequest {
     pub start_index: u64,
     pub end_index: u64,
     pub state_kind: StateKind,
+}
+
+/// A request for fetching hot state values at a version.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HotStateValuesWithProofRequest {
+    pub version: Version,
+    pub start_index: u64,
+    pub end_index: u64,
 }
 
 /// A client request for fetching epoch ending ledger infos.

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -5,9 +5,10 @@ use crate::{
     data_notification,
     data_notification::{
         DataClientRequest, DataNotification, DataPayload, EpochEndingLedgerInfosRequest,
-        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
-        NewTransactionsWithProofRequest, NotificationId, NumberOfStatesRequest,
-        StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
+        HotStateValuesWithProofRequest, NewTransactionOutputsWithProofRequest,
+        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest, NotificationId,
+        NumberOfStatesRequest, StateValuesWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
         TransactionsWithProofRequest,
@@ -36,6 +37,7 @@ use aptos_logger::prelude::*;
 #[cfg(test)]
 use aptos_storage_interface::StateKind;
 use aptos_time_service::{TimeService, TimeServiceTrait};
+use aptos_types::transaction::Version;
 use futures::{channel::mpsc, stream::FusedStream, SinkExt, Stream};
 use std::{
     cmp::min,
@@ -1048,6 +1050,9 @@ pub(crate) fn create_missing_data_request(
         DataClientRequest::StateValuesWithProof(request) => {
             create_missing_state_values_request(request, response_payload)
         },
+        DataClientRequest::HotStateValuesWithProof(request) => {
+            create_missing_hot_state_values_request(request, response_payload)
+        },
         DataClientRequest::TransactionsWithProof(request) => {
             create_missing_transactions_request(request, response_payload)
         },
@@ -1152,6 +1157,46 @@ fn create_missing_state_values_request(
 /// Creates and returns a missing transactions request if the given client
 /// response doesn't satisfy the original request. If the request is satisfied,
 /// None is returned.
+/// Creates and returns a missing hot state values request if the response is short.
+fn create_missing_hot_state_values_request(
+    request: &HotStateValuesWithProofRequest,
+    response_payload: &ResponsePayload,
+) -> Result<Option<DataClientRequest>, Error> {
+    let num_requested = request
+        .end_index
+        .checked_sub(request.start_index)
+        .and_then(|v| v.checked_add(1))
+        .ok_or_else(|| {
+            Error::IntegerOverflow("Number of requested hot states has overflown!".into())
+        })?;
+
+    match response_payload {
+        ResponsePayload::HotStateValuesWithProof(chunk) => {
+            let num_received = chunk.raw_values.len() as u64;
+            if num_received < num_requested {
+                let start_index = request
+                    .start_index
+                    .checked_add(num_received)
+                    .ok_or_else(|| Error::IntegerOverflow("Start index has overflown!".into()))?;
+                Ok(Some(DataClientRequest::HotStateValuesWithProof(
+                    HotStateValuesWithProofRequest {
+                        version: request.version,
+                        start_index,
+                        end_index: request.end_index,
+                    },
+                )))
+            } else {
+                Ok(None)
+            }
+        },
+        payload => Err(Error::AptosDataClientResponseIsInvalid(format!(
+            "Invalid response payload found for hot state values request: {:?}",
+            payload
+        ))),
+    }
+}
+
+/// Creates and returns a missing transactions request if the response is short.
 fn create_missing_transactions_request(
     request: &TransactionsWithProofRequest,
     response_payload: &ResponsePayload,
@@ -1325,10 +1370,16 @@ fn sanity_check_client_response_type(
                 ResponsePayload::NewTransactionOutputsWithProof(_)
             )
         },
-        DataClientRequest::NumberOfStates(_) => {
+        DataClientRequest::NumberOfHotStates(_) | DataClientRequest::NumberOfStates(_) => {
             matches!(
                 data_client_response.payload,
                 ResponsePayload::NumberOfStates(_)
+            )
+        },
+        DataClientRequest::HotStateValuesWithProof(_) => {
+            matches!(
+                data_client_response.payload,
+                ResponsePayload::HotStateValuesWithProof(_)
             )
         },
         DataClientRequest::StateValuesWithProof(_) => {
@@ -1445,8 +1496,15 @@ fn spawn_request_task<T: AptosDataClientInterface + Send + Clone + 'static>(
                 )
                 .await
             },
+            DataClientRequest::NumberOfHotStates(version) => {
+                get_number_of_hot_states(aptos_data_client, version, request_timeout_ms).await
+            },
             DataClientRequest::NumberOfStates(request) => {
                 get_number_of_states(aptos_data_client, request, request_timeout_ms).await
+            },
+            DataClientRequest::HotStateValuesWithProof(request) => {
+                get_hot_state_values_with_proof(aptos_data_client, request, request_timeout_ms)
+                    .await
             },
             DataClientRequest::StateValuesWithProof(request) => {
                 get_states_values_with_proof(aptos_data_client, request, request_timeout_ms).await
@@ -1525,6 +1583,33 @@ async fn get_states_values_with_proof<T: AptosDataClientInterface + Send + Clone
         )
         .await?;
     Ok(client_response.map(ResponsePayload::StateValuesWithProof))
+}
+
+async fn get_hot_state_values_with_proof<T: AptosDataClientInterface + Send + Clone + 'static>(
+    aptos_data_client: T,
+    request: HotStateValuesWithProofRequest,
+    request_timeout_ms: u64,
+) -> Result<Response<ResponsePayload>, aptos_data_client::error::Error> {
+    let client_response = aptos_data_client
+        .get_hot_state_values_with_proof(
+            request.version,
+            request.start_index,
+            request.end_index,
+            request_timeout_ms,
+        )
+        .await?;
+    Ok(client_response.map(ResponsePayload::HotStateValuesWithProof))
+}
+
+async fn get_number_of_hot_states<T: AptosDataClientInterface + Send + Clone + 'static>(
+    aptos_data_client: T,
+    version: Version,
+    request_timeout_ms: u64,
+) -> Result<Response<ResponsePayload>, aptos_data_client::error::Error> {
+    let client_response = aptos_data_client
+        .get_number_of_hot_states(version, request_timeout_ms)
+        .await?;
+    Ok(client_response.map(ResponsePayload::NumberOfStates))
 }
 
 async fn get_epoch_ending_ledger_infos<T: AptosDataClientInterface + Send + Clone + 'static>(

--- a/state-sync/data-streaming-service/src/dynamic_prefetching.rs
+++ b/state-sync/data-streaming-service/src/dynamic_prefetching.rs
@@ -4,7 +4,7 @@
 use crate::{metrics, stream_engine::StreamEngine};
 use aptos_config::config::{DataStreamingServiceConfig, DynamicPrefetchingConfig};
 #[cfg(test)]
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use std::{
     cmp::{max, min},
@@ -695,7 +695,7 @@ mod test {
         let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version: 0,
             start_index: 0,
-            state_kind: StateKind::MainState,
+            snapshot_kind: SnapshotKind::State(StateKind::MainState),
         });
 
         // Create and return the stream engine

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -2223,6 +2223,10 @@ fn create_data_notification(
         // The number of states is consumed internally by the engine for chunk
         // planning; it is never surfaced to the consumer as a notification.
         ResponsePayload::NumberOfStates(_) => invalid_response_type!(client_response_type),
+        // Hot state values are not streamed yet.
+        ResponsePayload::HotStateValuesWithProof(_) => {
+            invalid_response_type!(client_response_type)
+        },
         ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
             DataPayload::EpochEndingLedgerInfos(ledger_infos)
         },

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -5,15 +5,16 @@ use crate::{
     data_notification::{
         DataClientRequest,
         DataClientRequest::{
-            EpochEndingLedgerInfos, NewTransactionOutputsWithProof,
-            NewTransactionsOrOutputsWithProof, NewTransactionsWithProof, NumberOfStates,
-            StateValuesWithProof, SubscribeTransactionOutputsWithProof,
+            EpochEndingLedgerInfos, HotStateValuesWithProof, NewTransactionOutputsWithProof,
+            NewTransactionsOrOutputsWithProof, NewTransactionsWithProof, NumberOfHotStates,
+            NumberOfStates, StateValuesWithProof, SubscribeTransactionOutputsWithProof,
             SubscribeTransactionsOrOutputsWithProof, SubscribeTransactionsWithProof,
             TransactionOutputsWithProof, TransactionsOrOutputsWithProof, TransactionsWithProof,
         },
         DataNotification, DataPayload, EpochEndingLedgerInfosRequest,
-        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
-        NewTransactionsWithProofRequest, NumberOfStatesRequest, StateValuesWithProofRequest,
+        HotStateValuesWithProofRequest, NewTransactionOutputsWithProofRequest,
+        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
+        NumberOfStatesRequest, StateValuesWithProofRequest,
         SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
@@ -33,7 +34,7 @@ use aptos_data_client::{
 };
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
 use aptos_logger::prelude::*;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use enum_dispatch::enum_dispatch;
 use std::{cmp, cmp::min, sync::Arc};
@@ -170,7 +171,7 @@ pub struct StateStreamEngine {
     pub request: GetAllStatesRequest,
 
     // Which snapshot store this engine streams
-    pub kind: StateKind,
+    pub kind: SnapshotKind,
 
     // True iff a request has been created to fetch the number of states
     pub state_num_requested: bool,
@@ -194,7 +195,7 @@ impl StateStreamEngine {
     fn new(request: &GetAllStatesRequest) -> Result<Self, Error> {
         Ok(StateStreamEngine {
             request: request.clone(),
-            kind: request.state_kind,
+            kind: request.snapshot_kind,
             state_num_requested: false,
             number_of_states: None,
             next_stream_index: request.start_index,
@@ -215,6 +216,12 @@ impl StateStreamEngine {
                             Error::IntegerOverflow("Next request index has overflown!".into())
                         })?;
                 },
+                HotStateValuesWithProof(request) => {
+                    self.next_request_index =
+                        request.end_index.checked_add(1).ok_or_else(|| {
+                            Error::IntegerOverflow("Next request index has overflown!".into())
+                        })?;
+                },
                 request => invalid_client_request!(request, self),
             }
         }
@@ -225,6 +232,87 @@ impl StateStreamEngine {
         self.number_of_states.ok_or_else(|| {
             Error::UnexpectedErrorEncountered("Number of states is not initialized!".into())
         })
+    }
+
+    /// Shared chunk-response handling for the `StateValuesWithProof` and
+    /// `HotStateValuesWithProof` responses.
+    fn process_state_chunk(
+        &mut self,
+        start_index: u64,
+        end_index: u64,
+        last_received_index: u64,
+        client_response_payload: ResponsePayload,
+        notification_id_generator: Arc<U64IdGenerator>,
+    ) -> Result<Option<DataNotification>, Error> {
+        let last_received_index = bound_by_range(last_received_index, start_index, end_index);
+
+        // Update the next stream index
+        self.next_stream_index = last_received_index
+            .checked_add(1)
+            .ok_or_else(|| Error::IntegerOverflow("Next stream index has overflown!".into()))?;
+
+        // Check if the stream is complete
+        let last_stream_index = self
+            .get_number_of_states()?
+            .checked_sub(1)
+            .ok_or_else(|| Error::IntegerOverflow("End index has overflown!".into()))?;
+        if last_received_index >= last_stream_index {
+            self.stream_is_complete = true;
+        }
+
+        // Create a new data notification
+        let data_notification = create_data_notification(
+            notification_id_generator,
+            client_response_payload,
+            None,
+            self.clone().into(),
+        )?;
+        Ok(Some(data_notification))
+    }
+
+    /// Shared handling for the `NumberOfStates` and `NumberOfHotStates` responses.
+    fn handle_number_of_states(
+        &mut self,
+        request_version: Version,
+        client_response_payload: ResponsePayload,
+    ) -> Result<(), Error> {
+        if let ResponsePayload::NumberOfStates(number_of_states) = client_response_payload {
+            info!(
+                (LogSchema::new(LogEntry::ReceivedDataResponse)
+                    .event(LogEvent::Success)
+                    .message(&format!(
+                        "Received number of states at version: {:?}. Total states: {:?}",
+                        request_version, number_of_states
+                    )))
+            );
+            self.state_num_requested = false;
+
+            // Sanity check the response before saving it.
+            if number_of_states < self.next_request_index {
+                return Err(Error::NoDataToFetch(format!(
+                    "The next state index to fetch is higher than the \
+                    total number of states. Next index: {:?}, total states: {:?}",
+                    self.next_request_index, number_of_states
+                )));
+            }
+            // The number of states is an internal planning value, not
+            // consumer data. An empty tree (count 0) has no chunks: just
+            // end the stream (no notification). The bootstrapper detects
+            // the zero-chunk end and verifies emptiness against the
+            // committed snapshot root. Main state at a real snapshot is
+            // never empty, so a 0 there is an invalid response.
+            if number_of_states == 0 {
+                if self.kind == SnapshotKind::State(StateKind::MainState) {
+                    return Err(Error::AptosDataClientResponseIsInvalid(
+                        "Received a state count of 0 for the main state snapshot!".into(),
+                    ));
+                }
+                self.stream_is_complete = true;
+                return Ok(());
+            }
+            self.number_of_states = Some(number_of_states);
+        }
+        Ok(())
     }
 }
 
@@ -282,10 +370,15 @@ impl DataStreamEngine for StateStreamEngine {
 
         // Return the request
         self.state_num_requested = true;
-        let number_request = DataClientRequest::NumberOfStates(NumberOfStatesRequest {
-            version: self.request.version,
-            state_kind: self.kind,
-        });
+        let number_request = match self.kind {
+            SnapshotKind::State(state_kind) => {
+                DataClientRequest::NumberOfStates(NumberOfStatesRequest {
+                    version: self.request.version,
+                    state_kind,
+                })
+            },
+            SnapshotKind::HotState => DataClientRequest::NumberOfHotStates(self.request.version),
+        };
         Ok(vec![number_request])
     }
 
@@ -320,7 +413,7 @@ impl DataStreamEngine for StateStreamEngine {
                     request.end_index,
                 )?;
 
-                // Identify the last received state index and bound it appropriately
+                // Identify the last received state index
                 let last_received_index = match &client_response_payload {
                     ResponsePayload::StateValuesWithProof(state_values_with_proof) => {
                         // Verify that we received at least one state value
@@ -336,69 +429,51 @@ impl DataStreamEngine for StateStreamEngine {
                     },
                     _ => invalid_response_type!(client_response_payload),
                 };
-                let last_received_index =
-                    bound_by_range(last_received_index, request.start_index, request.end_index);
-
-                // Update the next stream index
-                self.next_stream_index = last_received_index.checked_add(1).ok_or_else(|| {
-                    Error::IntegerOverflow("Next stream index has overflown!".into())
-                })?;
-
-                // Check if the stream is complete
-                let last_stream_index = self
-                    .get_number_of_states()?
-                    .checked_sub(1)
-                    .ok_or_else(|| Error::IntegerOverflow("End index has overflown!".into()))?;
-                if last_received_index >= last_stream_index {
-                    self.stream_is_complete = true;
-                }
-
-                // Create a new data notification
-                let data_notification = create_data_notification(
-                    notification_id_generator,
+                return self.process_state_chunk(
+                    request.start_index,
+                    request.end_index,
+                    last_received_index,
                     client_response_payload,
-                    None,
-                    self.clone().into(),
+                    notification_id_generator,
+                );
+            },
+            HotStateValuesWithProof(request) => {
+                // Verify the client request indices
+                verify_client_request_indices(
+                    self.next_stream_index,
+                    request.start_index,
+                    request.end_index,
                 )?;
-                return Ok(Some(data_notification));
+
+                // Identify the last received state index
+                let last_received_index = match &client_response_payload {
+                    ResponsePayload::HotStateValuesWithProof(hot_state_values_with_proof) => {
+                        // Verify that we received at least one hot state value
+                        if hot_state_values_with_proof.raw_values.is_empty() {
+                            return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                                "Received an empty hot state values response! Request: {:?}",
+                                client_request
+                            )));
+                        }
+
+                        // Get the last received state index
+                        hot_state_values_with_proof.last_index
+                    },
+                    _ => invalid_response_type!(client_response_payload),
+                };
+                return self.process_state_chunk(
+                    request.start_index,
+                    request.end_index,
+                    last_received_index,
+                    client_response_payload,
+                    notification_id_generator,
+                );
             },
             NumberOfStates(request) => {
-                if let ResponsePayload::NumberOfStates(number_of_states) = client_response_payload {
-                    info!(
-                        (LogSchema::new(LogEntry::ReceivedDataResponse)
-                            .event(LogEvent::Success)
-                            .message(&format!(
-                                "Received number of states at version: {:?}. Total states: {:?}",
-                                request.version, number_of_states
-                            )))
-                    );
-                    self.state_num_requested = false;
-
-                    // Sanity check the response before saving it.
-                    if number_of_states < self.next_request_index {
-                        return Err(Error::NoDataToFetch(format!(
-                            "The next state index to fetch is higher than the \
-                            total number of states. Next index: {:?}, total states: {:?}",
-                            self.next_request_index, number_of_states
-                        )));
-                    }
-                    // The number of states is an internal planning value, not
-                    // consumer data. An empty tree (count 0) has no chunks: just
-                    // end the stream (no notification). The bootstrapper detects
-                    // the zero-chunk end and verifies emptiness against the
-                    // committed snapshot root. Main state at a real snapshot is
-                    // never empty, so a 0 there is an invalid response.
-                    if number_of_states == 0 {
-                        if self.kind == StateKind::MainState {
-                            return Err(Error::AptosDataClientResponseIsInvalid(
-                                "Received a state count of 0 for the main state snapshot!".into(),
-                            ));
-                        }
-                        self.stream_is_complete = true;
-                        return Ok(None);
-                    }
-                    self.number_of_states = Some(number_of_states);
-                }
+                self.handle_number_of_states(request.version, client_response_payload)?;
+            },
+            NumberOfHotStates(version) => {
+                self.handle_number_of_states(*version, client_response_payload)?;
             },
             request => invalid_client_request!(request, self),
         }
@@ -2125,13 +2200,18 @@ fn create_data_client_request(
     stream_engine: &StreamEngine,
 ) -> Result<DataClientRequest, Error> {
     let data_client_request = match stream_engine {
-        StreamEngine::StateStreamEngine(stream_engine) => {
-            StateValuesWithProof(StateValuesWithProofRequest {
+        StreamEngine::StateStreamEngine(stream_engine) => match stream_engine.kind {
+            SnapshotKind::State(state_kind) => StateValuesWithProof(StateValuesWithProofRequest {
                 version: stream_engine.request.version,
                 start_index,
                 end_index,
-                state_kind: stream_engine.kind,
-            })
+                state_kind,
+            }),
+            SnapshotKind::HotState => HotStateValuesWithProof(HotStateValuesWithProofRequest {
+                version: stream_engine.request.version,
+                start_index,
+                end_index,
+            }),
         },
         StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => {
             let target_ledger_info_version = stream_engine
@@ -2215,17 +2295,22 @@ fn create_data_notification(
     let client_response_type = client_response.get_label();
     let data_payload = match client_response {
         ResponsePayload::StateValuesWithProof(states_chunk) => match &stream_engine {
-            StreamEngine::StateStreamEngine(engine) => {
-                DataPayload::StateValuesWithProof(engine.kind, states_chunk)
+            StreamEngine::StateStreamEngine(engine) => match engine.kind {
+                SnapshotKind::State(state_kind) => {
+                    DataPayload::StateValuesWithProof(state_kind, states_chunk)
+                },
+                SnapshotKind::HotState => invalid_response_type!(client_response_type),
             },
             _ => invalid_response_type!(client_response_type),
         },
         // The number of states is consumed internally by the engine for chunk
         // planning; it is never surfaced to the consumer as a notification.
         ResponsePayload::NumberOfStates(_) => invalid_response_type!(client_response_type),
-        // Hot state values are not streamed yet.
-        ResponsePayload::HotStateValuesWithProof(_) => {
-            invalid_response_type!(client_response_type)
+        ResponsePayload::HotStateValuesWithProof(hot_states_chunk) => match &stream_engine {
+            StreamEngine::StateStreamEngine(engine) if engine.kind == SnapshotKind::HotState => {
+                DataPayload::HotStateValuesWithProof(hot_states_chunk)
+            },
+            _ => invalid_response_type!(client_response_type),
         },
         ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
             DataPayload::EpochEndingLedgerInfos(ledger_infos)

--- a/state-sync/data-streaming-service/src/streaming_client.rs
+++ b/state-sync/data-streaming-service/src/streaming_client.rs
@@ -6,7 +6,7 @@ use crate::{
     data_stream::{DataStreamId, DataStreamListener},
     error::Error,
 };
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::SnapshotKind;
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use async_trait::async_trait;
 use futures::{
@@ -34,16 +34,16 @@ pub type Epoch = u64;
 /// is the responsibility of the client to terminate the stream using this API.
 #[async_trait]
 pub trait DataStreamingClient {
-    /// Fetches the state values (of the given kind) at the specified version. If
-    /// `start_index` is specified, the state values will be fetched starting at
-    /// the `start_index` (inclusive). Otherwise, the start index will 0.
-    /// The specified version must be an epoch ending version, otherwise an
-    /// error will be returned. State proofs are at the same version.
+    /// Fetches the state values (of the given snapshot kind) at the specified
+    /// version. If `start_index` is specified, the state values will be fetched
+    /// starting at the `start_index` (inclusive). Otherwise, the start index
+    /// will 0. The specified version must be an epoch ending version, otherwise
+    /// an error will be returned. State proofs are at the same version.
     async fn get_all_state_values(
         &self,
         version: Version,
         start_index: Option<u64>,
-        state_kind: StateKind,
+        snapshot_kind: SnapshotKind,
     ) -> Result<DataStreamListener, Error>;
 
     /// Fetches all epoch ending ledger infos starting at `start_epoch`
@@ -210,12 +210,12 @@ pub struct GetAllEpochEndingLedgerInfosRequest {
     pub start_epoch: Epoch,
 }
 
-/// A client request for fetching all states (of the given kind) at a version.
+/// A client request for fetching all states (of the given snapshot kind) at a version.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GetAllStatesRequest {
     pub version: Version,
     pub start_index: u64,
-    pub state_kind: StateKind,
+    pub snapshot_kind: SnapshotKind,
 }
 
 /// A client request for fetching all transactions with proofs.
@@ -341,13 +341,13 @@ impl DataStreamingClient for StreamingServiceClient {
         &self,
         version: u64,
         start_index: Option<u64>,
-        state_kind: StateKind,
+        snapshot_kind: SnapshotKind,
     ) -> Result<DataStreamListener, Error> {
         let start_index = start_index.unwrap_or(0);
         let client_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version,
             start_index,
-            state_kind,
+            snapshot_kind,
         });
         self.send_request_and_await_response(client_request).await
     }

--- a/state-sync/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/streaming_service.rs
@@ -513,7 +513,7 @@ mod streaming_service_tests {
     };
     use aptos_channels::{aptos_channel, message_queues::QueueStyle};
     use aptos_config::config::DataStreamingServiceConfig;
-    use aptos_storage_interface::StateKind;
+    use aptos_storage_interface::{SnapshotKind, StateKind};
     use futures::{
         channel::{oneshot, oneshot::Receiver},
         FutureExt, StreamExt,
@@ -809,7 +809,7 @@ mod streaming_service_tests {
         let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version: MIN_ADVERTISED_STATES,
             start_index: 0,
-            state_kind: StateKind::MainState,
+            snapshot_kind: SnapshotKind::State(StateKind::MainState),
         });
         create_request_message_and_receiver(stream_request)
     }

--- a/state-sync/data-streaming-service/src/tests/client_requests.rs
+++ b/state-sync/data-streaming-service/src/tests/client_requests.rs
@@ -12,7 +12,7 @@ use crate::{
 use aptos_config::config::{DataStreamingServiceConfig, DynamicPrefetchingConfig};
 use aptos_data_client::global_summary::GlobalDataSummary;
 use aptos_id_generator::U64IdGenerator;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_storage_service_types::responses::CompleteDataRange;
 use std::sync::Arc;
 
@@ -62,7 +62,7 @@ fn create_client_requests_state_values_stream() {
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index,
-        state_kind: StateKind::MainState,
+        snapshot_kind: SnapshotKind::State(StateKind::MainState),
     });
 
     // Create a global data summary with a single state range

--- a/state-sync/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/data-streaming-service/src/tests/data_stream.rs
@@ -39,7 +39,7 @@ use aptos_data_client::{
 };
 use aptos_id_generator::U64IdGenerator;
 use aptos_infallible::Mutex;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_storage_service_types::responses::CompleteDataRange;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
@@ -3320,7 +3320,7 @@ fn create_state_value_stream(
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index: 0,
-        state_kind: StateKind::MainState,
+        snapshot_kind: SnapshotKind::State(StateKind::MainState),
     });
     let (data_stream, data_stream_listener, _) =
         create_data_stream(data_client_config, streaming_service_config, stream_request);

--- a/state-sync/data-streaming-service/src/tests/missing_data.rs
+++ b/state-sync/data-streaming-service/src/tests/missing_data.rs
@@ -23,7 +23,7 @@ use aptos_config::config::DataStreamingServiceConfig;
 use aptos_crypto::HashValue;
 use aptos_data_client::{global_summary::GlobalDataSummary, interface::ResponsePayload};
 use aptos_id_generator::U64IdGenerator;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_storage_service_types::responses::CompleteDataRange;
 use aptos_types::{
     proof::{SparseMerkleRangeProof, TransactionInfoListWithProof},
@@ -517,7 +517,7 @@ fn transform_state_values_stream_notifications() {
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index,
-        state_kind: StateKind::MainState,
+        snapshot_kind: SnapshotKind::State(StateKind::MainState),
     });
 
     // Create a global data summary with a single state range

--- a/state-sync/data-streaming-service/src/tests/streaming_client.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_client.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     tests::utils::{create_ledger_info, initialize_logger},
 };
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use claims::assert_ok;
 use futures::{channel::mpsc, executor::block_on, FutureExt, StreamExt};
 use std::thread::JoinHandle;
@@ -46,7 +46,7 @@ fn test_get_all_states() {
     let expected_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version: request_version,
         start_index: 0,
-        state_kind: StateKind::MainState,
+        snapshot_kind: SnapshotKind::State(StateKind::MainState),
     });
 
     // Spawn a new server thread to handle any stream requests
@@ -56,7 +56,7 @@ fn test_get_all_states() {
     let response = block_on(streaming_service_client.get_all_state_values(
         request_version,
         None,
-        StateKind::MainState,
+        SnapshotKind::State(StateKind::MainState),
     ));
     assert_ok!(response);
 }

--- a/state-sync/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_service.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 use aptos_config::config::{AptosDataClientConfig, DataStreamingServiceConfig};
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_time_service::TimeService;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -40,12 +40,46 @@ async fn test_notifications_state_values() {
 
     // Request a state value stream and get a data stream listener
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES, None, StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await
         .unwrap();
 
     // Verify that the stream listener receives all state value notifications
     verify_continuous_state_value_notifications(&mut stream_listener).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_notifications_hot_state_values() {
+    let streaming_client = create_streaming_client_and_service();
+    let mut stream_listener = streaming_client
+        .get_all_state_values(MAX_ADVERTISED_STATES, None, SnapshotKind::HotState)
+        .await
+        .unwrap();
+
+    let mut next_expected_index = 0;
+    loop {
+        let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
+        match data_notification.data_payload {
+            DataPayload::HotStateValuesWithProof(hot_state_values_with_proof) => {
+                assert_eq!(hot_state_values_with_proof.first_index, next_expected_index);
+                let num_hot_values = hot_state_values_with_proof.raw_values.len() as u64;
+                assert_eq!(
+                    hot_state_values_with_proof.last_index,
+                    next_expected_index + num_hot_values - 1
+                );
+                next_expected_index += num_hot_values;
+            },
+            DataPayload::EndOfStream => {
+                assert_eq!(next_expected_index, TOTAL_NUM_STATE_VALUES);
+                return;
+            },
+            data_payload => unexpected_payload_type!(data_payload),
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -55,7 +89,11 @@ async fn test_notifications_state_values_limited_chunks() {
 
     // Request a new state value stream starting at the next expected index
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES, Some(0), StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES,
+            Some(0),
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await
         .unwrap();
 
@@ -74,7 +112,7 @@ async fn test_notifications_state_values_multiple_streams() {
         .get_all_state_values(
             MAX_ADVERTISED_STATES,
             Some(next_expected_index),
-            StateKind::MainState,
+            SnapshotKind::State(StateKind::MainState),
         )
         .await
         .unwrap();
@@ -109,7 +147,7 @@ async fn test_notifications_state_values_multiple_streams() {
                         .get_all_state_values(
                             MAX_ADVERTISED_STATES,
                             Some(next_expected_index),
-                            StateKind::MainState,
+                            SnapshotKind::State(StateKind::MainState),
                         )
                         .await
                         .unwrap();
@@ -1255,19 +1293,31 @@ async fn test_stream_states() {
 
     // Request a state value stream and verify we get a data stream listener
     let result = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES - 1, None, StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES - 1,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await;
     assert_ok!(result);
 
     // Request a stream where states are missing (we are lower than advertised)
     let result = streaming_client
-        .get_all_state_values(MIN_ADVERTISED_STATES - 1, None, StateKind::MainState)
+        .get_all_state_values(
+            MIN_ADVERTISED_STATES - 1,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await;
     assert_matches!(result, Err(Error::DataIsUnavailable(_)));
 
     // Request a stream where states are missing (we are higher than advertised)
     let result = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_EPOCH_END + 1, None, StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_EPOCH_END + 1,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await;
     assert_matches!(result, Err(Error::DataIsUnavailable(_)));
 }
@@ -1566,7 +1616,11 @@ async fn test_terminate_stream() {
 
     // Request a state value stream
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES - 1, None, StateKind::MainState)
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES - 1,
+            None,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .await
         .unwrap();
 

--- a/state-sync/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/data-streaming-service/src/tests/utils.rs
@@ -16,9 +16,10 @@ use aptos_logger::Level;
 use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
-        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, HotStateValuesWithProofRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+        NewTransactionsWithProofRequest, StateValuesWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
@@ -35,6 +36,7 @@ use aptos_types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::SparseMerkleRangeProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -328,6 +330,54 @@ impl AptosDataClientInterface for MockAptosDataClient {
         Ok(create_data_client_response(state_value_chunk_with_proof))
     }
 
+    async fn get_hot_state_values_with_proof(
+        &self,
+        version: Version,
+        start_index: u64,
+        end_index: u64,
+        request_timeout_ms: u64,
+    ) -> Result<Response<HotStateValueChunkWithProof>, aptos_data_client::error::Error> {
+        // Verify the request timeout
+        let data_request =
+            DataRequest::GetHotStateValuesWithProof(HotStateValuesWithProofRequest {
+                version,
+                start_index,
+                end_index,
+            });
+        self.verify_request_timeout_value(request_timeout_ms, false, false, data_request);
+
+        // Emulate network latencies
+        self.emulate_network_latencies().await;
+
+        // Calculate the last index based on if we should limit the chunk size
+        let end_index = self.calculate_last_index(start_index, end_index);
+
+        // Create hot state keys and values according to the given indices
+        let mut hot_state_keys_and_values = vec![];
+        for _ in start_index..=end_index {
+            hot_state_keys_and_values.push((
+                StateKey::raw(HashValue::random().as_ref()),
+                HotStateValue::new(Some(StateValue::from(vec![])), version),
+            ));
+        }
+
+        // Create a hot state value chunk with proof
+        let hot_state_value_chunk_with_proof = HotStateValueChunkWithProof {
+            first_index: start_index,
+            last_index: end_index,
+            first_key: HashValue::random(),
+            last_key: HashValue::random(),
+            raw_values: hot_state_keys_and_values,
+            proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
+        };
+
+        // Create and send a data client response
+        Ok(create_data_client_response(
+            hot_state_value_chunk_with_proof,
+        ))
+    }
+
     async fn get_epoch_ending_ledger_infos(
         &self,
         start_epoch: Epoch,
@@ -535,6 +585,22 @@ impl AptosDataClientInterface for MockAptosDataClient {
     ) -> Result<Response<u64>, aptos_data_client::error::Error> {
         // Verify the request timeout
         let data_request = DataRequest::GetNumberOfStatesAtVersion(version);
+        self.verify_request_timeout_value(request_timeout_ms, false, false, data_request);
+
+        // Emulate network latencies
+        self.emulate_network_latencies().await;
+
+        // Create and send a data client response
+        Ok(create_data_client_response(TOTAL_NUM_STATE_VALUES))
+    }
+
+    async fn get_number_of_hot_states(
+        &self,
+        version: Version,
+        request_timeout_ms: u64,
+    ) -> Result<Response<u64>, aptos_data_client::error::Error> {
+        // Verify the request timeout
+        let data_request = DataRequest::GetNumberOfHotStatesAtVersion(version);
         self.verify_request_timeout_value(request_timeout_ms, false, false, data_request);
 
         // Emulate network latencies

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -26,7 +26,7 @@ use aptos_types::{
     epoch_change::Verifier,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
     waypoint::Waypoint,
 };
@@ -40,7 +40,11 @@ pub const GENESIS_TRANSACTION_VERSION: u64 = 0; // The expected version of the g
 // The snapshot stores synced during fast sync. They are peers (independent
 // stores at the same version); this is just the drive order, and the fast sync
 // is finalized once all of them are written.
-const FAST_SYNC_SNAPSHOT_KINDS: [StateKind; 2] = [StateKind::MainState, StateKind::Position];
+const FAST_SYNC_SNAPSHOT_KINDS: [SnapshotKind; 3] = [
+    SnapshotKind::State(StateKind::MainState),
+    SnapshotKind::State(StateKind::Position),
+    SnapshotKind::HotState,
+];
 
 /// A simple container for verified epoch states and epoch ending ledger infos
 /// that have been fetched from the network.
@@ -298,7 +302,7 @@ pub struct Bootstrapper<MetadataStorage, StorageSyncer, StreamingClient> {
 
     // The snapshot kind of the active data stream, if it is a state-value
     // snapshot stream (used to detect an empty tree on a clean end-of-stream).
-    active_snapshot_kind: Option<StateKind>,
+    active_snapshot_kind: Option<SnapshotKind>,
 
     // The channel used to notify a listener of successful bootstrapping
     bootstrap_notifier_channel: Option<oneshot::Sender<Result<(), Error>>>,
@@ -323,6 +327,9 @@ pub struct Bootstrapper<MetadataStorage, StorageSyncer, StreamingClient> {
 
     // The component used to sync native-position state values
     position_value_syncer: StateValueSyncer,
+
+    // The component used to sync hot state values
+    hot_state_value_syncer: StateValueSyncer,
 
     // The client through which to stream data from the Aptos network
     streaming_client: StreamingClient,
@@ -359,6 +366,7 @@ impl<
         Self {
             state_value_syncer: StateValueSyncer::new(),
             position_value_syncer: StateValueSyncer::new(),
+            hot_state_value_syncer: StateValueSyncer::new(),
             active_data_stream: None,
             active_snapshot_kind: None,
             bootstrap_notifier_channel: None,
@@ -560,7 +568,7 @@ impl<
             // known ledger info. (All snapshot kinds sync to the same target.)
             let target = match self
                 .metadata_storage
-                .previous_snapshot_sync_target(StateKind::MainState)?
+                .previous_snapshot_sync_target(SnapshotKind::State(StateKind::MainState))?
             {
                 Some(target) => target,
                 None => highest_known_ledger_info,
@@ -632,6 +640,13 @@ impl<
                     )
                     .await?;
                 },
+                DataPayload::HotStateValuesWithProof(hot_state_value_chunk_with_proof) => {
+                    self.process_hot_state_values_payload(
+                        data_notification.notification_id,
+                        hot_state_value_chunk_with_proof,
+                    )
+                    .await?;
+                },
                 DataPayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos) => {
                     self.process_epoch_ending_payload(
                         data_notification.notification_id,
@@ -685,7 +700,7 @@ impl<
     fn pin_ledger_info_to_sync(
         &mut self,
         target_ledger_info: LedgerInfoWithSignatures,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<(), Error> {
         if let Some(ledger_info_to_sync) = &self.state_value_syncer(kind).ledger_info_to_sync {
             if ledger_info_to_sync != &target_ledger_info {
@@ -712,7 +727,7 @@ impl<
         &mut self,
         target_ledger_info: LedgerInfoWithSignatures,
         existing_snapshot_progress: bool,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<(), Error> {
         // Initialize the target ledger info and verify it never changes
         self.pin_ledger_info_to_sync(target_ledger_info.clone(), kind)?;
@@ -745,7 +760,7 @@ impl<
             .get_all_state_values(
                 target_ledger_info_version,
                 Some(next_state_index_to_process),
-                SnapshotKind::State(kind),
+                kind,
             )
             .await?;
         self.active_data_stream = Some(data_stream);
@@ -947,23 +962,24 @@ impl<
         &mut self,
         notification_id: NotificationId,
         expected_start_index: u64,
-        kind: StateKind,
-        state_value_chunk_with_proof: &StateValueChunkWithProof,
+        kind: SnapshotKind,
+        first_index: u64,
+        last_index: u64,
+        num_values: usize,
     ) -> Result<(), Error> {
         // Verify the payload start index is valid
-        if expected_start_index != state_value_chunk_with_proof.first_index {
+        if expected_start_index != first_index {
             self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
                 .await?;
             return Err(Error::VerificationError(format!(
                 "The start index of the {:?} values was invalid! Expected: {:?}, received: {:?}",
-                kind, expected_start_index, state_value_chunk_with_proof.first_index
+                kind, expected_start_index, first_index
             )));
         }
 
         // Verify the end index and number of state values is valid
-        let expected_num_state_values = state_value_chunk_with_proof
-            .last_index
-            .checked_sub(state_value_chunk_with_proof.first_index)
+        let expected_num_state_values = last_index
+            .checked_sub(first_index)
             .and_then(|version| version.checked_add(1)) // expected_num_state_values = last_index - first_index + 1
             .ok_or_else(|| {
                 Error::IntegerOverflow(format!(
@@ -971,7 +987,7 @@ impl<
                     kind
                 ))
             })?;
-        let num_state_values = state_value_chunk_with_proof.raw_values.len() as u64;
+        let num_state_values = num_values as u64;
         if expected_num_state_values != num_state_values {
             self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
                 .await?;
@@ -985,18 +1001,20 @@ impl<
     }
 
     /// Returns the state value syncer for the given snapshot kind.
-    fn state_value_syncer(&self, kind: StateKind) -> &StateValueSyncer {
+    fn state_value_syncer(&self, kind: SnapshotKind) -> &StateValueSyncer {
         match kind {
-            StateKind::MainState => &self.state_value_syncer,
-            StateKind::Position => &self.position_value_syncer,
+            SnapshotKind::State(StateKind::MainState) => &self.state_value_syncer,
+            SnapshotKind::State(StateKind::Position) => &self.position_value_syncer,
+            SnapshotKind::HotState => &self.hot_state_value_syncer,
         }
     }
 
     /// Returns the mutable state value syncer for the given snapshot kind.
-    fn state_value_syncer_mut(&mut self, kind: StateKind) -> &mut StateValueSyncer {
+    fn state_value_syncer_mut(&mut self, kind: SnapshotKind) -> &mut StateValueSyncer {
         match kind {
-            StateKind::MainState => &mut self.state_value_syncer,
-            StateKind::Position => &mut self.position_value_syncer,
+            SnapshotKind::State(StateKind::MainState) => &mut self.state_value_syncer,
+            SnapshotKind::State(StateKind::Position) => &mut self.position_value_syncer,
+            SnapshotKind::HotState => &mut self.hot_state_value_syncer,
         }
     }
 
@@ -1005,7 +1023,7 @@ impl<
     /// the committed position state root (guaranteed present once the position
     /// stage runs, per `snapshot_kind_applies_to_target`). All kinds share the
     /// target version, so this is taken from the target output, not a storage read.
-    fn expected_snapshot_root(&mut self, kind: StateKind) -> Result<HashValue, Error> {
+    fn expected_snapshot_root(&mut self, kind: SnapshotKind) -> Result<HashValue, Error> {
         let transaction_output_to_sync = self.get_transaction_output_to_sync()?;
         let target_transaction_info = transaction_output_to_sync
             .get_output_list_with_proof()
@@ -1016,7 +1034,7 @@ impl<
                 Error::UnexpectedError("Target transaction info does not exist!".into())
             })?;
         match kind {
-            StateKind::MainState => target_transaction_info
+            SnapshotKind::State(StateKind::MainState) => target_transaction_info
                 .ensure_state_checkpoint_hash()
                 .map_err(|error| {
                     Error::UnexpectedError(format!(
@@ -1024,9 +1042,12 @@ impl<
                         error
                     ))
                 }),
-            StateKind::Position => target_transaction_info
+            SnapshotKind::State(StateKind::Position) => target_transaction_info
                 .position_state_checkpoint_hash()
                 .ok_or_else(|| Error::UnexpectedError("Missing position state root!".into())),
+            SnapshotKind::HotState => target_transaction_info
+                .hot_state_checkpoint_hash()
+                .ok_or_else(|| Error::UnexpectedError("Missing hot state root!".into())),
         }
     }
 
@@ -1035,11 +1056,10 @@ impl<
     async fn verify_state_value_chunk_root(
         &mut self,
         notification_id: NotificationId,
-        kind: StateKind,
-        state_value_chunk_with_proof: &StateValueChunkWithProof,
+        kind: SnapshotKind,
+        chunk_root_hash: HashValue,
     ) -> Result<HashValue, Error> {
         let expected_root_hash = self.expected_snapshot_root(kind)?;
-        let chunk_root_hash = state_value_chunk_with_proof.root_hash;
         if chunk_root_hash != expected_root_hash {
             self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
                 .await?;
@@ -1051,12 +1071,16 @@ impl<
         Ok(expected_root_hash)
     }
 
-    /// Process a single state value chunk with proof payload (of the given kind).
-    async fn process_state_values_payload(
+    /// Verifies a snapshot chunk of the given kind (mode, root, indices) and
+    /// latches the snapshot receiver on the first chunk.
+    async fn prepare_snapshot_chunk(
         &mut self,
         notification_id: NotificationId,
-        state_value_chunk_with_proof: StateValueChunkWithProof,
-        kind: StateKind,
+        kind: SnapshotKind,
+        chunk_root_hash: HashValue,
+        first_index: u64,
+        last_index: u64,
+        num_values: usize,
     ) -> Result<(), Error> {
         // Verify that we're expecting state value payloads
         if self.should_fetch_epoch_ending_ledger_infos()
@@ -1083,7 +1107,7 @@ impl<
         // receiver, so a bad first chunk doesn't latch a receiver bound to the
         // wrong root.
         let expected_root_hash = self
-            .verify_state_value_chunk_root(notification_id, kind, &state_value_chunk_with_proof)
+            .verify_state_value_chunk_root(notification_id, kind, chunk_root_hash)
             .await?;
 
         // Verify the state values payload start and end indices
@@ -1092,7 +1116,9 @@ impl<
             notification_id,
             expected_start_index,
             kind,
-            &state_value_chunk_with_proof,
+            first_index,
+            last_index,
+            num_values,
         )
         .await?;
 
@@ -1111,6 +1137,42 @@ impl<
             self.state_value_syncer_mut(kind)
                 .initialized_state_snapshot_receiver = true;
         }
+        Ok(())
+    }
+
+    /// Advances the kind's stream position after a chunk has been saved.
+    fn finish_snapshot_chunk(
+        &mut self,
+        kind: SnapshotKind,
+        last_state_value_index: u64,
+    ) -> Result<(), Error> {
+        self.state_value_syncer_mut(kind)
+            .next_state_index_to_process =
+            last_state_value_index.checked_add(1).ok_or_else(|| {
+                Error::IntegerOverflow(
+                    "The next state value index to process has overflown!".into(),
+                )
+            })?;
+        Ok(())
+    }
+
+    /// Process a single state value chunk with proof payload (of the given kind).
+    async fn process_state_values_payload(
+        &mut self,
+        notification_id: NotificationId,
+        state_value_chunk_with_proof: StateValueChunkWithProof,
+        state_kind: StateKind,
+    ) -> Result<(), Error> {
+        let kind = SnapshotKind::State(state_kind);
+        self.prepare_snapshot_chunk(
+            notification_id,
+            kind,
+            state_value_chunk_with_proof.root_hash,
+            state_value_chunk_with_proof.first_index,
+            state_value_chunk_with_proof.last_index,
+            state_value_chunk_with_proof.raw_values.len(),
+        )
+        .await?;
 
         // Process the state values chunk and proof
         let last_state_value_index = state_value_chunk_with_proof.last_index;
@@ -1126,17 +1188,41 @@ impl<
                 kind, error,
             )));
         }
+        self.finish_snapshot_chunk(kind, last_state_value_index)
+    }
 
-        // Update the next state value index to process
-        self.state_value_syncer_mut(kind)
-            .next_state_index_to_process =
-            last_state_value_index.checked_add(1).ok_or_else(|| {
-                Error::IntegerOverflow(
-                    "The next state value index to process has overflown!".into(),
-                )
-            })?;
+    /// Process a single hot state value chunk with proof payload.
+    async fn process_hot_state_values_payload(
+        &mut self,
+        notification_id: NotificationId,
+        hot_state_value_chunk_with_proof: HotStateValueChunkWithProof,
+    ) -> Result<(), Error> {
+        let kind = SnapshotKind::HotState;
+        self.prepare_snapshot_chunk(
+            notification_id,
+            kind,
+            hot_state_value_chunk_with_proof.root_hash,
+            hot_state_value_chunk_with_proof.first_index,
+            hot_state_value_chunk_with_proof.last_index,
+            hot_state_value_chunk_with_proof.raw_values.len(),
+        )
+        .await?;
 
-        Ok(())
+        // Process the hot state values chunk and proof
+        let last_state_value_index = hot_state_value_chunk_with_proof.last_index;
+        if let Err(error) = self
+            .storage_synchronizer
+            .save_hot_state_values(notification_id, hot_state_value_chunk_with_proof)
+            .await
+        {
+            self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::InvalidPayload(format!(
+                "The {:?} states chunk with proof was invalid! Error: {:?}",
+                kind, error,
+            )));
+        }
+        self.finish_snapshot_chunk(kind, last_state_value_index)
     }
 
     /// Whether the given snapshot kind participates in the fast sync to this
@@ -1145,10 +1231,10 @@ impl<
     /// executor sets it there is no authenticated position state to sync, so the
     /// stage is skipped rather than trusting an unproved peer-supplied root.
     /// Requires the target transaction output to already be fetched.
-    fn snapshot_kind_applies_to_target(&mut self, kind: StateKind) -> Result<bool, Error> {
+    fn snapshot_kind_applies_to_target(&mut self, kind: SnapshotKind) -> Result<bool, Error> {
         match kind {
-            StateKind::MainState => Ok(true),
-            StateKind::Position => {
+            SnapshotKind::State(StateKind::MainState) => Ok(true),
+            SnapshotKind::State(StateKind::Position) | SnapshotKind::HotState => {
                 let transaction_output_to_sync = self.get_transaction_output_to_sync()?;
                 let target_transaction_info = transaction_output_to_sync
                     .get_output_list_with_proof()
@@ -1158,9 +1244,14 @@ impl<
                     .ok_or_else(|| {
                         Error::UnexpectedError("Target transaction info does not exist!".into())
                     })?;
-                Ok(target_transaction_info
-                    .position_state_checkpoint_hash()
-                    .is_some())
+                let committed_root = match kind {
+                    SnapshotKind::State(StateKind::Position) => {
+                        target_transaction_info.position_state_checkpoint_hash()
+                    },
+                    SnapshotKind::HotState => target_transaction_info.hot_state_checkpoint_hash(),
+                    SnapshotKind::State(StateKind::MainState) => unreachable!(),
+                };
+                Ok(committed_root.is_some())
             },
         }
     }
@@ -1176,7 +1267,10 @@ impl<
     ) -> Result<(), Error> {
         // Pin the target (read by the output-verification path) and fetch the
         // target transaction output first, re-fetching it on resume.
-        self.pin_ledger_info_to_sync(target_ledger_info.clone(), StateKind::MainState)?;
+        self.pin_ledger_info_to_sync(
+            target_ledger_info.clone(),
+            SnapshotKind::State(StateKind::MainState),
+        )?;
         if self.state_value_syncer.transaction_output_to_sync.is_none() {
             let version = target_ledger_info.ledger_info().version();
             let data_stream = self

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -21,7 +21,7 @@ use aptos_data_streaming_service::{
     streaming_client::{DataStreamingClient, NotificationAndFeedback, NotificationFeedback},
 };
 use aptos_logger::{prelude::*, sample::SampleRate};
-use aptos_storage_interface::{DbReader, StateKind};
+use aptos_storage_interface::{DbReader, SnapshotKind, StateKind};
 use aptos_types::{
     epoch_change::Verifier,
     epoch_state::EpochState,
@@ -745,7 +745,7 @@ impl<
             .get_all_state_values(
                 target_ledger_info_version,
                 Some(next_state_index_to_process),
-                kind,
+                SnapshotKind::State(kind),
             )
             .await?;
         self.active_data_stream = Some(data_stream);

--- a/state-sync/state-sync-driver/src/metadata_storage.rs
+++ b/state-sync/state-sync-driver/src/metadata_storage.rs
@@ -13,7 +13,7 @@ use aptos_schemadb::{
     schema::{KeyCodec, ValueCodec},
     ColumnFamilyName, Options, DB,
 };
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_types::ledger_info::LedgerInfoWithSignatures;
 use serde::{Deserialize, Serialize};
 use std::{path::Path, sync::Arc, time::Instant};
@@ -29,7 +29,7 @@ pub trait MetadataStorageInterface {
     fn is_snapshot_sync_complete(
         &self,
         target_ledger_info: &LedgerInfoWithSignatures,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<bool, Error>;
 
     /// Gets the last persisted value index for the `kind` snapshot sync at the
@@ -37,14 +37,14 @@ pub trait MetadataStorageInterface {
     fn get_last_persisted_index(
         &self,
         target_ledger_info: &LedgerInfoWithSignatures,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<u64, Error>;
 
     /// Returns the target ledger info of any `kind` snapshot sync that has
     /// previously started. If no snapshot sync started, None is returned.
     fn previous_snapshot_sync_target(
         &self,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<Option<LedgerInfoWithSignatures>, Error>;
 
     /// Updates the last persisted value index for the `kind` snapshot sync at
@@ -54,32 +54,35 @@ pub trait MetadataStorageInterface {
         target_ledger_info: &LedgerInfoWithSignatures,
         last_persisted_index: u64,
         snapshot_sync_completed: bool,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<(), Error>;
 }
 
 /// The `MetadataKey` for the given snapshot kind's progress row. Each kind is an
 /// independent row carrying a `StateSnapshotProgress`.
-fn snapshot_metadata_key(kind: StateKind) -> MetadataKey {
+fn snapshot_metadata_key(kind: SnapshotKind) -> MetadataKey {
     match kind {
-        StateKind::MainState => MetadataKey::StateSnapshotSync,
-        StateKind::Position => MetadataKey::PositionSnapshotSync,
+        SnapshotKind::State(StateKind::MainState) => MetadataKey::StateSnapshotSync,
+        SnapshotKind::State(StateKind::Position) => MetadataKey::PositionSnapshotSync,
+        SnapshotKind::HotState => MetadataKey::HotStateSnapshotSync,
     }
 }
 
 /// The `MetadataValue` wrapping `progress` for the given snapshot kind.
-fn snapshot_metadata_value(kind: StateKind, progress: StateSnapshotProgress) -> MetadataValue {
+fn snapshot_metadata_value(kind: SnapshotKind, progress: StateSnapshotProgress) -> MetadataValue {
     match kind {
-        StateKind::MainState => MetadataValue::StateSnapshotSync(progress),
-        StateKind::Position => MetadataValue::PositionSnapshotSync(progress),
+        SnapshotKind::State(StateKind::MainState) => MetadataValue::StateSnapshotSync(progress),
+        SnapshotKind::State(StateKind::Position) => MetadataValue::PositionSnapshotSync(progress),
+        SnapshotKind::HotState => MetadataValue::HotStateSnapshotSync(progress),
     }
 }
 
 /// A short label for the given snapshot kind, used in log/error messages.
-fn snapshot_kind_label(kind: StateKind) -> &'static str {
+fn snapshot_kind_label(kind: SnapshotKind) -> &'static str {
     match kind {
-        StateKind::MainState => "state",
-        StateKind::Position => "position",
+        SnapshotKind::State(StateKind::MainState) => "state",
+        SnapshotKind::State(StateKind::Position) => "position",
+        SnapshotKind::HotState => "hot state",
     }
 }
 
@@ -130,7 +133,7 @@ impl PersistentMetadataStorage {
     /// Returns the existing snapshot sync progress for `kind`. None if not found.
     fn get_snapshot_progress(
         &self,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<Option<StateSnapshotProgress>, Error> {
         let metadata_key = snapshot_metadata_key(kind);
         let maybe_metadata_value =
@@ -147,12 +150,16 @@ impl PersistentMetadataStorage {
         let progress = match maybe_metadata_value {
             None => None,
             Some(MetadataValue::StateSnapshotSync(progress)) => match kind {
-                StateKind::MainState => Some(progress),
-                StateKind::Position => None,
+                SnapshotKind::State(StateKind::MainState) => Some(progress),
+                _ => None,
             },
             Some(MetadataValue::PositionSnapshotSync(progress)) => match kind {
-                StateKind::Position => Some(progress),
-                StateKind::MainState => None,
+                SnapshotKind::State(StateKind::Position) => Some(progress),
+                _ => None,
+            },
+            Some(MetadataValue::HotStateSnapshotSync(progress)) => match kind {
+                SnapshotKind::HotState => Some(progress),
+                _ => None,
             },
         };
         Ok(progress)
@@ -162,7 +169,7 @@ impl PersistentMetadataStorage {
     /// target. Returns an error if no progress was found.
     fn get_snapshot_progress_at_target(
         &self,
-        kind: StateKind,
+        kind: SnapshotKind,
         target_ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<StateSnapshotProgress, Error> {
         match self.get_snapshot_progress(kind)? {
@@ -229,7 +236,7 @@ impl MetadataStorageInterface for PersistentMetadataStorage {
     fn is_snapshot_sync_complete(
         &self,
         target: &LedgerInfoWithSignatures,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<bool, Error> {
         let snapshot_progress = self.get_snapshot_progress_at_target(kind, target)?;
         Ok(snapshot_progress.snapshot_sync_completed)
@@ -238,7 +245,7 @@ impl MetadataStorageInterface for PersistentMetadataStorage {
     fn get_last_persisted_index(
         &self,
         target: &LedgerInfoWithSignatures,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<u64, Error> {
         let snapshot_progress = self.get_snapshot_progress_at_target(kind, target)?;
         Ok(snapshot_progress.last_persisted_state_value_index)
@@ -246,7 +253,7 @@ impl MetadataStorageInterface for PersistentMetadataStorage {
 
     fn previous_snapshot_sync_target(
         &self,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<Option<LedgerInfoWithSignatures>, Error> {
         Ok(self
             .get_snapshot_progress(kind)?
@@ -258,7 +265,7 @@ impl MetadataStorageInterface for PersistentMetadataStorage {
         target_ledger_info: &LedgerInfoWithSignatures,
         last_persisted_index: u64,
         snapshot_sync_completed: bool,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<(), Error> {
         // Ensure any existing progress for this kind is for the same target.
         if let Some(snapshot_progress) = self.get_snapshot_progress(kind)? {
@@ -306,6 +313,7 @@ pub mod database_schema {
     pub enum MetadataKey {
         StateSnapshotSync,    // A state snapshot sync that was started
         PositionSnapshotSync, // A native-position snapshot sync that was started
+        HotStateSnapshotSync, // A hot state snapshot sync that was started
     }
 
     /// A metadata value that can be inserted into the database
@@ -314,6 +322,7 @@ pub mod database_schema {
     pub enum MetadataValue {
         StateSnapshotSync(StateSnapshotProgress), // A state snapshot sync progress marker
         PositionSnapshotSync(StateSnapshotProgress), // A native-position snapshot sync progress marker
+        HotStateSnapshotSync(StateSnapshotProgress), // A hot state snapshot sync progress marker
     }
 
     impl KeyCodec<MetadataSchema> for MetadataKey {

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -35,6 +35,7 @@ pub const STORAGE_SYNCHRONIZER_COMMIT_CHUNK: &str = "commit_chunk";
 pub const STORAGE_SYNCHRONIZER_COMMIT_POST_PROCESS: &str = "commit_post_process";
 pub const STORAGE_SYNCHRONIZER_STATE_VALUE_CHUNK: &str = "state_value_chunk";
 pub const STORAGE_SYNCHRONIZER_POSITION_STATE_VALUE_CHUNK: &str = "position_state_value_chunk";
+pub const STORAGE_SYNCHRONIZER_HOT_STATE_VALUE_CHUNK: &str = "hot_state_value_chunk";
 
 /// Storage synchronizer pipeline channel labels
 pub const STORAGE_SYNCHRONIZER_EXECUTOR: &str = "executor";
@@ -72,6 +73,7 @@ pub enum StorageSynchronizerOperations {
     SyncedIncremental, // The latest synced version (calculated as the sum of all processed transactions)
     SyncedStates,      // The total number of synced states
     SyncedPositionStates, // The total number of synced native-position states
+    SyncedHotStates,   // The total number of synced hot states
     SyncedEpoch,       // The latest synced epoch (as read from storage)
     SyncedEpochIncremental, // The latest synced epoch (calculated as the sum of all processed epochs)
 }
@@ -87,6 +89,7 @@ impl StorageSynchronizerOperations {
             StorageSynchronizerOperations::SyncedIncremental => "synced_incremental",
             StorageSynchronizerOperations::SyncedStates => "synced_states",
             StorageSynchronizerOperations::SyncedPositionStates => "synced_position_states",
+            StorageSynchronizerOperations::SyncedHotStates => "synced_hot_states",
             StorageSynchronizerOperations::SyncedEpoch => "synced_epoch",
             StorageSynchronizerOperations::SyncedEpochIncremental => "synced_epoch_incremental",
         }

--- a/state-sync/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/storage_synchronizer.rs
@@ -21,11 +21,15 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_mempool_notifications::MempoolNotificationSender;
 use aptos_metrics_core::HistogramTimer;
-use aptos_storage_interface::{DbReader, DbReaderWriter, StateKind, StateSnapshotReceiver};
+use aptos_storage_interface::{
+    DbReader, DbReaderWriter, SnapshotKind, StateKind, StateSnapshotReceiver,
+};
 use aptos_storage_service_notifications::StorageServiceNotificationSender;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
+    proof::SparseMerkleRangeProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -81,7 +85,7 @@ pub trait StorageSynchronizerInterface {
         &mut self,
         target_ledger_info: LedgerInfoWithSignatures,
         expected_root: HashValue,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<JoinHandle<()>, Error>;
 
     /// Returns true iff there is storage data that is still waiting
@@ -100,6 +104,14 @@ pub trait StorageSynchronizerInterface {
         &mut self,
         notification_id: NotificationId,
         state_value_chunk_with_proof: StateValueChunkWithProof,
+    ) -> Result<(), Error>;
+
+    /// Saves the given hot state values to storage, for whichever snapshot
+    /// synchronizer was last initialized.
+    async fn save_hot_state_values(
+        &mut self,
+        notification_id: NotificationId,
+        hot_state_value_chunk_with_proof: HotStateValueChunkWithProof,
     ) -> Result<(), Error>;
 
     /// Finalizes the whole fast-sync process once all snapshots have been
@@ -341,6 +353,31 @@ impl<
             Ok(())
         }
     }
+
+    /// Sends a snapshot data chunk to the currently-active snapshot receiver.
+    async fn send_snapshot_chunk(
+        &mut self,
+        storage_data_chunk: StorageDataChunk,
+    ) -> Result<(), Error> {
+        let state_snapshot_notifier = self.state_snapshot_notifier.as_mut().ok_or_else(|| {
+            Error::UnexpectedError("The state snapshot receiver has not been initialized!".into())
+        })?;
+        if let Err(error) = send_and_monitor_backpressure(
+            state_snapshot_notifier,
+            metrics::STORAGE_SYNCHRONIZER_STATE_SNAPSHOT_RECEIVER,
+            storage_data_chunk,
+        )
+        .await
+        {
+            Err(Error::UnexpectedError(format!(
+                "Failed to send storage data chunk to state snapshot listener: {:?}",
+                error
+            )))
+        } else {
+            increment_pending_data_chunks(self.pending_data_chunks.clone());
+            Ok(())
+        }
+    }
 }
 
 #[async_trait]
@@ -401,7 +438,7 @@ impl<
         &mut self,
         target_ledger_info: LedgerInfoWithSignatures,
         expected_root: HashValue,
-        kind: StateKind,
+        kind: SnapshotKind,
     ) -> Result<JoinHandle<()>, Error> {
         // Create a channel to notify the snapshot receiver when data chunks are ready
         let max_pending_data_chunks = self.driver_config.max_pending_data_chunks as usize;
@@ -450,29 +487,19 @@ impl<
         notification_id: NotificationId,
         state_value_chunk_with_proof: StateValueChunkWithProof,
     ) -> Result<(), Error> {
-        // Get the snapshot notifier and create the storage data chunk
-        let state_snapshot_notifier = self.state_snapshot_notifier.as_mut().ok_or_else(|| {
-            Error::UnexpectedError("The state snapshot receiver has not been initialized!".into())
-        })?;
         let storage_data_chunk =
             StorageDataChunk::States(notification_id, state_value_chunk_with_proof);
+        self.send_snapshot_chunk(storage_data_chunk).await
+    }
 
-        // Notify the snapshot receiver of the storage data chunk
-        if let Err(error) = send_and_monitor_backpressure(
-            state_snapshot_notifier,
-            metrics::STORAGE_SYNCHRONIZER_STATE_SNAPSHOT_RECEIVER,
-            storage_data_chunk,
-        )
-        .await
-        {
-            Err(Error::UnexpectedError(format!(
-                "Failed to send storage data chunk to state snapshot listener: {:?}",
-                error
-            )))
-        } else {
-            increment_pending_data_chunks(self.pending_data_chunks.clone());
-            Ok(())
-        }
+    async fn save_hot_state_values(
+        &mut self,
+        notification_id: NotificationId,
+        hot_state_value_chunk_with_proof: HotStateValueChunkWithProof,
+    ) -> Result<(), Error> {
+        let storage_data_chunk =
+            StorageDataChunk::HotStates(notification_id, hot_state_value_chunk_with_proof);
+        self.send_snapshot_chunk(storage_data_chunk).await
     }
 
     async fn finalize_fast_sync(
@@ -482,9 +509,10 @@ impl<
         target_output_with_proof: TransactionOutputListWithProofV2,
     ) -> Result<(), Error> {
         let version = target_ledger_info.ledger_info().version();
-        let last_committed_state_index = self
-            .metadata_storage
-            .get_last_persisted_index(&target_ledger_info, StateKind::MainState)?;
+        let last_committed_state_index = self.metadata_storage.get_last_persisted_index(
+            &target_ledger_info,
+            SnapshotKind::State(StateKind::MainState),
+        )?;
 
         // Bootstrap the transaction accumulator / ledger from the target output
         self.storage
@@ -560,6 +588,7 @@ pub struct StorageSynchronizerHandles {
 #[derive(Clone, Debug)]
 enum StorageDataChunk {
     States(NotificationId, StateValueChunkWithProof),
+    HotStates(NotificationId, HotStateValueChunkWithProof),
     Transactions(
         NotificationMetadata,
         TransactionListWithProofV2,
@@ -935,15 +964,22 @@ enum ChunkApplyOutcome {
     },
 }
 
+/// A snapshot receiver for a given snapshot kind. Hot state chunks carry
+/// `HotStateValue` leaves, so they need a separate receiver type.
+enum SnapshotReceiver {
+    State(Box<dyn StateSnapshotReceiver<StateKey, StateValue>>),
+    HotState(Box<dyn StateSnapshotReceiver<StateKey, HotStateValue>>),
+}
+
 /// Applies a single snapshot chunk to `receiver`,
 /// updating the per-chunk metrics and (for non-final chunks) the persisted
 /// progress. The divergent finalize step is left to the caller, which is
 /// signalled via [`ChunkApplyOutcome::Finalize`]. Decrements the pending-chunk
 /// counter except on the finalize path (the caller does so after finalizing).
 async fn apply_snapshot_chunk<MetadataStorage: MetadataStorageInterface + Clone>(
-    receiver: &mut Box<dyn StateSnapshotReceiver<StateKey, StateValue>>,
+    receiver: &mut SnapshotReceiver,
     storage_data_chunk: StorageDataChunk,
-    kind: StateKind,
+    kind: SnapshotKind,
     metadata_storage: &MetadataStorage,
     target_ledger_info: &LedgerInfoWithSignatures,
     error_notification_sender: &mpsc::UnboundedSender<ErrorNotification>,
@@ -951,86 +987,152 @@ async fn apply_snapshot_chunk<MetadataStorage: MetadataStorageInterface + Clone>
     pending_data_errors: &Arc<AtomicU64>,
     version: Version,
 ) -> ChunkApplyOutcome {
-    let (operation, noun) = match kind {
-        StateKind::MainState => (StorageSynchronizerOperations::SyncedStates, "state"),
-        StateKind::Position => (
-            StorageSynchronizerOperations::SyncedPositionStates,
+    let (operation_label, noun) = match kind {
+        SnapshotKind::State(StateKind::MainState) => (
+            StorageSynchronizerOperations::SyncedStates.get_label(),
+            "state",
+        ),
+        SnapshotKind::State(StateKind::Position) => (
+            StorageSynchronizerOperations::SyncedPositionStates.get_label(),
             "position state",
         ),
+        SnapshotKind::HotState => (
+            StorageSynchronizerOperations::SyncedHotStates.get_label(),
+            "hot state",
+        ),
     };
-    match storage_data_chunk {
-        StorageDataChunk::States(notification_id, states_with_proof) => {
-            let all_states_synced = states_with_proof.is_last_chunk();
-            let last_committed_state_index = states_with_proof.last_index;
-            let num_state_values = states_with_proof.raw_values.len();
-
-            match receiver.add_chunk(
-                states_with_proof.raw_values,
-                states_with_proof.proof.clone(),
-            ) {
-                Ok(()) => {
-                    info!(LogSchema::new(LogEntry::StorageSynchronizer).message(&format!(
-                        "Committed a new {} value chunk! Chunk size: {:?}, last persisted index: {:?}",
-                        noun, num_state_values, last_committed_state_index
-                    )));
-
-                    // Update the chunk metrics
-                    let operation_label = operation.get_label();
-                    metrics::set_gauge(
-                        &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
-                        operation_label,
-                        last_committed_state_index,
-                    );
-                    metrics::observe_value(
-                        &metrics::STORAGE_SYNCHRONIZER_CHUNK_SIZES,
-                        operation_label,
-                        num_state_values as u64,
-                    );
-
-                    if all_states_synced {
-                        // The caller performs the (kind-specific) finalize.
-                        return ChunkApplyOutcome::Finalize {
-                            notification_id,
-                            last_index: last_committed_state_index,
-                        };
-                    }
-
-                    // Persist the last committed index for crash resumption
-                    let update_result = metadata_storage.clone().update_last_persisted_index(
-                        target_ledger_info,
-                        last_committed_state_index,
-                        false,
-                        kind,
-                    );
-                    if let Err(error) = update_result {
-                        let error = format!("Failed to update the last persisted {} index at version: {:?}! Error: {:?}", noun, version, error);
-                        send_storage_synchronizer_error(
-                            error_notification_sender.clone(),
-                            notification_id,
-                            error,
-                            pending_data_errors,
-                        )
-                        .await;
-                    }
-                },
-                Err(error) => {
-                    let error =
-                        format!("Failed to commit {} value chunk! Error: {:?}", noun, error);
-                    send_storage_synchronizer_error(
-                        error_notification_sender.clone(),
-                        notification_id,
-                        error,
-                        pending_data_errors,
-                    )
-                    .await;
-                },
-            }
+    match (receiver, storage_data_chunk) {
+        (SnapshotReceiver::State(receiver), StorageDataChunk::States(notification_id, chunk)) => {
+            let all_states_synced = chunk.is_last_chunk();
+            let last_committed_state_index = chunk.last_index;
+            apply_snapshot_chunk_values(
+                receiver,
+                notification_id,
+                chunk.raw_values,
+                chunk.proof,
+                all_states_synced,
+                last_committed_state_index,
+                operation_label,
+                noun,
+                kind,
+                metadata_storage,
+                target_ledger_info,
+                error_notification_sender,
+                pending_data_chunks,
+                pending_data_errors,
+                version,
+            )
+            .await
         },
-        storage_data_chunk => {
+        (
+            SnapshotReceiver::HotState(receiver),
+            StorageDataChunk::HotStates(notification_id, chunk),
+        ) => {
+            let all_states_synced = chunk.is_last_chunk();
+            let last_committed_state_index = chunk.last_index;
+            apply_snapshot_chunk_values(
+                receiver,
+                notification_id,
+                chunk.raw_values,
+                chunk.proof,
+                all_states_synced,
+                last_committed_state_index,
+                operation_label,
+                noun,
+                kind,
+                metadata_storage,
+                target_ledger_info,
+                error_notification_sender,
+                pending_data_chunks,
+                pending_data_errors,
+                version,
+            )
+            .await
+        },
+        (_, storage_data_chunk) => {
             unimplemented!(
                 "Invalid storage data chunk sent to snapshot receiver! This shouldn't happen: {:?}",
                 storage_data_chunk
             );
+        },
+    }
+}
+
+/// Shared body of [`apply_snapshot_chunk`] for one leaf type.
+#[allow(clippy::too_many_arguments)]
+async fn apply_snapshot_chunk_values<V, MetadataStorage: MetadataStorageInterface + Clone>(
+    receiver: &mut Box<dyn StateSnapshotReceiver<StateKey, V>>,
+    notification_id: NotificationId,
+    raw_values: Vec<(StateKey, V)>,
+    proof: SparseMerkleRangeProof,
+    all_states_synced: bool,
+    last_committed_state_index: u64,
+    operation_label: &'static str,
+    noun: &'static str,
+    kind: SnapshotKind,
+    metadata_storage: &MetadataStorage,
+    target_ledger_info: &LedgerInfoWithSignatures,
+    error_notification_sender: &mpsc::UnboundedSender<ErrorNotification>,
+    pending_data_chunks: &Arc<AtomicU64>,
+    pending_data_errors: &Arc<AtomicU64>,
+    version: Version,
+) -> ChunkApplyOutcome {
+    let num_state_values = raw_values.len();
+    match receiver.add_chunk(raw_values, proof) {
+        Ok(()) => {
+            info!(
+                LogSchema::new(LogEntry::StorageSynchronizer).message(&format!(
+                    "Committed a new {} value chunk! Chunk size: {:?}, last persisted index: {:?}",
+                    noun, num_state_values, last_committed_state_index
+                ))
+            );
+
+            metrics::set_gauge(
+                &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+                operation_label,
+                last_committed_state_index,
+            );
+            metrics::observe_value(
+                &metrics::STORAGE_SYNCHRONIZER_CHUNK_SIZES,
+                operation_label,
+                num_state_values as u64,
+            );
+
+            if all_states_synced {
+                return ChunkApplyOutcome::Finalize {
+                    notification_id,
+                    last_index: last_committed_state_index,
+                };
+            }
+
+            if let Err(error) = metadata_storage.clone().update_last_persisted_index(
+                target_ledger_info,
+                last_committed_state_index,
+                false,
+                kind,
+            ) {
+                let error = format!(
+                    "Failed to update the last persisted {} index at version: {:?}! Error: {:?}",
+                    noun, version, error
+                );
+                send_storage_synchronizer_error(
+                    error_notification_sender.clone(),
+                    notification_id,
+                    error,
+                    pending_data_errors,
+                )
+                .await;
+            }
+        },
+        Err(error) => {
+            let error = format!("Failed to commit {} value chunk! Error: {:?}", noun, error);
+            send_storage_synchronizer_error(
+                error_notification_sender.clone(),
+                notification_id,
+                error,
+                pending_data_errors,
+            )
+            .await;
         },
     }
     decrement_pending_data_chunks(pending_data_chunks.clone());
@@ -1044,7 +1146,7 @@ async fn apply_snapshot_chunk<MetadataStorage: MetadataStorageInterface + Clone>
 fn spawn_snapshot_receiver<
     MetadataStorage: MetadataStorageInterface + Clone + Send + Sync + 'static,
 >(
-    kind: StateKind,
+    kind: SnapshotKind,
     mut snapshot_listener: mpsc::Receiver<StorageDataChunk>,
     error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
     pending_data_chunks: Arc<AtomicU64>,
@@ -1056,13 +1158,17 @@ fn spawn_snapshot_receiver<
     runtime: Option<Handle>,
 ) -> JoinHandle<()> {
     let timer_label = match kind {
-        StateKind::MainState => metrics::STORAGE_SYNCHRONIZER_STATE_VALUE_CHUNK,
-        StateKind::Position => metrics::STORAGE_SYNCHRONIZER_POSITION_STATE_VALUE_CHUNK,
+        SnapshotKind::State(StateKind::MainState) => {
+            metrics::STORAGE_SYNCHRONIZER_STATE_VALUE_CHUNK
+        },
+        SnapshotKind::State(StateKind::Position) => {
+            metrics::STORAGE_SYNCHRONIZER_POSITION_STATE_VALUE_CHUNK
+        },
+        SnapshotKind::HotState => metrics::STORAGE_SYNCHRONIZER_HOT_STATE_VALUE_CHUNK,
     };
     let receiver = async move {
         let version = target_ledger_info.ledger_info().version();
-        let mut snapshot_receiver: Option<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> =
-            None;
+        let mut snapshot_receiver: Option<SnapshotReceiver> = None;
 
         while let Some(storage_data_chunk) = snapshot_listener.next().await {
             let _timer =
@@ -1073,16 +1179,30 @@ fn spawn_snapshot_receiver<
             // a recoverable error notification tied to the chunk, rather than
             // panicking the receiver task.
             if snapshot_receiver.is_none() {
-                match storage
-                    .writer
-                    .get_state_snapshot_receiver(version, expected_root, kind)
-                {
+                let new_receiver = match kind {
+                    SnapshotKind::State(state_kind) => storage
+                        .writer
+                        .get_state_snapshot_receiver(version, expected_root, state_kind)
+                        .map(SnapshotReceiver::State),
+                    SnapshotKind::HotState => storage
+                        .writer
+                        .get_hot_state_snapshot_receiver(version, expected_root)
+                        .map(SnapshotReceiver::HotState),
+                };
+                match new_receiver {
                     Ok(new_receiver) => snapshot_receiver = Some(new_receiver),
                     Err(error) => {
-                        if let StorageDataChunk::States(notification_id, _) = &storage_data_chunk {
+                        let notification_id = match &storage_data_chunk {
+                            StorageDataChunk::States(notification_id, _)
+                            | StorageDataChunk::HotStates(notification_id, _) => {
+                                Some(*notification_id)
+                            },
+                            _ => None,
+                        };
+                        if let Some(notification_id) = notification_id {
                             send_storage_synchronizer_error(
                                 error_notification_sender.clone(),
-                                *notification_id,
+                                notification_id,
                                 format!(
                                     "Failed to initialize the {:?} snapshot receiver! Error: {:?}",
                                     kind, error
@@ -1119,10 +1239,14 @@ fn spawn_snapshot_receiver<
                 } => {
                     // Write the snapshot and record completion. The whole
                     // fast-sync (accumulator + commit) is finalized separately.
-                    let finalize_result = snapshot_receiver
+                    let receiver = snapshot_receiver
                         .take()
-                        .expect("The snapshot receiver was initialized above!")
-                        .finish_box()
+                        .expect("The snapshot receiver was initialized above!");
+                    let finish_result = match receiver {
+                        SnapshotReceiver::State(receiver) => receiver.finish_box(),
+                        SnapshotReceiver::HotState(receiver) => receiver.finish_box(),
+                    };
+                    let finalize_result = finish_result
                         .map_err(|error| {
                             format!("Failed to finish the snapshot! Error: {:?}", error)
                         })

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -27,7 +27,7 @@ use aptos_data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     streaming_client::{NotificationAndFeedback, NotificationFeedback},
 };
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_time_service::TimeService;
 use aptos_types::{
     transaction::{TransactionOutputListWithProofV2, Version},
@@ -1070,7 +1070,7 @@ async fn test_snapshot_sync_epoch_change() {
         .with(
             eq(target_version),
             eq(Some(last_persisted_index)),
-            eq(StateKind::MainState),
+            eq(SnapshotKind::State(StateKind::MainState)),
         )
         .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
@@ -1134,7 +1134,11 @@ async fn test_snapshot_sync_epoch_change_genesis() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(target_version), eq(Some(0)), eq(StateKind::MainState))
+        .with(
+            eq(target_version),
+            eq(Some(0)),
+            eq(SnapshotKind::State(StateKind::MainState)),
+        )
         .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
     // Create the mock metadata storage
@@ -1197,7 +1201,11 @@ async fn test_snapshot_sync_state_values_invalid_chunk_retries() {
         mock_streaming_client
             .expect_get_all_state_values()
             .times(1)
-            .with(always(), eq(Some(0)), eq(StateKind::MainState))
+            .with(
+                always(),
+                eq(Some(0)),
+                eq(SnapshotKind::State(StateKind::MainState)),
+            )
             .return_once(move |_, _, _| Ok(data_stream_listener))
             .in_sequence(&mut expectation_sequence);
     }
@@ -1292,7 +1300,7 @@ async fn test_snapshot_sync_epoch_change_genesis_restart() {
         .with(
             eq(target_version),
             eq(Some(last_persisted_index)),
-            eq(StateKind::MainState),
+            eq(SnapshotKind::State(StateKind::MainState)),
         )
         .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
@@ -1364,7 +1372,7 @@ async fn test_snapshot_sync_existing_state() {
         .with(
             eq(highest_version),
             eq(Some(last_persisted_index)),
-            eq(StateKind::MainState),
+            eq(SnapshotKind::State(StateKind::MainState)),
         )
         .return_once(move |_, _, _| Ok(data_stream_listener_1))
         .in_sequence(&mut expectation_sequence);
@@ -1387,7 +1395,7 @@ async fn test_snapshot_sync_existing_state() {
         .with(
             eq(highest_version),
             eq(Some(last_persisted_index)),
-            eq(StateKind::MainState),
+            eq(SnapshotKind::State(StateKind::MainState)),
         )
         .return_once(move |_, _, _| Ok(data_stream_listener_2))
         .in_sequence(&mut expectation_sequence);
@@ -1469,7 +1477,11 @@ async fn test_snapshot_sync_fresh_state() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(highest_version), eq(Some(0)), eq(StateKind::MainState))
+        .with(
+            eq(highest_version),
+            eq(Some(0)),
+            eq(SnapshotKind::State(StateKind::MainState)),
+        )
         .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
     // Create the mock metadata storage

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -15,13 +15,15 @@ use crate::{
             create_data_stream_listener, create_empty_epoch_state, create_epoch_ending_ledger_info,
             create_epoch_ending_ledger_info_for_epoch, create_full_node_driver_configuration,
             create_global_summary, create_global_summary_with_version,
-            create_output_list_with_proof, create_random_epoch_ending_ledger_info,
-            create_state_value_chunk_with_proof, create_transaction_list_with_proof,
+            create_output_list_with_proof, create_output_list_with_proof_v1,
+            create_random_epoch_ending_ledger_info, create_state_value_chunk_with_proof,
+            create_transaction_list_with_proof,
         },
     },
     utils::OutputFallbackHandler,
 };
 use aptos_config::config::BootstrappingMode;
+use aptos_crypto::HashValue;
 use aptos_data_client::global_summary::GlobalDataSummary;
 use aptos_data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
@@ -1111,6 +1113,74 @@ async fn test_snapshot_sync_epoch_change() {
     global_data_summary.advertised_data.synced_ledger_infos = vec![highest_ledger_info.clone()];
 
     // Drive progress to start the state value stream
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_snapshot_sync_hot_state_stage() {
+    // Create test data
+    let synced_version = GENESIS_TRANSACTION_VERSION; // Genesis is the highest synced
+    let target_version = 1000;
+    let highest_version = 5000;
+    let target_ledger_info = create_random_epoch_ending_ledger_info(target_version, 1);
+    let highest_ledger_info = create_random_epoch_ending_ledger_info(highest_version, 2);
+    let hot_state_root = HashValue::random();
+
+    // Create a driver configuration with a genesis waypoint and fast syncing
+    let mut driver_configuration = create_full_node_driver_configuration();
+    driver_configuration.config.bootstrapping_mode = BootstrappingMode::DownloadLatestStates;
+
+    // The main-state snapshot is complete; the hot-state snapshot hasn't started.
+    // (The position stage is skipped: the target commits no position root.)
+    let mut metadata_storage = MockMetadataStorage::new();
+    let target_ledger_info_clone = target_ledger_info.clone();
+    metadata_storage
+        .expect_previous_snapshot_sync_target()
+        .returning(move |kind| match kind {
+            SnapshotKind::State(StateKind::MainState) => Ok(Some(target_ledger_info_clone.clone())),
+            _ => Ok(None),
+        });
+    metadata_storage
+        .expect_is_snapshot_sync_complete()
+        .returning(|_, kind| Ok(kind == SnapshotKind::State(StateKind::MainState)));
+
+    // Expect the hot state stream to be created from index 0
+    let mut mock_streaming_client = create_mock_streaming_client();
+    let (_notification_sender, data_stream_listener) = create_data_stream_listener();
+    mock_streaming_client
+        .expect_get_all_state_values()
+        .times(1)
+        .with(eq(target_version), eq(Some(0)), eq(SnapshotKind::HotState))
+        .return_once(move |_, _, _| Ok(data_stream_listener));
+
+    // Create the bootstrapper
+    let mut bootstrapper = create_bootstrapper_with_storage(
+        driver_configuration,
+        mock_streaming_client,
+        metadata_storage,
+        None,
+        synced_version,
+        true,
+    );
+
+    // The target transaction output commits a hot state root
+    bootstrapper
+        .get_state_value_syncer()
+        .set_transaction_output_to_sync(create_output_list_with_proof_v1(
+            Some(hot_state_root),
+            None,
+        ));
+
+    // Insert an epoch ending ledger info into the verified states of the bootstrapper
+    manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
+
+    // Create a global data summary
+    let mut global_data_summary = create_global_summary(1);
+    global_data_summary.advertised_data.synced_ledger_infos = vec![highest_ledger_info.clone()];
+
+    // Drive progress to start the hot state value stream
     drive_progress(&mut bootstrapper, &global_data_summary, false)
         .await
         .unwrap();

--- a/state-sync/state-sync-driver/src/tests/metadata_storage.rs
+++ b/state-sync/state-sync-driver/src/tests/metadata_storage.rs
@@ -9,7 +9,7 @@ use crate::{
     tests::utils::{create_epoch_ending_ledger_info, create_ledger_info_at_version},
 };
 use aptos_schemadb::schema::fuzzing::assert_encode_decode;
-use aptos_storage_interface::StateKind;
+use aptos_storage_interface::{SnapshotKind, StateKind};
 use aptos_temppath::TempPath;
 use claims::{assert_err, assert_none};
 
@@ -21,7 +21,7 @@ fn test_create_then_open() {
 
     // Verify the storage is empty
     assert_none!(metadata_storage
-        .previous_snapshot_sync_target(StateKind::MainState)
+        .previous_snapshot_sync_target(SnapshotKind::State(StateKind::MainState))
         .unwrap());
 
     // Insert a new state value entry for the target
@@ -33,7 +33,7 @@ fn test_create_then_open() {
             &target_ledger_info,
             last_persisted_state_value,
             snapshot_sync_completed,
-            StateKind::MainState,
+            SnapshotKind::State(StateKind::MainState),
         )
         .unwrap();
 
@@ -45,19 +45,25 @@ fn test_create_then_open() {
     assert_eq!(
         Some(target_ledger_info.clone()),
         metadata_storage
-            .previous_snapshot_sync_target(StateKind::MainState)
+            .previous_snapshot_sync_target(SnapshotKind::State(StateKind::MainState))
             .unwrap()
     );
     assert_eq!(
         last_persisted_state_value,
         metadata_storage
-            .get_last_persisted_index(&target_ledger_info, StateKind::MainState)
+            .get_last_persisted_index(
+                &target_ledger_info,
+                SnapshotKind::State(StateKind::MainState)
+            )
             .unwrap()
     );
     assert_eq!(
         snapshot_sync_completed,
         metadata_storage
-            .is_snapshot_sync_complete(&target_ledger_info, StateKind::MainState)
+            .is_snapshot_sync_complete(
+                &target_ledger_info,
+                SnapshotKind::State(StateKind::MainState)
+            )
             .unwrap()
     );
 
@@ -69,7 +75,7 @@ fn test_create_then_open() {
             &target_ledger_info,
             last_persisted_state_value,
             snapshot_sync_completed,
-            StateKind::MainState,
+            SnapshotKind::State(StateKind::MainState),
         )
         .unwrap();
 
@@ -81,19 +87,25 @@ fn test_create_then_open() {
     assert_eq!(
         Some(target_ledger_info.clone()),
         metadata_storage
-            .previous_snapshot_sync_target(StateKind::MainState)
+            .previous_snapshot_sync_target(SnapshotKind::State(StateKind::MainState))
             .unwrap()
     );
     assert_eq!(
         last_persisted_state_value,
         metadata_storage
-            .get_last_persisted_index(&target_ledger_info, StateKind::MainState)
+            .get_last_persisted_index(
+                &target_ledger_info,
+                SnapshotKind::State(StateKind::MainState)
+            )
             .unwrap()
     );
     assert_eq!(
         snapshot_sync_completed,
         metadata_storage
-            .is_snapshot_sync_complete(&target_ledger_info, StateKind::MainState)
+            .is_snapshot_sync_complete(
+                &target_ledger_info,
+                SnapshotKind::State(StateKind::MainState)
+            )
             .unwrap()
     );
 }
@@ -108,6 +120,77 @@ fn test_metadata_schema_encode_decode() {
             snapshot_sync_completed: false,
         }),
     );
+    assert_encode_decode::<MetadataSchema>(
+        &MetadataKey::HotStateSnapshotSync,
+        &MetadataValue::HotStateSnapshotSync(StateSnapshotProgress {
+            target_ledger_info: create_epoch_ending_ledger_info(),
+            last_persisted_state_value_index: 1234,
+            snapshot_sync_completed: true,
+        }),
+    );
+}
+
+#[test]
+fn test_hot_state_snapshot_progress() {
+    // Create a new metadata storage
+    let tmp_dir = TempPath::new();
+    let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
+
+    // The hot state row starts empty
+    let target_ledger_info = create_ledger_info_at_version(12345);
+    assert_none!(metadata_storage
+        .previous_snapshot_sync_target(SnapshotKind::HotState)
+        .unwrap());
+    assert_err!(
+        metadata_storage.get_last_persisted_index(&target_ledger_info, SnapshotKind::HotState)
+    );
+    assert_err!(
+        metadata_storage.is_snapshot_sync_complete(&target_ledger_info, SnapshotKind::HotState)
+    );
+
+    // Write hot state and main state progress; each lands on its own row
+    metadata_storage
+        .update_last_persisted_index(&target_ledger_info, 777, true, SnapshotKind::HotState)
+        .unwrap();
+    metadata_storage
+        .update_last_persisted_index(
+            &target_ledger_info,
+            555,
+            false,
+            SnapshotKind::State(StateKind::MainState),
+        )
+        .unwrap();
+
+    assert_eq!(
+        Some(target_ledger_info.clone()),
+        metadata_storage
+            .previous_snapshot_sync_target(SnapshotKind::HotState)
+            .unwrap()
+    );
+    assert_eq!(
+        777,
+        metadata_storage
+            .get_last_persisted_index(&target_ledger_info, SnapshotKind::HotState)
+            .unwrap()
+    );
+    assert!(metadata_storage
+        .is_snapshot_sync_complete(&target_ledger_info, SnapshotKind::HotState)
+        .unwrap());
+    assert_eq!(
+        555,
+        metadata_storage
+            .get_last_persisted_index(
+                &target_ledger_info,
+                SnapshotKind::State(StateKind::MainState)
+            )
+            .unwrap()
+    );
+    assert!(!metadata_storage
+        .is_snapshot_sync_complete(
+            &target_ledger_info,
+            SnapshotKind::State(StateKind::MainState)
+        )
+        .unwrap());
 }
 
 #[test]
@@ -119,14 +202,16 @@ fn test_multiple_reads_and_writes() {
     // Verify the storage is empty
     let target_ledger_info = create_ledger_info_at_version(100000);
     assert_none!(metadata_storage
-        .previous_snapshot_sync_target(StateKind::MainState)
+        .previous_snapshot_sync_target(SnapshotKind::State(StateKind::MainState))
         .unwrap());
-    assert_err!(
-        metadata_storage.is_snapshot_sync_complete(&target_ledger_info, StateKind::MainState)
-    );
-    assert_err!(
-        metadata_storage.get_last_persisted_index(&target_ledger_info, StateKind::MainState)
-    );
+    assert_err!(metadata_storage.is_snapshot_sync_complete(
+        &target_ledger_info,
+        SnapshotKind::State(StateKind::MainState)
+    ));
+    assert_err!(metadata_storage.get_last_persisted_index(
+        &target_ledger_info,
+        SnapshotKind::State(StateKind::MainState)
+    ));
 
     // Do multiple writes
     for index in 0..100 {
@@ -138,7 +223,7 @@ fn test_multiple_reads_and_writes() {
                 &target_ledger_info,
                 last_persisted_state_value,
                 snapshot_sync_completed,
-                StateKind::MainState,
+                SnapshotKind::State(StateKind::MainState),
             )
             .unwrap();
 
@@ -146,19 +231,25 @@ fn test_multiple_reads_and_writes() {
         assert_eq!(
             Some(target_ledger_info.clone()),
             metadata_storage
-                .previous_snapshot_sync_target(StateKind::MainState)
+                .previous_snapshot_sync_target(SnapshotKind::State(StateKind::MainState))
                 .unwrap()
         );
         assert_eq!(
             last_persisted_state_value,
             metadata_storage
-                .get_last_persisted_index(&target_ledger_info, StateKind::MainState)
+                .get_last_persisted_index(
+                    &target_ledger_info,
+                    SnapshotKind::State(StateKind::MainState)
+                )
                 .unwrap()
         );
         assert_eq!(
             snapshot_sync_completed,
             metadata_storage
-                .is_snapshot_sync_complete(&target_ledger_info, StateKind::MainState)
+                .is_snapshot_sync_complete(
+                    &target_ledger_info,
+                    SnapshotKind::State(StateKind::MainState)
+                )
                 .unwrap()
         );
     }
@@ -172,18 +263,28 @@ fn test_writes_to_different_targets() {
 
     // Verify the storage is empty
     assert_none!(metadata_storage
-        .previous_snapshot_sync_target(StateKind::MainState)
+        .previous_snapshot_sync_target(SnapshotKind::State(StateKind::MainState))
         .unwrap());
 
     // Write a new progress entry into the storage
     let target_ledger_info = create_ledger_info_at_version(100);
     metadata_storage
-        .update_last_persisted_index(&target_ledger_info, 10101, false, StateKind::MainState)
+        .update_last_persisted_index(
+            &target_ledger_info,
+            10101,
+            false,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .unwrap();
 
     // Write another progress entry with a different target and verify that it fails
     let target_ledger_info = create_ledger_info_at_version(200);
     metadata_storage
-        .update_last_persisted_index(&target_ledger_info, 10101, false, StateKind::MainState)
+        .update_last_persisted_index(
+            &target_ledger_info,
+            10101,
+            false,
+            SnapshotKind::State(StateKind::MainState),
+        )
         .unwrap_err();
 }

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -17,7 +17,7 @@ use aptos_data_streaming_service::{
 use aptos_executor_types::{ChunkCommitNotification, ChunkExecutorTrait};
 use aptos_storage_interface::{
     chunk_to_commit::ChunkToCommit, DbReader, DbReaderWriter, DbWriter, LedgerSummary, Result,
-    StateKind, StateSnapshotReceiver,
+    SnapshotKind, StateKind, StateSnapshotReceiver,
 };
 use aptos_types::{
     epoch_change::EpochChangeProof,
@@ -363,7 +363,7 @@ mock! {
             &self,
             version: Version,
             start_index: Option<u64>,
-            state_kind: StateKind,
+            snapshot_kind: SnapshotKind,
         ) -> AnyhowResult<DataStreamListener, aptos_data_streaming_service::error::Error>;
 
         async fn get_all_epoch_ending_ledger_infos(

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -29,6 +29,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
+        hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::{StateValue, StateValueChunkWithProof},
     },
@@ -291,6 +292,12 @@ mock! {
             kind: StateKind,
         ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>>;
 
+        fn get_hot_state_snapshot_receiver(
+            &self,
+            version: Version,
+            expected_root_hash: HashValue,
+        ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, HotStateValue>>>;
+
         fn finalize_state_snapshot(
             &self,
             version: Version,
@@ -314,18 +321,18 @@ mock! {
         fn is_snapshot_sync_complete(
             &self,
             target_ledger_info: &LedgerInfoWithSignatures,
-            kind: StateKind,
+            kind: SnapshotKind,
         ) -> Result<bool, Error>;
 
         fn get_last_persisted_index(
             &self,
             target_ledger_info: &LedgerInfoWithSignatures,
-            kind: StateKind,
+            kind: SnapshotKind,
         ) -> Result<u64, Error>;
 
         fn previous_snapshot_sync_target(
             &self,
-            kind: StateKind,
+            kind: SnapshotKind,
         ) -> Result<Option<LedgerInfoWithSignatures>, Error>;
 
         fn update_last_persisted_index(
@@ -333,7 +340,7 @@ mock! {
             target_ledger_info: &LedgerInfoWithSignatures,
             last_persisted_index: u64,
             snapshot_sync_completed: bool,
-            kind: StateKind,
+            kind: SnapshotKind,
         ) -> Result<(), Error>;
     }
 
@@ -347,6 +354,18 @@ mock! {
     pub SnapshotReceiver {}
     impl StateSnapshotReceiver<StateKey, StateValue> for SnapshotReceiver {
         fn add_chunk(&mut self, chunk: Vec<(StateKey, StateValue)>, proof: SparseMerkleRangeProof) -> Result<()>;
+
+        fn finish(self) -> Result<()>;
+
+        fn finish_box(self: Box<Self>) -> Result<()>;
+    }
+}
+
+// This automatically creates a MockHotSnapshotReceiver.
+mock! {
+    pub HotSnapshotReceiver {}
+    impl StateSnapshotReceiver<StateKey, HotStateValue> for HotSnapshotReceiver {
+        fn add_chunk(&mut self, chunk: Vec<(StateKey, HotStateValue)>, proof: SparseMerkleRangeProof) -> Result<()>;
 
         fn finish(self) -> Result<()>;
 
@@ -453,7 +472,7 @@ mock! {
             &mut self,
             target_ledger_info: LedgerInfoWithSignatures,
             expected_root: HashValue,
-            kind: StateKind,
+            kind: SnapshotKind,
         ) -> AnyhowResult<JoinHandle<()>, crate::error::Error>;
 
         fn pending_storage_data(&self) -> bool;
@@ -466,6 +485,12 @@ mock! {
             &mut self,
             notification_id: NotificationId,
             state_value_chunk_with_proof: StateValueChunkWithProof,
+        ) -> AnyhowResult<(), crate::error::Error>;
+
+        async fn save_hot_state_values(
+            &mut self,
+            notification_id: NotificationId,
+            hot_state_value_chunk_with_proof: HotStateValueChunkWithProof,
         ) -> AnyhowResult<(), crate::error::Error>;
 
         async fn finalize_fast_sync(

--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -16,10 +16,11 @@ use crate::{
         mocks::{
             create_mock_db_writer, create_mock_executor, create_mock_reader_writer,
             create_mock_reader_writer_with_version, create_mock_receiver, MockChunkExecutor,
+            MockHotSnapshotReceiver,
         },
         utils::{
-            create_epoch_ending_ledger_info, create_event, create_output_list_with_proof,
-            create_state_value_chunk_with_proof, create_transaction,
+            create_epoch_ending_ledger_info, create_event, create_hot_state_value_chunk_with_proof,
+            create_output_list_with_proof, create_state_value_chunk_with_proof, create_transaction,
             create_transaction_list_with_proof, verify_commit_notification,
         },
     },
@@ -32,7 +33,7 @@ use aptos_event_notifications::EventSubscriptionService;
 use aptos_executor_types::ChunkCommitNotification;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_mempool_notifications::MempoolNotificationListener;
-use aptos_storage_interface::{AptosDbError, DbReaderWriter, StateKind};
+use aptos_storage_interface::{AptosDbError, DbReaderWriter, SnapshotKind, StateKind};
 use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -650,7 +651,7 @@ async fn test_save_states_receiver_error() {
         .initialize_snapshot_synchronizer(
             create_epoch_ending_ledger_info(),
             HashValue::random(),
-            StateKind::MainState,
+            SnapshotKind::State(StateKind::MainState),
         )
         .unwrap();
 
@@ -730,7 +731,7 @@ async fn test_save_states_completion() {
         .initialize_snapshot_synchronizer(
             target_ledger_info.clone(),
             HashValue::random(),
-            StateKind::MainState,
+            SnapshotKind::State(StateKind::MainState),
         )
         .unwrap();
 
@@ -777,6 +778,54 @@ async fn test_save_states_completion() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_save_hot_states_completion() {
+    // Setup the mock hot snapshot receiver
+    let mut snapshot_receiver = MockHotSnapshotReceiver::new();
+    snapshot_receiver
+        .expect_add_chunk()
+        .with(always(), always())
+        .returning(|_, _| Ok(()));
+    snapshot_receiver.expect_finish_box().returning(|| Ok(()));
+
+    // Setup the mock db writer
+    let mut db_writer = create_mock_db_writer();
+    db_writer
+        .expect_get_hot_state_snapshot_receiver()
+        .with(always(), always())
+        .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
+
+    // Create the storage synchronizer
+    let target_ledger_info = create_epoch_ending_ledger_info();
+    let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
+        create_mock_executor(),
+        create_mock_reader_writer(None, Some(db_writer)),
+    );
+
+    // Initialize the hot state snapshot synchronizer
+    let state_synchronizer_handle = storage_synchronizer
+        .initialize_snapshot_synchronizer(
+            target_ledger_info,
+            HashValue::random(),
+            SnapshotKind::HotState,
+        )
+        .unwrap();
+
+    // Save multiple hot state chunks (including the last chunk)
+    storage_synchronizer
+        .save_hot_state_values(0, create_hot_state_value_chunk_with_proof(false))
+        .await
+        .unwrap();
+    storage_synchronizer
+        .save_hot_state_values(1, create_hot_state_value_chunk_with_proof(true))
+        .await
+        .unwrap();
+
+    // The receiver should return once it has written the entire snapshot
+    state_synchronizer_handle.await.unwrap();
+    verify_no_pending_data(&storage_synchronizer);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_finalize_fast_sync_dropped_commit_listener() {
     // `finalize_fast_sync` sends the commit notification (it used to be sent by
     // the snapshot receiver). With the commit listener dropped, it should surface
@@ -816,7 +865,7 @@ async fn test_finalize_fast_sync_dropped_commit_listener() {
         .initialize_snapshot_synchronizer(
             target_ledger_info.clone(),
             HashValue::random(),
-            StateKind::MainState,
+            SnapshotKind::State(StateKind::MainState),
         )
         .unwrap();
     storage_synchronizer
@@ -863,7 +912,7 @@ async fn test_save_states_invalid_chunk() {
         .initialize_snapshot_synchronizer(
             create_epoch_ending_ledger_info(),
             HashValue::random(),
-            StateKind::MainState,
+            SnapshotKind::State(StateKind::MainState),
         )
         .unwrap();
 

--- a/state-sync/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-driver/src/tests/utils.rs
@@ -29,7 +29,7 @@ use aptos_types::{
     proof::{
         SparseMerkleRangeProof, TransactionAccumulatorRangeProof, TransactionInfoListWithProof,
     },
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{hot_state::HotStateValueChunkWithProof, state_value::StateValueChunkWithProof},
     transaction::{
         use_case::UseCaseAwareTransaction, ExecutionStatus, RawTransaction, ReplayProtector,
         Script, SignedTransaction, Transaction, TransactionAuxiliaryData, TransactionInfo,
@@ -153,6 +153,34 @@ pub fn create_output_list_with_proof() -> TransactionOutputListWithProofV2 {
     ))
 }
 
+/// Creates an output proof with V1 transaction-info snapshot roots.
+pub fn create_output_list_with_proof_v1(
+    hot_state_root: Option<HashValue>,
+    position_state_root: Option<HashValue>,
+) -> TransactionOutputListWithProofV2 {
+    let transaction_info = TransactionInfo::builder_v1()
+        .transaction_hash(HashValue::random())
+        .state_change_hash(HashValue::random())
+        .event_root_hash(HashValue::random())
+        .maybe_state_checkpoint_hash(Some(HashValue::random()))
+        .maybe_hot_state_checkpoint_hash(hot_state_root)
+        .gas_used(0)
+        .status(ExecutionStatus::Success)
+        .maybe_auxiliary_info_hash(Some(HashValue::random()))
+        .maybe_position_state_checkpoint_hash(position_state_root)
+        .build();
+    let transaction_info_list_with_proof =
+        TransactionInfoListWithProof::new(TransactionAccumulatorRangeProof::new_empty(), vec![
+            transaction_info,
+        ]);
+    let transaction_and_output = (create_transaction(), create_transaction_output());
+    TransactionOutputListWithProofV2::new_from_v1(TransactionOutputListWithProof::new(
+        vec![transaction_and_output],
+        Some(0),
+        transaction_info_list_with_proof,
+    ))
+}
+
 /// Creates a random epoch ending ledger info with the specified values
 pub fn create_random_epoch_ending_ledger_info(
     version: Version,
@@ -198,6 +226,24 @@ pub fn create_state_value_chunk_with_proof(last_chunk: bool) -> StateValueChunkW
         vec![HashValue::random()]
     };
     StateValueChunkWithProof {
+        first_index: 0,
+        last_index: 100,
+        first_key: HashValue::random(),
+        last_key: HashValue::random(),
+        raw_values: vec![],
+        proof: SparseMerkleRangeProof::new(right_siblings),
+        root_hash: HashValue::random(),
+    }
+}
+
+/// Creates a simple hot state value chunk with proof for testing
+pub fn create_hot_state_value_chunk_with_proof(last_chunk: bool) -> HotStateValueChunkWithProof {
+    let right_siblings = if last_chunk {
+        vec![]
+    } else {
+        vec![HashValue::random()]
+    };
+    HotStateValueChunkWithProof {
         first_index: 0,
         last_index: 100,
         first_key: HashValue::random(),

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -270,6 +270,18 @@ impl DbWriter for AptosDB {
                 .state_pruner
                 .state_kv_pruner
                 .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_state_merkle_pruner
+                .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_epoch_snapshot_pruner
+                .save_min_readable_version(version)?;
+            self.state_store
+                .state_pruner
+                .hot_state_kv_pruner
+                .save_min_readable_version(version)?;
 
             restore_utils::update_latest_ledger_info(self.ledger_db.metadata_db(), ledger_infos)?;
             self.state_store.reset();

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -42,6 +42,7 @@ use aptos_types::{
     state_proof::StateProof,
     state_store::{
         combine_sharded_state_updates,
+        hot_state::HotStateValue,
         state_key::{prefix::StateKeyPrefix, StateKey},
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueChunkWithProof},
@@ -443,6 +444,16 @@ impl DbWriter for FakeAptosDB {
     ) -> Result<Box<dyn aptos_storage_interface::StateSnapshotReceiver<StateKey, StateValue>>> {
         self.inner
             .get_state_snapshot_receiver(version, expected_root_hash, kind)
+    }
+
+    fn get_hot_state_snapshot_receiver(
+        &self,
+        version: Version,
+        expected_root_hash: HashValue,
+    ) -> Result<Box<dyn aptos_storage_interface::StateSnapshotReceiver<StateKey, HotStateValue>>>
+    {
+        self.inner
+            .get_hot_state_snapshot_receiver(version, expected_root_hash)
     }
 
     fn finalize_state_snapshot(

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -71,6 +71,13 @@ where
         self.inner.remove(key)
     }
 
+    fn replace(&self, map: DashMap<K, V>) {
+        self.inner.clear();
+        for (key, value) in map {
+            self.inner.insert(key, value);
+        }
+    }
+
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -153,6 +160,12 @@ enum CommitMsg {
         state: State,
         ack: Sender<()>,
     },
+    /// Sent by `reset_base_shards` to replace the base DashMaps' contents on the Committer
+    /// thread. Like `HackReset`, only valid when no commits are in flight.
+    ResetBase {
+        shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+        ack: Sender<()>,
+    },
 }
 
 /// Bundles the committed `State` with a `HotStateView` that is consistent with it.
@@ -228,6 +241,25 @@ impl HotState {
         ack_rx
             .recv()
             .expect("Failed to receive reset ack from hot state committer.");
+    }
+
+    /// Replaces the base DashMaps' contents with `shards`. Blocks until the Committer has done
+    /// so. Must be followed by `hack_reset` with the matching `State`, which re-validates the
+    /// LRU metadata against the new contents.
+    pub(crate) fn reset_base_shards(
+        &self,
+        shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+    ) {
+        let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+        self.commit_tx
+            .send(CommitMsg::ResetBase {
+                shards,
+                ack: ack_tx,
+            })
+            .expect("Failed to send base reset to hot state committer.");
+        ack_rx
+            .recv()
+            .expect("Failed to receive base reset ack from hot state committer.");
     }
 
     pub fn get_committed(&self) -> (Arc<dyn HotStateView>, State) {
@@ -478,6 +510,17 @@ impl Committer {
                     );
                     self.handle_reset(state, ack);
                 },
+                Ok(CommitMsg::ResetBase { shards, ack }) => {
+                    assert!(
+                        self.rx.try_recv().is_err(),
+                        "ResetBase must be the only message in the channel — \
+                         reset_base_shards is only valid when no commits are in flight."
+                    );
+                    for (shard, loaded) in self.base.shards.iter().zip(shards) {
+                        shard.replace(loaded);
+                    }
+                    let _ = ack.send(());
+                },
                 Err(RecvTimeoutError::Timeout) => {
                     self.try_merge();
                 },
@@ -494,10 +537,10 @@ impl Committer {
                     n_backlog += 1;
                     ret = state;
                 },
-                CommitMsg::HackReset { .. } => {
+                CommitMsg::HackReset { .. } | CommitMsg::ResetBase { .. } => {
                     unreachable!(
-                        "HackReset must not appear alongside Commit messages — \
-                         hack_reset is only valid when no commits are in flight."
+                        "Reset messages must not appear alongside Commit messages — \
+                         resets are only valid when no commits are in flight."
                     );
                 },
             }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -82,6 +82,7 @@ use aptos_types::{
     transaction::Version,
 };
 use claims::{assert_ge, assert_le};
+use dashmap::DashMap;
 use itertools::Itertools;
 use rayon::prelude::*;
 use std::{
@@ -990,24 +991,46 @@ impl StateStore {
         state_db: &Arc<StateDb>,
         hot_state_config: HotStateConfig,
     ) -> (PersistedState, [HotStateMetadata; NUM_STATE_SHARDS]) {
-        let empty = || {
-            (
+        match Self::try_load_hot_state_kvs(state_db, hot_state_config) {
+            None => (
                 PersistedState::new_empty(hot_state_config),
                 Default::default(),
-            )
-        };
-
-        if hot_state_config.delete_on_restart {
-            return empty();
+            ),
+            Some((snapshot_version, shards, metadata)) => {
+                let usage = state_db
+                    .get_state_storage_usage(Some(snapshot_version))
+                    .expect("Failed to query state storage usage on initialization.");
+                let state = State::new_at_version_with_hot_state_metadata(
+                    Some(snapshot_version),
+                    usage,
+                    hot_state_config,
+                    metadata.clone(),
+                );
+                (
+                    PersistedState::new_from_loaded(state, hot_state_config, shards),
+                    metadata,
+                )
+            },
         }
-        let snapshot_version = match state_db
+    }
+
+    /// Loads the hot state KV shards and per-shard LRU metadata at the latest snapshot
+    /// version. `None` when loading is not applicable (disabled, no snapshot).
+    fn try_load_hot_state_kvs(
+        state_db: &Arc<StateDb>,
+        hot_state_config: HotStateConfig,
+    ) -> Option<(
+        Version,
+        [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+        [HotStateMetadata; NUM_STATE_SHARDS],
+    )> {
+        if hot_state_config.delete_on_restart {
+            return None;
+        }
+        let snapshot_version = state_db
             .state_merkle_db
             .get_state_snapshot_version_before(Version::MAX)
-            .expect("Failed to query latest snapshot on initialization.")
-        {
-            Some(v) => v,
-            None => return empty(),
-        };
+            .expect("Failed to query latest snapshot on initialization.")?;
 
         let loaded = state_db
             .hot_state_kv_db
@@ -1021,21 +1044,7 @@ impl StateStore {
                 loaded[i].total_value_bytes,
             )
         });
-        let dashmaps = loaded.map(|s| s.map);
-        let usage = state_db
-            .get_state_storage_usage(Some(snapshot_version))
-            .expect("Failed to query state storage usage on initialization.");
-        let state = State::new_at_version_with_hot_state_metadata(
-            Some(snapshot_version),
-            usage,
-            hot_state_config,
-            metadata.clone(),
-        );
-
-        (
-            PersistedState::new_from_loaded(state, hot_state_config, dashmaps),
-            metadata,
-        )
+        Some((snapshot_version, loaded.map(|s| s.map), metadata))
     }
 
     pub fn reset(&self) {
@@ -1046,9 +1055,16 @@ impl StateStore {
         // drop-time `sync_commit` read the new family and panic on
         // `is_descendant_of`.
         self.buffered_state.lock().quit();
-        // TODO(HotState): restore does not reconstruct the hot state yet, so we pass empty
-        // metadata here. This is safe because callers (restore / state-sync) open the DB with
-        // `empty_buffered_state_for_restore`, so the DashMaps are always empty.
+        // A restore may have written a hot state snapshot since the DB was opened, so
+        // reload it into the in-memory hot state before rebuilding the buffered state.
+        // TODO(HotState): A restore must load this snapshot even when
+        // `delete_on_restart` is set.
+        let (shards, hot_state_metadata) =
+            match Self::try_load_hot_state_kvs(&self.state_db, self.hot_state_config) {
+                Some((_version, shards, metadata)) => (shards, metadata),
+                None => (std::array::from_fn(|_| DashMap::new()), Default::default()),
+            };
+        self.persisted_state.reset_hot_state_shards(shards);
         *self.buffered_state.lock() = Self::create_buffered_state_from_latest_snapshot(
             &self.state_db,
             self.buffered_state_target_items,
@@ -1056,7 +1072,7 @@ impl StateStore {
             true,
             self.current_state.clone(),
             self.persisted_state.clone(),
-            Default::default(),
+            hot_state_metadata,
             self.hot_state_config,
         )
         .expect("buffered state creation failed.");

--- a/storage/aptosdb/src/state_store/persisted_state.rs
+++ b/storage/aptosdb/src/state_store/persisted_state.rs
@@ -74,6 +74,17 @@ impl PersistedState {
         self.hot_state.enqueue_commit(state);
     }
 
+    /// Replaces the base hot state shards, e.g. with what a restore wrote. Must be followed by
+    /// `hack_reset` with the matching LRU metadata.
+    ///
+    /// n.b. Can only be used when no on the fly commit is in the queue.
+    pub fn reset_hot_state_shards(
+        &self,
+        shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+    ) {
+        self.hot_state.reset_base_shards(shards);
+    }
+
     // n.b. Can only be used when no on the fly commit is in the queue.
     pub fn hack_reset(&self, state_with_summary: StateWithSummary) {
         let (state, summary) = state_with_summary.into_inner();

--- a/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
@@ -12,7 +12,7 @@ use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_jellyfish_merkle::{
     mock_tree_store::MockTreeStore, restore::JellyfishMerkleRestore, JellyfishMerkleTree,
 };
-use aptos_storage_interface::{DbReader, DbWriter, Result as DbResult};
+use aptos_storage_interface::{DbReader, DbWriter, Result as DbResult, StateKind};
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -20,6 +20,7 @@ use aptos_types::{
         hot_state::{HotStateValue, HotStateValueChunkWithProof},
         state_key::StateKey,
         state_value::StateValue,
+        NUM_STATE_SHARDS,
     },
     transaction::{
         BlockEndInfo, ExecutionStatus, Transaction, TransactionAuxiliaryData, TransactionInfo,
@@ -469,6 +470,27 @@ fn open_persistent_hot_state_db(path: &TempPath) -> AptosDB {
     .unwrap()
 }
 
+/// Restores the cold state snapshot at `version` from `src` into `dst`, which `reset` needs
+/// to locate the latest snapshot.
+fn restore_cold_state(src: &AptosDB, dst: &AptosDB, version: Version) {
+    let root_hash = src.state_store.get_root_hash(version).unwrap();
+    let num_items = src
+        .get_state_item_count(version, StateKind::MainState)
+        .unwrap();
+    let mut receiver = dst
+        .get_state_snapshot_receiver(version, root_hash, StateKind::MainState)
+        .unwrap();
+    let mut first_index = 0;
+    while first_index < num_items {
+        let chunk = src
+            .get_state_value_chunk_with_proof(version, first_index, 2, StateKind::MainState)
+            .unwrap();
+        first_index += chunk.raw_values.len();
+        receiver.add_chunk(chunk.raw_values, chunk.proof).unwrap();
+    }
+    receiver.finish_box().unwrap();
+}
+
 #[test]
 fn test_hot_state_restore() {
     let tmp_src = TempPath::new();
@@ -487,6 +509,7 @@ fn test_hot_state_restore() {
 
     let tmp_dst = TempPath::new();
     let dst = open_persistent_hot_state_db(&tmp_dst);
+    restore_cold_state(&src, &dst, version);
     let mut receiver = dst
         .get_hot_state_snapshot_receiver(version, root_hash)
         .unwrap();
@@ -496,6 +519,7 @@ fn test_hot_state_restore() {
             .unwrap();
     }
     receiver.finish_box().unwrap();
+    dst.state_store.reset();
 
     // The restored DB serves the same snapshot.
     assert_eq!(
@@ -507,6 +531,31 @@ fn test_hot_state_restore() {
         dst.state_store
             .hot_state_merkle_db
             .get_root_hash(version)
+            .unwrap(),
+        root_hash
+    );
+
+    // `reset` reloaded the restored hot state into memory.
+    let (hot_view, state) = dst.get_persisted_state().unwrap();
+    let num_hot_items: usize = (0..NUM_STATE_SHARDS)
+        .map(|shard_id| state.num_hot_items(shard_id))
+        .sum();
+    assert_eq!(num_hot_items, expected.len());
+    for (key, hot_value) in &expected {
+        let slot = hot_view
+            .get_state_slot(key.crypto_hash_ref())
+            .expect("restored key must be hot");
+        assert_eq!(slot.as_state_value_opt(), hot_value.value_opt());
+        assert_eq!(
+            slot.expect_hot_since_version(),
+            hot_value.hot_since_version()
+        );
+    }
+    assert_eq!(
+        dst.state_store
+            .current_state_locked()
+            .summary()
+            .hot_root_hash()
             .unwrap(),
         root_hash
     );

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -49,7 +49,10 @@ use crate::{
         state_with_summary::LedgerWithSummary,
     },
 };
-pub use aptos_types::{block_info::BlockHeight, state_store::StateKind};
+pub use aptos_types::{
+    block_info::BlockHeight,
+    state_store::{SnapshotKind, StateKind},
+};
 pub use errors::AptosDbError;
 pub use ledger_summary::LedgerSummary;
 

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -38,6 +38,13 @@ pub enum StateKind {
     Position,
 }
 
+/// Identifies a snapshot store streamed by state sync. Hot state has a distinct leaf type and API.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum SnapshotKind {
+    State(StateKind),
+    HotState,
+}
+
 pub type StateViewResult<T, E = StateViewError> = std::result::Result<T, E>;
 
 /// A trait that defines a read-only snapshot of the global state. It is passed to the VM for


### PR DESCRIPTION

Download the hot state snapshot during fast sync so a freshly synced
node holds the same hot set as its peers. With the hot root committed
to the ledger, a node that restores only the cold state would
immediately diverge when recomputing hot roots.

Fast sync now drives a third snapshot stage after the main and position
states: the bootstrapper streams `HotStateValue` chunks and the storage
synchronizer restores them through the hot snapshot receiver. The stage
runs only when the target transaction info commits a hot state root;
per-kind progress is tracked in a new `HotStateSnapshotSync` metadata
row so a crash mid-sync resumes cleanly.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/20482).
* #20483
* __->__ #20482
* #20481
* #20480
* #20479