### PR TITLE
[storage] Persist restored hot state snapshots

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,7 +36,6 @@ xclippy = [
   "-Aclippy::unnecessary_sort_by",
   "-Aclippy::unneeded_wildcard_pattern",
   "-Aclippy::useless_borrows_in_formatting",
-  "-Aclippy::useless_format",
   "-Aclippy::while_let_loop",
 ]
 x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,7 +22,6 @@ xclippy = [
   # New/expanded lints surfaced by the Rust 1.98 upgrade, suppressed to keep the
   # toolchain bump mechanical. TODO: clean these up separately.
   "-Aclippy::chunks_exact_to_as_chunks",
-  "-Aclippy::drain_collect",
   "-Aclippy::explicit_counter_loop",
   "-Aclippy::extra_unused_lifetimes",
   "-Aclippy::manual_checked_ops",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,7 +22,6 @@ xclippy = [
   # New/expanded lints surfaced by the Rust 1.98 upgrade, suppressed to keep the
   # toolchain bump mechanical. TODO: clean these up separately.
   "-Aclippy::chunks_exact_to_as_chunks",
-  "-Aclippy::cloned_ref_to_slice_refs",
   "-Aclippy::drain_collect",
   "-Aclippy::explicit_counter_loop",
   "-Aclippy::extra_unused_lifetimes",

--- a/crates/aptos-telemetry/src/telemetry_log_sender.rs
+++ b/crates/aptos-telemetry/src/telemetry_log_sender.rs
@@ -31,7 +31,7 @@ impl TelemetryLogSender {
     }
 
     fn drain_batch(&mut self) -> Vec<String> {
-        let batch: Vec<_> = self.batch.drain(..).collect();
+        let batch = std::mem::take(&mut self.batch);
         self.current_bytes = 0;
         batch
     }

--- a/experimental/storage/layered-map/src/layer.rs
+++ b/experimental/storage/layered-map/src/layer.rs
@@ -80,7 +80,7 @@ impl<K: ArcAsyncDrop, V: ArcAsyncDrop> LayerInner<K, V> {
     }
 
     fn drain_children_for_drop(&self) -> Vec<Arc<Self>> {
-        self.children.lock().drain(..).collect()
+        std::mem::take(&mut *self.children.lock())
     }
 
     fn log_layer(&self, event: &'static str) {

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -350,7 +350,7 @@ impl EventSubscription {
 
     fn notify_subscriber_of_events(&mut self, version: Version) -> Result<(), Error> {
         let event_notification = EventNotification {
-            subscribed_events: self.event_buffer.drain(..).collect(),
+            subscribed_events: std::mem::take(&mut self.event_buffer),
             version,
         };
 

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -45,8 +45,8 @@ impl RestoreHandler {
         restore_mode: StateSnapshotRestoreMode,
     ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
         StateSnapshotRestore::new(
-            &self.state_store.state_merkle_db,
-            &self.state_store,
+            Arc::clone(&self.state_store.state_merkle_db),
+            Arc::clone(&self.state_store),
             version,
             expected_root_hash,
             true, /* async_commit */

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -37,14 +37,14 @@ use aptos_types::transaction::TransactionAuxiliaryData;
 use aptos_types::{
     account_config::new_block_event_key,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::{state_key::StateKey, state_value::StateValue},
+    state_store::{hot_state::HotStateValue, state_key::StateKey, state_value::StateValue},
     transaction::{
         Transaction, TransactionInfo, TransactionOutput, TransactionOutputListWithProofV2, Version,
     },
     write_set::WriteSet,
 };
 use rayon::prelude::*;
-use std::{collections::HashMap, iter::Iterator, time::Instant};
+use std::{collections::HashMap, iter::Iterator, sync::Arc, time::Instant};
 
 impl DbWriter for AptosDB {
     fn pre_commit_ledger(&self, chunk: ChunkToCommit, sync_commit: bool) -> Result<()> {
@@ -139,6 +139,21 @@ impl DbWriter for AptosDB {
                     expected_root_hash,
                 )
             },
+        })
+    }
+
+    fn get_hot_state_snapshot_receiver(
+        &self,
+        version: Version,
+        expected_root_hash: HashValue,
+    ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, HotStateValue>>> {
+        gauged_api("get_hot_state_snapshot_receiver", || {
+            crate::hot_state_restore::get_hot_state_snapshot_receiver(
+                Arc::clone(&self.state_store.hot_state_kv_db),
+                Arc::clone(&self.state_store.hot_state_merkle_db),
+                version,
+                expected_root_hash,
+            )
         })
     }
 

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -12,7 +12,7 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::{state_key::StateKey, state_value::StateValue},
+    state_store::{hot_state::HotStateValue, state_key::StateKey, state_value::StateValue},
     transaction::{TransactionOutputListWithProofV2, Version},
 };
 use either::Either;
@@ -152,6 +152,31 @@ impl DbWriter for FastSyncStorageWrapper {
         }
         self.get_aptos_db_write_ref()
             .get_state_snapshot_receiver(version, expected_root_hash, kind)
+    }
+
+    fn get_hot_state_snapshot_receiver(
+        &self,
+        version: Version,
+        expected_root_hash: HashValue,
+    ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, HotStateValue>>> {
+        // TODO(HotState): Reconstruct the fast-sync status before resuming a later
+        // snapshot stage.
+        //
+        // `fast_sync_status` lives only in memory, starting at UNKNOWN, and the
+        // main-state receiver above is the only place that moves it to STARTED.
+        // That covers a single uninterrupted run, where hot state always follows
+        // main state.
+        //
+        // A restart in the middle of fast sync breaks that. The wrapper comes back
+        // with UNKNOWN (the main DB still reports synced version 0 until
+        // finalize_state_snapshot), so a restore resuming straight into the hot
+        // state stage gets `temporary_db_with_genesis` here. The hot JMT and KV
+        // rows would land in the throwaway DB, and HotStateSnapshotKvRestoreProgress
+        // would be read from there as well, quietly restarting from the first
+        // chunk. Deriving the status from the persisted progress at startup fixes
+        // both.
+        self.get_aptos_db_write_ref()
+            .get_hot_state_snapshot_receiver(version, expected_root_hash)
     }
 
     fn finalize_state_snapshot(

--- a/storage/aptosdb/src/hot_state_restore.rs
+++ b/storage/aptosdb/src/hot_state_restore.rs
@@ -1,0 +1,112 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Receiver for hot state snapshots restored by fast sync, built on the generic
+//! `StateSnapshotRestore` machinery.
+
+use crate::{
+    schema::{
+        db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+        hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
+    },
+    state_kv_db::StateKvDb,
+    state_merkle_db::StateMerkleDb,
+    state_restore::{
+        StateSnapshotRestore, StateSnapshotRestoreMode, StateValueBatch, StateValueWriter,
+    },
+};
+use aptos_crypto::HashValue;
+use aptos_db_indexer_schemas::metadata::StateSnapshotProgress;
+use aptos_schemadb::batch::{SchemaBatch, WriteBatch};
+use aptos_storage_interface::{db_other_bail as bail, AptosDbError, Result, StateSnapshotReceiver};
+use aptos_types::{
+    state_store::{
+        hot_state::HotStateValue, state_key::StateKey, state_storage_usage::StateStorageUsage,
+    },
+    transaction::Version,
+};
+use std::sync::Arc;
+
+struct HotStateValueWriter {
+    hot_state_kv_db: Arc<StateKvDb>,
+}
+
+impl StateValueWriter<StateKey, HotStateValue> for HotStateValueWriter {
+    fn write_kv_batch(
+        &self,
+        version: Version,
+        kv_batch: &StateValueBatch<StateKey, Option<HotStateValue>>,
+        progress: StateSnapshotProgress,
+    ) -> Result<()> {
+        let mut sharded_batches = self.hot_state_kv_db.new_sharded_native_batches();
+        for ((state_key, _version), hot_value_opt) in kv_batch {
+            let hot_value = match hot_value_opt {
+                Some(value) => value,
+                None => {
+                    // `None` would mean an eviction, which a snapshot never carries.
+                    bail!(
+                        "Hot state snapshot chunk carries an evicted key: {:?}",
+                        state_key
+                    );
+                },
+            };
+            let hot_since_version = hot_value.hot_since_version();
+            // NOTE: `value_version` for this hot state entry MUST be set to `version` which is the
+            // version where the snapshot restore happens. The reason is that the cold state restore
+            // saves all keys at this version, and when an entry is overwritten, its `value_version`
+            // in hot state is used to derive the stale index for the old entry in cold state.
+            // TODO(HotState): maybe revisit when hot and cold are exclusive.
+            let entry = match hot_value.value_opt() {
+                Some(value) => HotStateEntry::Occupied {
+                    value: value.clone(),
+                    value_version: version,
+                },
+                None => HotStateEntry::Vacant,
+            };
+            sharded_batches[state_key.get_shard_id()].put::<HotStateValueByKeyHashSchema>(
+                &(*state_key.crypto_hash_ref(), hot_since_version),
+                &Some(entry),
+            )?;
+        }
+
+        let mut metadata_batch = SchemaBatch::new();
+        metadata_batch.put::<DbMetadataSchema>(
+            &DbMetadataKey::HotStateSnapshotKvRestoreProgress(version),
+            &DbMetadataValue::StateSnapshotProgress(progress),
+        )?;
+        self.hot_state_kv_db
+            .commit(version, Some(metadata_batch), sharded_batches)
+    }
+
+    fn kv_finish(&self, _version: Version, _usage: StateStorageUsage) -> Result<()> {
+        // Hot state usage is recomputed from the KV rows when they are loaded.
+        Ok(())
+    }
+
+    fn get_progress(&self, version: Version) -> Result<Option<StateSnapshotProgress>> {
+        Ok(self
+            .hot_state_kv_db
+            .metadata_db()
+            .get::<DbMetadataSchema>(&DbMetadataKey::HotStateSnapshotKvRestoreProgress(version))?
+            .map(|v| v.expect_state_snapshot_progress()))
+    }
+}
+
+/// Returns a snapshot receiver that verifies each chunk's range proof against
+/// `expected_root_hash` and writes the hot state JMT and KV.
+pub(crate) fn get_hot_state_snapshot_receiver(
+    hot_state_kv_db: Arc<StateKvDb>,
+    hot_state_merkle_db: Arc<StateMerkleDb>,
+    version: Version,
+    expected_root_hash: HashValue,
+) -> Result<Box<dyn StateSnapshotReceiver<StateKey, HotStateValue>>> {
+    let value_writer = Arc::new(HotStateValueWriter { hot_state_kv_db });
+    Ok(Box::new(StateSnapshotRestore::new(
+        hot_state_merkle_db,
+        value_writer,
+        version,
+        expected_root_hash,
+        false, /* async_commit */
+        StateSnapshotRestoreMode::Default,
+    )?))
+}

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -26,6 +26,7 @@ pub mod utils;
 #[cfg(feature = "db-debugger")]
 pub mod db_debugger;
 pub mod fast_sync_storage_wrapper;
+pub(crate) mod hot_state_restore;
 
 mod db_options;
 mod event_store;

--- a/storage/aptosdb/src/position_state_sync.rs
+++ b/storage/aptosdb/src/position_state_sync.rs
@@ -101,8 +101,8 @@ pub fn get_position_snapshot_receiver(
 ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
     let value_writer = Arc::new(PositionStateValueWriter::new(position_db));
     Ok(Box::new(StateSnapshotRestore::new(
-        position_merkle_db,
-        &value_writer,
+        Arc::clone(position_merkle_db),
+        value_writer,
         version,
         expected_root_hash,
         false, /* async_commit */

--- a/storage/aptosdb/src/schema/db_metadata/mod.rs
+++ b/storage/aptosdb/src/schema/db_metadata/mod.rs
@@ -81,6 +81,7 @@ pub enum DbMetadataKey {
     PositionEpochSnapshotPrunerProgress,
     PositionEpochSnapshotShardPrunerProgress(ShardId),
     PositionSnapshotKvRestoreProgress(Version),
+    HotStateSnapshotKvRestoreProgress(Version),
 }
 
 define_schema!(

--- a/storage/aptosdb/src/state_restore/mod.rs
+++ b/storage/aptosdb/src/state_restore/mod.rs
@@ -135,8 +135,8 @@ pub struct StateSnapshotRestore<K, V> {
 
 impl<K: Key + CryptoHash + Hash + Eq, V: Value> StateSnapshotRestore<K, V> {
     pub fn new<T: 'static + TreeReader<K> + TreeWriter<K>, S: 'static + StateValueWriter<K, V>>(
-        tree_store: &Arc<T>,
-        value_store: &Arc<S>,
+        tree_store: Arc<T>,
+        value_store: Arc<S>,
         version: Version,
         expected_root_hash: HashValue,
         async_commit: bool,
@@ -144,13 +144,13 @@ impl<K: Key + CryptoHash + Hash + Eq, V: Value> StateSnapshotRestore<K, V> {
     ) -> Result<Self> {
         Ok(Self {
             tree_restore: Arc::new(Mutex::new(Some(JellyfishMerkleRestore::new(
-                Arc::clone(tree_store),
+                tree_store,
                 version,
                 expected_root_hash,
                 async_commit,
             )?))),
             kv_restore: Arc::new(Mutex::new(Some(StateValueRestore::new(
-                Arc::clone(value_store),
+                value_store,
                 version,
             )))),
             restore_mode,
@@ -158,20 +158,20 @@ impl<K: Key + CryptoHash + Hash + Eq, V: Value> StateSnapshotRestore<K, V> {
     }
 
     pub fn new_overwrite<T: 'static + TreeWriter<K>, S: 'static + StateValueWriter<K, V>>(
-        tree_store: &Arc<T>,
-        value_store: &Arc<S>,
+        tree_store: Arc<T>,
+        value_store: Arc<S>,
         version: Version,
         expected_root_hash: HashValue,
         restore_mode: StateSnapshotRestoreMode,
     ) -> Result<Self> {
         Ok(Self {
             tree_restore: Arc::new(Mutex::new(Some(JellyfishMerkleRestore::new_overwrite(
-                Arc::clone(tree_store),
+                tree_store,
                 version,
                 expected_root_hash,
             )?))),
             kv_restore: Arc::new(Mutex::new(Some(StateValueRestore::new(
-                Arc::clone(value_store),
+                value_store,
                 version,
             )))),
             restore_mode,

--- a/storage/aptosdb/src/state_restore/restore_test.rs
+++ b/storage/aptosdb/src/state_restore/restore_test.rs
@@ -187,7 +187,7 @@ proptest! {
         let restore_db = Arc::new(MockSnapshotStore::default());
         {
             let mut restore =
-                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async_commit */, StateSnapshotRestoreMode::Default).unwrap();
+                StateSnapshotRestore::new(Arc::clone(&restore_db), Arc::clone(&restore_db),  version, expected_root_hash, true /* async_commit */, StateSnapshotRestoreMode::Default).unwrap();
             let proof = tree
                 .get_range_proof(batch1.last().map(|(key, _value)| *key).unwrap(), version)
                 .unwrap();
@@ -199,7 +199,7 @@ proptest! {
             let remaining_accounts: Vec<_> = all.clone().into_iter().skip(batch1_size - overlap_size).collect();
 
             let mut restore =
-                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async commit */, StateSnapshotRestoreMode::Default ).unwrap();
+                StateSnapshotRestore::new(Arc::clone(&restore_db), Arc::clone(&restore_db),  version, expected_root_hash, true /* async commit */, StateSnapshotRestoreMode::Default ).unwrap();
             let proof = tree
                 .get_range_proof(
                     remaining_accounts.last().map(|(h, _)| *h).unwrap(),
@@ -275,8 +275,8 @@ fn restore_without_interruption<V>(
 
     let mut restore = if try_resume {
         StateSnapshotRestore::new(
-            target_db,
-            target_db,
+            Arc::clone(target_db),
+            Arc::clone(target_db),
             target_version,
             expected_root_hash,
             true, /* async_commit */
@@ -285,8 +285,8 @@ fn restore_without_interruption<V>(
         .unwrap()
     } else {
         StateSnapshotRestore::new_overwrite(
-            target_db,
-            target_db,
+            Arc::clone(target_db),
+            Arc::clone(target_db),
             target_version,
             expected_root_hash,
             StateSnapshotRestoreMode::Default,

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -1548,8 +1548,8 @@ impl StateStore {
         expected_root_hash: HashValue,
     ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
         Ok(Box::new(StateSnapshotRestore::new(
-            &self.state_merkle_db,
-            self,
+            Arc::clone(&self.state_merkle_db),
+            Arc::clone(self),
             version,
             expected_root_hash,
             false, /* async_commit */

--- a/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_snapshot.rs
@@ -1,14 +1,18 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Tests for the hot state snapshot read APIs used by fast sync to serve hot state.
+//! Tests for the hot state snapshot APIs used by fast sync to serve and restore hot state.
 
 use crate::{db::test_helper::arb_blocks_to_commit_with_params, AptosDB};
+use aptos_config::config::{
+    HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
+    DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
+};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_jellyfish_merkle::{
     mock_tree_store::MockTreeStore, restore::JellyfishMerkleRestore, JellyfishMerkleTree,
 };
-use aptos_storage_interface::{DbReader, Result as DbResult};
+use aptos_storage_interface::{DbReader, DbWriter, Result as DbResult};
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -445,4 +449,65 @@ proptest! {
         // Reading at/after the end yields nothing.
         prop_assert!(collect_chunk(&db, ckpt, expected.len(), usize::MAX).is_empty());
     }
+}
+
+/// Opens a DB that keeps hot state across restarts, as a fast-syncing node must.
+fn open_persistent_hot_state_db(path: &TempPath) -> AptosDB {
+    AptosDB::open(
+        StorageDirPaths::from_path(path.path()),
+        false, /* readonly */
+        NO_OP_STORAGE_PRUNER_CONFIG,
+        RocksdbConfigs::default(),
+        BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
+        DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
+        None, /* internal_indexer_db */
+        HotStateConfig {
+            delete_on_restart: false,
+            ..HotStateConfig::default()
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_hot_state_restore() {
+    let tmp_src = TempPath::new();
+    let src = AptosDB::new_for_test(&tmp_src);
+    // Spread `hot_since_version` across checkpoints, refresh a key and leave a vacancy.
+    let version = commit_blocks(&src, vec![
+        vec![(key("a"), Some(val(b"a0"))), (key("b"), Some(val(b"b0")))],
+        vec![(key("c"), Some(val(b"c1"))), (key("a"), Some(val(b"a1")))],
+        vec![(key("d"), Some(val(b"d2"))), (key("b"), None)],
+        vec![(key("e"), Some(val(b"e3")))],
+    ]);
+    let expected = collect_paged(&src, version, usize::MAX);
+    assert!(!expected.is_empty());
+    let chunks = collect_chunks_with_proof(&src, version, 2);
+    let root_hash = chunks[0].root_hash;
+
+    let tmp_dst = TempPath::new();
+    let dst = open_persistent_hot_state_db(&tmp_dst);
+    let mut receiver = dst
+        .get_hot_state_snapshot_receiver(version, root_hash)
+        .unwrap();
+    for chunk in &chunks {
+        receiver
+            .add_chunk(chunk.raw_values.clone(), chunk.proof.clone())
+            .unwrap();
+    }
+    receiver.finish_box().unwrap();
+
+    // The restored DB serves the same snapshot.
+    assert_eq!(
+        dst.get_hot_state_item_count(version).unwrap(),
+        expected.len()
+    );
+    assert_eq!(collect_paged(&dst, version, 3), expected);
+    assert_eq!(
+        dst.state_store
+            .hot_state_merkle_db
+            .get_root_hash(version)
+            .unwrap(),
+        root_hash
+    );
 }

--- a/storage/aptosdb/src/state_store/tests/mod.rs
+++ b/storage/aptosdb/src/state_store/tests/mod.rs
@@ -243,7 +243,7 @@ proptest! {
         let store2 = &db2.state_store;
 
         let mut restore =
-            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true /* async_commit */, StateSnapshotRestoreMode::Default).unwrap();
+            StateSnapshotRestore::new(Arc::clone(&store2.state_merkle_db), Arc::clone(store2), version, expected_root_hash, true /* async_commit */, StateSnapshotRestoreMode::Default).unwrap();
 
         let mut ordered_input: Vec<_> = input
             .into_iter()
@@ -342,7 +342,7 @@ proptest! {
 
         let store2 = &db2.state_store;
         let mut restore =
-            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true, /* async_commit */ StateSnapshotRestoreMode::Default).unwrap();
+            StateSnapshotRestore::new(Arc::clone(&store2.state_merkle_db), Arc::clone(store2), version, expected_root_hash, true, /* async_commit */ StateSnapshotRestoreMode::Default).unwrap();
         let max_hash = HashValue::new([0xff; HashValue::LENGTH]);
         let dummy_state_key = StateKey::raw(&[]);
         let (top_levels_batch, sharded_batches, _) = store2.state_merkle_db.merklize_value_set(vec![(max_hash, Some(&(HashValue::random(), dummy_state_key)))], 0, None, None).unwrap();
@@ -393,7 +393,7 @@ proptest! {
         let db2 = AptosDB::new_for_test(&tmp_dir2);
         let store2 = &db2.state_store;
         let mut restore =
-            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true, /* async_commit */ StateSnapshotRestoreMode::Default).unwrap();
+            StateSnapshotRestore::new(Arc::clone(&store2.state_merkle_db), Arc::clone(store2), version, expected_root_hash, true, /* async_commit */ StateSnapshotRestoreMode::Default).unwrap();
         let max_hash = HashValue::new([0xff; HashValue::LENGTH]);
         let dummy_state_key = StateKey::raw(&[]);
         let (top_levels_batch, sharded_batches, _) = store2.state_merkle_db.merklize_value_set(vec![(max_hash, Some(&(HashValue::random(), dummy_state_key)))], 0, None, None).unwrap();

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -228,8 +228,8 @@ impl RestoreRunMode {
             Self::Verify => {
                 let mock_store = Arc::new(MockStore);
                 StateSnapshotRestore::new_overwrite(
-                    &mock_store,
-                    &mock_store,
+                    Arc::clone(&mock_store),
+                    mock_store,
                     version,
                     expected_root_hash,
                     restore_mode,

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -90,7 +90,7 @@ use aptos_storage_interface::{db_ensure as ensure, db_other_bail, AptosDbError, 
 use aptos_types::{
     nibble::{nibble_path::NibblePath, Nibble, ROOT_NIBBLE_HEIGHT},
     proof::{SparseMerkleProof, SparseMerkleProofExt, SparseMerkleRangeProof},
-    state_store::{state_key::StateKey, state_value::StateValue},
+    state_store::{hot_state::HotStateValue, state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
 use arr_macro::arr;
@@ -172,6 +172,12 @@ impl Key for StateKey {
 impl Value for StateValue {
     fn value_size(&self) -> usize {
         self.size()
+    }
+}
+
+impl Value for HotStateValue {
+    fn value_size(&self) -> usize {
+        self.value_opt().map_or(0, StateValue::size)
     }
 }
 

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -169,7 +169,7 @@ impl Inner {
     }
 
     fn drain_children_for_drop(&self) -> Vec<Arc<Self>> {
-        self.children.lock().drain(..).collect()
+        std::mem::take(&mut *self.children.lock())
     }
 
     fn log_generation(&self, name: &'static str) {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -602,6 +602,16 @@ pub trait DbWriter: Send + Sync {
         unimplemented!()
     }
 
+    /// Get a (stateful) snapshot receiver for the hot state at `version`. Separate from
+    /// `get_state_snapshot_receiver` because hot state leaves are `HotStateValue`s.
+    fn get_hot_state_snapshot_receiver(
+        &self,
+        version: Version,
+        expected_root_hash: HashValue,
+    ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, HotStateValue>>> {
+        unimplemented!()
+    }
+
     /// Finalizes a state snapshot that has already been restored to the database through
     /// a state snapshot receiver. This is required to bootstrap the transaction accumulator,
     /// populate transaction information, save the epoch ending ledger infos and delete genesis.

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/command_line/compiler.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/command_line/compiler.rs
@@ -505,7 +505,7 @@ pub fn generate_interface_files(
     {
         let (id, interface_contents) =
             interface_generator::write_file_to_string(module_to_named_address, &path)?;
-        let addr_dir = dir_path!(all_addr_dir.clone(), format!("{}", id.address().to_hex()));
+        let addr_dir = dir_path!(all_addr_dir.clone(), id.address().to_hex());
         let file_path = file_path!(addr_dir.clone(), format!("{}", id.name()), MOVE_EXTENSION);
         result.push(IndexedPackagePath {
             path: Symbol::from(file_path.clone().into_os_string().into_string().unwrap()),

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -8236,7 +8236,7 @@ impl FunctionTranslator<'_> {
                             &mut || dst_value.clone(),
                             &get_path_index,
                             src_value,
-                            &[edge.to_owned()],
+                            std::slice::from_ref(edge),
                             0,
                             &root_ty,
                             root_bv_flag,


### PR DESCRIPTION

Add a hot-state snapshot receiver backed by the generic snapshot restore machinery. Verify chunk proofs and write the hot JMT and KV rows while preserving the persisted LRU order.

Record KV progress so interrupted restores can resume.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes fast-sync persistence for hot state JMT/KV and coordinates `value_version` with cold state stale indexing; incorrect restore or fast-sync DB routing could corrupt or silently restart hot state restore.
> 
> **Overview**
> Adds **hot state snapshot restore** for fast sync: a new `get_hot_state_snapshot_receiver` on `DbWriter` (wired through `AptosDB` and `FastSyncStorageWrapper`) that reuses `StateSnapshotRestore` with a dedicated `HotStateValueWriter` to verify chunk proofs, write the hot JMT, and persist sharded hot KV rows (occupied/vacant entries with `value_version` tied to the restore version).
> 
> Restore progress is tracked via **`HotStateSnapshotKvRestoreProgress`** metadata so interrupted KV restores can resume; `HotStateValue` now implements the JMT **`Value`** trait for this path.
> 
> **`StateSnapshotRestore::new`** now takes owned `Arc` stores instead of `&Arc`, with call sites updated accordingly. Includes an integration **`test_hot_state_restore`** and minor Rust 1.98/clippy cleanups (`mem::take` instead of `drain().collect()`, trimmed lint allowlist).
> 
> `FastSyncStorageWrapper` documents a **TODO**: resuming hot-state restore after a mid–fast-sync restart may still route writes to the temporary DB until status is reconstructed from persisted progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ed3bb1cbcae4a1c6e870e1fe20fd9f65bc39208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->