### PR TITLE
[compiler-v2] Fix multiple compiler ICE

### DIFF
--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -3279,6 +3279,114 @@ impl Bytecode {
         self.is_conditional_branch() || self.is_unconditional_branch()
     }
 
+    /// Returns the local this bytecode instruction accesses, if any.
+    pub fn local_index(&self) -> Option<LocalIndex> {
+        use Bytecode::*;
+        match self {
+            CopyLoc(local) | MoveLoc(local) | StLoc(local) | MutBorrowLoc(local)
+            | ImmBorrowLoc(local) => Some(*local),
+            Pop
+            | Ret
+            | BrTrue(..)
+            | BrFalse(..)
+            | Branch(..)
+            | LdU8(..)
+            | LdU16(..)
+            | LdU32(..)
+            | LdU64(..)
+            | LdU128(..)
+            | LdU256(..)
+            | LdI8(..)
+            | LdI16(..)
+            | LdI32(..)
+            | LdI64(..)
+            | LdI128(..)
+            | LdI256(..)
+            | LdConst(..)
+            | LdTrue
+            | LdFalse
+            | CastU8
+            | CastU16
+            | CastU32
+            | CastU64
+            | CastU128
+            | CastU256
+            | CastI8
+            | CastI16
+            | CastI32
+            | CastI64
+            | CastI128
+            | CastI256
+            | Call(..)
+            | CallGeneric(..)
+            | Pack(..)
+            | PackGeneric(..)
+            | PackVariant(..)
+            | PackVariantGeneric(..)
+            | Unpack(..)
+            | UnpackGeneric(..)
+            | UnpackVariant(..)
+            | UnpackVariantGeneric(..)
+            | TestVariant(..)
+            | TestVariantGeneric(..)
+            | ReadRef
+            | WriteRef
+            | FreezeRef
+            | MutBorrowField(..)
+            | MutBorrowVariantField(..)
+            | MutBorrowFieldGeneric(..)
+            | MutBorrowVariantFieldGeneric(..)
+            | ImmBorrowField(..)
+            | ImmBorrowVariantField(..)
+            | ImmBorrowFieldGeneric(..)
+            | ImmBorrowVariantFieldGeneric(..)
+            | MutBorrowGlobal(..)
+            | MutBorrowGlobalGeneric(..)
+            | ImmBorrowGlobal(..)
+            | ImmBorrowGlobalGeneric(..)
+            | Add
+            | Sub
+            | Mul
+            | Mod
+            | Div
+            | BitOr
+            | BitAnd
+            | Xor
+            | Or
+            | And
+            | Not
+            | Negate
+            | Eq
+            | Neq
+            | Lt
+            | Gt
+            | Le
+            | Ge
+            | Shl
+            | Shr
+            | Abort
+            | AbortMsg
+            | Nop
+            | Exists(..)
+            | ExistsGeneric(..)
+            | MoveFrom(..)
+            | MoveFromGeneric(..)
+            | MoveTo(..)
+            | MoveToGeneric(..)
+            | VecPack(..)
+            | VecLen(..)
+            | VecImmBorrow(..)
+            | VecMutBorrow(..)
+            | VecPushBack(..)
+            | VecPopBack(..)
+            | VecUnpack(..)
+            | VecSwap(..)
+            | PackClosure(..)
+            | PackClosureGeneric(..)
+            | CallClosure(..) => None,
+        }
+    }
+
     /// Returns the offset that this bytecode instruction branches to, if any.
     /// Note that return and abort are branch instructions, but have no offset.
     pub fn offset(&self) -> Option<&CodeOffset> {

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -52,6 +52,9 @@ pub struct FunctionGenerator<'a> {
     stack: Vec<(TempIndex, bool)>,
     /// The locals which have been used so far. This contains the parameters of the function.
     locals: Vec<Type>,
+    /// Scratch-local pairs keyed by the type to which both equality operands are coerced.
+    /// Each pair ensures that `Eq` or `Neq` receives operands with exactly the same type.
+    equality_scratch: BTreeMap<Type, (FF::LocalIndex, FF::LocalIndex)>,
     /// A map from branching labels to information about them.
     label_info: BTreeMap<Label, LabelInfo>,
     /// A map from code offset to spec blocks associated with them
@@ -145,6 +148,7 @@ impl<'a> FunctionGenerator<'a> {
                 temps: Default::default(),
                 stack: vec![],
                 locals: vec![],
+                equality_scratch: Default::default(),
                 label_info: Default::default(),
                 spec_blocks: BTreeMap::new(),
                 code: vec![],
@@ -162,7 +166,8 @@ impl<'a> FunctionGenerator<'a> {
                 .get_extension::<Options>()
                 .expect("Options is available");
             if options.experiment_on(Experiment::PEEPHOLE_OPTIMIZATION) {
-                let transformed_code_chunk = peephole_optimizer::optimize(&code.code);
+                let transformed_code_chunk =
+                    peephole_optimizer::optimize(&code.code, fun_gen.protected_locals());
                 // Fix the source map for the optimized code.
                 fun_gen
                     .genr
@@ -659,6 +664,8 @@ impl<'a> FunctionGenerator<'a> {
         self.locals = (0..ctx.fun.get_parameter_count())
             .map(|temp| ctx.temp_type(temp).to_owned())
             .collect();
+        // Reset cached indices whenever the local table is rebuilt.
+        self.equality_scratch.clear();
 
         // Walk the bytecode
         let bytecode = ctx.fun.get_bytecode();
@@ -1193,8 +1200,8 @@ impl<'a> FunctionGenerator<'a> {
             Operation::Ge => self.gen_builtin(ctx, dest, FF::Bytecode::Ge, source),
             Operation::Or => self.gen_builtin(ctx, dest, FF::Bytecode::Or, source),
             Operation::And => self.gen_builtin(ctx, dest, FF::Bytecode::And, source),
-            Operation::Eq => self.gen_builtin(ctx, dest, FF::Bytecode::Eq, source),
-            Operation::Neq => self.gen_builtin(ctx, dest, FF::Bytecode::Neq, source),
+            Operation::Eq => self.gen_equality(ctx, dest, FF::Bytecode::Eq, source),
+            Operation::Neq => self.gen_equality(ctx, dest, FF::Bytecode::Neq, source),
             Operation::Negate => self.gen_builtin(ctx, dest, FF::Bytecode::Negate, source),
 
             Operation::TraceLocal(_)
@@ -1774,6 +1781,104 @@ impl<'a> FunctionGenerator<'a> {
         self.abstract_push_result(ctx, dest);
     }
 
+    /// Generates `Eq` or `Neq` after normalizing the operand types.
+    fn gen_equality(
+        &mut self,
+        ctx: &BytecodeContext,
+        dest: &[TempIndex],
+        bc: FF::Bytecode,
+        source: &[TempIndex],
+    ) {
+        let coercion = self.equality_coercion(ctx, source);
+        self.gen_builtin_with_prelude(ctx, dest, bc, source, coercion)
+    }
+
+    /// Returns a prelude that normalizes both `Eq` or `Neq` operands to their equality join.
+    ///
+    /// The verifier gives `PackClosure` its precise derived abilities and requires equality
+    /// operands to have identical types. An operand can therefore reach this point with a wider
+    /// file-format type than the compiler assigned it. Round-tripping both operands through
+    /// scratch locals typed as the join uses `StLoc` assignability to accept each value and
+    /// `MoveLoc` to restore the exact join type.
+    ///
+    /// Whenever either operand can widen, both are normalized because detecting only actual
+    /// mismatches would duplicate the verifier's ability derivation. This adds one
+    /// `StLoc`/`MoveLoc` pair per operand.
+    fn equality_coercion(
+        &mut self,
+        ctx: &BytecodeContext,
+        source: &[TempIndex],
+    ) -> Vec<FF::Bytecode> {
+        let fun_ctx = ctx.fun_ctx;
+        let [lhs, rhs] = source else {
+            fun_ctx.internal_error("equality expects two operands");
+            return vec![];
+        };
+        let (lhs_ty, rhs_ty) = (fun_ctx.temp_type(*lhs), fun_ctx.temp_type(*rhs));
+        if !can_widen_abilities(lhs_ty) && !can_widen_abilities(rhs_ty) {
+            return vec![];
+        }
+        let Some(join_ty) = equality_join(lhs_ty, rhs_ty) else {
+            let display_ctx = fun_ctx.fun.func_env.get_type_display_ctx();
+            fun_ctx.internal_error(format!(
+                "no common type for comparing `{}` with `{}`",
+                lhs_ty.display(&display_ctx),
+                rhs_ty.display(&display_ctx)
+            ));
+            return vec![];
+        };
+        let (lhs_local, rhs_local) = self.equality_scratch_locals(fun_ctx, join_ty);
+        vec![
+            FF::Bytecode::StLoc(rhs_local),
+            FF::Bytecode::StLoc(lhs_local),
+            FF::Bytecode::MoveLoc(lhs_local),
+            FF::Bytecode::MoveLoc(rhs_local),
+        ]
+    }
+
+    /// Returns reusable scratch locals of type `ty`. Each comparison moves both values out,
+    /// leaving the pair available for the next comparison.
+    fn equality_scratch_locals(
+        &mut self,
+        ctx: &FunctionContext,
+        ty: Type,
+    ) -> (FF::LocalIndex, FF::LocalIndex) {
+        if let Some(locals) = self.equality_scratch.get(&ty) {
+            return *locals;
+        }
+        let locals = (
+            self.new_scratch_local(ctx, ty.clone()),
+            self.new_scratch_local(ctx, ty.clone()),
+        );
+        self.equality_scratch.insert(ty, locals);
+        locals
+    }
+
+    /// Allocates a scratch local with no stackless temporary. Non-parameter locals are positional
+    /// in the source map, so each scratch local needs a placeholder entry to preserve subsequent
+    /// names. The `tmp#$` marker identifies it as compiler-generated.
+    fn new_scratch_local(&mut self, ctx: &FunctionContext, ty: Type) -> FF::LocalIndex {
+        let local = self.new_local(ctx, ty);
+        let name = ctx
+            .module
+            .env
+            .symbol_pool()
+            .make(&format!("tmp#${}", local));
+        self.genr
+            .source_map
+            .add_local_mapping(ctx.def_idx, ctx.module.source_name(name, &ctx.loc))
+            .expect(SOURCE_MAP_OK);
+        local
+    }
+
+    /// Returns the scratch locals whose coercion round-trips must survive peephole optimization.
+    fn protected_locals(&self) -> BTreeSet<FF::LocalIndex> {
+        self.equality_scratch
+            .values()
+            .flat_map(|(lhs_local, rhs_local)| [*lhs_local, *rhs_local])
+            .collect()
+    }
+
     /// Generate code for a general builtin instruction.
     fn gen_builtin(
         &mut self,
@@ -1782,7 +1887,23 @@ impl<'a> FunctionGenerator<'a> {
         bc: FF::Bytecode,
         source: &[TempIndex],
     ) {
+        self.gen_builtin_with_prelude(ctx, dest, bc, source, vec![])
+    }
+
+    /// Generates a builtin, inserting `prelude` after its arguments are pushed. The prelude must
+    /// preserve the operand count and order.
+    fn gen_builtin_with_prelude(
+        &mut self,
+        ctx: &BytecodeContext,
+        dest: &[TempIndex],
+        bc: FF::Bytecode,
+        source: &[TempIndex],
+        prelude: Vec<FF::Bytecode>,
+    ) {
         self.abstract_push_args(ctx, source, None);
+        for instr in prelude {
+            self.emit(instr)
+        }
         self.emit(bc);
         self.abstract_pop_n(ctx, source.len());
         self.abstract_push_result(ctx, dest)
@@ -2171,6 +2292,53 @@ impl<'a> FunctionGenerator<'a> {
                 idx
             }
         }
+    }
+}
+
+/// Returns whether `ty` has a form whose bytecode assignability can weaken function abilities.
+/// This includes function types and immutable references recursively; every other type position
+/// requires equality.
+fn can_widen_abilities(ty: &Type) -> bool {
+    match ty {
+        Type::Fun(..) => true,
+        Type::Reference(ReferenceKind::Immutable, target_ty) => can_widen_abilities(target_ty),
+        Type::Primitive(_)
+        | Type::Tuple(_)
+        | Type::Vector(_)
+        | Type::Struct(..)
+        | Type::TypeParameter(_)
+        | Type::Reference(ReferenceKind::Mutable, _)
+        | Type::TypeDomain(_)
+        | Type::ResourceDomain(..)
+        | Type::StateDomain
+        | Type::Error
+        | Type::Var(_) => false,
+    }
+}
+
+/// Returns a common target type to which both operands are bytecode-assignable, or `None` if none
+/// exists. Function signatures must match and their abilities are intersected; immutable
+/// references recurse; all other types must be equal. If both operands support equality, the
+/// function ability intersection retains `drop`.
+fn equality_join(ty1: &Type, ty2: &Type) -> Option<Type> {
+    match (ty1, ty2) {
+        (Type::Fun(args1, result1, abilities1), Type::Fun(args2, result2, abilities2))
+            if args1 == args2 && result1 == result2 =>
+        {
+            Some(Type::Fun(
+                args1.clone(),
+                result1.clone(),
+                abilities1.intersect(*abilities2),
+            ))
+        },
+        (
+            Type::Reference(ReferenceKind::Immutable, target_ty1),
+            Type::Reference(ReferenceKind::Immutable, target_ty2),
+        ) => Some(Type::Reference(
+            ReferenceKind::Immutable,
+            Box::new(equality_join(target_ty1, target_ty2)?),
+        )),
+        _ => (ty1 == ty2).then(|| ty1.clone()),
     }
 }
 

--- a/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer.rs
@@ -12,18 +12,18 @@ pub mod reducible_pairs;
 use inefficient_loads::InefficientLoads;
 use move_binary_format::{
     control_flow_graph::{ControlFlowGraph, VMControlFlowGraph},
-    file_format::{Bytecode, CodeOffset},
+    file_format::{Bytecode, CodeOffset, LocalIndex},
 };
 use optimizers::{BasicBlockOptimizer, TransformedCodeChunk, WindowProcessor};
 use reducible_pairs::ReduciblePairs;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-/// Pre-requisite: `code` should not have spec block associations.
-/// Run peephole optimizers on the given `code`, possibly modifying it.
-/// Returns the optimized code, along with mapping to original offsets
-/// in `code`.
-pub fn optimize(code: &[Bytecode]) -> TransformedCodeChunk {
-    BasicBlockOptimizerPipeline::default().optimize(code)
+/// Runs peephole optimizers on `code` and returns the optimized code with its original offsets.
+///
+/// `code` must have no spec-block associations. Window optimizers preserve every instruction
+/// that accesses a protected local.
+pub fn optimize(code: &[Bytecode], protected_locals: BTreeSet<LocalIndex>) -> TransformedCodeChunk {
+    BasicBlockOptimizerPipeline::new(protected_locals).optimize(code)
 }
 
 /// A pipeline of basic block optimizers.
@@ -33,12 +33,15 @@ struct BasicBlockOptimizerPipeline {
 }
 
 impl BasicBlockOptimizerPipeline {
-    /// Default optimization pipeline of basic block optimizers.
-    pub fn default() -> Self {
+    /// Builds the standard optimizer pipeline with the specified protected locals.
+    pub fn new(protected_locals: BTreeSet<LocalIndex>) -> Self {
         Self {
             optimizers: vec![
-                Box::new(WindowProcessor::new(ReduciblePairs)),
-                Box::new(WindowProcessor::new(InefficientLoads)),
+                Box::new(WindowProcessor::new(
+                    ReduciblePairs,
+                    protected_locals.clone(),
+                )),
+                Box::new(WindowProcessor::new(InefficientLoads, protected_locals)),
             ],
         }
     }
@@ -122,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_basic_block_optimizer_pipeline() {
-        let pipeline = BasicBlockOptimizerPipeline::default();
+        let pipeline = BasicBlockOptimizerPipeline::new(BTreeSet::new());
         use Bytecode::*;
         // Below, we handcraft a scenario where multiple peephole optimizations can be applied,
         // in multiple passes, including merging basic blocks multiple times.
@@ -168,5 +171,93 @@ mod tests {
             vec![0, 1, 2, 3, 16, 17, 18, 19, 22],
         );
         assert!(optimized_code_chunk == expected_code_chunk);
+    }
+
+    #[test]
+    fn test_protected_locals_keep_their_round_trip() {
+        use Bytecode::*;
+        // The `Eq` prelude uses protected locals 4 and 5; local 3 is an unprotected control.
+        let code = vec![
+            MoveLoc(1), // 0
+            MoveLoc(2), // 1
+            StLoc(5),   // 2
+            StLoc(4),   // 3
+            MoveLoc(4), // 4
+            MoveLoc(5), // 5
+            Eq,         // 6
+            StLoc(3),   // 7
+            MoveLoc(3), // 8
+            Ret,        // 9
+        ];
+        let protected = BasicBlockOptimizerPipeline::new(BTreeSet::from([4, 5])).optimize(&code);
+        let expected_protected = TransformedCodeChunk::new(
+            vec![
+                MoveLoc(1),
+                MoveLoc(2),
+                StLoc(5),
+                StLoc(4),
+                MoveLoc(4),
+                MoveLoc(5),
+                Eq,
+                Ret,
+            ],
+            vec![0, 1, 2, 3, 4, 5, 6, 9],
+        );
+        assert!(protected == expected_protected);
+        // With no protected locals, both round-trips are removed.
+        let unprotected = BasicBlockOptimizerPipeline::new(BTreeSet::new()).optimize(&code);
+        let expected_unprotected =
+            TransformedCodeChunk::new(vec![MoveLoc(1), MoveLoc(2), Eq, Ret], vec![0, 1, 6, 9]);
+        assert!(unprotected == expected_unprotected);
+    }
+
+    #[test]
+    fn test_protected_locals_block_inefficient_loads() {
+        use Bytecode::*;
+        // `InefficientLoads` moves the constant load past `sequence`. Reject the transformation
+        // if either the destination or a local accessed by `sequence` is protected.
+        let stores_to_protected = vec![
+            LdU64(7),   // 0
+            StLoc(4),   // 1
+            Nop,        // 2
+            MoveLoc(4), // 3
+            Ret,        // 4
+        ];
+        let protected =
+            BasicBlockOptimizerPipeline::new(BTreeSet::from([4])).optimize(&stores_to_protected);
+        assert!(protected == TransformedCodeChunk::make_from(&stores_to_protected));
+        let unprotected =
+            BasicBlockOptimizerPipeline::new(BTreeSet::new()).optimize(&stores_to_protected);
+        let expected_unprotected =
+            TransformedCodeChunk::new(vec![Nop, LdU64(7), Ret], vec![2, 0, 4]);
+        assert!(unprotected == expected_unprotected);
+
+        // The `sequence` contains an `Eq` coercion on protected locals 4 and 5, while the load
+        // targets unprotected local 1.
+        let coercion_in_sequence = vec![
+            LdU64(7),   // 0
+            StLoc(1),   // 1
+            MoveLoc(2), // 2
+            MoveLoc(3), // 3
+            StLoc(5),   // 4
+            StLoc(4),   // 5
+            MoveLoc(4), // 6
+            MoveLoc(5), // 7
+            Eq,         // 8
+            Pop,        // 9
+            MoveLoc(1), // 10
+            Ret,        // 11
+        ];
+        let protected = BasicBlockOptimizerPipeline::new(BTreeSet::from([4, 5]))
+            .optimize(&coercion_in_sequence);
+        assert!(protected == TransformedCodeChunk::make_from(&coercion_in_sequence));
+        // Without protection the coercion is removed and the load then sinks past `sequence`.
+        let unprotected =
+            BasicBlockOptimizerPipeline::new(BTreeSet::new()).optimize(&coercion_in_sequence);
+        let expected_unprotected =
+            TransformedCodeChunk::new(vec![MoveLoc(2), MoveLoc(3), Eq, Pop, LdU64(7), Ret], vec![
+                2, 3, 8, 9, 0, 11,
+            ]);
+        assert!(unprotected == expected_unprotected);
     }
 }

--- a/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/optimizers.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/optimizers.rs
@@ -3,7 +3,8 @@
 
 //! This module contains setup for basic block peephole optimizers.
 
-use move_binary_format::file_format::{Bytecode, CodeOffset};
+use move_binary_format::file_format::{Bytecode, CodeOffset, LocalIndex};
+use std::collections::BTreeSet;
 
 /// A contiguous chunk of bytecode that may have been transformed from some
 /// other "original" contiguous chunk of bytecode.
@@ -76,6 +77,9 @@ pub trait BasicBlockOptimizer {
 
 /// An optimizer for a window of bytecode within a basic block.
 /// The window is always a suffix of a basic block.
+///
+/// Implementations need not inspect protected locals: `WindowProcessor` rejects
+/// transformations that consume an instruction accessing one.
 pub trait WindowOptimizer {
     /// Given a `window` of bytecode, return a tuple containing:
     ///   1. an optimized version of a non-empty prefix of the `window`. [*]
@@ -88,7 +92,11 @@ pub trait WindowOptimizer {
 }
 
 /// A processor to perform window optimizations of a particular style on a basic block.
-pub struct WindowProcessor<T: WindowOptimizer>(T);
+pub struct WindowProcessor<T: WindowOptimizer> {
+    optimizer: T,
+    /// Locals whose accesses no window transformation may consume.
+    protected_locals: BTreeSet<LocalIndex>,
+}
 
 impl<T: WindowOptimizer> BasicBlockOptimizer for WindowProcessor<T> {
     fn optimize(&self, block: &[Bytecode]) -> TransformedCodeChunk {
@@ -102,9 +110,18 @@ impl<T: WindowOptimizer> BasicBlockOptimizer for WindowProcessor<T> {
 }
 
 impl<T: WindowOptimizer> WindowProcessor<T> {
-    /// Create a new `WindowProcessor` with the given `optimizer`.
-    pub fn new(optimizer: T) -> Self {
-        Self(optimizer)
+    /// Creates a processor for `optimizer` that preserves accesses to `protected_locals`.
+    pub fn new(optimizer: T, protected_locals: BTreeSet<LocalIndex>) -> Self {
+        Self {
+            optimizer,
+            protected_locals,
+        }
+    }
+
+    /// Returns whether `bc` accesses a protected local.
+    fn is_protected(&self, bc: &Bytecode) -> bool {
+        bc.local_index()
+            .is_some_and(|local| self.protected_locals.contains(&local))
     }
 
     /// Run a single pass of the window peephole optimization on the given basic `block`.
@@ -115,8 +132,14 @@ impl<T: WindowOptimizer> WindowProcessor<T> {
         let mut left = 0;
         while left < block.len() {
             let window = &block[left..];
-            if let Some((optimized_window, consumed)) = self.0.optimize_window(window) {
-                debug_assert!(consumed != 0);
+            let optimized = self
+                .optimizer
+                .optimize_window(window)
+                .filter(|(_, consumed)| {
+                    debug_assert!(*consumed != 0 && *consumed <= window.len());
+                    !window[..*consumed].iter().any(|bc| self.is_protected(bc))
+                });
+            if let Some((optimized_window, consumed)) = optimized {
                 new_block.extend(optimized_window, left as CodeOffset);
                 left += consumed;
                 changed = true;

--- a/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/reducible_pairs.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/reducible_pairs.rs
@@ -11,7 +11,11 @@
 //!
 //! Below are the implemented optimizations (which all retain the control flow behavior):
 //! 1. `StLoc` and `MoveLoc` of the same local `l`: Remove the pair.
-//!    - stack is left unaffected (the top remains the same)
+//!    - the runtime stack is unaffected, but the verifier-visible type can change: `StLoc`
+//!      accepts a value assignable to `l`, while `MoveLoc` pushes `l`'s declared type. For
+//!      function values, the round-trip can erase abilities. Locals used to normalize `Eq`/`Neq`
+//!      operands are "protected" because those instructions require exact operand types. Any new
+//!      consumer with the same requirement must also protect its coercion locals.
 //!    - local `l` would not be accessed again (without a future store), because before
 //!      the transformation, the value in it has been moved from, leaving it invalid.
 //! 2. `CopyLoc` and `StLoc` of the same local `l`: Remove the pair.

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_operand_order.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_operand_order.exp
@@ -1,0 +1,33 @@
+
+Diagnostics:
+error: type `|u64|u64 has drop` is missing required ability `copy`
+  ┌─ tests/file-format-generator/closure_equality_operand_order.move:4:14
+  │
+4 │         f == g
+  │              ^
+
+error: type `|u64|u64 has drop` is missing required ability `copy`
+  ┌─ tests/file-format-generator/closure_equality_operand_order.move:9:14
+  │
+9 │         f != g
+  │              ^
+
+error: reference type `&|u64|u64 has copy + drop` is not allowed as a type argument (type was inferred)
+   ┌─ tests/file-format-generator/closure_equality_operand_order.move:16:11
+   │
+16 │         f == g
+   │           ^^
+   │
+   = required by instantiating type parameter `T` of function `==`
+
+error: type `|u64|u64 has drop + store` is missing required ability `copy`
+   ┌─ tests/file-format-generator/closure_equality_operand_order.move:21:14
+   │
+21 │         f == g
+   │              ^
+
+error: type `|u64|u64 has copy + drop` is missing required ability `store`
+   ┌─ tests/file-format-generator/closure_equality_operand_order.move:28:14
+   │
+28 │         g == f
+   │              ^

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_operand_order.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_operand_order.move
@@ -1,0 +1,30 @@
+module 0xc0ffee::m {
+    // Wide operand first; the reversed expression `g == f` is accepted.
+    public fun wide_first(f: |u64|u64 has copy + drop, g: |u64|u64 has drop): bool {
+        f == g
+    }
+
+    // Covers the separate `!=` inference path.
+    public fun wide_first_neq(f: |u64|u64 has copy + drop, g: |u64|u64 has drop): bool {
+        f != g
+    }
+
+    // Immutable-reference case. The `(&T, &T)` overload fails before `(T, T)` binds `T` to a
+    // reference, so the diagnostic reports an invalid type argument instead of an ability
+    // mismatch.
+    public fun wide_first_ref(f: &|u64|u64 has copy + drop, g: &|u64|u64 has drop): bool {
+        f == g
+    }
+
+    // Neither ability set is a subset of the other, so both operand orders fail.
+    public fun incomparable(f: |u64|u64 has copy + drop, g: |u64|u64 has drop + store): bool {
+        f == g
+    }
+
+    public fun incomparable_swapped(
+        f: |u64|u64 has copy + drop,
+        g: |u64|u64 has drop + store
+    ): bool {
+        g == f
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_operand_order.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_operand_order.opt.exp
@@ -1,0 +1,33 @@
+
+Diagnostics:
+error: type `|u64|u64 has drop` is missing required ability `copy`
+  ┌─ tests/file-format-generator/closure_equality_operand_order.move:4:14
+  │
+4 │         f == g
+  │              ^
+
+error: type `|u64|u64 has drop` is missing required ability `copy`
+  ┌─ tests/file-format-generator/closure_equality_operand_order.move:9:14
+  │
+9 │         f != g
+  │              ^
+
+error: reference type `&|u64|u64 has copy + drop` is not allowed as a type argument (type was inferred)
+   ┌─ tests/file-format-generator/closure_equality_operand_order.move:16:11
+   │
+16 │         f == g
+   │           ^^
+   │
+   = required by instantiating type parameter `T` of function `==`
+
+error: type `|u64|u64 has drop + store` is missing required ability `copy`
+   ┌─ tests/file-format-generator/closure_equality_operand_order.move:21:14
+   │
+21 │         f == g
+   │              ^
+
+error: type `|u64|u64 has copy + drop` is missing required ability `store`
+   ┌─ tests/file-format-generator/closure_equality_operand_order.move:28:14
+   │
+28 │         g == f
+   │              ^

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_widened.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_widened.exp
@@ -1,0 +1,162 @@
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0xc0ffee::m
+struct CopyDropStore has copy + drop + store
+  x: u64
+
+struct DropStore has drop + store
+  x: u64
+
+// Function definition at index 0
+#[persistent] public fun both_widened(l0: DropStore, l1: CopyDropStore): bool
+    local l2: |u64|u64 has drop
+    local l3: |u64|u64 has drop
+    local l4: |u64|u64 has drop
+    local l5: |u64|u64 has drop
+    move_loc l0
+    pack_closure with_capture, 1
+    move_loc l1
+    pack_closure with_copy_capture, 1
+    st_loc l2
+    // @5
+    st_loc l3
+    move_loc l3
+    move_loc l2
+    st_loc l5
+    st_loc l4
+    // @10
+    move_loc l4
+    move_loc l5
+    eq
+    ret
+
+// Function definition at index 1
+#[persistent] public fun differently_declared(l0: |u64|u64 has copy + drop + store, l1: |u64|u64 has drop): bool
+    local l2: |u64|u64 has drop
+    local l3: |u64|u64 has drop
+    move_loc l1
+    move_loc l0
+    st_loc l3
+    st_loc l2
+    move_loc l2
+    // @5
+    move_loc l3
+    eq
+    ret
+
+// Function definition at index 2
+#[persistent] public fun differently_declared_neq(l0: |u64|u64 has copy + drop + store, l1: |u64|u64 has drop): bool
+    local l2: |u64|u64 has drop
+    local l3: |u64|u64 has drop
+    move_loc l1
+    move_loc l0
+    st_loc l3
+    st_loc l2
+    move_loc l2
+    // @5
+    move_loc l3
+    neq
+    ret
+
+// Function definition at index 3
+#[persistent] public fun plain(l0: u64, l1: u64): bool
+    move_loc l0
+    move_loc l1
+    eq
+    ret
+
+// Function definition at index 4
+#[persistent] public fun ref_compare(l0: &|u64|u64 has copy + drop + store, l1: &|u64|u64 has drop): bool
+    local l2: &|u64|u64 has drop
+    local l3: &|u64|u64 has drop
+    move_loc l1
+    move_loc l0
+    st_loc l3
+    st_loc l2
+    move_loc l2
+    // @5
+    move_loc l3
+    eq
+    ret
+
+// Function definition at index 5
+#[persistent] public fun reuses_scratch(l0: |u64|u64 has copy + drop + store, l1: |u64|u64 has drop, l2: |u64|u64 has drop): bool
+    local l3: |u64|u64 has drop
+    local l4: |u64|u64 has drop
+    local l5: bool
+    move_loc l1
+    copy_loc l0
+    st_loc l4
+    st_loc l3
+    move_loc l3
+    // @5
+    move_loc l4
+    eq
+    br_false l0
+    move_loc l2
+    move_loc l0
+    // @10
+    st_loc l4
+    st_loc l3
+    move_loc l3
+    move_loc l4
+    eq
+    // @15
+    st_loc l5
+    branch l1
+l0: ld_false
+    st_loc l5
+l1: move_loc l5
+    // @20
+    ret
+
+// Function definition at index 6
+#[persistent] public fun same_operand(l0: |u64|u64 has copy + drop): bool
+    local l1: |u64|u64 has copy + drop
+    local l2: |u64|u64 has copy + drop
+    copy_loc l0
+    move_loc l0
+    st_loc l2
+    st_loc l1
+    move_loc l1
+    // @5
+    move_loc l2
+    eq
+    ret
+
+// Function definition at index 7
+#[persistent] public fun widened_producer(l0: DropStore, l1: |u64|u64 has drop): bool
+    local l2: |u64|u64 has drop
+    local l3: |u64|u64 has drop
+    move_loc l0
+    pack_closure with_capture, 1
+    move_loc l1
+    st_loc l3
+    st_loc l2
+    // @5
+    move_loc l2
+    move_loc l3
+    eq
+    ret
+
+// Function definition at index 8
+#[persistent] public fun with_capture(l0: DropStore, l1: u64): u64
+    move_loc l0
+    unpack DropStore
+    move_loc l1
+    add
+    ret
+
+// Function definition at index 9
+#[persistent] public fun with_copy_capture(l0: CopyDropStore, l1: u64): u64
+    borrow_loc l0
+    borrow_field CopyDropStore, x
+    read_ref
+    move_loc l1
+    add
+    // @5
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_widened.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_widened.move
@@ -1,0 +1,69 @@
+module 0xc0ffee::m {
+    struct DropStore has drop, store { x: u64 }
+
+    struct CopyDropStore has copy, drop, store { x: u64 }
+
+    public fun with_capture(d: DropStore, y: u64): u64 {
+        let DropStore { x } = d;
+        x + y
+    }
+
+    public fun with_copy_capture(c: CopyDropStore, y: u64): u64 {
+        c.x + y
+    }
+
+    // The verifier derives a wider `PackClosure` type than the shared source type.
+    public fun widened_producer(d: DropStore, g: |u64|u64 has drop): bool {
+        (|y| with_capture(d, y)) == g
+    }
+
+    // The operands have different declared ability sets.
+    public fun differently_declared(
+        f: |u64|u64 has copy + drop + store,
+        g: |u64|u64 has drop
+    ): bool {
+        g == f
+    }
+
+    public fun differently_declared_neq(
+        f: |u64|u64 has copy + drop + store,
+        g: |u64|u64 has drop
+    ): bool {
+        g != f
+    }
+
+    // Both operands share the checked type `|u64|u64 has drop` but derive different abilities,
+    // so each must be normalized to the join.
+    public fun both_widened(d: DropStore, c: CopyDropStore): bool {
+        let lhs: |u64|u64 has drop = |y| with_capture(d, y);
+        let rhs: |u64|u64 has drop = |y| with_copy_capture(c, y);
+        lhs == rhs
+    }
+
+    // Exercises repeated-operand copy/move handling in the two-scratch sequence.
+    public fun same_operand(f: |u64|u64 has copy + drop): bool {
+        f == f
+    }
+
+    // Exercises equality joining through immutable references.
+    public fun ref_compare(
+        f: &|u64|u64 has copy + drop + store,
+        g: &|u64|u64 has drop
+    ): bool {
+        g == f
+    }
+
+    // Reuses one scratch-local pair across two comparisons with the same join type.
+    public fun reuses_scratch(
+        f: |u64|u64 has copy + drop + store,
+        g: |u64|u64 has drop,
+        h: |u64|u64 has drop
+    ): bool {
+        (g == f) && (h == f)
+    }
+
+    // A non-function comparison bypasses normalization and emits plain `Eq`.
+    public fun plain(x: u64, y: u64): bool {
+        x == y
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_widened.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/closure_equality_widened.opt.exp
@@ -1,0 +1,152 @@
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0xc0ffee::m
+struct CopyDropStore has copy + drop + store
+  x: u64
+
+struct DropStore has drop + store
+  x: u64
+
+// Function definition at index 0
+#[persistent] public fun both_widened(l0: DropStore, l1: CopyDropStore): bool
+    local l2: |u64|u64 has drop
+    local l3: |u64|u64 has drop
+    local l4: |u64|u64 has drop
+    local l5: |u64|u64 has drop
+    move_loc l0
+    pack_closure with_capture, 1
+    move_loc l1
+    pack_closure with_copy_capture, 1
+    st_loc l5
+    // @5
+    st_loc l4
+    move_loc l4
+    move_loc l5
+    eq
+    ret
+
+// Function definition at index 1
+#[persistent] public fun differently_declared(l0: |u64|u64 has copy + drop + store, l1: |u64|u64 has drop): bool
+    local l2: |u64|u64 has drop
+    local l3: |u64|u64 has drop
+    move_loc l1
+    move_loc l0
+    st_loc l3
+    st_loc l2
+    move_loc l2
+    // @5
+    move_loc l3
+    eq
+    ret
+
+// Function definition at index 2
+#[persistent] public fun differently_declared_neq(l0: |u64|u64 has copy + drop + store, l1: |u64|u64 has drop): bool
+    local l2: |u64|u64 has drop
+    local l3: |u64|u64 has drop
+    move_loc l1
+    move_loc l0
+    st_loc l3
+    st_loc l2
+    move_loc l2
+    // @5
+    move_loc l3
+    neq
+    ret
+
+// Function definition at index 3
+#[persistent] public fun plain(l0: u64, l1: u64): bool
+    move_loc l0
+    move_loc l1
+    eq
+    ret
+
+// Function definition at index 4
+#[persistent] public fun ref_compare(l0: &|u64|u64 has copy + drop + store, l1: &|u64|u64 has drop): bool
+    local l2: &|u64|u64 has drop
+    local l3: &|u64|u64 has drop
+    move_loc l1
+    move_loc l0
+    st_loc l3
+    st_loc l2
+    move_loc l2
+    // @5
+    move_loc l3
+    eq
+    ret
+
+// Function definition at index 5
+#[persistent] public fun reuses_scratch(l0: |u64|u64 has copy + drop + store, l1: |u64|u64 has drop, l2: |u64|u64 has drop): bool
+    local l3: |u64|u64 has drop
+    local l4: |u64|u64 has drop
+    move_loc l1
+    copy_loc l0
+    st_loc l4
+    st_loc l3
+    move_loc l3
+    // @5
+    move_loc l4
+    eq
+    br_false l0
+    move_loc l2
+    move_loc l0
+    // @10
+    st_loc l4
+    st_loc l3
+    move_loc l3
+    move_loc l4
+    eq
+    // @15
+    ret
+l0: ld_false
+    ret
+
+// Function definition at index 6
+#[persistent] public fun same_operand(l0: |u64|u64 has copy + drop): bool
+    local l1: |u64|u64 has copy + drop
+    local l2: |u64|u64 has copy + drop
+    copy_loc l0
+    move_loc l0
+    st_loc l2
+    st_loc l1
+    move_loc l1
+    // @5
+    move_loc l2
+    eq
+    ret
+
+// Function definition at index 7
+#[persistent] public fun widened_producer(l0: DropStore, l1: |u64|u64 has drop): bool
+    local l2: |u64|u64 has drop
+    local l3: |u64|u64 has drop
+    move_loc l0
+    pack_closure with_capture, 1
+    move_loc l1
+    st_loc l3
+    st_loc l2
+    // @5
+    move_loc l2
+    move_loc l3
+    eq
+    ret
+
+// Function definition at index 8
+#[persistent] public fun with_capture(l0: DropStore, l1: u64): u64
+    move_loc l0
+    unpack DropStore
+    move_loc l1
+    add
+    ret
+
+// Function definition at index 9
+#[persistent] public fun with_copy_capture(l0: CopyDropStore, l1: u64): u64
+    borrow_loc l0
+    borrow_field CopyDropStore, x
+    read_ref
+    move_loc l1
+    add
+    // @5
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_type_arg_function_abilities.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_type_arg_function_abilities.exp
@@ -1,0 +1,39 @@
+
+Diagnostics:
+error: cannot pass `S<|u64|u64 has copy + drop>` to a function which expects argument of type `S<|u64|u64 has drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:15:15
+   │
+15 │         takes(s)
+   │               ^
+
+error: cannot return `S<|u64|u64 has copy + drop>` from a function with result type `S<|u64|u64 has drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:20:9
+   │
+20 │         s
+   │         ^
+
+error: expected `S<|u64|u64 has drop>` but found a value of type `S<|u64|u64 has copy + drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:25:16
+   │
+25 │         S { v: s }
+   │                ^
+
+error: cannot adapt `S<|u64|u64 has copy + drop>` to annotated type `S<|u64|u64 has drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:30:39
+   │
+30 │         let t: S<|u64|u64 has drop> = s;
+   │                                       ^
+
+error: cannot use `S<|u64|u64 has copy + drop>` with an operator which expects a value of type `S<|u64|u64 has drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:37:14
+   │
+37 │         b == a
+   │              ^
+
+error: reference type `&S<|u64|u64 has drop>` is not allowed as a type argument (type was inferred)
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:42:11
+   │
+42 │         b == a
+   │           ^^
+   │
+   = required by instantiating type parameter `T` of function `==`

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_type_arg_function_abilities.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_type_arg_function_abilities.move
@@ -1,0 +1,49 @@
+// Struct type arguments are invariant: bytecode assignability requires complete struct
+// instantiations to be equal. These mismatches must fail during source type checking instead of
+// producing invalid bytecode. The functions below cover call, return, pack, local-binding, and
+// equality contexts.
+module 0xc0ffee::m {
+    struct S<T> has drop, store { v: T }
+
+    fun takes(x: S<|u64|u64 has drop>): bool {
+        let S { v: _ } = x;
+        true
+    }
+
+    // Rejects widening in a call argument.
+    public fun via_call(s: S<|u64|u64 has copy + drop>): bool {
+        takes(s)
+    }
+
+    // Rejects widening in a return value.
+    public fun via_return(s: S<|u64|u64 has copy + drop>): S<|u64|u64 has drop> {
+        s
+    }
+
+    // Rejects widening while packing the outer struct.
+    public fun via_pack(s: S<|u64|u64 has copy + drop>): S<S<|u64|u64 has drop>> {
+        S { v: s }
+    }
+
+    // Rejects widening to an annotated local type.
+    public fun via_let(s: S<|u64|u64 has copy + drop>): bool {
+        let t: S<|u64|u64 has drop> = s;
+        let S { v: _ } = t;
+        true
+    }
+
+    // Rejects widening between equality operands.
+    public fun via_eq(a: S<|u64|u64 has copy + drop>, b: S<|u64|u64 has drop>): bool {
+        b == a
+    }
+
+    // Rejects equality widening through immutable references.
+    public fun via_eq_ref(a: &S<|u64|u64 has copy + drop>, b: &S<|u64|u64 has drop>): bool {
+        b == a
+    }
+
+    // Control case: identical instantiations remain accepted.
+    public fun same_instantiation(a: S<|u64|u64 has drop>, b: S<|u64|u64 has drop>): bool {
+        b == a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_type_arg_function_abilities.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_type_arg_function_abilities.opt.exp
@@ -1,0 +1,39 @@
+
+Diagnostics:
+error: cannot pass `S<|u64|u64 has copy + drop>` to a function which expects argument of type `S<|u64|u64 has drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:15:15
+   │
+15 │         takes(s)
+   │               ^
+
+error: cannot return `S<|u64|u64 has copy + drop>` from a function with result type `S<|u64|u64 has drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:20:9
+   │
+20 │         s
+   │         ^
+
+error: expected `S<|u64|u64 has drop>` but found a value of type `S<|u64|u64 has copy + drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:25:16
+   │
+25 │         S { v: s }
+   │                ^
+
+error: cannot adapt `S<|u64|u64 has copy + drop>` to annotated type `S<|u64|u64 has drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:30:39
+   │
+30 │         let t: S<|u64|u64 has drop> = s;
+   │                                       ^
+
+error: cannot use `S<|u64|u64 has copy + drop>` with an operator which expects a value of type `S<|u64|u64 has drop>`
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:37:14
+   │
+37 │         b == a
+   │              ^
+
+error: reference type `&S<|u64|u64 has drop>` is not allowed as a type argument (type was inferred)
+   ┌─ tests/file-format-generator/struct_type_arg_function_abilities.move:42:11
+   │
+42 │         b == a
+   │           ^^
+   │
+   = required by instantiating type parameter `T` of function `==`

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/closure_equality_widened.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/closure_equality_widened.exp
@@ -1,0 +1,7 @@
+processed 6 tasks
+task 0 lines 1-13:  publish [module 0xc0ffee::m {]
+task 1 lines 15-40:  publish [module 0xc0ffee::via_call {]
+task 2 lines 42-47:  publish [module 0xc0ffee::rigid {]
+task 3 lines 49-102:  publish [module 0xc0ffee::shapes {]
+task 4 lines 104-104:  run 0xc0ffee::via_call::main
+task 5 lines 106-106:  run 0xc0ffee::shapes::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/closure_equality_widened.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/closure_equality_widened.move
@@ -1,0 +1,106 @@
+//# publish
+module 0xc0ffee::m {
+    struct DropStore has drop, store { x: u64 }
+
+    public fun with_capture(d: DropStore, y: u64): u64 {
+        let DropStore { x } = d;
+        x + y
+    }
+
+    public fun compare(d: DropStore, g: |u64|u64 has drop): bool {
+        (|y| with_capture(d, y)) == g
+    }
+}
+
+//# publish
+module 0xc0ffee::via_call {
+    struct DropStore has drop, store { x: u64 }
+
+    public fun with_capture(d: DropStore, y: u64): u64 {
+        let DropStore { x } = d;
+        x + y
+    }
+
+    fun eq_helper(a: |u64|u64 has drop, b: |u64|u64 has drop): bool {
+        a == b
+    }
+
+    public fun compare(d: DropStore, g: |u64|u64 has drop): bool {
+        eq_helper(|y| with_capture(d, y), g)
+    }
+
+    fun main() {
+        let d1 = DropStore { x: 7 };
+        let d2 = DropStore { x: 7 };
+        let d3 = DropStore { x: 8 };
+        let d4 = DropStore { x: 7 };
+        assert!(compare(d1, |y| with_capture(d2, y)), 0);
+        assert!(!compare(d3, |y| with_capture(d4, y)), 1);
+    }
+}
+
+//# publish
+module 0xc0ffee::rigid {
+    public fun compare(f: |u64|u64 has copy + drop + store, g: |u64|u64 has drop): bool {
+        g == f
+    }
+}
+
+//# publish
+module 0xc0ffee::shapes {
+    struct DropStore has drop, store { x: u64 }
+
+    struct CopyDropStore has copy, drop, store { x: u64 }
+
+    public fun with_capture(d: DropStore, y: u64): u64 {
+        let DropStore { x } = d;
+        x + y
+    }
+
+    public fun with_copy_capture(c: CopyDropStore, y: u64): u64 {
+        c.x + y
+    }
+
+    public fun inc(y: u64): u64 {
+        y + 1
+    }
+
+    public fun inc2(y: u64): u64 {
+        y + 2
+    }
+
+    // Exercises repeated-operand copy/move handling.
+    fun same_operand(f: |u64|u64 has copy + drop): bool {
+        f == f
+    }
+
+    // `!=` follows a separate generator arm and requires the same normalization.
+    fun differently_declared_neq(f: |u64|u64 has copy + drop + store, g: |u64|u64 has drop): bool {
+        g != f
+    }
+
+    // Exercises equality joining through immutable references.
+    fun ref_compare(f: &|u64|u64 has copy + drop + store, g: &|u64|u64 has drop): bool {
+        g == f
+    }
+
+    fun main() {
+        assert!(same_operand(inc), 0);
+        assert!(differently_declared_neq(inc, inc2), 1);
+
+        // Both operands share a checked type but derive different ability sets.
+        let lhs: |u64|u64 has drop = |y| with_capture(DropStore { x: 7 }, y);
+        let rhs: |u64|u64 has drop = |y| with_copy_capture(CopyDropStore { x: 7 }, y);
+        assert!(rhs != lhs, 2);
+
+        let wide: |u64|u64 has copy + drop + store = inc;
+        let narrow: |u64|u64 has drop = inc;
+        let other: |u64|u64 has drop = inc2;
+        assert!(ref_compare(&wide, &narrow), 3);
+        assert!(!ref_compare(&wide, &other), 4);
+    }
+}
+
+//# run 0xc0ffee::via_call::main
+
+//# run 0xc0ffee::shapes::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/round-trip/closure_equality_widened.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/round-trip/closure_equality_widened.decompiled
@@ -1,0 +1,112 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/closures/closure_equality_widened.move`
+
+//# publish
+module 0xc0ffee::m {
+    struct DropStore has drop, store {
+        x: u64,
+    }
+    public fun compare(p0: DropStore, p1: |u64|(u64) has drop): bool {
+        (|x| with_capture(p0, x)) == p1
+    }
+    public fun with_capture(p0: DropStore, p1: u64): u64 {
+        let DropStore{x: _v0} = p0;
+        _v0 + p1
+    }
+}
+
+
+//# publish
+module 0xc0ffee::via_call {
+    struct DropStore has drop, store {
+        x: u64,
+    }
+    public fun compare(p0: DropStore, p1: |u64|(u64) has drop): bool {
+        eq_helper(|x| with_capture(p0, x), p1)
+    }
+    public fun with_capture(p0: DropStore, p1: u64): u64 {
+        let DropStore{x: _v0} = p0;
+        _v0 + p1
+    }
+    fun eq_helper(p0: |u64|(u64) has drop, p1: |u64|(u64) has drop): bool {
+        p0 == p1
+    }
+    fun main() {
+        let _v0 = DropStore{x: 7};
+        let _v1 = DropStore{x: 7};
+        let _v2 = DropStore{x: 8};
+        let _v3 = DropStore{x: 7};
+        let _v4: |u64|u64 has drop + store = |x| with_capture(_v1, x);
+        assert!(compare(_v0, _v4), 0);
+        let _v5: |u64|u64 has drop + store = |x| with_capture(_v3, x);
+        if (compare(_v2, _v5)) abort 1;
+    }
+}
+
+
+//# publish
+module 0xc0ffee::rigid {
+    public fun compare(p0: |u64|(u64) has copy + drop + store, p1: |u64|(u64) has drop): bool {
+        p1 == p0
+    }
+}
+
+
+//# publish
+module 0xc0ffee::shapes {
+    struct CopyDropStore has copy, drop, store {
+        x: u64,
+    }
+    struct DropStore has drop, store {
+        x: u64,
+    }
+    fun differently_declared_neq(p0: |u64|(u64) has copy + drop + store, p1: |u64|(u64) has drop): bool {
+        p1 != p0
+    }
+    public fun inc(p0: u64): u64 {
+        p0 + 1
+    }
+    public fun inc2(p0: u64): u64 {
+        p0 + 2
+    }
+    fun main() {
+        assert!(same_operand(|x| inc(x)), 0);
+        let _v0: |u64|u64 has copy + drop + store = |x| inc(x);
+        let _v1: |u64|u64 has copy + drop + store = |x| inc2(x);
+        assert!(differently_declared_neq(_v0, _v1), 1);
+        let _v2: |u64|(u64) has drop = |x| lambda__1__main(x);
+        assert!((|x| lambda__2__main(x)) != _v2, 2);
+        let _v3: |u64|(u64) has copy + drop + store = |x| inc(x);
+        let _v4: |u64|(u64) has drop = |x| inc(x);
+        let _v5: |u64|(u64) has drop = |x| inc2(x);
+        let _v6 = &_v3;
+        let _v7 = &_v4;
+        assert!(ref_compare(_v6, _v7), 3);
+        let _v8 = &_v3;
+        let _v9 = &_v5;
+        if (ref_compare(_v8, _v9)) abort 4;
+    }
+    fun same_operand(p0: |u64|(u64) has copy + drop): bool {
+        p0 == p0
+    }
+    fun lambda__1__main(p0: u64): u64 {
+        with_capture(DropStore{x: 7}, p0)
+    }
+    fun lambda__2__main(p0: u64): u64 {
+        with_copy_capture(CopyDropStore{x: 7}, p0)
+    }
+    fun ref_compare(p0: &|u64|(u64) has copy + drop + store, p1: &|u64|(u64) has drop): bool {
+        p1 == p0
+    }
+    public fun with_capture(p0: DropStore, p1: u64): u64 {
+        let DropStore{x: _v0} = p0;
+        _v0 + p1
+    }
+    public fun with_copy_capture(p0: CopyDropStore, p1: u64): u64 {
+        *&(&p0).x + p1
+    }
+}
+
+
+//# run 0xc0ffee::via_call::main
+
+//# run 0xc0ffee::shapes::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/round-trip/closure_equality_widened.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/round-trip/closure_equality_widened.decompiled.baseline.exp
@@ -1,0 +1,7 @@
+processed 6 tasks
+task 0 lines 3-15:  publish [module 0xc0ffee::m {]
+task 1 lines 18-43:  publish [module 0xc0ffee::via_call {]
+task 2 lines 46-51:  publish [module 0xc0ffee::rigid {]
+task 3 lines 54-107:  publish [module 0xc0ffee::shapes {]
+task 4 lines 110-110:  run 0xc0ffee::via_call::main
+task 5 lines 112-112:  run 0xc0ffee::shapes::main

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -2918,12 +2918,12 @@ impl Substitution {
             },
             (Type::Struct(m1, s1, ts1), Type::Struct(m2, s2, ts2)) => {
                 if m1 == m2 && s1 == s2 {
-                    // For structs, also pass on `variance`, not `sub_variance`, to inherit
-                    // shallow processing to fields.
+                    // Shallow variance does not apply to struct type arguments. Bytecode
+                    // assignability requires complete struct instantiations to be equal.
                     return Ok(Type::Struct(
                         *m1,
                         *s1,
-                        self.unify_vec(context, variance, order, None, ts1, ts2)
+                        self.unify_vec(context, sub_variance, order, None, ts1, ts2)
                             .map_err(TypeUnificationError::lift(order, t1, t2))?,
                     ));
                 }


### PR DESCRIPTION
## Description

This PR fixes two classes of ICE due to compiler generating bytecode that the verifier rejects. 

1.
When `PackClosure` assigns a closure to a local, the bytecode verifier derives abilities from the captured values rather than from the declared type. This means a closure value can arrive at an `Eq` or `Neq` instruction with a wider file-format type than the compiler assigned it, causing the verifier to reject the bytecode because `Eq`/`Neq` require both operands to have identical types.

This change fixes the issue by inserting a `StLoc`/`MoveLoc` round-trip through scratch locals typed at the ability intersection ("join") of the two operands before emitting `Eq` or `Neq`. The round-trip uses `StLoc` assignability to accept each value and `MoveLoc` to restore the exact join type, ensuring the verifier sees matching operand types.

To prevent the peephole optimizer from eliminating these normalization round-trips, scratch locals used for equality coercion are tracked as "protected locals." The `WindowProcessor` now rejects any window transformation that would consume an instruction accessing a protected local. A new `Bytecode::local_index()` helper is added to `file_format.rs` to support this check.

2.
Struct type arguments are corrected to use `sub_variance` rather than `variance` during unification, enforcing that bytecode assignability requires complete struct instantiations to be equal rather than allowing shallow covariance through type arguments. This fixes several different manifestations of ICEs.

## How Has This Been Tested?

- `closure_equality_widened` file-format generator tests verify that scratch locals are emitted for widened operands, that the same scratch-local pair is reused across multiple comparisons with the same join type, that `!=` is handled alongside `==`, that immutable-reference operands recurse correctly, and that non-function comparisons bypass normalization entirely.
- `closure_equality_operand_order` tests confirm that operand-order mismatches (where no common type exists) are rejected at the source level.
- `struct_type_arg_function_abilities` tests confirm that struct type arguments with differing function abilities are rejected during source type checking rather than producing invalid bytecode.
- Transactional tests in `closure_equality_widened.move` exercise the generated bytecode at runtime, including `via_call::main` and `shapes::main`, verifying correct equality semantics for widened closures, `!=`, same-operand comparisons, and reference comparisons.
- Peephole optimizer unit tests (`test_protected_locals_keep_their_round_trip`, `test_protected_locals_block_inefficient_loads`) verify that protected locals suppress both `ReduciblePairs` and `InefficientLoads` transformations, while unprotected locals continue to be optimized.

## Key Areas to Review

- **`equality_coercion` and `equality_join`** in `function_generator.rs`: The core logic that determines when normalization is needed and computes the ability intersection. The join intersects abilities for matching function signatures and recurses through immutable references; all other types must be equal.
- **`can_widen_abilities`**: The guard that avoids emitting scratch locals for types that cannot widen (primitives, structs, mutable references, etc.). This must remain conservative — false negatives produce invalid bytecode.
- **`protected_locals` and `WindowProcessor`**: The mechanism that prevents the peephole optimizer from removing the coercion round-trips. The `is_protected` check uses the new `Bytecode::local_index()` to identify instructions that access a protected local, and any window whose consumed prefix contains such an instruction is left untransformed.
- **`sub_variance` fix in `ty.rs`**: Changing struct type-argument unification from `variance` to `sub_variance` makes struct instantiations invariant in their type arguments, which matches bytecode semantics. This is a correctness fix but may affect existing type-checking behavior for struct-parameterized function types.
- **Source map placeholders in `new_scratch_local`**: Each scratch local needs a source-map entry to preserve the positional indexing of subsequent locals. The `tmp#$` naming convention marks these as compiler-generated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler codegen and struct generic unification semantics; incorrect join or protection logic would still produce invalid bytecode, but behavior is heavily tested.
> 
> **Overview**
> Fixes compiler ICEs where generated bytecode failed the Move verifier, in two related areas.
> 
> **Equality on widened function/reference types:** `Eq`/`Neq` now go through `gen_equality`, which may insert a prelude that stores both operands into scratch locals typed at an **ability join** (intersection for matching function signatures, recursive join for `&T`), then reloads them so operand types match what the verifier expects after `PackClosure` widening. Scratch locals are cached per join type, registered in the source map as `tmp#$`, and exposed to peephole optimization as **protected locals** so `StLoc`/`MoveLoc` round-trips are not folded away. `Bytecode::local_index()` was added so window optimizers can detect local accesses; `optimize` and `WindowProcessor` take a `BTreeSet` of protected indices.
> 
> **Struct type arguments:** Unification for struct instantiations now uses **`sub_variance`** instead of **`variance`** on type arguments, so source checking matches bytecode rule that full struct instantiations must be equal (rejecting ability mismatches like `S<|…| copy+drop>` vs `S<|…| drop>` at compile time).
> 
> New file-format, transactional, and peephole unit tests cover widened closure comparisons, operand-order failures, struct generic mismatches, and protected-local behavior with/without optimization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50dd2a31cda54e3ffdf18d06660ed09559613640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->