### PR TITLE
[ci] Move the framework upgrade test off the PR blocking path

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -366,7 +366,13 @@ jobs:
       SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' }}
       SEND_RESULTS_TO_TRUNK: true
   
-  # Run forge framework upgradability test. This is a PR required job.
+  # Run forge framework upgradability test. Forge only runs when the
+  # CICD:run-framework-upgrade-test label is present; otherwise SKIP_JOB short-circuits it.
+  # The `if:` below deliberately stays broad so the job still materializes and reports a
+  # (skipped) check -- this job is a PR required check, and a check that never runs would
+  # leave auto-merge PRs waiting forever. There is no workflow_dispatch arm: dispatch has no
+  # PR labels, so SKIP_JOB would always be true and the job would only ever skip. Manual and
+  # scheduled runs live in .github/workflows/forge-framework-upgrade.yaml instead.
   forge-framework-upgrade-test:
     needs:
       - permission-check
@@ -376,11 +382,9 @@ jobs:
       - rust-images-failpoints
       - rust-images-performance
       - rust-images-consensus-only-perf-test
-      - test-target-determinator
     if: |
       !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
-        github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test') ||
         github.event.pull_request.auto_merge != null
       )
@@ -393,7 +397,7 @@ jobs:
       FORGE_RUNNER_DURATION_SECS: 3600
       COMMENT_HEADER: forge-framework-upgrade
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-      SKIP_JOB: ${{ !contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test') && (needs.test-target-determinator.outputs.run_framework_upgrade_test == 'false') }}
+      SKIP_JOB: ${{ !contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test') }}
       SEND_RESULTS_TO_TRUNK: true
 
   forge-consensus-only-perf-test:

--- a/.github/workflows/forge-framework-upgrade.yaml
+++ b/.github/workflows/forge-framework-upgrade.yaml
@@ -1,0 +1,161 @@
+# Forge framework upgrade test. Was land-blocking in docker-build-test.yaml; that job
+# is now opt-in via the CICD:run-framework-upgrade-test label, and scheduled/manual runs
+# live here. Structure follows forge-stable.yaml.
+name: Forge Framework Upgrade
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      TARGET_BRANCH:
+        required: false
+        type: string
+        description: >-
+          Branch to upgrade to. Defaults to the branch selected above. Images must
+          already be built for it.
+      FORGE_CLUSTER_NAME:
+        required: false
+        type: string
+        description: The Forge k8s cluster to be used for test
+      FORGE_RUNNER_DURATION_SECS:
+        required: false
+        type: string
+        description: Duration of the forge test run, in seconds
+        default: "300"
+
+  # No pull_request or push trigger: a run here is a full Forge swarm, which is the
+  # cost this workflow exists to move off PRs.
+  # schedule: # NOTE: the schedule is dictated by PIES
+
+env:
+  AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: us-west-2
+
+jobs:
+  permission-check:
+    runs-on: 2cpu-gh-ubuntu24-x64
+    steps:
+      - name: Check repository permission for user which triggered workflow
+        uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
+        with:
+          required-permission: write
+          comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
+
+  # Resolves the two image tags the suite upgrades between.
+  #
+  # Actions are pinned @main, not `./`: a `./` ref loads the action from the dispatched
+  # ref, running that branch's code with credentials configured. Same as forge-stable.
+  determine-test-metadata:
+    needs: [permission-check]
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success'
+    runs-on: 2cpu-gh-ubuntu24-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      # The actions below interpolate their inputs unquoted into Bash, and `${{ }}` is
+      # substituted before Bash parses. Git permits $( ) in branch names, so read the
+      # value via `env` (never expression-substituted) and validate the charset.
+      - name: Resolve and validate target branch
+        id: target
+        env:
+          RAW_TARGET: ${{ inputs.TARGET_BRANCH || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RAW_TARGET}" ]]; then
+            echo "::error::No target branch resolved"
+            exit 1
+          fi
+          if ! [[ "${RAW_TARGET}" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
+            echo "::error::Refusing target branch with unexpected characters"
+            exit 1
+          fi
+          echo "BRANCH=${RAW_TARGET}" >> "$GITHUB_OUTPUT"
+
+          # Baseline is resolved separately: a release branch against its predecessor,
+          # anything else against "main" (newest aptos-release-vX.Y, by version). Passing
+          # a feature branch through instead takes determine_target_branch()'s
+          # personal-branch path, which orders by tip commit date and can pick an older
+          # release that merely had a recent hotfix.
+          if [[ "${RAW_TARGET}" =~ ^aptos-release-v ]]; then
+            echo "BASE_BRANCH=${RAW_TARGET}" >> "$GITHUB_OUTPUT"
+          else
+            echo "BASE_BRANCH=main" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Target branch: ${RAW_TARGET}"
+
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        id: docker-setup
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          EXPORT_GCP_PROJECT_VARIABLES: "false"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      # Upgrade target. No variants: framework_upgrade needs only the plain validator
+      # image, and requiring failpoints/performance would skip past the branch's own
+      # commits (those are never built for a PR branch) onto an ancestor on main.
+      - uses: aptos-labs/aptos-core/.github/actions/get-latest-docker-image-tag@main
+        id: get-latest-image-tag
+        with:
+          branch: ${{ steps.target.outputs.BRANCH }}
+
+      # Upgrade baseline. Must not be empty: the action only resolves a last released
+      # image when base-branch is set, otherwise it falls back to the latest image on the
+      # current branch and the suite would "upgrade" the binary under test to itself.
+      - uses: aptos-labs/aptos-core/.github/actions/determine-or-use-target-branch-and-get-last-released-image@main
+        id: get-last-released-image-tag
+        with:
+          base-branch: ${{ steps.target.outputs.BASE_BRANCH }}
+          variants: "failpoints performance"
+
+      # Timestamped so concurrent runs cannot collide on one k8s namespace.
+      - name: Derive Forge namespace suffix
+        id: normalize
+        run: |
+          GHA_TRIGGER_EVENT_NAME=${{ github.event_name == 'workflow_dispatch' && 'w-d' || github.event_name }}
+          TIMESTAMP=$(date +%s)
+          FORGE_NAMESPACE_SUFFIX="fwup-${GHA_TRIGGER_EVENT_NAME}-${TIMESTAMP}"
+          FORGE_NAMESPACE_SUFFIX=${FORGE_NAMESPACE_SUFFIX:0:30}
+          echo "FORGE_NAMESPACE_SUFFIX=${FORGE_NAMESPACE_SUFFIX}" >> "$GITHUB_OUTPUT"
+
+      - name: Write summary
+        run: |
+          echo "## Framework upgrade test" >> $GITHUB_STEP_SUMMARY
+          echo "Upgrading FROM \`${{ steps.get-last-released-image-tag.outputs.IMAGE_TAG }}\` (branch \`${{ steps.get-last-released-image-tag.outputs.TARGET_BRANCH }}\`)" >> $GITHUB_STEP_SUMMARY
+          echo "Upgrading TO \`${{ steps.get-latest-image-tag.outputs.IMAGE_TAG }}\` (branch \`${{ steps.target.outputs.BRANCH }}\`)" >> $GITHUB_STEP_SUMMARY
+
+    outputs:
+      IMAGE_TAG_NEW: ${{ steps.get-latest-image-tag.outputs.IMAGE_TAG }}
+      IMAGE_TAG_BASELINE: ${{ steps.get-last-released-image-tag.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE_SUFFIX: ${{ steps.normalize.outputs.FORGE_NAMESPACE_SUFFIX }}
+
+  forge-framework-upgrade-test:
+    needs:
+      - permission-check
+      - determine-test-metadata
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success'
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      # Swarm starts on IMAGE_TAG (last release) and upgrades to images Forge resolves
+      # from GIT_SHA's history.
+      GIT_SHA: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG_NEW }}
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG_BASELINE }}
+      FORGE_TEST_SUITE: framework_upgrade
+      FORGE_RUNNER_DURATION_SECS: ${{ fromJSON(inputs.FORGE_RUNNER_DURATION_SECS || '300') }}
+      FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}
+      COMMENT_HEADER: forge-framework-upgrade
+      FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-test-metadata.outputs.FORGE_NAMESPACE_SUFFIX }}
+      SEND_RESULTS_TO_TRUNK: true


### PR DESCRIPTION
## Description

The `framework_upgrade` Forge suite has been land-blocking: 3600s on a 4-validator Kubernetes swarm, triggered by any change under `.github`, `testsuite`, `aptos-move/aptos-release-builder`, or `aptos-move/framework` — matched as **path prefixes**, so every `.move` edit qualifies, and a large share of Rust changes pull it in transitively.

This takes it off the PR path and gives it a dispatchable/schedulable home.

**`docker-build-test.yaml`** — Forge now runs only with the `CICD:run-framework-upgrade-test` label. `SKIP_JOB` no longer consults the determinator, and `test-target-determinator` is dropped from the job's `needs:`.

The `if:` is deliberately left broad. `forge-framework-upgrade-test / forge` is in the `main-branch-status-check` ruleset, so gating on the label alone would stop the check materializing on unlabelled PRs and leave auto-merge waiting forever. Keeping `if:` broad and short-circuiting via `SKIP_JOB` is the pattern `forge-compat-test` and `forge-e2e-test` use: the check still reports (skipped), but no cluster is created.

**New `forge-framework-upgrade.yaml`** — modelled on `forge-stable.yaml`: `workflow_dispatch` plus a commented `schedule:` carrying the `# NOTE: the schedule is dictated by PIES` convention. Once merged, the Actions "Run workflow" button can run the suite against any branch, replacing the label for manual use.

> [!IMPORTANT]
> **Not scheduled yet.** The commented `schedule:` is a marker, not a schedule, and `workflow_dispatch` only lists workflows already on the default branch. Until PIES is pointed at this workflow it cannot run at all — not on PRs, not on a schedule, not manually. Wiring that up is the step that turns the nightly on.

## How the two image tags resolve

| | source |
|---|---|
| **TO** — branch under test | the selected branch, no variant filter |
| **FROM** — upgrade baseline | `main` (→ newest `aptos-release-vX.Y`), unless the target is itself a release branch (→ minor − 1) |

Both are printed to the step summary, so one glance confirms the baseline landed on a release branch.

## Key areas to review

- **`if:` vs `SKIP_JOB`.** Forge is prevented from running by `SKIP_JOB`, not by `if:`. Gating on `if:` instead would silently break required-check reporting.
- **Everything is pinned `@main`, and no input reaches a shell.** Actions loaded via `./` resolve from the dispatched ref, so a writer could run their own action code on a credentialed runner; `forge-stable` pins the same actions. The branch input is read through `env` and regex-validated before use, because both image-resolution actions interpolate their inputs unquoted into Bash and git permits `$( )` in branch names.
- **The determinator arm is now dead code.** `SKIP_JOB` was its only consumer. Left in place; removing it and the `RELEVANT_*_FOR_FRAMEWORK_UPGRADE_TESTS` constants is separate cleanup.
- **Deleting the job later needs an admin.** `forge-framework-upgrade-test / forge` must come out of ruleset `main-branch-status-check` in the same change, or PRs wait on a check that never reports.

## Testing

Validated end to end from this branch via a temporary `push:` trigger, since neither file can be exercised any other way pre-merge (`docker-build-test.yaml` runs on `pull_request_target`, so it executes `main`'s copy). **That trigger has been removed** — `workflow_dispatch` is the only trigger at the head commit.

Run [33921083568](https://github.com/aptos-labs/aptos-core/actions/runs/33921083568) passed, resolving:

```
Upgrading FROM 26fcea0290 (branch aptos-release-v1.49)
Upgrading TO   0339c7eee7 (branch teng/change-framewore-upgrade-test-to-nightly)
```

The first run surfaced two defects, both since fixed: the branch under test required `failpoints`/`performance` variants that PR branches never build, so it silently resolved to a `main` commit; and the baseline was resolved from the branch under test, which takes `determine_target_branch()`'s tip-date-ordered path and picked v1.48 over v1.49.

Separately, out of scope here: `get_branch_creation_time` (`testsuite/test_framework/git.py:116`) runs `rev-list --first-parent --max-count=1`, which returns the branch tip, not its first commit, contradicting its docstring. Not hit by any caller after this change; worth its own issue.

## Type of Change
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure
