### PR TITLE
[mono-move] Cut down CLAUDE.md contents

### DIFF
--- a/third_party/move/mono-move/CLAUDE.md
+++ b/third_party/move/mono-move/CLAUDE.md
@@ -1,3 +1,1 @@
-# mono-move
-
 @AGENTS.md

--- a/third_party/move/mono-move/aptos-state-view-providers/CLAUDE.md
+++ b/third_party/move/mono-move/aptos-state-view-providers/CLAUDE.md
@@ -1,3 +1,1 @@
-# CLAUDE.md
-
-See [AGENTS.md](AGENTS.md) for crate documentation.
+@AGENTS.md

--- a/third_party/move/mono-move/aptos-transaction-executor/AGENTS.md
+++ b/third_party/move/mono-move/aptos-transaction-executor/AGENTS.md
@@ -1,8 +1,9 @@
 # aptos-transaction-executor
 
-The AptosVM transaction-execution layer on the MonoMove VM: one Aptos user
-transaction, prologue → payload → epilogue, producing an unmaterialized
-`TxnOutcome`. Block-level coordination lives above this crate.
+The AptosVM transaction-execution layer on the MonoMove VM. User transactions
+run prologue → payload → epilogue and produce an unmaterialized `TxnOutcome`;
+system transactions run unmetered and fee-free. Block-level coordination lives
+above this crate.
 
 ## Working assumptions
 
@@ -21,33 +22,19 @@ transaction, prologue → payload → epilogue, producing an unmaterialized
 
 ## Before wiring to the block coordinator
 
-There are critical issues we need to address before wiring up the transaction
-executor to the block coordinator:
+Still open before the transaction executor can be wired to the block
+coordinator:
 
 - Entry-function validation: `entry` visibility, no return values, admissible
-  argument types. Without the visibility check a signed payload naming any
-  loadable function runs it.
-- Argument and signer checks: duplicate signers, signer counts, malformed
-  arguments.
-- `check_gas` pre-flight: transaction size, gas price bounds, intrinsic gas.
-  Without it a zero gas price buys a full `max_gas_amount` budget.
+  argument types, constructed arguments. Without the visibility check a signed
+  payload naming any loadable function runs it. See the `TODO(security,
+  completeness)` in `user_txn/execute.rs`.
+- Multi-agent transactions are untested.
 
-## Modules
+## Conventions
 
 Modules stay private; anything public is re-exported from `lib.rs`, which holds
 nothing else.
-
-| Module | Purpose |
-|---|---|
-| `executor.rs` | `AptosTransactionExecutor`: the transaction lifecycle driver |
-| `outcome.rs` | `TxnOutcome`: the unmaterialized conclusion, and `materialize()` |
-| `errors.rs` | The typed outcome taxonomy: `DiscardReason`, `ExecutionStatus`, and the per-stage failure enums |
-| `materialize/` | `txn_output.rs` drains the write set (with resource-group merge-back) into a `TransactionOutput`; `vm_status.rs` projects the taxonomy onto `VMStatus` |
-| `providers.rs` | The `AptosDataProvider` trait: what write-set materialization needs from the data layer |
-| `natives.rs` | The production native registry and the per-transaction native extensions |
-| `calls.rs` | Making one function call in the shared interpreter context |
-| `metadata.rs` | The slice of transaction metadata the prologue needs |
-| `sys_calls.rs` | The unmetered prologue and epilogue calls |
 
 ## Testing
 

--- a/third_party/move/mono-move/aptos-transaction-executor/CLAUDE.md
+++ b/third_party/move/mono-move/aptos-transaction-executor/CLAUDE.md
@@ -1,3 +1,1 @@
-# CLAUDE.md
-
-See [AGENTS.md](AGENTS.md) for crate documentation, architecture, and commands.
+@AGENTS.md

--- a/third_party/move/mono-move/runtime/AGENTS.md
+++ b/third_party/move/mono-move/runtime/AGENTS.md
@@ -1,94 +1,53 @@
 # mono-move-runtime
 
-Runtime for the MonoMove VM: a register-based interpreter with a unified linear stack, bump-allocated heap, and Cheney's copying garbage collector.
+Executes **micro-ops**: the flat, monomorphic instruction set the specializer
+produces from Move bytecode. Register-based interpreter over a unified linear
+stack, with a bump-allocated heap and Cheney's copying GC. Input is assumed
+already verified and lowered by the MonoMove pipeline.
 
-## Overview
+Design rationale lives in `../docs/`. Read the relevant one before changing a
+value layout, the calling convention, or the GC.
 
-This crate executes **micro-ops** — a low-level, flat instruction set that a specializer produces from Move bytecode after monomorphization and destackification. It is not a general-purpose VM; it assumes its input has already been verified and lowered by the MonoMove compiler pipeline.
+## Safety model
 
-The runtime is at proof-of-concept stage. See `TODO.md` for the backlog of missing features.
+The interpreter uses raw pointer arithmetic throughout. Correctness rests on
+three invariants held jointly by the compiler, the verifier, and the runtime.
+Any change that could break one needs a matching verifier check or a proof:
 
-## Architecture
+1. **Frame metadata integrity** — saved `fp`/`pc`/`func_ptr` are written only by
+   call/return, never by user micro-ops.
+2. **Pointer-slot accuracy** — `Function::frame_layout` and the matching
+   `safe_point_layouts` entries exactly describe the frame slots holding live
+   heap pointers. The GC trusts them to find roots.
+3. **Object header integrity** — `descriptor_id` and `size_in_bytes` sit at
+   `obj_ptr - 8` and `obj_ptr - 4`, written by the allocator. User micro-ops
+   address only offsets `>= 0`, so they cannot reach the header.
 
-### Modules
+`verify_program` checks frame-access bounds, metadata overlap, jump targets, and
+descriptor validity before execution. Everything else is the compiler's
+responsibility.
 
-| Module | Purpose |
-|---|---|
-| `interpreter.rs` | Core interpreter loop (`step`/`run`), `InterpreterContext` (owns stack + heap + pc state), call/return protocol |
-| `heap/mod.rs` | Bump allocator, vector/struct/enum allocation, vector growth, Cheney's copying GC |
-| `heap/pinned_roots.rs` | Auxiliary GC root set for pointers that must survive across allocations (used by `PackClosure`, native functions) |
-| `memory.rs` | `MemoryRegion` (owned 8-byte-aligned allocation), raw pointer helpers (`read_u64`, `write_ptr`, etc.) |
-| `types.rs` | `ObjectDescriptor` (GC tracing layouts), `StepResult`, layout constants (header offsets, frame metadata offsets) |
-| `verifier.rs` | Static verification of `Function` bodies before execution (frame bounds, jump targets, descriptor validity) |
+## Conventions
 
-### Key concepts
-
-**Unified stack.** Call frames live in a single contiguous `MemoryRegion`. See `docs/stack_and_calling_convention.md` for the frame layout diagram and full calling convention.
-
-**Bump-allocated heap with copying GC.** Heap objects (vectors, structs, enums) are bump-allocated. When the bump pointer hits the end, Cheney's copying GC runs: it walks the call stack using per-function `frame_layout` (and per-safe-point `safe_point_layouts`) to find roots, then does a breadth-first copy of all reachable objects into a fresh to-space. Forwarding pointers handle cycles and double-scans.
-
-**Object layout.** Every heap object has an 8-byte header `[descriptor_id: u32, size_in_bytes: u32]` at *negative* offsets relative to the object pointer (descriptor at `obj_ptr - 8`, size at `obj_ptr - 4`). The allocator reserves `OBJECT_HEADER_SIZE = MAX_ALIGN` bytes before each data region; when `MAX_ALIGN > 8` the leading bytes are unused header padding, keeping the data start `MAX_ALIGN`-aligned. Per-type layouts (struct fields, enum tag/variants, vector length/data, closure fields, captured-data values) are expressed relative to the data start, so the shared header is invisible to them. Vectors store a `length` field at offset 0 of the data region (capacity is derived from `size_in_bytes`). The descriptor tells the GC how to trace internal pointers.
-
-**Fat pointers.** References are 16-byte `(base_ptr, byte_offset)` pairs. This lets borrows point into the interior of heap objects (e.g., a struct field or vector element) without a separate indirection.
-
-**Static verification.** Before execution, `verify_program` checks every function for frame-access bounds, metadata overlap, valid jump targets, and valid descriptor references. This prevents undefined behavior from malformed micro-ops.
-
-### Safety model
-
-The interpreter uses raw pointer arithmetic extensively (`unsafe`). Correctness depends on invariants maintained jointly by the compiler, verifier, and runtime:
-
-1. **Frame metadata integrity** — saved `fp`/`pc`/`func_ptr` are written only by call/return, never by user micro-ops
-2. **Pointer-slot accuracy** — `Function::frame_layout` (and matching `safe_point_layouts` entries) together exactly match slots that hold live heap pointers
-3. **Object header integrity** — `descriptor_id` and `size` live at fixed negative offsets (`obj_ptr - 8` / `obj_ptr - 4`) set by the allocator; user micro-ops only access offsets within the data region (≥ 0) so they cannot reach the header
-
-The verifier checks what it can statically; the rest is the compiler's responsibility.
-
-## Related Docs
-
-Detailed design documents live in `../docs/`:
-
-| Doc | Covers |
-|---|---|
-| `stack_and_calling_convention.md` | Frame layout, call/return protocol, unified vs separate stack, GC root discovery via `frame_layout` and `safe_point_layouts`, security considerations |
-| `heap_and_gc.md` | Block/transaction memory management, bump allocator + Cheney's copying GC, GC design space analysis (four approaches), memory safety |
-| `value_representation.md` | Heap object header, primitive/struct/enum/vector layouts, fat pointer references, vector growth semantics |
-| `native_functions.md` | Native function calling convention, error handling, gas metering, generics (WIP — not yet implemented) |
-| `vm_security_and_correctness.md` | VM-wide invariants: arithmetic safety, type/memory safety, gas metering, boundedness, determinism, cache consistency |
+- Every `unsafe` block carries a `// SAFETY:` comment naming the invariants it
+  relies on.
+- Bare `unwrap()` is banned outside tests. Use `expect()` only when the property
+  is local and easy to prove; otherwise return an error. Tests may use
+  `unwrap()` freely.
+- All arithmetic is checked unless the absence of overflow is proven.
+- New micro-ops follow the naming in `mono-move-core/src/instruction/`.
 
 ## Commands
 
 ```bash
-cargo check -p mono-move-runtime         # Quick compile check
-cargo test -p mono-move-runtime           # Run all tests
-cargo test -p mono-move-runtime -- <name> # Run a specific test
+cargo check -p mono-move-runtime
+cargo test -p mono-move-runtime
+cargo test -p mono-move-runtime -- <name>
 ```
 
-## Tests
-
-Integration tests live in `tests/`:
-
-| Test file | What it covers |
-|---|---|
-| `vec_sum.rs` | Vector operations, push/pop, iteration, arithmetic |
-| `struct_test.rs` | Heap-allocated structs, field access, GC with struct roots |
-| `enum_test.rs` | Enum allocation, tag dispatch, GC tracing per-variant |
-| `ref_test.rs` | Fat pointer references, borrow/read/write through refs |
-| `gc_stress.rs` | GC pressure scenarios, survival of live objects across collections |
-| `verifier_test.rs` | Verification error detection for malformed programs |
-
-Additional end-to-end tests and benchmarks live in the sibling `../programs` crate.
-
-## Coding Conventions
-
-- All `unsafe` blocks must have a `// SAFETY:` comment documenting the invariants they rely on
-- Bare `unwrap()` is banned in non-test code. `expect()` is only permitted when the property is local and can be proven easily. Otherwise, return an error (`bail!` for now; proper VM errors or invariant violations in the future). Tests may use `unwrap()` freely.
-- All arithmetic must be checked (no wrapping/overflowing) unless correctness is proven
-- Follow the naming conventions in `mono-move-core/src/instruction/` when adding new micro-ops
-
-## Pre-PR Checklist
+## Pre-PR
 
 - [ ] `cargo +nightly fmt -- --check` passes
 - [ ] `cargo test -p mono-move-runtime` passes
-- [ ] If your change affects design docs (in `../docs/`) or this file, keep them up to date — check for stale descriptions, renamed files/modules, changed layouts, etc.
-- [ ] If your change implements something listed in `TODO.md`, update or remove the corresponding entry
-- [ ] Consider running tests and benchmarks in the `../programs` crate for broader coverage
+- [ ] Affected docs in `../docs/` and this file updated — check for renamed
+      modules, changed layouts, stale descriptions

--- a/third_party/move/mono-move/runtime/CLAUDE.md
+++ b/third_party/move/mono-move/runtime/CLAUDE.md
@@ -1,3 +1,1 @@
-# CLAUDE.md
-
-See [AGENTS.md](AGENTS.md) for crate documentation, architecture, safety model, and commands.
+@AGENTS.md

--- a/third_party/move/mono-move/specializer/CLAUDE.md
+++ b/third_party/move/mono-move/specializer/CLAUDE.md
@@ -1,3 +1,1 @@
-# specializer
-
 @AGENTS.md

--- a/third_party/move/mono-move/testsuite/CLAUDE.md
+++ b/third_party/move/mono-move/testsuite/CLAUDE.md
@@ -1,3 +1,1 @@
-# mono-move-testsuite
-
 @AGENTS.md


### PR DESCRIPTION
## Description

The per-crate agent instructions under `third_party/move/mono-move/` had drifted from the tree, and two of them were not being loaded at all.

Stale content:

- `runtime/AGENTS.md` listed `heap/pinned_roots.rs`, which was deleted, and omitted `error.rs`, `global_storage.rs`, `heap/deep_copy.rs`, `native_context.rs`, and `value_utils.rs` — six of eleven modules wrong or missing. It referred twice to a `TODO.md` that does not exist and that the parent `AGENTS.md` explicitly bans, twice to a `../programs` crate that does not exist, and named four test files that do not exist (`vec_sum.rs`, `struct_test.rs`, `enum_test.rs`, `gc_stress.rs`).
- `aptos-transaction-executor/AGENTS.md` listed `sys_calls.rs` (gone) and a top-level `metadata.rs` (moved into `user_txn/`), and showed neither the `user_txn/` nor the `system_txns/` subdirectory. Its blocker list named a `check_gas` pre-flight as missing, which `user_txn/pre_execution_checks.rs` already implements in full — transaction size, gas price bounds, gas budget bounds, and intrinsic gas.

Every stale entry sat in a module or file table. `lib.rs` and `mod.rs` cannot drift from the tree, so the tables are gone and the code describes itself. All nine transaction-executor modules already carry the same descriptions the table did, four as `//!` module docs and five as item docs on `AptosTransactionExecutor`, `TxnOutcome`, `AptosDataProvider`, `production_natives`, and the error enums. No source changes were needed and nothing was lost.

Loading was the other half of the problem. Claude Code's nested-directory memory loader reads `CLAUDE.md`, `.claude/CLAUDE.md`, `CLAUDE.local.md`, and `.claude/rules/` — it does not discover `AGENTS.md`, so the `CLAUDE.md` stubs are load-bearing. Three of the six used `See [AGENTS.md](AGENTS.md)`, a plain markdown link rather than an import, so `runtime/` and `aptos-transaction-executor/` were contributing none of their instructions. All six stubs are now the `@AGENTS.md` import form.

What remains in each file is only what the code cannot state: the runtime's three safety invariants and its `unsafe`/`unwrap`/checked-arithmetic rules, and the transaction executor's working assumptions and open blockers.

Net: 3574 → 2115 tokens on disk. `runtime/AGENTS.md` 1689 → 548, `aptos-transaction-executor/AGENTS.md` 711 → 466. The two crates that previously loaded nothing now load roughly 1,000 tokens of verified content.

## How Has This Been Tested?

Documentation only — no Rust changed, so no tests apply and `fmt`/`clippy` were skipped.

Every retained claim was checked against the tree rather than carried forward:

- The runtime's three safety invariants still hold. The `-8` / `-4` negative object-header offsets match `runtime/src/memory.rs:165-168`, and `frame_layout` / `safe_point_layouts` are still what the verifier checks at `runtime/src/verifier.rs:95-96`.
- The remaining entry-function blocker is real, with a live `TODO(security, completeness)` at `user_txn/execute.rs:213`; the multi-agent gap is at `execute.rs:218`.
- The `check_gas` bullet was removed only after confirming all four checks exist in `user_txn/pre_execution_checks.rs`.
- `testsuite/`, `specializer/`, `aptos-state-view-providers/`, and the root `AGENTS.md` were verified accurate and left unchanged.

## Key Areas to Review

The judgment call worth a second opinion is dropping the module tables. The argument is that a markdown table duplicating `lib.rs` will always drift, and every stale entry in this PR came from one. If you would rather keep an at-a-glance map of a crate, that is the thing to push back on.

Also worth confirming: the five transaction-executor modules without `//!` docs do carry equivalent item-level docs. I judged that sufficient and added no new doc comments.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): agent instruction files under `third_party/move/mono-move/`

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent instruction files; no runtime or VM code paths affected.
> 
> **Overview**
> **Refreshes mono-move agent instructions** so Claude Code actually loads crate guidance and the text matches the tree.
> 
> All six per-crate **`CLAUDE.md`** files are now a single **`@AGENTS.md`** import instead of headers or “See AGENTS.md” links that the nested loader did not pull in. **`runtime/AGENTS.md`** and **`aptos-transaction-executor/AGENTS.md`** are shortened: module/file tables and duplicated architecture (heap layout, test file lists, stale blockers like missing **`check_gas`**) are removed in favor of safety invariants, coding conventions, working assumptions, and the remaining pre–block-coordinator gaps (entry-function validation, multi-agent coverage). Other **`CLAUDE.md`** stubs drop redundant titles only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e24c43b672328c3290e6e8cf70da2592435f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->