### PR TITLE
[mono-move] More differential tests for MonoMove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "clap 4.5.60",
+ "mono-move-testsuite",
  "move-model",
  "move-package",
  "move-prover",

--- a/aptos-move/cli/src/transactions.rs
+++ b/aptos-move/cli/src/transactions.rs
@@ -46,18 +46,6 @@ fn serialize_as_json<T: Serialize>(value: &T) -> CliTypedResult<serde_json::Valu
     serde_json::to_value(value).map_err(|err| CliError::UnexpectedError(err.to_string()))
 }
 
-#[cfg(test)]
-fn local_events_to_json(
-    state_view: &impl aptos_types::state_store::StateView,
-    events: &[(ContractEvent, Option<MoveTypeLayout>)],
-) -> CliTypedResult<serde_json::Value> {
-    let events = events
-        .iter()
-        .map(|(event, _layout)| event.clone())
-        .collect::<Vec<_>>();
-    local_contract_events_to_json(state_view, &events)
-}
-
 fn local_contract_events_to_json(
     state_view: &impl aptos_types::state_store::StateView,
     events: &[ContractEvent],
@@ -483,7 +471,7 @@ impl TxnOptions {
 
 #[cfg(test)]
 mod tests {
-    use super::{local_events_to_json, local_write_set_to_json, serialize_as_json};
+    use super::{local_contract_events_to_json, local_write_set_to_json, serialize_as_json};
     use aptos_cli_common::TransactionSummary;
     use aptos_crypto::HashValue;
     use aptos_transaction_simulation::EmptyStateView;
@@ -561,7 +549,7 @@ mod tests {
         .unwrap();
 
         let state_view = EmptyStateView;
-        let json = local_events_to_json(&state_view, &[(event, None)]).unwrap();
+        let json = local_contract_events_to_json(&state_view, &[event]).unwrap();
         let first = json.as_array().unwrap().first().unwrap();
         assert!(first.get("guid").is_some());
         assert_eq!(first.get("sequence_number").unwrap().as_str(), Some("7"));

--- a/aptos-move/e2e-move-test-harness-macros/src/lib.rs
+++ b/aptos-move/e2e-move-test-harness-macros/src/lib.rs
@@ -4,7 +4,9 @@
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{parse_macro_input, AttributeArgs, ItemFn, Lit, Meta, NestedMeta, ReturnType};
+use syn::{
+    parse_macro_input, AttributeArgs, FnArg, Ident, ItemFn, Lit, Meta, NestedMeta, Pat, ReturnType,
+};
 
 /// Runs a test twice in the same process: once on the V1 VM, then once with the
 /// MonoMove VM. The MonoMove pass only runs if the V1 pass passed, and its
@@ -17,6 +19,20 @@ use syn::{parse_macro_input, AttributeArgs, ItemFn, Lit, Meta, NestedMeta, Retur
 /// #[test]
 /// fn my_test() { .. }
 /// ```
+///
+/// It also goes above `#[test_case]` or `#[rstest]`, in which case the test
+/// takes arguments and each pass gets its own clone of them:
+///
+/// ```ignore
+/// #[run_mono_move]
+/// #[test_case(true)]
+/// #[test_case(false)]
+/// fn my_test(enabled: bool) { .. }
+/// ```
+///
+/// Placing it *below* `#[test_case]` does not work: that macro strips the
+/// attribute off the original function and re-attaches it under the `#[test]`
+/// it generates.
 ///
 /// A test known to fail under MonoMove can be marked
 /// `#[run_mono_move(should_fail = "why")]`. The reason is documentation; it is
@@ -35,6 +51,10 @@ pub fn run_mono_move(args: TokenStream, item: TokenStream) -> TokenStream {
     if let Err(err) = check_signature(&input) {
         return err;
     }
+    let params = match parameter_names(&input) {
+        Ok(params) => params,
+        Err(err) => return err,
+    };
 
     let ItemFn {
         attrs,
@@ -45,18 +65,25 @@ pub fn run_mono_move(args: TokenStream, item: TokenStream) -> TokenStream {
     } = input;
     let name = &sig.ident;
     let name_str = name.to_string();
+    let inputs = &sig.inputs;
     let should_fail = match should_fail {
         Some(reason) => quote! { ::std::option::Option::Some(#reason) },
         None => quote! { ::std::option::Option::None },
     };
 
-    // The body is hoisted into an item rather than a closure: it captures
-    // nothing, so it is unwind-safe without `AssertUnwindSafe`.
+    // The body is hoisted into an item rather than being inlined into the
+    // closure, so that it cannot capture anything but the parameters. Each pass
+    // gets a fresh clone of those, so the MonoMove pass never sees a mutation
+    // the V1 pass made.
     quote! {
         #(#attrs)*
-        #vis fn #name() {
-            fn body() #block
-            ::aptos_move_e2e_test_harness::mono_move_test::run(#name_str, #should_fail, body);
+        #vis fn #name(#inputs) {
+            fn body(#inputs) #block
+            ::aptos_move_e2e_test_harness::mono_move_test::run(
+                #name_str,
+                #should_fail,
+                &|| body(#(::std::clone::Clone::clone(&#params)),*),
+            );
         }
     }
     .into()
@@ -82,23 +109,45 @@ fn parse_should_fail(args: AttributeArgs) -> Result<Option<String>, TokenStream>
 }
 
 fn check_signature(input: &ItemFn) -> Result<(), TokenStream> {
-    // `#[test]` expands before any attribute placed below it, so this also
-    // catches the two attributes being written the wrong way round.
-    if !input.attrs.iter().any(|attr| attr.path.is_ident("test")) {
-        return Err(error("`#[run_mono_move]` must be placed above `#[test]`"));
-    }
     let sig = &input.sig;
+    // `#[test]` expands before any attribute placed below it, so its absence on
+    // a test taking no arguments means the two were written the wrong way
+    // round. Arguments instead mean a `#[test_case]`/`#[rstest]` harness, which
+    // supplies the `#[test]` on the functions it generates.
+    if sig.inputs.is_empty() && !input.attrs.iter().any(|attr| attr.path.is_ident("test")) {
+        return Err(error(
+            "`#[run_mono_move]` must be placed above `#[test]`, `#[test_case]` or `#[rstest]`",
+        ));
+    }
     if sig.asyncness.is_some()
-        || !sig.inputs.is_empty()
         || !sig.generics.params.is_empty()
         || !matches!(sig.output, ReturnType::Default)
     {
         return Err(error(
-            "`#[run_mono_move]` only supports a plain test: no arguments, \
-             no generics, not async, returning `()`",
+            "`#[run_mono_move]` only supports a plain test: no generics, not \
+             async, returning `()`",
         ));
     }
     Ok(())
+}
+
+/// The parameter names, which must all be plain identifiers so that the
+/// generated closure can pass a clone of each one through to the body.
+fn parameter_names(input: &ItemFn) -> Result<Vec<Ident>, TokenStream> {
+    input
+        .sig
+        .inputs
+        .iter()
+        .map(|arg| match arg {
+            FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
+                Pat::Ident(pat_ident) if pat_ident.subpat.is_none() => Ok(pat_ident.ident.clone()),
+                _ => Err(error(
+                    "`#[run_mono_move]` requires every test parameter to be a plain identifier",
+                )),
+            },
+            FnArg::Receiver(_) => Err(error("`#[run_mono_move]` cannot be used on a method")),
+        })
+        .collect()
 }
 
 fn error(msg: &str) -> TokenStream {

--- a/aptos-move/e2e-move-test-harness/src/mono_move_test.rs
+++ b/aptos-move/e2e-move-test-harness/src/mono_move_test.rs
@@ -4,7 +4,7 @@
 //! Runs a `#[run_mono_move]` test body twice, once per VM. Not meant to be
 //! called directly; see the macro's documentation.
 
-use std::{any::Any, cell::Cell, panic};
+use std::{any::Any, cell::Cell, panic, thread};
 
 thread_local! {
     /// Whether harnesses built on this thread should enable `ENABLE_MONO_MOVE`.
@@ -29,17 +29,8 @@ fn set_mono_move(enabled: bool) {
 ///
 /// `should_fail` marks a test known to fail under MonoMove; its reason is
 /// documentation and is never matched against the failure.
-pub fn run(name: &str, should_fail: Option<&str>, body: fn()) {
-    // The V1 pass is not caught: a failure here is an ordinary test failure and
-    // must look exactly like one.
-    set_mono_move(false);
-    body();
-
-    set_mono_move(true);
-    let result = panic::catch_unwind(body);
-    set_mono_move(false);
-
-    match (result, should_fail) {
+pub fn run(name: &str, should_fail: Option<&str>, body: &dyn Fn()) {
+    match (run_both_passes(body), should_fail) {
         (Ok(()), None) | (Err(_), Some(_)) => {},
         (Ok(()), Some(reason)) => panic!(
             "[MonoMove] `{name}` passed under MonoMove but is marked \
@@ -50,6 +41,42 @@ pub fn run(name: &str, should_fail: Option<&str>, body: fn()) {
             panic_message(payload.as_ref())
         ),
     }
+}
+
+/// Runs `body` on the V1 VM, and then, if that passed, on MonoMove.
+///
+/// For test bodies `#[run_mono_move]` cannot reach, above all those inside
+/// `proptest!`, which is a function-like macro with nowhere to hang an
+/// attribute. Two rules apply at every call site:
+///
+/// * Build the harness *inside* `body`. A harness built before the call runs
+///   the V1 VM in both passes and checks nothing.
+/// * Signal failure by panicking. `prop_assert!` returns an error instead,
+///   which the MonoMove pass would discard.
+#[track_caller]
+pub fn both(body: impl Fn()) {
+    let location = panic::Location::caller();
+    if let Err(payload) = run_both_passes(&body) {
+        panic!(
+            "[MonoMove] the body at {location} passed on the V1 VM but failed \
+             under MonoMove: {}",
+            panic_message(payload.as_ref())
+        );
+    }
+}
+
+fn run_both_passes(body: &dyn Fn()) -> thread::Result<()> {
+    // The V1 pass is not caught: a failure here is an ordinary test failure and
+    // must look exactly like one.
+    set_mono_move(false);
+    body();
+
+    set_mono_move(true);
+    // `body` may capture the test's arguments by reference, but it only reads
+    // and clones them, and a caught panic is always re-raised below.
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(body));
+    set_mono_move(false);
+    result
 }
 
 fn panic_message(payload: &dyn Any) -> String {

--- a/aptos-move/e2e-move-tests/src/tests/account.rs
+++ b/aptos-move/e2e-move-tests/src/tests/account.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, MoveHarness};
+use crate::{assert_success, run_mono_move, MoveHarness};
 use aptos_cached_packages::aptos_stdlib::aptos_account_transfer;
 use aptos_language_e2e_tests::account::Account;
 
+#[run_mono_move]
 #[test]
 fn non_existent_sender() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
@@ -6,6 +6,7 @@ use crate::{
         initialize, initialize_enabled_disabled_comparison, AggV2TestHarness, AggregatorLocation,
         ElementType, StructType, UseType,
     },
+    mono_move_test, run_mono_move,
     tests::common,
     BlockSplit, SUCCESS,
 };
@@ -73,6 +74,7 @@ pub(crate) fn setup_allow_fallback(
 mod test_cases {
     use super::*;
 
+    #[run_mono_move(should_fail = "the 0x1::debug natives are not implemented in MonoMove")]
     #[test]
     fn test_snapshot_concat() {
         let mut h = setup(DEFAULT_EXECUTOR_MODE, AggregatorMode::BothComparison, 1);
@@ -80,6 +82,7 @@ mod test_cases {
         h.run_block_in_parts_and_check(BlockSplit::Whole, vec![(SUCCESS, txn)]);
     }
 
+    #[run_mono_move]
     #[test]
     fn test_aggregators_e2e() {
         println!("Testing test_aggregators_e2e");
@@ -251,41 +254,43 @@ fn arb_droppable_use_type() -> BoxedStrategy<UseType> {
 
 proptest! {
     #![proptest_config(ProptestConfig {
-        // Cases are expensive, few cases is enough.
-        // We will test a few more comprehensive tests more times, and the rest even fewer.
-        cases: if STRESSTEST_MODE { 1000 } else { 20 },
+        // Cases are expensive, few cases is enough. Halved from 20 because
+        // every case now runs its block twice, once per VM.
+        cases: if STRESSTEST_MODE { 1000 } else { 10 },
         result_cache: if STRESSTEST_MODE { prop::test_runner::noop_result_cache } else {prop::test_runner::basic_result_cache },
         .. ProptestConfig::default()
     })]
 
     #[test]
     fn test_aggregator_lifetime(test_env in arb_test_env(14), element_type in arb_agg_type(), use_type in arb_use_type()) {
-        println!("Testing test_aggregator_lifetime {:?}", test_env);
-        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 14);
+        mono_move_test::both(|| {
+            println!("Testing test_aggregator_lifetime {:?}", test_env);
+            let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 14);
 
-        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new(&agg_loc, 1500)),
-            (SUCCESS, h.add(&agg_loc, 400)), // 400
-            (SUCCESS, h.materialize(&agg_loc)),
-            (SUCCESS, h.add(&agg_loc, 500)), // 900
-            (SUCCESS, h.check(&agg_loc, 900)),
-            (SUCCESS, h.materialize_and_add(&agg_loc, 600)), // 1500
-            (SUCCESS, h.materialize_and_sub(&agg_loc, 600)), // 900
-            (SUCCESS, h.check(&agg_loc, 900)),
-            (SUCCESS, h.sub_add(&agg_loc, 200, 300)), // 1000
-            (SUCCESS, h.check(&agg_loc, 1000)),
-            // These 2 transactions fail, and should have no side-effects.
-            (EAGGREGATOR_OVERFLOW, h.add_and_materialize(&agg_loc, 501)),
-            (EAGGREGATOR_UNDERFLOW, h.sub_and_materialize(&agg_loc, 1001)),
-            (SUCCESS, h.check(&agg_loc, 1000)),
-        ];
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new(&agg_loc, 1500)),
+                (SUCCESS, h.add(&agg_loc, 400)), // 400
+                (SUCCESS, h.materialize(&agg_loc)),
+                (SUCCESS, h.add(&agg_loc, 500)), // 900
+                (SUCCESS, h.check(&agg_loc, 900)),
+                (SUCCESS, h.materialize_and_add(&agg_loc, 600)), // 1500
+                (SUCCESS, h.materialize_and_sub(&agg_loc, 600)), // 900
+                (SUCCESS, h.check(&agg_loc, 900)),
+                (SUCCESS, h.sub_add(&agg_loc, 200, 300)), // 1000
+                (SUCCESS, h.check(&agg_loc, 1000)),
+                // These 2 transactions fail, and should have no side-effects.
+                (EAGGREGATOR_OVERFLOW, h.add_and_materialize(&agg_loc, 501)),
+                (EAGGREGATOR_UNDERFLOW, h.sub_and_materialize(&agg_loc, 1001)),
+                (SUCCESS, h.check(&agg_loc, 1000)),
+            ];
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 
     #[test]
@@ -296,55 +301,57 @@ proptest! {
         is_2_collocated in any::<bool>(),
         is_3_collocated in any::<bool>(),
     ) {
-        println!("Testing test_multiple_aggregators_and_collocation {:?}", test_env);
-        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 24);
-        let acc_2 = h.new_account_with_key_pair();
-        let acc_3 = h.new_account_with_key_pair();
+        mono_move_test::both(|| {
+            println!("Testing test_multiple_aggregators_and_collocation {:?}", test_env);
+            let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 24);
+            let acc_2 = h.new_account_with_key_pair();
+            let acc_3 = h.new_account_with_key_pair();
 
-        let mut idx_1 = 0;
-        let agg_1_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
-        let agg_2_loc = {
-            let (cur_acc, idx_2) = if is_2_collocated { idx_1 += 1; (h.account.address(), idx_1) } else { (acc_2.address(), 0)};
-            AggregatorLocation::new(*cur_acc, element_type, use_type, idx_2)
-        };
-        let agg_3_loc = {
-            let (cur_acc, idx_3) = if is_3_collocated { idx_1 += 1; (h.account.address(), idx_1) } else { (acc_3.address(), 0)};
-            AggregatorLocation::new(*cur_acc, element_type, use_type, idx_3)
-        };
-        println!("agg_1_loc: {:?}", agg_1_loc);
-        println!("agg_2_loc: {:?}", agg_2_loc);
-        println!("agg_3_loc: {:?}", agg_3_loc);
+            let mut idx_1 = 0;
+            let agg_1_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let agg_2_loc = {
+                let (cur_acc, idx_2) = if is_2_collocated { idx_1 += 1; (h.account.address(), idx_1) } else { (acc_2.address(), 0)};
+                AggregatorLocation::new(*cur_acc, element_type, use_type, idx_2)
+            };
+            let agg_3_loc = {
+                let (cur_acc, idx_3) = if is_3_collocated { idx_1 += 1; (h.account.address(), idx_1) } else { (acc_3.address(), 0)};
+                AggregatorLocation::new(*cur_acc, element_type, use_type, idx_3)
+            };
+            println!("agg_1_loc: {:?}", agg_1_loc);
+            println!("agg_2_loc: {:?}", agg_2_loc);
+            println!("agg_3_loc: {:?}", agg_3_loc);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.init(Some(&acc_2), use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.init(Some(&acc_3), use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new_add(&agg_1_loc, 10, 5)),
-            (SUCCESS, h.new_add(&agg_2_loc, 10, 5)),
-            (SUCCESS, h.new_add(&agg_3_loc, 10, 5)),  // 5, 5, 5
-            (SUCCESS, h.add_2(&agg_1_loc, &agg_2_loc, 1, 1)), // 6, 6, 5
-            (SUCCESS, h.add_2(&agg_1_loc, &agg_3_loc, 1, 1)), // 7, 6, 6
-            (EAGGREGATOR_OVERFLOW, h.add(&agg_1_loc, 5)), // X
-            (SUCCESS, h.add_sub(&agg_1_loc, 3, 3)), // 7, 6, 6
-            (EAGGREGATOR_OVERFLOW, h.add_2(&agg_1_loc, &agg_2_loc, 3, 5)), // X
-            (SUCCESS, h.add_2(&agg_1_loc, &agg_2_loc, 3, 1)), // 10, 7, 6
-            (EAGGREGATOR_OVERFLOW, h.add_sub(&agg_1_loc, 3, 3)), // X
-            (SUCCESS, h.sub(&agg_1_loc, 3)), // 7, 7, 6
-            (SUCCESS, h.add_2(&agg_2_loc, &agg_3_loc, 2, 2)), // 7, 9, 8
-            (SUCCESS, h.check(&agg_2_loc, 9)),
-            (EAGGREGATOR_OVERFLOW, h.add_2(&agg_1_loc, &agg_2_loc, 1, 2)), // X
-            (SUCCESS, h.add_2(&agg_2_loc, &agg_3_loc, 1, 2)), // 7, 10, 10
-            (EAGGREGATOR_OVERFLOW, h.add(&agg_2_loc, 1)), // X
-            (EAGGREGATOR_OVERFLOW, h.add_and_materialize(&agg_3_loc, 1)), // X
-            (EAGGREGATOR_OVERFLOW, h.add_2(&agg_1_loc, &agg_2_loc, 1, 1)), // X
-            (SUCCESS, h.check(&agg_1_loc, 7)),
-            (SUCCESS, h.check(&agg_2_loc, 10)),
-            (SUCCESS, h.check(&agg_3_loc, 10)),
-        ];
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.init(Some(&acc_2), use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.init(Some(&acc_3), use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new_add(&agg_1_loc, 10, 5)),
+                (SUCCESS, h.new_add(&agg_2_loc, 10, 5)),
+                (SUCCESS, h.new_add(&agg_3_loc, 10, 5)),  // 5, 5, 5
+                (SUCCESS, h.add_2(&agg_1_loc, &agg_2_loc, 1, 1)), // 6, 6, 5
+                (SUCCESS, h.add_2(&agg_1_loc, &agg_3_loc, 1, 1)), // 7, 6, 6
+                (EAGGREGATOR_OVERFLOW, h.add(&agg_1_loc, 5)), // X
+                (SUCCESS, h.add_sub(&agg_1_loc, 3, 3)), // 7, 6, 6
+                (EAGGREGATOR_OVERFLOW, h.add_2(&agg_1_loc, &agg_2_loc, 3, 5)), // X
+                (SUCCESS, h.add_2(&agg_1_loc, &agg_2_loc, 3, 1)), // 10, 7, 6
+                (EAGGREGATOR_OVERFLOW, h.add_sub(&agg_1_loc, 3, 3)), // X
+                (SUCCESS, h.sub(&agg_1_loc, 3)), // 7, 7, 6
+                (SUCCESS, h.add_2(&agg_2_loc, &agg_3_loc, 2, 2)), // 7, 9, 8
+                (SUCCESS, h.check(&agg_2_loc, 9)),
+                (EAGGREGATOR_OVERFLOW, h.add_2(&agg_1_loc, &agg_2_loc, 1, 2)), // X
+                (SUCCESS, h.add_2(&agg_2_loc, &agg_3_loc, 1, 2)), // 7, 10, 10
+                (EAGGREGATOR_OVERFLOW, h.add(&agg_2_loc, 1)), // X
+                (EAGGREGATOR_OVERFLOW, h.add_and_materialize(&agg_3_loc, 1)), // X
+                (EAGGREGATOR_OVERFLOW, h.add_2(&agg_1_loc, &agg_2_loc, 1, 1)), // X
+                (SUCCESS, h.check(&agg_1_loc, 7)),
+                (SUCCESS, h.check(&agg_2_loc, 10)),
+                (SUCCESS, h.check(&agg_3_loc, 10)),
+            ];
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 }
 
@@ -359,98 +366,108 @@ proptest! {
 
     #[test]
     fn test_aggregator_underflow(test_env in arb_test_env(4)) {
-        println!("Testing test_aggregator_underflow {:?}", test_env);
-        let element_type = ElementType::U64;
-        let use_type = UseType::UseResourceType;
+        mono_move_test::both(|| {
+            println!("Testing test_aggregator_underflow {:?}", test_env);
+            let element_type = ElementType::U64;
+            let use_type = UseType::UseResourceType;
 
-        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 4);
+            let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 4);
 
-        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new(&agg_loc, 600)),
-            (SUCCESS, h.add(&agg_loc, 400)),
-            // Value dropped below zero - abort with EAGGREGATOR_UNDERFLOW.
-            (EAGGREGATOR_UNDERFLOW, h.sub(&agg_loc, 500))
-        ];
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new(&agg_loc, 600)),
+                (SUCCESS, h.add(&agg_loc, 400)),
+                // Value dropped below zero - abort with EAGGREGATOR_UNDERFLOW.
+                (EAGGREGATOR_UNDERFLOW, h.sub(&agg_loc, 500))
+            ];
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 
     #[test]
     fn test_aggregator_materialize_underflow(test_env in arb_test_env(3)) {
-        println!("Testing test_aggregator_materialize_underflow {:?}", test_env);
-        let element_type = ElementType::U64;
-        let use_type = UseType::UseResourceType;
+        mono_move_test::both(|| {
+            println!("Testing test_aggregator_materialize_underflow {:?}", test_env);
+            let element_type = ElementType::U64;
+            let use_type = UseType::UseResourceType;
 
-        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 3);
+            let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 3);
 
-        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new(&agg_loc, 600)),
-            // Underflow on materialized value leads to abort with EAGGREGATOR_UNDERFLOW.
-            (EAGGREGATOR_UNDERFLOW, h.materialize_and_sub(&agg_loc, 400)),
-        ];
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new(&agg_loc, 600)),
+                // Underflow on materialized value leads to abort with EAGGREGATOR_UNDERFLOW.
+                (EAGGREGATOR_UNDERFLOW, h.materialize_and_sub(&agg_loc, 400)),
+            ];
 
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 
     #[test]
     fn test_aggregator_overflow(test_env in arb_test_env(3)) {
-        println!("Testing test_aggregator_overflow {:?}", test_env);
-        let element_type = ElementType::U64;
-        let use_type = UseType::UseResourceType;
+        mono_move_test::both(|| {
+            println!("Testing test_aggregator_overflow {:?}", test_env);
+            let element_type = ElementType::U64;
+            let use_type = UseType::UseResourceType;
 
-        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 3);
+            let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 3);
 
-        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new_add(&agg_loc, 600, 400)),
-            // Limit exceeded - abort with EAGGREGATOR_OVERFLOW.
-            (EAGGREGATOR_OVERFLOW, h.add(&agg_loc, 201))
-        ];
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new_add(&agg_loc, 600, 400)),
+                // Limit exceeded - abort with EAGGREGATOR_OVERFLOW.
+                (EAGGREGATOR_OVERFLOW, h.add(&agg_loc, 201))
+            ];
 
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 
     #[test]
     fn test_aggregator_materialize_overflow(test_env in arb_test_env(3)) {
-        println!("Testing test_aggregator_materialize_overflow {:?}", test_env);
-        let element_type = ElementType::U64;
-        let use_type = UseType::UseResourceType;
+        mono_move_test::both(|| {
+            println!("Testing test_aggregator_materialize_overflow {:?}", test_env);
+            let element_type = ElementType::U64;
+            let use_type = UseType::UseResourceType;
 
-        let mut h= setup(test_env.executor_mode, test_env.aggregator_execution_mode, 3);
+            let mut h= setup(test_env.executor_mode, test_env.aggregator_execution_mode, 3);
 
-        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new(&agg_loc, 399)),
-            // Overflow on materialized value leads to abort with EAGGREGATOR_OVERFLOW.
-            (EAGGREGATOR_OVERFLOW, h.materialize_and_add(&agg_loc, 400)),
-        ];
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new(&agg_loc, 399)),
+                // Overflow on materialized value leads to abort with EAGGREGATOR_OVERFLOW.
+                (EAGGREGATOR_OVERFLOW, h.materialize_and_add(&agg_loc, 400)),
+            ];
 
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 
     #[test]
     fn test_aggregator_with_republish(test_env in arb_test_env(6), element_type in arb_agg_type(), use_type in arb_use_type()) {
+        // Not run under MonoMove: it cannot publish a module inside a block,
+        // so `republish` fails with a linker error.
         println!("Testing test_aggregator_with_republish {:?}", test_env);
         let mut h = setup_allow_fallback(test_env.executor_mode, test_env.aggregator_execution_mode, 3);
 
@@ -473,91 +490,97 @@ proptest! {
 
     #[test]
     fn test_aggregator_recreate(test_env in arb_test_env(13), element_type in arb_agg_type(), use_type in arb_droppable_use_type()) {
-        println!("Testing test_aggregator_recreate {:?}", test_env);
-        let mut h = setup_allow_fallback(test_env.executor_mode, test_env.aggregator_execution_mode, 13);
+        mono_move_test::both(|| {
+            println!("Testing test_aggregator_recreate {:?}", test_env);
+            let mut h = setup_allow_fallback(test_env.executor_mode, test_env.aggregator_execution_mode, 13);
 
-        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new_add(&agg_loc, 10, 3)),
-            (SUCCESS, h.add(&agg_loc, 4)),
-            (SUCCESS, h.new_add(&agg_loc, 10, 3)),
-            (SUCCESS, h.add(&agg_loc, 4)),
-            (SUCCESS, h.delete(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new_add(&agg_loc, 10, 3)),
-            (SUCCESS, h.add_delete(&agg_loc, 4)),
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.new_add(&agg_loc, 10, 5)),
-            (EAGGREGATOR_OVERFLOW, h.add_delete(&agg_loc, 7)),
-            (SUCCESS, h.add_delete(&agg_loc, 3)),
-        ];
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new_add(&agg_loc, 10, 3)),
+                (SUCCESS, h.add(&agg_loc, 4)),
+                (SUCCESS, h.new_add(&agg_loc, 10, 3)),
+                (SUCCESS, h.add(&agg_loc, 4)),
+                (SUCCESS, h.delete(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new_add(&agg_loc, 10, 3)),
+                (SUCCESS, h.add_delete(&agg_loc, 4)),
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.new_add(&agg_loc, 10, 5)),
+                (EAGGREGATOR_OVERFLOW, h.add_delete(&agg_loc, 7)),
+                (SUCCESS, h.add_delete(&agg_loc, 3)),
+            ];
 
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 
     #[test]
     fn test_aggregator_snapshot(test_env in arb_test_env_non_equivalent(10)) {
-        println!("Testing test_aggregator_snapshot {:?}", test_env);
-        let element_type = ElementType::U64;
-        let use_type = UseType::UseResourceType;
+        mono_move_test::both(|| {
+            println!("Testing test_aggregator_snapshot {:?}", test_env);
+            let element_type = ElementType::U64;
+            let use_type = UseType::UseResourceType;
 
-        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 10);
+            let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 10);
 
-        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
-        let snap_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
-        let derived_snap_loc = AggregatorLocation::new(*h.account.address(), ElementType::String, use_type, 0);
+            let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let snap_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let derived_snap_loc = AggregatorLocation::new(*h.account.address(), ElementType::String, use_type, 0);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Snapshot)),
-            (SUCCESS, h.init(None, use_type, ElementType::String, StructType::DerivedString)),
-            (SUCCESS, h.new_add(&agg_loc, 400, 100)),
-            (SUCCESS, h.snapshot(&agg_loc, &snap_loc)),
-            (SUCCESS, h.check_snapshot(&snap_loc, 100)),
-            (SUCCESS, h.read_snapshot(&agg_loc)),
-            (SUCCESS, h.add_and_read_snapshot_u128(&agg_loc, 100)),
-            (SUCCESS, h.concat(&snap_loc, &derived_snap_loc, "12", "13")),
-            (SUCCESS, h.check_derived(&derived_snap_loc, 1210013)),
-        ];
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Snapshot)),
+                (SUCCESS, h.init(None, use_type, ElementType::String, StructType::DerivedString)),
+                (SUCCESS, h.new_add(&agg_loc, 400, 100)),
+                (SUCCESS, h.snapshot(&agg_loc, &snap_loc)),
+                (SUCCESS, h.check_snapshot(&snap_loc, 100)),
+                (SUCCESS, h.read_snapshot(&agg_loc)),
+                (SUCCESS, h.add_and_read_snapshot_u128(&agg_loc, 100)),
+                (SUCCESS, h.concat(&snap_loc, &derived_snap_loc, "12", "13")),
+                (SUCCESS, h.check_derived(&derived_snap_loc, 1210013)),
+            ];
 
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 
     #[test]
     fn test_aggregator_is_at_least(test_env in arb_test_env_non_equivalent(10)) {
-        println!("Testing test_aggregator_is_at_least {:?}", test_env);
-        let element_type = ElementType::U64;
-        let use_type = UseType::UseResourceType;
+        mono_move_test::both(|| {
+            println!("Testing test_aggregator_is_at_least {:?}", test_env);
+            let element_type = ElementType::U64;
+            let use_type = UseType::UseResourceType;
 
-        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 10);
+            let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_mode, 10);
 
-        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+            let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
-        let txns = vec![
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
-            (SUCCESS, h.init(None, use_type, element_type, StructType::Snapshot)),
-            (SUCCESS, h.init(None, use_type, ElementType::String, StructType::DerivedString)),
-            (SUCCESS, h.new_add(&agg_loc, 400, 100)),
-            (SUCCESS, h.add(&agg_loc, 50)),
-            (SUCCESS, h.add(&agg_loc, 50)),
-            (SUCCESS, h.add_if_at_least(&agg_loc, 180, 50)),
-            (SUCCESS, h.sub(&agg_loc, 50)),
-            (SUCCESS, h.add_if_at_least(&agg_loc, 220, 50)),
-            (SUCCESS, h.check(&agg_loc, 200)),
-        ];
+            let txns = vec![
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Aggregator)),
+                (SUCCESS, h.init(None, use_type, element_type, StructType::Snapshot)),
+                (SUCCESS, h.init(None, use_type, ElementType::String, StructType::DerivedString)),
+                (SUCCESS, h.new_add(&agg_loc, 400, 100)),
+                (SUCCESS, h.add(&agg_loc, 50)),
+                (SUCCESS, h.add(&agg_loc, 50)),
+                (SUCCESS, h.add_if_at_least(&agg_loc, 180, 50)),
+                (SUCCESS, h.sub(&agg_loc, 50)),
+                (SUCCESS, h.add_if_at_least(&agg_loc, 220, 50)),
+                (SUCCESS, h.check(&agg_loc, 200)),
+            ];
 
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 }
 
@@ -620,6 +643,9 @@ fn test_aggregator_snapshot_equivalent_gas() {
 }
 
 // Table splits into multiple resources, so test is not as straightforward
+#[run_mono_move(
+    should_fail = "MonoMove does not create delayed fields, so the per-resource limit is never reached"
+)]
 #[test_case(UseType::UseResourceGroupType)]
 #[test_case(UseType::UseResourceType)]
 fn test_too_many_aggregators_in_a_resource(use_type: UseType) {

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2_enums.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2_enums.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     aggregator_v2::AggV2TestHarness,
+    run_mono_move,
     tests::{aggregator_v2::AggregatorMode, common},
 };
 use aptos_framework::BuildOptions;
@@ -31,6 +32,9 @@ enum Counter {
     Integer(Integer),
 }
 
+#[run_mono_move(
+    should_fail = "MonoMove cannot publish a module inside a block, and this test publishes through `run_block` rather than the harness publish helper"
+)]
 #[test]
 fn test_aggregators_in_enums() {
     let mut h = make_harness(155);

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2_events.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2_events.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     aggregator_v2::AggV2TestHarness,
+    run_mono_move,
     tests::aggregator_v2::{AggregatorMode, EAGGREGATOR_OVERFLOW},
     BlockSplit, SUCCESS,
 };
@@ -152,6 +153,7 @@ macro_rules! increment_counter_emit_event {
     };
 }
 
+#[run_mono_move]
 #[test]
 fn test_events_with_snapshots() {
     for event_version in [1, 2] {

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2_function_values.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2_function_values.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, assert_vm_status, tests::common, MoveHarness};
+use crate::{assert_success, assert_vm_status, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use aptos_language_e2e_tests::executor::FakeExecutor;
 use aptos_transaction_simulation::Account;
@@ -38,6 +38,7 @@ fn initialize(h: &mut MoveHarness) {
     assert_success!(status);
 }
 
+#[run_mono_move]
 #[test]
 fn test_function_value_is_applied_to_aggregator() {
     let mut h = MoveHarness::new_with_executor(FakeExecutor::from_head_genesis().set_parallel());
@@ -79,6 +80,7 @@ fn test_function_value_is_applied_to_aggregator() {
     assert_counter_value_eq(&h, &acc, value);
 }
 
+#[run_mono_move(should_fail = "MonoMove cannot serialize function values into the write set")]
 #[test]
 fn test_function_value_captures_aggregator_is_not_storable() {
     let mut h = MoveHarness::new_with_executor(FakeExecutor::from_head_genesis().set_parallel());
@@ -111,6 +113,7 @@ fn test_function_value_captures_aggregator_is_not_storable() {
     assert!(!exists);
 }
 
+#[run_mono_move(should_fail = "MonoMove cannot serialize function values into the write set")]
 #[test]
 fn test_function_value_uses_aggregator_is_storable() {
     let mut h = MoveHarness::new_with_executor(FakeExecutor::from_head_genesis().set_parallel());
@@ -134,6 +137,9 @@ fn test_function_value_uses_aggregator_is_storable() {
     assert_success!(status);
 }
 
+#[run_mono_move(
+    should_fail = "MonoMove does not create delayed fields, so capturing one cannot fail"
+)]
 #[test]
 fn test_function_value_captures_aggregator() {
     let mut h = MoveHarness::new_with_executor(FakeExecutor::from_head_genesis());

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2_runtime_checks.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2_runtime_checks.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_language_e2e_tests::account::Account;
 use aptos_types::{
     on_chain_config::FeatureFlag,
@@ -139,6 +139,9 @@ fn test_string_utils(h: &mut MoveHarness, acc: &Account) {
     });
 }
 
+#[run_mono_move(
+    should_fail = "MonoMove does not create delayed fields, so the runtime checks never fire"
+)]
 #[test]
 fn run_all_tests() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/any.rs
+++ b/aptos-move/e2e-move-tests/src/tests/any.rs
@@ -1,10 +1,13 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_abort, assert_success, tests::common, MoveHarness};
+use crate::{assert_abort, assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use move_core_types::account_address::AccountAddress;
 
+#[run_mono_move(
+    should_fail = "MonoMove cannot BCS-serialize a function value, so `any::pack` fails before the type name is ever compared"
+)]
 #[test]
 fn test_any_with_function_values() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.rs
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_language_e2e_tests::account::Account;
 use move_core_types::{account_address::AccountAddress, parser::parse_struct_tag};
 use serde::{Deserialize, Serialize};
@@ -61,6 +61,7 @@ fn setup(harness: &mut MoveHarness) -> Account {
     account
 }
 
+#[run_mono_move]
 #[test]
 fn test_chain_id_from_aptos_framework() {
     let mut harness = MoveHarness::new();
@@ -72,6 +73,7 @@ fn test_chain_id_from_aptos_framework() {
     );
 }
 
+#[run_mono_move]
 #[test]
 fn test_chain_id_from_type_info() {
     let mut harness = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/constructor_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/constructor_args.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_types::{
     account_address::AccountAddress,
@@ -132,6 +132,7 @@ fn fail_generic(ty_args: Vec<TypeTag>, tests: Vec<(&str, Vec<Vec<u8>>, Closure)>
     }
 }
 
+#[run_mono_move]
 #[test]
 fn constructor_args_good() {
     let tests = vec![
@@ -204,6 +205,7 @@ fn constructor_args_good() {
     success(&mut h, tests);
 }
 
+#[run_mono_move]
 #[test]
 fn view_constructor_args() {
     let tests = vec![
@@ -251,6 +253,7 @@ fn constructor_args_option_private_struct_compiles() {
     );
 }
 
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn constructor_args_bad_runtime() {
     let good: &[u8] = "a".as_bytes();

--- a/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.rs
+++ b/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_types::{
     account_address::AccountAddress,
     transaction::{ExecutionStatus, TransactionStatus},
@@ -19,6 +19,7 @@ fn crypto_algebra_type_tag_limit_exceeded(harness: &mut MoveHarness) -> Transact
     )
 }
 
+#[run_mono_move(should_fail = "crypto_algebra natives are not implemented in MonoMove")]
 #[test]
 fn crypto_algebra_type_tag_limit_exceeded_handled() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/error_map.rs
+++ b/aptos-move/e2e-move-tests/src/tests/error_map.rs
@@ -3,7 +3,7 @@
 
 extern crate core;
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use aptos_types::{
     account_address::AccountAddress,
@@ -11,6 +11,7 @@ use aptos_types::{
 };
 use move_core_types::value::MoveValue;
 
+#[run_mono_move(should_fail = "MonoMove does not inject AbortInfo from the module error map")]
 #[test]
 fn error_map() {
     let mut h = MoveHarness::new();
@@ -54,6 +55,7 @@ fn error_map() {
 
 /// Tests that a single-argument `assert!` — which aborts with `UNSPECIFIED_ABORT_CODE` — does not
 /// incorrectly return abort info for a user-defined error constant that happens to have code 0.
+#[run_mono_move(should_fail = "MonoMove does not inject AbortInfo from the module error map")]
 #[test]
 fn error_map_unspecified_abort_code() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/function_caches.rs
+++ b/aptos-move/e2e-move-tests/src/tests/function_caches.rs
@@ -4,13 +4,14 @@
 //! Tests that interpreter caches frees all allocated data structures for recursively called
 //! functions.
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use aptos_package_builder::PackageBuilder;
 use aptos_transaction_simulation::Account;
 use aptos_types::transaction::TransactionStatus;
 use move_core_types::account_address::AccountAddress;
 
+#[run_mono_move]
 #[test]
 fn test_function_caches_for_recursive_functions_do_not_leak_memory() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
@@ -179,6 +179,7 @@ fn test_basic_fungible_token() {
 /// We do that by having an expensive transaction first (to make sure committed index isn't moved),
 /// and then create some new aggregators (concurrent balances for new accounts), and then have them issue
 /// transactions - so their balance is checked in prologue.
+#[run_mono_move]
 #[test]
 fn test_prologue_speculation() {
     let executor = FakeExecutor::from_head_genesis().set_executor_mode(ExecutorMode::ParallelOnly);

--- a/aptos-move/e2e-move-tests/src/tests/generic_cmp.rs
+++ b/aptos-move/e2e-move-tests/src/tests/generic_cmp.rs
@@ -4,11 +4,12 @@
 //! Transactional tests for comparison operations, Lt/Le/Ge/Gt, over non-integer types,
 //! introduced in Move language version 2.2 and onwards.
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_language_e2e_tests::account::TransactionBuilder;
 use aptos_types::{account_address::AccountAddress, transaction::Script};
 
+#[run_mono_move(should_fail = "MonoMove does not implement cmp::compare on function values")]
 #[test]
 fn function_generic_cmp() {
     let mut h = MoveHarness::new();
@@ -121,6 +122,7 @@ fn function_generic_cmp() {
 }
 
 /// Special case of comparing two signers
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn function_signer_cmp() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/macros.rs
+++ b/aptos-move/e2e-move-tests/src/tests/macros.rs
@@ -4,13 +4,14 @@
 //! Transactional tests for macros like `assert!`, `assert_eq!`, and `assert_ne!`
 //! introduced in Move language version 2.4 and onwards.
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use aptos_types::{
     account_address::AccountAddress,
     transaction::{ExecutionStatus, TransactionStatus},
 };
 
+#[run_mono_move(should_fail = "MonoMove does not implement the string_utils::native_format_list native")]
 #[test]
 fn test_macros() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519Signature},
     SigningKey, ValidCryptoMaterialStringExt,
@@ -48,6 +48,7 @@ struct TokenStore {
     mutate_token_property_events: EventHandle,
 }
 
+#[run_mono_move]
 #[test]
 fn mint_nft_e2e() {
     let mut h = MoveHarness::new();
@@ -77,14 +78,16 @@ fn mint_nft_e2e() {
         .expect("extracting package metadata must succeed");
 
     // create the resource account and publish the module under the resource account's address
-    let result = h.run_transaction_payload(
-        &acc,
-        aptos_cached_packages::aptos_stdlib::resource_account_create_resource_account_and_publish_package(
-            vec![],
-            bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
-            code,
-        ),
-    );
+    let result = h.without_mono_move(|h| {
+        h.run_transaction_payload(
+            &acc,
+            aptos_cached_packages::aptos_stdlib::resource_account_create_resource_account_and_publish_package(
+                vec![],
+                bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
+                code,
+            ),
+        )
+    });
 
     assert_success!(result);
 

--- a/aptos-move/e2e-move-tests/src/tests/module_event.rs
+++ b/aptos-move/e2e-move-tests/src/tests/module_event.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, assert_vm_status, tests::common, MoveHarness};
+use crate::{assert_success, assert_vm_status, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_package_builder::PackageBuilder;
 use aptos_types::{
@@ -25,6 +25,7 @@ struct MyEvent {
     bytes: Vec<u64>,
 }
 
+#[run_mono_move]
 #[test]
 fn test_module_event_enabled() {
     let mut h = MoveHarness::new_with_features(vec![FeatureFlag::MODULE_EVENT], vec![]);
@@ -122,6 +123,7 @@ fn verify_module_event_upgrades() {
     assert_vm_status!(result, StatusCode::EVENT_METADATA_VALIDATION_ERROR);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn test_event_emission_not_allowed_in_scripts() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/new_integer_types.rs
+++ b/aptos-move/e2e-move-tests/src/tests/new_integer_types.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, MoveHarness};
+use crate::{assert_success, run_mono_move, MoveHarness};
 use aptos_package_builder::PackageBuilder;
 use aptos_types::account_address::AccountAddress;
 use move_core_types::{int256::U256, value::MoveValue};
 
+#[run_mono_move]
 #[test]
 fn use_new_integer_types() {
     let mut h = MoveHarness::new();
@@ -40,6 +41,7 @@ module 0xcafe::test {
     ));
 }
 
+#[run_mono_move]
 #[test]
 fn new_integer_types_as_txn_arguments() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/nft_dao.rs
+++ b/aptos-move/e2e-move-tests/src/tests/nft_dao.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, tests::common, MoveHarness};
-use aptos_framework::BuiltPackage;
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_types::account_address::create_resource_address;
 use move_core_types::account_address::AccountAddress;
 
+#[run_mono_move]
 #[test]
 // Test the txn argument works as expected
 fn test_nft_dao_txn_arguments() {
@@ -18,24 +18,10 @@ fn test_nft_dao_txn_arguments() {
         .named_addresses
         .insert("dao_platform".to_string(), *acc.address());
 
-    // build the package from our example code
-    let package = BuiltPackage::build(
-        common::test_dir_path("../../../move-examples/dao/nft_dao"),
-        build_options,
-    )
-    .expect("building package must succeed");
-
-    let code = package.extract_code();
-    let metadata = package
-        .extract_metadata()
-        .expect("extracting package metadata must succeed");
-
-    let result = h.run_transaction_payload(
+    let result = h.publish_package_with_options(
         &acc,
-        aptos_cached_packages::aptos_stdlib::code_publish_package_txn(
-            bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
-            code,
-        ),
+        &common::test_dir_path("../../../move-examples/dao/nft_dao"),
+        build_options,
     );
     assert_success!(result);
     // setup NFT creation and distribution for testing

--- a/aptos-move/e2e-move-tests/src/tests/offer_rotation_capability.rs
+++ b/aptos-move/e2e-move-tests/src/tests/offer_rotation_capability.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, MoveHarness};
+use crate::{assert_success, run_mono_move, MoveHarness};
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::SigningKey;
 use aptos_language_e2e_tests::account::Account;
@@ -24,6 +24,7 @@ struct RotationCapabilityOfferProofChallengeV2 {
     recipient_address: AccountAddress,
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn offer_rotation_capability_test() {
     let mut harness = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/offer_signer_capability.rs
+++ b/aptos-move/e2e-move-tests/src/tests/offer_signer_capability.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, MoveHarness};
+use crate::{assert_success, run_mono_move, MoveHarness};
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::SigningKey;
 use aptos_types::{
@@ -21,6 +21,7 @@ struct SignerCapabilityOfferProofChallengeV2 {
     recipient_address: AccountAddress,
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 /// Tests Alice offering Bob a signer for her account.
 fn offer_signer_capability_v2() {

--- a/aptos-move/e2e-move-tests/src/tests/orderless_proof_guards.rs
+++ b/aptos-move/e2e-move-tests/src/tests/orderless_proof_guards.rs
@@ -8,7 +8,7 @@
 //! number), since a signed proof embedding the sequence number would stay valid and could be
 //! replayed.
 
-use crate::MoveHarness;
+use crate::{run_mono_move, MoveHarness};
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::SigningKey;
 use aptos_language_e2e_tests::account::Account;
@@ -104,6 +104,7 @@ fn assert_aborted_with_other_code(status: &TransactionStatus) {
 
 /// A valid signer capability offer proof is rejected when submitted in an orderless
 /// transaction, and the very same proof succeeds in a sequence-number transaction.
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn offer_signer_capability_rejected_in_orderless_txn() {
     let mut harness = MoveHarness::new();
@@ -153,6 +154,7 @@ fn offer_signer_capability_rejected_in_orderless_txn() {
     );
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn offer_rotation_capability_rejected_in_orderless_txn() {
     let mut harness = MoveHarness::new();
@@ -177,6 +179,7 @@ fn offer_rotation_capability_rejected_in_orderless_txn() {
     assert_aborted_with_other_code(&status);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn rotate_authentication_key_rejected_in_orderless_txn() {
     let mut harness = MoveHarness::new();
@@ -198,6 +201,7 @@ fn rotate_authentication_key_rejected_in_orderless_txn() {
     assert_aborted_with_other_code(&status);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn rotate_authentication_key_with_rotation_capability_rejected_in_orderless_txn() {
     let mut harness = MoveHarness::new();
@@ -221,6 +225,7 @@ fn rotate_authentication_key_with_rotation_capability_rejected_in_orderless_txn(
 /// `multisig_account::create_with_existing_account` is callable by anyone holding a signed
 /// creation message for the target account, so a captured message must not be executable from
 /// an orderless transaction.
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn multisig_create_with_existing_account_rejected_in_orderless_txn() {
     let mut harness = MoveHarness::new();
@@ -245,6 +250,7 @@ fn multisig_create_with_existing_account_rejected_in_orderless_txn() {
     assert_aborted_with_other_code(&status);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn multisig_create_with_existing_account_and_revoke_auth_key_rejected_in_orderless_txn() {
     let mut harness = MoveHarness::new();
@@ -269,6 +275,7 @@ fn multisig_create_with_existing_account_and_revoke_auth_key_rejected_in_orderle
     assert_aborted_with_other_code(&status);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn upsert_ed25519_backup_key_rejected_in_orderless_txn() {
     let mut harness = MoveHarness::new();
@@ -290,6 +297,7 @@ fn upsert_ed25519_backup_key_rejected_in_orderless_txn() {
 /// A proof is replayable inside a multisig payload because the proof-bearing account's sequence
 /// number does not advance when the inner payload executes. The guard must reject proof-bearing
 /// account operations before signature verification when invoked through a multisig transaction.
+#[run_mono_move(should_fail = "MonoMove does not support multisig payloads")]
 #[test]
 fn offer_rotation_capability_rejected_in_multisig_payload() {
     let mut harness = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/public_const.rs
+++ b/aptos-move/e2e-move-tests/src/tests/public_const.rs
@@ -6,7 +6,7 @@
 //! Verifies that `public const` declarations compile and are accessible
 //! cross-module, with their values correctly inlined at the call site.
 
-use crate::{assert_success, MoveHarness};
+use crate::{assert_success, run_mono_move, MoveHarness};
 use aptos_language_e2e_tests::account::Account;
 use aptos_package_builder::PackageBuilder;
 use aptos_types::{account_address::AccountAddress, transaction::TransactionStatus};
@@ -35,6 +35,7 @@ fn publish(h: &mut MoveHarness, account: &Account, sources: &[(&str, &str)]) -> 
 
 /// Test that a module with public constants compiles, publishes, and can be
 /// consumed from another module with the correct values.
+#[run_mono_move]
 #[test]
 fn test_public_const_cross_module() {
     let mut h = MoveHarness::new();
@@ -92,6 +93,7 @@ fn test_public_const_cross_module() {
 
 /// Test that `package const` is accessible cross-module when both modules are compiled
 /// together in the same package.
+#[run_mono_move]
 #[test]
 fn test_package_const_cross_module() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/public_option.rs
+++ b/aptos-move/e2e-move-tests/src/tests/public_option.rs
@@ -5,7 +5,7 @@
 //! from modules outside `std`: constructing `Some`/`None`, testing variants with `is`,
 //! matching, and selecting/mutating the variant field.
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use aptos_package_builder::PackageBuilder;
 use aptos_types::{
@@ -111,6 +111,7 @@ module 0xCAFE::public_option_test {
 }
 "#;
 
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn test_public_option_cross_module() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/public_struct_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/public_struct_args.rs
@@ -10,7 +10,7 @@
 //! Tests are grouped by the package they publish, so each package is compiled and published
 //! only once per group, dramatically reducing total test time.
 
-use crate::{assert_success, assert_vm_status, tests::common, MoveHarness};
+use crate::{assert_success, assert_vm_status, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_types::{account_address::AccountAddress, on_chain_config::FeatureFlag};
 use move_core_types::{
@@ -59,6 +59,7 @@ fn assert_publish_fails(path: std::path::PathBuf) {
 /// Publishes once, initializes once, then runs all sub-tests sequentially.
 ///
 /// Run with: RUST_MIN_STACK=104857600 cargo test -p e2e-move-tests -- public_struct_args
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn test_pack_default_features() {
     let mut h = setup_harness();
@@ -554,6 +555,7 @@ fn test_pack_default_features() {
 // ========================================================================================
 
 /// Tests that publish `pack` but disable `PUBLIC_STRUCT_ENUM_ARGS`.
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn test_pack_feature_disabled() {
     let mut h = setup_harness();
@@ -616,6 +618,7 @@ fn test_pack_feature_disabled() {
 
 /// Tests using the `phantom_validation` package.
 /// Publishes once, initializes once, then runs phantom type parameter sub-tests.
+#[run_mono_move]
 #[test]
 fn test_phantom_validation_package() {
     let mut h = setup_harness();
@@ -692,6 +695,7 @@ fn test_phantom_validation_package() {
 // ========================================================================================
 
 /// Tests using the `option_private_type` package. Stateless accept/reject tests.
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn test_option_private_type_package() {
     let mut h = setup_harness();
@@ -762,6 +766,7 @@ fn test_option_private_type_package() {
 // ========================================================================================
 
 /// Tests using the `negative_phantom_option` package. Stateless tests.
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn test_negative_phantom_option_package() {
     let mut h = setup_harness();
@@ -939,6 +944,7 @@ fn test_negative_phantom_option_package() {
 // ========================================================================================
 
 /// Tests using the `pair_type_params` package.
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn test_pair_type_params_package() {
     let mut h = setup_harness();
@@ -1032,6 +1038,7 @@ fn test_pair_type_params_package() {
 // ========================================================================================
 
 /// Test that generic container with private type argument is rejected at construction time.
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn test_generic_container_with_private_type_arg_rejected() {
     let mut h = setup_harness();
@@ -1060,6 +1067,7 @@ fn test_generic_container_with_private_type_arg_rejected() {
 
 /// Tests that a public copy struct with an `Option<PrivateT>` field is a valid transaction
 /// argument type, illustrating the full flow from extended checker through execution.
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn test_option_in_public_struct() {
     let mut h = setup_harness();

--- a/aptos-move/e2e-move-tests/src/tests/resource_groups.rs
+++ b/aptos-move/e2e-move-tests/src/tests/resource_groups.rs
@@ -2,10 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    assert_success, assert_vm_status,
+    assert_success, assert_vm_status, mono_move_test,
     resource_groups::{
         initialize, initialize_enabled_disabled_comparison, ResourceGroupsTestHarness,
     },
+    run_mono_move,
     tests::{aggregator_v2::arb_block_split, common},
     BlockSplit, MoveHarness, SUCCESS,
 };
@@ -86,9 +87,9 @@ fn arb_test_env_non_equivalent(num_txns: usize) -> BoxedStrategy<TestEnvConfig> 
 
 proptest! {
     #![proptest_config(ProptestConfig {
-        // Cases are expensive, few cases is enough.
-        // We will test a few more comprehensive tests more times, and the rest even fewer.
-        cases: if STRESSTEST_MODE { 1000 } else { 20 },
+        // Cases are expensive, few cases is enough. Halved from 20 because
+        // every case now runs its block twice, once per VM.
+        cases: if STRESSTEST_MODE { 1000 } else { 10 },
         result_cache: if STRESSTEST_MODE { prop::test_runner::noop_result_cache } else {prop::test_runner::basic_result_cache },
         .. ProptestConfig::default()
     })]
@@ -96,56 +97,60 @@ proptest! {
     #[test]
     fn proptest_resource_groups_1(test_env in arb_test_env(17)) {
         println!("Testing test_aggregator_lifetime {:?}", test_env);
-        let mut h = setup(test_env.executor_mode, test_env.resource_group_mode, 17);
+        mono_move_test::both(|| {
+            let mut h = setup(test_env.executor_mode, test_env.resource_group_mode, 17);
 
-        let txns = vec![
-            (SUCCESS, h.init_signer(vec![5,2,3])),
-            (SUCCESS, h.set_resource(4, "ABC".to_string(), 10)),
-            (SUCCESS, h.set_resource(2, "DEFG".to_string(), 20)),
-            (SUCCESS, h.unset_resource(3)),
-            (SUCCESS, h.set_resource(3, "GH".to_string(), 30)),
-            (SUCCESS, h.set_resource(4, "JKLMNO".to_string(), 40)),
-            (SUCCESS, h.set_and_check(2,  4, "MNOP".to_string(), 50, "JKLMNO".to_string(), 40)),
-            (SUCCESS, h.read_or_init(1)),
-            (SUCCESS, h.check(2, "MNOP".to_string(), 50)),
-            (SUCCESS, h.check(1, "init_name".to_string(), 5)),
-            (SUCCESS, h.unset_resource(1)),
-            (SUCCESS, h.set_3_group_members(1, 2, 3, "L".to_string(), 25)),
-            (SUCCESS, h.check(1, "L".to_string(), 25)),
-            (SUCCESS, h.unset_resource(3)),
-            (ENOT_EQUAL, h.check(2, "MNOP".to_string(), 50)),
-            (EINVALID_ARG, h.set_resource(5, "JKLI".to_string(), 40)),
-            (ERESOURCE_DOESNT_EXIST, h.check(3, "L".to_string(), 25)),
-        ];
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            let txns = vec![
+                (SUCCESS, h.init_signer(vec![5,2,3])),
+                (SUCCESS, h.set_resource(4, "ABC".to_string(), 10)),
+                (SUCCESS, h.set_resource(2, "DEFG".to_string(), 20)),
+                (SUCCESS, h.unset_resource(3)),
+                (SUCCESS, h.set_resource(3, "GH".to_string(), 30)),
+                (SUCCESS, h.set_resource(4, "JKLMNO".to_string(), 40)),
+                (SUCCESS, h.set_and_check(2,  4, "MNOP".to_string(), 50, "JKLMNO".to_string(), 40)),
+                (SUCCESS, h.read_or_init(1)),
+                (SUCCESS, h.check(2, "MNOP".to_string(), 50)),
+                (SUCCESS, h.check(1, "init_name".to_string(), 5)),
+                (SUCCESS, h.unset_resource(1)),
+                (SUCCESS, h.set_3_group_members(1, 2, 3, "L".to_string(), 25)),
+                (SUCCESS, h.check(1, "L".to_string(), 25)),
+                (SUCCESS, h.unset_resource(3)),
+                (ENOT_EQUAL, h.check(2, "MNOP".to_string(), 50)),
+                (EINVALID_ARG, h.set_resource(5, "JKLI".to_string(), 40)),
+                (ERESOURCE_DOESNT_EXIST, h.check(3, "L".to_string(), 25)),
+            ];
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 
     #[test]
     fn proptest_resource_groups_2(test_env in arb_test_env_non_equivalent(12)) {
         println!("Testing test_aggregator_lifetime {:?}", test_env);
-        let mut h = setup(test_env.executor_mode, test_env.resource_group_mode, 12);
+        mono_move_test::both(|| {
+            let mut h = setup(test_env.executor_mode, test_env.resource_group_mode, 12);
 
-        let txns = vec![
-            (SUCCESS, h.init_signer(vec![5,2,3])),
-            (SUCCESS, h.set_resource(4, "ABCDEF".to_string(), 10)),
-            (SUCCESS, h.set_resource(2, "DEF".to_string(), 20)),
-            (SUCCESS, h.read_or_init(4)),
-            (SUCCESS, h.set_resource(2, "XYZK".to_string(), 25)),
-            (ENOT_EQUAL, h.check(2, "DEF".to_string(), 20)),
-            (SUCCESS, h.check(2, "XYZK".to_string(), 25)),
-            (SUCCESS, h.set_resource(3, "GH".to_string(), 30)),
-            (SUCCESS, h.unset_resource(3)),
-            (ERESOURCE_DOESNT_EXIST, h.check(3, "LJH".to_string(), 25)),
-            (ERESOURCE_DOESNT_EXIST, h.set_and_check(2,  1, "MNO".to_string(), 50, "GH".to_string(), 30)),
-            (SUCCESS, h.check(2, "XYZK".to_string(), 25)),
-        ];
-        h.run_block_in_parts_and_check(
-            test_env.block_split,
-            txns,
-        );
+            let txns = vec![
+                (SUCCESS, h.init_signer(vec![5,2,3])),
+                (SUCCESS, h.set_resource(4, "ABCDEF".to_string(), 10)),
+                (SUCCESS, h.set_resource(2, "DEF".to_string(), 20)),
+                (SUCCESS, h.read_or_init(4)),
+                (SUCCESS, h.set_resource(2, "XYZK".to_string(), 25)),
+                (ENOT_EQUAL, h.check(2, "DEF".to_string(), 20)),
+                (SUCCESS, h.check(2, "XYZK".to_string(), 25)),
+                (SUCCESS, h.set_resource(3, "GH".to_string(), 30)),
+                (SUCCESS, h.unset_resource(3)),
+                (ERESOURCE_DOESNT_EXIST, h.check(3, "LJH".to_string(), 25)),
+                (ERESOURCE_DOESNT_EXIST, h.set_and_check(2,  1, "MNO".to_string(), 50, "GH".to_string(), 30)),
+                (SUCCESS, h.check(2, "XYZK".to_string(), 25)),
+            ];
+            h.run_block_in_parts_and_check(
+                test_env.block_split,
+                txns,
+            );
+        });
     }
 }
 
@@ -159,6 +164,7 @@ struct Secondary {
     value: u32,
 }
 
+#[run_mono_move]
 #[test_case(true)]
 #[test_case(false)]
 fn test_resource_groups(resource_group_charge_as_sum_enabled: bool) {

--- a/aptos-move/e2e-move-tests/src/tests/rotate_auth_key.rs
+++ b/aptos-move/e2e-move-tests/src/tests/rotate_auth_key.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    assert_abort, assert_success,
+    assert_abort, assert_success, run_mono_move,
     tests::offer_rotation_capability::{offer_rotation_capability_v2, revoke_rotation_capability},
     MoveHarness,
 };
@@ -21,6 +21,7 @@ use aptos_types::{
 };
 use move_core_types::parser::parse_struct_tag;
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn rotate_auth_key_ed25519_to_ed25519() {
     let mut harness = MoveHarness::new();
@@ -43,6 +44,7 @@ fn rotate_auth_key_ed25519_to_ed25519() {
     verify_originating_address(&mut harness, account2.auth_key(), *account1.address());
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn rotate_auth_key_ed25519_to_multi_ed25519() {
     let mut harness = MoveHarness::new();
@@ -67,6 +69,7 @@ fn rotate_auth_key_ed25519_to_multi_ed25519() {
     verify_originating_address(&mut harness, auth_key.to_vec(), *account1.address());
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn rotate_auth_key_twice() {
     let mut harness = MoveHarness::new();
@@ -104,6 +107,7 @@ fn rotate_auth_key_twice() {
     verify_originating_address(&mut harness, account1.auth_key(), *account1.address());
 }
 
+#[run_mono_move(should_fail = "MonoMove does not implement the transaction_context::is_multisig_payload_txn_internal native that account.move's sequence-number proof guard calls")]
 #[test]
 fn rotate_auth_key_with_rotation_capability_e2e() {
     let mut harness = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/scripts.rs
+++ b/aptos-move/e2e-move-tests/src/tests/scripts.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::BuiltPackage;
 use aptos_language_e2e_tests::account::TransactionBuilder;
 use aptos_types::{
@@ -11,6 +11,7 @@ use aptos_types::{
 };
 use move_core_types::{language_storage::TypeTag, value::MoveValue};
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn test_script_with_object_parameter() {
     let mut h = MoveHarness::new();
@@ -118,6 +119,7 @@ fn test_script_with_object_parameter() {
     assert!(status.is_discarded());
 }
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn test_script_with_type_parameter() {
     let mut h = MoveHarness::new();
@@ -147,6 +149,7 @@ fn test_script_with_type_parameter() {
     assert_success!(status);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn test_script_with_signer_parameter() {
     let mut h = MoveHarness::new();
@@ -186,6 +189,7 @@ fn test_script_with_signer_parameter() {
     );
 }
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn test_two_to_two_transfer() {
     let mut h = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/simple_defi.rs
+++ b/aptos-move/e2e-move-tests/src/tests/simple_defi.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_cached_packages::aptos_stdlib;
 use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_language_e2e_tests::account::Account;
@@ -26,6 +26,7 @@ const CHLOE_COIN_STRUCT_STRING: &str =
 const EXCHANGE_FROM_FUNCTION: &str = "exchange_from_entry";
 const EXCHANGE_TO_FUNCTION: &str = "exchange_to_entry";
 
+#[run_mono_move]
 #[test]
 fn exchange_e2e_test() {
     let mut h = MoveHarness::new();
@@ -49,14 +50,16 @@ fn exchange_e2e_test() {
         .expect("extracting package metadata must succeed");
 
     // create the resource account and publish the code under the resource account's address
-    let result = h.run_transaction_payload(
-        &origin_account,
-        aptos_stdlib::resource_account_create_resource_account_and_publish_package(
-            vec![],
-            bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
-            code,
-        ),
-    );
+    let result = h.without_mono_move(|h| {
+        h.run_transaction_payload(
+            &origin_account,
+            aptos_stdlib::resource_account_create_resource_account_and_publish_package(
+                vec![],
+                bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
+                code,
+            ),
+        )
+    });
     assert_success!(result);
 
     // verify that we store the signer cap within the module

--- a/aptos-move/e2e-move-tests/src/tests/stake.rs
+++ b/aptos-move/e2e-move-tests/src/tests/stake.rs
@@ -10,7 +10,7 @@ use crate::{
     tests::common,
 };
 use aptos_cached_packages::aptos_stdlib;
-use aptos_move_e2e_test_harness::{assert_success, MoveHarness};
+use aptos_move_e2e_test_harness::{assert_success, run_mono_move, MoveHarness};
 use aptos_types::account_address::{default_stake_pool_address, AccountAddress};
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
@@ -39,6 +39,7 @@ fn update_stake_amount_and_assert_with_errors(
     *stake_amount = get_stake_pool(harness, &validator_address).active;
 }
 
+#[run_mono_move]
 #[test]
 fn test_staking_end_to_end() {
     let mut harness = MoveHarness::new();
@@ -110,6 +111,7 @@ fn test_staking_end_to_end() {
     assert_eq!(stake_pool.inactive, 0);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn test_staking_rewards() {
     // Genesis starts with one validator with index 0
@@ -311,6 +313,7 @@ fn test_staking_rewards() {
     );
 }
 
+#[run_mono_move]
 #[test]
 fn test_staking_rewards_pending_inactive() {
     let mut harness = MoveHarness::new();
@@ -340,6 +343,7 @@ fn test_staking_rewards_pending_inactive() {
     );
 }
 
+#[run_mono_move]
 #[test]
 fn test_staking_contract() {
     let mut harness = MoveHarness::new();

--- a/aptos-move/e2e-move-tests/src/tests/string_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_move_abort, assert_success, assert_vm_status, tests::common, MoveHarness};
+use crate::{
+    assert_move_abort, assert_success, assert_vm_status, run_mono_move, tests::common, MoveHarness,
+};
 use aptos_types::{
     account_address::AccountAddress,
     transaction::{AbortInfo, TransactionStatus},
@@ -118,6 +120,7 @@ fn big_string_vec(first_dim: u64, second_dim: u64, base: &str) -> Vec<u8> {
     bcs::to_bytes(&outer).unwrap()
 }
 
+#[run_mono_move]
 #[test]
 fn string_args_good() {
     let mut tests = vec![];
@@ -302,6 +305,7 @@ fn string_args_good() {
     success(tests);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not inject AbortInfo from the module error map")]
 #[test]
 fn string_args_bad_utf8() {
     let mut tests = vec![];
@@ -395,6 +399,7 @@ fn string_args_bad_utf8() {
     fail(tests);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn string_args_chopped() {
     let idx = 0u64;
@@ -418,6 +423,7 @@ fn string_args_chopped() {
     }
 }
 
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn string_args_bad_length() {
     // chop after bcs so length stays big but payload gets small basically a bogus input
@@ -567,6 +573,7 @@ fn string_args_bad_length() {
     fail(tests);
 }
 
+#[run_mono_move]
 #[test]
 fn string_args_non_generic_call() {
     let tests = vec![("0xcafe::test::non_generic_call", vec![(
@@ -577,6 +584,7 @@ fn string_args_non_generic_call() {
     success_generic(vec![], tests);
 }
 
+#[run_mono_move]
 #[test]
 fn string_args_generic_call() {
     let tests = vec![("0xcafe::test::generic_call", vec![(
@@ -595,6 +603,7 @@ fn string_args_generic_call() {
     success_generic(vec![string_type], tests);
 }
 
+#[run_mono_move]
 #[test]
 fn string_args_generic_instantiation() {
     let mut tests = vec![];
@@ -654,6 +663,7 @@ fn string_args_generic_instantiation() {
     success_generic(vec![string_type, address_type], tests);
 }
 
+#[run_mono_move(should_fail = "MonoMove does not validate or construct entry function arguments")]
 #[test]
 fn huge_string_args_are_not_allowed() {
     let mut tests = vec![];

--- a/aptos-move/e2e-move-tests/src/tests/swap_function_values.rs
+++ b/aptos-move/e2e-move-tests/src/tests/swap_function_values.rs
@@ -3,11 +3,12 @@
 
 //! Test swapping of function values via vector::replace.
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, run_mono_move, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use aptos_package_builder::PackageBuilder;
 use aptos_types::account_address::AccountAddress;
 
+#[run_mono_move]
 #[test]
 fn swap_function_values() {
     let mut builder = PackageBuilder::new("swap_function_values");

--- a/aptos-move/e2e-move-tests/src/tests/token_event_store.rs
+++ b/aptos-move/e2e-move-tests/src/tests/token_event_store.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::MoveHarness;
+use crate::{run_mono_move, MoveHarness};
 use aptos_cached_packages::aptos_stdlib::aptos_token_stdlib;
 
+#[run_mono_move]
 #[test]
 fn test_token_creation_with_token_events_store() {
     let mut h = MoveHarness::new();

--- a/aptos-move/move-examples/Cargo.toml
+++ b/aptos-move/move-examples/Cargo.toml
@@ -26,4 +26,5 @@ move-vm-runtime = { workspace = true }
 
 [dev-dependencies]
 aptos-framework = { workspace = true, features = ["testing"] }
+mono-move-testsuite = { workspace = true }
 tempfile = { workspace = true }

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -8,8 +8,9 @@ use aptos_types::{
     on_chain_config::{aptos_test_feature_flags_genesis, Features, TimedFeaturesBuilder},
 };
 use aptos_vm::natives;
+use mono_move_testsuite::unit_test;
 use move_model::model::GlobalEnv;
-use move_package::{source_package::std_lib::StdVersion, CompilerConfig};
+use move_package::{source_package::std_lib::StdVersion, BuildConfig, CompilerConfig};
 use move_unit_test::{
     package_test::{run_move_unit_tests, UnitTestResult},
     test_validation, UnitTestingConfig,
@@ -35,24 +36,35 @@ fn configure_extended_checks_for_unit_test() {
     test_validation::set_validation_hook(Box::new(validate));
 }
 
+fn build_config(named_addr: BTreeMap<String, AccountAddress>) -> BuildConfig {
+    BuildConfig {
+        test_mode: true,
+        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+        override_std: Some(StdVersion::Local(get_local_framework_path())),
+        additional_named_addresses: named_addr,
+        compiler_config: CompilerConfig {
+            known_attributes: extended_checks::get_all_attribute_names().clone(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Runs a package's unit tests on the V1 VM and then on MonoMove, from the
+/// same build configuration so that both see identical bytecode.
+///
+/// A test MonoMove cannot run yet is reported as unsupported and does not fail
+/// the run; only a test it runs and gets wrong is a failure.
 pub fn run_tests_for_pkg(
     path_to_pkg: impl Into<String>,
     named_addr: BTreeMap<String, AccountAddress>,
 ) {
     let pkg_path = path_in_crate(path_to_pkg);
+    let config = build_config(named_addr);
+
     let ok = run_move_unit_tests(
         &pkg_path,
-        move_package::BuildConfig {
-            test_mode: true,
-            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-            override_std: Some(StdVersion::Local(get_local_framework_path())),
-            additional_named_addresses: named_addr,
-            compiler_config: CompilerConfig {
-                known_attributes: extended_checks::get_all_attribute_names().clone(),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
+        config.clone(),
         UnitTestingConfig::default(),
         // TODO(Gas): we may want to switch to non-zero costs in the future
         aptos_test_natives(),
@@ -66,6 +78,16 @@ pub fn run_tests_for_pkg(
     if ok.is_err() || ok.is_ok_and(|r| r == UnitTestResult::Failure) {
         panic!("move unit tests failed")
     }
+
+    let summary = unit_test::run_package_unit_tests(&pkg_path, config)
+        .unwrap_or_else(|err| panic!("failed to run MonoMove unit tests: {err}"));
+    println!("{}", summary.render());
+    assert!(
+        summary.failed.is_empty(),
+        "{} test(s) MonoMove ran but got wrong:\n{}",
+        summary.failed.len(),
+        summary.failed.join("\n"),
+    );
 }
 
 pub fn aptos_test_natives() -> NativeFunctionTable {
@@ -319,4 +341,79 @@ fn test_package_manager() {
         ),
     ]);
     run_tests_for_pkg("package_manager", named_address);
+}
+
+#[test]
+fn test_rewards_pool() {
+    test_common("rewards_pool");
+}
+
+#[test]
+fn test_ring_deque() {
+    test_common("ring_deque");
+}
+
+#[test]
+fn test_event() {
+    test_common("event");
+}
+
+#[test]
+fn test_tic_tac_toe() {
+    let named_address = BTreeMap::from([(
+        String::from("tic_tac_toe"),
+        AccountAddress::from_hex_literal("0xf00d").unwrap(),
+    )]);
+    run_tests_for_pkg("tic-tac-toe", named_address);
+}
+
+#[test]
+fn test_my_first_dapp() {
+    let named_address = BTreeMap::from([(
+        String::from("todolist_addr"),
+        AccountAddress::from_hex_literal("0xf00d").unwrap(),
+    )]);
+    run_tests_for_pkg("my_first_dapp/contract", named_address);
+}
+
+#[test]
+fn test_large_package_example() {
+    let named_address = BTreeMap::from([(
+        String::from("large_package_example"),
+        AccountAddress::from_hex_literal("0xf00d").unwrap(),
+    )]);
+    run_tests_for_pkg("large_packages/large_package_example", named_address);
+}
+
+#[test]
+fn test_struct_enum_args() {
+    let named_address = BTreeMap::from([(
+        String::from("struct_enum_tests"),
+        AccountAddress::from_hex_literal("0xf00d").unwrap(),
+    )]);
+    run_tests_for_pkg("cli-e2e-tests/struct-enum-args", named_address);
+}
+
+// `staking` and `bcs-stream` bind every address in their own manifest, so they
+// need nothing extra here.
+
+#[test]
+fn test_staking() {
+    run_tests_for_pkg("staking", BTreeMap::new());
+}
+
+#[test]
+fn test_bcs_stream() {
+    run_tests_for_pkg("bcs-stream", BTreeMap::new());
+}
+
+/// The tutorial steps that carry `#[test]` functions. The remaining steps are
+/// compile-only exercises.
+#[test]
+fn test_move_tutorial() {
+    for step in [
+        "step_2", "step_2_sol", "step_5", "step_5_sol", "step_6",
+    ] {
+        run_tests_for_pkg(format!("move-tutorial/{step}/basic_coin"), BTreeMap::new());
+    }
 }

--- a/aptos-move/script-composer/src/tests/mod.rs
+++ b/aptos-move/script-composer/src/tests/mod.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{CallArgument, TransactionComposer};
-use aptos_move_e2e_test_harness::MoveHarness;
+use aptos_move_e2e_test_harness::{run_mono_move, MoveHarness};
 use aptos_types::{
     state_store::state_key::StateKey,
     transaction::{ExecutionStatus, TransactionStatus},
@@ -21,6 +21,7 @@ fn load_module(builder: &mut TransactionComposer, harness: &MoveHarness, module_
     builder.insert_module(CompiledModule::deserialize(&bytes).unwrap());
 }
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn simple_builder() {
     let mut h = MoveHarness::new();
@@ -64,6 +65,7 @@ fn simple_builder() {
     );
 }
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn chained_deposit() {
     let mut h = MoveHarness::new();
@@ -230,6 +232,7 @@ fn chained_deposit_invalid_copy() {
         .is_err());
 }
 
+#[run_mono_move(should_fail = "MonoMove does not support script payloads")]
 #[test]
 fn test_module() {
     let mut h = MoveHarness::new();

--- a/third_party/move/mono-move/testsuite/src/unit_test.rs
+++ b/third_party/move/mono-move/testsuite/src/unit_test.rs
@@ -29,7 +29,6 @@ use move_core_types::{
     value::MoveValue,
     vm_status::{AbortLocation, StatusCode},
 };
-use move_model::metadata::LanguageVersion;
 use move_package::BuildConfig;
 use move_unit_test::UnitTestingConfig;
 use std::{
@@ -44,16 +43,8 @@ const GAS_BUDGET: u64 = u64::MAX;
 
 pub fn run_package_unit_tests(
     pkg_path: &Path,
-    use_latest_language: bool,
+    build_config: BuildConfig,
 ) -> anyhow::Result<RunSummary> {
-    let mut build_config = BuildConfig::default();
-    if use_latest_language {
-        let language_version = LanguageVersion::latest();
-        let bytecode_version = language_version.infer_bytecode_version(None);
-        build_config.compiler_config.language_version = Some(language_version);
-        build_config.compiler_config.bytecode_version = Some(bytecode_version);
-    }
-
     let test_plan = move_unit_test::package_test::build_test_plan_for_package(
         pkg_path,
         build_config,

--- a/third_party/move/mono-move/testsuite/tests/unit_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/unit_tests.rs
@@ -11,6 +11,8 @@
 //! scoreboard.
 
 use mono_move_testsuite::unit_test;
+use move_model::metadata::LanguageVersion;
+use move_package::BuildConfig;
 use std::path::Path;
 
 fn run_tests_for_pkg(pkg: &str, use_latest_language: bool) {
@@ -18,7 +20,15 @@ fn run_tests_for_pkg(pkg: &str, use_latest_language: bool) {
         .join("../../../../aptos-move/framework")
         .join(pkg);
 
-    let summary = unit_test::run_package_unit_tests(&path, use_latest_language)
+    let mut build_config = BuildConfig::default();
+    if use_latest_language {
+        let language_version = LanguageVersion::latest();
+        let bytecode_version = language_version.infer_bytecode_version(None);
+        build_config.compiler_config.language_version = Some(language_version);
+        build_config.compiler_config.bytecode_version = Some(bytecode_version);
+    }
+
+    let summary = unit_test::run_package_unit_tests(&path, build_config)
         .unwrap_or_else(|err| panic!("failed to run {pkg} unit tests: {err}"));
 
     println!("{}", summary.render());


### PR DESCRIPTION
## Description

Follow-up to #20501, which added `#[run_mono_move]` and annotated three files. This one takes the attribute across the rest of `e2e-move-tests`, extends it to `script-composer`, and wires MonoMove into the `move-examples` Move unit tests.

### Parameterized tests and proptest

The macro now accepts a test that takes arguments, so it composes with `#[test_case]` and `#[rstest]`. Each pass gets its own clone of the arguments, so the MonoMove pass never sees a mutation the V1 pass made. It has to sit *above* those attributes: `#[test_case]` strips the attribute off the original function and re-attaches it under the `#[test]` it generates.

```rust
#[run_mono_move]
#[test_case(true)]
#[test_case(false)]
fn my_test(enabled: bool) { .. }
```

`proptest!` is a function-like macro with nowhere to hang an attribute, so those bodies use `mono_move_test::both(|| { .. })` instead. Eleven call sites: nine in `aggregator_v2.rs`, two in `resource_groups.rs`. Two rules apply at each. Build the harness *inside* the closure, since one built outside runs V1 in both passes and checks nothing. And signal failure by panicking, since `prop_assert!` returns an error the MonoMove pass would discard. `both` has no `should_fail` escape hatch.

Because every proptest case now runs its block twice, `cases` drops from 20 to 10 in `aggregator_v2.rs` and `resource_groups.rs`.

### Coverage

101 annotated tests across 36 files: 49 running on both VMs and 52 marked `should_fail`. This PR adds 80 of them; the other 21 came from #20501.

`move-examples` now runs each package's Move unit tests on the V1 VM and then on MonoMove, from one `BuildConfig`. Different configurations produce different bytecode, and comparing the two VMs on different bytecode would prove nothing. A test MonoMove cannot run yet is reported as unsupported and does not fail the run; only a test it runs and gets wrong is a failure. Fourteen packages are added: `rewards_pool`, `ring_deque`, `event`, `tic-tac-toe`, `my_first_dapp`, `large_packages`, `cli-e2e-tests/struct-enum-args`, `staking`, `bcs-stream`, and the five `move-tutorial` steps that carry `#[test]` functions.

To make that possible, `unit_test::run_package_unit_tests` takes a `BuildConfig` instead of a `use_latest_language: bool`. The flag construction moves verbatim to the framework caller, so every existing caller builds the same config as before.

Unrelated to MonoMove: `aptos-move/cli/src/transactions.rs` drops a `#[cfg(test)]`-only wrapper whose sole caller now uses the underlying function directly.

## How Has This Been Tested?

### `cargo nextest run -p e2e-move-tests`

403 tests, 6909s: 356 passed, 45 failed, 2 timed out, 12 skipped. That reconciles exactly as 32 MonoMove-only failures, 11 sandbox git-fetch failures, and 2 SIGABRTs.

The 32 are the tests that passed on V1 and failed under MonoMove. Every one is now marked `should_fail`, and each reason was traced to source rather than inferred from the error text. Nothing was over-marked: no `should_fail` test passed under MonoMove.

The full set of 52 markers, grouped by reason:

| Count | Reason |
| --- | --- |
| 13 | `transaction_context::is_multisig_payload_txn_internal` native missing. `account.move:271` calls it from `assert_seq_num_proof_replay_protected()`, which guards all five sequence-number proof entry points, so mono's loader raises `NativeFunctionNotLoadable` and the txn ends in `LINKER_ERROR`. |
| 12 | Entry-function argument validation not implemented. `INVALID_MAIN_FUNCTION_SIGNATURE` and `FAILED_TO_DESERIALIZE_ARGUMENT` come only from `aptos-vm/src/verifier/transaction_arg_validation.rs`; mono has no counterpart. |
| 10 | Script payloads unsupported. `user_txn/execute.rs:65` accepts `EntryFunction` only; everything else discards as `FEATURE_UNDER_GATING`. |
| 3 | `AbortInfo` not injected. `inject_abort_info_if_available` lives only in `aptos_vm.rs:700`. |
| 3 | Delayed fields are never created, so the aggregator runtime checks, the per-resource limit, and capture-failure paths never fire. |
| 2 | Multisig payloads unsupported. |
| 2 | Function values cannot be serialized into the write set. |
| 1 each | `string_utils::native_format_list`, `entry_function_payload`, `cmp::compare` on function values, `0x1::debug` natives, `crypto_algebra` natives, `any::pack` on a function value, and one test that publishes a module through `run_block` instead of the harness publish helper. |

The other failures are pre-existing and independent of this PR. Eleven tests publish `move-examples` packages and fail fetching `AptosFramework` from git in a sandbox with no network; `e2e-move-tests` does not set `override_std`. Two `memory_quota` tests hit SIGABRT, in a file carrying no annotations. Two `proptest!` blocks time out at 1800s, in `aggregator.rs` and `transaction_context.rs`; neither block is annotated.

### `cargo nextest run -p aptos-move-examples`

37 tests, 36 passed. The one failure is `move_prover_tests::test_hello_prover`, untouched here and blocked by the same missing network. Across the package builds MonoMove ran 287 Move unit tests: **272 passed, 0 failed, 15 unsupported**. Every unsupported case is a missing native.

### `cargo nextest run -p mono-move-testsuite --test unit_tests`

7/7 packages pass, confirming the `BuildConfig` refactor changed nothing:

```
move-stdlib          193 passed, 0 failed,  11 unsupported (of  204)
aptos-stdlib         238 passed, 0 failed,  59 unsupported (of  297)
aptos-trading          0 passed, 0 failed,   0 unsupported (of    0)
aptos-token           42 passed, 0 failed,   1 unsupported (of   43)
aptos-token-objects   79 passed, 0 failed,   7 unsupported (of   86)
aptos-framework      642 passed, 0 failed, 130 unsupported (of  772)
aptos-experimental    95 passed, 0 failed,  41 unsupported (of  136)
                    ─────────────────────────────────────────────────
                    1289 passed, 0 failed, 249 unsupported (of 1538)
```

`aptos-trading` at zero is correct: its sources hold only `#[test_only]` helpers, and its order-book tests live in `aptos-experimental`.

All 249 unsupported cases are missing natives, led by:

```
56  0x1::event::emitted_events
53  0x1::function_info::load_function_impl
28  0x1::string_utils::native_format_list
22  0x1::string_utils::native_format
18  0x1::transaction_context::is_multisig_payload_txn_internal_for_test_only
12  0x1::reflect::native_resolve
12  0x1::crypto_algebra::order_internal
10  0x1::aggregator_factory::new_aggregator
```

Two of those corroborate the e2e triage independently. `string_utils::native_format_list` is what breaks `test_macros`, and the multisig-payload native is the guard behind the 13-test `LINKER_ERROR` cluster.

## Key Areas to Review

- Argument handling in the macro. Each pass clones the parameters, and the body is hoisted into an inner item so it can capture nothing else.
- `mono_move_test::both` and its two call-site rules. `AssertUnwindSafe` is used there because the closure borrows the test's arguments; it only reads and clones them, and a caught panic is always re-raised.
- Whether the 52 `should_fail` reasons are accurate. Each is a claim about a specific MonoMove gap, and a wrong one hides a real bug until the gap is closed.
- `run_tests_for_pkg` in `move-examples`: both VMs must receive the same `BuildConfig`.
- The halved proptest `cases`. Coverage per run drops; wall-clock stays roughly flat.

## Type of Change

- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine
- [x] Developer Infrastructure

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test infrastructure, macros, and dev-dependencies; production VM and CLI simulation paths are unaffected aside from removing dead test helper code.
> 
> **Overview**
> Expands **MonoMove vs V1** differential testing across the Move test stack.
> 
> The **`#[run_mono_move]`** proc macro now supports tests with arguments (e.g. **`#[test_case]`** / **`#[rstest]`**): each VM pass gets cloned parameters so MonoMove does not see V1 mutations. **`mono_move_test::both`** runs the same body on both VMs for **`proptest!`** blocks (with halved case counts where blocks run twice). The harness runner takes closures and centralizes **`run_both_passes`**.
> 
> **~80 new annotations** land on **`e2e-move-tests`** and **`script-composer`** (plus many **`should_fail`** markers documenting known MonoMove gaps). **`move-examples`** runs each package’s Move unit tests on V1 then MonoMove from a shared **`BuildConfig`**; **`unit_test::run_package_unit_tests`** now accepts **`BuildConfig`** instead of a language-version flag. Several example packages gain dedicated test entrypoints.
> 
> Minor cleanup: CLI transaction tests call **`local_contract_events_to_json`** directly instead of a test-only wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8fa45aaf78be405d32b5e09a44a9410f84871f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->