### PR TITLE
Replay-verify: increase GCP token duration to 2 hours

### DIFF
--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -27,7 +27,7 @@ on:
       END_TIME:
         required: false
         type: string
-        description: 'Optional end time. Same formats as START_TIME. Mutually exclusive with END_VERSION.'
+        description: "Optional end time. Same formats as START_TIME. Mutually exclusive with END_VERSION."
       DRY_RUN:
         required: false
         type: boolean
@@ -81,7 +81,7 @@ on:
       END_TIME:
         required: false
         type: string
-        description: 'Optional end time. Same formats as START_TIME. Mutually exclusive with END_VERSION.'
+        description: "Optional end time. Same formats as START_TIME. Mutually exclusive with END_VERSION."
       DRY_RUN:
         required: false
         type: boolean
@@ -186,7 +186,7 @@ jobs:
           create_credentials_file: true
 
       # This is required since we need to switch from aptos-ci to aptos-devinfra-0
-      - name: Setup credentials  
+      - name: Setup credentials
         run: |
           echo "GOOGLE_APPLICATION_CREDENTIALS=${{ steps.auth.outputs.credentials_file_path }}" >> $GITHUB_ENV
           echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${{ steps.auth.outputs.credentials_file_path }}" >> $GITHUB_ENV 

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -182,6 +182,7 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          access_token_lifetime: "7200s" # 2 hours
           export_environment_variables: false
           create_credentials_file: true
 


### PR DESCRIPTION
## Description

Replay-verify testnet workflows are failing https://github.com/aptos-labs/aptos-core/actions/runs/33153590340/job/99070082771.

The error seems to be that the Oauth2 toke is expiring: https://www.googleapis.com/compute/v1/projects/aptos-devinfra-0/zones/us-central1-a/operations/operation-1787994954723-65a2c0422f149-b31fa551-d61c96ef

```
{
  "error": {
    "code": 401,
    "message": "Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.",
    "errors": [
      {
        "message": "Login Required.",
        "domain": "global",
        "reason": "required",
        "location": "Authorization",
        "locationType": "header"
      }
    ],
    "status": "UNAUTHENTICATED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "CREDENTIALS_MISSING",
        "domain": "googleapis.com",
        "metadata": {
          "service": "compute.googleapis.com",
          "method": "compute.v1.ZoneOperationsService.Get"
        }
      }
    ]
  }
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change that lengthens GCP token lifetime; no application or production runtime impact.
> 
> **Overview**
> Replay-verify on archive was failing with **401 UNAUTHENTICATED** when long-running GKE/compute work outlasted the default OAuth access token from the separate **Authenticate to Google Cloud** step (used after `docker-setup` to target `aptos-devinfra-0`).
> 
> This PR sets **`access_token_lifetime: "7200s"`** (2 hours) on that `google-github-actions/auth@v2` step so credentials stay valid longer during replay scheduling and cleanup. It also makes minor YAML-only tweaks (double-quoted `END_TIME` descriptions, trailing whitespace on the setup-credentials step name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f5b5ad846e16975c2cf3d3b2ab1cf20f3b82b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->