### PR TITLE
[vm] Gate function-type ability bounds check on `CHECK_FUNCTION_TYPE_ABILITIES` feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8916,6 +8916,7 @@ dependencies = [
  "rstest",
  "serde",
  "sha3 0.9.1",
+ "tempfile",
  "test-case",
  "thousands",
  "tokio",

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -179,6 +179,7 @@ pub enum FeatureFlag {
     DisableClosureBcsSerialization,
     LazyModuleInitialization,
     EnableMonoMove,
+    CheckFunctionTypeAbilities,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -465,6 +466,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             },
             FeatureFlag::LazyModuleInitialization => AptosFeatureFlag::LAZY_MODULE_INITIALIZATION,
             FeatureFlag::EnableMonoMove => AptosFeatureFlag::ENABLE_MONO_MOVE,
+            FeatureFlag::CheckFunctionTypeAbilities => {
+                AptosFeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES
+            },
         }
     }
 }
@@ -678,6 +682,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             },
             AptosFeatureFlag::LAZY_MODULE_INITIALIZATION => FeatureFlag::LazyModuleInitialization,
             AptosFeatureFlag::ENABLE_MONO_MOVE => FeatureFlag::EnableMonoMove,
+            AptosFeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES => {
+                FeatureFlag::CheckFunctionTypeAbilities
+            },
         }
     }
 }

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.exp
@@ -1,4 +1,5 @@
 processed 3 tasks
-task 1 lines 7-28:  publish --private-key Alice [module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check]
-task 2 lines 31-31:  run --signers Alice -- 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check::closure_type_rejected
-Error: Failed to execute transaction. ExecutionStatus: MoveAbort { location: 0000000000000000000000000000000000000000000000000000000000000001::object, code: 11, info: Some(AbortInfo { reason_name: "ENOT_A_RESOURCE_TYPE", description: "Object type argument must be a resource (struct) type" }) }
+task 1 lines 6-27:  publish --private-key Alice [module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check]
+Error: VMError with status CONSTRAINT_NOT_SATISFIED at location Module ModuleId { address: f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6, name: Identifier("object_type_check") } and message function type has invalid abilities: only copy, drop, and store are allowed at type 0 at index 7 for signature
+task 2 lines 30-30:  run --signers Alice -- 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check::closure_type_rejected
+Error: Failed to execute transaction. ExecutionStatus: MiscellaneousError(Some(LINKER_ERROR))

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.masm
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/closure_key_address_to_object.masm
@@ -1,8 +1,7 @@
 //# init --addresses Alice=0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6 --private-keys Alice=56a26140eb233750cd14fb168c3eb4bd0782b099cde626ec8aff7f3cceb6364f
 
-// A closure type can have `key` and thus satisfy `T: key`, so object natives must
-// check that the type argument is a struct: `address_to_object<||u64 has key>` aborts
-// with ENOT_A_RESOURCE_TYPE.
+// Function types cannot have `key`, so this module fails verification at publication and the
+// subsequent call cannot link.
 
 //# publish --private-key Alice
 module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::object_type_check

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/reflect_key_ability.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/reflect_key_ability.exp
@@ -1,5 +1,6 @@
 processed 4 tasks
 task 1 lines 3-8:  publish --private-key Alice [module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::target]
 task 2 lines 10-47:  publish --private-key Alice [module 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::test_module]
+Error: VMError with status CONSTRAINT_NOT_SATISFIED at location Module ModuleId { address: f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6, name: Identifier("test_module") } and message function type has invalid abilities: only copy, drop, and store are allowed at type 0 at index 5 for signature
 task 3 lines 50-50:  run --signers Alice -- 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::test_module::key_ability_rejected
-Error: Failed to execute transaction. ExecutionStatus: MoveAbort { location: 0000000000000000000000000000000000000000000000000000000000000001::result, code: 65536, info: Some(AbortInfo { reason_name: "E_UNWRAP_OK", description: "Attempt to unwrap value but found error" }) }
+Error: Failed to execute transaction. ExecutionStatus: MiscellaneousError(Some(LINKER_ERROR))

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -10,7 +10,9 @@ use crate::{
     },
 };
 use aptos_gas_algebra::DynamicExpression;
-use aptos_gas_schedule::{AptosGasParameters, MiscGasParameters, NativeGasParameters};
+use aptos_gas_schedule::{
+    AptosGasParameters, MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION,
+};
 use aptos_native_interface::SafeNativeBuilder;
 use aptos_types::{
     chain_id::ChainId,
@@ -253,7 +255,7 @@ impl Environment {
             get_gas_parameters(&mut sha3_256, &features, state_view);
         let (native_gas_params, misc_gas_params, ty_builder) = match &gas_params {
             Ok(gas_params) => {
-                let ty_builder = aptos_prod_ty_builder(gas_feature_version, gas_params);
+                let ty_builder = aptos_prod_ty_builder(gas_feature_version, &features, gas_params);
                 (
                     gas_params.natives.clone(),
                     gas_params.vm.misc.clone(),
@@ -261,7 +263,7 @@ impl Environment {
                 )
             },
             Err(_) => {
-                let ty_builder = aptos_default_ty_builder(true, true);
+                let ty_builder = aptos_default_ty_builder(LATEST_GAS_FEATURE_VERSION, &features);
                 (
                     NativeGasParameters::zeros(),
                     MiscGasParameters::zeros(),

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -118,37 +118,44 @@ pub fn get_layout_caches() -> bool {
 /// Returns [TypeBuilder] used by the Aptos blockchain in production.
 pub fn aptos_prod_ty_builder(
     gas_feature_version: u64,
+    features: &Features,
     gas_params: &AptosGasParameters,
 ) -> TypeBuilder {
     if gas_feature_version >= RELEASE_V1_15 {
         let max_ty_size = gas_params.vm.txn.max_ty_size;
         let max_ty_depth = gas_params.vm.txn.max_ty_depth;
 
-        let check_depth_on_type_counts_v2 = gas_feature_version >= RELEASE_V1_42;
-        let count_function_type_node = gas_feature_version >= RELEASE_V1_49;
-        TypeBuilder::with_limits(
+        ty_builder_for(
+            gas_feature_version,
+            features,
             max_ty_size.into(),
             max_ty_depth.into(),
-            check_depth_on_type_counts_v2,
-            count_function_type_node,
         )
     } else {
-        aptos_default_ty_builder(false, false)
+        aptos_default_ty_builder(gas_feature_version, features)
     }
 }
 
 /// Returns default [TypeBuilder], used only when:
 ///  1. Type size gas parameters are not yet in gas schedule (before 1.15).
 ///   2. No gas parameters are found on-chain.
-pub fn aptos_default_ty_builder(
-    check_depth_on_type_counts_v2: bool,
-    count_function_type_node: bool,
+pub fn aptos_default_ty_builder(gas_feature_version: u64, features: &Features) -> TypeBuilder {
+    ty_builder_for(gas_feature_version, features, 128, 20)
+}
+
+/// Applies gas-version and feature gates consistently across production and default builders.
+fn ty_builder_for(
+    gas_feature_version: u64,
+    features: &Features,
+    max_ty_size: u64,
+    max_ty_depth: u64,
 ) -> TypeBuilder {
     TypeBuilder::with_limits(
-        128,
-        20,
-        check_depth_on_type_counts_v2,
-        count_function_type_node,
+        max_ty_size,
+        max_ty_depth,
+        gas_feature_version >= RELEASE_V1_42,
+        gas_feature_version >= RELEASE_V1_49,
+        features.is_enabled(FeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES),
     )
 }
 
@@ -169,6 +176,8 @@ pub fn aptos_prod_verifier_config(
     let sig_checker_v2_fix_script_ty_param_count =
         features.is_enabled(FeatureFlag::SIGNATURE_CHECKER_V2_SCRIPT_FIX);
     let sig_checker_v2_fix_function_signatures = gas_feature_version >= RELEASE_V1_34;
+    let check_function_type_abilities =
+        features.is_enabled(FeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES);
     let enable_enum_types = features.is_enabled(FeatureFlag::ENABLE_ENUM_TYPES);
     // Resource access control was never enabled and has been removed. Access specifiers
     // are permanently rejected by the verifier.
@@ -220,6 +229,7 @@ pub fn aptos_prod_verifier_config(
         _use_signature_checker_v2: true,
         sig_checker_v2_fix_script_ty_param_count,
         sig_checker_v2_fix_function_signatures,
+        check_function_type_abilities,
         enable_enum_types,
         enable_resource_access_control,
         enable_function_values,

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -35,7 +35,7 @@ impl GenesisRuntimeBuilder {
             LATEST_GAS_FEATURE_VERSION,
             &features,
             &timed_features,
-            aptos_default_ty_builder(true, true),
+            aptos_default_ty_builder(LATEST_GAS_FEATURE_VERSION, &features),
         );
 
         // All genesis sessions run with unmetered gas meter, and here we set

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -63,6 +63,7 @@ memory-stats = { workspace = true }
 move-bytecode-utils = { workspace = true }
 move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true }
+tempfile = { workspace = true }
 test-case = { workspace = true }
 thousands = { workspace = true }
 tokio = { workspace = true }

--- a/aptos-move/e2e-move-tests/src/tests/function_type_ability_bounds.rs
+++ b/aptos-move/e2e-move-tests/src/tests/function_type_ability_bounds.rs
@@ -1,0 +1,310 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! End-to-end tests for function-type ability validation.
+//!
+//! Function-type ability sets may contain only `copy`, `drop`, and `store`. With
+//! `FeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES` enabled, `TypeBuilder::create_ty` rejects
+//! `TypeTag`s containing `key` or undefined bits; while disabled, the raw bits are retained for
+//! deterministic replay.
+
+use crate::{assert_success, assert_vm_status, tests::common, MoveHarness};
+use aptos_framework::BuildOptions;
+use aptos_package_builder::PackageBuilder;
+use aptos_transaction_simulation::Account;
+use aptos_types::{
+    account_address::AccountAddress,
+    on_chain_config::FeatureFlag,
+    transaction::{EntryFunction, TransactionPayload, TransactionStatus},
+};
+use move_core_types::{
+    ability::AbilitySet,
+    identifier::Identifier,
+    language_storage::{FunctionTag, ModuleId, StructTag, TypeTag},
+    vm_status::StatusCode,
+};
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use tempfile::TempDir;
+
+/// `copy + drop + store`, i.e. `AbilitySet::PUBLIC_FUNCTIONS`.
+const LEGAL_ABILITY_BYTE: u8 = 0x07;
+
+/// Representative subsets of `AbilitySet::PUBLIC_FUNCTIONS`.
+const LEGAL_ABILITY_BYTES: [u8; 6] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x07];
+
+/// `copy + drop + store` plus bit `0x10`, which is not assigned to any ability. Rejected by
+/// `AbilitySet::from_u8`, so it is unreachable through module bytecode but not through a `TypeTag`.
+const UNKNOWN_BIT_ABILITY_BYTE: u8 = 0x17;
+
+/// `copy + drop + store + key`. Accepted by `AbilitySet::from_u8`, so validating the ability
+/// *encoding* would not reject it, yet no function value can ever carry `key`.
+const FAKE_KEY_ABILITY_BYTE: u8 = 0x0F;
+
+const MODULE_ADDRESS: &str = "0xcafe";
+const MODULE_NAME: &str = "fn_ability_bounds";
+
+const MODULE_SOURCE: &str = r#"
+module 0xcafe::fn_ability_bounds {
+    use std::signer;
+    use std::string::String;
+    use std::vector;
+    use aptos_std::type_info;
+    use aptos_framework::object;
+
+    /// Canonical type names recorded in call order.
+    struct Observed has key {
+        type_arg_names: vector<String>,
+    }
+
+    /// Stores one resource per `T` without requiring a value of `T`.
+    struct Holder<phantom T> has key {
+        value: u64,
+    }
+
+    /// Constrains `T` to `key`, which no function type can legitimately satisfy.
+    struct KeyBound<phantom T: key> has key {
+        value: u64,
+    }
+
+    fun init_module(publisher: &signer) {
+        move_to(publisher, Observed { type_arg_names: vector::empty() });
+    }
+
+    /// Instantiable at any `T`, so it isolates the type-argument construction step.
+    public entry fun observe<T>(caller: &signer, value: u64) acquires Observed {
+        let observed = borrow_global_mut<Observed>(@0xcafe);
+        vector::push_back(&mut observed.type_arg_names, type_info::type_name<T>());
+        move_to(caller, Holder<T> { value });
+    }
+
+    /// Stores a resource parameterized by a `T: key` type argument.
+    public entry fun make_object<T: key>(caller: &signer, value: u64) {
+        let constructor_ref = object::create_object(signer::address_of(caller));
+        let object_signer = object::generate_signer(&constructor_ref);
+        move_to(&object_signer, KeyBound<T> { value });
+    }
+}
+"#;
+
+#[derive(Deserialize)]
+struct Observed {
+    type_arg_names: Vec<String>,
+}
+
+/// Reuses one package path because `MoveHarness` caches compiled packages by path.
+static PACKAGE: Lazy<TempDir> = Lazy::new(|| {
+    let mut builder = PackageBuilder::new("FnAbilityBounds");
+    builder.add_source("fn_ability_bounds.move", MODULE_SOURCE);
+    for (name, path) in [
+        ("MoveStdlib", "move-stdlib"),
+        ("AptosStdlib", "aptos-stdlib"),
+        ("AptosFramework", "aptos-framework"),
+    ] {
+        builder.add_local_dep(name, &common::framework_dir_path(path).to_string_lossy());
+    }
+    builder.write_to_temp().unwrap()
+});
+
+fn module_address() -> AccountAddress {
+    AccountAddress::from_hex_literal(MODULE_ADDRESS).unwrap()
+}
+
+fn publish() -> (MoveHarness, Account) {
+    let mut harness = MoveHarness::new();
+    let account = harness.new_account_at(module_address());
+    let status = harness.publish_package_with_options(
+        &account,
+        PACKAGE.path(),
+        BuildOptions::move_2().set_latest_language(),
+    );
+    assert_success!(status);
+    (harness, account)
+}
+
+/// Builds a nullary function `TypeTag` with the exact raw ability byte. BCS decoding is used because
+/// `AbilitySet::from_u8` rejects bytes containing undefined bits.
+fn function_type_tag(ability_byte: u8) -> TypeTag {
+    let abilities: AbilitySet =
+        bcs::from_bytes(&[ability_byte]).expect("AbilitySet BCS decoding accepts any byte");
+    TypeTag::Function(Box::new(FunctionTag {
+        args: vec![],
+        results: vec![],
+        abilities,
+    }))
+}
+
+fn holder_struct_tag(ability_byte: u8) -> StructTag {
+    StructTag {
+        address: module_address(),
+        module: Identifier::new(MODULE_NAME).unwrap(),
+        name: Identifier::new("Holder").unwrap(),
+        type_args: vec![function_type_tag(ability_byte)],
+    }
+}
+
+fn observed_struct_tag() -> StructTag {
+    StructTag {
+        address: module_address(),
+        module: Identifier::new(MODULE_NAME).unwrap(),
+        name: Identifier::new("Observed").unwrap(),
+        type_args: vec![],
+    }
+}
+
+fn entry_function_payload(name: &str, ty_args: Vec<TypeTag>, value: u64) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(module_address(), Identifier::new(MODULE_NAME).unwrap()),
+        Identifier::new(name).unwrap(),
+        ty_args,
+        vec![bcs::to_bytes(&value).unwrap()],
+    ))
+}
+
+fn run_with_ability_byte(
+    harness: &mut MoveHarness,
+    account: &Account,
+    entry_function_name: &str,
+    ability_byte: u8,
+    value: u64,
+) -> TransactionStatus {
+    let payload = entry_function_payload(
+        entry_function_name,
+        vec![function_type_tag(ability_byte)],
+        value,
+    );
+    harness.run_transaction_payload(account, payload)
+}
+
+/// Rejects excess function abilities during type-argument construction, before entry-function
+/// execution.
+#[test]
+fn excess_function_type_abilities_are_rejected() {
+    assert!(
+        AbilitySet::from_u8(UNKNOWN_BIT_ABILITY_BYTE).is_none(),
+        "{UNKNOWN_BIT_ABILITY_BYTE:#04x} must be rejected by the only validating constructor"
+    );
+    assert!(
+        AbilitySet::from_u8(FAKE_KEY_ABILITY_BYTE).is_some(),
+        "{FAKE_KEY_ABILITY_BYTE:#04x} is a well-formed ability set, so encoding checks miss it"
+    );
+
+    let (mut harness, account) = publish();
+
+    for ability_byte in [UNKNOWN_BIT_ABILITY_BYTE, FAKE_KEY_ABILITY_BYTE, 0xFF] {
+        let status = run_with_ability_byte(&mut harness, &account, "observe", ability_byte, 7);
+        assert_vm_status!(status, StatusCode::CONSTRAINT_NOT_SATISFIED);
+    }
+
+    // Rejected type arguments leave the module state unchanged.
+    let observed = harness
+        .read_resource::<Observed>(account.address(), observed_struct_tag())
+        .expect("Observed resource must exist");
+    assert!(observed.type_arg_names.is_empty());
+    for ability_byte in [UNKNOWN_BIT_ABILITY_BYTE, FAKE_KEY_ABILITY_BYTE] {
+        assert_eq!(
+            harness.read_resource::<u64>(account.address(), holder_struct_tag(ability_byte)),
+            None
+        );
+    }
+}
+
+/// Accepts representative subsets of `AbilitySet::PUBLIC_FUNCTIONS`.
+#[test]
+fn legal_function_type_abilities_are_still_accepted() {
+    let (mut harness, account) = publish();
+
+    for (index, ability_byte) in LEGAL_ABILITY_BYTES.into_iter().enumerate() {
+        let status = run_with_ability_byte(
+            &mut harness,
+            &account,
+            "observe",
+            ability_byte,
+            index as u64,
+        );
+        assert_success!(
+            status,
+            "ability byte {ability_byte:#04x} is legal and must still be accepted"
+        );
+        assert_eq!(
+            harness.read_resource::<u64>(account.address(), holder_struct_tag(ability_byte)),
+            Some(index as u64)
+        );
+    }
+
+    let observed = harness
+        .read_resource::<Observed>(account.address(), observed_struct_tag())
+        .expect("Observed resource must exist");
+    assert_eq!(observed.type_arg_names.len(), LEGAL_ABILITY_BYTES.len());
+}
+
+/// Rejects a well-formed `0x0f` ability set before its `key` bit can satisfy `T: key`.
+#[test]
+fn fake_key_no_longer_satisfies_a_key_constraint() {
+    let (mut harness, account) = publish();
+
+    let status = run_with_ability_byte(
+        &mut harness,
+        &account,
+        "make_object",
+        FAKE_KEY_ABILITY_BYTE,
+        1,
+    );
+    assert_vm_status!(status, StatusCode::CONSTRAINT_NOT_SATISFIED);
+
+    // `AbilitySet::PUBLIC_FUNCTIONS` does not satisfy `T: key`.
+    let status =
+        run_with_ability_byte(&mut harness, &account, "make_object", LEGAL_ABILITY_BYTE, 1);
+    assert_vm_status!(status, StatusCode::CONSTRAINT_NOT_SATISFIED);
+}
+
+/// With the check disabled, canonical-name collisions remain and function types that claim `key`
+/// satisfy `T: key`.
+#[test]
+fn behavior_with_the_check_disabled_is_unchanged() {
+    let (mut harness, account) = publish();
+
+    harness.enable_features(vec![], vec![FeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES]);
+
+    for (ability_byte, value) in [(LEGAL_ABILITY_BYTE, 7u64), (UNKNOWN_BIT_ABILITY_BYTE, 9u64)] {
+        let status = run_with_ability_byte(&mut harness, &account, "observe", ability_byte, value);
+        assert_success!(status);
+    }
+
+    let observed = harness
+        .read_resource::<Observed>(account.address(), observed_struct_tag())
+        .expect("Observed resource must exist");
+    assert_eq!(observed.type_arg_names, vec![
+        "||() has copy + drop + store".to_string(),
+        "||() has copy + drop + store".to_string(),
+    ]);
+
+    // Canonical-name collisions do not collapse BCS-derived state keys.
+    assert_ne!(
+        holder_struct_tag(LEGAL_ABILITY_BYTE).access_vector(),
+        holder_struct_tag(UNKNOWN_BIT_ABILITY_BYTE).access_vector()
+    );
+    assert_eq!(
+        harness.read_resource::<u64>(account.address(), holder_struct_tag(LEGAL_ABILITY_BYTE)),
+        Some(7)
+    );
+    assert_eq!(
+        harness.read_resource::<u64>(
+            account.address(),
+            holder_struct_tag(UNKNOWN_BIT_ABILITY_BYTE)
+        ),
+        Some(9)
+    );
+
+    let status = run_with_ability_byte(
+        &mut harness,
+        &account,
+        "make_object",
+        FAKE_KEY_ABILITY_BYTE,
+        1,
+    );
+    assert_success!(
+        status,
+        "with the check disabled a function type claiming `key` still satisfies a `T: key` bound"
+    );
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod error_map;
 mod fee_payer;
 mod friends;
 mod function_caches;
+mod function_type_ability_bounds;
 mod function_value_depth;
 mod function_value_layout_dag;
 mod function_value_serialization_restriction;

--- a/aptos-move/framework/natives/src/storage_slot.rs
+++ b/aptos-move/framework/natives/src/storage_slot.rs
@@ -22,6 +22,20 @@ use std::collections::VecDeque;
 
 // Error codes
 const ESTORAGE_SLOT_NOT_FOUND: u64 = 0x2;
+const ENOT_A_RESOURCE_TYPE: u64 = 0x3;
+
+/// The natives below take the resource type to borrow as an unconstrained type parameter, and
+/// Move cannot restrict a type parameter to structs and enums. Reject other runtime types before
+/// the global storage lookup, where they would cause an invariant violation.
+fn check_is_resource_type(ty: &Type) -> SafeNativeResult<()> {
+    if !ty.is_struct_or_enum() {
+        return Err(SafeNativeError::abort_with_message(
+            ENOT_A_RESOURCE_TYPE,
+            "Storage slot resource type argument must be a struct type",
+        ));
+    }
+    Ok(())
+}
 
 /***************************************************************************************************
  * native fun borrow_storage_slot_resource<T: store, BR>(self: &StorageSlot<T>): &BR
@@ -53,6 +67,7 @@ fn native_borrow_storage_slot_resource(
 
     // ty_args[1] is StorageSlotResource<T> - the type we want to borrow from global storage
     let storage_slot_resource_ty = &ty_args[1];
+    check_is_resource_type(storage_slot_resource_ty)?;
 
     // Borrow the resource from global storage
     let (gv, num_bytes, amount) =
@@ -101,6 +116,7 @@ fn native_borrow_storage_slot_resource_mut(
 
     // ty_args[1] is StorageSlotResource<T> - the type we want to borrow from global storage
     let storage_slot_resource_ty = &ty_args[1];
+    check_is_resource_type(storage_slot_resource_ty)?;
 
     // Borrow the resource mutably from global storage
     let (gv, num_bytes, amount) =

--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -47,6 +47,11 @@ fn compatibility_test_features() -> Features {
     // feature is not enabled yet. When enabled, old and new binaries can
     // disagree on the hotness portion of transaction outputs.
     features.disable(FeatureFlag::HOTNESS_IN_EPILOGUE);
+    // The old binary's genesis panics on feature indices it does not know, so a
+    // flag must stay disabled here until the newest release branch has it.
+    // TODO: remove once `CHECK_FUNCTION_TYPE_ABILITIES` is on the newest
+    // `aptos-release-v*` branch (v1.50 cut).
+    features.disable(FeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES);
     features
 }
 

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/type_tag_to_string.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/type_tag_to_string.rs
@@ -14,7 +14,8 @@ struct FuzzData {
     b: TypeTag,
 }
 
-/// Validates that all identifiers are valid Move identifiers and contains valid ability sets
+/// Returns whether every identifier is valid and every function ability set contains only defined
+/// bits.
 fn is_valid_type_tag(type_tag: &TypeTag) -> bool {
     match type_tag {
         TypeTag::Struct(struct_tag) => {
@@ -24,7 +25,9 @@ fn is_valid_type_tag(type_tag: &TypeTag) -> bool {
         },
         TypeTag::Vector(inner_type_tag) => is_valid_type_tag(inner_type_tag),
         TypeTag::Function(function_tag) => {
-            function_tag.abilities.into_u8() <= AbilitySet::ALL.into_u8()
+            // Undefined ability bits survive `TypeTag` decoding but are omitted from canonical
+            // strings, so exclude them from the injectivity property below.
+            function_tag.abilities.is_subset(AbilitySet::ALL)
                 && function_tag
                     .args
                     .iter()

--- a/third_party/move/mono-move/core/src/prepared_module.rs
+++ b/third_party/move/mono-move/core/src/prepared_module.rs
@@ -653,6 +653,8 @@ pub fn intern_type_tag(tag: &TypeTag, interner: &impl Interner) -> anyhow::Resul
         TypeTag::Vector(elem) => interner.vector_of(intern_type_tag(elem, interner)?),
         TypeTag::Struct(struct_tag) => intern_struct_tag(struct_tag, interner)?,
         TypeTag::Function(function_tag) => {
+            // TODO: reject abilities for which `is_valid_for_function_type()` is false, as the
+            // MoveVM does when converting tags to runtime types.
             let args = intern_function_param_tags(&function_tag.args, interner)?;
             let results = intern_function_param_tags(&function_tag.results, interner)?;
             interner.function_of(

--- a/third_party/move/move-binary-format/src/errors.rs
+++ b/third_party/move/move-binary-format/src/errors.rs
@@ -698,6 +698,15 @@ pub fn verification_error(status: StatusCode, kind: IndexKind, idx: TableIndex) 
     PartialVMError::new(status).at_index(kind, idx)
 }
 
+/// Constructs the shared error for function abilities outside `AbilitySet::PUBLIC_FUNCTIONS`.
+#[cold]
+#[inline(never)]
+pub fn excess_function_type_abilities_error() -> PartialVMError {
+    PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED).with_message(
+        "function type has invalid abilities: only copy, drop, and store are allowed".to_string(),
+    )
+}
+
 impl fmt::Debug for PartialVMError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.0, f)

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -3,8 +3,9 @@
 // Parts of the file are Copyright (c) Aptos Foundation
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use move_binary_format::file_format::{
-    Bytecode::*, CompiledModule, SignatureToken::*, Visibility::Public, *,
+use move_binary_format::{
+    errors::VMResult,
+    file_format::{Bytecode::*, CompiledModule, SignatureToken::*, Visibility::Public, *},
 };
 use move_bytecode_verifier::{verify_module, verify_module_with_config_for_test, VerifierConfig};
 use move_core_types::{
@@ -191,6 +192,97 @@ fn big_signature_test() {
     )
     .unwrap_err();
     assert_eq!(res.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
+}
+
+/// Builds a module whose only declared function takes `parameter`.
+fn module_with_function_type_parameter(parameter: SignatureToken) -> CompiledModule {
+    let mut module = empty_module();
+    module.identifiers.push(Identifier::new("f").unwrap());
+    module.signatures.push(Signature(vec![parameter]));
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(1),
+        return_: SignatureIndex(0),
+        parameters: SignatureIndex(1),
+        type_parameters: vec![],
+        access_specifiers: None,
+        attributes: vec![],
+    });
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: Public,
+        is_entry: false,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![Ret],
+        }),
+    });
+    module
+}
+
+fn verify_function_type_abilities(module: &CompiledModule) -> VMResult<()> {
+    verify_module_with_config_for_test(
+        "function_type_abilities",
+        &VerifierConfig::production(),
+        module,
+    )
+}
+
+/// Rejects `key`, which no function value can carry, in top-level and nested function types.
+#[test]
+fn function_type_abilities_are_bounded_by_public_functions() {
+    let excess = AbilitySet::ALL;
+    assert!(!excess.is_subset(AbilitySet::PUBLIC_FUNCTIONS));
+
+    for parameter in [
+        Function(vec![], vec![], excess),
+        Vector(Box::new(Function(vec![], vec![], excess))),
+        Function(
+            vec![Function(vec![], vec![], excess)],
+            vec![],
+            AbilitySet::PUBLIC_FUNCTIONS,
+        ),
+    ] {
+        let module = module_with_function_type_parameter(parameter);
+        let err = verify_function_type_abilities(&module).unwrap_err();
+        assert_eq!(err.major_status(), StatusCode::CONSTRAINT_NOT_SATISFIED);
+    }
+}
+
+/// Accepts representative valid function ability sets. Top-level parameters require `drop` because
+/// the helper function returns without consuming them, so `EMPTY` is tested in a nested position.
+#[test]
+fn legal_function_type_abilities_still_verify() {
+    for parameter in [
+        Function(vec![], vec![], AbilitySet::FUNCTIONS),
+        Function(vec![], vec![], AbilitySet::PRIVATE_FUNCTIONS),
+        Function(vec![], vec![], AbilitySet::PUBLIC_FUNCTIONS),
+        Function(
+            vec![Function(vec![], vec![], AbilitySet::EMPTY)],
+            vec![],
+            AbilitySet::PUBLIC_FUNCTIONS,
+        ),
+        Vector(Box::new(Function(
+            vec![],
+            vec![],
+            AbilitySet::PUBLIC_FUNCTIONS,
+        ))),
+    ] {
+        let module = module_with_function_type_parameter(parameter);
+        verify_function_type_abilities(&module).unwrap();
+    }
+}
+
+/// Allows excess function abilities when the verifier check is disabled.
+#[test]
+fn excess_function_type_abilities_verify_when_the_check_is_disabled() {
+    let module = module_with_function_type_parameter(Function(vec![], vec![], AbilitySet::ALL));
+    let config = VerifierConfig {
+        check_function_type_abilities: false,
+        ..VerifierConfig::production()
+    };
+    verify_module_with_config_for_test("function_type_abilities", &config, &module).unwrap();
 }
 
 #[test]

--- a/third_party/move/move-bytecode-verifier/src/signature_v2.rs
+++ b/third_party/move/move-bytecode-verifier/src/signature_v2.rs
@@ -6,7 +6,9 @@
 use crate::VerifierConfig;
 use move_binary_format::{
     binary_views::BinaryIndexedView,
-    errors::{Location, PartialVMError, PartialVMResult, VMResult},
+    errors::{
+        excess_function_type_abilities_error, Location, PartialVMError, PartialVMResult, VMResult,
+    },
     file_format::{
         Bytecode, CodeUnit, CompiledModule, CompiledScript, FieldDefinition,
         FieldInstantiationIndex, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
@@ -173,7 +175,13 @@ impl<'a, const N: usize> SignatureChecker<'a, N> {
             },
             Function(params, results, abilities) => {
                 assert_abilities(*abilities, required_abilities)?;
-                if self.sig_checker_v2_fix_function_signatures {
+                if self.config.check_function_type_abilities
+                    && !abilities.is_valid_for_function_type()
+                {
+                    // Function types cannot carry `key` or undefined abilities.
+                    return Err(excess_function_type_abilities_error());
+                }
+                if self.config.sig_checker_v2_fix_function_signatures {
                     for ty in params.iter().chain(results) {
                         self.check_ty(
                             ty,
@@ -301,8 +309,7 @@ fn check_phantom_params(
 
 struct SignatureChecker<'a, const N: usize> {
     resolver: BinaryIndexedView<'a>,
-    // If enabled, recurses into function signature to check type signatures.
-    sig_checker_v2_fix_function_signatures: bool,
+    config: &'a VerifierConfig,
 
     // Here the arena is used as a scoped interner, allowing us to store references in the
     // caches below.
@@ -345,12 +352,12 @@ impl<'a, const N: usize> SignatureChecker<'a, N> {
     fn new(
         constraints: &'a Arena<BitsetTypeParameterConstraints<N>>,
         resolver: BinaryIndexedView<'a>,
-        sig_checker_v2_fix_function_signatures: bool,
+        config: &'a VerifierConfig,
     ) -> Self {
         Self {
             resolver,
             constraints,
-            sig_checker_v2_fix_function_signatures,
+            config,
 
             ty_results: RefCell::new(BTreeMap::new()),
             sig_results: RefCell::new(BTreeMap::new()),
@@ -1150,11 +1157,7 @@ fn verify_module_impl<const N: usize>(
     module: &CompiledModule,
 ) -> PartialVMResult<()> {
     let arena = Arena::<BitsetTypeParameterConstraints<N>>::new();
-    let checker = SignatureChecker::new(
-        &arena,
-        BinaryIndexedView::Module(module),
-        config.sig_checker_v2_fix_function_signatures,
-    );
+    let checker = SignatureChecker::new(&arena, BinaryIndexedView::Module(module), config);
 
     // Check if all signatures & instantiations are well-formed without any specific contexts.
     // This is only needed if we want to keep the binary format super clean.
@@ -1177,11 +1180,7 @@ fn verify_script_impl<const N: usize>(
     script: &CompiledScript,
 ) -> PartialVMResult<()> {
     let arena = Arena::<BitsetTypeParameterConstraints<N>>::new();
-    let checker = SignatureChecker::new(
-        &arena,
-        BinaryIndexedView::Script(script),
-        config.sig_checker_v2_fix_function_signatures,
-    );
+    let checker = SignatureChecker::new(&arena, BinaryIndexedView::Script(script), config);
 
     // Check if all signatures & instantiations are well-formed without any specific contexts.
     // This is only needed if we want to keep the binary format super clean.

--- a/third_party/move/move-bytecode-verifier/src/verifier.rs
+++ b/third_party/move/move-bytecode-verifier/src/verifier.rs
@@ -65,6 +65,9 @@ pub struct VerifierConfig {
     /// If enabled, signature checker V2 also checks parameter and return types in function
     /// signatures.
     pub sig_checker_v2_fix_function_signatures: bool,
+    /// Rejects function types whose abilities are not a subset of
+    /// `AbilitySet::PUBLIC_FUNCTIONS` when enabled.
+    pub check_function_type_abilities: bool,
 }
 
 /// Scope of verification.
@@ -262,6 +265,7 @@ impl Default for VerifierConfig {
 
             sig_checker_v2_fix_script_ty_param_count: true,
             sig_checker_v2_fix_function_signatures: true,
+            check_function_type_abilities: true,
 
             enable_enum_types: true,
             enable_resource_access_control: false,
@@ -311,6 +315,7 @@ impl VerifierConfig {
             _use_signature_checker_v2: true,
             sig_checker_v2_fix_script_ty_param_count: true,
             sig_checker_v2_fix_function_signatures: true,
+            check_function_type_abilities: true,
 
             enable_enum_types: true,
             enable_resource_access_control: false,

--- a/third_party/move/move-core/types/src/ability.rs
+++ b/third_party/move/move-core/types/src/ability.rs
@@ -119,6 +119,11 @@ impl AbilitySet {
     pub const VECTOR: AbilitySet =
         Self((Ability::Copy as u8) | (Ability::Drop as u8) | (Ability::Store as u8));
 
+    /// Returns whether this set can describe a function value.
+    pub fn is_valid_for_function_type(self) -> bool {
+        self.is_subset(Self::PUBLIC_FUNCTIONS)
+    }
+
     /// Create a representation as a display postfix if the ability set is not empty.
     pub fn display_postfix(&self) -> String {
         if self.is_empty() {
@@ -334,6 +339,9 @@ impl fmt::Debug for AbilitySet {
     }
 }
 
+// This proptest strategy covers only defined ability sets. The derived
+// `arbitrary` implementation covers all 256 raw bytes, including encodings
+// rejected by `from_u8`.
 #[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for AbilitySet {
     type Parameters = ();

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -694,6 +694,50 @@ mod tests {
         }
     }
 
+    /// Ensures the generator exercises function tags covered by the canonical-string uniqueness
+    /// property.
+    #[test]
+    fn test_arbitrary_type_tag_generates_function_tags() {
+        use proptest::{strategy::ValueTree, test_runner::TestRunner};
+
+        let mut runner = TestRunner::deterministic();
+        let strategy = any::<TypeTag>();
+        let saw_function = (0..2000).any(|_| {
+            let tag = strategy.new_tree(&mut runner).unwrap().current();
+            tag.preorder_traversal_iter()
+                .any(|inner| matches!(inner, TypeTag::Function(_)))
+        });
+        assert!(
+            saw_function,
+            "the TypeTag proptest generator never produced a function tag"
+        );
+    }
+
+    /// Demonstrates that BCS preserves undefined function-ability bits while canonical strings
+    /// omit them.
+    #[test]
+    fn test_unknown_function_ability_bits_collide_in_canonical_string() {
+        let valid = make_function_tag(vec![], vec![], AbilitySet::PUBLIC_FUNCTIONS);
+        let unknown_bit = make_function_tag(
+            vec![],
+            vec![],
+            bcs::from_bytes::<AbilitySet>(&[0x17]).expect("Deserialize accepts any ability byte"),
+        );
+
+        assert_ne!(valid, unknown_bit);
+        assert_eq!(
+            valid.to_canonical_string(),
+            unknown_bit.to_canonical_string()
+        );
+        assert_eq!(
+            unknown_bit.to_canonical_string(),
+            "||() has copy + drop + store"
+        );
+
+        let encoded = bcs::to_bytes(&unknown_bit).unwrap();
+        assert_eq!(bcs::from_bytes::<TypeTag>(&encoded).unwrap(), unknown_bit);
+    }
+
     #[test]
     fn test_tag_iter() {
         let tag = TypeTag::from_str("vector<0x1::a::A<u8, 0x2::b::B, vector<vector<0x3::c::C>>>>")

--- a/third_party/move/move-core/types/src/proptest_types.rs
+++ b/third_party/move/move-core/types/src/proptest_types.rs
@@ -4,9 +4,10 @@
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
+    ability::AbilitySet,
     account_address::AccountAddress,
     identifier::Identifier,
-    language_storage::{StructTag, TypeTag},
+    language_storage::{FunctionParamOrReturnTag, FunctionTag, StructTag, TypeTag},
     transaction_argument::TransactionArgument,
 };
 use proptest::{collection::vec, prelude::*};
@@ -24,28 +25,56 @@ impl Arbitrary for TypeTag {
             Just(U64),
             Just(U128),
             Just(U256),
+            Just(I8),
+            Just(I16),
+            Just(I32),
+            Just(I64),
+            Just(I128),
+            Just(I256),
             Just(Address),
-            Just(Vector(Box::new(Bool))),
+            Just(Signer),
         ];
         leaf.prop_recursive(
             8,  // levels deep
             16, // max size
             4,  // max number of items per collection
             |inner| {
-                (
-                    any::<AccountAddress>(),
-                    any::<Identifier>(),
-                    any::<Identifier>(),
-                    vec(inner, 0..4),
-                )
-                    .prop_map(|(address, module, name, type_args)| {
-                        Struct(Box::new(StructTag {
-                            address,
-                            module,
-                            name,
-                            type_args,
-                        }))
-                    })
+                let param_or_return = prop_oneof![
+                    inner.clone().prop_map(FunctionParamOrReturnTag::Value),
+                    inner.clone().prop_map(FunctionParamOrReturnTag::Reference),
+                    inner
+                        .clone()
+                        .prop_map(FunctionParamOrReturnTag::MutableReference),
+                ];
+                prop_oneof![
+                    (
+                        any::<AccountAddress>(),
+                        any::<Identifier>(),
+                        any::<Identifier>(),
+                        vec(inner.clone(), 0..4),
+                    )
+                        .prop_map(|(address, module, name, type_args)| {
+                            Struct(Box::new(StructTag {
+                                address,
+                                module,
+                                name,
+                                type_args,
+                            }))
+                        }),
+                    (
+                        vec(param_or_return.clone(), 0..3),
+                        vec(param_or_return, 0..3),
+                        any::<AbilitySet>(),
+                    )
+                        .prop_map(|(args, results, abilities)| {
+                            Function(Box::new(FunctionTag {
+                                args,
+                                results,
+                                abilities,
+                            }))
+                        }),
+                    inner.prop_map(|ty| Vector(Box::new(ty))),
+                ]
             },
         )
         .boxed()

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -100,7 +100,7 @@ impl Default for VMConfig {
             type_base_cost: 0,
             type_byte_cost: 0,
             delayed_field_optimization_enabled: false,
-            ty_builder: TypeBuilder::with_limits(128, 20, true, true),
+            ty_builder: TypeBuilder::with_limits(128, 20, true, true, true),
             enable_function_caches: true,
             enable_lazy_loading: true,
             enable_depth_checks: true,

--- a/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
@@ -480,7 +480,7 @@ mod tests {
 
     #[test]
     fn test_ty_to_ty_tag() {
-        let ty_builder = TypeBuilder::with_limits(10, 10, true, true);
+        let ty_builder = TypeBuilder::with_limits(10, 10, true, true, true);
 
         let runtime_environment = RuntimeEnvironment::new(vec![]);
         let ty_tag_converter = TypeTagConverter::new(&runtime_environment);
@@ -577,7 +577,7 @@ mod tests {
 
     #[test]
     fn test_ty_to_ty_tag_too_complex() {
-        let ty_builder = TypeBuilder::with_limits(10, 10, true, true);
+        let ty_builder = TypeBuilder::with_limits(10, 10, true, true, true);
 
         let vm_config = VMConfig {
             type_base_cost: 1,

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -12,7 +12,7 @@ use crate::{
 use derivative::Derivative;
 use itertools::Itertools;
 use move_binary_format::{
-    errors::{PartialVMError, PartialVMResult},
+    errors::{excess_function_type_abilities_error, PartialVMError, PartialVMResult},
     file_format::{
         SignatureToken, StructHandle, StructTypeParameter, TypeParameterIndex, VariantIndex,
     },
@@ -1058,8 +1058,7 @@ impl fmt::Display for Type {
     }
 }
 
-/// Controls creation of runtime types, i.e., methods offered by this struct
-/// should be the only way to construct any type.
+/// Constructs runtime types while enforcing configured size and depth limits.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct TypeBuilder {
     // Maximum number of nodes a fully-instantiated type has.
@@ -1073,6 +1072,8 @@ pub struct TypeBuilder {
     pub count_function_type_node: bool,
     ref_ty_count_decrement: u64,
     ref_ty_depth_increment: u64,
+    // Enables function-ability validation for `TypeTag` inputs.
+    check_function_type_abilities: bool,
 }
 
 impl TypeBuilder {
@@ -1081,6 +1082,7 @@ impl TypeBuilder {
         max_ty_depth: u64,
         check_depth_on_type_counts_v2: bool,
         count_function_type_node: bool,
+        check_function_type_abilities: bool,
     ) -> Self {
         Self {
             max_ty_size,
@@ -1095,6 +1097,7 @@ impl TypeBuilder {
             // successfully.
             ref_ty_count_decrement: if check_depth_on_type_counts_v2 { 1 } else { 0 },
             ref_ty_depth_increment: if check_depth_on_type_counts_v2 { 0 } else { 1 },
+            check_function_type_abilities,
         }
     }
 
@@ -1668,6 +1671,9 @@ impl TypeBuilder {
                     results,
                     abilities,
                 } = fun.as_ref();
+                if self.check_function_type_abilities && !abilities.is_valid_for_function_type() {
+                    return Err(excess_function_type_abilities_error());
+                }
                 let mut to_list = |ts: &[FunctionParamOrReturnTag]| {
                     ts.iter()
                         .map(|t| {
@@ -1884,6 +1890,134 @@ mod unit_tests {
     use claims::{assert_err, assert_matches, assert_ok};
     use move_binary_format::file_format::StructHandleIndex;
 
+    #[test]
+    fn unknown_function_ability_bits_satisfy_known_ability_constraints() {
+        let expected = AbilitySet::from_u8(0x07).expect("0x07 is a valid ability set");
+        let malformed =
+            bcs::from_bytes::<AbilitySet>(&[0x17]).expect("Deserialize accepts any ability byte");
+        let function_type = Type::Function {
+            args: vec![],
+            results: vec![],
+            abilities: malformed,
+        };
+
+        assert_ne!(expected, malformed);
+        assert!(expected.is_subset(malformed));
+        assert!(Type::verify_ty_arg_abilities([&expected], &[function_type]).is_ok());
+    }
+
+    fn function_tag_with_abilities(abilities_byte: u8) -> TypeTag {
+        TypeTag::Function(Box::new(FunctionTag {
+            args: vec![],
+            results: vec![],
+            abilities: bcs::from_bytes::<AbilitySet>(&[abilities_byte])
+                .expect("Deserialize accepts any ability byte"),
+        }))
+    }
+
+    #[test]
+    fn create_ty_rejects_function_types_with_excess_abilities() {
+        let ty_builder = TypeBuilder::with_limits(11, 5, true, true, true);
+        let no_op = |_: &StructTag| unreachable!("Should not be called");
+
+        // 0x08 and 0x0f include `key`; 0x10, 0x17, and 0xff include undefined bits.
+        for abilities_byte in [0x0F, 0x08, 0x17, 0x10, 0xFF] {
+            let err = assert_err!(
+                ty_builder.create_ty(&function_tag_with_abilities(abilities_byte), no_op)
+            );
+            assert_eq!(
+                err.major_status(),
+                StatusCode::CONSTRAINT_NOT_SATISFIED,
+                "expected ability byte {:#x} to be rejected",
+                abilities_byte
+            );
+        }
+
+        // Representative subsets of `PUBLIC_FUNCTIONS` remain valid.
+        for abilities_byte in [0x00, 0x01, 0x02, 0x03, 0x04, 0x07] {
+            assert_ok!(ty_builder.create_ty(&function_tag_with_abilities(abilities_byte), no_op));
+        }
+    }
+
+    /// Rejects excess abilities in nested function types as well as top-level tags.
+    #[test]
+    fn create_ty_rejects_nested_function_types_with_excess_abilities() {
+        let ty_builder = TypeBuilder::with_limits(20, 10, true, true, true);
+        let no_op = |_: &StructTag| unreachable!("Should not be called");
+
+        let bad = function_tag_with_abilities(0x0F);
+        let nested = [
+            TypeTag::Vector(Box::new(bad.clone())),
+            TypeTag::Vector(Box::new(TypeTag::Vector(Box::new(bad.clone())))),
+            TypeTag::Function(Box::new(FunctionTag {
+                args: vec![FunctionParamOrReturnTag::Value(bad.clone())],
+                results: vec![],
+                abilities: AbilitySet::PUBLIC_FUNCTIONS,
+            })),
+            TypeTag::Function(Box::new(FunctionTag {
+                args: vec![],
+                results: vec![FunctionParamOrReturnTag::Reference(bad)],
+                abilities: AbilitySet::PUBLIC_FUNCTIONS,
+            })),
+        ];
+
+        for ty_tag in nested {
+            let err = assert_err!(ty_builder.create_ty(&ty_tag, no_op));
+            assert_eq!(
+                err.major_status(),
+                StatusCode::CONSTRAINT_NOT_SATISFIED,
+                "nested function type must be rejected in {:?}",
+                ty_tag
+            );
+        }
+    }
+
+    /// Retains raw ability bytes when function-ability validation is disabled.
+    #[test]
+    fn create_ty_preserves_excess_abilities_when_the_check_is_disabled() {
+        let ty_builder = TypeBuilder::with_limits(11, 5, true, true, false);
+        let no_op = |_: &StructTag| unreachable!("Should not be called");
+
+        for abilities_byte in [0x0F, 0x17] {
+            let ty = assert_ok!(
+                ty_builder.create_ty(&function_tag_with_abilities(abilities_byte), no_op)
+            );
+            assert_eq!(assert_ok!(ty.abilities()).into_u8(), abilities_byte);
+        }
+    }
+
+    /// Subset-based type-argument checks accept a function type that claims `key`. Because `0x0f`
+    /// is a valid `AbilitySet` encoding, encoding validation alone cannot prevent this.
+    #[test]
+    fn function_type_claiming_key_satisfies_a_key_constraint() {
+        let claims_key = AbilitySet::from_u8(0x0F).expect("0x0F is a well-formed ability set");
+        assert!(claims_key.has_key());
+        assert!(!claims_key.is_subset(AbilitySet::PUBLIC_FUNCTIONS));
+
+        let function_type = Type::Function {
+            args: vec![],
+            results: vec![],
+            abilities: claims_key,
+        };
+        assert_eq!(function_type.abilities().unwrap(), claims_key);
+
+        let key_constraint = AbilitySet::singleton(Ability::Key);
+        assert_ok!(Type::verify_ty_arg_abilities(
+            [&key_constraint],
+            std::slice::from_ref(&function_type)
+        ));
+        assert_ok!(function_type.paranoid_check_abilities(key_constraint));
+
+        let honest_function_type = Type::Function {
+            args: vec![],
+            results: vec![],
+            abilities: AbilitySet::PUBLIC_FUNCTIONS,
+        };
+        assert_err!(Type::verify_ty_arg_abilities([&key_constraint], &[
+            honest_function_type
+        ]));
+    }
+
     fn struct_instantiation_ty_for_test(ty_args: Vec<Type>) -> Type {
         Type::StructInstantiation {
             idx: StructNameIndex::new(0),
@@ -1949,7 +2083,7 @@ mod unit_tests {
     fn test_num_nodes_in_subst() {
         use Type::*;
 
-        let ty_builder = TypeBuilder::with_limits(11, 5, true, true);
+        let ty_builder = TypeBuilder::with_limits(11, 5, true, true, true);
         let cases: Vec<(Type, Vec<Type>, usize, usize)> = vec![
             (TyParam(0), vec![Bool], 1, 1),
             (TyParam(0), vec![Vector(TriompheArc::new(Bool))], 2, 2),
@@ -1984,7 +2118,7 @@ mod unit_tests {
     fn test_substitution_large_depth() {
         use Type::*;
 
-        let ty_builder = TypeBuilder::with_limits(11, 5, true, true);
+        let ty_builder = TypeBuilder::with_limits(11, 5, true, true, true);
 
         let ty = Vector(TriompheArc::new(Vector(TriompheArc::new(TyParam(0)))));
         let ty_arg = Vector(TriompheArc::new(Vector(TriompheArc::new(Bool))));
@@ -1999,7 +2133,7 @@ mod unit_tests {
     fn test_substitution_large_count() {
         use Type::*;
 
-        let ty_builder = TypeBuilder::with_limits(11, 5, true, true);
+        let ty_builder = TypeBuilder::with_limits(11, 5, true, true, true);
 
         let ty_params: Vec<Type> = (0..5).map(TyParam).collect();
         let ty = struct_instantiation_ty_for_test(ty_params);
@@ -2028,7 +2162,7 @@ mod unit_tests {
         use Type::*;
 
         // Limits are irrelevant here.
-        let ty_builder = TypeBuilder::with_limits(1, 1, true, true);
+        let ty_builder = TypeBuilder::with_limits(1, 1, true, true, true);
 
         assert_eq!(ty_builder.create_u8_ty(), U8);
         assert_eq!(ty_builder.create_u16_ty(), U16);
@@ -2045,8 +2179,8 @@ mod unit_tests {
         let ability_info = AbilityInfo::struct_(AbilitySet::EMPTY);
 
         // Limits are not relevant here.
-        let struct_ty =
-            TypeBuilder::with_limits(1, 1, true, true).create_struct_ty(idx, ability_info.clone());
+        let struct_ty = TypeBuilder::with_limits(1, 1, true, true, true)
+            .create_struct_ty(idx, ability_info.clone());
         assert_matches!(struct_ty, Type::Struct { .. });
     }
 
@@ -2058,7 +2192,7 @@ mod unit_tests {
         let ty_params = [TyParam(0), Bool, TyParam(1)];
 
         // Should succeed, type size limit is 5, and we have 5 nodes.
-        let ty_builder = TypeBuilder::with_limits(5, 100, true, true);
+        let ty_builder = TypeBuilder::with_limits(5, 100, true, true, true);
         let ty_args = [Bool, Vector(TriompheArc::new(Bool))];
         assert_ok!(ty_builder.create_struct_instantiation_ty(&struct_ty, &ty_params, &ty_args));
 
@@ -2075,7 +2209,7 @@ mod unit_tests {
         // Should succeed, type depth limit is 4, and we have 4 nodes (3 in type parameter + struct).
         let nested_vec = Vector(TriompheArc::new(Vector(TriompheArc::new(Bool))));
         let ty_args = vec![Bool, nested_vec.clone()];
-        let ty_builder = TypeBuilder::with_limits(100, 4, true, true);
+        let ty_builder = TypeBuilder::with_limits(100, 4, true, true, true);
         assert_ok!(ty_builder.create_struct_instantiation_ty(&struct_ty, &ty_params, &ty_args));
 
         // Should fail, we have depth of 5 now.
@@ -2089,7 +2223,7 @@ mod unit_tests {
     #[test]
     fn test_create_vec_ty() {
         let max_ty_depth = 5;
-        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth, true, true);
+        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth, true, true, true);
 
         let mut depth = 1;
         let mut ty = Type::Bool;
@@ -2108,7 +2242,7 @@ mod unit_tests {
         // a type builder with smaller than depth size limit must return a different
         // error code.
         let max_ty_size = 5;
-        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true);
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true, true);
         let err = assert_err!(ty_builder.create_vec_ty(&ty));
         assert_eq!(err.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
     }
@@ -2117,7 +2251,7 @@ mod unit_tests {
     fn test_create_ref_ty() {
         let limit = 5;
 
-        let ty_builder = TypeBuilder::with_limits(100, limit, true, true);
+        let ty_builder = TypeBuilder::with_limits(100, limit, true, true, true);
 
         let mut depth = 1;
         let mut ty = Type::Bool;
@@ -2129,7 +2263,7 @@ mod unit_tests {
         let ref_ty = assert_ok!(ty_builder.create_ref_ty(&ty, false));
         assert_matches!(ref_ty, Type::Reference(_));
 
-        let ty_builder = TypeBuilder::with_limits(limit, 100, true, true);
+        let ty_builder = TypeBuilder::with_limits(limit, 100, true, true, true);
 
         let ref_ty = assert_ok!(ty_builder.create_ref_ty(&ty, false));
         assert_matches!(ref_ty, Type::Reference(_));
@@ -2139,7 +2273,7 @@ mod unit_tests {
     fn test_create_mut_ref_ty() {
         let limit = 5;
 
-        let ty_builder = TypeBuilder::with_limits(100, limit, true, true);
+        let ty_builder = TypeBuilder::with_limits(100, limit, true, true, true);
 
         let mut depth = 1;
         let mut ty = Type::Bool;
@@ -2151,7 +2285,7 @@ mod unit_tests {
         let ref_ty = assert_ok!(ty_builder.create_ref_ty(&ty, true));
         assert_matches!(ref_ty, Type::MutableReference(_));
 
-        let ty_builder = TypeBuilder::with_limits(limit, 100, true, true);
+        let ty_builder = TypeBuilder::with_limits(limit, 100, true, true, true);
 
         let ref_ty = assert_ok!(ty_builder.create_ref_ty(&ty, true));
         assert_matches!(ref_ty, Type::MutableReference(_));
@@ -2163,7 +2297,7 @@ mod unit_tests {
         use Type::*;
 
         let max_ty_depth = 5;
-        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth, true, true);
+        let ty_builder = TypeBuilder::with_limits(100, max_ty_depth, true, true, true);
 
         assert_eq!(assert_ok!(ty_builder.create_constant_ty(&S::U8)), U8);
         assert_eq!(assert_ok!(ty_builder.create_constant_ty(&S::U16)), U16);
@@ -2197,7 +2331,7 @@ mod unit_tests {
         assert_eq!(err.major_status(), StatusCode::VM_MAX_TYPE_DEPTH_REACHED);
 
         let max_ty_size = 5;
-        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true);
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true, true);
 
         for size in [max_ty_size - 1, max_ty_size] {
             let (expected_ty, vec_tok, _) = nested_vec_for_test(size);
@@ -2236,7 +2370,7 @@ mod unit_tests {
 
         let max_ty_size = 11;
         let max_ty_depth = 5;
-        let ty_builder = TypeBuilder::with_limits(max_ty_size, max_ty_depth, true, true);
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, max_ty_depth, true, true, true);
 
         let no_op = |_: &StructTag| unreachable!("Should not be called");
 
@@ -2268,7 +2402,7 @@ mod unit_tests {
         assert_eq!(err.major_status(), StatusCode::VM_MAX_TYPE_DEPTH_REACHED);
 
         let max_ty_size = 5;
-        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true);
+        let ty_builder = TypeBuilder::with_limits(max_ty_size, 100, true, true, true);
 
         for size in [max_ty_size - 1, max_ty_size] {
             let (expected_ty, _, vec_tag) = nested_vec_for_test(size);

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -227,6 +227,11 @@ pub enum FeatureFlag {
     LAZY_MODULE_INITIALIZATION = 127,
     /// When enabled, new MonoMove VM is used for execution instead of the V1 Move VM.
     ENABLE_MONO_MOVE = 128,
+    /// When enabled, function types whose abilities are not a subset of `copy + drop + store`
+    /// are rejected during `TypeTag` construction and module or script verification. Modules
+    /// are verified on every load, so a previously published module with such a signature
+    /// stops loading once this is enabled.
+    CHECK_FUNCTION_TYPE_ABILITIES = 129,
 }
 
 impl FeatureFlag {
@@ -341,6 +346,7 @@ impl FeatureFlag {
             Self::ALLOW_FRIEND_ENTRY_VISIBILITY_DOWNGRADE,
             Self::HOTNESS_IN_EPILOGUE,
             Self::ENCRYPTED_TRANSACTIONS,
+            Self::CHECK_FUNCTION_TYPE_ABILITIES,
         ]
     }
 }


### PR DESCRIPTION
## Description

We address a couple of issues here:
- **Invalid function abilities were accepted:** transaction `TypeTag`s could contain `key` or undefined ability bits, while module/script bytecode could contain `key`. This could violate ability constraints and make distinct types share a canonical name.
- Storage-slot natives now reject non-resource type arguments before global storage access instead of triggering a VM invariant violation.

Introduces `FeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES`, which enforces that function types in Move may only carry abilities from `{copy, drop, store}`.

When enabled:
- The bytecode verifier (`signature_v2`) rejects modules and scripts whose signatures contain function types with abilities outside `AbilitySet::PUBLIC_FUNCTIONS`.
- `TypeBuilder::create_ty` rejects `TypeTag` inputs carrying excess function abilities before any entry-function execution begins, returning `CONSTRAINT_NOT_SATISFIED`.

Previously published modules containing such signatures stop loading once the flag is enabled, because modules are re-verified on every load.

Two existing transactional test expectations are updated: the `closure_key_address_to_object` and `reflect_key_ability` tests now reflect that the invalid module is rejected at publication rather than at runtime.

## How Has This Been Tested?

- **Bytecode verifier unit tests** (`signature_tests.rs`): cover rejection of `key` and undefined bits in top-level and nested function types, acceptance of all valid subsets of `PUBLIC_FUNCTIONS`, and a disabled-check path.
- **`TypeBuilder` unit tests** (`runtime_types.rs`): cover `create_ty` rejection of excess abilities in top-level and nested tags, preservation of raw bytes when the check is disabled, and the demonstration that a function type claiming `key` satisfies a `T: key` constraint without the guard.
- **End-to-end tests** (`function_type_ability_bounds.rs`): four scenarios exercised against a deployed module—excess abilities rejected before execution, legal subsets still accepted, fake `key` no longer satisfies a `T: key` bound, and legacy behavior preserved when the flag is disabled.
- **Transactional tests** updated to match the new earlier-rejection behavior.
- **Fuzz target** (`type_tag_to_string.rs`) updated to use `is_subset(AbilitySet::ALL)` instead of a raw byte comparison, correctly excluding undefined bits from the injectivity property.
- **Proptest generator** for `TypeTag` extended to produce `Function` variants, with a regression test confirming the generator exercises function tags.

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Refactoring
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [x] Validator Node


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Move VM verification and runtime type construction behind a feature flag, but enabling it can break loading of existing modules and reject transaction type arguments that were previously accepted.
> 
> **Overview**
> Adds **`FeatureFlag::CHECK_FUNCTION_TYPE_ABILITIES`** and wires it through release tooling, default genesis features, and VM production configs so verifier and **`TypeBuilder`** behavior stay aligned.
> 
> When the flag is **on**, function types must use only **`copy`**, **`drop`**, and **`store`**: **`signature_v2`** rejects invalid abilities in module/script bytecode at verification, and **`TypeBuilder::create_ty`** rejects bad function **`TypeTag`**s with **`CONSTRAINT_NOT_SATISFIED`** before entry execution. Previously published modules with illegal function signatures **fail to load** after enablement because verification runs on every load. With the flag **off**, prior behavior (raw ability bytes, subset-based **`T: key`** satisfaction) is preserved for replay compatibility.
> 
> **`AbilitySet::is_valid_for_function_type()`** centralizes the rule. Storage-slot borrow natives now **abort with `ENOT_A_RESOURCE_TYPE`** if the resource type argument is not a struct/enum, instead of hitting a VM invariant on global lookup.
> 
> Transactional harness expectations move failure **earlier** (publish-time verification + linker errors). Forge compat/framework-upgrade genesis overrides **disable** the new flag until the oldest supported release branch knows index 129. Tests and fuzz/proptest generators are extended for function **`TypeTag`**s and undefined ability bits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b5c755e66f7069f8a2b358d7d2106213a01bb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->