### PR TITLE
[cli] Add propose-bundle and execute-bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "aptos-genesis",
  "aptos-github-client",
  "aptos-global-constants",
+ "aptos-governance-bundle",
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-processor-sdk",
  "aptos-keygen",
@@ -2244,6 +2245,19 @@ name = "aptos-global-constants"
 version = "0.1.0"
 
 [[package]]
+name = "aptos-governance-bundle"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
+ "serde",
+ "sha2 0.9.9",
+ "sha3 0.9.1",
+ "tempfile",
+ "toml 0.7.8",
+]
+
+[[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
 
@@ -4006,6 +4020,7 @@ dependencies = [
  "aptos-cached-packages",
  "aptos-cli-common",
  "aptos-crypto",
+ "aptos-governance-bundle",
  "aptos-infallible",
  "aptos-move-cli",
  "aptos-release-builder",
@@ -4015,17 +4030,14 @@ dependencies = [
  "chrono",
  "clap 4.5.60",
  "git2 0.16.1",
- "hex",
  "move-command-line-common",
  "move-core-types",
  "move-model",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
- "sha2 0.9.9",
  "tempfile",
  "tokio",
- "toml 0.7.8",
  "url",
 ]
 
@@ -18559,6 +18571,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-genesis",
  "aptos-global-constants",
+ "aptos-governance-bundle",
  "aptos-indexer-grpc-table-info",
  "aptos-infallible",
  "aptos-inspection-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "aptos-move/aptos-gas-profiling",
     "aptos-move/aptos-gas-schedule",
     "aptos-move/aptos-gas-schedule-updator",
+    "aptos-move/aptos-governance-bundle",
     "aptos-move/aptos-memory-usage-tracker",
     "aptos-move/aptos-native-interface",
     "aptos-move/aptos-release-builder",
@@ -379,6 +380,7 @@ aptos-gas-schedule-updator = { path = "aptos-move/aptos-gas-schedule-updator" }
 aptos-genesis = { path = "crates/aptos-genesis" }
 aptos-github-client = { path = "crates/aptos-github-client" }
 aptos-global-constants = { path = "config/global-constants" }
+aptos-governance-bundle = { path = "aptos-move/aptos-governance-bundle" }
 aptos-id-generator = { path = "crates/aptos-id-generator" }
 aptos-in-memory-cache = { path = "crates/aptos-in-memory-cache" }
 aptos-indexer-grpc-cache-worker = { path = "ecosystem/indexer-grpc/indexer-grpc-cache-worker" }

--- a/aptos-move/aptos-governance-bundle/Cargo.toml
+++ b/aptos-move/aptos-governance-bundle/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "aptos-governance-bundle"
+description = "On-disk format of a self-contained governance bundle"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+sha3 = { workspace = true }
+toml = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/aptos-move/aptos-governance-bundle/src/lib.rs
+++ b/aptos-move/aptos-governance-bundle/src/lib.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! On-disk layout and `bundle.toml` manifest for a governance bundle.
+//! On-disk layout and `bundle.toml` manifest for a governance bundle, and the
+//! checks a bundle must pass (see [`verify`]).
 //!
 //! A governance bundle is a single self-contained directory packaging one
 //! on-chain governance proposal, along with additional artifacts for
@@ -17,6 +18,8 @@
 //! ├── bytecode/N-*.mv        # the compiled scripts actually deployed
 //! └── summary/*.md           # human-reviewable change summaries
 //! ```
+
+pub mod verify;
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -86,6 +89,22 @@ pub struct IntegritySection {
 }
 
 impl BundleManifest {
+    /// Build the manifest for the files currently under `bundle_dir`, with the
+    /// checksums and digest computed.
+    pub fn new(bundle_dir: &Path, bundle: BundleSection, source: SourceSection) -> Result<Self> {
+        let mut manifest = Self {
+            format_version: BUNDLE_FORMAT_VERSION,
+            bundle,
+            source,
+            integrity: IntegritySection {
+                digest: String::new(),
+            },
+            checksums: compute_checksums(bundle_dir)?,
+        };
+        manifest.integrity.digest = manifest.compute_digest();
+        Ok(manifest)
+    }
+
     /// Serialize and write the manifest to `<bundle_dir>/bundle.toml`.
     pub fn write(&self, bundle_dir: &Path) -> Result<()> {
         let contents = toml::to_string_pretty(self)
@@ -190,7 +209,7 @@ fn normalize_for_checksum<'a>(rel: &str, bytes: &'a [u8]) -> Cow<'a, [u8]> {
 /// A single difference found while comparing recorded checksums against the
 /// files actually present on disk.
 #[derive(Debug)]
-pub enum ChecksumError {
+pub(crate) enum ChecksumError {
     /// File is listed in the manifest but missing on disk.
     Missing(String),
     /// File is present on disk but not listed in the manifest.
@@ -222,7 +241,7 @@ impl std::fmt::Display for ChecksumError {
 }
 
 /// Compare the manifest's recorded checksums against the files on disk.
-pub fn verify_checksums(
+pub(crate) fn verify_checksums(
     bundle_dir: &Path,
     expected: &BTreeMap<String, String>,
 ) -> Result<Vec<ChecksumError>> {
@@ -251,18 +270,28 @@ pub fn verify_checksums(
     Ok(errors)
 }
 
-/// The bundle's compiled scripts as `(file stem, bytecode)`, sorted by file
-/// name (which is zero-padded, so lexical order is step order).
-pub fn load_compiled_scripts(bundle_dir: &Path) -> Result<Vec<(String, Vec<u8>)>> {
-    let dir = bundle_dir.join(BYTECODE_DIR);
-    let mut paths: Vec<PathBuf> = fs::read_dir(&dir)
-        .with_context(|| format!("failed to read {}", dir.display()))?
+/// The bundle's compiled script files, sorted by file name (which is
+/// zero-padded, so lexical order is step order).
+pub(crate) fn compiled_script_paths(bundle_dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(bundle_dir.join(BYTECODE_DIR)) else {
+        return vec![];
+    };
+    let mut paths: Vec<PathBuf> = entries
         .filter_map(|e| e.ok().map(|e| e.path()))
         .filter(|p| p.extension().map(|x| x == "mv").unwrap_or(false))
         .collect();
     paths.sort();
+    paths
+}
+
+/// The bundle's compiled scripts as `(file stem, bytecode)`, in step order.
+pub fn load_compiled_scripts(bundle_dir: &Path) -> Result<Vec<(String, Vec<u8>)>> {
+    let paths = compiled_script_paths(bundle_dir);
     if paths.is_empty() {
-        bail!("no compiled scripts found in {}", dir.display());
+        bail!(
+            "no compiled scripts found in {}",
+            bundle_dir.join(BYTECODE_DIR).display()
+        );
     }
 
     paths
@@ -280,33 +309,6 @@ pub fn load_compiled_scripts(bundle_dir: &Path) -> Result<Vec<(String, Vec<u8>)>
         .collect()
 }
 
-/// Git revision and branch the bundle was generated from, read from the working
-/// tree at `core_path`.
-pub struct SourceInfo {
-    pub commit: String,
-    pub branch: Option<String>,
-}
-
-/// Read the current commit and branch from the git repository containing
-/// `core_path`.
-pub fn read_source_info(core_path: &Path) -> Result<SourceInfo> {
-    let repo = git2::Repository::discover(core_path)
-        .with_context(|| format!("failed to open git repo at {}", core_path.display()))?;
-    let head = repo.head().context("failed to resolve git HEAD")?;
-    let commit = head
-        .peel_to_commit()
-        .context("failed to peel HEAD to a commit")?
-        .id()
-        .to_string();
-    // Only report an actual branch (a detached HEAD's shorthand is a commit hash).
-    let branch = if head.is_branch() {
-        head.shorthand().map(|s| s.to_string())
-    } else {
-        None
-    };
-    Ok(SourceInfo { commit, branch })
-}
-
 /// Create the bundle directory, refusing to overwrite an existing one.
 pub fn create_bundle_dir(bundle_dir: &Path) -> Result<()> {
     if bundle_dir.exists() {
@@ -318,4 +320,117 @@ pub fn create_bundle_dir(bundle_dir: &Path) -> Result<()> {
     fs::create_dir_all(bundle_dir)
         .with_context(|| format!("failed to create {}", bundle_dir.display()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha3::Sha3_256;
+
+    /// A minimal bundle on disk: one compiled script with its stamped source, a
+    /// metadata file, a summary with one unticked box, and a sealed manifest.
+    fn write_bundle(dir: &Path) -> BundleManifest {
+        for sub_dir in [SCRIPTS_DIR, BYTECODE_DIR, SUMMARY_DIR] {
+            fs::create_dir_all(dir.join(sub_dir)).unwrap();
+        }
+        let blob = b"bytecode";
+        fs::write(dir.join(BYTECODE_DIR).join("0-step.mv"), blob).unwrap();
+        fs::write(
+            dir.join(SCRIPTS_DIR).join("0-step.move"),
+            format!(
+                "// Script hash: {}\nscript {{ fun main() {{}} }}",
+                hex::encode(Sha3_256::digest(blob))
+            ),
+        )
+        .unwrap();
+        fs::write(dir.join(METADATA_JSON), b"{}").unwrap();
+        fs::write(dir.join(SUMMARY_DIR).join("notes.md"), "- [ ] reviewed\n").unwrap();
+
+        let manifest = BundleManifest::new(
+            dir,
+            BundleSection {
+                name: "test".to_string(),
+                created_at: "now".to_string(),
+            },
+            SourceSection {
+                branch: None,
+                commit: "abc".to_string(),
+            },
+        )
+        .unwrap();
+        manifest.write(dir).unwrap();
+        manifest
+    }
+
+    #[test]
+    fn manifest_round_trips_and_verifies() {
+        let dir = tempfile::tempdir().unwrap();
+        let written = write_bundle(dir.path());
+
+        let read = verify::verify(dir.path(), false).unwrap();
+        assert_eq!(read.integrity.digest, written.integrity.digest);
+
+        let scripts = load_compiled_scripts(dir.path()).unwrap();
+        assert_eq!(scripts, vec![("0-step".to_string(), b"bytecode".to_vec())]);
+    }
+
+    #[test]
+    fn verification_reports_every_problem() {
+        let dir = tempfile::tempdir().unwrap();
+        write_bundle(dir.path());
+
+        fs::write(dir.path().join(BYTECODE_DIR).join("0-step.mv"), b"tampered").unwrap();
+        fs::write(dir.path().join("extra.txt"), b"extra").unwrap();
+        fs::remove_file(dir.path().join(METADATA_JSON)).unwrap();
+
+        let message = verify::verify(dir.path(), false).unwrap_err().to_string();
+        for problem in [
+            "checksum mismatch for bytecode/0-step.mv",
+            "unexpected file (not in manifest): extra.txt",
+            "missing file (listed in manifest): metadata.json",
+            "missing metadata.json",
+            "does not match the hash stamped on its source",
+        ] {
+            assert!(message.contains(problem), "{}", message);
+        }
+    }
+
+    #[test]
+    fn ticking_a_summary_box_keeps_checksums_stable() {
+        let dir = tempfile::tempdir().unwrap();
+        write_bundle(dir.path());
+        let message = verify::verify(dir.path(), true).unwrap_err().to_string();
+        assert!(
+            message.contains("notes.md has unchecked boxes"),
+            "{}",
+            message
+        );
+
+        fs::write(
+            dir.path().join(SUMMARY_DIR).join("notes.md"),
+            "- [x] reviewed\n",
+        )
+        .unwrap();
+        verify::verify(dir.path(), true).unwrap();
+        assert_eq!(
+            verify::signoff_status(dir.path())
+                .into_iter()
+                .map(|(_, ticked, total)| (ticked, total))
+                .collect::<Vec<_>>(),
+            vec![(1, 1)]
+        );
+    }
+
+    #[test]
+    fn unsupported_format_version_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manifest = write_bundle(dir.path());
+        manifest.format_version = BUNDLE_FORMAT_VERSION + 1;
+        manifest.write(dir.path()).unwrap();
+
+        let err = BundleManifest::read(dir.path()).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("unsupported bundle format version"));
+    }
 }

--- a/aptos-move/aptos-governance-bundle/src/verify.rs
+++ b/aptos-move/aptos-governance-bundle/src/verify.rs
@@ -1,33 +1,57 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! `verify-bundle`: validate that a bundle is internally self-consistent.
+//! What makes a bundle valid, behind a single [`verify`] entry point.
 
-use crate::{bundle, commands::combine_errors, config::BundleConfig, summary};
-use anyhow::Result;
-use aptos_crypto::HashValue;
+use crate::{
+    compiled_script_paths, verify_checksums, BundleManifest, BYTECODE_DIR, METADATA_JSON,
+    SCRIPTS_DIR, SUMMARY_DIR,
+};
+use anyhow::{bail, Result};
+use sha3::{Digest, Sha3_256};
 use std::{
     collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
 
-pub fn run(bundle_path: &Path, require_signoff: bool) -> Result<()> {
+const UNTICKED_BOX: &str = "[ ]";
+
+/// Check that `bundle_path` holds a valid bundle, returning its manifest. The
+/// error lists every problem found.
+/// - Every file matches the manifest's checksums, and the digest matches.
+/// - `metadata.json` and at least one compiled script are present.
+/// - Every script source pairs with a compiled script and is stamped with its hash.
+/// - Every sign-off checkbox is ticked, if `require_signoff`.
+pub fn verify(bundle_path: &Path, require_signoff: bool) -> Result<BundleManifest> {
+    let manifest = BundleManifest::read(bundle_path)?;
+
+    let mut errors = integrity_errors(bundle_path, &manifest);
+    errors.extend(layout_errors(bundle_path));
+    errors.extend(source_errors(bundle_path));
+    if require_signoff {
+        errors.extend(signoff_errors(bundle_path));
+    }
+
+    if errors.is_empty() {
+        Ok(manifest)
+    } else {
+        bail!(
+            "bundle {} failed verification with {} error(s):\n  - {}",
+            bundle_path.display(),
+            errors.len(),
+            errors.join("\n  - ")
+        );
+    }
+}
+
+/// Check the bundle's files against its manifest: a checksum mismatch, a
+/// missing or extra file, or a digest mismatch.
+fn integrity_errors(bundle_path: &Path, manifest: &BundleManifest) -> Vec<String> {
     let mut errors: Vec<String> = vec![];
 
-    let manifest = bundle::BundleManifest::read(bundle_path)?;
-
-    let config_yaml = bundle_path.join(bundle::CONFIG_YAML);
-    let config = match BundleConfig::load(&config_yaml) {
-        Ok(c) => Some(c),
-        Err(e) => {
-            errors.push(format!("failed to load {}: {}", config_yaml.display(), e));
-            None
-        },
-    };
-
     // 1. Checksums: every file matches the manifest, with none missing or extra.
-    match bundle::verify_checksums(bundle_path, &manifest.checksums) {
+    match verify_checksums(bundle_path, &manifest.checksums) {
         Ok(checksum_errors) => {
             for p in checksum_errors {
                 errors.push(p.to_string());
@@ -45,67 +69,39 @@ pub fn run(bundle_path: &Path, require_signoff: bool) -> Result<()> {
         ));
     }
 
-    // 2. Consistency between bundle.toml and config.yaml, plus layout.
-    if let Some(config) = &config
-        && manifest.bundle.name != config.name
-    {
-        errors.push(format!(
-            "bundle.toml name ({}) does not match config.yaml name ({})",
-            manifest.bundle.name, config.name
-        ));
-    }
-    check_layout(bundle_path, &mut errors);
-
-    // 3. Optional sign-off enforcement.
-    if require_signoff {
-        check_signoff(bundle_path, &mut errors);
-    }
-
-    // Informational: report which summaries have been signed off.
-    report_signoff_info(bundle_path);
-
-    if errors.is_empty() {
-        println!("verify-bundle: OK ({})", bundle_path.display());
-        Ok(())
-    } else {
-        Err(combine_errors("verify-bundle", &errors))
-    }
+    errors
 }
 
-/// Check the single-proposal layout: a top-level `metadata.json`, plus the
-/// script sources and compiled bytecode (see [`check_scripts`]).
-fn check_layout(bundle_path: &Path, errors: &mut Vec<String>) {
-    if !bundle_path.join(bundle::METADATA_JSON).is_file() {
-        errors.push(format!("missing {}", bundle::METADATA_JSON));
+/// Check the single-proposal layout: a top-level `metadata.json`, plus at
+/// least one compiled script.
+fn layout_errors(bundle_path: &Path) -> Vec<String> {
+    let mut errors = vec![];
+    if !bundle_path.join(METADATA_JSON).is_file() {
+        errors.push(format!("missing {}", METADATA_JSON));
     }
-    check_scripts(bundle_path, errors);
+    if compiled_script_paths(bundle_path).is_empty() {
+        errors.push(format!("{}/ has no compiled .mv scripts", BYTECODE_DIR));
+    }
+    errors
 }
 
 /// Check that `scripts/` sources and `bytecode/` blobs pair 1:1 by file stem,
 /// and that each blob's hash matches the execution hash stamped on its source
 /// -- so what was audited (the stamped source) is what gets deployed (the
 /// blob), without needing a compiler.
-fn check_scripts(bundle_path: &Path, errors: &mut Vec<String>) {
-    let sources = files_by_stem(&bundle_path.join(bundle::SCRIPTS_DIR), "move");
-    let blobs = files_by_stem(&bundle_path.join(bundle::BYTECODE_DIR), "mv");
+fn source_errors(bundle_path: &Path) -> Vec<String> {
+    let mut errors = vec![];
+    let sources = files_by_stem(&bundle_path.join(SCRIPTS_DIR), "move");
+    let blobs = files_by_stem(&bundle_path.join(BYTECODE_DIR), "mv");
     if sources.is_empty() {
-        errors.push(format!("{}/ has no .move scripts", bundle::SCRIPTS_DIR));
-    }
-    if blobs.is_empty() {
-        errors.push(format!(
-            "{}/ has no compiled .mv scripts",
-            bundle::BYTECODE_DIR
-        ));
+        errors.push(format!("{}/ has no .move scripts", SCRIPTS_DIR));
     }
 
     for (stem, source_path) in &sources {
         let Some(blob_path) = blobs.get(stem) else {
             errors.push(format!(
                 "{}/{}.move has no compiled counterpart {}/{}.mv",
-                bundle::SCRIPTS_DIR,
-                stem,
-                bundle::BYTECODE_DIR,
-                stem
+                SCRIPTS_DIR, stem, BYTECODE_DIR, stem
             ));
             continue;
         };
@@ -127,18 +123,14 @@ fn check_scripts(bundle_path: &Path, errors: &mut Vec<String>) {
             None => errors.push(format!(
                 "{}/{}.move has no stamped execution hash (expected a leading \
                  '// Script hash: ...' comment, added by generate-bundle)",
-                bundle::SCRIPTS_DIR,
-                stem
+                SCRIPTS_DIR, stem
             )),
             Some(stamped) => {
-                let actual = HashValue::sha3_256_of(&blob).to_hex().to_lowercase();
+                let actual = hex::encode(Sha3_256::digest(&blob));
                 if actual != stamped {
                     errors.push(format!(
                         "{}/{}.mv hash {} does not match the hash stamped on its source {}",
-                        bundle::BYTECODE_DIR,
-                        stem,
-                        actual,
-                        stamped
+                        BYTECODE_DIR, stem, actual, stamped
                     ));
                 }
             },
@@ -148,13 +140,11 @@ fn check_scripts(bundle_path: &Path, errors: &mut Vec<String>) {
         if !sources.contains_key(stem) {
             errors.push(format!(
                 "{}/{}.mv has no source counterpart {}/{}.move",
-                bundle::BYTECODE_DIR,
-                stem,
-                bundle::SCRIPTS_DIR,
-                stem
+                BYTECODE_DIR, stem, SCRIPTS_DIR, stem
             ));
         }
     }
+    errors
 }
 
 /// The files with the given extension directly under `dir`, keyed by file
@@ -186,7 +176,7 @@ fn stamped_hash(source: &str) -> Option<String> {
 /// Every `*.md` file under `summary/` as `(path, contents)`, sorted by path;
 /// unreadable or absent files are skipped.
 fn summary_files(bundle_path: &Path) -> Vec<(PathBuf, String)> {
-    let summary_dir = bundle_path.join(bundle::SUMMARY_DIR);
+    let summary_dir = bundle_path.join(SUMMARY_DIR);
     let Ok(entries) = fs::read_dir(&summary_dir) else {
         return vec![];
     };
@@ -200,40 +190,31 @@ fn summary_files(bundle_path: &Path) -> Vec<(PathBuf, String)> {
     files
 }
 
-/// Print each summary file's sign-off state (informational; box ticks are
-/// checksum-neutral).
-fn report_signoff_info(bundle_path: &Path) {
-    for (path, contents) in summary_files(bundle_path) {
-        let (ticked, total) = summary::box_counts(&contents);
-        if total == 0 {
-            continue;
-        }
-        let status = if ticked == total {
-            "fully signed off"
-        } else if ticked > 0 {
-            "partially signed off"
-        } else {
-            "not signed off"
-        };
-        println!(
-            "info: {} ({}/{}) in {}",
-            status,
-            ticked,
-            total,
-            path.file_name().unwrap_or_default().to_string_lossy()
-        );
-    }
+/// The sign-off state of each summary file as `(path, ticked, total)`
+/// checkboxes, sorted by path.
+pub fn signoff_status(bundle_path: &Path) -> Vec<(PathBuf, usize, usize)> {
+    summary_files(bundle_path)
+        .into_iter()
+        .map(|(path, contents)| {
+            let ticked = contents.matches("[x]").count() + contents.matches("[X]").count();
+            let unticked = contents.matches(UNTICKED_BOX).count();
+            (path, ticked, ticked + unticked)
+        })
+        .collect()
 }
 
-fn check_signoff(bundle_path: &Path, errors: &mut Vec<String>) {
+/// One message per summary file that still has an unticked checkbox.
+fn signoff_errors(bundle_path: &Path) -> Vec<String> {
+    let mut errors = vec![];
     for (path, contents) in summary_files(bundle_path) {
-        if summary::has_unchecked_boxes(&contents) {
+        if contents.contains(UNTICKED_BOX) {
             errors.push(format!(
                 "sign-off required but {} has unchecked boxes",
                 path.file_name().unwrap_or_default().to_string_lossy()
             ));
         }
     }
+    errors
 }
 
 #[cfg(test)]

--- a/aptos-move/aptos-release-tool/Cargo.toml
+++ b/aptos-move/aptos-release-tool/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-cli-common = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-governance-bundle = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-move-cli = { workspace = true }
 aptos-release-builder = { workspace = true }
@@ -30,15 +31,12 @@ aptos-types = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 git2 = { workspace = true }
-hex = { workspace = true }
 move-core-types = { workspace = true }
 move-model = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-sha2 = { workspace = true }
 tokio = { workspace = true }
-toml = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/aptos-move/aptos-release-tool/README.md
+++ b/aptos-move/aptos-release-tool/README.md
@@ -9,9 +9,11 @@ and the design reference for the release process as a whole.
 ## Status: Partially implemented
 
 The bundle format and the `aptos-release-tool` CLI (`generate-bundle`,
-`verify-bundle`, `simulate`, `verify-framework-deployment`) are implemented. The
-GitHub Actions workflows that orchestrate the process (section 3.3) live in
-`internal-ops` and are added separately.
+`verify-bundle`, `simulate`, `deploy-testnet`, `verify-framework-deployment`) are
+implemented, as are the operator-side `aptos governance propose-bundle` and
+`execute-bundle` commands in the Aptos CLI (section 3.2). The GitHub Actions
+workflows that orchestrate the process (section 3.3) live in `internal-ops` and
+are added separately.
 
 ---
 
@@ -138,9 +140,13 @@ aptos-framework-v1.45.1/
 ├── gas/                                 # Present only when the release changes the gas schedule
 │   ├── old.json                         # Previous gas schedule snapshot
 │   └── new.json                         # New gas schedule snapshot
-├── scripts/                             # The proposal's multi-step governance scripts
+├── scripts/                             # The proposal's multi-step governance scripts (sources, for review)
 │   ├── 0-....move
 │   ├── 1-....move
+│   └── ...
+├── bytecode/                            # The compiled scripts, the artifacts actually submitted
+│   ├── 0-....mv
+│   ├── 1-....mv
 │   └── ...
 └── summary/                             # Human-reviewable change summaries
     ├── gas-schedule-changes.md          # Gas parameter diff with sign-off checkboxes
@@ -148,10 +154,16 @@ aptos-framework-v1.45.1/
 ```
 
 A bundle holds exactly one governance proposal — a framework release or an ad-hoc
-change — emitted as a single multi-step proposal whose steps are the numbered Move
-scripts under `scripts/`, with `metadata.json` holding the proposal's metadata.
-`config.yaml` is the exact release config the bundle was generated from, copied
-verbatim, so the bundle is self-describing.
+change — emitted as a single multi-step proposal whose steps are the numbered
+scripts under `bytecode/`, with `metadata.json` holding the proposal's metadata.
+The sources under `scripts/` are review material: each is stamped with the
+execution hash of its compiled counterpart, and nothing recompiles them at
+deployment time. `config.yaml` is the exact release config the bundle was
+generated from, copied verbatim, so the bundle is self-describing.
+
+The format is shared by `aptos-release-tool` and the Aptos CLI through the
+`aptos-governance-bundle` crate, so the manifest's `format_version` is a contract
+between binaries built at different times.
 
 The `summary/` directory contains auto-generated, human-readable summaries of key
 changes. These serve two purposes: (1) giving reviewers a quick overview without
@@ -256,7 +268,29 @@ fall back to running the same commands manually.
 | `generate-bundle` | Builds a complete bundle from a release config, and self-verifies it before returning. |
 | `verify-bundle` | Checks the bundle is internally self-consistent; `--require-signoff` also requires every summary checkbox to be ticked. |
 | `simulate` | Simulates the bundle's governance proposal against a network (reuses `aptos-release-builder`). |
+| `deploy-testnet` | Executes the bundle's proposal end to end on a test network: shrinks the voting period as root, proposes and votes as the validator, executes every step, restores the voting period. Refuses mainnet. |
 | `verify-framework-deployment` | Checks a deployed framework release on-chain against the bundle — currently the gas schedule only (bytecode verification is a TODO). |
+
+On mainnet, proposing and executing is done by node operators, who install the
+Aptos CLI rather than build this tool. The CLI therefore carries the two
+operator-facing commands, under `aptos governance`. Both verify the bundle the
+same way `verify-bundle` does and submit only the compiled scripts under
+`bytecode/`; signing uses the CLI's usual profiles, keys, and hardware wallets.
+
+| Command | What it does |
+|---------|-------------|
+| `propose-bundle` | Checks that `--metadata-url` serves the bundle's `metadata.json` and that the stake pool may propose, then creates the multi-step proposal for the first script's hash. |
+| `execute-bundle` | Executes the steps of an approved proposal that have not run yet, starting from the one the chain expects next, so a re-run after a failure resumes where it stopped. |
+
+```bash
+aptos governance propose-bundle --bundle "$BUNDLE_DIR" --pool-address "$POOL" \
+    --metadata-url "https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/framework-releases/$VERSION/metadata.json" \
+    --profile mainnet-voter
+
+# After the vote passes
+aptos governance execute-bundle --bundle "$BUNDLE_DIR" --proposal-id "$PROPOSAL_ID" \
+    --profile mainnet-executor
+```
 
 Example usage:
 
@@ -325,11 +359,11 @@ cherry-picked onto the release branch after testnet deployment (or after initial
 generation), the bundle must be regenerated; the PR branch name is deterministic, so
 regenerating updates the existing PR rather than opening a new one.
 
-#### Workflow 2: Deploy to Testnet (planned, not yet implemented)
+#### Workflow 2: Deploy to Testnet
 
 Takes a committed bundle, simulates it against testnet, and if successful, executes
-the full testnet release — including the governance proposal, framework tag, branch
-update, and post-deploy verification.
+the full testnet release — including the governance proposal (via `deploy-testnet`),
+framework tag, branch update, and post-deploy verification.
 
 ```yaml
 on:
@@ -442,17 +476,16 @@ How a release captain uses the three workflows to complete a full release cycle.
                    │
                    ▼
 ┌─────────────────────────────────────┐
-│ Coordinate with operator &          │
-│ Foundation (create on-chain         │
-│ proposal, initiate voting,          │
+│ Operator: aptos governance          │
+│ propose-bundle (voting opens,       │
 │ 3-day window)                       │
 └──────────────────┬──────────────────┘
                    │
                    ▼
 ┌─────────────────────────────────────┐
-│ Execute proposal (simulation runs   │
-│ before executing for real, verify   │
-│ on-chain after)                     │
+│ Operator: aptos governance          │
+│ execute-bundle; then                │
+│ verify-framework-deployment         │
 └──────────────────┬──────────────────┘
                    │
                    ▼
@@ -462,7 +495,8 @@ How a release captain uses the three workflows to complete a full release cycle.
 ```
 
 Note: mainnet deployment still involves manual coordination (operator, Foundation,
-voting). The automation covers artifact generation, simulation, and verification.
+voting). The automation covers artifact generation, simulation, and verification;
+the operator's two steps are single CLI commands that take the bundle as input.
 
 ---
 
@@ -507,11 +541,13 @@ is the same artifact regardless of whether CI or a human drives the process.
 2. Simulate against mainnet:
      simulate --bundle aptos-framework-v1.45.1 --network mainnet
 
-3. Coordinate with operator & Foundation (create on-chain proposal,
-   initiate voting, 3-day window)
+3. Operator creates the proposal from the merged bundle (voting opens, 3-day window):
+     aptos governance propose-bundle --bundle aptos-framework-v1.45.1 --pool-address <pool> \
+         --metadata-url <raw URL of the bundle's metadata.json in aptos-networks>
 
-4. Execute proposal (simulation runs before executing for real,
-   verify on-chain after)
+4. Operator executes the approved proposal, then anyone verifies on-chain:
+     aptos governance execute-bundle --bundle aptos-framework-v1.45.1 --proposal-id <id>
+     verify-framework-deployment --bundle aptos-framework-v1.45.1 --network mainnet
 
 5. Update mainnet branch (push-branch workflow in internal-ops)
 ```
@@ -527,8 +563,10 @@ files provide a clear review surface.
 
 ### Phase 1: Build new tooling alongside existing
 - Build a new CLI tool (separate from `aptos-release-builder`) with the new commands
-  (`generate-bundle`, `verify-bundle`, `simulate`, `verify-framework-deployment`), and
-  the three GitHub Actions workflows (generate, deploy-testnet, simulate)
+  (`generate-bundle`, `verify-bundle`, `simulate`, `deploy-testnet`,
+  `verify-framework-deployment`), the operator-side `propose-bundle` and
+  `execute-bundle` commands in the Aptos CLI, and the three GitHub Actions
+  workflows (generate, deploy-testnet, simulate)
 - Leave `aptos-release-builder` and existing workflows in place — ongoing releases
   continue to use the existing process without disruption
 
@@ -548,9 +586,10 @@ files provide a clear review surface.
    release artifacts, but the name is restrictive — it doesn't fit testnet-only
    releases. A rename of that repo could resolve this.
 
-2. **Operator coordination**: Can governance proposal submission be automated via
-   a GitHub workflow, or does it inherently require the operator? What does the
-   operator actually do that tooling can't?
+2. **Operator coordination**: Proposal submission requires the stake pool's voter
+   key, so it stays with the operator; `propose-bundle` and `execute-bundle`
+   reduce their part to two CLI commands. Whether execution could move to a
+   GitHub workflow (it needs only a funded account) is still open.
 
 3. **Sign-off enforcement**: Should summary checkboxes be enforced by tooling
    (`verify-bundle --require-signoff`) or by process (PR review)? Needs evaluation

--- a/aptos-move/aptos-release-tool/src/commands/deploy.rs
+++ b/aptos-move/aptos-release-tool/src/commands/deploy.rs
@@ -21,7 +21,7 @@
 //! hash approval, and execution are all signed by the validator; execution is
 //! permissionless on-chain, the validator is just a convenient funded sender.
 
-use crate::commands::verify;
+use crate::commands::verify_bundle;
 use anyhow::{anyhow, bail, Context, Result};
 use aptos_cached_packages::aptos_stdlib;
 use aptos_cli_common::PromptOptions;
@@ -100,7 +100,7 @@ pub async fn run(
     dry_run: bool,
 ) -> Result<()> {
     // 1. Bundle integrity, and by default the full sign-off.
-    verify::run(bundle_path, !skip_signoff)?;
+    verify_bundle::run(bundle_path, !skip_signoff)?;
 
     // The metadata location recorded on-chain is informational only; nothing
     // fetches it. The on-chain limit is 256 bytes; check here rather than
@@ -279,7 +279,7 @@ async fn run_governance(
     .await
     .context("failed to increase the validator's lockup")?;
 
-    let metadata = fs::read(bundle_path.join(crate::bundle::METADATA_JSON))
+    let metadata = fs::read(bundle_path.join(aptos_governance_bundle::METADATA_JSON))
         .context("failed to read the bundle's metadata.json")?;
     let first = scripts
         .first()
@@ -613,7 +613,7 @@ async fn ledger_timestamp_secs(client: &Client) -> Result<u64> {
 /// Load the bundle's compiled scripts (in execution order) and hash each blob.
 /// Nothing is recompiled.
 fn load_bundle_scripts(bundle_path: &Path) -> Result<Vec<BundleScript>> {
-    Ok(crate::bundle::load_compiled_scripts(bundle_path)?
+    Ok(aptos_governance_bundle::load_compiled_scripts(bundle_path)?
         .into_iter()
         .map(|(name, blob)| {
             let hash = HashValue::sha3_256_of(&blob);

--- a/aptos-move/aptos-release-tool/src/commands/generate.rs
+++ b/aptos-move/aptos-release-tool/src/commands/generate.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{bundle, config::BundleConfig, release, summary};
+use crate::{config::BundleConfig, release, summary};
 use anyhow::{Context, Result};
+use aptos_governance_bundle as bundle;
 use aptos_release_builder::{components::compile_script_and_hash, ExecutionMode};
 use aptos_types::on_chain_config::GasScheduleV2;
 use chrono::Utc;
@@ -60,31 +61,25 @@ async fn build_bundle(
     fs::copy(release_config_path, bundle_path.join(bundle::CONFIG_YAML))
         .context("failed to copy config into bundle")?;
 
-    // 5. Build and write the manifest (with checksums computed last).
+    // 5. Build and write the manifest, once every other file is in place.
     println!("Building manifest...");
-    let source = bundle::read_source_info(core_path)?;
-    let mut manifest = bundle::BundleManifest {
-        format_version: bundle::BUNDLE_FORMAT_VERSION,
-        bundle: bundle::BundleSection {
+    let source = read_source_info(core_path)?;
+    bundle::BundleManifest::new(
+        bundle_path,
+        bundle::BundleSection {
             name: config.name.clone(),
             created_at: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
         },
-        source: bundle::SourceSection {
+        bundle::SourceSection {
             branch: source.branch,
             commit: source.commit,
         },
-        integrity: bundle::IntegritySection {
-            digest: String::new(),
-        },
-        checksums: Default::default(),
-    };
-    manifest.checksums = bundle::compute_checksums(bundle_path)?;
-    manifest.integrity.digest = manifest.compute_digest();
-    manifest.write(bundle_path)?;
+    )?
+    .write(bundle_path)?;
 
     // 6. Verify integrity before declaring success.
     println!("Verifying bundle integrity...");
-    crate::commands::verify::run(bundle_path, false)?;
+    crate::commands::verify_bundle::run(bundle_path, false)?;
     Ok(())
 }
 
@@ -173,4 +168,31 @@ async fn generate_scripts(config: &BundleConfig, bundle_path: &Path) -> Result<(
     )
     .with_context(|| format!("failed to write {}", metadata_path.display()))?;
     Ok(())
+}
+
+/// Git revision and branch the bundle is generated from, read from the working
+/// tree at `core_path`.
+struct SourceInfo {
+    commit: String,
+    branch: Option<String>,
+}
+
+/// Read the current commit and branch from the git repository containing
+/// `core_path`.
+fn read_source_info(core_path: &Path) -> Result<SourceInfo> {
+    let repo = git2::Repository::discover(core_path)
+        .with_context(|| format!("failed to open git repo at {}", core_path.display()))?;
+    let head = repo.head().context("failed to resolve git HEAD")?;
+    let commit = head
+        .peel_to_commit()
+        .context("failed to peel HEAD to a commit")?
+        .id()
+        .to_string();
+    // Only report an actual branch (a detached HEAD's shorthand is a commit hash).
+    let branch = if head.is_branch() {
+        head.shorthand().map(|s| s.to_string())
+    } else {
+        None
+    };
+    Ok(SourceInfo { commit, branch })
 }

--- a/aptos-move/aptos-release-tool/src/commands/mod.rs
+++ b/aptos-move/aptos-release-tool/src/commands/mod.rs
@@ -4,14 +4,5 @@
 pub mod deploy;
 pub mod generate;
 pub mod simulate;
-pub mod verify;
+pub mod verify_bundle;
 pub mod verify_framework_deployment;
-
-/// Collapse a non-empty list of errors into a single aggregated error.
-pub(crate) fn combine_errors(label: &str, errors: &[String]) -> anyhow::Error {
-    let mut msg = format!("{} found {} error(s):\n", label, errors.len());
-    for error in errors {
-        msg.push_str(&format!("  - {}\n", error));
-    }
-    anyhow::anyhow!(msg)
-}

--- a/aptos-move/aptos-release-tool/src/commands/simulate.rs
+++ b/aptos-move/aptos-release-tool/src/commands/simulate.rs
@@ -7,8 +7,9 @@
 //! deploy-testnet submits -- against a fork of the target network. The
 //! bundle's script sources are never recompiled; they are audit material.
 
-use crate::{bundle, network::NetworkSelection};
+use crate::network::NetworkSelection;
 use anyhow::Result;
+use aptos_governance_bundle as bundle;
 use std::path::Path;
 
 pub async fn run(
@@ -18,7 +19,7 @@ pub async fn run(
     node_api_key: Option<String>,
 ) -> Result<()> {
     // Gate on the bundle's own integrity before simulating its scripts.
-    crate::commands::verify::run(bundle_path, false)?;
+    crate::commands::verify_bundle::run(bundle_path, false)?;
 
     let scripts = bundle::load_compiled_scripts(bundle_path)?;
 

--- a/aptos-move/aptos-release-tool/src/commands/verify_bundle.rs
+++ b/aptos-move/aptos-release-tool/src/commands/verify_bundle.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `verify-bundle`: validate that a bundle is internally self-consistent.
+
+use crate::config::BundleConfig;
+use anyhow::{bail, Context, Result};
+use aptos_governance_bundle::{self as bundle, verify};
+use std::path::Path;
+
+pub fn run(bundle_path: &Path, require_signoff: bool) -> Result<()> {
+    let manifest = verify::verify(bundle_path, require_signoff)?;
+
+    // The config the bundle was generated from must load and agree with the manifest.
+    // TODO: move this into `aptos_governance_bundle::verify` once the old release-builder code is
+    // gone and the bundle config definition can live in that crate too.
+    let config_yaml = bundle_path.join(bundle::CONFIG_YAML);
+    let config = BundleConfig::load(&config_yaml)
+        .with_context(|| format!("failed to load {}", config_yaml.display()))?;
+    if manifest.bundle.name != config.name {
+        bail!(
+            "bundle.toml name ({}) does not match config.yaml name ({})",
+            manifest.bundle.name,
+            config.name
+        );
+    }
+
+    report_signoff_info(bundle_path);
+    println!("verify-bundle: OK ({})", bundle_path.display());
+    Ok(())
+}
+
+/// Print each summary file's sign-off state (informational; box ticks are
+/// checksum-neutral).
+fn report_signoff_info(bundle_path: &Path) {
+    for (path, ticked, total) in verify::signoff_status(bundle_path) {
+        if total == 0 {
+            continue;
+        }
+        let status = if ticked == total {
+            "fully signed off"
+        } else if ticked > 0 {
+            "partially signed off"
+        } else {
+            "not signed off"
+        };
+        println!(
+            "info: {} ({}/{}) in {}",
+            status,
+            ticked,
+            total,
+            path.file_name().unwrap_or_default().to_string_lossy()
+        );
+    }
+}

--- a/aptos-move/aptos-release-tool/src/commands/verify_framework_deployment.rs
+++ b/aptos-move/aptos-release-tool/src/commands/verify_framework_deployment.rs
@@ -9,8 +9,9 @@
 //! signal that the release executed. Add a real framework-code check in the
 //! future -- this may not be trivial and might require significant work.
 
-use crate::{bundle, network::NetworkSelection};
+use crate::network::NetworkSelection;
 use anyhow::{bail, Context, Result};
+use aptos_governance_bundle as bundle;
 use aptos_release_builder::components::fetch_config;
 use aptos_rest_client::{AptosBaseUrl, Client};
 use aptos_types::on_chain_config::GasScheduleV2;
@@ -23,7 +24,7 @@ pub async fn run(
 ) -> Result<()> {
     // Gate on the bundle's own integrity first, so we compare the chain against
     // trusted expected values.
-    crate::commands::verify::run(bundle_path, false)?;
+    crate::commands::verify_bundle::run(bundle_path, false)?;
 
     let mut client = Client::builder(AptosBaseUrl::Custom(network.to_url()?));
     if let Some(key) = node_api_key.as_ref() {

--- a/aptos-move/aptos-release-tool/src/lib.rs
+++ b/aptos-move/aptos-release-tool/src/lib.rs
@@ -9,7 +9,6 @@
 //! simulate its governance proposal against a network, and verify on-chain state
 //! after deployment.
 
-pub mod bundle;
 pub mod commands;
 pub mod config;
 pub mod network;
@@ -185,7 +184,7 @@ pub async fn run(args: Argument) -> Result<()> {
         Commands::VerifyBundle {
             bundle,
             require_signoff,
-        } => commands::verify::run(&bundle, require_signoff),
+        } => commands::verify_bundle::run(&bundle, require_signoff),
         Commands::DeployTestnet {
             bundle,
             network,

--- a/aptos-move/aptos-release-tool/src/summary.rs
+++ b/aptos-move/aptos-release-tool/src/summary.rs
@@ -155,19 +155,6 @@ pub fn write_feature_flag_summary(
     Ok(())
 }
 
-/// Scan a summary file's contents for unchecked checkboxes (`[ ]`). Used by
-/// `verify --require-signoff`.
-pub fn has_unchecked_boxes(contents: &str) -> bool {
-    contents.contains("[ ]")
-}
-
-/// Count `(ticked, total)` checkboxes in a summary file's contents.
-pub fn box_counts(contents: &str) -> (usize, usize) {
-    let ticked = contents.matches("[x]").count() + contents.matches("[X]").count();
-    let unchecked = contents.matches("[ ]").count();
-    (ticked, ticked + unchecked)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aptos-move/aptos-release-tool/tests/e2e.rs
+++ b/aptos-move/aptos-release-tool/tests/e2e.rs
@@ -4,7 +4,8 @@
 //! End-to-end: generate a (move-stdlib-only) bundle from the synthetic config,
 //! verify it, and check the expected file layout.
 
-use aptos_release_tool::{bundle, commands, init_core_path};
+use aptos_governance_bundle as bundle;
+use aptos_release_tool::{commands, init_core_path};
 use std::path::PathBuf;
 
 fn test_data_dir() -> PathBuf {

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
-- _No changes yet._
+- Add `aptos governance propose-bundle` and `aptos governance execute-bundle`, which submit and execute a governance bundle's proposal using the bundle's compiled scripts. `execute-bundle` resumes from the step the chain expects next.
+- `aptos governance propose` and `execute-proposal` now print a hint pointing at the bundle commands.
 
 ## [9.5.1]
 - Change default REST URLs for `aptos init` from `fullnode.*.aptoslabs.com` to `api.*.aptoslabs.com` for mainnet, testnet, and devnet.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -34,6 +34,7 @@ aptos-framework = { workspace = true }
 aptos-genesis = { workspace = true }
 aptos-github-client = { workspace = true }
 aptos-global-constants = { workspace = true }
+aptos-governance-bundle = { workspace = true }
 aptos-indexer-grpc-server-framework = { workspace = true }
 aptos-indexer-processor-sdk = { workspace = true }
 aptos-keygen = { workspace = true }

--- a/crates/aptos/src/governance/bundle.rs
+++ b/crates/aptos/src/governance/bundle.rs
@@ -1,0 +1,486 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `propose-bundle` and `execute-bundle`: drive a governance bundle's proposal
+//! on a live network.
+
+use crate::{
+    common::{
+        types::{
+            CliError, CliTypedResult, PoolAddressArgs, TransactionOptions, TransactionOptionsExt,
+            TransactionSummary,
+        },
+        utils::{prompt_yes_with_override, read_from_file},
+    },
+    governance::{
+        create_proposal, execution_payload, get_metadata_from_url, parse_proposal_metadata,
+        ProposalSubmissionSummary,
+    },
+    CliCommand,
+};
+use aptos_api_types::{Address, HashValue as ApiHashValue, ViewFunction, U64};
+use aptos_cached_packages::aptos_stdlib;
+use aptos_crypto::HashValue;
+use aptos_governance_bundle::{self as bundle, verify};
+use aptos_rest_client::{Client, Transaction};
+use aptos_types::{
+    account_address::AccountAddress, on_chain_config::ApprovedExecutionHashes,
+    transaction::TransactionPayload,
+};
+use async_trait::async_trait;
+use clap::Parser;
+use futures::try_join;
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    language_storage::{ModuleId, TypeTag},
+    parser::parse_type_tag,
+};
+use reqwest::Url;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// `0x1::voting::PROPOSAL_STATE_*`.
+const PROPOSAL_STATE_PENDING: u64 = 0;
+const PROPOSAL_STATE_SUCCEEDED: u64 = 1;
+const PROPOSAL_STATE_FAILED: u64 = 3;
+
+/// Which bundle to use and how strictly to check it.
+#[derive(Parser)]
+pub struct BundleArgs {
+    /// Path to the governance bundle directory
+    #[clap(long)]
+    pub(crate) bundle: PathBuf,
+
+    /// Do not require the bundle's sign-off checkboxes to be ticked
+    #[clap(long)]
+    pub(crate) skip_signoff: bool,
+}
+
+/// A compiled script from the bundle's `bytecode/` directory.
+struct BundleScript {
+    name: String,
+    blob: Vec<u8>,
+    /// The script's on-chain execution hash: the hash of `blob`.
+    hash: HashValue,
+}
+
+impl BundleArgs {
+    /// Verify the bundle, requiring sign-off unless `--skip-signoff`, and load
+    /// its compiled scripts in execution order.
+    fn load(&self) -> CliTypedResult<Vec<BundleScript>> {
+        verify::verify(&self.bundle, !self.skip_signoff).map_err(bundle_error)?;
+
+        let scripts = bundle::load_compiled_scripts(&self.bundle)
+            .map_err(bundle_error)?
+            .into_iter()
+            .map(|(name, blob)| {
+                let hash = HashValue::sha3_256_of(&blob);
+                BundleScript { name, blob, hash }
+            })
+            .collect();
+        Ok(scripts)
+    }
+
+    /// The bundle's `metadata.json`, byte for byte.
+    fn read_metadata(&self) -> CliTypedResult<Vec<u8>> {
+        read_from_file(&self.bundle.join(bundle::METADATA_JSON))
+    }
+}
+
+fn bundle_error(err: anyhow::Error) -> CliError {
+    CliError::CommandArgumentError(format!("{:#}", err))
+}
+
+/// Submit a governance bundle's proposal
+///
+/// Verifies the bundle, checks that the metadata URL serves the bundle's
+/// `metadata.json`, checks that the stake pool may propose, and creates a
+/// multi-step proposal for the bundle's compiled scripts. Nothing is compiled.
+#[derive(Parser)]
+pub struct ProposeBundle {
+    #[clap(flatten)]
+    pub(crate) bundle_args: BundleArgs,
+    #[clap(flatten)]
+    pub(crate) pool_address_args: PoolAddressArgs,
+
+    /// URL where the bundle's `metadata.json` is published
+    ///
+    /// Recorded on-chain so voters can read the proposal's title and description.
+    /// It must serve exactly the bundle's `metadata.json`.
+    #[clap(long)]
+    pub(crate) metadata_url: Url,
+
+    /// Do not check that the metadata URL serves the bundle's `metadata.json`
+    #[clap(long)]
+    pub(crate) skip_metadata_url_check: bool,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<ProposalSubmissionSummary> for ProposeBundle {
+    fn command_name(&self) -> &'static str {
+        "ProposeBundle"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<ProposalSubmissionSummary> {
+        let scripts = self.bundle_args.load()?;
+
+        let metadata_bytes = self.bundle_args.read_metadata()?;
+        let metadata = parse_proposal_metadata(&metadata_bytes)?;
+        if !self.skip_metadata_url_check {
+            let served = get_metadata_from_url(&self.metadata_url).await?;
+            if served != metadata_bytes {
+                return Err(CliError::CommandArgumentError(format!(
+                    "{} does not serve the bundle's {} byte for byte; publish the bundle \
+                     there first, or pass --skip-metadata-url-check",
+                    self.metadata_url,
+                    bundle::METADATA_JSON
+                )));
+            }
+        }
+        let metadata_hash = HashValue::sha3_256_of(&metadata_bytes);
+
+        let pool_address = self.pool_address_args.pool_address;
+        let client = self.txn_options.rest_client()?;
+        let (_, sender) = self.txn_options.get_public_key_and_address()?;
+        check_proposer_eligibility(&client, sender, pool_address).await?;
+
+        println!(
+            "{}\n\tMetadata Hash: {}\n\tScript Hash: {}\n\tSteps: {}",
+            metadata,
+            metadata_hash.to_hex(),
+            scripts[0].hash.to_hex(),
+            scripts.len()
+        );
+        prompt_yes_with_override(
+            "Do you want to submit this proposal?",
+            self.txn_options.prompt_options,
+        )?;
+
+        create_proposal(
+            &self.txn_options,
+            pool_address,
+            scripts[0].hash,
+            &self.metadata_url,
+            metadata_hash,
+            true,
+        )
+        .await
+    }
+}
+
+/// Fail early, with a readable message, on the conditions `create_proposal_v2`
+/// checks on-chain.
+/// - The sender is the stake pool's delegated voter.
+/// - The stake pool has the required proposer stake.
+/// - The stake pool's lockup outlasts the voting period.
+async fn check_proposer_eligibility(
+    client: &Client,
+    sender: AccountAddress,
+    pool_address: AccountAddress,
+) -> CliTypedResult<()> {
+    let (voter, voting_power, required_stake, voting_duration, lockup_end, now) = try_join!(
+        view_one::<Address>(
+            client,
+            ident_str!("stake"),
+            ident_str!("get_delegated_voter"),
+            vec![],
+            vec![bcs_arg(&pool_address)],
+        ),
+        view_one::<U64>(
+            client,
+            ident_str!("aptos_governance"),
+            ident_str!("get_voting_power"),
+            vec![],
+            vec![bcs_arg(&pool_address)],
+        ),
+        view_one::<U64>(
+            client,
+            ident_str!("aptos_governance"),
+            ident_str!("get_required_proposer_stake"),
+            vec![],
+            vec![],
+        ),
+        view_one::<U64>(
+            client,
+            ident_str!("aptos_governance"),
+            ident_str!("get_voting_duration_secs"),
+            vec![],
+            vec![],
+        ),
+        view_one::<U64>(
+            client,
+            ident_str!("stake"),
+            ident_str!("get_lockup_secs"),
+            vec![],
+            vec![bcs_arg(&pool_address)],
+        ),
+        ledger_timestamp_secs(client),
+    )?;
+
+    let voter = AccountAddress::from(voter);
+    if voter != sender {
+        return Err(CliError::CommandArgumentError(format!(
+            "the sender {} is not the delegated voter of stake pool {} (the voter is {})",
+            sender, pool_address, voter
+        )));
+    }
+    if voting_power.0 < required_stake.0 {
+        return Err(CliError::CommandArgumentError(format!(
+            "stake pool {} has voting power {} but proposing requires at least {}",
+            pool_address, voting_power.0, required_stake.0
+        )));
+    }
+    let voting_end = now + voting_duration.0;
+    if voting_end >= lockup_end.0 {
+        return Err(CliError::CommandArgumentError(format!(
+            "the lockup of stake pool {} ends at unix second {}, before the voting period would \
+             end at {}; the pool owner must increase the lockup before proposing",
+            pool_address, lockup_end.0, voting_end
+        )));
+    }
+    Ok(())
+}
+
+/// Execute an approved governance bundle's proposal
+///
+/// Submits the bundle's compiled scripts that have not been executed yet, in
+/// order, starting from the step the chain expects next. Re-running after a
+/// failure resumes from the failed step. Nothing is compiled.
+#[derive(Parser)]
+pub struct ExecuteBundle {
+    #[clap(flatten)]
+    pub(crate) bundle_args: BundleArgs,
+
+    /// Id of the approved proposal to execute
+    #[clap(long)]
+    pub(crate) proposal_id: u64,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+/// One executed step of a bundle's proposal.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ExecutedStep {
+    pub script: String,
+    #[serde(flatten)]
+    pub transaction: TransactionSummary,
+}
+
+#[async_trait]
+impl CliCommand<Vec<ExecutedStep>> for ExecuteBundle {
+    fn command_name(&self) -> &'static str {
+        "ExecuteBundle"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Vec<ExecutedStep>> {
+        let scripts = self.bundle_args.load()?;
+        let proposal_id = self.proposal_id;
+        let client = self.txn_options.rest_client()?;
+
+        let (next_hash, approved) = try_join!(
+            expected_next_hash(&client, proposal_id),
+            approved_hashes(&client),
+        )?;
+        let Some(start) = scripts.iter().position(|s| s.hash == next_hash) else {
+            return Err(CliError::CommandArgumentError(format!(
+                "proposal {} expects a script with execution hash {} next, but no script in the \
+                 bundle has that hash; check the proposal id and that this is the bundle that \
+                 was proposed",
+                proposal_id, next_hash
+            )));
+        };
+        if start > 0 {
+            println!(
+                "{} of {} steps already executed; resuming at {}",
+                start,
+                scripts.len(),
+                scripts[start].name
+            );
+        }
+
+        prompt_yes_with_override(
+            &format!(
+                "Execute {} step(s) of proposal {}?",
+                scripts.len() - start,
+                proposal_id
+            ),
+            self.txn_options.prompt_options,
+        )?;
+
+        // The approved-hash entry lets an oversized script clear the mempool
+        // size limit. Each executed step rolls it forward on-chain, so only the
+        // first needs seeding.
+        if !approved.entries.iter().any(|(id, _)| *id == proposal_id) {
+            println!(
+                "Approving the execution hash of proposal {}...",
+                proposal_id
+            );
+            submit_step(
+                &self.txn_options,
+                aptos_stdlib::aptos_governance_add_approved_script_hash_script(proposal_id),
+                "approving the execution hash",
+            )
+            .await?;
+        }
+
+        let mut executed = Vec::with_capacity(scripts.len() - start);
+        for BundleScript { name, blob, .. } in scripts.into_iter().skip(start) {
+            println!("Executing {}...", name);
+            let txn = submit_step(
+                &self.txn_options,
+                execution_payload(blob, proposal_id),
+                &name,
+            )
+            .await?;
+            executed.push(ExecutedStep {
+                script: name,
+                transaction: TransactionSummary::from(&txn),
+            });
+        }
+        Ok(executed)
+    }
+}
+
+/// The execution hash of the step the chain expects next, for a proposal that
+/// has passed and is not fully executed. The chain rolls a proposal's execution
+/// hash forward after each executed step.
+async fn expected_next_hash(client: &Client, proposal_id: u64) -> CliTypedResult<HashValue> {
+    let (state, resolved, next_hash) = try_join!(
+        voting_view::<U64>(client, ident_str!("get_proposal_state"), proposal_id),
+        voting_view::<bool>(client, ident_str!("is_resolved"), proposal_id),
+        voting_view::<ApiHashValue>(client, ident_str!("get_execution_hash"), proposal_id),
+    )?;
+
+    match state.0 {
+        PROPOSAL_STATE_SUCCEEDED => {},
+        PROPOSAL_STATE_PENDING => {
+            let expiration: U64 = voting_view(
+                client,
+                ident_str!("get_proposal_expiration_secs"),
+                proposal_id,
+            )
+            .await?;
+            return Err(CliError::CommandArgumentError(format!(
+                "proposal {} is still open for voting until unix second {}",
+                proposal_id, expiration.0
+            )));
+        },
+        PROPOSAL_STATE_FAILED => {
+            return Err(CliError::CommandArgumentError(format!(
+                "proposal {} did not pass and cannot be executed",
+                proposal_id
+            )));
+        },
+        other => {
+            return Err(CliError::UnexpectedError(format!(
+                "proposal {} is in unknown state {}",
+                proposal_id, other
+            )));
+        },
+    }
+    if resolved {
+        return Err(CliError::CommandArgumentError(format!(
+            "proposal {} has already been fully executed",
+            proposal_id
+        )));
+    }
+    Ok(next_hash.into())
+}
+
+async fn approved_hashes(client: &Client) -> CliTypedResult<ApprovedExecutionHashes> {
+    Ok(client
+        .get_account_resource_bcs::<ApprovedExecutionHashes>(
+            AccountAddress::ONE,
+            "0x1::aptos_governance::ApprovedExecutionHashes",
+        )
+        .await?
+        .into_inner())
+}
+
+/// Submit one transaction of the execution; on failure, say how to resume.
+async fn submit_step(
+    txn_options: &TransactionOptions,
+    payload: TransactionPayload,
+    step: &str,
+) -> CliTypedResult<Transaction> {
+    txn_options
+        .submit_transaction(payload)
+        .await
+        .inspect_err(|_| {
+            eprintln!(
+                "Step {} failed. Once the cause is fixed, re-run this command to resume from it.",
+                step
+            )
+        })
+}
+
+async fn ledger_timestamp_secs(client: &Client) -> CliTypedResult<u64> {
+    Ok(client
+        .get_ledger_information()
+        .await?
+        .into_inner()
+        .timestamp_usecs
+        / 1_000_000)
+}
+
+/// Call a view function of a `0x1` module and deserialize its single return value.
+async fn view_one<T: DeserializeOwned>(
+    client: &Client,
+    module: &IdentStr,
+    function: &IdentStr,
+    ty_args: Vec<TypeTag>,
+    args: Vec<Vec<u8>>,
+) -> CliTypedResult<T> {
+    let request = ViewFunction {
+        module: ModuleId::new(AccountAddress::ONE, module.to_owned()),
+        function: function.to_owned(),
+        ty_args,
+        args,
+    };
+    let mut values = client
+        .view_bcs_with_json_response(&request, None)
+        .await?
+        .into_inner();
+    if values.len() != 1 {
+        return Err(CliError::UnexpectedError(format!(
+            "view function {}::{} returned {} values, expected 1",
+            module,
+            function,
+            values.len()
+        )));
+    }
+    serde_json::from_value(values.remove(0)).map_err(|err| {
+        CliError::UnexpectedError(format!(
+            "failed to parse the result of view function {}::{}: {}",
+            module, function, err
+        ))
+    })
+}
+
+/// Call a `0x1::voting` view function on a governance proposal.
+async fn voting_view<T: DeserializeOwned>(
+    client: &Client,
+    function: &IdentStr,
+    proposal_id: u64,
+) -> CliTypedResult<T> {
+    view_one(
+        client,
+        ident_str!("voting"),
+        function,
+        vec![
+            parse_type_tag("0x1::governance_proposal::GovernanceProposal")
+                .expect("the governance proposal type tag is well-formed"),
+        ],
+        vec![bcs_arg(&AccountAddress::ONE), bcs_arg(&proposal_id)],
+    )
+    .await
+}
+
+fn bcs_arg<T: Serialize>(value: &T) -> Vec<u8> {
+    bcs::to_bytes(value).expect("BCS-encoding a view function argument cannot fail")
+}

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+pub mod bundle;
 pub mod delegation_pool;
 pub mod utils;
 
@@ -61,6 +62,8 @@ pub enum GovernanceTool {
     ListProposals(ListProposals),
     VerifyProposal(VerifyProposal),
     ExecuteProposal(ExecuteProposal),
+    ProposeBundle(bundle::ProposeBundle),
+    ExecuteBundle(bundle::ExecuteBundle),
     GenerateUpgradeProposal(GenerateUpgradeProposal),
     ApproveExecutionHash(ApproveExecutionHash),
     #[clap(subcommand)]
@@ -74,6 +77,8 @@ impl GovernanceTool {
             Propose(tool) => tool.execute_serialized().await,
             Vote(tool) => tool.execute_serialized().await,
             ExecuteProposal(tool) => tool.execute_serialized().await,
+            ProposeBundle(tool) => tool.execute_serialized().await,
+            ExecuteBundle(tool) => tool.execute_serialized().await,
             GenerateUpgradeProposal(tool) => tool.execute_serialized_success().await,
             ShowProposal(tool) => tool.execute_serialized().await,
             ListProposals(tool) => tool.execute_serialized().await,
@@ -280,6 +285,8 @@ async fn get_proposal(
 }
 
 /// Submit a governance proposal
+///
+/// For a governance bundle, use `propose-bundle` instead.
 #[derive(Parser)]
 pub struct SubmitProposal {
     #[clap(flatten)]
@@ -350,27 +357,30 @@ impl SubmitProposalArgs {
         #[cfg(not(feature = "no-upload-proposal"))]
         let bytes = get_metadata_from_url(&self.metadata_url).await?;
 
-        let metadata: ProposalMetadata = serde_json::from_slice(&bytes).map_err(|err| {
-            CliError::CommandArgumentError(format!(
-                "Metadata is not in a proper JSON format: {}",
-                err
-            ))
-        })?;
-        Url::parse(&metadata.source_code_url).map_err(|err| {
-            CliError::CommandArgumentError(format!(
-                "Source code URL {} is invalid {}",
-                metadata.source_code_url, err
-            ))
-        })?;
-        Url::parse(&metadata.discussion_url).map_err(|err| {
-            CliError::CommandArgumentError(format!(
-                "Discussion URL {} is invalid {}",
-                metadata.discussion_url, err
-            ))
-        })?;
+        let metadata = parse_proposal_metadata(&bytes)?;
         let metadata_hash = HashValue::sha3_256_of(&bytes);
         Ok((metadata, metadata_hash))
     }
+}
+
+/// Parse proposal metadata JSON, requiring its URLs to be well-formed.
+fn parse_proposal_metadata(bytes: &[u8]) -> CliTypedResult<ProposalMetadata> {
+    let metadata: ProposalMetadata = serde_json::from_slice(bytes).map_err(|err| {
+        CliError::CommandArgumentError(format!("Metadata is not in a proper JSON format: {}", err))
+    })?;
+    Url::parse(&metadata.source_code_url).map_err(|err| {
+        CliError::CommandArgumentError(format!(
+            "Source code URL {} is invalid {}",
+            metadata.source_code_url, err
+        ))
+    })?;
+    Url::parse(&metadata.discussion_url).map_err(|err| {
+        CliError::CommandArgumentError(format!(
+            "Discussion URL {} is invalid {}",
+            metadata.discussion_url, err
+        ))
+    })?;
+    Ok(metadata)
 }
 
 #[async_trait]
@@ -380,6 +390,11 @@ impl CliCommand<ProposalSubmissionSummary> for SubmitProposal {
     }
 
     async fn execute(mut self) -> CliTypedResult<ProposalSubmissionSummary> {
+        eprintln!(
+            "Note: to submit a governance bundle, use `aptos governance propose-bundle`, which \
+             takes the compiled scripts and metadata from the bundle."
+        );
+
         // Validate the proposal metadata
         let (script_hash, metadata_hash) = self.args.compile_proposals().await?;
         prompt_yes_with_override(
@@ -387,35 +402,57 @@ impl CliCommand<ProposalSubmissionSummary> for SubmitProposal {
             self.args.txn_options.prompt_options,
         )?;
 
-        let txn: Transaction = if self.args.is_multi_step {
-            self.args
-                .txn_options
-                .submit_transaction(aptos_stdlib::aptos_governance_create_proposal_v2(
-                    self.pool_address_args.pool_address,
-                    script_hash.to_vec(),
-                    self.args.metadata_url.to_string().as_bytes().to_vec(),
-                    metadata_hash.to_hex().as_bytes().to_vec(),
-                    true,
-                ))
-                .await?
-        } else {
-            self.args
-                .txn_options
-                .submit_transaction(aptos_stdlib::aptos_governance_create_proposal(
-                    self.pool_address_args.pool_address,
-                    script_hash.to_vec(),
-                    self.args.metadata_url.to_string().as_bytes().to_vec(),
-                    metadata_hash.to_hex().as_bytes().to_vec(),
-                ))
-                .await?
-        };
-        let txn_summary = TransactionSummary::from(&txn);
-        let proposal_id = extract_proposal_id(&txn)?;
-        Ok(ProposalSubmissionSummary {
-            proposal_id,
-            transaction: txn_summary,
-        })
+        create_proposal(
+            &self.args.txn_options,
+            self.pool_address_args.pool_address,
+            script_hash,
+            &self.args.metadata_url,
+            metadata_hash,
+            self.args.is_multi_step,
+        )
+        .await
     }
+}
+
+/// Create the on-chain proposal for a script's execution hash and report its id.
+async fn create_proposal(
+    txn_options: &TransactionOptions,
+    pool_address: AccountAddress,
+    script_hash: HashValue,
+    metadata_url: &Url,
+    metadata_hash: HashValue,
+    is_multi_step: bool,
+) -> CliTypedResult<ProposalSubmissionSummary> {
+    let metadata_url = metadata_url.to_string().as_bytes().to_vec();
+    let metadata_hash = metadata_hash.to_hex().as_bytes().to_vec();
+    let payload = if is_multi_step {
+        aptos_stdlib::aptos_governance_create_proposal_v2(
+            pool_address,
+            script_hash.to_vec(),
+            metadata_url,
+            metadata_hash,
+            true,
+        )
+    } else {
+        aptos_stdlib::aptos_governance_create_proposal(
+            pool_address,
+            script_hash.to_vec(),
+            metadata_url,
+            metadata_hash,
+        )
+    };
+    let txn = txn_options.submit_transaction(payload).await?;
+    Ok(ProposalSubmissionSummary {
+        proposal_id: extract_proposal_id(&txn)?,
+        transaction: TransactionSummary::from(&txn),
+    })
+}
+
+/// The transaction executing one step of a proposal.
+fn execution_payload(bytecode: Vec<u8>, proposal_id: u64) -> TransactionPayload {
+    TransactionPayload::Script(Script::new(bytecode, vec![], vec![
+        TransactionArgument::U64(proposal_id),
+    ]))
 }
 
 /// Retrieve the Metadata from the given URL
@@ -780,6 +817,8 @@ impl std::fmt::Display for ProposalMetadata {
 }
 
 /// Execute a proposal that has passed voting requirements
+///
+/// For a governance bundle, use `execute-bundle` instead.
 #[derive(Parser)]
 pub struct ExecuteProposal {
     /// Proposal Id being executed
@@ -798,6 +837,11 @@ impl CliCommand<TransactionSummary> for ExecuteProposal {
     }
 
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
+        eprintln!(
+            "Note: to execute a governance bundle, use `aptos governance execute-bundle`, which \
+             runs the bundle's compiled scripts in order and resumes where it left off."
+        );
+
         let (bytecode, _script_hash) = self.compile_proposal_args.compile(
             &DiagWriter::stderr(),
             "ExecuteProposal",
@@ -805,11 +849,8 @@ impl CliCommand<TransactionSummary> for ExecuteProposal {
         )?;
         // TODO: Check hash so we don't do a failed roundtrip?
 
-        let args = vec![TransactionArgument::U64(self.proposal_id)];
-        let txn = TransactionPayload::Script(Script::new(bytecode, vec![], args));
-
         self.txn_options
-            .submit_transaction(txn)
+            .submit_transaction(execution_payload(bytecode, self.proposal_id))
             .await
             .map(TransactionSummary::from)
     }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -23,8 +23,10 @@ use crate::{
         utils::write_to_file,
     },
     governance::{
-        CompileScriptFunction, ProposalSubmissionSummary, SubmitProposal, SubmitProposalArgs,
-        SubmitVote, SubmitVoteArgs, VerifyProposal, VerifyProposalResponse,
+        bundle::{BundleArgs, ExecuteBundle, ExecutedStep, ProposeBundle},
+        CompileScriptFunction, ExecuteProposal, GenerateExecutionHash, ProposalSubmissionSummary,
+        SubmitProposal, SubmitProposalArgs, SubmitVote, SubmitVoteArgs, VerifyProposal,
+        VerifyProposalResponse,
     },
     node::{
         AnalyzeMode, AnalyzeValidatorPerformance, GetStakePool, InitializeValidator,
@@ -44,7 +46,7 @@ use aptos_config::config::Peer;
 use aptos_crypto::{
     bls12381,
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    x25519, PrivateKey,
+    x25519, HashValue, PrivateKey,
 };
 use aptos_framework::chunked_publish::CHUNK_SIZE_IN_BYTES;
 use aptos_genesis::config::HostAndPort;
@@ -71,7 +73,7 @@ use serde_json::Value;
 use std::{
     collections::{BTreeMap, HashMap},
     mem,
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -1029,18 +1031,7 @@ impl CliTestFramework {
         framework_package_args: FrameworkPackageArgs,
         gas_options: Option<GasOptions>,
     ) -> CliTypedResult<TransactionSummary> {
-        // Make a temporary directory for compilation
-        let temp_dir = TempDir::new().map_err(|err| {
-            CliError::UnexpectedError(format!("Failed to create temporary directory {}", err))
-        })?;
-
-        let source_path = temp_dir.path().join("script.move");
-        write_to_file(
-            source_path.as_path(),
-            &source_path.display().to_string(),
-            script_contents.as_bytes(),
-        )
-        .unwrap();
+        let (_temp_dir, source_path) = Self::write_temp_script(script_contents)?;
 
         RunScript {
             txn_options: self.transaction_options(index, gas_options),
@@ -1221,6 +1212,89 @@ impl CliTestFramework {
                     ..CompileScriptFunction::default()
                 },
             },
+        }
+        .execute()
+        .await
+    }
+
+    /// Write a script to `script.move` in a fresh temporary directory, which the
+    /// caller keeps alive for as long as the file is needed.
+    fn write_temp_script(script_contents: &str) -> CliTypedResult<(TempDir, PathBuf)> {
+        let temp_dir = TempDir::new().map_err(|err| {
+            CliError::UnexpectedError(format!("Failed to create temporary directory {}", err))
+        })?;
+        let source_path = temp_dir.path().join("script.move");
+        write_to_file(
+            source_path.as_path(),
+            &source_path.display().to_string(),
+            script_contents.as_bytes(),
+        )?;
+        Ok((temp_dir, source_path))
+    }
+
+    /// Compile a script against the local framework, returning its bytecode and
+    /// execution hash.
+    pub fn compile_script(&self, script_contents: &str) -> CliTypedResult<(Vec<u8>, HashValue)> {
+        let (_temp_dir, source_path) = Self::write_temp_script(script_contents)?;
+        GenerateExecutionHash {
+            script_path: Some(source_path),
+            framework_local_dir: Some(Self::aptos_framework_dir()),
+        }
+        .generate_hash()
+    }
+
+    pub async fn execute_proposal_compiled(
+        &self,
+        index: usize,
+        proposal_id: u64,
+        compiled_script_path: &Path,
+    ) -> CliTypedResult<TransactionSummary> {
+        ExecuteProposal {
+            proposal_id,
+            txn_options: self.transaction_options(index, None),
+            compile_proposal_args: CompileScriptFunction {
+                compiled_script_path: Some(compiled_script_path.to_path_buf()),
+                ..CompileScriptFunction::default()
+            },
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn propose_bundle(
+        &self,
+        index: usize,
+        bundle: &Path,
+        pool_address: AccountAddress,
+        metadata_url: &str,
+    ) -> CliTypedResult<ProposalSubmissionSummary> {
+        ProposeBundle {
+            bundle_args: BundleArgs {
+                bundle: bundle.to_path_buf(),
+                skip_signoff: false,
+            },
+            pool_address_args: PoolAddressArgs { pool_address },
+            metadata_url: Url::parse(metadata_url).unwrap(),
+            skip_metadata_url_check: true,
+            txn_options: self.transaction_options(index, None),
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn execute_bundle(
+        &self,
+        index: usize,
+        bundle: &Path,
+        proposal_id: u64,
+    ) -> CliTypedResult<Vec<ExecutedStep>> {
+        ExecuteBundle {
+            bundle_args: BundleArgs {
+                bundle: bundle.to_path_buf(),
+                skip_signoff: false,
+            },
+            proposal_id,
+            txn_options: self.transaction_options(index, None),
         }
         .execute()
         .await

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -29,6 +29,7 @@ aptos-forge = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-global-constants = { workspace = true }
+aptos-governance-bundle = { workspace = true }
 aptos-indexer-grpc-table-info = { workspace = true }
 aptos-inspection-service = { workspace = true }
 aptos-keygen = { workspace = true }

--- a/testsuite/smoke-test/src/aptos_cli/governance_bundle.rs
+++ b/testsuite/smoke-test/src/aptos_cli/governance_bundle.rs
@@ -1,0 +1,262 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! `aptos governance propose-bundle` and `execute-bundle` against a local swarm,
+//! with a two-step governance bundle proposed twice: once executed from the
+//! start, and once resumed after the first step was run by other means.
+
+use crate::smoke_test_environment::SwarmBuilder;
+use aptos::{governance::bundle::ExecutedStep, test::CliTestFramework};
+use aptos_forge::NodeExt;
+use aptos_governance_bundle::{
+    BundleManifest, BundleSection, SourceSection, BYTECODE_DIR, METADATA_JSON, SUMMARY_DIR,
+};
+use aptos_rest_client::{aptos_api_types::ViewRequest, Client};
+use aptos_temppath::TempPath;
+use aptos_types::account_address::AccountAddress;
+use serde_json::json;
+use std::{
+    fs,
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// Voting period of the swarm's governance, in seconds.
+const VOTING_DURATION_SECS: u64 = 10;
+const VOTING_CLOSE_TIMEOUT: Duration = Duration::from_secs(120);
+/// Gas funds for the validator's account (1000 APT).
+const GAS_FUNDS_OCTAS: u64 = 100_000_000_000;
+
+#[tokio::test]
+async fn test_propose_and_execute_bundle() {
+    let (swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .with_init_genesis_config(Arc::new(|genesis_config| {
+            genesis_config.voting_duration_secs = VOTING_DURATION_SECS;
+        }))
+        .build_with_cli(0)
+        .await;
+    let validator = swarm.validators().next().unwrap();
+    let validator_idx = cli.add_account_to_cli(
+        validator
+            .account_private_key()
+            .as_ref()
+            .unwrap()
+            .private_key(),
+    );
+    let pool_address = cli.account_id(validator_idx);
+    let client = validator.rest_client();
+    // The validator's stake is locked; give its account APT to pay for gas.
+    cli.fund_account(validator_idx, Some(GAS_FUNDS_OCTAS))
+        .await
+        .unwrap();
+    // The proposer's lockup must outlast the voting period.
+    cli.increase_lockup(validator_idx).await.unwrap();
+
+    let bundle_dir = TempPath::new();
+    bundle_dir.create_as_dir().unwrap();
+    let bundle_path = bundle_dir.path();
+    write_bundle(&cli, bundle_path);
+
+    // Round one: execute-bundle runs every step from the start.
+    let proposal_id =
+        propose_and_pass(&cli, &client, validator_idx, bundle_path, pool_address).await;
+    let steps = cli
+        .execute_bundle(validator_idx, bundle_path, proposal_id)
+        .await
+        .unwrap();
+    assert_eq!(step_names(&steps), vec!["0-first", "1-last"]);
+    assert!(is_resolved(&client, proposal_id).await);
+
+    // Nothing left to execute.
+    let err = cli
+        .execute_bundle(validator_idx, bundle_path, proposal_id)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("already been fully executed"),
+        "{}",
+        err
+    );
+
+    // Round two: the same bundle again, with the first step run through
+    // `execute-proposal` to stand in for an interrupted run. execute-bundle
+    // must pick up at the second step.
+    let proposal_id =
+        propose_and_pass(&cli, &client, validator_idx, bundle_path, pool_address).await;
+    cli.execute_proposal_compiled(
+        validator_idx,
+        proposal_id,
+        &bundle_path.join(BYTECODE_DIR).join("0-first.mv"),
+    )
+    .await
+    .unwrap();
+    let steps = cli
+        .execute_bundle(validator_idx, bundle_path, proposal_id)
+        .await
+        .unwrap();
+    assert_eq!(step_names(&steps), vec!["1-last"]);
+    assert!(is_resolved(&client, proposal_id).await);
+}
+
+/// Propose the bundle, check it cannot be executed while the vote is open, vote
+/// for it, and wait until it can be resolved. Returns the proposal id.
+async fn propose_and_pass(
+    cli: &CliTestFramework,
+    client: &Client,
+    validator_idx: usize,
+    bundle_path: &Path,
+    pool_address: AccountAddress,
+) -> u64 {
+    let proposal_id = cli
+        .propose_bundle(
+            validator_idx,
+            bundle_path,
+            pool_address,
+            "https://dummy.invalid/metadata.json",
+        )
+        .await
+        .unwrap()
+        .proposal_id
+        .unwrap();
+
+    let err = cli
+        .execute_bundle(validator_idx, bundle_path, proposal_id)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("still open for voting"), "{}", err);
+
+    cli.vote(validator_idx, proposal_id, true, false, vec![pool_address])
+        .await;
+    wait_for_voting_closed(client, proposal_id).await;
+    proposal_id
+}
+
+fn step_names(steps: &[ExecutedStep]) -> Vec<&str> {
+    steps.iter().map(|step| step.script.as_str()).collect()
+}
+
+async fn is_resolved(client: &Client, proposal_id: u64) -> bool {
+    proposal_view(client, "is_resolved", proposal_id)
+        .await
+        .as_bool()
+        .unwrap()
+}
+
+/// Write a two-step bundle at `dir`: the first step only hands off to the
+/// second, which completes the proposal.
+fn write_bundle(cli: &CliTestFramework, dir: &Path) {
+    let last_source = r#"script {
+    use aptos_framework::aptos_governance;
+    use std::vector;
+
+    fun main(proposal_id: u64) {
+        let _framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, vector::empty<u8>());
+    }
+}
+"#;
+    let (last_blob, last_hash) = cli.compile_script(last_source).unwrap();
+
+    let first_source = format!(
+        r#"script {{
+    use aptos_framework::aptos_governance;
+
+    fun main(proposal_id: u64) {{
+        let _framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @0x1, x"{}");
+    }}
+}}
+"#,
+        last_hash.to_hex()
+    );
+    let (first_blob, _) = cli.compile_script(&first_source).unwrap();
+
+    fs::create_dir_all(dir.join(BYTECODE_DIR)).unwrap();
+    fs::create_dir_all(dir.join(SUMMARY_DIR)).unwrap();
+    fs::write(dir.join(BYTECODE_DIR).join("0-first.mv"), first_blob).unwrap();
+    fs::write(dir.join(BYTECODE_DIR).join("1-last.mv"), last_blob).unwrap();
+    fs::write(
+        dir.join(METADATA_JSON),
+        json!({
+            "title": "Smoke test bundle",
+            "description": "A two-step proposal that changes nothing.",
+            "source_code_url": "https://github.com/aptos-labs/aptos-core",
+            "discussion_url": "https://github.com/aptos-labs/aptos-core",
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        dir.join(SUMMARY_DIR).join("changes.md"),
+        "- [x] Reviewed.\n",
+    )
+    .unwrap();
+
+    BundleManifest::new(
+        dir,
+        BundleSection {
+            name: "smoke-test".to_string(),
+            created_at: "1970-01-01T00:00:00Z".to_string(),
+        },
+        SourceSection {
+            branch: None,
+            commit: "0".repeat(40),
+        },
+    )
+    .unwrap()
+    .write(dir)
+    .unwrap();
+}
+
+/// Call a `0x1::voting` view function on a governance proposal.
+async fn proposal_view(client: &Client, function: &str, proposal_id: u64) -> serde_json::Value {
+    let request = ViewRequest {
+        function: format!("0x1::voting::{}", function).parse().unwrap(),
+        type_arguments: vec!["0x1::governance_proposal::GovernanceProposal"
+            .parse()
+            .unwrap()],
+        arguments: vec![json!("0x1"), json!(proposal_id.to_string())],
+    };
+    client
+        .view(&request, None)
+        .await
+        .unwrap()
+        .into_inner()
+        .remove(0)
+}
+
+async fn ledger_timestamp_secs(client: &Client) -> u64 {
+    client
+        .get_ledger_information()
+        .await
+        .unwrap()
+        .into_inner()
+        .timestamp_usecs
+        / 1_000_000
+}
+
+/// Wait until the proposal can be resolved: voting is closed, and on-chain time
+/// has moved strictly past the last vote.
+async fn wait_for_voting_closed(client: &Client, proposal_id: u64) {
+    let deadline = Instant::now() + VOTING_CLOSE_TIMEOUT;
+    while !proposal_view(client, "is_voting_closed", proposal_id)
+        .await
+        .as_bool()
+        .unwrap()
+    {
+        assert!(
+            Instant::now() < deadline,
+            "voting on proposal {} did not close in time",
+            proposal_id
+        );
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    let closed_at = ledger_timestamp_secs(client).await;
+    while ledger_timestamp_secs(client).await <= closed_at {
+        assert!(
+            Instant::now() < deadline,
+            "the on-chain clock did not advance past the vote in time"
+        );
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/testsuite/smoke-test/src/aptos_cli/mod.rs
+++ b/testsuite/smoke-test/src/aptos_cli/mod.rs
@@ -4,6 +4,7 @@
 #![allow(unexpected_cfgs)]
 
 mod account;
+mod governance_bundle;
 #[cfg(feature = "cli-framework-test-move")]
 mod r#move;
 pub mod validator;


### PR DESCRIPTION
## Description

Adds the two operator-facing steps of the bundle-based framework release process ([design doc](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/aptos-release-tool/README.md)) to the Aptos CLI:

- **`aptos governance propose-bundle`** verifies the bundle, checks that `--metadata-url` serves the bundle's `metadata.json` byte for byte, pre-checks the proposer conditions `create_proposal_v2` asserts on-chain (delegated voter, proposer stake, lockup) so failures are readable, and creates the multi-step proposal for the first script's hash.
- **`aptos governance execute-bundle`** verifies the bundle, requires the proposal to be succeeded and unresolved, finds the next step from the proposal's on-chain execution hash, seeds the approved-hash entry if missing, and executes the remaining steps in order. Re-running after a failure resumes from the failed step; a proposal that does not match the bundle is refused.

Both commands submit only the compiled scripts under `bytecode/`; nothing is compiled. Signing goes through the CLI's usual transaction options (profiles, keys, Ledger). The on-chain reads each command needs are made on one REST client and joined, so a propose costs one round trip for its pre-checks.

**Why the CLI and not `aptos-release-tool`:** node operators run these steps on mainnet, and they install the CLI rather than build the release tool from source.

**New crate `aptos-governance-bundle`:** the CLI cannot depend on `aptos-release-tool`, which depends on `aptos-release-builder`, which depends on the `aptos` crate. The bundle format moves into the new crate (`lib.rs`, which git tracks as a rename of the release tool's `bundle.rs`), and so does the definition of a valid bundle: `verify::verify(bundle_dir, require_signoff)` is the single entry point (git tracks it as a rename of the release tool's `commands/verify.rs`), covering manifest checksums and digest, layout, source-to-bytecode stamps, and sign-off. The CLI and the release tool's `verify-bundle` (now `commands/verify_bundle.rs`) both call it; the release tool adds only the `config.yaml` name check, which needs release-builder types, and the sign-off report. `BundleManifest::new` computes checksums and digest in one place. Only the git provenance reader stays in the release tool, in `generate.rs`, so the CLI does not pick up git2.

Also: `propose` and `execute-proposal` print a stderr hint pointing at the bundle commands and share `create_proposal` / `execution_payload` with them, a CHANGELOG entry, and README updates (bundle layout now shows `bytecode/`, the operator commands, and the mainnet flow).

## How Has This Been Tested?

- Unit tests in `aptos-governance-bundle` (manifest round trip, every verification problem reported at once, checksum stability across sign-off ticks, format version rejection, stamp parsing).
- `cargo test -p aptos --lib verify_tool` (clap self-check), `cargo test -p aptos-release-tool --lib`, and the release tool's end-to-end `generate_then_verify_bundle`.
- New smoke test `test_propose_and_execute_bundle`: builds a two-step bundle against a swarm with a short genesis voting period and proposes it twice. Round one: `propose-bundle`, check `execute-bundle` is refused while the vote is open, vote, and let `execute-bundle` run both steps from the start (which also seeds the approved hash). Round two: the same, but the first step is run through `execute-proposal --compiled-script-path` to stand in for an interrupted run, and `execute-bundle` must resume with the second step. Passes locally with `RUST_MIN_STACK=4297152`, the value CI sets; the Move compiler overflows the default test-thread stack otherwise.
- Manual end-to-end run against `aptos node run-localnet` with the built binaries: a `generate-bundle` bundle (current gas schedule plus a move-stdlib upgrade) proposed twice; once executed from the start by `execute-bundle` (approved-hash seeding, both steps, `verify-framework-deployment` OK afterwards), once resumed after step one ran through `execute-proposal --compiled-script-path`. Failure paths checked: unreachable metadata URL, sender not the delegated voter, tampered bytecode, execution before the vote closes, and re-execution after resolution.
- Clippy is clean on the four touched crates.

## Key Areas to Review

- `crates/aptos/src/governance/bundle.rs`: `expected_next_hash` (matching the on-chain execution hash against the bundle's scripts) and `check_proposer_eligibility`.
- `aptos-governance-bundle/src/verify.rs`: the single `verify` entry point, now shared by `aptos-move/aptos-release-tool/src/commands/verify_bundle.rs` and the CLI. The stamp check hashes with the `sha3` crate, which matches `HashValue::sha3_256_of`; the release tool's end-to-end test exercises that agreement.
- Deferred on purpose: recording a default metadata URL in `bundle.toml`, auto-discovering the proposal id, sharing the resume logic with `deploy-testnet`.

## Type of Change
- [x] New feature
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK
- [x] Other (specify): release tooling (`aptos-release-tool`, new `aptos-governance-bundle`)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how on-chain governance proposals are created and multi-step scripts executed, including hash matching and stake-pool pre-checks—errors could block or mis-order mainnet upgrades.
> 
> **Overview**
> Introduces **`aptos governance propose-bundle`** and **`execute-bundle`** so mainnet operators can submit and run framework releases from a self-contained bundle directory using only **`bytecode/`** (no recompilation), with resume-after-failure based on the chain’s next execution hash.
> 
> To share the bundle contract without a circular dependency on `aptos-release-tool`, the PR adds **`aptos-governance-bundle`**: manifest/checksum/digest handling, **`BundleManifest::new`**, and a single **`verify::verify`** path (integrity, layout, stamped source↔bytecode hashes, optional sign-off). **`aptos-release-tool`** now depends on that crate ( **`verify-bundle`** keeps the extra `config.yaml` name check and sign-off reporting); git provenance stays in **`generate-bundle`**.
> 
> Legacy **`propose`** / **`execute-proposal`** get stderr hints and shared **`create_proposal`** / **`execution_payload`** helpers. Docs and CHANGELOG describe the **`bytecode/`** layout and operator flow; a new smoke test covers full execution and resume after a partial run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f310d195a0cd58a7730c523f56ddfa12970f6c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->