### PR TITLE
Replay-verify: increase Testnet PFN snapshot size

### DIFF
--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -34,7 +34,7 @@ NAMESPACE = "replay-verify"
 ZONE = "us-central1-a"
 
 DEFAULT_PVC_ACCESS_MODE = "ReadOnlyMany"  # Default access mode for PVCs
-TESTNET_SNAPSHOT_DISK_SIZE = "26Ti"  # Must be >= the testnet PFN disk size (26Ti as of 2026-08)
+TESTNET_SNAPSHOT_DISK_SIZE = "28Ti"  # Must be >= the testnet PFN disk size (26Ti as of 2026-09)
 MAINNET_SNAPSHOT_DISK_SIZE = "25Ti"  # Must be >= the mainnet PFN disk size (25Ti as of 2026-08)
 
 def get_disk_size_for_snapshot(snapshot_name: str) -> str:


### PR DESCRIPTION
## Description

Update disk size to match live Testnet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in replay-verify tooling with no auth, data, or production runtime impact beyond larger requested test PVC capacity.
> 
> **Overview**
> Raises **`TESTNET_SNAPSHOT_DISK_SIZE`** in `archive_disk_utils.py` from **26Ti** to **28Ti** so replay-verify PVCs provisioned from testnet archive snapshots request enough storage for the current live Testnet PFN disk.
> 
> That size flows through **`get_disk_size_for_snapshot`** into testnet snapshot-backed PVC creation paths; the inline comment is updated to reflect the September 2026 sizing note. Mainnet sizing is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5479263af006466143ace4cb6d34e187e88d84ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->