### PR TITLE
Fix RunsOn image generator

### DIFF
--- a/buildtools/packer/aws-ubuntu.pkr.hcl
+++ b/buildtools/packer/aws-ubuntu.pkr.hcl
@@ -64,7 +64,7 @@ build {
       "sudo apt-get install apt-transport-https ca-certificates gnupg -y",
       "echo 'deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main' | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list",
       "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -",
-      "sudo apt-get update && sudo apt-get install google-cloud-sdk kubectl google-cloud-sdk-gke-gcloud-auth-plugin -y",
+      "sudo apt-get update && sudo apt-get install kubectl google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin -y",
       // Verify installations
       "gcloud --version",
       "kubectl version --client",


### PR DESCRIPTION
## Description

Debian package `google-cloud-sdk` has been deprecated in favor of `google-cloud-cli`.
