### PR TITLE
[ci] Skip full unit tests for infra-only diffs

### DIFF
--- a/.github/actions/file-change-determinator/action.yaml
+++ b/.github/actions/file-change-determinator/action.yaml
@@ -2,16 +2,17 @@ name: File Change Determinator
 description: Runs the file change determinator (to identify which files changed in a pull request)
 outputs:
   only_docs_changed:
-    description: "Returns true if only docs files were changed in the pull request"
+    description: "Returns true if only docs/infra files unrelated to Rust were changed in the pull request"
     value: ${{ steps.doc_change_determinator.outputs.should_skip }}
 
 runs:
   using: composite
   steps:
-    # Run the docs only change determinator
+    # Skip heavy Rust jobs when the diff is docs or non-Rust infra (packer, terraform, dashboards, docker).
+    # Do not ignore `.github/**` here: workflow-only PRs still need jobs to execute so the YAML change is exercised.
     - id: doc_change_determinator
       continue-on-error: true # Avoid skipping any checks if this job fails (see: https://github.com/fkirc/skip-duplicate-actions/issues/301)
       uses: fkirc/skip-duplicate-actions@v5
       with:
         skip_after_successful_duplicate: false # Don't skip if the action is a duplicate (this may cause false positives)
-        paths_ignore: '["**/*.md"]'
+        paths_ignore: '["**/*.md", "buildtools/**", "terraform/**", "dashboards/**", "developer-docs-site/**", "docker/**"]'

--- a/.github/actions/file-change-determinator/action.yaml
+++ b/.github/actions/file-change-determinator/action.yaml
@@ -2,17 +2,19 @@ name: File Change Determinator
 description: Runs the file change determinator (to identify which files changed in a pull request)
 outputs:
   only_docs_changed:
-    description: "Returns true if only docs/infra files unrelated to Rust were changed in the pull request"
+    description: "Returns true if only docs/packer/dashboard files were changed in the pull request"
     value: ${{ steps.doc_change_determinator.outputs.should_skip }}
 
 runs:
   using: composite
   steps:
-    # Skip heavy Rust jobs when the diff is docs or non-Rust infra (packer, terraform, dashboards, docker).
-    # Do not ignore `.github/**` here: workflow-only PRs still need jobs to execute so the YAML change is exercised.
+    # Skip heavy jobs when the diff cannot affect Rust, Docker images, or Forge.
+    # Do not ignore terraform/** or docker/**: forge.Dockerfile copies terraform/helm
+    # into the Forge image, and only_docs_changed sets SKIP_JOB on Forge/e2e workflows.
+    # Do not ignore `.github/**`: workflow-only PRs still need jobs to execute.
     - id: doc_change_determinator
       continue-on-error: true # Avoid skipping any checks if this job fails (see: https://github.com/fkirc/skip-duplicate-actions/issues/301)
       uses: fkirc/skip-duplicate-actions@v5
       with:
         skip_after_successful_duplicate: false # Don't skip if the action is a duplicate (this may cause false positives)
-        paths_ignore: '["**/*.md", "buildtools/**", "terraform/**", "dashboards/**", "developer-docs-site/**", "docker/**"]'
+        paths_ignore: '["**/*.md", "buildtools/**", "dashboards/**", "developer-docs-site/**"]'

--- a/.github/actions/rust-check-merge-base/action.yaml
+++ b/.github/actions/rust-check-merge-base/action.yaml
@@ -9,9 +9,28 @@ runs:
   using: composite
   steps:
     # The source code must be checked out by the workflow that invokes this action.
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+    #
+    # Do not use rust-setup here: merge-base only builds aptos-cargo-cli. rust-setup
+    # installs LLVM, Move Prover, PostgreSQL, Node, and protoc plugins.
+
+    - name: Set up Rust toolchain
+      uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # pin@v1
+
+    - name: Restore Cargo registry cache
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # pin@v2.9.1
       with:
-        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+        cache-bin: false
+        cache-targets: false
+        save-if: false
+
+    - name: Setup git credentials
+      if: inputs.GIT_CREDENTIALS != ''
+      shell: bash
+      env:
+        MERGE_BASE_GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+      run: |
+        git config --global credential.helper store
+        printf '%s\n' "$MERGE_BASE_GIT_CREDENTIALS" > ~/.git-credentials
 
     # Check the freshness of the merge base
     - name: Check the freshness of the merge base

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -72,8 +72,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
-        with:
-          fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - name: Run rust lints
         uses: ./.github/actions/rust-lints
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -159,16 +157,21 @@ jobs:
         !contains(github.event.pull_request.base.ref, '-release-')
       )
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    # Lightweight cargo-x check: does not need a 64-core builder.
+    runs-on: runs-on,cpu=4,ram=16,family=m7a+m7i-flex,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
       - name: Run the merge base freshness check
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         uses: ./.github/actions/rust-check-merge-base
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - run: echo "Skipping merge base check! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
   # Run only the targeted rust unit tests. This is a PR required job.
   rust-targeted-unit-tests:
@@ -180,18 +183,24 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
 
       - name: Run dev_setup.sh
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         run: |
           scripts/dev_setup.sh -b -p -r -y -P -t
 
       - name: Run targeted rust unit tests
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         uses: ./.github/actions/rust-targeted-unit-tests
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      - run: echo "Skipping targeted rust unit tests! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
   # Run aptos-batch-encryption (i.e., with TypeScript/Node.js). This is a PR required job.
   rust-batch-encryption-tests:

--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -30,19 +30,30 @@ const DEVTOOL_TARGET_DIRECTORY: &str = "target/aptos-x-tool";
 
 // File types in `aptos-core` that are not relevant to the rust build and test process.
 // Note: this is a best effort list and will need to be updated as time goes on.
-const IGNORED_DETERMINATOR_FILE_TYPES: [&str; 1] = ["*.md"];
+//
+// These globs are passed to cargo-guppy's determinator. Unmatched paths default to
+// marking *every* workspace package as changed, so nested docs/infra files must use
+// recursive `**` patterns (e.g. `**/*.md`, not `*.md`).
+pub(crate) const IGNORED_DETERMINATOR_FILE_TYPES: [&str; 1] = ["**/*.md"];
 
 // Paths in `aptos-core` that are not relevant to the rust build and test process.
 // Note: this is a best effort list and will need to be updated as time goes on.
-const IGNORED_DETERMINATOR_PATHS: [&str; 8] = [
-    ".assets/*",
-    ".github/*",
-    ".vscode/*",
-    "dashboards/*",
-    "developer-docs-site/*",
-    "docker/*",
-    "scripts/*",
-    "terraform/*",
+//
+// Use `/**` so nested files are ignored. A glob like `docker/*` does not match
+// `docker/builder/foo` and would otherwise invalidate the entire workspace.
+pub(crate) const IGNORED_DETERMINATOR_PATHS: [&str; 12] = [
+    ".assets/**",
+    ".claude/**",
+    ".cursor/**",
+    ".github/**",
+    ".vscode/**",
+    "buildtools/**",
+    "dashboards/**",
+    "developer-docs-site/**",
+    "docker/**",
+    "scripts/**",
+    "terraform/**",
+    "CODEOWNERS",
 ];
 
 // The maximum number of days allowed since the merge-base commit for the branch.

--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -717,4 +717,37 @@ mod tests {
         // Extract the package name from the path (this should panic)
         get_package_name_from_path(package_path);
     }
+
+    #[test]
+    fn ignored_path_globs_are_recursive() {
+        // cargo-guppy marks *all* packages changed for unmatched paths. A glob
+        // like `docker/*` does not match `docker/builder/foo`, so ignore rules
+        // must use `/**` (or be a single filename).
+        for glob in crate::common::IGNORED_DETERMINATOR_PATHS {
+            assert!(
+                glob.ends_with("/**") || !glob.contains('/'),
+                "ignore glob `{glob}` must be recursive (`dir/**`) or a filename"
+            );
+        }
+    }
+
+    #[test]
+    fn markdown_ignore_matches_nested_files() {
+        assert!(
+            crate::common::IGNORED_DETERMINATOR_FILE_TYPES.contains(&"**/*.md"),
+            "nested markdown must be ignored; `*.md` only matches the repo root"
+        );
+    }
+
+    #[test]
+    fn buildtools_packer_paths_are_ignored() {
+        // Regression: changing buildtools/packer/aws-ubuntu.pkr.hcl previously
+        // selected every workspace package (~50 minutes of unit tests).
+        assert!(
+            crate::common::IGNORED_DETERMINATOR_PATHS
+                .iter()
+                .any(|glob| glob.starts_with("buildtools")),
+            "buildtools/** must be ignored by the unit-test determinator"
+        );
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

PR `Lint+Test` wall-clock is ~50 minutes on a typical change, almost entirely `rust-targeted-unit-tests`. A Packer-only PR (`buildtools/packer/aws-ubuntu.pkr.hcl`, 20517) still compiled and ran **12,663 tests across 279 packages** because cargo-guppy's determinator **marks every workspace package changed for unmatched paths**.

Ignore globs used `dir/*` (one path component). That does not match nested files such as `docker/builder/foo` or `buildtools/packer/...`, so infra diffs looked like "the whole repo changed."

This PR:

1. Switches ignore globs to recursive `/**` and adds `buildtools/**`, `.cursor/**`, `.claude/**`, `CODEOWNERS`.
2. Matches nested markdown with `**/*.md` (not `*.md`).
3. Expands the file-change skip list so docs/infra-only PRs skip the 64-core unit-test job entirely (that job previously ignored `only_docs_changed`).
4. Stops fetching full git history for `rust-lints` (clippy/fmt do not need it).
5. Runs `rust-check-merge-base` on a 4-vCPU runner with a light toolchain setup instead of `rust-setup` (LLVM + Prover + Postgres + Node).

## How Has This Been Tested?

- `cargo test -p aptos-cargo-cli --lib` (9 tests, including new glob/regression checks).

## Key Areas to Review

- Determinator ignore list: unmatched paths still invalidate the **entire** workspace. Do not ignore `rust-toolchain.toml`, `Cargo.toml`, `Cargo.lock`, `clippy.toml`, or `deny.toml`.
- `.github/**` is ignored for **package selection** (no rust tests for workflow-only diffs) but **not** in the file-change skipper, so workflow PRs still run jobs and exercise the YAML.

## Type of Change
- [x] Performance improvement
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure

## Checklist
- [x] I have read and followed the CONTRIBUTING doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

---

## CI / developer-speed breakdown

Measured on recent successful `Lint+Test` runs (e.g. 20517 Packer PR and a VM-gated PR with land-blocking tests):

| Job | Typical wall clock | Notes |
|---|---|---|
| **rust-targeted-unit-tests** | **~50 min (critical path)** | ~16 min compile (`--cargo-profile ci` = release `opt-level=3`) + ~31 min nextest (~12.6k tests, `threads-required=3`) |
| rust-lints | ~3 min | Full-workspace clippy on the `aptos-ubuntu-x64` image |
| rust-check-merge-base | ~2 min | Was 64-core + full `rust-setup` for `cargo x check-merge-base` |
| rust-cargo-deny / general-lints | ~1–2 min | |
| smoke tests (auto-merge or CICD:run-e2e-tests only) | ~28 min | Already split: parallel node+archive build, 8 partitions |
| Docker rust-images (same opt-in path) | ~30 min | Bake cache + skip-if-exists already in place |

### Shipped here (infra-only and skip-job waste)

- Fix guppy ignore globs so Packer/docker/terraform/docs diffs do not select 274 crates.
- Honor `only_docs_changed` on targeted unit tests and merge-base (required checks still go green via skip steps).
- Cheaper merge-base job.

Expected: infra/docs-only PRs drop from ~50 min to a couple of minutes. Typical Rust PRs are unchanged until the items below.

### Highest remaining wins (Rust PRs, ~50 min to ~20–25 min)

1. **Shard targeted unit tests like smoke tests**
   Compile once (`nextest archive` or cached `target/`), run 6–8 partitions. Test phase is ~31 min today; shards would cut wall clock roughly in half. Archive size for the full workspace may be large — needs a spike.

2. **Shared compile cache (sccache on GCS/S3)**
   Every PR compiles the `ci` profile from a cold `target/` on a fresh VM. Image has the toolchain, not artifacts. sccache would help leaf crates and incremental PRs.

3. **Keep `profile.ci` optimized, or split compile vs test profiles**
   `profile.ci` inherits `release` (`opt-level=3`) plus `debug-assertions` and overflow checks. Lowering opt-level speeds compile but can slow the 31 min test phase (compiler-v2 transactional tests are a large slice). Measure before changing.

4. **Tune nextest `threads-required = 3`**
   On 64 cores this is ~21 concurrent tests. Dropping to 2 or 1 would raise concurrency; it was set to avoid saturation/timeouts on heavy tests. Try on a non-blocking job first.

5. **Isolate huge test suites**
   `move-compiler-v2` / transactional tests dominate the tail. Gate them on compiler/Move package changes (determinator already does this when ignore rules work). Prover tests run whenever `MVP_TEST_ON_CI=true` — skip unless prover packages are affected.

### Medium wins (cost and setup)

6. **Stop using 64-core machines for non-compile jobs** (merge-base done here; cargo-deny/general-lints already small).
7. **Slim `rust-setup`**: `apt-get` + LLVM 22 + full `dev_setup.sh` (Prover, Postgres, Node) on jobs that only need `rustc`. The RunsOn image already has most of this.
8. **Targeted clippy** (`cargo x xclippy`) — lints are not the bottleneck (~3 min).
9. **`cargo install cargo-sort` on every lint job** — pin a binary in the image instead.
10. **Do not `fetch-depth: 0` unless the determinator needs history** (lints fixed here).

### Docker / Forge

11. Image builds already use bake cache, `TARGET_CACHE_ID=pr-N`, and skip-if-exists. They only run on auto-merge or the `CICD:run-e2e-tests` label — keep that.
12. Framework-upgrade was already moved off the PR blocking path (20497).
13. Forge realistic-env is 8 minutes of load plus image wait; not the default PR path.
14. **Footgun:** `docker-build-test.yaml` treats the substring `#` + `e2e` in the PR body as opt-in. Documenting that tag in a PR description starts land-blocking Forge/Docker. Prefer the label.

### Local development (same 200+ crate workspace)

14. `cargo x targeted-unit-tests` / `cargo nextest run -p <crate>` instead of workspace `cargo test`.
15. `sccache` or `RUSTC_WRAPPER` locally; `CARGO_INCREMENTAL=1` (CI correctly sets incremental off).
16. Linker is already `clang` + `lld` in `.cargo/config.toml`.
17. Avoid `--release` / `profile.ci` for everyday unit tests; use the `ci` profile only when matching CI.
18. After any `aptos-move/framework/**/*.move` change, rebuild `aptos-cached-packages` (`head.mrb`) or tests run the old framework.
19. Cranelift (`-Zcodegen-backend=cranelift`) can speed unoptimized local compiles; not a CI substitute for `profile.ci`.
20. Keep branches within 7 days of `origin/main` (`rust-check-merge-base`); stale merge-base also makes GCS cargo-metadata miss and forces a local recompute.

### Suggested order

1. Land this PR (infra-only 50 min to minutes; glob correctness for docker/scripts).
2. Spike sharded targeted unit tests (largest remaining wall-clock cut for code PRs).
3. sccache on the RunsOn image with a shared bucket.
4. Optionally split compiler-v2 / prover jobs off the default targeted-test process.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b27c37d-3ce1-4fa1-bef0-4ad9c1c7e07b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b27c37d-3ce1-4fa1-bef0-4ad9c1c7e07b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

