### PR TITLE
[ci] Use smaller runners for jobs that do not compile Rust

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,5 @@ self-hosted-runner:
   # Labels of self-hosted runners in array of string
   labels:
     - runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    - runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    - runs-on,cpu=4,ram=16,family=m7a+m7i-flex,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}

--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -28,7 +28,7 @@ jobs:
   # we ensure that the Aptos CLI works with all 3 prod networks, at least
   # based on the tests in the test suite.
   run-cli-tests:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/faucet-tests-main.yaml
+++ b/.github/workflows/faucet-tests-main.yaml
@@ -51,7 +51,7 @@ jobs:
   # be compatible in production.
   run-tests-main:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/faucet-tests-prod.yaml
+++ b/.github/workflows/faucet-tests-prod.yaml
@@ -37,7 +37,7 @@ jobs:
   run-tests-devnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -57,7 +57,7 @@ jobs:
   run-tests-testnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,11 +56,12 @@ jobs:
       - run: echo "Skipping general lints! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
-  # Run the crypto hasher domain separation checks
+  # Run the crypto hasher domain separation checks.
+  # The Python wrapper runs `cargo doc --workspace --no-deps --document-private-items`,
+  # so this needs the same class of runner as rust-doc-tests.
   rust-cryptohasher-domain-separation-check:
     needs: file_change_determinator
-    # Python symbol check; does not compile Rust.
-    runs-on: runs-on,cpu=4,ram=16,family=m7a+m7i-flex,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -59,7 +59,8 @@ jobs:
   # Run the crypto hasher domain separation checks
   rust-cryptohasher-domain-separation-check:
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    # Python symbol check; does not compile Rust.
+    runs-on: runs-on,cpu=4,ram=16,family=m7a+m7i-flex,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -46,7 +46,7 @@ jobs:
   # if there are any changes that would affect it within the PR / commit. If
   # everything is checked in, run tests, build the SDK, and upload it to npmjs.
   node-api-compatibility-tests:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -31,7 +31,7 @@ jobs:
   run-tests-devnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -50,7 +50,7 @@ jobs:
   run-tests-testnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -69,7 +69,7 @@ jobs:
   run-tests-mainnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Stacks on https://github.com/aptos-labs/aptos-core/pull/20520.

Stop paying for 64-core c7 instances on jobs that never invoke rustc:

- `rust-check-merge-base`: lightweight cargo-x check → 4 vCPU.
- CLI / faucet / node-API / Rust-client Docker e2e: prebuilt images → 16 vCPU (same class as smoke and unit-test shards).

Left on 64 cores on purpose: clippy, doc tests, cryptohasher (`cargo doc --workspace`), unit-test archive, full unit tests, cached-packages, consensus-only cargo, and Docker rust image builds.

## Type of Change
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure

## Checklist
- [x] I have performed a self-review of my own code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b27c37d-3ce1-4fa1-bef0-4ad9c1c7e07b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b27c37d-3ce1-4fa1-bef0-4ad9c1c7e07b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

