### PR TITLE
[ci] Add a localnet framework upgrade compatibility test

### DIFF
--- a/.github/workflows/framework-upgrade-compat.yaml
+++ b/.github/workflows/framework-upgrade-compat.yaml
@@ -1,0 +1,115 @@
+# Framework upgrade compatibility test.
+#
+# Asserts that a node running the previous release's binary can execute the
+# framework on this branch. On mainnet, validators take a new binary first and
+# the framework upgrade follows, so a fullnode still on the old binary has to
+# execute that upgrade or it stops there.
+#
+# One localnet, no consensus, no Forge cluster. See
+# scripts/test_framework_upgrade_compat.sh for the mechanics.
+name: Framework Upgrade Compatibility
+
+# Nothing here authenticates to a cloud or a registry: both binaries are built
+# from source and the localnet is reached over loopback. Read access is enough.
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      OLD_BRANCH:
+        required: false
+        type: string
+        description: >-
+          Release branch supplying the old binary. Defaults to the newest
+          aptos-release-vX.Y branch.
+
+  # schedule: # NOTE: the schedule is dictated by PIES
+
+jobs:
+  framework-upgrade-compat:
+    # Two debug cargo builds plus a localnet. disk=large is required: a debug
+    # aptos binary alone is ~775MB, and this builds two trees.
+    runs-on: runs-on,cpu=32,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+
+      # Resolve the previous release branch: the highest-numbered
+      # aptos-release-vX.Y, which is what determine_target_branch("main") picks.
+      #
+      # Done with git rather than the Forge action that resolves the same thing.
+      # That action also resolves a docker image tag, which needs crane and
+      # registry credentials -- and this job has no other use for a registry: it
+      # builds both binaries from source and talks only to localhost. Keeping it
+      # out means no cloud credentials are in scope here at all.
+      - name: Resolve and validate the old branch
+        id: old
+        env:
+          RAW: ${{ inputs.OLD_BRANCH }}
+        run: |
+          set -euo pipefail
+          BRANCH="${RAW}"
+          if [[ -z "${BRANCH}" ]]; then
+            BRANCH="$(git ls-remote --heads origin 'refs/heads/aptos-release-v*' \
+              | sed 's|.*refs/heads/||' \
+              | grep -E '^aptos-release-v[0-9]+\.[0-9]+$' \
+              | sort -t v -k2 -V \
+              | tail -1)"
+          fi
+          [[ -n "${BRANCH}" ]] || { echo "::error::could not resolve a release branch"; exit 1; }
+          # Read via env, never expression-substituted into this script, and
+          # constrain the charset: this value becomes a git ref below.
+          if ! [[ "${BRANCH}" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
+            echo "::error::Refusing branch name with unexpected characters"
+            exit 1
+          fi
+          echo "BRANCH=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Old binary will be built from ${BRANCH}"
+
+      # The CLI embeds aptos-node, so the CLI *is* the VM under test. It has to be
+      # built from the release branch: CLI releases are versioned independently of
+      # node releases (CLI 9.x vs node 1.4x), so a downloaded CLI has no defined
+      # relationship to a given release branch.
+      - name: Check out the old release branch
+        env:
+          BRANCH: ${{ steps.old.outputs.BRANCH }}
+        run: git worktree add --detach ../aptos-old "origin/${BRANCH}"
+
+      - name: Build the old CLI
+        run: cargo build -p aptos --bin aptos
+        working-directory: ../aptos-old
+
+      - name: Build aptos-release-tool from this branch
+        run: cargo build -p aptos-release-tool
+
+      # TMPDIR is pinned so the work directory lands somewhere the upload step can
+      # find: the script uses ${TMPDIR:-/tmp}, and a runner may set TMPDIR anywhere.
+      - name: Run the compatibility test
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: |
+          ./scripts/test_framework_upgrade_compat.sh \
+            --old-cli ../aptos-old/target/debug/aptos \
+            --release-tool ./target/debug/aptos-release-tool
+
+      # The script keeps every localnet, bundle and transaction log in its work
+      # directory; without these a failure is just an exit code.
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: framework-upgrade-compat-logs
+          # Exclude the localnet's key material. It only authorises a throwaway
+          # chain and is reproducible from the fixed seed anyway, but there is no
+          # reason to ship private keys in an artifact.
+          path: |
+            ${{ runner.temp }}/fwup-compat.*/
+            !${{ runner.temp }}/fwup-compat.*/**/mint.key
+            !${{ runner.temp }}/fwup-compat.*/**/*identity.yaml
+          retention-days: 7
+          if-no-files-found: warn

--- a/scripts/test_framework_upgrade_compat.sh
+++ b/scripts/test_framework_upgrade_compat.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# Framework upgrade compatibility test.
+#
+# Asserts that a node running the PREVIOUS release's binary can execute the
+# framework in THIS checkout. On mainnet, validators take a new binary first and
+# the framework upgrade follows; fullnodes lag behind both, so when the upgrade
+# lands a fullnode still on the old binary must execute it or it stops there.
+# This reproduces that on a single node, without consensus or a Forge cluster.
+#
+#   old CLI  -> runs the localnet, i.e. supplies the VM under test
+#   this repo -> supplies the framework, built into a governance bundle
+#
+# The upgrade goes through governance rather than a direct publish, and that is
+# not ceremony: a normal transaction is capped at max_transaction_size_in_bytes
+# (64 KiB), and only a script whose hash is in the on-chain ApprovedExecutionHashes
+# gets max_transaction_size_in_bytes.gov (1 MiB). The aptos-framework package is
+# far past 64 KiB, so nothing but an approved governance script can carry it.
+# See aptos-move/aptos-vm/src/transaction_metadata.rs:66 and
+# aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs:77.
+#
+# Usage:
+#   scripts/test_framework_upgrade_compat.sh --old-cli <path/to/aptos>
+#                                            [--release-tool <path>]
+#                                            [--control]
+#
+#   --control  rerun with the new binary as the node, as a positive control.
+#              Old fails + control passes => a compatibility problem.
+#              Both fail => the framework or this harness is broken instead.
+#
+# Note: the aptos CLI reads and writes ~/.aptos, and the localnet binds fixed
+# ports (8080 API, 50051 stream), so only one run at a time on a host.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ROOT_ACCOUNT="0xa550c18"
+API_URL="http://127.0.0.1:8080"
+SEED="0000000000000000000000000000000000000000000000000000000000000001"
+
+OLD_CLI=""
+NEW_CLI="$(command -v aptos || true)"
+RELEASE_TOOL="${REPO_ROOT}/target/debug/aptos-release-tool"
+RUN_CONTROL=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --old-cli) OLD_CLI="$2"; shift 2 ;;
+    --new-cli) NEW_CLI="$2"; shift 2 ;;
+    --release-tool) RELEASE_TOOL="$2"; shift 2 ;;
+    --control) RUN_CONTROL=1; shift ;;
+    -h|--help) sed -n '2,32p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -x "${OLD_CLI}" ]]      || { echo "--old-cli must be an executable aptos CLI" >&2; exit 2; }
+[[ -x "${RELEASE_TOOL}" ]] || { echo "aptos-release-tool not found at ${RELEASE_TOOL}; build it with 'cargo build -p aptos-release-tool'" >&2; exit 2; }
+# Only --control needs a second binary: it reruns the whole thing with the new
+# CLI as the node. Everywhere else the CLI is just a client submitting to the
+# node under test, so the node's own CLI is used.
+if [[ "${RUN_CONTROL}" -eq 1 && ! -x "${NEW_CLI}" ]]; then
+  echo "--control needs --new-cli to point at an executable aptos CLI (or one on PATH)" >&2
+  exit 2
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fwup-compat.XXXXXX")"
+LOCALNET_PID=""
+
+cleanup() {
+  if [[ -n "${LOCALNET_PID}" ]] && kill -0 "${LOCALNET_PID}" 2>/dev/null; then
+    kill "${LOCALNET_PID}" 2>/dev/null || true
+    wait "${LOCALNET_PID}" 2>/dev/null || true
+  fi
+  LOCALNET_PID=""
+}
+trap cleanup EXIT
+
+log()  { printf '\n=== %s\n' "$*"; }
+fail() { printf '\nFAIL: %s\n' "$*" >&2; exit 1; }
+
+start_localnet() {
+  local cli="$1" test_dir="$2" log_file="$3"
+
+  "${cli}" node run-localnet \
+    --test-dir "${test_dir}" --seed "${SEED}" --no-faucet --assume-yes \
+    >"${log_file}" 2>&1 &
+  LOCALNET_PID=$!
+
+  for _ in $(seq 1 120); do
+    if curl -sf "${API_URL}/v1" >/dev/null 2>&1; then
+      [[ -f "${test_dir}/mint.key" ]] || fail "localnet is up but ${test_dir}/mint.key is missing"
+      return 0
+    fi
+    kill -0 "${LOCALNET_PID}" 2>/dev/null || fail "localnet exited early; see ${log_file}"
+    sleep 2
+  done
+  fail "localnet did not become ready within 240s; see ${log_file}"
+}
+
+# mint.key is BCS: a 0x20 length prefix followed by the 32-byte key. deploy-testnet
+# wants it hex-encoded, so drop the prefix.
+root_key_hex() {
+  xxd -p -c 64 "$1/mint.key" | tr -d '\n' | cut -c3-
+}
+
+# The localnet's validator, whose stake proposes and votes.
+validator_field() {
+  grep "^$2:" "$1/0/private-identity.yaml" | awk '{print $2}' | tr -d '"'
+}
+
+# One package set, one proposal. No Gas entry: a gas change is a release concern,
+# and this test is only asking whether the old VM can execute the new framework.
+write_bundle_config() {
+  cat >"$1" <<'YAML'
+---
+name: "framework-upgrade-compat"
+metadata:
+  title: "Framework upgrade compatibility test"
+  description: "Publishes this checkout's framework onto a localnet running the previous release's binary."
+update_sequence:
+  - Framework:
+      bytecode_version: 10
+      git_hash: ~
+YAML
+}
+
+run_upgrade() {
+  local label="$1" cli="$2"
+  local test_dir="${WORK_DIR}/${label}"       ; mkdir -p "${test_dir}"
+  local bundle="${WORK_DIR}/${label}-bundle"
+  local config="${WORK_DIR}/${label}-config.yaml"
+
+  log "[${label}] starting localnet with $("${cli}" --version 2>/dev/null | head -1)"
+  start_localnet "${cli}" "${test_dir}" "${WORK_DIR}/${label}-localnet.log"
+
+  log "[${label}] generating the governance bundle from this checkout"
+  write_bundle_config "${config}"
+  "${RELEASE_TOOL}" generate-bundle --release-config "${config}" --bundle "${bundle}" \
+    >"${WORK_DIR}/${label}-generate.log" 2>&1 \
+    || { tail -30 "${WORK_DIR}/${label}-generate.log" >&2; fail "[${label}] could not generate the bundle"; }
+
+  log "[${label}] deploying it through governance"
+  # --skip-signoff: the sign-off checkboxes are a human review gate, not applicable here.
+  # --mint-to-validator: funds the validator's gas; refused on testnet, intended for
+  #   throwaway networks exactly like this one.
+  #
+  # Keys go through the environment rather than argv so they do not sit in the
+  # process table. deploy-testnet declares these with hide_env_values, so they
+  # are also kept out of its own diagnostics. They only authorise this
+  # throwaway localnet -- the seed is fixed, so they are reproducible by anyone
+  # reading this script -- but argv is a bad habit to set.
+  ROOT_KEY="$(root_key_hex "${test_dir}")" \
+  VALIDATOR_ADDRESS="$(validator_field "${test_dir}" account_address)" \
+  VALIDATOR_KEY="$(validator_field "${test_dir}" account_private_key)" \
+  "${RELEASE_TOOL}" deploy-testnet \
+    --bundle "${bundle}" \
+    --network "${API_URL}" \
+    --mint-to-validator \
+    --skip-signoff \
+    >"${WORK_DIR}/${label}-deploy.log" 2>&1 \
+    || { tail -40 "${WORK_DIR}/${label}-deploy.log" >&2; fail "[${label}] the upgrade did not execute -- this binary cannot run the new framework"; }
+
+  # The publish is only half of it: every later transaction has to load the new
+  # modules, so a node that accepted the upgrade can still fail afterwards.
+  # Submitted with the node's own CLI: the client version is irrelevant here,
+  # what matters is the node executing against the framework it just took.
+  log "[${label}] executing a transaction against the upgraded framework"
+  local post="${WORK_DIR}/${label}-post-upgrade.log"
+  "${cli}" move run \
+    --function-id 0x1::aptos_account::transfer \
+    --args "address:${ROOT_ACCOUNT}" u64:1 \
+    --sender-account "${ROOT_ACCOUNT}" \
+    --private-key-file "${test_dir}/mint.key" \
+    --encoding bcs \
+    --url "${API_URL}" \
+    --max-gas 2000000 \
+    --assume-yes \
+    >"${post}" 2>&1 || true
+  grep -q '"success": true' "${post}" \
+    || { cat "${post}" >&2; fail "[${label}] transactions fail after the upgrade"; }
+
+  cleanup
+  log "[${label}] PASS"
+}
+
+log "work dir: ${WORK_DIR}"
+run_upgrade old "${OLD_CLI}"
+[[ "${RUN_CONTROL}" -eq 1 ]] && run_upgrade control "${NEW_CLI}"
+
+log "PASS: the old binary executed this checkout's framework"


### PR DESCRIPTION
## Description

A framework upgrade compatibility test that runs on a single localnet instead of a Forge cluster.

On mainnet, validators take a new binary first and the framework upgrade follows some time later. Fullnodes lag behind both, so when the upgrade lands a fullnode still on the old binary has to execute it or it stops there, until its operator upgrades. At scale that is indexers, RPC providers and exchanges going dark while the chain itself is healthy.

That is a VM compatibility question — can the old VM load and run the new Move code — so it needs neither consensus nor a cluster:

```
localnet on the previous release's binary
  -> governance bundle built from this branch
  -> deployed through governance
  -> transaction executed against the upgraded framework
```

The upgrade goes through governance because that is the only way to carry it. A normal transaction is capped at `max_transaction_size_in_bytes` (64 KiB); the 1 MiB `max_transaction_size_in_bytes.gov` allowance applies only when the script's hash is in the on-chain `ApprovedExecutionHashes` (`aptos-move/aptos-vm/src/transaction_metadata.rs:66`), which only a passed proposal puts there. `move-stdlib` fits under 64 KiB; `aptos-stdlib` and `aptos-framework` do not.

`aptos-release-tool deploy-testnet` already drives that flow against an arbitrary endpoint, with `--mint-to-validator` intended for throwaway networks, and it polls rather than sleeping.

## Intended use

Nightly on `main`, against the newest release branch.

Framework compatibility breaks silently: nothing in a PR check tells you that a node one release behind can no longer execute the framework, and the cost only lands later, when fullnode operators stall at the upgrade block. Running this on a schedule turns that into a build failure the morning after the offending change lands, while it is still cheap to attribute and revert.

Once PIES is pointed at it, a red result means a node on the previous release cannot execute `main`'s framework. Whether that blocks a release or just gets documented in release notes for fullnode operators is a judgement call, but it should be a deliberate one rather than a surprise during the rollout.

## How to run it

**In CI** — Actions -> *Framework Upgrade Compatibility* -> **Run workflow**. Two independent selectors:

| | picks |
|---|---|
| *Use workflow from* (GitHub's branch dropdown) | the branch supplying the **new** framework — the checkout has no explicit `ref`, so the bundle is built from whatever you select |
| `OLD_BRANCH` (optional input) | the release branch supplying the **old binary**. Leave blank and it resolves the highest-numbered `aptos-release-vX.Y` |

So the usual case is: select your branch, leave the input empty, and it tests your framework against the newest release. ~17 minutes, most of it the two cargo builds.

Note the workflow file itself comes from the branch you select, so this only works on branches that contain it.

**Locally:**

```bash
# build the old CLI once from the release branch you want as the baseline
git worktree add --detach ../aptos-old origin/aptos-release-v1.49
(cd ../aptos-old && cargo build -p aptos --bin aptos)
cargo build -p aptos-release-tool

scripts/test_framework_upgrade_compat.sh --old-cli ../aptos-old/target/debug/aptos
```

Add `--control` to rerun with the new binary as the node. Only one run per host: the CLI reads and writes `~/.aptos`, and the localnet binds fixed ports (8080 API, 50051 stream).

## Testing

**Passes against a real version gap.** Run against a CLI built from `aptos-release-v1.49` (`26fcea0290`, the same commit the Forge suites resolve as their baseline), publishing this branch's framework:

```
Loaded 6 compiled script(s) from the bundle.
Executed 0-move-stdlib … 5-aptos-trading (6/6)
Deployment complete: proposal 0 fully executed (6 scripts).
post-upgrade txn: "success": true
```

Green locally and in CI ([run 34438752526](https://github.com/aptos-labs/aptos-core/actions/runs/34438752526), 17.4 min end to end).

**Fails when it should.** Adding a field to `BitVector` in `move-stdlib` — compiles cleanly, changes the struct layout — is correctly rejected:

```
BACKWARD_INCOMPATIBLE_MODULE_UPDATE
Error: simulation failed; refusing to deploy
Caused by: failed to execute governance script: 0-move-stdlib

FAIL: [old] the upgrade did not execute -- this binary cannot run the new framework
```

Worth noting this is caught by `deploy-testnet`'s simulation step before anything is submitted, so a bad framework never mutates chain state.

## Notes for review

- **Bash rather than python.** Bash is the norm at the CI boundary here: ~20 distinct bash scripts are invoked from workflows and actions versus 8 python ones, and this sits in the same company as `scripts/rust_lint.sh`, `scripts/install_deps.sh` and `scripts/indexer_processor_tests_status_poll.sh` (which also polls an endpoint). The work is process orchestration — start a node, wait for it, run three CLI commands in order, check the results — not logic. `testsuite/` is overwhelmingly python and has a proper framework for tests with real logic; `testsuite/run_forge.sh` shows the split, with bash at the boundary and python doing the thinking. If this grows to comparing state between the old and new nodes, moving it there would be the right call.
- **The assertions grep for `"success": true`.** Substring matching on structured output is the weakest part of this. `jq` would make it a real field check and could also surface `vm_status` on failure; worth doing, but flagging it rather than sneaking it in.
- **No cloud credentials are in scope.** Both binaries are built from source and the localnet is reached over loopback, so `permissions: contents: read` is enough. The release branch is resolved with `git ls-remote` rather than the Forge action that resolves the same thing, because that action also resolves a docker image tag and needs `crane` plus registry credentials.
- **The old CLI is built from the release branch, not downloaded.** The CLI embeds `aptos-node`, so the CLI *is* the VM under test, and CLI releases are versioned independently of node releases (9.x vs 1.4x) — a downloaded CLI has no defined relationship to a given release branch.
- **`--control`** reruns with the new binary as the node, to separate "old binary cannot handle it" from "the framework or the harness is broken". Untested so far.
- **Not scheduled yet.** The commented `schedule:` is a marker; PIES has to be pointed at this workflow, otherwise it is dispatch-only. See *Intended use* above — running it nightly on `main` is the point.
- Only one run per host: the CLI reads and writes `~/.aptos`, and the localnet binds fixed ports (8080 API, 50051 stream).

## Type of Change
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional CI and a local test harness only; no changes to node, VM, or on-chain release paths.
> 
> **Overview**
> Adds **framework upgrade compatibility** coverage so CI can verify a **previous release `aptos` binary** can run **this branch’s framework** via governance on a single localnet (no Forge).
> 
> A new workflow **Framework Upgrade Compatibility** (`workflow_dispatch`, optional `OLD_BRANCH` defaulting to the latest `aptos-release-v*`) checks out the old release in a worktree, builds the old CLI and current `aptos-release-tool`, runs `scripts/test_framework_upgrade_compat.sh`, and on failure uploads logs while excluding localnet key material. The script starts localnet with the old CLI, generates a framework bundle from the checkout, deploys with `aptos-release-tool deploy-testnet`, and asserts a post-upgrade `aptos_account::transfer` succeeds; optional `--control` reruns with the new binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b32b664588f4574f38396aef052f7c74db2a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

