### PR TITLE
[mono-move] Gate micro-benches on retired instructions (experimental)

### DIFF
--- a/.github/workflows/mono-move-micro-bench.yaml
+++ b/.github/workflows/mono-move-micro-bench.yaml
@@ -48,6 +48,13 @@ jobs:
              third_party/move/mono-move/testsuite/benches/perf/config.json \
              "$RUNNER_TEMP/perf/"
 
+      # The gate counts retired instructions through perf_event; record what the
+      # runner allows so a counter failure in the logs is easy to place.
+      - name: Show hardware counter access
+        run: |
+          echo "kernel.perf_event_paranoid=$(cat /proc/sys/kernel/perf_event_paranoid)"
+          grep -m1 'model name' /proc/cpuinfo || true
+
       - name: Run A/B benchmark gate
         id: gate
         run: |
@@ -80,5 +87,5 @@ jobs:
       - name: Fail on regression
         if: ${{ steps.gate.outputs.exit_code != '0' }}
         run: |
-          echo "mono-move benchmark gate failed: regression beyond the noise band." >&2
+          echo "mono-move benchmark gate failed: instruction count regressed beyond the threshold, or the benches could not run." >&2
           exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13170,6 +13170,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
+ "perf-event",
  "rand_core 0.5.1",
  "smallvec",
  "specializer",
@@ -15295,6 +15296,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "perf-event"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2529f39584dbaa980f4959510c963ae95f119c127c046012c2834365f694438"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "perf-event-open-sys",
+]
+
+[[package]]
+name = "perf-event-open-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f8d1487a4ffa23c80a1c355dd27235f9b66fb71ba0f261eb417e4fe8451347"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "pest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -742,6 +742,7 @@ paste = "1.0.7"
 pathsearch = "0.2.0"
 pbjson = "0.5.1"
 percent-encoding = "2.1.0"
+perf-event = "0.4.8"
 petgraph = "0.6.5"
 pin-project = "1.0.10"
 plotters = { version = "0.3.5", default-features = false }

--- a/third_party/move/mono-move/testsuite/Cargo.toml
+++ b/third_party/move/mono-move/testsuite/Cargo.toml
@@ -54,6 +54,9 @@ datatest-stable = { workspace = true }
 libtest-mimic = { workspace = true }
 walkdir = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+perf-event = { workspace = true }
+
 [[test]]
 name = "differential"
 harness = false

--- a/third_party/move/mono-move/testsuite/benches/bst.rs
+++ b/third_party/move/mono-move/testsuite/benches/bst.rs
@@ -1,75 +1,67 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+#[path = "support/mod.rs"]
+mod support;
+
+use criterion::{black_box, measurement::Measurement, BenchmarkId, Criterion};
+use mono_move_testsuite::{
+    programs::{
+        bst::{move_bytecode_bst, native_run_ops_checksum, SOURCE},
+        testing,
+    },
+    with_loaded_mono_function, SourceKind,
+};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
 const N_OPS: u64 = 5000;
 const KEY_RANGE: u64 = 2500;
 const SEED: u64 = 42;
 
-fn bench_bst(c: &mut Criterion) {
-    use mono_move_testsuite::{
-        programs::{
-            bst::{move_bytecode_bst, native_run_ops_checksum, SOURCE},
-            testing,
-        },
-        with_loaded_mono_function, SourceKind,
-    };
-    use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
-
-    // -- native (control) + mono-move pipeline ----------------------------
-    {
-        let mut group = c.benchmark_group("bst");
-        group
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        group.bench_function("native", |b| {
-            b.iter(|| black_box(native_run_ops_checksum(N_OPS, KEY_RANGE, SEED)));
-        });
-
-        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
-        with_loaded_mono_function(
-            SOURCE,
-            SourceKind::Move,
-            addr,
-            IdentStr::new("bst").unwrap(),
-            IdentStr::new("run_ops_checksum").unwrap(),
-            |runner| {
-                group.bench_function("mono", |b| {
-                    b.iter(|| black_box(runner.call_words(&[N_OPS, KEY_RANGE, SEED]).unwrap()));
-                });
-            },
-        )
-        .unwrap();
-
-        group.finish();
-    }
-
-    // -- move_vm ----------------------------------------------------------
-    {
-        let mut group = c.benchmark_group("bst");
-        group
-            .sample_size(10)
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        let module = move_bytecode_bst();
-        testing::with_loaded_move_function(&module, "run_ops_checksum", |env| {
-            group.bench_function("move_vm", |b| {
-                b.iter(|| {
-                    let result = env.run(vec![
-                        testing::arg_u64(N_OPS),
-                        testing::arg_u64(KEY_RANGE),
-                        testing::arg_u64(SEED),
-                    ]);
-                    black_box(testing::return_u64(&result))
-                });
+fn mono<M: Measurement>(c: &mut Criterion<M>, metric: &str) {
+    let mut group = c.benchmark_group("bst");
+    let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+    with_loaded_mono_function(
+        SOURCE,
+        SourceKind::Move,
+        addr,
+        IdentStr::new("bst").unwrap(),
+        IdentStr::new("run_ops_checksum").unwrap(),
+        |runner| {
+            group.bench_function(BenchmarkId::new("mono", metric), |b| {
+                b.iter(|| black_box(runner.call_words(&[N_OPS, KEY_RANGE, SEED]).unwrap()));
             });
-        });
-        group.finish();
-    }
+        },
+    )
+    .unwrap();
+    group.finish();
 }
 
-criterion_group!(benches, bench_bst);
-criterion_main!(benches);
+/// Reference points: native Rust and the production Move VM.
+fn controls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bst");
+    group.bench_function("native", |b| {
+        b.iter(|| black_box(native_run_ops_checksum(N_OPS, KEY_RANGE, SEED)));
+    });
+    group.finish();
+
+    // The Move VM is slower, so it gets a smaller sample.
+    let mut group = c.benchmark_group("bst");
+    group.sample_size(10);
+    let module = move_bytecode_bst();
+    testing::with_loaded_move_function(&module, "run_ops_checksum", |env| {
+        group.bench_function("move_vm", |b| {
+            b.iter(|| {
+                let result = env.run(vec![
+                    testing::arg_u64(N_OPS),
+                    testing::arg_u64(KEY_RANGE),
+                    testing::arg_u64(SEED),
+                ]);
+                black_box(testing::return_u64(&result))
+            });
+        });
+    });
+    group.finish();
+}
+
+support::bench_main!(mono, controls);

--- a/third_party/move/mono-move/testsuite/benches/fib.rs
+++ b/third_party/move/mono-move/testsuite/benches/fib.rs
@@ -1,69 +1,61 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+#[path = "support/mod.rs"]
+mod support;
+
+use criterion::{black_box, measurement::Measurement, BenchmarkId, Criterion};
+use mono_move_testsuite::{
+    programs::{
+        fib::{move_bytecode_fib, native_fib, SOURCE},
+        testing,
+    },
+    with_loaded_mono_function, SourceKind,
+};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
 const N: u64 = 25;
 
-fn bench_fib(c: &mut Criterion) {
-    use mono_move_testsuite::{
-        programs::{
-            fib::{move_bytecode_fib, native_fib, SOURCE},
-            testing,
-        },
-        with_loaded_mono_function, SourceKind,
-    };
-    use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
-
-    // -- native (control) + mono-move pipeline ----------------------------
-    {
-        let mut group = c.benchmark_group("fib");
-        group
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        group.bench_function("native", |b| {
-            b.iter(|| black_box(native_fib(N)));
-        });
-
-        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
-        with_loaded_mono_function(
-            SOURCE,
-            SourceKind::Move,
-            addr,
-            IdentStr::new("fib").unwrap(),
-            IdentStr::new("fib").unwrap(),
-            |runner| {
-                group.bench_function("mono", |b| {
-                    b.iter(|| black_box(runner.call_words(&[N]).unwrap()));
-                });
-            },
-        )
-        .unwrap();
-
-        group.finish();
-    }
-
-    // -- move_vm (production interpreter, slower → smaller sample) ---------
-    {
-        let mut group = c.benchmark_group("fib");
-        group
-            .sample_size(10)
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        let module = move_bytecode_fib();
-        testing::with_loaded_move_function(&module, "fib", |env| {
-            group.bench_function("move_vm", |b| {
-                b.iter(|| {
-                    let result = env.run(vec![testing::arg_u64(N)]);
-                    black_box(testing::return_u64(&result))
-                });
+fn mono<M: Measurement>(c: &mut Criterion<M>, metric: &str) {
+    let mut group = c.benchmark_group("fib");
+    let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+    with_loaded_mono_function(
+        SOURCE,
+        SourceKind::Move,
+        addr,
+        IdentStr::new("fib").unwrap(),
+        IdentStr::new("fib").unwrap(),
+        |runner| {
+            group.bench_function(BenchmarkId::new("mono", metric), |b| {
+                b.iter(|| black_box(runner.call_words(&[N]).unwrap()));
             });
-        });
-        group.finish();
-    }
+        },
+    )
+    .unwrap();
+    group.finish();
 }
 
-criterion_group!(benches, bench_fib);
-criterion_main!(benches);
+/// Reference points: native Rust and the production Move VM.
+fn controls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fib");
+    group.bench_function("native", |b| {
+        b.iter(|| black_box(native_fib(N)));
+    });
+    group.finish();
+
+    // The Move VM is slower, so it gets a smaller sample.
+    let mut group = c.benchmark_group("fib");
+    group.sample_size(10);
+    let module = move_bytecode_fib();
+    testing::with_loaded_move_function(&module, "fib", |env| {
+        group.bench_function("move_vm", |b| {
+            b.iter(|| {
+                let result = env.run(vec![testing::arg_u64(N)]);
+                black_box(testing::return_u64(&result))
+            });
+        });
+    });
+    group.finish();
+}
+
+support::bench_main!(mono, controls);

--- a/third_party/move/mono-move/testsuite/benches/int_arith_loop.rs
+++ b/third_party/move/mono-move/testsuite/benches/int_arith_loop.rs
@@ -5,97 +5,86 @@
 //! `i64_loop` run the same loop, so the u64 (specialized) vs i64
 //! (unspecialized) delta is the per-op dispatch difference.
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+#[path = "support/mod.rs"]
+mod support;
+
+use criterion::{black_box, measurement::Measurement, BenchmarkId, Criterion};
+use mono_move_testsuite::{
+    programs::{
+        int_arith_loop::{move_bytecode_int_arith_loop, native_i64_loop, native_u64_loop, SOURCE},
+        testing,
+    },
+    with_loaded_mono_function, SourceKind,
+};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
 const ITERS: u64 = 1_000;
 
-fn bench_int_arith_loop(c: &mut Criterion) {
-    use mono_move_testsuite::{
-        programs::{
-            int_arith_loop::{
-                move_bytecode_int_arith_loop, native_i64_loop, native_u64_loop, SOURCE,
-            },
-            testing,
-        },
-        with_loaded_mono_function, SourceKind,
-    };
-    use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
-
+fn mono<M: Measurement>(c: &mut Criterion<M>, metric: &str) {
+    let mut group = c.benchmark_group("int_arith_loop");
     let addr = AccountAddress::from_hex_literal("0x1").unwrap();
-
-    // -- native (control) + mono-move pipeline ----------------------------
-    {
-        let mut group = c.benchmark_group("int_arith_loop");
-        group
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        group.bench_function("native_u64", |b| {
-            b.iter(|| black_box(native_u64_loop(ITERS)));
-        });
-        group.bench_function("native_i64", |b| {
-            b.iter(|| black_box(native_i64_loop(ITERS)));
-        });
-
-        with_loaded_mono_function(
-            SOURCE,
-            SourceKind::Move,
-            addr,
-            IdentStr::new("int_arith_loop").unwrap(),
-            IdentStr::new("u64_loop").unwrap(),
-            |runner| {
-                group.bench_function("mono_u64", |b| {
-                    b.iter(|| black_box(runner.call_words(&[ITERS]).unwrap()));
-                });
-            },
-        )
-        .unwrap();
-        with_loaded_mono_function(
-            SOURCE,
-            SourceKind::Move,
-            addr,
-            IdentStr::new("int_arith_loop").unwrap(),
-            IdentStr::new("i64_loop").unwrap(),
-            |runner| {
-                group.bench_function("mono_i64", |b| {
-                    // Same 8 bytes; reinterpret as i64.
-                    b.iter(|| black_box(runner.call_words(&[ITERS]).unwrap() as i64));
-                });
-            },
-        )
-        .unwrap();
-
-        group.finish();
-    }
-
-    // -- move_vm ----------------------------------------------------------
-    {
-        let mut group = c.benchmark_group("int_arith_loop");
-        group
-            .sample_size(10)
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        let module = move_bytecode_int_arith_loop();
-        testing::with_loaded_move_function(&module, "u64_loop", |env| {
-            group.bench_function("move_vm_u64", |b| {
-                b.iter(|| {
-                    let result = env.run(vec![testing::arg_u64(ITERS)]);
-                    black_box(testing::return_u64(&result))
-                });
+    with_loaded_mono_function(
+        SOURCE,
+        SourceKind::Move,
+        addr,
+        IdentStr::new("int_arith_loop").unwrap(),
+        IdentStr::new("u64_loop").unwrap(),
+        |runner| {
+            group.bench_function(BenchmarkId::new("mono_u64", metric), |b| {
+                b.iter(|| black_box(runner.call_words(&[ITERS]).unwrap()));
             });
-        });
-        testing::with_loaded_move_function(&module, "i64_loop", |env| {
-            group.bench_function("move_vm_i64", |b| {
-                b.iter(|| {
-                    let result = env.run(vec![testing::arg_u64(ITERS)]);
-                    black_box(testing::return_i64(&result))
-                });
+        },
+    )
+    .unwrap();
+    with_loaded_mono_function(
+        SOURCE,
+        SourceKind::Move,
+        addr,
+        IdentStr::new("int_arith_loop").unwrap(),
+        IdentStr::new("i64_loop").unwrap(),
+        |runner| {
+            group.bench_function(BenchmarkId::new("mono_i64", metric), |b| {
+                // Same 8 bytes; reinterpret as i64.
+                b.iter(|| black_box(runner.call_words(&[ITERS]).unwrap() as i64));
             });
-        });
-        group.finish();
-    }
+        },
+    )
+    .unwrap();
+    group.finish();
 }
 
-criterion_group!(benches, bench_int_arith_loop);
-criterion_main!(benches);
+/// Reference points: native Rust and the production Move VM.
+fn controls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("int_arith_loop");
+    group.bench_function("native_u64", |b| {
+        b.iter(|| black_box(native_u64_loop(ITERS)));
+    });
+    group.bench_function("native_i64", |b| {
+        b.iter(|| black_box(native_i64_loop(ITERS)));
+    });
+    group.finish();
+
+    // The Move VM is slower, so it gets a smaller sample.
+    let mut group = c.benchmark_group("int_arith_loop");
+    group.sample_size(10);
+    let module = move_bytecode_int_arith_loop();
+    testing::with_loaded_move_function(&module, "u64_loop", |env| {
+        group.bench_function("move_vm_u64", |b| {
+            b.iter(|| {
+                let result = env.run(vec![testing::arg_u64(ITERS)]);
+                black_box(testing::return_u64(&result))
+            });
+        });
+    });
+    testing::with_loaded_move_function(&module, "i64_loop", |env| {
+        group.bench_function("move_vm_i64", |b| {
+            b.iter(|| {
+                let result = env.run(vec![testing::arg_u64(ITERS)]);
+                black_box(testing::return_i64(&result))
+            });
+        });
+    });
+    group.finish();
+}
+
+support::bench_main!(mono, controls);

--- a/third_party/move/mono-move/testsuite/benches/match_sum.rs
+++ b/third_party/move/mono-move/testsuite/benches/match_sum.rs
@@ -1,69 +1,61 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+#[path = "support/mod.rs"]
+mod support;
+
+use criterion::{black_box, measurement::Measurement, BenchmarkId, Criterion};
+use mono_move_testsuite::{
+    programs::{
+        match_sum::{move_bytecode_match_sum, native_match_sum, SOURCE},
+        testing,
+    },
+    with_loaded_mono_function, SourceKind,
+};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
 const N: u64 = 1_000_000;
 
-fn bench_match_sum(c: &mut Criterion) {
-    use mono_move_testsuite::{
-        programs::{
-            match_sum::{move_bytecode_match_sum, native_match_sum, SOURCE},
-            testing,
-        },
-        with_loaded_mono_function, SourceKind,
-    };
-    use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
-
-    // -- native (control) + mono-move pipeline ----------------------------
-    {
-        let mut group = c.benchmark_group("match_sum");
-        group
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        group.bench_function("native", |b| {
-            b.iter(|| black_box(native_match_sum(N)));
-        });
-
-        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
-        with_loaded_mono_function(
-            SOURCE,
-            SourceKind::Move,
-            addr,
-            IdentStr::new("match_sum").unwrap(),
-            IdentStr::new("match_sum").unwrap(),
-            |runner| {
-                group.bench_function("mono", |b| {
-                    b.iter(|| black_box(runner.call_words(&[N]).unwrap()));
-                });
-            },
-        )
-        .unwrap();
-
-        group.finish();
-    }
-
-    // -- move_vm ----------------------------------------------------------
-    {
-        let mut group = c.benchmark_group("match_sum");
-        group
-            .sample_size(10)
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        let module = move_bytecode_match_sum();
-        testing::with_loaded_move_function(&module, "match_sum", |env| {
-            group.bench_function("move_vm", |b| {
-                b.iter(|| {
-                    let result = env.run(vec![testing::arg_u64(N)]);
-                    black_box(testing::return_u64(&result))
-                });
+fn mono<M: Measurement>(c: &mut Criterion<M>, metric: &str) {
+    let mut group = c.benchmark_group("match_sum");
+    let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+    with_loaded_mono_function(
+        SOURCE,
+        SourceKind::Move,
+        addr,
+        IdentStr::new("match_sum").unwrap(),
+        IdentStr::new("match_sum").unwrap(),
+        |runner| {
+            group.bench_function(BenchmarkId::new("mono", metric), |b| {
+                b.iter(|| black_box(runner.call_words(&[N]).unwrap()));
             });
-        });
-        group.finish();
-    }
+        },
+    )
+    .unwrap();
+    group.finish();
 }
 
-criterion_group!(benches, bench_match_sum);
-criterion_main!(benches);
+/// Reference points: native Rust and the production Move VM.
+fn controls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("match_sum");
+    group.bench_function("native", |b| {
+        b.iter(|| black_box(native_match_sum(N)));
+    });
+    group.finish();
+
+    // The Move VM is slower, so it gets a smaller sample.
+    let mut group = c.benchmark_group("match_sum");
+    group.sample_size(10);
+    let module = move_bytecode_match_sum();
+    testing::with_loaded_move_function(&module, "match_sum", |env| {
+        group.bench_function("move_vm", |b| {
+            b.iter(|| {
+                let result = env.run(vec![testing::arg_u64(N)]);
+                black_box(testing::return_u64(&result))
+            });
+        });
+    });
+    group.finish();
+}
+
+support::bench_main!(mono, controls);

--- a/third_party/move/mono-move/testsuite/benches/merge_sort.rs
+++ b/third_party/move/mono-move/testsuite/benches/merge_sort.rs
@@ -1,70 +1,62 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+#[path = "support/mod.rs"]
+mod support;
+
+use criterion::{black_box, measurement::Measurement, BenchmarkId, Criterion};
+use mono_move_testsuite::{
+    programs::{
+        merge_sort::{move_bytecode_merge_sort, native_sort_checksum, SOURCE},
+        testing,
+    },
+    with_loaded_mono_function, SourceKind,
+};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
 const N: u64 = 1000;
 const SEED: u64 = 42;
 
-fn bench_merge_sort(c: &mut Criterion) {
-    use mono_move_testsuite::{
-        programs::{
-            merge_sort::{move_bytecode_merge_sort, native_sort_checksum, SOURCE},
-            testing,
-        },
-        with_loaded_mono_function, SourceKind,
-    };
-    use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
-
-    // -- native (control) + mono-move pipeline ----------------------------
-    {
-        let mut group = c.benchmark_group("merge_sort");
-        group
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        group.bench_function("native", |b| {
-            b.iter(|| black_box(native_sort_checksum(N, SEED)));
-        });
-
-        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
-        with_loaded_mono_function(
-            SOURCE,
-            SourceKind::Move,
-            addr,
-            IdentStr::new("merge_sort").unwrap(),
-            IdentStr::new("sort_checksum").unwrap(),
-            |runner| {
-                group.bench_function("mono", |b| {
-                    b.iter(|| black_box(runner.call_words(&[N, SEED]).unwrap()));
-                });
-            },
-        )
-        .unwrap();
-
-        group.finish();
-    }
-
-    // -- move_vm ----------------------------------------------------------
-    {
-        let mut group = c.benchmark_group("merge_sort");
-        group
-            .sample_size(10)
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        let module = move_bytecode_merge_sort();
-        testing::with_loaded_move_function(&module, "sort_checksum", |env| {
-            group.bench_function("move_vm", |b| {
-                b.iter(|| {
-                    let result = env.run(vec![testing::arg_u64(N), testing::arg_u64(SEED)]);
-                    black_box(testing::return_u64(&result))
-                });
+fn mono<M: Measurement>(c: &mut Criterion<M>, metric: &str) {
+    let mut group = c.benchmark_group("merge_sort");
+    let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+    with_loaded_mono_function(
+        SOURCE,
+        SourceKind::Move,
+        addr,
+        IdentStr::new("merge_sort").unwrap(),
+        IdentStr::new("sort_checksum").unwrap(),
+        |runner| {
+            group.bench_function(BenchmarkId::new("mono", metric), |b| {
+                b.iter(|| black_box(runner.call_words(&[N, SEED]).unwrap()));
             });
-        });
-        group.finish();
-    }
+        },
+    )
+    .unwrap();
+    group.finish();
 }
 
-criterion_group!(benches, bench_merge_sort);
-criterion_main!(benches);
+/// Reference points: native Rust and the production Move VM.
+fn controls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merge_sort");
+    group.bench_function("native", |b| {
+        b.iter(|| black_box(native_sort_checksum(N, SEED)));
+    });
+    group.finish();
+
+    // The Move VM is slower, so it gets a smaller sample.
+    let mut group = c.benchmark_group("merge_sort");
+    group.sample_size(10);
+    let module = move_bytecode_merge_sort();
+    testing::with_loaded_move_function(&module, "sort_checksum", |env| {
+        group.bench_function("move_vm", |b| {
+            b.iter(|| {
+                let result = env.run(vec![testing::arg_u64(N), testing::arg_u64(SEED)]);
+                black_box(testing::return_u64(&result))
+            });
+        });
+    });
+    group.finish();
+}
+
+support::bench_main!(mono, controls);

--- a/third_party/move/mono-move/testsuite/benches/nested_loop.rs
+++ b/third_party/move/mono-move/testsuite/benches/nested_loop.rs
@@ -1,69 +1,61 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+#[path = "support/mod.rs"]
+mod support;
+
+use criterion::{black_box, measurement::Measurement, BenchmarkId, Criterion};
+use mono_move_testsuite::{
+    programs::{
+        nested_loop::{move_bytecode_nested_loop, native_nested_loop, SOURCE},
+        testing,
+    },
+    with_loaded_mono_function, SourceKind,
+};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 
 const N: u64 = 1000;
 
-fn bench_nested_loop(c: &mut Criterion) {
-    use mono_move_testsuite::{
-        programs::{
-            nested_loop::{move_bytecode_nested_loop, native_nested_loop, SOURCE},
-            testing,
-        },
-        with_loaded_mono_function, SourceKind,
-    };
-    use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
-
-    // -- native (control) + mono-move pipeline ----------------------------
-    {
-        let mut group = c.benchmark_group("nested_loop");
-        group
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        group.bench_function("native", |b| {
-            b.iter(|| black_box(native_nested_loop(N)));
-        });
-
-        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
-        with_loaded_mono_function(
-            SOURCE,
-            SourceKind::Move,
-            addr,
-            IdentStr::new("nested_loop").unwrap(),
-            IdentStr::new("nested_loop").unwrap(),
-            |runner| {
-                group.bench_function("mono", |b| {
-                    b.iter(|| black_box(runner.call_words(&[N]).unwrap()));
-                });
-            },
-        )
-        .unwrap();
-
-        group.finish();
-    }
-
-    // -- move_vm ----------------------------------------------------------
-    {
-        let mut group = c.benchmark_group("nested_loop");
-        group
-            .sample_size(10)
-            .warm_up_time(std::time::Duration::from_secs(1))
-            .measurement_time(std::time::Duration::from_secs(3));
-
-        let module = move_bytecode_nested_loop();
-        testing::with_loaded_move_function(&module, "nested_loop", |env| {
-            group.bench_function("move_vm", |b| {
-                b.iter(|| {
-                    let result = env.run(vec![testing::arg_u64(N)]);
-                    black_box(testing::return_u64(&result))
-                });
+fn mono<M: Measurement>(c: &mut Criterion<M>, metric: &str) {
+    let mut group = c.benchmark_group("nested_loop");
+    let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+    with_loaded_mono_function(
+        SOURCE,
+        SourceKind::Move,
+        addr,
+        IdentStr::new("nested_loop").unwrap(),
+        IdentStr::new("nested_loop").unwrap(),
+        |runner| {
+            group.bench_function(BenchmarkId::new("mono", metric), |b| {
+                b.iter(|| black_box(runner.call_words(&[N]).unwrap()));
             });
-        });
-        group.finish();
-    }
+        },
+    )
+    .unwrap();
+    group.finish();
 }
 
-criterion_group!(benches, bench_nested_loop);
-criterion_main!(benches);
+/// Reference points: native Rust and the production Move VM.
+fn controls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nested_loop");
+    group.bench_function("native", |b| {
+        b.iter(|| black_box(native_nested_loop(N)));
+    });
+    group.finish();
+
+    // The Move VM is slower, so it gets a smaller sample.
+    let mut group = c.benchmark_group("nested_loop");
+    group.sample_size(10);
+    let module = move_bytecode_nested_loop();
+    testing::with_loaded_move_function(&module, "nested_loop", |env| {
+        group.bench_function("move_vm", |b| {
+            b.iter(|| {
+                let result = env.run(vec![testing::arg_u64(N)]);
+                black_box(testing::return_u64(&result))
+            });
+        });
+    });
+    group.finish();
+}
+
+support::bench_main!(mono, controls);

--- a/third_party/move/mono-move/testsuite/benches/perf/README.md
+++ b/third_party/move/mono-move/testsuite/benches/perf/README.md
@@ -1,27 +1,58 @@
 # mono-move bench regression gate
 
-Catches wall-time regressions in the new VM (the `mono` criterion benches under
-`../`). Runs on each PR labeled `mono-move` via
+Catches regressions in the new VM (the `mono` criterion benches under `../`).
+Runs on each PR labeled `mono-move` via
 `.github/workflows/mono-move-micro-bench.yaml`.
 
 ## How it works
 
 Same-job A/B on a dedicated runner: the benches run on the PR's merge-base with
-`main`, then on the PR head compared against it. criterion reports each bench's
-slowdown as a 95% confidence interval -- a range that accounts for run-to-run
-noise, not a single number. A bench fails the gate only when that whole interval
-exceeds `threshold_percent` (in `config.json`, default 3%); if the interval
-straddles the threshold the change counts as noise and passes.
+`main`, then on the PR head compared against it. There is no committed
+baseline. `main` is the live baseline, so merging a PR automatically becomes
+the baseline the next PR compares against.
 
-There is no committed baseline. `main` is the live baseline, so merging a PR
-automatically becomes the baseline the next PR compares against.
+Each mono bench is measured three ways, as criterion parameters of one id:
+
+- `<id>/instructions` — retired user-space instructions per iteration. This is
+  the gate. The count is a property of the code, not of the machine's mood:
+  it does not move with CPU frequency, cache state, co-tenants, or where the
+  linker happened to place a function, so it varies by parts per million
+  between runs where wall time varies by 10% or more.
+- `<id>/time` — wall time. Informational: it is what users feel, but on a
+  shared runner it cannot tell a 5% slowdown from noise.
+- `<id>/cycles` — CPU cycles. Informational: the same instructions taking more
+  cycles points at a memory or branch-prediction effect rather than a code
+  change.
+
+criterion reports each metric's change as a 95% confidence interval. A bench
+fails the gate only when the whole instruction-count interval exceeds
+`threshold_percent` (in `config.json`); if the interval straddles the threshold
+the change counts as noise and passes.
+
+What the gate cannot see: a slowdown that keeps the instruction stream
+identical, such as a larger cache footprint or a new dependent load. Those show
+up only in the time and cycles columns, which is why they stay in the report.
+
+## Requirements
+
+The counters use Linux `perf_event_open` on the calling thread. The runner
+needs `kernel.perf_event_paranoid <= 2` (or `CAP_PERFMON`) and, on a virtual
+machine, a virtualized PMU. `run.sh` sets `MONO_MOVE_BENCH_REQUIRE_COUNTERS`
+so a bench binary aborts, naming the counter and the OS error, instead of
+silently gating on nothing. A plain `cargo bench` without that variable skips
+the counters with a warning, so the benches still run on macOS and in VMs
+without a PMU.
 
 ## Files
 
-- `compare.py` — reads `target/criterion/<id>/change/estimates.json`, classifies
-  each mono bench, writes the markdown report, exits 1 on a regression.
+- `../support/mod.rs` — the criterion `Measurement` over a hardware counter
+  and the `bench_main!` macro that runs each mono bench under every metric.
+- `compare.py` — reads `target/criterion/<id>/<metric>/change/estimates.json`,
+  classifies each mono bench by the gate metric, writes the markdown report,
+  exits 1 on a regression.
 - `run.sh` — the A/B driver (`ab`) and the noise-floor helper (`calibrate-noise`).
-- `config.json` — `threshold_percent` and the gated criterion ids.
+- `config.json` — `gate_metric`, `threshold_percent`, the reported `metrics`,
+  and the gated criterion ids.
 
 When you add or rename a mono bench, update `mono_benches` in `config.json`.
 

--- a/third_party/move/mono-move/testsuite/benches/perf/compare.py
+++ b/third_party/move/mono-move/testsuite/benches/perf/compare.py
@@ -4,16 +4,19 @@
 
 """Compare mono-move criterion benches against a baseline and gate on regressions.
 
-This reads the JSON criterion writes under `target/criterion/<id>/`:
+Every mono bench is measured several ways; `config.json` lists the metrics and
+names the one that gates. criterion writes each measurement under
+`target/criterion/<bench id>/<metric>/`:
   - `change/estimates.json` exists after a `--baseline <name>` run and holds the
     relative change of this run vs the baseline. Its `mean`/`median` values are
-    ratios (`new/old - 1`), so `+0.05` means 5% slower.
-  - `new/estimates.json` holds the current run's absolute estimates, in
-    nanoseconds per iteration.
+    ratios (`new/old - 1`), so `+0.05` means 5% more.
+  - `new/estimates.json` and `<baseline>/estimates.json` hold absolute
+    per-iteration estimates: nanoseconds for `time`, plain counts otherwise.
 
-The verdict uses the `mean` estimate's confidence interval: a regression needs the
-whole CI above the noise threshold `T`, an improvement needs it below `-T`,
-otherwise the change is within noise.
+The verdict uses the gate metric's `mean` confidence interval: a regression
+needs the whole CI above the noise threshold `T`, an improvement needs it below
+`-T`, otherwise the change is within noise. The other metrics are shown for
+context and never fail the gate.
 """
 
 import argparse
@@ -30,11 +33,15 @@ NOISE = "noise"
 NEW = "new"
 ABSENT = "absent"
 
+BASELINE = "main"
+
 
 def load_config(path):
     with open(path) as f:
         cfg = json.load(f)
-    # `threshold_percent` is a percentage (3.0 == 3%); the CI bounds are ratios.
+    if cfg["gate_metric"] not in cfg["metrics"]:
+        sys.exit(f"config: gate_metric {cfg['gate_metric']!r} is not in metrics {cfg['metrics']}")
+    # `threshold_percent` is a percentage (1.0 == 1%); the CI bounds are ratios.
     cfg["threshold"] = cfg["threshold_percent"] / 100.0
     return cfg
 
@@ -47,12 +54,10 @@ def read_estimates(path):
 
 
 def fmt_pct(ratio):
-    return f"{ratio * 100:+.1f}%"
+    return f"{ratio * 100:+.2f}%"
 
 
 def fmt_ns(ns):
-    if ns is None:
-        return "n/a"
     if ns < 1_000.0:
         return f"{ns:.1f}ns"
     if ns < 1_000_000.0:
@@ -62,57 +67,73 @@ def fmt_ns(ns):
     return f"{ns / 1_000_000_000.0:.2f}s"
 
 
-def classify(change, threshold):
-    """Verdict for a change `mean` estimate: regression if the whole CI is above
+def fmt_count(count):
+    if count < 1_000.0:
+        return f"{count:.0f}"
+    if count < 1_000_000.0:
+        return f"{count / 1_000.0:.2f}K"
+    if count < 1_000_000_000.0:
+        return f"{count / 1_000_000.0:.3f}M"
+    return f"{count / 1_000_000_000.0:.3f}G"
+
+
+def fmt_value(metric, value):
+    if value is None:
+        return "n/a"
+    return fmt_ns(value) if metric == "time" else fmt_count(value)
+
+
+def read_metric(criterion_dir, bench_id, metric):
+    """One bench's estimates for one metric, or None if it produced no results."""
+    metric_dir = criterion_dir / bench_id / metric
+    new = read_estimates(metric_dir / "new" / "estimates.json")
+    if new is None:
+        return None
+    base = read_estimates(metric_dir / BASELINE / "estimates.json")
+    change = read_estimates(metric_dir / "change" / "estimates.json")
+    result = {
+        "new_median": new["median"]["point_estimate"],
+        "base_median": base["median"]["point_estimate"] if base else None,
+        "mean_pct": None,
+        "ci_lo": None,
+        "ci_hi": None,
+    }
+    if change is not None:
+        ci = change["mean"]["confidence_interval"]
+        result["mean_pct"] = change["mean"]["point_estimate"]
+        result["ci_lo"] = ci["lower_bound"]
+        result["ci_hi"] = ci["upper_bound"]
+    return result
+
+
+def classify(metric, threshold):
+    """Verdict for a metric's change: regression if the whole CI is above
     `threshold`, improvement if below `-threshold`, else noise.
     """
-    ci = change["mean"]["confidence_interval"]
-    lo = ci["lower_bound"]
-    hi = ci["upper_bound"]
-    if lo > threshold:
+    if metric["ci_lo"] > threshold:
         return REGRESSION
-    if hi < -threshold:
+    if metric["ci_hi"] < -threshold:
         return IMPROVEMENT
     return NOISE
 
 
 def evaluate(cfg, criterion_dir):
     """Evaluate every configured mono bench id; return a list of result dicts."""
-    threshold = cfg["threshold"]
     results = []
     for entry in cfg["mono_benches"]:
         bench_id = entry["id"]
-        id_dir = criterion_dir / bench_id
-        change = read_estimates(id_dir / "change" / "estimates.json")
-        new = read_estimates(id_dir / "new" / "estimates.json")
-        base = read_estimates(id_dir / "main" / "estimates.json")
-
-        new_median = new["median"]["point_estimate"] if new else None
-        base_median = base["median"]["point_estimate"] if base else None
-
-        if change is not None:
-            verdict = classify(change, threshold)
-            mean_pct = change["mean"]["point_estimate"]
-            ci = change["mean"]["confidence_interval"]
-            ci_lo, ci_hi = ci["lower_bound"], ci["upper_bound"]
-        elif new is not None:
+        metrics = {m: read_metric(criterion_dir, bench_id, m) for m in cfg["metrics"]}
+        gate = metrics[cfg["gate_metric"]]
+        if gate is None:
+            # Configured bench produced no results (removed, renamed, not run,
+            # or the counter could not be opened).
+            verdict = ABSENT
+        elif gate["mean_pct"] is None:
             # Ran but no baseline to compare against -- a bench new to this PR.
             verdict = NEW
-            mean_pct = ci_lo = ci_hi = None
         else:
-            # Configured bench produced no results (removed, renamed, or not run).
-            verdict = ABSENT
-            mean_pct = ci_lo = ci_hi = None
-
-        results.append({
-            "id": bench_id,
-            "verdict": verdict,
-            "mean_pct": mean_pct,
-            "ci_lo": ci_lo,
-            "ci_hi": ci_hi,
-            "base_median_ns": base_median,
-            "new_median_ns": new_median,
-        })
+            verdict = classify(gate, cfg["threshold"])
+        results.append({"id": bench_id, "verdict": verdict, "metrics": metrics})
     return results
 
 
@@ -125,8 +146,19 @@ VERDICT_CELL = {
 }
 
 
+def fmt_medians(metric, m, with_delta):
+    if m is None:
+        return "n/a"
+    cell = f"{fmt_value(metric, m['base_median'])} → {fmt_value(metric, m['new_median'])}"
+    if with_delta and m["mean_pct"] is not None:
+        cell += f" ({fmt_pct(m['mean_pct'])})"
+    return cell
+
+
 def render_markdown(results, cfg):
+    gate_metric = cfg["gate_metric"]
     threshold_percent = cfg["threshold_percent"]
+    others = [m for m in cfg["metrics"] if m != gate_metric]
     n_reg = sum(1 for r in results if r["verdict"] == REGRESSION)
     n_imp = sum(1 for r in results if r["verdict"] == IMPROVEMENT)
     n_ok = sum(1 for r in results if r["verdict"] == NOISE)
@@ -134,44 +166,49 @@ def render_markdown(results, cfg):
     n_absent = sum(1 for r in results if r["verdict"] == ABSENT)
 
     if n_reg:
-        headline = f"{n_reg} regression(s) beyond ±{threshold_percent:g}% noise band"
+        headline = f"{n_reg} regression(s): `{gate_metric}` beyond ±{threshold_percent:g}%"
     else:
-        headline = f"No regressions beyond ±{threshold_percent:g}% noise band"
+        headline = f"No regressions: `{gate_metric}` within ±{threshold_percent:g}%"
 
+    others_list = ", ".join(f"`{m}`" for m in others)
     lines = [
         "### mono-move benchmark gate",
         "",
         headline,
         "",
         f"`{n_ok} ok · {n_imp} improved · {n_new} new · {n_absent} absent` "
-        f"(threshold T = ±{threshold_percent:g}%, criterion mean CI vs `main`)",
+        f"(gate: criterion mean CI of `{gate_metric}` per iteration vs `{BASELINE}`, "
+        f"T = ±{threshold_percent:g}%; {others_list} are informational)",
         "",
-        "| Benchmark | mean Δ | 95% CI | median (main → PR) | Verdict |",
-        "| --- | ---: | :---: | :---: | :--- |",
+        f"| Benchmark | {gate_metric} Δ | 95% CI | {gate_metric} ({BASELINE} → PR) | "
+        + " | ".join(f"{m} ({BASELINE} → PR)" for m in others)
+        + " | Verdict |",
+        "| --- | ---: | :---: | :---: | " + " | ".join(":---:" for _ in others) + " | :--- |",
     ]
     for r in results:
-        if r["mean_pct"] is None:
-            mean_cell = "n/a"
+        gate = r["metrics"][gate_metric]
+        if gate is None or gate["mean_pct"] is None:
+            delta_cell = "n/a"
             ci_cell = "n/a"
         else:
-            mean_cell = fmt_pct(r["mean_pct"])
-            ci_cell = f"[{fmt_pct(r['ci_lo'])}, {fmt_pct(r['ci_hi'])}]"
-        median_cell = f"{fmt_ns(r['base_median_ns'])} → {fmt_ns(r['new_median_ns'])}"
-        lines.append(
-            f"| `{r['id']}` | {mean_cell} | {ci_cell} | {median_cell} | "
-            f"{VERDICT_CELL[r['verdict']]} |"
-        )
+            delta_cell = fmt_pct(gate["mean_pct"])
+            ci_cell = f"[{fmt_pct(gate['ci_lo'])}, {fmt_pct(gate['ci_hi'])}]"
+        cells = [f"`{r['id']}`", delta_cell, ci_cell, fmt_medians(gate_metric, gate, False)]
+        cells += [fmt_medians(m, r["metrics"][m], True) for m in others]
+        cells.append(VERDICT_CELL[r["verdict"]])
+        lines.append("| " + " | ".join(cells) + " |")
     lines.append("")
     if n_imp:
         lines.append(
-            "> Improvements are not failures. `main` rebaselines on merge, so the "
-            "next PR compares against the faster code automatically."
+            f"> Improvements are not failures. `{BASELINE}` rebaselines on merge, so the "
+            "next PR compares against the improved code automatically."
         )
         lines.append("")
     if n_absent:
         lines.append(
-            "> `absent` means a configured bench produced no results (removed, or "
-            "not run). Update `benches/perf/config.json` if a bench was renamed."
+            f"> `absent` means `{gate_metric}` produced no results for a configured bench "
+            "(removed, not run, or the hardware counter could not be opened). Update "
+            "`benches/perf/config.json` if a bench was renamed."
         )
         lines.append("")
     return "\n".join(lines) + "\n"
@@ -183,13 +220,20 @@ def emit_json_lines(results, cfg):
             "grep": "grep_json_mono_move_bench",
             "id": r["id"],
             "verdict": r["verdict"],
-            "mean_pct": None if r["mean_pct"] is None else r["mean_pct"] * 100.0,
-            "ci_lo_pct": None if r["ci_lo"] is None else r["ci_lo"] * 100.0,
-            "ci_hi_pct": None if r["ci_hi"] is None else r["ci_hi"] * 100.0,
-            "base_median_ns": r["base_median_ns"],
-            "new_median_ns": r["new_median_ns"],
+            "gate_metric": cfg["gate_metric"],
             "threshold_percent": cfg["threshold_percent"],
         }
+        for metric, m in r["metrics"].items():
+            if m is None:
+                line[metric] = None
+                continue
+            line[metric] = {
+                "mean_pct": None if m["mean_pct"] is None else m["mean_pct"] * 100.0,
+                "ci_lo_pct": None if m["ci_lo"] is None else m["ci_lo"] * 100.0,
+                "ci_hi_pct": None if m["ci_hi"] is None else m["ci_hi"] * 100.0,
+                "base_median": m["base_median"],
+                "new_median": m["new_median"],
+            }
         print(json.dumps(line))
 
 
@@ -213,27 +257,30 @@ def cmd_calibrate_noise(args, cfg):
     """Report the runner's observed noise floor from a `main`-vs-`main` A/B.
 
     With identical code on both sides every change should be ~0; the largest CI
-    bound magnitude across benches is the floor `T` must sit above.
+    bound magnitude across benches is the floor `T` must sit above. Every
+    metric is reported, but only the gate metric drives the suggestion.
     """
     criterion_dir = Path(args.criterion_dir)
-    floor = 0.0
-    print(f"{'benchmark':<28} {'mean Δ':>9} {'|CI| max':>9}")
+    metrics = cfg["metrics"]
+    floors = {m: 0.0 for m in metrics}
+    print(f"{'benchmark':<28}" + "".join(f" {m + ' |CI| max':>22}" for m in metrics))
     for entry in cfg["mono_benches"]:
-        bench_id = entry["id"]
-        change = read_estimates(criterion_dir / bench_id / "change" / "estimates.json")
-        if change is None:
-            print(f"{bench_id:<28} {'n/a':>9} {'n/a':>9}")
-            continue
-        ci = change["mean"]["confidence_interval"]
-        ci_max = max(abs(ci["lower_bound"]), abs(ci["upper_bound"]))
-        floor = max(floor, ci_max)
-        print(f"{bench_id:<28} {fmt_pct(change['mean']['point_estimate']):>9} "
-              f"{fmt_pct(ci_max):>9}")
+        row = f"{entry['id']:<28}"
+        for metric in metrics:
+            m = read_metric(criterion_dir, entry["id"], metric)
+            if m is None or m["mean_pct"] is None:
+                row += f" {'n/a':>22}"
+                continue
+            ci_max = max(abs(m["ci_lo"]), abs(m["ci_hi"]))
+            floors[metric] = max(floors[metric], ci_max)
+            row += f" {fmt_pct(ci_max):>22}"
+        print(row)
     # Suggest T as the floor rounded up to the next 0.5%, plus a 0.5% margin.
-    floor_pct = floor * 100.0
+    gate_metric = cfg["gate_metric"]
+    floor_pct = floors[gate_metric] * 100.0
     suggested = math.ceil(floor_pct / 0.5) * 0.5 + 0.5
     print()
-    print(f"observed noise floor: {floor_pct:.2f}%")
+    print(f"observed {gate_metric} noise floor: {floor_pct:.3f}%")
     print(f"suggested threshold_percent: {suggested:.1f}  (set in config.json)")
     return 0
 

--- a/third_party/move/mono-move/testsuite/benches/perf/config.json
+++ b/third_party/move/mono-move/testsuite/benches/perf/config.json
@@ -1,5 +1,7 @@
 {
-  "threshold_percent": 3.0,
+  "gate_metric": "instructions",
+  "threshold_percent": 1.0,
+  "metrics": ["instructions", "time", "cycles"],
   "mono_benches": [
     { "id": "fib/mono" },
     { "id": "nested_loop/mono" },

--- a/third_party/move/mono-move/testsuite/benches/perf/run.sh
+++ b/third_party/move/mono-move/testsuite/benches/perf/run.sh
@@ -13,6 +13,9 @@
 #       Run the benches twice on the current checkout (identical code both times)
 #       and report the runner's noise floor, to pick threshold_percent in config.json.
 #
+# The gate reads hardware counters (Linux perf_event), so both commands refuse
+# to run where the counters cannot be opened rather than report a hollow pass.
+#
 # Because `ab` checks out other refs in the repo, run this script from a COPY
 # placed OUTSIDE the working tree (e.g. $RUNNER_TEMP/perf), or the checkout will
 # replace the script while it executes. CWD must be inside the target git repo.
@@ -23,6 +26,9 @@
 # hand. The gate still protects every unchanged bench.
 
 set -euo pipefail
+
+# Make the bench binaries abort instead of skipping a counter they cannot open.
+export MONO_MOVE_BENCH_REQUIRE_COUNTERS=1
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/third_party/move/mono-move/testsuite/benches/support/mod.rs
+++ b/third_party/move/mono-move/testsuite/benches/support/mod.rs
@@ -1,0 +1,246 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Shared harness for the mono benches: each `mono` bench runs under wall
+//! time and, where the platform allows, under hardware counters.
+
+use criterion::{
+    measurement::{Measurement, ValueFormatter},
+    Criterion, Throughput,
+};
+use std::{cell::RefCell, io, time::Duration};
+
+/// Criterion parameter naming the wall-time measurement in bench ids.
+pub const WALL_TIME: &str = "time";
+
+/// When set, a counter that cannot be opened aborts the run instead of being skipped.
+pub const REQUIRE_COUNTERS: &str = "MONO_MOVE_BENCH_REQUIRE_COUNTERS";
+
+/// A hardware event counted per iteration.
+#[derive(Clone, Copy)]
+pub enum Counter {
+    Instructions,
+    Cycles,
+}
+
+impl Counter {
+    pub const ALL: [Counter; 2] = [Counter::Instructions, Counter::Cycles];
+
+    /// Criterion parameter naming this measurement in bench ids.
+    pub fn name(self) -> &'static str {
+        match self {
+            Counter::Instructions => "instructions",
+            Counter::Cycles => "cycles",
+        }
+    }
+
+    /// Unit labels for counts scaled by 1, 10^3, 10^6 and 10^9.
+    fn units(self) -> [&'static str; 4] {
+        match self {
+            Counter::Instructions => ["instr", "Kinstr", "Minstr", "Ginstr"],
+            Counter::Cycles => ["cycles", "Kcycles", "Mcycles", "Gcycles"],
+        }
+    }
+}
+
+/// Wall-time configuration shared by every bench.
+pub fn wall_time() -> Criterion {
+    Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3))
+}
+
+/// Configuration counting `counter` per iteration, or `None` if the counter
+/// cannot be opened on this machine.
+pub fn hardware_counter(counter: Counter) -> Option<Criterion<HardwareCounter>> {
+    match HardwareCounter::open(counter) {
+        Ok(measurement) => Some(
+            // Counts barely vary between samples, so a few short samples suffice.
+            Criterion::default()
+                .with_measurement(measurement)
+                .sample_size(10)
+                .warm_up_time(Duration::from_millis(500))
+                .measurement_time(Duration::from_millis(1500)),
+        ),
+        Err(err) => {
+            let message = format!("cannot open the {} counter: {err}", counter.name());
+            if std::env::var_os(REQUIRE_COUNTERS).is_some() {
+                panic!("{message}");
+            }
+            eprintln!("warning: {message}; skipping");
+            None
+        },
+    }
+}
+
+/// Defines `main`: `$mono` runs under wall time and every available hardware
+/// counter, `$controls` under wall time only.
+macro_rules! bench_main {
+    ($mono:path, $controls:path) => {
+        fn main() {
+            {
+                let mut criterion = $crate::support::wall_time().configure_from_args();
+                $mono(&mut criterion, $crate::support::WALL_TIME);
+                $controls(&mut criterion);
+            }
+            for counter in $crate::support::Counter::ALL {
+                if let Some(criterion) = $crate::support::hardware_counter(counter) {
+                    let mut criterion = criterion.configure_from_args();
+                    $mono(&mut criterion, counter.name());
+                }
+            }
+            $crate::support::wall_time()
+                .configure_from_args()
+                .final_summary();
+        }
+    };
+}
+pub(crate) use bench_main;
+
+/// Criterion measurement counting a hardware event on the calling thread, in
+/// user space only.
+pub struct HardwareCounter {
+    counter: RefCell<imp::Counter>,
+    formatter: CountFormatter,
+}
+
+impl HardwareCounter {
+    fn open(counter: Counter) -> io::Result<Self> {
+        Ok(Self {
+            counter: RefCell::new(imp::Counter::open(counter)?),
+            formatter: CountFormatter {
+                units: counter.units(),
+            },
+        })
+    }
+
+    fn read(&self) -> u64 {
+        self.counter
+            .borrow_mut()
+            .read()
+            .expect("a counter that opened can be read")
+    }
+}
+
+impl Measurement for HardwareCounter {
+    type Intermediate = u64;
+    type Value = u64;
+
+    fn start(&self) -> u64 {
+        self.read()
+    }
+
+    fn end(&self, start: u64) -> u64 {
+        self.read() - start
+    }
+
+    fn add(&self, v1: &u64, v2: &u64) -> u64 {
+        v1 + v2
+    }
+
+    fn zero(&self) -> u64 {
+        0
+    }
+
+    fn to_f64(&self, value: &u64) -> f64 {
+        *value as f64
+    }
+
+    fn formatter(&self) -> &dyn ValueFormatter {
+        &self.formatter
+    }
+}
+
+/// Formats counts with a metric prefix.
+struct CountFormatter {
+    units: [&'static str; 4],
+}
+
+impl CountFormatter {
+    fn scale(&self, typical: f64, values: &mut [f64]) -> &'static str {
+        let (factor, unit) = if typical < 1e3 {
+            (1.0, self.units[0])
+        } else if typical < 1e6 {
+            (1e-3, self.units[1])
+        } else if typical < 1e9 {
+            (1e-6, self.units[2])
+        } else {
+            (1e-9, self.units[3])
+        };
+        for value in values {
+            *value *= factor;
+        }
+        unit
+    }
+}
+
+impl ValueFormatter for CountFormatter {
+    fn scale_values(&self, typical_value: f64, values: &mut [f64]) -> &'static str {
+        self.scale(typical_value, values)
+    }
+
+    /// Reports the count per element or byte rather than a rate.
+    fn scale_throughputs(
+        &self,
+        typical_value: f64,
+        throughput: &Throughput,
+        values: &mut [f64],
+    ) -> &'static str {
+        let per_iteration = match throughput {
+            Throughput::Bytes(n) | Throughput::Elements(n) => *n as f64,
+        };
+        for value in values.iter_mut() {
+            *value /= per_iteration;
+        }
+        self.scale(typical_value / per_iteration, values)
+    }
+
+    fn scale_for_machines(&self, _values: &mut [f64]) -> &'static str {
+        self.units[0]
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use perf_event::{events::Hardware, Builder};
+    use std::io;
+
+    pub struct Counter(perf_event::Counter);
+
+    impl Counter {
+        pub fn open(counter: super::Counter) -> io::Result<Self> {
+            let event = match counter {
+                super::Counter::Instructions => Hardware::INSTRUCTIONS,
+                super::Counter::Cycles => Hardware::CPU_CYCLES,
+            };
+            // The builder's defaults observe only this thread and only user space.
+            let mut inner = Builder::new().kind(event).build()?;
+            inner.enable()?;
+            Ok(Self(inner))
+        }
+
+        pub fn read(&mut self) -> io::Result<u64> {
+            self.0.read()
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    use std::io;
+
+    pub enum Counter {}
+
+    impl Counter {
+        pub fn open(_counter: super::Counter) -> io::Result<Self> {
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "hardware counters need Linux perf_event",
+            ))
+        }
+
+        pub fn read(&mut self) -> io::Result<u64> {
+            match *self {}
+        }
+    }
+}


### PR DESCRIPTION
Experimental. Makes the mono-move micro-bench gate decide on retired instructions per iteration instead of wall time. Wall time and CPU cycles stay in the report as informational columns.

### Why

The current gate compares one wall-time run of `main` against one of the PR with a 3% band. On #20529 it reported `int_arith_loop/mono_u64` at +27% while the interpreter's dispatch loop was byte-for-byte identical; the difference was code placement. Locally, identical code measured 10% apart between pinned runs.

Retired user-space instructions are a property of the code, not of the machine's state. On identical code they vary by parts per million, so a tight threshold catches a real change to the interpreter (an extra instruction in a hot handler) without false alarms from frequency, cache state, co-tenants, or linker layout. What they cannot see is a slowdown with an unchanged instruction stream, such as a larger cache footprint; that is why time and cycles remain in the table.

### Design

- **One criterion `Measurement` over a perf counter** (`benches/support/mod.rs`), reading `perf_event_open` for the calling thread, user space only. Each `mono` bench is parametrized by metric, so the ids become `fib/mono/{time,instructions,cycles}` and criterion's own baseline and change machinery applies unchanged.
- **Every bench file is split into `mono` and `controls`.** `bench_main!` runs `mono` under wall time and every counter that opens, and the native and Move VM controls under wall time only. Counter passes use 10 short samples; counts barely vary.
- **`compare.py` gates on `gate_metric` from `config.json`** (instructions, T = 1%) and shows the other metrics with their medians and mean delta. `calibrate-noise` reports the floor per metric and suggests T from the gate metric.
- **Counters are required by `run.sh`, optional for `cargo bench`.** `MONO_MOVE_BENCH_REQUIRE_COUNTERS` makes a bench abort with the counter name and OS error rather than report a hollow pass; without it the counters are skipped with a warning, so the benches still run on macOS and in VMs without a PMU.

### What the first CI run will tell us

The runner needs `kernel.perf_event_paranoid <= 2` (or `CAP_PERFMON`) and a virtualized PMU. The workflow now prints the paranoid level, and a counter failure names the OS error. If the c3d runner lacks either, the gate fails loudly and the fix is on the runner side, not in this PR.

### Testing

Local `run.sh calibrate-noise` (main vs main, `int_arith_loop`):

| metric | max \|CI\| on identical code |
| --- | ---: |
| instructions | 0.000% |
| time | 3.83% |
| cycles | 10.60% |

`compare.py ab` renders the new table; the `fib`, `bst`, and other benches show `absent` in that local run only because the calibration was limited to one bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
