### PR TITLE
[mono-move] Support function types in `type_tag_of`, `type_name`, and `type_of` natives

### DIFF
--- a/third_party/move/mono-move/core/src/interner.rs
+++ b/third_party/move/mono-move/core/src/interner.rs
@@ -13,7 +13,9 @@ use move_core_types::{
     account_address::AccountAddress,
     ident_str,
     identifier::{IdentStr, Identifier},
-    language_storage::{self, pseudo_script_module_id, StructTag, TypeTag},
+    language_storage::{
+        self, pseudo_script_module_id, FunctionParamOrReturnTag, FunctionTag, StructTag, TypeTag,
+    },
 };
 use thiserror::Error;
 
@@ -195,8 +197,9 @@ pub trait Interner {
     ) -> Result<InternedTypeList, TypeSubstitutionError>;
 }
 
-/// The [`TypeTag`] for an interned type, or [`None`] for types that have no tag
-/// representation (references, functions, and unsubstituted type parameters).
+/// Converts an interned type to a [`TypeTag`]. References are supported only as
+/// function arguments or results. Returns [`None`] for unsupported types,
+/// unsubstituted type parameters, or invalid module or type identifiers.
 ///
 /// TODO(perf): cache the tag per interned type (e.g. in the global context)
 /// instead of re-walking the type graph on every call.
@@ -222,11 +225,54 @@ pub fn type_tag_of(ty: InternedType) -> Option<TypeTag> {
         Type::Signer => TypeTag::Signer,
         Type::Vector { elem } => TypeTag::Vector(Box::new(type_tag_of(*elem)?)),
         Type::Nominal { .. } => TypeTag::Struct(Box::new(struct_tag_of(ty)?)),
-        Type::ImmutRef { .. }
-        | Type::MutRef { .. }
-        | Type::Function { .. }
-        | Type::TypeParam { .. } => return None,
+        Type::Function {
+            args,
+            results,
+            abilities,
+        } => TypeTag::Function(Box::new(FunctionTag {
+            args: function_param_tags_of(*args)?,
+            results: function_param_tags_of(*results)?,
+            abilities: *abilities,
+        })),
+        Type::ImmutRef { .. } | Type::MutRef { .. } | Type::TypeParam { .. } => return None,
     })
+}
+
+/// Converts function arguments or results to tags, preserving reference kinds.
+/// Returns [`None`] if a value type or referent has no tag.
+fn function_param_tags_of(types: InternedTypeList) -> Option<Vec<FunctionParamOrReturnTag>> {
+    view_type_list(types)
+        .iter()
+        .map(|ty| {
+            Some(match view_type(*ty) {
+                Type::ImmutRef { inner } => {
+                    FunctionParamOrReturnTag::Reference(type_tag_of(*inner)?)
+                },
+                Type::MutRef { inner } => {
+                    FunctionParamOrReturnTag::MutableReference(type_tag_of(*inner)?)
+                },
+                Type::Bool
+                | Type::U8
+                | Type::U16
+                | Type::U32
+                | Type::U64
+                | Type::U128
+                | Type::U256
+                | Type::I8
+                | Type::I16
+                | Type::I32
+                | Type::I64
+                | Type::I128
+                | Type::I256
+                | Type::Address
+                | Type::Signer
+                | Type::Vector { .. }
+                | Type::Nominal { .. }
+                | Type::Function { .. }
+                | Type::TypeParam { .. } => FunctionParamOrReturnTag::Value(type_tag_of(*ty)?),
+            })
+        })
+        .collect()
 }
 
 /// The owned [`language_storage::ModuleId`] for an interned module ID.

--- a/third_party/move/mono-move/core/src/prepared_module.rs
+++ b/third_party/move/mono-move/core/src/prepared_module.rs
@@ -659,8 +659,12 @@ pub fn intern_type_tag(tag: &TypeTag, interner: &impl Interner) -> anyhow::Resul
         TypeTag::Vector(elem) => interner.vector_of(intern_type_tag(elem, interner)?),
         TypeTag::Struct(struct_tag) => intern_struct_tag(struct_tag, interner)?,
         TypeTag::Function(function_tag) => {
-            // TODO: reject abilities for which `is_valid_for_function_type()` is false, as the
-            // MoveVM does when converting tags to runtime types.
+            // Abilities are interned as-is: resource group decoding interns every stored member
+            // tag, and stored tags may predate the v1 VM's validation.
+            // TODO(correctness): reject abilities outside copy+drop+store in transaction type
+            // arguments after the prologue, as the v1 VM does (CONSTRAINT_NOT_SATISFIED).
+            // TODO(cleanup): look up group members by `StructTag` (via `struct_tag_of`) instead of
+            // interning stored tags; the rejection can then move here.
             let args = intern_function_param_tags(&function_tag.args, interner)?;
             let results = intern_function_param_tags(&function_tag.results, interner)?;
             interner.function_of(

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -404,33 +404,6 @@ pub fn is_signer_or_signer_immut_ref(ty: InternedType) -> bool {
 }
 
 impl Type {
-    /// The short kind word for this type (`"u64"`, `"vector"`, `"struct"`, ...).
-    /// Mirrors the legacy VM's `TypeTag::to_short_string`.
-    pub fn short_name(&self) -> &'static str {
-        match self {
-            Type::Bool => "bool",
-            Type::U8 => "u8",
-            Type::U16 => "u16",
-            Type::U32 => "u32",
-            Type::U64 => "u64",
-            Type::U128 => "u128",
-            Type::U256 => "u256",
-            Type::I8 => "i8",
-            Type::I16 => "i16",
-            Type::I32 => "i32",
-            Type::I64 => "i64",
-            Type::I128 => "i128",
-            Type::I256 => "i256",
-            Type::Address => "address",
-            Type::Signer => "signer",
-            Type::Vector { .. } => "vector",
-            Type::Nominal { .. } => "struct",
-            Type::Function { .. } => "function",
-            Type::ImmutRef { .. } | Type::MutRef { .. } => "reference",
-            Type::TypeParam { .. } => "type parameter",
-        }
-    }
-
     /// True iff this is `Type::U64`. Used by the specializer to gate the
     /// u64-specialized micro-op fast paths.
     #[inline(always)]
@@ -487,9 +460,8 @@ pub const SIGNER_TY: InternedType = GlobalArenaPtr::from_static(&SIGNER);
 pub const EMPTY_TYPE_LIST: InternedTypeList =
     InternedTypeList(GlobalArenaPtr::from_static(&EMPTY_LIST));
 
-/// Writes a textual representation of an interned type. Nominals print
-/// just their name — IR variants that carry `ty_args` show them
-/// separately. Inherits the arena safety contract on [`view_type`].
+/// Writes a textual representation of an interned type. Inherits the arena
+/// safety contract on [`view_type`].
 pub fn display_type(f: &mut fmt::Formatter<'_>, ty: InternedType) -> fmt::Result {
     match view_type(ty) {
         Type::Bool => write!(f, "bool"),
@@ -545,14 +517,14 @@ pub fn display_type(f: &mut fmt::Formatter<'_>, ty: InternedType) -> fmt::Result
         } => {
             write!(f, "|")?;
             display_type_list(f, *args)?;
-            write!(f, "|")?;
+            write!(f, "|(")?;
             display_type_list(f, *results)?;
-            write!(f, "{}", abilities.display_postfix())
+            write!(f, "){}", abilities.display_postfix())
         },
     }
 }
 
-/// Renders an interned type to its textual representation (see [`display_type`]).
+/// Renders an interned type to a string (see [`display_type`]).
 //
 // TODO(metering): this traversal is unbounded; replace with a metered, depth-bounded
 // version.

--- a/third_party/move/mono-move/natives/src/type_info.rs
+++ b/third_party/move/mono-move/natives/src/type_info.rs
@@ -8,25 +8,26 @@ use crate::{
     NativeEntry,
 };
 use mono_move_core::{
-    native::{NativeContext, NativeContextFamily, NativeStatus, RootPool, VMValue, Vector},
-    types::{type_to_string, view_name, view_type, view_type_list, Type},
+    native::{
+        native_invariant_violation, NativeContext, NativeContextFamily, NativeStatus, RootPool,
+        VMValue, Vector,
+    },
+    type_tag_of,
+    types::type_to_string,
     VMResult,
 };
-use move_core_types::account_address::AccountAddress;
+use move_core_types::{account_address::AccountAddress, language_storage::TypeTag};
 
 /// `0x1::type_info::type_name<T>(): String`
 ///
-/// Returns the fully-qualified name of `T` as a string.
+/// Returns the canonical type name of `T`.
 //
 // TODO(metering): charge gas for the (currently unbounded) type traversal.
-//
-// TODO(correctness, metering): `type_to_string` is a placeholder — check it against the canonical
-// string format the legacy VM uses.
 //
 // TODO(completeness): with monomorphization the name is known at specialization time, so the
 // specializer could write it directly rather than going through a native.
 pub fn native_type_name<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
-    let name = type_to_string(ctx.ty_arg(0)?);
+    let name = type_tag_of_arg(ctx, 0)?.to_canonical_string();
     let bytes = ctx.new_byte_vector(name.as_bytes())?;
     // SAFETY: structs are flattened inline rather than heap-boxed, so the
     // single-field `String { bytes: vector<u8> }` has the same representation as
@@ -34,6 +35,17 @@ pub fn native_type_name<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
     // separate struct header.
     unsafe { ctx.set_return(0, bytes)? };
     Ok(NativeStatus::Success)
+}
+
+/// The [`TypeTag`] of the native's type argument at `index`.
+fn type_tag_of_arg<C: NativeContext>(ctx: &C, index: usize) -> VMResult<TypeTag> {
+    let ty = ctx.ty_arg(index)?;
+    type_tag_of(ty).ok_or_else(|| {
+        native_invariant_violation(format!(
+            "type argument has no type tag: {}",
+            type_to_string(ty)
+        ))
+    })
 }
 
 /// Abort code raised when `type_of` is given a non-struct type. Matches the
@@ -86,50 +98,32 @@ impl<'a> VMValue<'a> for TypeInfo<'a> {
 //
 // TODO(completeness): with monomorphization `T` is fully known at specialization time, so the
 // specializer could synthesize this `TypeInfo` directly rather than via a native.
-//
-// TODO(correctness): double check that the result matches the legacy VM's completely.
 pub fn native_type_of<C: NativeContext>(ctx: &C) -> VMResult<NativeStatus> {
-    let (address, module_name, struct_name) = match view_type(ctx.ty_arg(0)?) {
-        Type::Nominal {
-            module_id,
-            name,
-            ty_args,
-            ..
-        } => {
-            // SAFETY: interned ids are valid for the executable's lifetime.
-            let module_id = unsafe { module_id.as_ref_unchecked() };
-            let mut struct_name = view_name(*name).to_string();
-            let ty_args = view_type_list(*ty_args);
-            if !ty_args.is_empty() {
-                struct_name.push('<');
-                for (i, arg) in ty_args.iter().enumerate() {
-                    if i > 0 {
-                        struct_name.push_str(", ");
-                    }
-                    struct_name.push_str(&type_to_string(*arg));
-                }
-                struct_name.push('>');
-            }
-            (
-                *module_id.address(),
-                view_name(module_id.name()),
-                struct_name,
-            )
-        },
-        other => {
-            return Ok(NativeStatus::Abort {
-                code: EXPECTED_STRUCT_ABORT_CODE,
-                message: Some(format!(
-                    "Expected a struct type, found: {}",
-                    other.short_name()
-                )),
-            })
-        },
+    let type_tag = type_tag_of_arg(ctx, 0)?;
+    let TypeTag::Struct(struct_tag) = type_tag else {
+        return Ok(NativeStatus::Abort {
+            code: EXPECTED_STRUCT_ABORT_CODE,
+            message: Some(format!(
+                "Expected a struct type, found: {}",
+                type_tag.to_short_string()
+            )),
+        });
     };
-    let module_name = ctx.new_byte_vector(module_name.as_bytes())?;
+    let struct_name = if struct_tag.type_args.is_empty() {
+        struct_tag.name.to_string()
+    } else {
+        let type_args = struct_tag
+            .type_args
+            .iter()
+            .map(TypeTag::to_canonical_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{}<{}>", struct_tag.name, type_args)
+    };
+    let module_name = ctx.new_byte_vector(struct_tag.module.as_bytes())?;
     let struct_name = ctx.new_byte_vector(struct_name.as_bytes())?;
     let info = TypeInfo {
-        account_address: address,
+        account_address: struct_tag.address,
         module_name,
         struct_name,
     };

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_alignment.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_alignment.exp
@@ -70,7 +70,7 @@ fun run(r0): u64 {
   slots: params(1), locals(2), temps(2)
     r0: bool
     r1: vector<u64>
-    r2: |u64|u64 has drop
+    r2: |u64|(u64) has drop
     r3: &mut vector<u64>
     r4: u64
   code:
@@ -84,7 +84,7 @@ fun run(r0): u64 {
     6: vec_push_back u64, r3, r4 @7
     7: r2 := pack_closure combine, 11, [r0, r1] @10
     8: r4 := ld_u64 100 @12
-    9: [r4] := call_closure [|u64|u64 has drop], [r4, r2] @14
+    9: [r4] := call_closure [|u64|(u64) has drop], [r4, r2] @14
     10: ret [r4] @15
 }
 === micro-ops ===

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_middle_interleave.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_middle_interleave.exp
@@ -32,7 +32,7 @@ fun g(r0, r1, r2): u64 {
 
 fun caller(): u64 {
   slots: params(0), locals(1), temps(3), transfer(3)
-    r0: |u64, u64|u64 has drop
+    r0: |u64, u64|(u64) has drop
     r1: u64
     r2: u64
     r3: u64
@@ -41,7 +41,7 @@ fun caller(): u64 {
     0: r1 := ld_u64 7 @0
     1: r0 := pack_closure g, 10, [r1] @1
     2: [r1, r2, r3] := call three_rets, [] @3
-    3: [r2] := call_closure [|u64, u64|u64 has drop], [r1, r2, r0] @6
+    3: [r2] := call_closure [|u64, u64|(u64) has drop], [r1, r2, r0] @6
     4: ret [r2] @7
 }
 === micro-ops ===

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_vector.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capture_vector.exp
@@ -92,7 +92,7 @@ fun capture_one(r0): u64 {
   slots: params(1), locals(2), temps(2)
     r0: u64
     r1: vector<u64>
-    r2: |u64|u64 has drop
+    r2: |u64|(u64) has drop
     r3: &mut vector<u64>
     r4: u64
   code:
@@ -108,7 +108,7 @@ fun capture_one(r0): u64 {
     8: r4 := ld_u64 30 @9
     9: vec_push_back u64, r3, r4 @10
     10: r2 := pack_closure len_plus, 1, [r1] @12
-    11: [r4] := call_closure [|u64|u64 has drop], [r0, r2] @16
+    11: [r4] := call_closure [|u64|(u64) has drop], [r0, r2] @16
     12: ret [r4] @17
 }
 
@@ -117,7 +117,7 @@ fun capture_two(r0): u64 {
     r0: u64
     r1: vector<u64>
     r2: vector<u64>
-    r3: |u64|u64 has drop
+    r3: |u64|(u64) has drop
     r4: &mut vector<u64>
     r5: u64
   code:
@@ -140,7 +140,7 @@ fun capture_two(r0): u64 {
     15: r5 := ld_u64 5 @17
     16: vec_push_back u64, r4, r5 @18
     17: r3 := pack_closure len_sum, 11, [r1, r2] @21
-    18: [r5] := call_closure [|u64|u64 has drop], [r0, r3] @25
+    18: [r5] := call_closure [|u64|(u64) has drop], [r0, r3] @25
     19: ret [r5] @26
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capturing.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/capturing.exp
@@ -138,13 +138,13 @@ fun add_u64(r0, r1): u64 {
 fun adder(r0): u64 {
   slots: params(1), locals(1), temps(1)
     r0: u64
-    r1: |u64|u64 has drop
+    r1: |u64|(u64) has drop
     r2: u64
   code:
   L0:
     0: r1 := pack_closure __lambda__1__adder, 1, [r0] @1
     1: r2 := ld_u64 8 @3
-    2: [r2] := call_closure [|u64|u64 has drop], [r2, r1] @5
+    2: [r2] := call_closure [|u64|(u64) has drop], [r2, r1] @5
     3: ret [r2] @6
 }
 
@@ -152,12 +152,12 @@ fun all_captured(r0, r1): u64 {
   slots: params(2), locals(0), temps(2)
     r0: u64
     r1: u64
-    r2: ||u64 has copy + drop
+    r2: ||(u64) has copy + drop
     r3: u64
   code:
   L0:
     0: r2 := pack_closure add_u64, 11, [r0, r1] @2
-    1: [r3] := call_closure [||u64 has drop], [r2] @3
+    1: [r3] := call_closure [||(u64) has drop], [r2] @3
     2: ret [r3] @4
 }
 
@@ -165,26 +165,26 @@ fun capture_ends(r0, r1): u64 {
   slots: params(2), locals(1), temps(1)
     r0: u64
     r1: u64
-    r2: |u64|u64 has drop
+    r2: |u64|(u64) has drop
     r3: u64
   code:
   L0:
     0: r2 := pack_closure add3, 101, [r0, r1] @2
     1: r3 := ld_u64 100 @4
-    2: [r3] := call_closure [|u64|u64 has drop], [r3, r2] @6
+    2: [r3] := call_closure [|u64|(u64) has drop], [r3, r2] @6
     3: ret [r3] @7
 }
 
 fun capture_second(r0): u64 {
   slots: params(1), locals(1), temps(1)
     r0: u64
-    r1: |u64|u64 has drop
+    r1: |u64|(u64) has drop
     r2: u64
   code:
   L0:
     0: r1 := pack_closure add_u64, 10, [r0] @1
     1: r2 := ld_u64 7 @3
-    2: [r2] := call_closure [|u64|u64 has drop], [r2, r1] @5
+    2: [r2] := call_closure [|u64|(u64) has drop], [r2, r1] @5
     3: ret [r2] @6
 }
 
@@ -192,20 +192,20 @@ fun capture_two(r0, r1): u64 {
   slots: params(2), locals(1), temps(1)
     r0: u64
     r1: u64
-    r2: |u64|u64 has drop
+    r2: |u64|(u64) has drop
     r3: u64
   code:
   L0:
     0: r2 := pack_closure add3, 11, [r0, r1] @2
     1: r3 := ld_u64 1 @4
-    2: [r3] := call_closure [|u64|u64 has drop], [r3, r2] @6
+    2: [r3] := call_closure [|u64|(u64) has drop], [r3, r2] @6
     3: ret [r3] @7
 }
 
 fun make_adder(r0): |u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: u64
-    r1: |u64|u64 has copy + drop
+    r1: |u64|(u64) has copy + drop
   code:
   L0:
     0: r1 := pack_closure __lambda__1__make_adder, 1, [r0] @1
@@ -216,12 +216,12 @@ fun use_adder(r0, r1): u64 {
   slots: params(2), locals(1), temps(1), transfer(1)
     r0: u64
     r1: u64
-    r2: |u64|u64 has drop
+    r2: |u64|(u64) has drop
     r3: u64
   code:
   L0:
     0: [r2] := call make_adder, [r0] @1
-    1: [r3] := call_closure [|u64|u64 has drop], [r1, r2] @5
+    1: [r3] := call_closure [|u64|(u64) has drop], [r1, r2] @5
     2: ret [r3] @6
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_abilities.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_abilities.exp
@@ -19,7 +19,7 @@ fun all_captured(r0, r1, r2): ||u64 {
     r0: u64
     r1: u64
     r2: u64
-    r3: ||u64 has copy + drop
+    r3: ||(u64) has copy + drop
   code:
   L0:
     0: r3 := pack_closure add3, 111, [r0, r1, r2] @3
@@ -29,7 +29,7 @@ fun all_captured(r0, r1, r2): ||u64 {
 fun captures_box2_res(r0): |u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: 0x99::closure_abilities::Box2<0x99::closure_abilities::Res>
-    r1: |u64|u64 has copy + drop + store
+    r1: |u64|(u64) has copy + drop + store
   code:
   L0:
     0: r1 := pack_closure drop_box2, 1, [r0] @1
@@ -39,7 +39,7 @@ fun captures_box2_res(r0): |u64|u64 {
 fun captures_box_res(r0): |u64|Box<Res> {
   slots: params(1), locals(0), temps(1)
     r0: 0x99::closure_abilities::Box<0x99::closure_abilities::Res>
-    r1: |u64|0x99::closure_abilities::Box<0x99::closure_abilities::Res> has store
+    r1: |u64|(0x99::closure_abilities::Box<0x99::closure_abilities::Res>) has store
   code:
   L0:
     0: r1 := pack_closure keep_box_res, 1, [r0] @1
@@ -49,7 +49,7 @@ fun captures_box_res(r0): |u64|Box<Res> {
 fun captures_box_u64(r0): |u64|Box<u64> {
   slots: params(1), locals(0), temps(1)
     r0: 0x99::closure_abilities::Box<u64>
-    r1: |u64|0x99::closure_abilities::Box<u64> has copy + drop + store
+    r1: |u64|(0x99::closure_abilities::Box<u64>) has copy + drop + store
   code:
   L0:
     0: r1 := pack_closure keep_box_u64, 1, [r0] @1
@@ -59,7 +59,7 @@ fun captures_box_u64(r0): |u64|Box<u64> {
 fun captures_enum(r0): |u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: 0x99::closure_abilities::E
-    r1: |u64|u64 has copy + drop
+    r1: |u64|(u64) has copy + drop
   code:
   L0:
     0: r1 := pack_closure drop_enum, 1, [r0] @1
@@ -69,7 +69,7 @@ fun captures_enum(r0): |u64|u64 {
 fun captures_plain(r0): |u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: 0x99::closure_abilities::Plain
-    r1: |u64|u64 has copy + drop
+    r1: |u64|(u64) has copy + drop
   code:
   L0:
     0: r1 := pack_closure takes_plain, 1, [r0] @1
@@ -79,7 +79,7 @@ fun captures_plain(r0): |u64|u64 {
 fun captures_resource(r0): |u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: 0x99::closure_abilities::Res
-    r1: |u64|u64
+    r1: |u64|(u64)
   code:
   L0:
     0: r1 := pack_closure takes_res, 1, [r0] @1
@@ -89,7 +89,7 @@ fun captures_resource(r0): |u64|u64 {
 fun captures_signer(r0): |u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: signer
-    r1: |u64|u64 has drop
+    r1: |u64|(u64) has drop
   code:
   L0:
     0: r1 := pack_closure drop_signer, 1, [r0] @1
@@ -99,7 +99,7 @@ fun captures_signer(r0): |u64|u64 {
 fun captures_vec_res(r0): |u64|vector<Res> {
   slots: params(1), locals(0), temps(1)
     r0: vector<0x99::closure_abilities::Res>
-    r1: |u64|vector<0x99::closure_abilities::Res> has store
+    r1: |u64|(vector<0x99::closure_abilities::Res>) has store
   code:
   L0:
     0: r1 := pack_closure keep_vec_res, 1, [r0] @1
@@ -109,7 +109,7 @@ fun captures_vec_res(r0): |u64|vector<Res> {
 fun captures_vec_u64(r0): |u64|vector<u64> {
   slots: params(1), locals(0), temps(1)
     r0: vector<u64>
-    r1: |u64|vector<u64> has copy + drop + store
+    r1: |u64|(vector<u64>) has copy + drop + store
   code:
   L0:
     0: r1 := pack_closure keep_vec_u64, 1, [r0] @1
@@ -146,7 +146,7 @@ fun drop_signer(r0, r1): u64 {
 fun generic_captured(r0): |_0, bool|_0 {
   slots: params(1), locals(0), temps(1)
     r0: _0
-    r1: |_0, bool|_0 has drop
+    r1: |_0, bool|(_0) has drop
   code:
   L0:
     0: r1 := pack_closure generic_pick<_0>, 1, [r0] @1
@@ -205,7 +205,7 @@ fun keep_vec_u64(r0, r1): vector<u64> {
 
 fun none_captured(): |u64, u64, u64|u64 {
   slots: params(0), locals(0), temps(1)
-    r0: |u64, u64, u64|u64 has copy + drop
+    r0: |u64, u64, u64|(u64) has copy + drop
   code:
   L0:
     0: r0 := pack_closure add3, 0, [] @0
@@ -215,7 +215,7 @@ fun none_captured(): |u64, u64, u64|u64 {
 fun one_captured(r0): |u64, u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: u64
-    r1: |u64, u64|u64 has copy + drop
+    r1: |u64, u64|(u64) has copy + drop
   code:
   L0:
     0: r1 := pack_closure add3, 1, [r0] @1
@@ -226,7 +226,7 @@ fun private_callee(r0): |u64|u64 {
   slots: params(1), locals(0), temps(2)
     r0: u64
     r1: u64
-    r2: |u64|u64 has copy + drop
+    r2: |u64|(u64) has copy + drop
   code:
   L0:
     0: r1 := ld_u64 0 @1
@@ -248,7 +248,7 @@ fun public_add(r0, r1): u64 {
 fun public_callee(r0): |u64|u64 {
   slots: params(1), locals(0), temps(1)
     r0: u64
-    r1: |u64|u64 has copy + drop + store
+    r1: |u64|(u64) has copy + drop + store
   code:
   L0:
     0: r1 := pack_closure public_add, 1, [r0] @1

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_as_arg.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/closure_as_arg.exp
@@ -39,12 +39,12 @@ fun add_u64(r0, r1): u64 {
 
 fun apply(r0, r1): u64 {
   slots: params(2), locals(0), temps(1)
-    r0: |u64|u64
+    r0: |u64|(u64)
     r1: u64
     r2: u64
   code:
   L0:
-    0: [r2] := call_closure [|u64|u64], [r1, r0] @2
+    0: [r2] := call_closure [|u64|(u64)], [r1, r0] @2
     1: ret [r2] @3
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/noncapturing.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/closures/noncapturing.exp
@@ -45,16 +45,16 @@ fun identity(l0: u64): u64
 fun call_double_twice(r0): u64 {
   slots: params(1), locals(1), temps(3)
     r0: u64
-    r1: |u64|u64 has copy + drop
-    r2: |u64|u64 has copy + drop
+    r1: |u64|(u64) has copy + drop
+    r2: |u64|(u64) has copy + drop
     r3: u64
     r4: u64
   code:
   L0:
     0: r1 := pack_closure double, 0, [] @0
     1: r2 := copy r1 @3
-    2: [r3] := call_closure [|u64|u64 has copy + drop], [r0, r2] @4
-    3: [r4] := call_closure [|u64|u64 has copy + drop], [r0, r1] @7
+    2: [r3] := call_closure [|u64|(u64) has copy + drop], [r0, r2] @4
+    3: [r4] := call_closure [|u64|(u64) has copy + drop], [r0, r1] @7
     4: r4 := add r3, r4 @8
     5: ret [r4] @9
 }
@@ -62,12 +62,12 @@ fun call_double_twice(r0): u64 {
 fun call_identity(r0): u64 {
   slots: params(1), locals(1), temps(1)
     r0: u64
-    r1: |u64|u64 has drop
+    r1: |u64|(u64) has drop
     r2: u64
   code:
   L0:
     0: r1 := pack_closure identity, 0, [] @0
-    1: [r2] := call_closure [|u64|u64 has drop], [r0, r1] @4
+    1: [r2] := call_closure [|u64|(u64) has drop], [r0, r1] @4
     2: ret [r2] @5
 }
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_closure_pack.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/generics/generic_closure_pack.exp
@@ -4,20 +4,20 @@
 fun call_identity(r0): u64 {
   slots: params(1), locals(1), temps(1)
     r0: u64
-    r1: |u64|u64 has drop
+    r1: |u64|(u64) has drop
     r2: u64
   code:
   L0:
     0: r1 := pack_closure identity<u64>, 0, [] @0
-    1: [r2] := call_closure [|u64|u64 has drop], [r0, r1] @4
+    1: [r2] := call_closure [|u64|(u64) has drop], [r0, r1] @4
     2: ret [r2] @5
 }
 
 fun call_pick(r0): u64 {
   slots: params(1), locals(2), temps(3), transfer(1)
     r0: u64
-    r1: |u64, bool|u64 has drop
-    r2: |u64, bool|u64 has drop
+    r1: |u64, bool|(u64) has drop
+    r2: |u64, bool|(u64) has drop
     r3: u64
     r4: bool
     r5: u64
@@ -27,11 +27,11 @@ fun call_pick(r0): u64 {
     1: [r2] := call make_pick<u64>, [r0] @4
     2: r3 := add r0, #1 @8
     3: r4 := ld_true @9
-    4: [r3] := call_closure [|u64, bool|u64 has drop], [r3, r4, r1] @11
+    4: [r3] := call_closure [|u64, bool|(u64) has drop], [r3, r4, r1] @11
     5: r3 := mul r3, #1000 @13
     6: r5 := add r0, #1 @16
     7: r4 := ld_false @17
-    8: [r5] := call_closure [|u64, bool|u64 has drop], [r5, r4, r2] @19
+    8: [r5] := call_closure [|u64, bool|(u64) has drop], [r5, r4, r2] @19
     9: r5 := add r3, r5 @20
     10: ret [r5] @21
 }
@@ -47,7 +47,7 @@ fun identity(r0): _0 {
 fun make_pick(r0): |_0, bool|_0 {
   slots: params(1), locals(0), temps(1)
     r0: _0
-    r1: |_0, bool|_0 has drop
+    r1: |_0, bool|(_0) has drop
   code:
   L0:
     0: r1 := pack_closure pick<_0>, 1, [r0] @1

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/global_storage/function_type_arg.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/global_storage/function_type_arg.move
@@ -1,0 +1,32 @@
+// Resource state keys include function type arguments in the struct tag.
+
+// RUN: publish
+module 0x42::function_type_arg {
+    struct Tagged<phantom T> has key { value: u64 }
+
+    public fun publish_and_read(owner: signer, addr: address): u64 {
+        move_to(&owner, Tagged<|u8|(u8, u16) has copy + drop> { value: 7 });
+        borrow_global<Tagged<|u8|(u8, u16) has copy + drop>>(addr).value
+    }
+
+    public fun publish_and_take(owner: signer, addr: address): bool {
+        move_to(&owner, Tagged<|&u8|u8 has copy + drop + store> { value: 9 });
+        let Tagged { value: _ } = move_from<Tagged<|&u8|u8 has copy + drop + store>>(addr);
+        exists<Tagged<|&u8|u8 has copy + drop + store>>(addr)
+    }
+
+    // Different function type arguments produce distinct resource keys.
+    public fun distinct_instantiations(owner: signer, addr: address): bool {
+        move_to(&owner, Tagged<|u8|u8 has copy + drop> { value: 1 });
+        exists<Tagged<|u8|(u8, u16) has copy + drop>>(addr)
+    }
+}
+
+// RUN: execute 0x42::function_type_arg::publish_and_read --args 0x42, 0x42
+// CHECK: results: 7
+
+// RUN: execute 0x42::function_type_arg::publish_and_take --args 0x43, 0x43
+// CHECK: results: false
+
+// RUN: execute 0x42::function_type_arg::distinct_instantiations --args 0x44, 0x44
+// CHECK: results: false

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/events.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/events.move
@@ -10,6 +10,10 @@ module 0x1::event {
         data: vector<u8>,
     }
 
+    struct Tagged<phantom T> has drop, store {
+        a: u64,
+    }
+
     native fun write_module_event_to_store<T: drop + store>(msg: T);
     native fun write_to_event_store<T: drop + store>(guid: vector<u8>, count: u64, msg: T);
 
@@ -36,6 +40,15 @@ module 0x1::event {
         do_emit();
     }
 
+    fun do_emit_function_type_arg() {
+        write_module_event_to_store(Tagged<|u8|(u8, u16) has copy + drop> { a: 11 });
+    }
+
+    // The event's type tag carries a function type argument.
+    public fun emit_module_function_type_arg() {
+        do_emit_function_type_arg();
+    }
+
     // Mock `guid` -- the BCS encoding of an `EventKey { creation_number: 1,
     // account_address: 0x0 }`
     fun handle_guid(): vector<u8> {
@@ -57,6 +70,9 @@ module 0x1::event {
 
 // RUN: execute 0x1::event::emit_module
 // CHECK: events: module 0x1::event::MyEvent 0x070000000000000003010203
+
+// RUN: execute 0x1::event::emit_module_function_type_arg
+// CHECK: events: module 0x1::event::Tagged<|u8|(u8, u16) has copy + drop> 0x0b00000000000000
 
 // RUN: execute 0x1::event::emit_handle
 // CHECK: events: handle creator=0x0 seq=5 0x1::event::MyEvent 0x090000000000000003010203

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/type_name.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/type_name.move
@@ -48,7 +48,41 @@ module 0x1::main {
         0x1::type_info::type_name<Bar<Choice<address>>>()
     }
 
-    // TODO: cover function types once the specializer supports them.
+    // Canonical function type names always parenthesize results.
+
+    public fun function_name(): String {
+        0x1::type_info::type_name<|u64|u64>()
+    }
+
+    public fun multi_result_function_name(): String {
+        0x1::type_info::type_name<|u8|(u8, u16)>()
+    }
+
+    public fun no_arg_function_name(): String {
+        0x1::type_info::type_name<||u8>()
+    }
+
+    public fun no_result_function_name(): String {
+        0x1::type_info::type_name<|u8|()>()
+    }
+
+    public fun ref_arg_function_name(): String {
+        0x1::type_info::type_name<|&u8, &mut u64|bool>()
+    }
+
+    public fun function_in_struct_name(): String {
+        0x1::type_info::type_name<Bar<|u8|u8 has copy + drop>>()
+    }
+
+    // Result parentheses distinguish a function returning `||u8` from one
+    // taking `||()` and returning `u8`.
+    public fun function_in_function_name(): String {
+        0x1::type_info::type_name<||(||u8)>()
+    }
+
+    public fun vector_of_functions_name(): String {
+        0x1::type_info::type_name<vector<|Foo|Bar<u64>>>()
+    }
 }
 
 // RUN: execute 0x1::main::u64_name
@@ -74,3 +108,27 @@ module 0x1::main {
 
 // RUN: execute 0x1::main::nested_enum_name
 // CHECK: results: "0x1::main::Bar<0x1::main::Choice<address>>"
+
+// RUN: execute 0x1::main::function_name
+// CHECK: results: "|u64|(u64)"
+
+// RUN: execute 0x1::main::multi_result_function_name
+// CHECK: results: "|u8|(u8, u16)"
+
+// RUN: execute 0x1::main::no_arg_function_name
+// CHECK: results: "||(u8)"
+
+// RUN: execute 0x1::main::no_result_function_name
+// CHECK: results: "|u8|()"
+
+// RUN: execute 0x1::main::ref_arg_function_name
+// CHECK: results: "|&u8, &mut u64|(bool)"
+
+// RUN: execute 0x1::main::function_in_struct_name
+// CHECK: results: "0x1::main::Bar<|u8|(u8) has copy + drop>"
+
+// RUN: execute 0x1::main::function_in_function_name
+// CHECK: results: "||(||(u8))"
+
+// RUN: execute 0x1::main::vector_of_functions_name
+// CHECK: results: "vector<|0x1::main::Foo|(0x1::main::Bar<u64>)>"

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/type_of.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/type_of.move
@@ -1,11 +1,9 @@
 // Differential test for `type_info::type_of`.
-//
-// TODO: `module_name` / `struct_name` are `vector<u8>`, so they render as hex
-// byte dumps below. Render them as strings once the V2 test harness has the
-// `string` natives (e.g. `string::utf8`) needed to decode them.
 
 // RUN: publish
 module 0x1::type_info {
+    use std::string::{Self, String};
+
     struct TypeInfo has copy, drop, store {
         account_address: address,
         module_name: vector<u8>,
@@ -13,34 +11,47 @@ module 0x1::type_info {
     }
     struct Foo has drop {}
     struct Bar<phantom T> has drop {}
+    struct Pair<phantom T, phantom U> has drop {}
 
     public native fun type_of<T>(): TypeInfo;
 
     public fun foo_address(): address {
-        let t = type_of<Foo>();
-        t.account_address
+        let info = type_of<Foo>();
+        info.account_address
     }
 
-    public fun foo_module(): vector<u8> {
-        let t = type_of<Foo>();
-        t.module_name
+    public fun foo_module(): String {
+        let info = type_of<Foo>();
+        string::utf8(info.module_name)
     }
 
-    public fun foo_struct(): vector<u8> {
-        let t = type_of<Foo>();
-        t.struct_name
+    public fun foo_struct(): String {
+        let info = type_of<Foo>();
+        string::utf8(info.struct_name)
     }
 
     // `struct_name` must carry the generic instantiation, not just `Bar`.
-    public fun bar_struct(): vector<u8> {
-        let t = type_of<Bar<u64>>();
-        t.struct_name
+    public fun bar_struct(): String {
+        let info = type_of<Bar<u64>>();
+        string::utf8(info.struct_name)
+    }
+
+    // Struct type arguments are fully qualified; type arguments are comma separated.
+    public fun pair_struct(): String {
+        let info = type_of<Pair<u64, Bar<u8>>>();
+        string::utf8(info.struct_name)
+    }
+
+    // Function type arguments render canonically, with parenthesized results.
+    public fun bar_function_struct(): String {
+        let info = type_of<Bar<|u8|(u8, u16) has copy + drop>>();
+        string::utf8(info.struct_name)
     }
 
     // Aborts on a non-struct type, matching the legacy VM's code and message.
     public fun non_struct_aborts(): address {
-        let t = type_of<u64>();
-        t.account_address
+        let info = type_of<u64>();
+        info.account_address
     }
 }
 
@@ -48,13 +59,19 @@ module 0x1::type_info {
 // CHECK: results: 0x1
 
 // RUN: execute 0x1::type_info::foo_module
-// CHECK: results: 0x747970655f696e666f
+// CHECK: results: "type_info"
 
 // RUN: execute 0x1::type_info::foo_struct
-// CHECK: results: 0x466f6f
+// CHECK: results: "Foo"
 
 // RUN: execute 0x1::type_info::bar_struct
-// CHECK: results: 0x4261723c7536343e
+// CHECK: results: "Bar<u64>"
+
+// RUN: execute 0x1::type_info::pair_struct
+// CHECK: results: "Pair<u64, 0x1::type_info::Bar<u8>>"
+
+// RUN: execute 0x1::type_info::bar_function_struct
+// CHECK: results: "Bar<|u8|(u8, u16) has copy + drop>"
 
 // RUN: execute 0x1::type_info::non_struct_aborts
 // CHECK: aborted: code 1 (Expected a struct type, found: u64) in 0x1::type_info


### PR DESCRIPTION
## Description

Adds support for converting function types to `TypeTag` (via `FunctionTag`) in the mono-move interner, enabling function types to participate in type tag–based operations such as global storage keys, event type tags, and `type_info` natives.

The `type_tag_of` function now handles `Type::Function`, converting its arguments and results to `FunctionParamOrReturnTag` values (preserving reference kinds as `Reference` or `MutableReference`). Previously, function types returned `None` from `type_tag_of`, which blocked their use as struct type arguments in resource keys and event tags.

The `native_type_name` and `native_type_of` implementations are updated to use `type_tag_of` and `TypeTag::to_canonical_string` rather than the ad-hoc `type_to_string` traversal, aligning their output with the canonical tag format. The `type_of` test is updated to decode `module_name` and `struct_name` as UTF-8 strings rather than raw hex, and new cases cover function type arguments in struct names.

The function type display format is updated so that results are always parenthesized — `|args|(results)` — making the format unambiguous when a function type appears as a result type itself (e.g., `||(||u8)` vs. `|||u8`). All `.exp` snapshot files are updated accordingly.

The unused `Type::short_name` method is removed; call sites now use `TypeTag::to_short_string` instead.

## How Has This Been Tested?

- New differential test `function_type_arg.move` covers `move_to`, `borrow_global`, `move_from`, and `exists` with function type arguments, and verifies that distinct function type arguments produce distinct resource keys.
- Extended `type_name.move` with cases for single-result, multi-result, no-arg, no-result, reference-arg, nested, struct-wrapped, and vector-wrapped function types, checking canonical string output.
- Extended `type_of.move` with `pair_struct` and `bar_function_struct` cases, and updated existing cases to assert decoded string values.
- Extended `events.move` with `emit_module_function_type_arg` to verify that event type tags correctly carry function type arguments.
- All existing closure `.exp` snapshots are updated to reflect the new parenthesized result format.

## Key Areas to Review

- `function_param_tags_of` in `interner.rs`: this is the new function that maps reference and value types to `FunctionParamOrReturnTag`. The exhaustive match on value types is intentional to ensure new types are not silently dropped.
- The ability interning comment in `prepared_module.rs` explains why abilities are not validated at intern time (stored tags may predate VM validation), with TODOs tracking the correctness gap.
- The display format change (`|args|results` → `|args|(results)`) is a breaking change to the textual representation of function types. All snapshot files are updated, but any external tooling that parses this format will need updating.

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Refactoring
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Move Compiler

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes type tag conversion and canonical naming for function types, affecting global storage keys, events, and reflection; display format is a breaking textual change for parsers of function type strings.
> 
> **Overview**
> **Function types can now be converted to `TypeTag`**, so they work as struct type arguments in global storage keys, event tags, and `type_info` reflection. `type_tag_of` maps `Type::Function` to `FunctionTag`, with `function_param_tags_of` preserving `&` / `&mut` on parameters and results; standalone reference types still return `None`.
> 
> **`type_name` and `type_of` natives** route through `type_tag_of` and `TypeTag::to_canonical_string` / struct tags instead of custom interned-type string building. Non-struct abort messages use `TypeTag::to_short_string`. `Type::short_name` is removed.
> 
> **Textual function types** always parenthesize results (`|u64|(u64)` not `|u64|u64`), including in `display_type` and closure stackless snapshots.
> 
> Differential tests cover function-typed resources, events, and extended `type_name` / `type_of` cases; `prepared_module` documents deferred ability validation when interning stored function tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c9e10cab5b1ee4f8b71beceaf360a4981e1acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->