### PR TITLE
[vm] Enforce value depth while deserializing

### DIFF
--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -97,7 +97,7 @@ pub struct ValueSerDeContext<'a> {
     pub(crate) function_extension: Option<FunctionValueExtensionWithContext<'a>>,
     pub(crate) delayed_fields_extension: Option<DelayedFieldsExtension<'a>>,
     pub(crate) legacy_signer: bool,
-    /// Maximum allowed depth of a VM value. Enforced by serializer.
+    /// Maximum allowed depth of a VM value. Enforced during (de)serialization.
     pub(crate) max_value_nested_depth: Option<u64>,
     /// If true, serialization of any value containing a closure fails.
     pub(crate) closure_serialization_disabled: bool,
@@ -248,7 +248,11 @@ impl<'a> ValueSerDeContext<'a> {
 
     /// Deserializes the bytes using the provided layout into a Move [Value].
     pub fn deserialize(self, bytes: &[u8], layout: &MoveTypeLayout) -> Option<Value> {
-        let seed = DeserializationSeed { ctx: &self, layout };
+        let seed = DeserializationSeed {
+            ctx: &self,
+            layout,
+            depth: 1,
+        };
         bcs::from_bytes_seed(seed, bytes).ok()
     }
 
@@ -259,7 +263,11 @@ impl<'a> ValueSerDeContext<'a> {
         bytes: &[u8],
         layout: &MoveTypeLayout,
     ) -> PartialVMResult<Value> {
-        let seed = DeserializationSeed { ctx: &self, layout };
+        let seed = DeserializationSeed {
+            ctx: &self,
+            layout,
+            depth: 1,
+        };
         bcs::from_bytes_seed(seed, bytes).map_err(|e| {
             PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_RESOURCE)
                 .with_message(format!("deserializer error: {}", e))

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -199,6 +199,7 @@ impl<'d, 'c> serde::de::Visitor<'d> for ClosureVisitor<'c> {
             match seq.next_element_seed(DeserializationSeed {
                 ctx: self.0.ctx,
                 layout: &layout,
+                depth: self.0.depth + 1,
             })? {
                 Some(v) => {
                     captured_layouts.push(layout);

--- a/third_party/move/move-vm/types/src/values/value_depth_tests.rs
+++ b/third_party/move/move-vm/types/src/values/value_depth_tests.rs
@@ -5,7 +5,10 @@
 
 use crate::{
     value_serde::{MockFunctionValueExtension, ValueSerDeContext},
-    values::{AbstractFunction, GlobalValue, SerializedFunctionData, Struct, StructRef, Value},
+    values::{
+        AbstractFunction, GlobalValue, SerializedFunctionData, Struct, StructRef, Value,
+        DEFAULT_MAX_VM_VALUE_NESTED_DEPTH,
+    },
 };
 use better_any::{Tid, TidAble, TidExt};
 use claims::{assert_err, assert_none, assert_ok, assert_some};
@@ -175,6 +178,92 @@ fn test_serialization() {
         assert_none!(assert_ok!(ctx(1).serialize(v, l)));
         assert_err!(ctx(1).serialized_size(v, l));
     }
+}
+
+#[test]
+fn test_deserialization() {
+    use MoveStructLayout::Runtime;
+    use MoveTypeLayout as L;
+
+    let mut extension = MockFunctionValueExtension::new();
+    extension
+        .expect_get_serialization_data()
+        .returning(move |af| Ok(af.downcast_ref::<MockFunction>().unwrap().data.clone()));
+    extension
+        .expect_create_from_serialization_data()
+        .returning(|data| Ok(Box::new(MockFunction { data })));
+
+    let cases = [
+        (
+            Value::vector_unchecked(vec![Value::vector_u8(vec![0, 1])]).unwrap(),
+            L::Vector(Box::new(L::Vector(Box::new(L::U8)))),
+            2,
+        ),
+        (
+            Value::struct_(Struct::pack(vec![Value::vector_u8(vec![0, 1])])),
+            L::new_struct(Runtime(vec![L::Vector(Box::new(L::U8))])),
+            2,
+        ),
+        (
+            MockFunction::closure(
+                ClosureMask::new_for_leading(1).expect("capturing one argument should not fail"),
+                vec![Value::u16(0)],
+                vec![L::U16],
+            ),
+            L::Function,
+            2,
+        ),
+    ];
+
+    for (value, layout, depth) in cases {
+        let bytes = assert_some!(assert_ok!(ValueSerDeContext::new(None)
+            .with_func_args_deserialization(&extension)
+            .serialize(&value, &layout)));
+        let deserialize = |max_depth| {
+            ValueSerDeContext::new(Some(max_depth))
+                .with_func_args_deserialization(&extension)
+                .deserialize(&bytes, &layout)
+        };
+        assert_some!(deserialize(depth));
+        assert_some!(deserialize(depth + 1));
+        assert_none!(deserialize(depth - 1));
+    }
+}
+
+#[test]
+fn test_deserialization_default_depth_boundary() {
+    fn nested_vector(depth: u64) -> (Value, MoveTypeLayout) {
+        let mut value = Value::vector_u8(vec![0]);
+        let mut layout = MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8));
+        for _ in 1..depth {
+            value = Value::vector_unchecked(vec![value]).unwrap();
+            layout = MoveTypeLayout::Vector(Box::new(layout));
+        }
+        (value, layout)
+    }
+
+    for depth in [
+        DEFAULT_MAX_VM_VALUE_NESTED_DEPTH - 1,
+        DEFAULT_MAX_VM_VALUE_NESTED_DEPTH,
+    ] {
+        let (value, layout) = nested_vector(depth);
+        let bytes = assert_some!(assert_ok!(
+            ValueSerDeContext::new(None).serialize(&value, &layout)
+        ));
+        assert_some!(
+            ValueSerDeContext::new(Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+                .deserialize(&bytes, &layout)
+        );
+    }
+
+    let (value, layout) = nested_vector(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH + 1);
+    let bytes = assert_some!(assert_ok!(
+        ValueSerDeContext::new(None).serialize(&value, &layout)
+    ));
+    assert_none!(
+        ValueSerDeContext::new(Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+            .deserialize(&bytes, &layout)
+    );
 }
 
 fn test_binop_with_max_depth<F, T>(f: F)

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5534,6 +5534,7 @@ pub(crate) struct DeserializationSeed<'c, L> {
     pub(crate) ctx: &'c ValueSerDeContext<'c>,
     // Layout to guide deserialization.
     pub(crate) layout: L,
+    pub(crate) depth: u64,
 }
 
 impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLayout> {
@@ -5545,6 +5546,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
     ) -> Result<Self::Value, D::Error> {
         use MoveTypeLayout as L;
 
+        self.ctx.check_depth(self.depth).map_err(D::Error::custom)?;
         match self.layout {
             // Primitive types.
             L::Bool => bool::deserialize(deserializer).map(Value::bool),
@@ -5570,6 +5572,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
                     let seed = DeserializationSeed {
                         ctx: self.ctx,
                         layout: &MoveStructLayout::signer_serialization_layout(),
+                        depth: self.depth,
                     };
                     Ok(Value::struct_(seed.deserialize(deserializer)?))
                 }
@@ -5580,6 +5583,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
                 let seed = DeserializationSeed {
                     ctx: self.ctx,
                     layout: struct_layout.as_ref(),
+                    depth: self.depth,
                 };
                 Ok(Value::struct_(seed.deserialize(deserializer)?))
             },
@@ -5604,6 +5608,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
                     let seed = DeserializationSeed {
                         ctx: self.ctx,
                         layout,
+                        depth: self.depth + 1,
                     };
                     let vector = deserializer.deserialize_seq(VectorElementVisitor(seed))?;
                     Value::Container(Container::Vec(NestedValues::new(vector)))
@@ -5615,6 +5620,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
                 let seed = DeserializationSeed {
                     ctx: self.ctx,
                     layout: (),
+                    depth: self.depth,
                 };
                 let closure = deserializer.deserialize_seq(ClosureVisitor(seed))?;
                 Ok(Value::ClosureValue(closure))
@@ -5631,6 +5637,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
                         let value = DeserializationSeed {
                             ctx: &self.ctx.clone_without_delayed_fields(),
                             layout: layout.as_ref(),
+                            depth: self.depth,
                         }
                         .deserialize(deserializer)?;
                         let id = match delayed_fields_extension.mapping {
@@ -5680,7 +5687,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveStructL
             MoveStructLayout::Runtime(field_layouts) => {
                 let fields = deserializer.deserialize_tuple(
                     field_layouts.len(),
-                    StructFieldVisitor(self.ctx, field_layouts),
+                    StructFieldVisitor(self.ctx, field_layouts, self.depth),
                 )?;
                 Ok(Struct::pack(fields))
             },
@@ -5693,7 +5700,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveStructL
                 let fields = deserializer.deserialize_enum(
                     value::MOVE_ENUM_NAME,
                     variant_names,
-                    StructVariantVisitor(self.ctx, variants),
+                    StructVariantVisitor(self.ctx, variants, self.depth),
                 )?;
                 Ok(Struct::pack(fields))
             },
@@ -5723,6 +5730,7 @@ impl<'d, 'c, 'l> serde::de::Visitor<'d> for VectorElementVisitor<'c, 'l> {
         while let Some(elem) = seq.next_element_seed(DeserializationSeed {
             ctx: self.0.ctx,
             layout: self.0.layout,
+            depth: self.0.depth,
         })? {
             vals.push(elem)
         }
@@ -5730,7 +5738,7 @@ impl<'d, 'c, 'l> serde::de::Visitor<'d> for VectorElementVisitor<'c, 'l> {
     }
 }
 
-struct StructFieldVisitor<'c, 'l>(&'c ValueSerDeContext<'c>, &'l [MoveTypeLayout]);
+struct StructFieldVisitor<'c, 'l>(&'c ValueSerDeContext<'c>, &'l [MoveTypeLayout], u64);
 
 impl<'d, 'c, 'l> serde::de::Visitor<'d> for StructFieldVisitor<'c, 'l> {
     type Value = Vec<Value>;
@@ -5748,6 +5756,7 @@ impl<'d, 'c, 'l> serde::de::Visitor<'d> for StructFieldVisitor<'c, 'l> {
             if let Some(elem) = seq.next_element_seed(DeserializationSeed {
                 ctx: self.0,
                 layout: field_layout,
+                depth: self.2 + 1,
             })? {
                 val.push(elem)
             } else {
@@ -5758,7 +5767,7 @@ impl<'d, 'c, 'l> serde::de::Visitor<'d> for StructFieldVisitor<'c, 'l> {
     }
 }
 
-struct StructVariantVisitor<'c, 'l>(&'c ValueSerDeContext<'c>, &'l [Vec<MoveTypeLayout>]);
+struct StructVariantVisitor<'c, 'l>(&'c ValueSerDeContext<'c>, &'l [Vec<MoveTypeLayout>], u64);
 
 impl<'d, 'c, 'l> serde::de::Visitor<'d> for StructVariantVisitor<'c, 'l> {
     type Value = Vec<Value>;
@@ -5786,13 +5795,16 @@ impl<'d, 'c, 'l> serde::de::Visitor<'d> for StructVariantVisitor<'c, 'l> {
                     values.push(rest.newtype_variant_seed(DeserializationSeed {
                         ctx: self.0,
                         layout: &fields[0],
+                        depth: self.2 + 1,
                     })?);
                     Ok(values)
                 },
                 _ => {
                     values.append(
-                        &mut rest
-                            .tuple_variant(fields.len(), StructFieldVisitor(self.0, fields))?,
+                        &mut rest.tuple_variant(
+                            fields.len(),
+                            StructFieldVisitor(self.0, fields, self.2),
+                        )?,
                     );
                     Ok(values)
                 },
@@ -5812,6 +5824,7 @@ impl<'d, 'c, 'l> serde::de::Visitor<'d> for StructVariantVisitor<'c, 'l> {
         let variant_tag = match seq.next_element_seed(DeserializationSeed {
             ctx: self.0,
             layout: &MoveTypeLayout::U16,
+            depth: self.2,
         })? {
             Some(elem) => {
                 let variant_tag = if let Ok(tag) = elem.value_as::<u16>() {
@@ -5838,6 +5851,7 @@ impl<'d, 'c, 'l> serde::de::Visitor<'d> for StructVariantVisitor<'c, 'l> {
             if let Some(elem) = seq.next_element_seed(DeserializationSeed {
                 ctx: self.0,
                 layout: field_layout,
+                depth: self.2 + 1,
             })? {
                 val.push(elem)
             } else {
@@ -5890,7 +5904,7 @@ impl Value {
         let layout = Self::constant_sig_token_to_layout(&constant.type_)?;
         // INVARIANT:
         //   For constants, layout depth is bounded and cannot contain function values. Hence,
-        //   serialization depth is bounded. We still enable depth checks as a precaution.
+        //   value depth is bounded. We still enable depth checks as a precaution.
         ValueSerDeContext::new(Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
             .deserialize(&constant.data, &layout)
     }


### PR DESCRIPTION
## Motivation

`ValueSerDeContext` accepts a maximum nested value depth, but deserialization seeds carried only the context and layout. As a result, recursive deserialization did not independently enforce the configured limit even though serialization did.

## Implementation

Start deserialization at depth 1, check the depth for each `MoveTypeLayout`, and propagate it with the existing serialization semantics: struct and variant fields, general vector elements, and closure captures increment depth, while transparent signer and native wrappers preserve it. This makes the context limit symmetric and adds defense in depth for deserialization callers.

Regression tests cover vector, struct, and closure recursion, including acceptance at depths 127 and 128 and rejection at 129 for the default limit.

## Compatibility

This does not change the configured limit, BCS wire format, gas accounting, or verifier behavior. Values within the existing limit deserialize as before; values whose realized recursive depth exceeds a caller's configured limit are rejected.

## Tests

- `cargo test -p move-vm-types value_depth_tests::test_deserialization` (2 passed)
- `cargo test -p move-vm-types` (103 passed)
- `cargo test -p move-vm-runtime` (42 passed; 2 doc tests passed)
- `cargo check -p move-vm-types`
- `cargo clippy -p move-vm-types --all-targets` with the repository warning policy
- `cargo +nightly fmt --package move-vm-types -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VM (de)serialization paths for resources and constants; behavior change only for values exceeding a caller's depth limit, but that can reject previously accepted malicious or edge-case BCS input.
> 
> **Overview**
> **Enforces `max_value_nested_depth` during Move VM value deserialization**, matching behavior that already applied on serialization.
> 
> `DeserializationSeed` now tracks a **depth** counter (starting at 1 in `deserialize` / `deserialize_or_err`). Each layout node calls `ValueSerDeContext::check_depth` before building values; nested **vectors**, **struct/variant fields**, and **closure captures** bump depth by one, while **signer** and **native/delayed-field** inner layouts keep the current depth. Closure capture deserialization in `function_values_impl.rs` passes the incremented depth into nested seeds.
> 
> Docs now state the limit is enforced on **(de)serialization**. New tests in `value_depth_tests` assert round-trip success/failure at configured limits (including vectors, structs, closures) and at the default cap (`DEFAULT_MAX_VM_VALUE_NESTED_DEPTH`: accept at 128, reject at 129).
> 
> Wire format, default limit, and values within the limit are unchanged; overly deep payloads fail deserialization where they were previously accepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46284fce22f1b30f58497110c579fa7ca8670266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->